### PR TITLE
Add leases duration endpoint

### DIFF
--- a/api/src/routers/internalRouter.ts
+++ b/api/src/routers/internalRouter.ts
@@ -1,10 +1,12 @@
-import { Provider } from "@shared/dbSchemas/akash";
+import { Block } from "@shared/dbSchemas";
+import { Lease, Provider } from "@shared/dbSchemas/akash";
 import { chainDb } from "@src/db/dbConnection";
 import { isValidBech32Address } from "@src/utils/addresses";
 import { round } from "@src/utils/math";
+import { differenceInSeconds } from "date-fns";
 import { Hono } from "hono";
 import * as semver from "semver";
-import { QueryTypes } from "sequelize";
+import { Op, QueryTypes } from "sequelize";
 
 export const internalRouter = new Hono();
 
@@ -153,4 +155,71 @@ internalRouter.get("/gpu", async (c) => {
   }
 
   return c.json(response);
+});
+
+internalRouter.get("leases-duration/:owner/:dseq?", async (c) => {
+  let dseq: null | number = null;
+  let startTime: null | Date = null;
+  let endTime: null | Date = null;
+
+  if (c.req.param("dseq")) {
+    dseq = parseInt(c.req.param("dseq"));
+
+    if (!isNaN(dseq)) return c.text("Invalid dseq", 400);
+  }
+
+  if (c.req.query("startDate")) { // TODO Check format
+    const startMs = Date.parse(c.req.query("start"));
+
+    if (isNaN(startMs)) return c.text("Invalid start date", 400);
+
+    startTime = new Date(startMs);
+  }
+
+  if (c.req.query("endDate")) { // TODO Check format
+    const endMs = Date.parse(c.req.query("end"));
+
+    if (isNaN(endMs)) return c.text("Invalid end date", 400);
+
+    endTime = new Date(endMs);
+  }
+
+  if (endTime <= startTime) {
+    return c.text("End time must be greater than start time", 400);
+  }
+
+  const closedLeases = await Lease.findAll({
+    where: {
+      owner: c.req.param("owner"),
+      closedHeight: { [Op.not]: null },
+      "$closedBlock.datetime$": { [Op.gte]: startTime, [Op.lte]: endTime }
+    },
+    include: [
+      { model: Block, as: "createdBlock" },
+      { model: Block, as: "closedBlock" }
+    ]
+  });
+
+  const leases = closedLeases.map((x) => ({
+    dseq: x.dseq,
+    oseq: x.oseq,
+    gseq: x.gseq,
+    provider: x.providerAddress,
+    startHeight: x.createdHeight,
+    startDate: x.createdBlock.datetime,
+    closedHeight: x.closedHeight,
+    closedDate: x.closedBlock.datetime,
+    durationInBlocks: x.closedHeight - x.createdHeight,
+    durationInSeconds: differenceInSeconds(x.closedBlock.datetime, x.createdBlock.datetime),
+    durationInHours: differenceInSeconds(x.closedBlock.datetime, x.createdBlock.datetime) / 3600
+  }));
+
+  const totalSeconds = leases.map((x) => x.durationInSeconds).reduce((a, b) => a + b, 0);
+
+  return c.json({
+    leaseCount: leases.length,
+    totalDurationInSeconds: totalSeconds,
+    totalDurationInHours: totalSeconds / 3600,
+    leases
+  });
 });


### PR DESCRIPTION
# New endpoint for querying leases duration #119 
New endpoint under `/internal`, could be moved to public api once specs are stable. 

Url: `https://api.cloudmos.io/internal/leases-duration/<owner_address>`

Preview Url: https://api-preview.cloudmos.io/internal/leases-duration/akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd

|Query Parameter|Format|Example
| - | - | - |
|`dseq`|Number|`6919663`
|`startDate`|`YYYY-MM-DD`|`2024-03-01`
|`endDate`|`YYYY-MM-DD`|`2024-03-10`

## Notes
- All query parameters are optional
- Durations are given in blocks, seconds and hours
- Only closed leases are shown
- Date filtering is done based on the closed date and treated as UTC

## Example Response
```
{
  "leaseCount": 1,
  "totalDurationInSeconds": 362,
  "totalDurationInHours": 0.10055555555555555,
  "leases": [
    {
      "dseq": "15102861",
      "oseq": 1,
      "gseq": 1,
      "provider": "akash15ksejj7g4su7ljufsg0a8eglvkje94z8qsh68a",
      "startHeight": 15102887,
      "startDate": "2024-02-21T03:00:46.861Z",
      "closedHeight": 15102947,
      "closedDate": "2024-02-21T03:06:49.063Z",
      "durationInBlocks": 60,
      "durationInSeconds": 362,
      "durationInHours": 0.10055555555555555
    }
  ]
}
```