### PR TITLE
Unifies nodes fetching and caching under a dedicated class

### DIFF
--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -1,37 +1,38 @@
 const MAP_ALIASES = {
-  '^@src(.*)$': "<rootDir>/src$1",
-  '^@shared/(.*)$': '<rootDir>/../shared/$1',
+  "^@src(.*)$": "<rootDir>/src/$1",
+  "^@test/(.*)$": "<rootDir>/test/$1",
+  "^@shared/(.*)$": "<rootDir>/../shared/$1"
 };
 const MAP_TO_SAME_SEQUELIZE_PACKAGE = {
-  '^sequelize(.*)$': '<rootDir>/node_modules/sequelize$1',
-}
+  "^sequelize(.*)$": "<rootDir>/node_modules/sequelize$1"
+};
 
 const common = {
   transform: {
-    '^.+\\.(t|j)s$': ['ts-jest', { tsconfig: './tsconfig.json' }],
+    "^.+\\.(t|j)s$": ["ts-jest", { tsconfig: "./tsconfig.json" }]
   },
-  rootDir: '.',
+  rootDir: ".",
   moduleNameMapper: {
     ...MAP_ALIASES,
-    ...MAP_TO_SAME_SEQUELIZE_PACKAGE,
+    ...MAP_TO_SAME_SEQUELIZE_PACKAGE
   },
-  setupFiles: ['./test/setup.ts'],
+  setupFiles: ["./test/setup.ts"]
 };
 
 module.exports = {
-  collectCoverageFrom: ['./src/**/*.{js,ts}'],
+  collectCoverageFrom: ["./src/**/*.{js,ts}"],
   projects: [
     {
-      displayName: 'unit',
+      displayName: "unit",
       ...common,
-      testMatch: ['<rootDir>/src/**/*.spec.ts'],
-      setupFilesAfterEnv: ['./test/setup-unit-tests.ts'],
+      testMatch: ["<rootDir>/src/**/*.spec.ts"],
+      setupFilesAfterEnv: ["./test/setup-unit-tests.ts"]
     },
     {
-      displayName: 'functional',
+      displayName: "functional",
       ...common,
-      testMatch: ['<rootDir>/test/functional/**/*.spec.ts'],
-      setupFilesAfterEnv: ['./test/setup-functional-tests.ts'],
-    },
-  ],
+      testMatch: ["<rootDir>/test/functional/**/*.spec.ts"],
+      setupFilesAfterEnv: ["./test/setup-functional-tests.ts"]
+    }
+  ]
 };

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -31,6 +31,7 @@
         "hono": "3.12.0",
         "human-interval": "^2.0.1",
         "js-sha256": "^0.9.0",
+        "lodash": "^4.17.21",
         "markdown-to-txt": "^2.0.1",
         "memory-cache": "^0.2.0",
         "node-fetch": "^2.6.1",
@@ -44,7 +45,9 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@faker-js/faker": "^8.4.1",
         "@types/jest": "^29.5.12",
+        "@types/lodash": "^4.17.0",
         "@types/memory-cache": "^0.2.2",
         "@types/node": "^16.6.0",
         "@types/node-fetch": "^2.6.2",
@@ -56,6 +59,7 @@
         "alias-hq": "^5.1.6",
         "eslint": "^8.56.0",
         "jest": "^29.7.0",
+        "nock": "^13.5.4",
         "nodemon": "^2.0.7",
         "nodemon-webpack-plugin": "^4.5.2",
         "prettier": "^3.2.5",
@@ -3258,6 +3262,22 @@
         "@ethersproject/logger": "^5.7.0"
       }
     },
+    "node_modules/@faker-js/faker": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
+      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.4.0.tgz",
@@ -4882,6 +4902,12 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
       "dev": true
     },
     "node_modules/@types/long": {
@@ -10933,6 +10959,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -11421,6 +11453,43 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "node_modules/nock": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
+      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
+    "node_modules/nock/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nock/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "node_modules/node-abi": {
@@ -12235,6 +12304,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/protobufjs": {
@@ -17195,6 +17273,12 @@
         "@ethersproject/logger": "^5.7.0"
       }
     },
