### PR TITLE
Add total count on provider deployments endpoint

### DIFF
--- a/api/src/db/deploymentProvider.ts
+++ b/api/src/db/deploymentProvider.ts
@@ -70,6 +70,19 @@ export async function getDeploymentRelatedMessages(owner: string, dseq: string) 
   }));
 }
 
+export async function getProviderDeploymentsCount(provider: string, status?: "active" | "closed") {
+  let leaseFilter = { providerAddress: provider };
+  if (status) {
+    leaseFilter["closedHeight"] = status === "active" ? null : { [Op.ne]: null };
+  }
+
+  const result = await Deployment.count({
+    include: [{ model: Lease, attributes: [], required: true, where: leaseFilter }]
+  });
+
+  return result;
+}
+
 export async function getProviderDeployments(provider: string, skip: number, limit: number, status?: "active" | "closed") {
   let leaseFilter = { providerAddress: provider };
 

--- a/api/src/routers/apiRouter.ts
+++ b/api/src/routers/apiRouter.ts
@@ -24,7 +24,7 @@ import axios from "axios";
 import { getMarketData } from "@src/providers/marketDataProvider";
 import { getAuditors, getProviderAttributesSchema } from "@src/providers/githubProvider";
 import { getProviderRegions } from "@src/db/providerDataProvider";
-import { getProviderDeployments } from "@src/db/deploymentProvider";
+import { getProviderDeployments, getProviderDeploymentsCount } from "@src/db/deploymentProvider";
 
 export const apiRouter = express.Router();
 
@@ -205,9 +205,15 @@ apiRouter.get(
       return;
     }
 
-    const deployments = await getProviderDeployments(req.params.provider, skip, limit, statusParam);
+    const deploymentCountQuery = getProviderDeploymentsCount(req.params.provider, statusParam);
+    const deploymentsQuery = getProviderDeployments(req.params.provider, skip, limit, statusParam);
 
-    res.send(deployments);
+    const [deploymentCount, deployments] = await Promise.all([deploymentCountQuery, deploymentsQuery]);
+
+    res.send({
+      total: deploymentCount,
+      deployments: deployments
+    });
   })
 );
 


### PR DESCRIPTION
Added a `total` count in the response and moved the deployments to `deployments`

![image](https://github.com/akash-network/cloudmos/assets/2829180/0947a9c4-a305-4e77-81f1-55636d629549)

Improvement for #53
