### PR TITLE
Bugfixes/fix provider gpus UI

### DIFF
--- a/api/src/routes/v1/providers/byAddress.ts
+++ b/api/src/routes/v1/providers/byAddress.ts
@@ -62,6 +62,14 @@ const route = createRoute({
               memory: z.number(),
               storage: z.number()
             }),
+            gpuModels: z.array(
+              z.object({
+                vendor: z.string(),
+                model: z.string(),
+                ram: z.string(),
+                interface: z.string()
+              })
+            ),
             attributes: z.array(
               z.object({
                 key: z.string(),

--- a/api/src/routes/v1/providers/list.ts
+++ b/api/src/routes/v1/providers/list.ts
@@ -55,6 +55,14 @@ const route = createRoute({
                 memory: z.number(),
                 storage: z.number()
               }),
+              gpuModels: z.array(
+                z.object({
+                  vendor: z.string(),
+                  model: z.string(),
+                  ram: z.string(),
+                  interface: z.string()
+                })
+              ),
               attributes: z.array(
                 z.object({
                   key: z.string(),

--- a/api/src/services/db/providerStatusService.ts
+++ b/api/src/services/db/providerStatusService.ts
@@ -42,8 +42,7 @@ export async function getNetworkCapacity() {
 }
 
 export const getProviderList = async () => {
-  // Fetch provider list with their attributes & auditors
-  const providers = await Provider.findAll({
+  const providersWithAttributesAndAuditors = await Provider.findAll({
     where: {
       deletedHeight: null
     },
@@ -58,8 +57,7 @@ export const getProviderList = async () => {
     ]
   });
 
-  // Fetch latest snapshot nodes for each provider
-  const providerNodes = await Provider.findAll({
+  const providerWithNodes = await Provider.findAll({
     attributes: ["owner"],
     where: {
       deletedHeight: null
@@ -82,14 +80,14 @@ export const getProviderList = async () => {
     ]
   });
 
-  const filteredProviders = providers.filter((value, index, self) => self.map((x) => x.hostUri).lastIndexOf(value.hostUri) === index);
+  const distinctProviders = providersWithAttributesAndAuditors.filter((value, index, self) => self.map((x) => x.hostUri).lastIndexOf(value.hostUri) === index);
   const providerAttributeSchemaQuery = getProviderAttributesSchema();
   const auditorsQuery = getAuditors();
 
   const [auditors, providerAttributeSchema] = await Promise.all([auditorsQuery, providerAttributeSchemaQuery]);
 
-  return filteredProviders.map((x) => {
-    const nodes = providerNodes.find((p) => p.owner === x.owner)?.lastSnapshot?.nodes;
+  return distinctProviders.map((x) => {
+    const nodes = providerWithNodes.find((p) => p.owner === x.owner)?.lastSnapshot?.nodes;
     return mapProviderToList(x, providerAttributeSchema, auditors, nodes);
   });
 };

--- a/api/src/services/db/providerStatusService.ts
+++ b/api/src/services/db/providerStatusService.ts
@@ -88,9 +88,10 @@ export const getProviderList = async () => {
 
   const [auditors, providerAttributeSchema] = await Promise.all([auditorsQuery, providerAttributeSchemaQuery]);
 
-  return filteredProviders.map((x) =>
-    mapProviderToList(x, providerAttributeSchema, auditors, providerNodes.find((p) => p.owner === x.owner)?.lastSnapshot?.nodes)
-  );
+  return filteredProviders.map((x) => {
+    const nodes = providerNodes.find((p) => p.owner === x.owner)?.lastSnapshot?.nodes;
+    return mapProviderToList(x, providerAttributeSchema, auditors, nodes);
+  });
 };
 
 export const getProviderDetail = async (address: string): Promise<ProviderDetail> => {
@@ -122,7 +123,7 @@ export const getProviderDetail = async (address: string): Promise<ProviderDetail
     }
   });
 
-  const lastOnlineSnapshot = await ProviderSnapshot.findOne({
+  const lastSnapshot = await ProviderSnapshot.findOne({
     where: {
       id: provider.lastSnapshotId
     },
@@ -141,7 +142,7 @@ export const getProviderDetail = async (address: string): Promise<ProviderDetail
   const [auditors, providerAttributeSchema] = await Promise.all([auditorsQuery, providerAttributeSchemaQuery]);
 
   return {
-    ...mapProviderToList(provider, providerAttributeSchema, auditors, lastOnlineSnapshot?.nodes),
+    ...mapProviderToList(provider, providerAttributeSchema, auditors, lastSnapshot?.nodes),
     uptime: uptimeSnapshots.map((ps) => ({
       id: ps.id,
       isOnline: ps.isOnline,

--- a/api/src/services/db/providerStatusService.ts
+++ b/api/src/services/db/providerStatusService.ts
@@ -1,4 +1,4 @@
-import { Provider, ProviderAttribute, ProviderAttributeSignature } from "@shared/dbSchemas/akash";
+import { Provider, ProviderAttribute, ProviderAttributeSignature, ProviderSnapshotNode, ProviderSnapshotNodeGPU } from "@shared/dbSchemas/akash";
 import { ProviderSnapshot } from "@shared/dbSchemas/akash/providerSnapshot";
 import { toUTC } from "@src/utils";
 import { add } from "date-fns";
@@ -42,6 +42,7 @@ export async function getNetworkCapacity() {
 }
 
 export const getProviderList = async () => {
+  // Fetch provider list with their attributes & auditors
   const providers = await Provider.findAll({
     where: {
       deletedHeight: null
@@ -56,13 +57,39 @@ export const getProviderList = async () => {
       }
     ]
   });
+
+  // Fetch latest snapshot nodes for each provider
+  const providerNodes = await Provider.findAll({
+    attributes: ["owner"],
+    where: {
+      deletedHeight: null
+    },
+    include: [
+      {
+        attributes: ["id"],
+        model: ProviderSnapshot,
+        as: "lastSnapshot",
+        include: [
+          {
+            model: ProviderSnapshotNode,
+            attributes: ["id"],
+            required: true,
+            include: [{ model: ProviderSnapshotNodeGPU, required: true }]
+          }
+        ]
+      }
+    ]
+  });
+
   const filteredProviders = providers.filter((value, index, self) => self.map((x) => x.hostUri).lastIndexOf(value.hostUri) === index);
   const providerAttributeSchemaQuery = getProviderAttributesSchema();
   const auditorsQuery = getAuditors();
 
   const [auditors, providerAttributeSchema] = await Promise.all([auditorsQuery, providerAttributeSchemaQuery]);
 
-  return filteredProviders.map((x) => mapProviderToList(x, providerAttributeSchema, auditors));
+  return filteredProviders.map((x) =>
+    mapProviderToList(x, providerAttributeSchema, auditors, providerNodes.find((p) => p.owner === x.owner)?.lastSnapshot?.nodes)
+  );
 };
 
 export const getProviderDetail = async (address: string): Promise<ProviderDetail> => {
@@ -78,23 +105,34 @@ export const getProviderDetail = async (address: string): Promise<ProviderDetail
       },
       {
         model: ProviderAttributeSignature
-      },
-      {
-        model: ProviderSnapshot,
-        as: "providerSnapshots",
-        attributes: ["isOnline", "id", "checkDate"],
-        required: false,
-        separate: true,
-        where: {
-          checkDate: {
-            [Op.gte]: add(nowUtc, { days: -1 })
-          }
-        }
       }
     ]
   });
 
   if (!provider) return null;
+
+  const uptimeSnapshots = await ProviderSnapshot.findAll({
+    attributes: ["isOnline", "id", "checkDate"],
+    where: {
+      owner: provider.owner,
+      checkDate: {
+        [Op.gte]: add(nowUtc, { days: -1 })
+      }
+    }
+  });
+
+  const lastOnlineSnapshot = await ProviderSnapshot.findOne({
+    where: {
+      id: provider.lastSnapshotId
+    },
+    order: [["checkDate", "DESC"]],
+    include: [
+      {
+        model: ProviderSnapshotNode,
+        include: [{ model: ProviderSnapshotNodeGPU }]
+      }
+    ]
+  });
 
   const providerAttributeSchemaQuery = getProviderAttributesSchema();
   const auditorsQuery = getAuditors();
@@ -102,8 +140,8 @@ export const getProviderDetail = async (address: string): Promise<ProviderDetail
   const [auditors, providerAttributeSchema] = await Promise.all([auditorsQuery, providerAttributeSchemaQuery]);
 
   return {
-    ...mapProviderToList(provider, providerAttributeSchema, auditors),
-    uptime: provider.providerSnapshots.map((ps) => ({
+    ...mapProviderToList(provider, providerAttributeSchema, auditors, lastOnlineSnapshot?.nodes),
+    uptime: uptimeSnapshots.map((ps) => ({
       id: ps.id,
       isOnline: ps.isOnline,
       checkDate: ps.checkDate

--- a/api/src/services/db/providerStatusService.ts
+++ b/api/src/services/db/providerStatusService.ts
@@ -66,8 +66,9 @@ export const getProviderList = async () => {
     },
     include: [
       {
-        attributes: ["id"],
         model: ProviderSnapshot,
+        attributes: ["id"],
+        required: true,
         as: "lastSnapshot",
         include: [
           {

--- a/api/src/types/provider.ts
+++ b/api/src/types/provider.ts
@@ -22,6 +22,7 @@ export interface ProviderList {
   isValidVersion: boolean;
   isOnline: boolean;
   isAudited: boolean;
+  gpuModels: { vendor: string; model: string; ram: string; interface: string }[];
   activeStats: {
     cpu: number;
     gpu: number;

--- a/api/src/utils/array/array.spec.ts
+++ b/api/src/utils/array/array.spec.ts
@@ -1,0 +1,19 @@
+import { createFilterUnique } from "./array";
+
+describe("array helpers", () => {
+  describe("createFilterUnique", () => {
+    it("should return a functionning unique filter with default equality matcher", () => {
+      const arrayWithDuplicate = [1, 2, 2, 3, 3, 3];
+      const expected = [1, 2, 3];
+
+      expect(arrayWithDuplicate.filter(createFilterUnique())).toEqual(expected);
+    });
+
+    it("should return a functionning unique filter with custom matcher", () => {
+      const arrayWithDuplicate = [{ v: 1 }, { v: 2 }, { v: 2 }, { v: 3 }, { v: 3 }, { v: 3 }];
+      const expected = [{ v: 1 }, { v: 2 }, { v: 3 }];
+
+      expect(arrayWithDuplicate.filter(createFilterUnique((a, b) => a.v === b.v))).toEqual(expected);
+    });
+  });
+});

--- a/api/src/utils/array/array.ts
+++ b/api/src/utils/array/array.ts
@@ -1,0 +1,7 @@
+type Matcher<T> = (a: T, b: T) => boolean;
+
+export function createFilterUnique<T>(matcher: Matcher<T> = (a, b) => a === b): (value: T, index: number, array: T[]) => boolean {
+  return (value, index, array) => {
+    return array.findIndex((other) => matcher(value, other)) === index;
+  };
+}

--- a/api/src/utils/map/provider.ts
+++ b/api/src/utils/map/provider.ts
@@ -91,10 +91,11 @@ export const mapProviderToList = (
 };
 
 function getDistinctGpuModelsFromNodes(nodes: ProviderSnapshotNode[]) {
-  return nodes
-    .flatMap((x) => x.gpus)
-    .map((x) => ({ vendor: x.vendor, model: x.name, ram: x.memorySize, interface: x.interface }))
-    .filter((x, i, arr) => arr.findIndex((o) => x.vendor === o.vendor && x.model === o.model && x.ram === o.ram && x.interface === o.interface) === i);
+  const gpuModels = nodes.flatMap((x) => x.gpus).map((x) => ({ vendor: x.vendor, model: x.name, ram: x.memorySize, interface: x.interface }));
+  const distinctGpuModels = gpuModels.filter(
+    (x, i, arr) => arr.findIndex((o) => x.vendor === o.vendor && x.model === o.model && x.ram === o.ram && x.interface === o.interface) === i
+  );
+  return distinctGpuModels;
 }
 
 export const getProviderAttributeValue = (

--- a/api/src/utils/map/provider.ts
+++ b/api/src/utils/map/provider.ts
@@ -1,5 +1,6 @@
 import { Provider, ProviderSnapshotNode } from "@shared/dbSchemas/akash";
 import { Auditor, ProviderAttributesSchema, ProviderList } from "@src/types/provider";
+import { createFilterUnique } from "../array/array";
 import semver from "semver";
 
 export const mapProviderToList = (
@@ -93,8 +94,9 @@ export const mapProviderToList = (
 function getDistinctGpuModelsFromNodes(nodes: ProviderSnapshotNode[]) {
   const gpuModels = nodes.flatMap((x) => x.gpus).map((x) => ({ vendor: x.vendor, model: x.name, ram: x.memorySize, interface: x.interface }));
   const distinctGpuModels = gpuModels.filter(
-    (x, i, arr) => arr.findIndex((o) => x.vendor === o.vendor && x.model === o.model && x.ram === o.ram && x.interface === o.interface) === i
+    createFilterUnique((a, b) => a.vendor === b.vendor && a.model === b.model && a.ram === b.ram && a.interface === b.interface)
   );
+
   return distinctGpuModels;
 }
 

--- a/api/src/utils/map/provider.ts
+++ b/api/src/utils/map/provider.ts
@@ -10,10 +10,7 @@ export const mapProviderToList = (
 ): ProviderList => {
   const isValidVersion = provider.cosmosSdkVersion ? semver.gte(provider.cosmosSdkVersion, "v0.45.9") : false;
   const name = provider.isOnline ? new URL(provider.hostUri).hostname : null;
-  const gpuModels = (nodes || [])
-    .flatMap((x) => x.gpus)
-    .map((x) => ({ vendor: x.vendor, model: x.name, ram: x.memorySize, interface: x.interface }))
-    .filter((x, i, arr) => arr.findIndex((o) => x.vendor === o.vendor && x.model === o.model && x.ram === o.ram && x.interface === o.interface) === i);
+  const gpuModels = getDistinctGpuModelsFromNodes(nodes || []);
 
   return {
     owner: provider.owner,
@@ -92,6 +89,13 @@ export const mapProviderToList = (
     featEndpointIp: getProviderAttributeValue("feat-endpoint-ip", provider, providerAttributeSchema)
   } as ProviderList;
 };
+
+function getDistinctGpuModelsFromNodes(nodes: ProviderSnapshotNode[]) {
+  return nodes
+    .flatMap((x) => x.gpus)
+    .map((x) => ({ vendor: x.vendor, model: x.name, ram: x.memorySize, interface: x.interface }))
+    .filter((x, i, arr) => arr.findIndex((o) => x.vendor === o.vendor && x.model === o.model && x.ram === o.ram && x.interface === o.interface) === i);
+}
 
 export const getProviderAttributeValue = (
   key: keyof ProviderAttributesSchema,

--- a/deploy-web/src/components/providers/ProviderListRow.tsx
+++ b/deploy-web/src/components/providers/ProviderListRow.tsx
@@ -16,8 +16,8 @@ import { Uptime } from "./Uptime";
 import React from "react";
 import { hasSomeParentTheClass } from "@src/utils/domUtils";
 import { cx } from "@emotion/css";
-import CheckIcon from "@mui/icons-material/Check";
 import WarningIcon from "@mui/icons-material/Warning";
+import { createFilterUnique } from "@src/utils/array";
 
 const useStyles = makeStyles()(theme => ({
   root: {
@@ -62,7 +62,7 @@ export const ProviderListRow: React.FunctionComponent<Props> = ({ provider }) =>
   const _totalStorage = provider.isOnline
     ? bytesToShrink(provider.availableStats.storage + provider.pendingStats.storage + provider.activeStats.storage)
     : null;
-  const gpuModels = provider.gpuModels.map(x => x.model).filter((x, i, arr) => arr.indexOf(x) === i);
+  const gpuModels = provider.gpuModels.map(x => x.model).filter(createFilterUnique());
 
   const onStarClick = event => {
     event.preventDefault();

--- a/deploy-web/src/components/providers/ProviderListRow.tsx
+++ b/deploy-web/src/components/providers/ProviderListRow.tsx
@@ -62,7 +62,7 @@ export const ProviderListRow: React.FunctionComponent<Props> = ({ provider }) =>
   const _totalStorage = provider.isOnline
     ? bytesToShrink(provider.availableStats.storage + provider.pendingStats.storage + provider.activeStats.storage)
     : null;
-  const gpuModels = provider.hardwareGpuModels.map(gpu => gpu.substring(gpu.lastIndexOf(" ") + 1, gpu.length));
+  const gpuModels = provider.gpuModels.map(x => x.model).filter((x, i, arr) => arr.indexOf(x) === i);
 
   const onStarClick = event => {
     event.preventDefault();

--- a/deploy-web/src/components/providers/ProviderSpecs.tsx
+++ b/deploy-web/src/components/providers/ProviderSpecs.tsx
@@ -3,6 +3,7 @@ import { makeStyles } from "tss-react/mui";
 import { ClientProviderDetailWithStatus } from "@src/types/provider";
 import { LabelValue } from "../shared/LabelValue";
 import CheckIcon from "@mui/icons-material/Check";
+import { createFilterUnique } from "@src/utils/array";
 
 const useStyles = makeStyles()(theme => ({
   root: {
@@ -26,7 +27,7 @@ export const ProviderSpecs: React.FunctionComponent<Props> = ({ provider }) => {
   const gpuModels =
     provider?.gpuModels
       ?.map(x => x.model + " " + x.ram)
-      .filter((x, i, arr) => arr.indexOf(x) === i)
+      .filter(createFilterUnique())
       .sort((a, b) => a.localeCompare(b)) || [];
 
   return (

--- a/deploy-web/src/components/providers/ProviderSpecs.tsx
+++ b/deploy-web/src/components/providers/ProviderSpecs.tsx
@@ -1,10 +1,8 @@
 import { Box, Chip, Paper } from "@mui/material";
 import { makeStyles } from "tss-react/mui";
-import { useRouter } from "next/router";
 import { ClientProviderDetailWithStatus } from "@src/types/provider";
 import { LabelValue } from "../shared/LabelValue";
 import CheckIcon from "@mui/icons-material/Check";
-import { ProviderAttributesSchema } from "@src/types/providerAttributes";
 
 const useStyles = makeStyles()(theme => ({
   root: {
@@ -20,12 +18,16 @@ const useStyles = makeStyles()(theme => ({
 
 type Props = {
   provider: Partial<ClientProviderDetailWithStatus>;
-  providerAttributesSchema: ProviderAttributesSchema;
 };
 
-export const ProviderSpecs: React.FunctionComponent<Props> = ({ provider, providerAttributesSchema }) => {
+export const ProviderSpecs: React.FunctionComponent<Props> = ({ provider }) => {
   const { classes } = useStyles();
-  const router = useRouter();
+
+  const gpuModels =
+    provider?.gpuModels
+      ?.map(x => x.model + " " + x.ram)
+      .filter((x, i, arr) => arr.indexOf(x) === i)
+      .sort((a, b) => a.localeCompare(b)) || [];
 
   return (
     <Paper className={classes.root}>
@@ -41,7 +43,7 @@ export const ProviderSpecs: React.FunctionComponent<Props> = ({ provider, provid
       <Box>
         <LabelValue
           label="GPU Models"
-          value={provider.hardwareGpuModels.map(x => (
+          value={gpuModels.map(x => (
             <Chip key={x} label={x} size="small" sx={{ marginRight: ".5rem" }} />
           ))}
         />

--- a/deploy-web/src/pages/providers/[owner]/index.tsx
+++ b/deploy-web/src/pages/providers/[owner]/index.tsx
@@ -186,7 +186,7 @@ const ProviderDetailPage: React.FunctionComponent<Props> = ({ owner, _provider }
               <Typography variant="body2" sx={{ marginBottom: "1rem" }}>
                 Specs
               </Typography>
-              <ProviderSpecs provider={provider} providerAttributesSchema={providerAttributesSchema} />
+              <ProviderSpecs provider={provider} />
 
               <Typography variant="body2" sx={{ marginBottom: "1rem", marginTop: "1rem" }}>
                 Features

--- a/deploy-web/src/types/provider.ts
+++ b/deploy-web/src/types/provider.ts
@@ -206,6 +206,7 @@ export interface ApiProviderList {
   isValidVersion: boolean;
   isOnline: boolean;
   isAudited: boolean;
+  gpuModels: { vendor: string; model: string; ram: string; interface: string }[];
   activeStats: {
     cpu: number;
     gpu: number;

--- a/deploy-web/src/utils/array.ts
+++ b/deploy-web/src/utils/array.ts
@@ -1,0 +1,7 @@
+type Matcher<T> = (a: T, b: T) => boolean;
+
+export function createFilterUnique<T>(matcher: Matcher<T> = (a, b) => a === b): (value: T, index: number, array: T[]) => boolean {
+  return (value, index, array) => {
+    return array.findIndex(other => matcher(value, other)) === index;
+  };
+}

--- a/shared/dbSchemas/akash/providerSnapshot.ts
+++ b/shared/dbSchemas/akash/providerSnapshot.ts
@@ -1,6 +1,7 @@
-import { Column, Default, Model, PrimaryKey, Table } from "sequelize-typescript";
+import { Column, Default, HasMany, Model, PrimaryKey, Table } from "sequelize-typescript";
 import { DataTypes } from "sequelize";
 import { Required } from "../decorators/requiredDecorator";
+import { ProviderSnapshotNode } from "./providerSnapshotNode";
 
 @Table({
   modelName: "providerSnapshot",
@@ -33,4 +34,6 @@ export class ProviderSnapshot extends Model {
   @Column(DataTypes.BIGINT) availableGPU?: number;
   @Column(DataTypes.BIGINT) availableMemory?: number;
   @Column(DataTypes.BIGINT) availableStorage?: number;
+
+  @HasMany(() => ProviderSnapshotNode, "snapshotId") nodes: ProviderSnapshotNode[];
 }

--- a/shared/dbSchemas/akash/providerSnapshotNode.ts
+++ b/shared/dbSchemas/akash/providerSnapshotNode.ts
@@ -1,9 +1,12 @@
-import { Column, Default, Model, PrimaryKey, Table } from "sequelize-typescript";
+import { Column, Default, HasMany, Model, PrimaryKey, Table } from "sequelize-typescript";
 import { DataTypes } from "sequelize";
 import { Required } from "../decorators/requiredDecorator";
+import { ProviderSnapshotNodeGPU } from "./providerSnapshotNodeGPU";
+import { ProviderSnapshotNodeCPU } from "./providerSnapshotNodeCPU";
 
 @Table({
-  modelName: "providerSnapshotNode"
+  modelName: "providerSnapshotNode",
+  indexes: [{ unique: false, fields: ["snapshotId"] }]
 })
 export class ProviderSnapshotNode extends Model {
   @Required @PrimaryKey @Default(DataTypes.UUIDV4) @Column(DataTypes.UUID) id: string;
@@ -26,4 +29,7 @@ export class ProviderSnapshotNode extends Model {
 
   @Column(DataTypes.BIGINT) gpuAllocatable: number;
   @Column(DataTypes.BIGINT) gpuAllocated: number;
+
+  @HasMany(() => ProviderSnapshotNodeGPU, "snapshotNodeId") gpus: ProviderSnapshotNodeGPU[];
+  @HasMany(() => ProviderSnapshotNodeCPU, "snapshotNodeId") cpus: ProviderSnapshotNodeCPU[];
 }

--- a/shared/dbSchemas/akash/providerSnapshotNodeCPU.ts
+++ b/shared/dbSchemas/akash/providerSnapshotNodeCPU.ts
@@ -3,7 +3,8 @@ import { DataTypes } from "sequelize";
 import { Required } from "../decorators/requiredDecorator";
 
 @Table({
-  modelName: "providerSnapshotNodeCPU"
+  modelName: "providerSnapshotNodeCPU",
+  indexes: [{ unique: false, fields: ["snapshotNodeId"] }]
 })
 export class ProviderSnapshotNodeCPU extends Model {
   @Required @PrimaryKey @Default(DataTypes.UUIDV4) @Column(DataTypes.UUID) id: string;

--- a/shared/dbSchemas/akash/providerSnapshotNodeGPU.ts
+++ b/shared/dbSchemas/akash/providerSnapshotNodeGPU.ts
@@ -3,7 +3,8 @@ import { DataTypes } from "sequelize";
 import { Required } from "../decorators/requiredDecorator";
 
 @Table({
-  modelName: "providerSnapshotNodeGPU"
+  modelName: "providerSnapshotNodeGPU",
+  indexes: [{ unique: false, fields: ["snapshotNodeId"] }]
 })
 export class ProviderSnapshotNodeGPU extends Model {
   @Required @PrimaryKey @Default(DataTypes.UUIDV4) @Column(DataTypes.UUID) id: string;


### PR DESCRIPTION
## Display gpu models from feature discovery instead of capabilities attributes
- Return gpu models from feature discovery in providers endpoints
- Use those model instead of capabilities in provider list/detail pages
- Added missing indexes to improve performance

```
CREATE INDEX IF NOT EXISTS provider_snapshot_node_snapshot_id
    ON public."providerSnapshotNode" USING btree
    ("snapshotId" ASC NULLS LAST)
    WITH (deduplicate_items=True)
    TABLESPACE pg_default;
	
CREATE INDEX IF NOT EXISTS provider_snapshot_node_cpu_snapshot_node_id
    ON public."providerSnapshotNodeCPU" USING btree
    ("snapshotNodeId" ASC NULLS LAST)
    WITH (deduplicate_items=True)
    TABLESPACE pg_default;
	
CREATE INDEX IF NOT EXISTS provider_snapshot_node_gpu_snapshot_node_id
    ON public."providerSnapshotNodeGPU" USING btree
    ("snapshotNodeId" ASC NULLS LAST)
    WITH (deduplicate_items=True)
    TABLESPACE pg_default;
```