+    "@faker-js/faker": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
+      "integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
+      "dev": true
+    },
     "@hono/node-server": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.4.0.tgz",
@@ -18577,6 +18661,12 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
       "dev": true
     },
     "@types/long": {
@@ -23191,6 +23281,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
     "json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -23600,6 +23696,34 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "nock": {
+      "version": "13.5.4",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.4.tgz",
+      "integrity": "sha512-yAyTfdeNJGGBFxWdzSKCBYxs5FxLbCg5X5Q4ets974hcQzG1+qCxvIyOo4j2Ry6MUlhWVMX4OoYDefAIIwupjw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
     },
     "node-abi": {
       "version": "3.22.0",
@@ -24199,6 +24323,12 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "protobufjs": {
       "version": "6.11.3",

--- a/api/package.json
+++ b/api/package.json
@@ -46,6 +46,7 @@
     "hono": "3.12.0",
     "human-interval": "^2.0.1",
     "js-sha256": "^0.9.0",
+    "lodash": "^4.17.21",
     "markdown-to-txt": "^2.0.1",
     "memory-cache": "^0.2.0",
     "node-fetch": "^2.6.1",
@@ -59,7 +60,9 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@faker-js/faker": "^8.4.1",
     "@types/jest": "^29.5.12",
+    "@types/lodash": "^4.17.0",
     "@types/memory-cache": "^0.2.2",
     "@types/node": "^16.6.0",
     "@types/node-fetch": "^2.6.2",
@@ -71,6 +74,7 @@
     "alias-hq": "^5.1.6",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
+    "nock": "^13.5.4",
     "nodemon": "^2.0.7",
     "nodemon-webpack-plugin": "^4.5.2",
     "prettier": "^3.2.5",

--- a/api/src/caching/helpers.ts
+++ b/api/src/caching/helpers.ts
@@ -19,23 +19,16 @@ interface MemoizeOptions {
 export const Memoize = (options?: MemoizeOptions) => (target: object, propertyName: string, descriptor: PropertyDescriptor) => {
   const originalMethod = descriptor.value;
 
-  const cacheKeySymbol = options?.key || `${target.constructor.name}#${propertyName}`;
+  const cacheKey = options?.key || `${target.constructor.name}#${propertyName}`;
 
   descriptor.value = async function memoizedFunction(...args: unknown[]) {
-    return await cacheResponse(
-      options?.ttlInSeconds || 60 * 2,
-      cacheKeySymbol,
-      originalMethod.bind(this, ...args),
-      options?.keepData
-    );
-  }
-}
-
+    return await cacheResponse(options?.ttlInSeconds || 60 * 2, cacheKey, originalMethod.bind(this, ...args), options?.keepData);
+  };
+};
 
 export async function cacheResponse<T>(seconds: number, key: string, refreshRequest: () => Promise<T>, keepData?: boolean): Promise<T> {
   const duration = seconds * 1000;
   const cachedObject = cacheEngine.getFromCache(key) as CachedObject<T> | undefined;
-
   console.log(`Cache key: ${key}`);
 
   // If first time or expired, must refresh data if not already refreshing
@@ -83,5 +76,5 @@ export const cacheKeys = {
   getMainnetVersion: "getMainnetVersion",
   getTestnetVersion: "getTestnetVersion",
   getSandboxVersion: "getSandboxVersion",
-  getGpuModels: "getGpuModels",
+  getGpuModels: "getGpuModels"
 };

--- a/api/src/routes/v1/nodes/mainnet.ts
+++ b/api/src/routes/v1/nodes/mainnet.ts
@@ -1,6 +1,5 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { cacheKeys, cacheResponse } from "@src/caching/helpers";
-import axios from "axios";
+import { nodeClient } from '@src/routes/v1/nodes/node-client';
 
 const route = createRoute({
   method: "get",
@@ -26,11 +25,5 @@ const route = createRoute({
 });
 
 export default new OpenAPIHono().openapi(route, async (c) => {
-  const response = await cacheResponse(60 * 2, cacheKeys.getMainnetNodes, async () => {
-    const res = await axios.get<{ id: string; api: string; rpc: string }[]>(
-      "https://raw.githubusercontent.com/akash-network/cloudmos/main/config/mainnet-nodes.json"
-    );
-    return res.data;
-  });
-  return c.json(response);
+  return c.json(await nodeClient.getMainnetNodes());
 });

--- a/api/src/routes/v1/nodes/mainnet.ts
+++ b/api/src/routes/v1/nodes/mainnet.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { nodeClient } from '@src/routes/v1/nodes/node-client';
+import { nodeClient } from '@src/routes/v1/nodes/nodeClient';
 
 const route = createRoute({
   method: "get",

--- a/api/src/routes/v1/nodes/nodeClient.ts
+++ b/api/src/routes/v1/nodes/nodeClient.ts
@@ -1,64 +1,52 @@
-import axios, { AxiosInstance } from 'axios';
-import { Memoize } from '@src/caching/helpers';
+import axios, { AxiosInstance } from "axios";
+import { Memoize } from "@src/caching/helpers";
+import { env } from "@src/utils/env";
 
-interface Node {
+export interface Node {
   id: string;
   api: string;
-  rpc: string
+  rpc: string;
 }
 
 export class NodeClient {
-  constructor(private readonly http: AxiosInstance = axios.create({
-    baseURL: "https://raw.githubusercontent.com/akash-network",
-  })) {}
+  constructor(
+    private readonly http: AxiosInstance = axios.create({
+      baseURL: env.NODE_API_BASE_PATH
+    })
+  ) {}
 
   @Memoize()
   async getMainnetNodes() {
-    return await this.get<Node[]>(
-      "cloudmos/main/config/mainnet-nodes.json"
-    );
+    return await this.get<Node[]>("cloudmos/main/config/mainnet-nodes.json");
   }
 
   @Memoize()
   async getMainnetVersion() {
-    return await this.get<string>(
-      "net/master/mainnet/version.txt"
-    );
+    return await this.get<string>("net/master/mainnet/version.txt");
   }
 
   @Memoize()
   async getSandboxNodes() {
-    return await this.get<Node[]>(
-      "cloudmos/main/config/sandbox-nodes.json"
-    );
+    return await this.get<Node[]>("cloudmos/main/config/sandbox-nodes.json");
   }
 
   @Memoize()
   async getSandboxVersion() {
-    return await this.get<string>(
-      "net/master/sandbox/version.txt"
-    );
+    return await this.get<string>("net/master/sandbox/version.txt");
   }
 
   @Memoize()
   async getTestnetNodes() {
-    return await this.get<Node[]>(
-      "cloudmos/main/config/testnet-nodes.json"
-    );
+    return await this.get<Node[]>("cloudmos/main/config/testnet-nodes.json");
   }
 
   @Memoize()
   async getTestnetVersion() {
-    return await this.get<string>(
-      "net/master/testnet-02/version.txt"
-    );
+    return await this.get<string>("net/master/testnet-02/version.txt");
   }
 
   private async get<T>(path: string) {
-    const response = await this.http.get<T>(
-      path
-    );
-
+    const response = await this.http.get<T>(path);
     return response.data;
   }
 }

--- a/api/src/routes/v1/nodes/nodeClient.ts
+++ b/api/src/routes/v1/nodes/nodeClient.ts
@@ -1,0 +1,66 @@
+import axios, { AxiosInstance } from 'axios';
+import { Memoize } from '@src/caching/helpers';
+
+interface Node {
+  id: string;
+  api: string;
+  rpc: string
+}
+
+export class NodeClient {
+  constructor(private readonly http: AxiosInstance = axios.create({
+    baseURL: "https://raw.githubusercontent.com/akash-network",
+  })) {}
+
+  @Memoize()
+  async getMainnetNodes() {
+    return await this.get<Node[]>(
+      "cloudmos/main/config/mainnet-nodes.json"
+    );
+  }
+
+  @Memoize()
+  async getMainnetVersion() {
+    return await this.get<string>(
+      "net/master/mainnet/version.txt"
+    );
+  }
+
+  @Memoize()
+  async getSandboxNodes() {
+    return await this.get<Node[]>(
+      "cloudmos/main/config/sandbox-nodes.json"
+    );
+  }
+
+  @Memoize()
+  async getSandboxVersion() {
+    return await this.get<string>(
+      "net/master/sandbox/version.txt"
+    );
+  }
+
+  @Memoize()
+  async getTestnetNodes() {
+    return await this.get<Node[]>(
+      "cloudmos/main/config/testnet-nodes.json"
+    );
+  }
+
+  @Memoize()
+  async getTestnetVersion() {
+    return await this.get<string>(
+      "net/master/testnet-02/version.txt"
+    );
+  }
+
+  private async get<T>(path: string) {
+    const response = await this.http.get<T>(
+      path
+    );
+
+    return response.data;
+  }
+}
+
+export const nodeClient = new NodeClient();

--- a/api/src/routes/v1/nodes/sandbox.ts
+++ b/api/src/routes/v1/nodes/sandbox.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { nodeClient } from '@src/routes/v1/nodes/node-client';
+import { nodeClient } from '@src/routes/v1/nodes/nodeClient';
 
 const route = createRoute({
   method: "get",

--- a/api/src/routes/v1/nodes/sandbox.ts
+++ b/api/src/routes/v1/nodes/sandbox.ts
@@ -1,6 +1,5 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { cacheKeys, cacheResponse } from "@src/caching/helpers";
-import axios from "axios";
+import { nodeClient } from '@src/routes/v1/nodes/node-client';
 
 const route = createRoute({
   method: "get",
@@ -26,11 +25,5 @@ const route = createRoute({
 });
 
 export default new OpenAPIHono().openapi(route, async (c) => {
-  const response = await cacheResponse(60 * 2, cacheKeys.getSandboxNodes, async () => {
-    const res = await axios.get<{ id: string; api: string; rpc: string }[]>(
-      "https://raw.githubusercontent.com/akash-network/cloudmos/main/config/sandbox-nodes.json"
-    );
-    return res.data;
-  });
-  return c.json(response);
+  return c.json(await nodeClient.getSandboxNodes());
 });

--- a/api/src/routes/v1/nodes/testnet.ts
+++ b/api/src/routes/v1/nodes/testnet.ts
@@ -1,6 +1,5 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { cacheKeys, cacheResponse } from "@src/caching/helpers";
-import axios from "axios";
+import { nodeClient } from '@src/routes/v1/nodes/node-client';
 
 const route = createRoute({
   method: "get",
@@ -26,11 +25,5 @@ const route = createRoute({
 });
 
 export default new OpenAPIHono().openapi(route, async (c) => {
-  const response = await cacheResponse(60 * 2, cacheKeys.getTestnetNodes, async () => {
-    const res = await axios.get<{ id: string; api: string; rpc: string }[]>(
-      "https://raw.githubusercontent.com/akash-network/cloudmos/main/config/testnet-nodes.json"
-    );
-    return res.data;
-  });
-  return c.json(response);
+  return c.json(await nodeClient.getTestnetNodes());
 });

--- a/api/src/routes/v1/nodes/testnet.ts
+++ b/api/src/routes/v1/nodes/testnet.ts
@@ -1,5 +1,5 @@
 import { OpenAPIHono, createRoute, z } from "@hono/zod-openapi";
-import { nodeClient } from '@src/routes/v1/nodes/node-client';
+import { nodeClient } from '@src/routes/v1/nodes/nodeClient';
 
 const route = createRoute({
   method: "get",

--- a/api/src/routes/v1/version/mainnet.ts
+++ b/api/src/routes/v1/version/mainnet.ts
@@ -1,6 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { cacheKeys, cacheResponse } from "@src/caching/helpers";
-import axios from "axios";
+import { nodeClient } from "@src/routes/v1/nodes/nodeClient";
 
 const route = createRoute({
   method: "get",
@@ -17,9 +16,5 @@ const route = createRoute({
 });
 
 export default new OpenAPIHono().openapi(route, async (c) => {
-  const response = await cacheResponse(60 * 5, cacheKeys.getMainnetVersion, async () => {
-    const res = await axios.get<string>("https://raw.githubusercontent.com/akash-network/net/master/mainnet/version.txt");
-    return res.data;
-  });
-  return c.text(response);
+  return c.text(await nodeClient.getMainnetVersion());
 });

--- a/api/src/routes/v1/version/sandbox.ts
+++ b/api/src/routes/v1/version/sandbox.ts
@@ -1,6 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { cacheKeys, cacheResponse } from "@src/caching/helpers";
-import axios from "axios";
+import { nodeClient } from "@src/routes/v1/nodes/nodeClient";
 
 const route = createRoute({
   method: "get",
@@ -17,9 +16,5 @@ const route = createRoute({
 });
 
 export default new OpenAPIHono().openapi(route, async (c) => {
-  const response = await cacheResponse(60 * 5, cacheKeys.getSandboxVersion, async () => {
-    const res = await axios.get<string>("https://raw.githubusercontent.com/akash-network/net/master/sandbox/version.txt");
-    return res.data;
-  });
-  return c.text(response);
+  return c.text(await nodeClient.getSandboxVersion());
 });

--- a/api/src/routes/v1/version/testnet.ts
+++ b/api/src/routes/v1/version/testnet.ts
@@ -1,6 +1,5 @@
 import { OpenAPIHono, createRoute } from "@hono/zod-openapi";
-import { cacheKeys, cacheResponse } from "@src/caching/helpers";
-import axios from "axios";
+import { nodeClient } from "@src/routes/v1/nodes/nodeClient";
 
 const route = createRoute({
   method: "get",
@@ -15,11 +14,6 @@ const route = createRoute({
     }
   }
 });
-
 export default new OpenAPIHono().openapi(route, async (c) => {
-  const response = await cacheResponse(60 * 5, cacheKeys.getTestnetVersion, async () => {
-    const res = await axios.get<string>("https://raw.githubusercontent.com/akash-network/net/master/testnet-02/version.txt");
-    return res.data;
-  });
-  return c.text(response);
+  return c.text(await nodeClient.getTestnetVersion());
 });

--- a/api/src/utils/env.ts
+++ b/api/src/utils/env.ts
@@ -1,24 +1,28 @@
 import dotenv from "dotenv";
+import { z } from "zod";
 
 dotenv.config({ path: ".env.local" });
 dotenv.config();
 
-export const env = {
-  SentryDSN: process.env.SentryDSN,
-  AKASHLYTICS_CORS_WEBSITE_URLS: process.env.AKASHLYTICS_CORS_WEBSITE_URLS,
-  NODE_ENV: process.env.NODE_ENV,
-  SentryServerName: process.env.SentryServerName,
-  HealthchecksEnabled: process.env.HealthchecksEnabled,
-  AkashDatabaseCS: process.env.AkashDatabaseCS,
-  AkashTestnetDatabaseCS: process.env.AkashTestnetDatabaseCS,
-  AkashSandboxDatabaseCS: process.env.AkashSandboxDatabaseCS,
-  UserDatabaseCS: process.env.UserDatabaseCS,
-  Network: process.env.Network ?? "mainnet",
-  RestApiNodeUrl: process.env.RestApiNodeUrl,
-  AkashlyticsGithubPAT: process.env.AkashlyticsGithubPAT,
-  Auth0JWKSUri: process.env.Auth0JWKSUri,
-  Auth0Audience: process.env.Auth0Audience,
-  Auth0Issuer: process.env.Auth0Issuer,
-  WebsiteUrl: process.env.WebsiteUrl,
-  SecretToken: process.env.SecretToken
-};
+export const env = z
+  .object({
+    SentryDSN: z.string().optional(),
+    AKASHLYTICS_CORS_WEBSITE_URLS: z.string().optional(),
+    NODE_ENV: z.string().optional(),
+    SentryServerName: z.string().optional(),
+    HealthchecksEnabled: z.string().optional(),
+    AkashDatabaseCS: z.string().optional(),
+    AkashTestnetDatabaseCS: z.string().optional(),
+    AkashSandboxDatabaseCS: z.string().optional(),
+    UserDatabaseCS: z.string().optional(),
+    Network: z.string().default("mainnet"),
+    RestApiNodeUrl: z.string().optional(),
+    AkashlyticsGithubPAT: z.string().optional(),
+    Auth0JWKSUri: z.string().optional(),
+    Auth0Audience: z.string().optional(),
+    Auth0Issuer: z.string().optional(),
+    WebsiteUrl: z.string().optional(),
+    SecretToken: z.string().optional(),
+    NODE_API_BASE_PATH: z.string().optional().default("https://raw.githubusercontent.com/akash-network")
+  })
+  .parse(process.env);

--- a/api/test/functional/nodes-v1.spec.ts
+++ b/api/test/functional/nodes-v1.spec.ts
@@ -1,0 +1,62 @@
+import { app, initDb } from "@src/app";
+import { closeConnections } from "@src/db/dbConnection";
+import nock from "nock";
+import { env } from "@src/utils/env";
+import { NodeSeeder } from "@test/seeders/node-seeder";
+import { faker } from "@faker-js/faker";
+import mcache from "memory-cache";
+
+describe("Nodes API", () => {
+  const interceptor = nock(env.NODE_API_BASE_PATH);
+
+  beforeAll(async () => {
+    await initDb({ log: false });
+  });
+
+  afterAll(async () => {
+    await closeConnections();
+    mcache.clear();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe("GET /nodes/*", () => {
+    it.each(["mainnet", "sandbox", "testnet"])("should return %s node", async (network) => {
+      const node = NodeSeeder.create();
+      interceptor.get(`/cloudmos/main/config/${network}-nodes.json`).times(1).reply(200, node);
+
+      const resInit = await app.request(`v1/nodes/${network}`);
+      expect(resInit.status).toBe(200);
+      expect(await resInit.json()).toMatchObject(node);
+
+      const resCached = await app.request(`v1/nodes/${network}`);
+      expect(resCached.status).toBe(200);
+      expect(await resCached.json()).toMatchObject(node);
+    });
+  });
+
+  describe("GET /version/*", () => {
+    const PATH_REWRITE: Record<string, string> = {
+      testnet: "testnet-02"
+    };
+    it.each(["mainnet", "sandbox", "testnet"])("should return %s node version", async (network) => {
+      const version = `v${faker.number.int()}.${faker.number.int()}.${faker.number.int()}`;
+      interceptor
+        .get(`/net/master/${PATH_REWRITE[network] || network}/version.txt`)
+        .times(1)
+        .reply(200, version, {
+          "Content-Type": "text/plain"
+        });
+
+      const resInit = await app.request(`v1/version/${network}`);
+      expect(resInit.status).toBe(200);
+      expect(await resInit.text()).toEqual(version);
+
+      const resCached = await app.request(`v1/version/${network}`);
+      expect(resCached.status).toBe(200);
+      expect(await resCached.text()).toEqual(version);
+    });
+  });
+});

--- a/api/test/seeders/node-seeder.ts
+++ b/api/test/seeders/node-seeder.ts
@@ -1,0 +1,12 @@
+import { faker } from "@faker-js/faker";
+import type { Node } from "@src/routes/v1/nodes/nodeClient";
+
+export class NodeSeeder {
+  static create({ id = faker.string.alphanumeric(), api = faker.string.alphanumeric(), rpc = faker.string.alphanumeric() }: Partial<Node> = {}): Node {
+    return {
+      id,
+      api,
+      rpc
+    };
+  }
+}


### PR DESCRIPTION
a couple of things are refactored here:
1) a single class to get nodes data is created. After all that looks like a single API and it makes sense to have single service/class/sdk for it. Also this way it looks more clear and maintainable
2) a memoize decorator is created for better readability 
3) loads env with validation schema so that it is typed. this way it will be hard to miss it too