### PR TITLE
GPU pricing endpoint improvements

### DIFF
--- a/api/src/routes/internal/gpuPrices.ts
+++ b/api/src/routes/internal/gpuPrices.ts
@@ -328,7 +328,7 @@ async function getGpus() {
         WHERE p."isOnline" IS TRUE
         ORDER BY p."hostUri", p."createdHeight" DESC
       )
-      SELECT s."hostUri", s."owner", n."name", n."gpuAllocatable" AS allocatable, n."gpuAllocated" AS allocated, gpu."modelId", gpu.vendor, gpu.name AS "modelName", gpu.interface, gpu."memorySize"
+      SELECT s."hostUri", s."owner", n."name", n."gpuAllocatable" AS allocatable, LEAST(n."gpuAllocated", n."gpuAllocatable") AS allocated, gpu."modelId", gpu.vendor, gpu.name AS "modelName", gpu.interface, gpu."memorySize"
       FROM snapshots s
       INNER JOIN "providerSnapshotNode" n ON n."snapshotId"=s.id AND n."gpuAllocatable" > 0
       LEFT JOIN (

--- a/api/src/utils/math.ts
+++ b/api/src/utils/math.ts
@@ -19,11 +19,11 @@ export function median(values: number[]): number {
     throw new Error("Input array is empty");
   }
 
-  values = [...values].sort((a, b) => a - b);
+  const sortedValues = [...values].sort((a, b) => a - b);
 
-  const half = Math.floor(values.length / 2);
+  const half = Math.floor(sortedValues.length / 2);
 
-  return values.length % 2 === 0 ? (values[half - 1] + values[half]) / 2 : values[half];
+  return sortedValues.length % 2 === 0 ? (sortedValues[half - 1] + sortedValues[half]) / 2 : sortedValues[half];
 }
 
 export function average(values: number[]): number {

--- a/api/src/utils/math.ts
+++ b/api/src/utils/math.ts
@@ -13,3 +13,33 @@ export function uaktToAKT(amount: number, precision = 2) {
 export function udenomToDenom(amount: number, precision = 2) {
   return round(amount / 1_000_000, precision);
 }
+
+export function median(values: number[]): number {
+  if (values.length === 0) {
+    throw new Error("Input array is empty");
+  }
+
+  values = [...values].sort((a, b) => a - b);
+
+  const half = Math.floor(values.length / 2);
+
+  return values.length % 2 === 0 ? (values[half - 1] + values[half]) / 2 : values[half];
+}
+
+export function average(values: number[]): number {
+  if (values.length === 0) {
+    throw new Error("Input array is empty");
+  }
+
+  return values.reduce((acc, x) => acc + x, 0) / values.length;
+}
+
+export function weightedAverage(values: { value: number; weight: number }[]): number {
+  if (values.length === 0) {
+    throw new Error("Input array is empty");
+  }
+
+  const totalWeight = values.map((x) => x.weight).reduce((acc, x) => acc + x, 0);
+
+  return values.map((x) => x.value * x.weight).reduce((acc, x) => acc + x, 0) / totalWeight;
+}


### PR DESCRIPTION
- Fixed the median calculation when there is even number of providers (use average of the two middle values)
- Add weighted average based on provider's gpu count
- Return price object of `null` if there is an issue during price calculation
- Cap allocated gpu amounts to allocatable amount to prevent numbers going into the negative when feature discovery return wrong values 
  - https://github.com/akash-network/support/issues/192