### PR TITLE
Limit price history fetching to 365 days

### DIFF
--- a/deploy-web/Dockerfile
+++ b/deploy-web/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:18-alpine3.18 AS base
+FROM node:18 AS base
 # Pinned to 3.18 to avoid this issue: https://github.com/nodejs/docker-node/issues/2009
 
 # Install dependencies only when needed
 FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
+#RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager

--- a/indexer/src/db/priceHistoryProvider.ts
+++ b/indexer/src/db/priceHistoryProvider.ts
@@ -15,7 +15,7 @@ export const syncPriceHistory = async () => {
     return;
   }
 
-  const endpointUrl = `https://api.coingecko.com/api/v3/coins/${activeChain.coinGeckoId}/market_chart?vs_currency=usd&days=max`;
+  const endpointUrl = `https://api.coingecko.com/api/v3/coins/${activeChain.coinGeckoId}/market_chart?vs_currency=usd&days=365`;
 
   console.log("Fetching latest market data from " + endpointUrl);
 


### PR DESCRIPTION
- CoinGecko started limiting free access to their api to 365 days in the past. This PR limits to fetching to 365 days to stop getting errors. It is no longer possible to use the CoinGecko integration as-is to do a full re-indexing of the chain. We will need to either switch to a [paid plan](https://www.coingecko.com/en/api/pricing) or find another free service.
- Switched to `node:18` as base image for the deploy web Dockerfile to fix [an issue](https://github.com/akash-network/cloudmos/actions/runs/8454977780) that randomly started happening during build.