### PR TITLE
feat: Add grace period to uptime check

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,6 @@ docker-compose up
 ```
 This command spins up the database service and automatically handles the downloading and importing of the specified data.
 
-
-```bash
-
 # Database Structure
 
 The database schemas is defined using [sequelize-typescript](https://github.com/sequelize/sequelize-typescript) in [/shared/dbSchemas/](./shared/dbSchemas/). Models are separated into the following folders:
@@ -311,12 +308,18 @@ Created for each days (UTC based), simplifies querying for daily stats.
 |owner|varchar|Address of the wallet that owns this provider
 |hostUri|varchar|ex: `https://provider.europlots.com:8443`
 |createdHeight|integer|Height at which the provider is created on-chain. (`MsgCreateProvider`)
+|updatedHeight|integer|Height at which the provider was last updated. (`MsgUpdateProvider`)
 |deletedHeight|integer|Height at which the provider is deleted on-chain. (`MsgDeleteProvider`)
 |email|varchar
 |website|varchar
 |isOnline|boolean|Indicates if the latest uptime check was successful
 |lastCheckDate|timestamp|Date & Time of the latest uptime check
-|error|text|`null` if the latest uptime check was successful, otherwise this wil contain the error message.
+|lastSnapshotId|uuid|ID of the last snapshot taken
+|nextCheckDate|timestamp|Planned Date & Time of the next uptime check
+|failedCheckCount|integer|Amount of consecutive failed checks, `NULL` if currently online.
+|lastSuccessfulSnapshotId|uuid|Snapshot ID of the last successful check
+|downtimeFirstSnapshotId|uuid|Snapshot ID of the first failed check of the current downtime period. `NULL` if currently online.
+|error|text|`NULL` if the latest uptime check was successful, otherwise this wil contain the error message.
 |deploymentCount|integer
 |leaseCount|integer
 |activeCPU|bigint|Thousandth of CPU
@@ -368,6 +371,7 @@ Similar to stats on the [Provider](#provider), but a new row is inserted for eve
 |id|uuid|
 |owner|varchar|Address of the wallet that owns this provider
 |isOnline|boolean|Indicates if this uptime check was successful
+|isLastOfDay|boolean|Indicates if this is the last snapshot of the day for this provider
 |checkDate|timestamp|Date & Time of this uptime check
 |error|text|`null` if the uptime check was successful, otherwise this wil contain the error message.
 |deploymentCount|integer
@@ -381,6 +385,53 @@ Similar to stats on the [Provider](#provider), but a new row is inserted for eve
 |availableCPU|bigint|Thousandth of CPU
 |availableMemory|bigint|Memory in bytes
 |availableStorage|bigint|Storage in bytes
+
+## ProviderSnapshotNodes
+
+Keep track of ressources of individual provider nodes obtained through feature discovery.
+
+|Column|Type|Note|
+|-|-|-
+|id|uuid
+|snapshotId|uuid|Snapshot ID
+|name|varchar|Name of the node
+|cpuAllocatable|bigint|Thousandth of CPU
+|cpuAllocated|bigint|Thousandth of CPU
+|memoryAllocatable|bigint|Memory in bytes
+|memoryAllocated|bigint|Memory in bytes
+|ephemeralStorageAllocatable|bigint|Storage in bytes
+ephemeralStorageAllocated|bigint|Storage in bytes
+|capabilitiesStorageHDD|boolean|Indicates if the node supports HDD storage
+|capabilitiesStorageSSD|boolean|Indicates if the node supports SSD storage
+|capabilitiesStorageNVME|boolean|Indicates if the node supports NVME storage
+|gpuAllocatable|bigint
+|gpuAllocated|bigint
+
+## ProviderSnapshotNodeCPU
+
+Store CPU informations for each [Provider Nodes](#providersnapshotnodes)
+
+|Column|Type|Note
+|-|-|-
+|id|uuid
+|snapshotNodeId|uuid|Snapshot node ID
+|vendor|varchar|ex: `GenuineIntel`
+|model|varchar|ex: `Intel(R) Xeon(R) CPU @ 2.30GHz`
+|vcores|smallint|
+
+## ProviderSnapshotNodeGPU
+
+Store GPU informations for each [Provider Nodes](#providersnapshotnodes)
+
+|Column|Type|Note
+|-|-|-
+|id|uuid
+|snapshotNodeId|uuid|Snapshot node ID
+|vendor|varchar|ex: `nvidia`
+|name|varchar|Model name (ex: `rtx4090`)
+|modelId|varchar|On the provider, this gets mapped to vendor, name, interface and memorySize based on [this file](https://github.com/akash-network/provider-configs/blob/main/devices/pcie/gpus.json).
+|interface|varchar|ex: `PCIe`
+|memorySize|varchar|ex: `24Gi`
 
 ## Template
 

--- a/api/src/routes/v1/providers/byAddress.ts
+++ b/api/src/routes/v1/providers/byAddress.ts
@@ -43,6 +43,7 @@ const route = createRoute({
             uptime30d: z.number(),
             isValidVersion: z.boolean(),
             isOnline: z.boolean(),
+            lastOnlineDate: z.string().nullable(),
             isAudited: z.boolean(),
             activeStats: z.object({
               cpu: z.number(),

--- a/api/src/routes/v1/providers/list.ts
+++ b/api/src/routes/v1/providers/list.ts
@@ -36,6 +36,7 @@ const route = createRoute({
               uptime30d: z.number(),
               isValidVersion: z.boolean(),
               isOnline: z.boolean(),
+              lastOnlineDate: z.string().nullable(),
               isAudited: z.boolean(),
               activeStats: z.object({
                 cpu: z.number(),

--- a/api/src/types/provider.ts
+++ b/api/src/types/provider.ts
@@ -76,11 +76,11 @@ export interface ProviderList {
 }
 
 export interface ProviderDetail extends ProviderList {
-  uptime: Array<{
+  uptime: {
     id: string;
     isOnline: boolean;
     checkDate: Date;
-  }>;
+  }[];
 }
 
 export type ProviderAttributesSchema = {

--- a/api/src/utils/env.ts
+++ b/api/src/utils/env.ts
@@ -23,6 +23,10 @@ export const env = z
     Auth0Issuer: z.string().optional(),
     WebsiteUrl: z.string().optional(),
     SecretToken: z.string().optional(),
+    ProviderUptimeGracePeriodMinutes: z
+      .number()
+      .optional()
+      .default(3 * 60),
     NODE_API_BASE_PATH: z.string().optional().default("https://raw.githubusercontent.com/akash-network")
   })
   .parse(process.env);

--- a/api/src/utils/map/provider.ts
+++ b/api/src/utils/map/provider.ts
@@ -1,4 +1,4 @@
-import { Provider, ProviderSnapshotNode } from "@shared/dbSchemas/akash";
+import { Provider, ProviderSnapshot, ProviderSnapshotNode } from "@shared/dbSchemas/akash";
 import { Auditor, ProviderAttributesSchema, ProviderList } from "@src/types/provider";
 import { createFilterUnique } from "../array/array";
 import semver from "semver";
@@ -7,11 +7,11 @@ export const mapProviderToList = (
   provider: Provider,
   providerAttributeSchema: ProviderAttributesSchema,
   auditors: Array<Auditor>,
-  nodes?: ProviderSnapshotNode[]
+  lastSuccessfulSnapshot?: ProviderSnapshot
 ): ProviderList => {
   const isValidVersion = provider.cosmosSdkVersion ? semver.gte(provider.cosmosSdkVersion, "v0.45.9") : false;
   const name = provider.isOnline ? new URL(provider.hostUri).hostname : null;
-  const gpuModels = getDistinctGpuModelsFromNodes(nodes || []);
+  const gpuModels = getDistinctGpuModelsFromNodes(lastSuccessfulSnapshot?.nodes || []);
 
   return {
     owner: provider.owner,
@@ -55,6 +55,7 @@ export const mapProviderToList = (
     uptime30d: provider.uptime30d,
     isValidVersion,
     isOnline: provider.isOnline,
+    lastOnlineDate: lastSuccessfulSnapshot?.checkDate,
     isAudited: provider.providerAttributeSignatures.some((a) => auditors.some((y) => y.address === a.auditor)),
     attributes: provider.providerAttributes.map((attr) => ({
       key: attr.key,

--- a/deploy-web/src/components/providers/ProviderMap.tsx
+++ b/deploy-web/src/components/providers/ProviderMap.tsx
@@ -29,7 +29,7 @@ export const ProviderMap: React.FunctionComponent<Props> = ({ providers, initial
   const { classes } = useStyles();
   const [dotSize, setDotSize] = useState({ r: 5, w: 1 });
   const theme = useTheme();
-  const activeProviders = providers.filter(x => x.isOnline || x.isOnline);
+  const activeProviders = providers.filter(x => x.isOnline);
   const bgColor = theme.palette.mode === "dark" ? theme.palette.grey[800] : theme.palette.grey[400];
   const [position, setPosition] = useState({ coordinates: initialCoordinates, zoom: initialZoom });
   const isInitialPosition =

--- a/deploy-web/src/types/provider.ts
+++ b/deploy-web/src/types/provider.ts
@@ -268,7 +268,7 @@ export interface ApiProviderDetail extends ApiProviderList {
   uptime: Array<{
     id: string;
     isOnline: boolean;
-    checkDate: Date;
+    checkDate: string;
   }>;
 }
 

--- a/indexer/src/index.ts
+++ b/indexer/src/index.ts
@@ -92,7 +92,7 @@ function startScheduler() {
   scheduler.registerTask("Address Balance Monitor", () => addressBalanceMonitor.run(), "10 minutes");
 
   if (env.ActiveChain === "akash" || env.ActiveChain === "akashTestnet" || env.ActiveChain === "akashSandbox") {
-    scheduler.registerTask("Sync Providers Info", syncProvidersInfo, "15 minutes", true, {
+    scheduler.registerTask("Sync Providers Info", syncProvidersInfo, "10 seconds", true, {
       id: env.HealthChecks_SyncProviderInfo,
       measureDuration: true
     });

--- a/indexer/src/providers/providerStatusProvider.ts
+++ b/indexer/src/providers/providerStatusProvider.ts
@@ -7,23 +7,26 @@ import { ProviderSnapshot } from "@src/../../shared/dbSchemas/akash/providerSnap
 import { sequelize } from "@src/db/dbConnection";
 import { toUTC } from "@src/shared/utils/date";
 import { ProviderStatusInfo, ProviderVersionEndpointResponseType } from "./statusEndpointHandlers/types";
-import { isSameDay } from "date-fns";
+import { add, differenceInDays, differenceInHours, differenceInMinutes, isSameDay } from "date-fns";
 import { fetchProviderStatusFromGRPC } from "./statusEndpointHandlers/grpc";
 import { fetchProviderStatusFromREST } from "./statusEndpointHandlers/rest";
+import { Op } from "sequelize";
 
 const ConcurrentStatusCall = 10;
 const StatusCallTimeout = 10_000; // 10 seconds
+const UptimeCheckIntervalSeconds = 15 * 60; // 15 minutes
 
 export async function syncProvidersInfo() {
   let providers = await Provider.findAll({
     where: {
-      deletedHeight: null
+      deletedHeight: null,
+      nextCheckDate: { [Op.lte]: toUTC(new Date()) }
     },
-    include: [{ model: ProviderSnapshot, as: "lastSnapshot" }],
-    order: [
-      ["isOnline", "DESC"],
-      ["uptime30d", "DESC"]
-    ]
+    include: [
+      { model: ProviderSnapshot, as: "lastSnapshot" },
+      { model: ProviderSnapshot, as: "downtimeFirstSnapshot" }
+    ],
+    order: [["nextCheckDate", "ASC"]]
   });
 
   const httpsAgent = new https.Agent({
@@ -66,8 +69,6 @@ export async function syncProvidersInfo() {
       console.log("Fetched provider info: " + doneCount + " / " + providers.length);
     })
   );
-
-  console.log("Finished refreshing provider infos");
 }
 
 async function saveProviderStatus(
@@ -85,6 +86,7 @@ async function saveProviderStatus(
         owner: provider.owner,
         isOnline: !!providerStatus,
         isLastOfDay: true,
+        isLastSuccessOfDay: !!providerStatus,
         error: error,
         checkDate: checkDate,
         deploymentCount: providerStatus?.resources.deploymentCount,
@@ -108,21 +110,38 @@ async function saveProviderStatus(
     if (provider.lastSnapshot && isSameDay(provider.lastSnapshot.checkDate, checkDate)) {
       await ProviderSnapshot.update(
         {
-          isLastOfDay: false
+          isLastOfDay: false,
+          isLastSuccessOfDay: false
         },
         {
           where: { id: provider.lastSnapshot.id },
           transaction: t
         }
       );
+
+      if (providerStatus && provider.lastSuccessfulSnapshotId && provider.lastSuccessfulSnapshotId !== provider.lastSnapshotId) {
+        await ProviderSnapshot.update(
+          {
+            isLastSuccessOfDay: false
+          },
+          {
+            where: { id: provider.lastSuccessfulSnapshotId },
+            transaction: t
+          }
+        );
+      }
     }
 
     await Provider.update(
       {
         lastSnapshotId: createdSnapshot.id,
+        lastSuccessfulSnapshotId: createdSnapshot.isOnline ? createdSnapshot.id : provider.lastSuccessfulSnapshotId,
+        downtimeFirstSnapshotId: createdSnapshot.isOnline ? null : provider.downtimeFirstSnapshotId ?? createdSnapshot.id,
         isOnline: !!providerStatus,
         error: error,
         lastCheckDate: checkDate,
+        failedCheckCount: providerStatus ? 0 : provider.failedCheckCount + 1,
+        nextCheckDate: getNextCheckDate(!!providerStatus, checkDate, provider.downtimeFirstSnapshot?.checkDate ?? createdSnapshot.checkDate),
         cosmosSdkVersion: cosmosVersion,
         akashVersion: akashVersion,
         deploymentCount: providerStatus?.resources.deploymentCount,
@@ -191,4 +210,24 @@ async function saveProviderStatus(
       }
     }
   });
+}
+
+function getNextCheckDate(successful: boolean, checkDate: Date, downtimeStartDate: Date) {
+  if (successful) {
+    return add(checkDate, { seconds: UptimeCheckIntervalSeconds });
+  }
+
+  if (differenceInMinutes(checkDate, downtimeStartDate) < 15) {
+    return add(checkDate, { minutes: 1 });
+  } else if (differenceInHours(checkDate, downtimeStartDate) < 1) {
+    return add(checkDate, { minutes: 5 });
+  } else if (differenceInHours(checkDate, downtimeStartDate) < 6) {
+    return add(checkDate, { minutes: 15 });
+  } else if (differenceInHours(checkDate, downtimeStartDate) < 24) {
+    return add(checkDate, { minutes: 30 });
+  } else if (differenceInDays(checkDate, downtimeStartDate) < 7) {
+    return add(checkDate, { hours: 1 });
+  } else {
+    return add(checkDate, { hours: 24 });
+  }
 }

--- a/shared/dbSchemas/akash/provider.ts
+++ b/shared/dbSchemas/akash/provider.ts
@@ -22,8 +22,12 @@ export class Provider extends Model {
 
   // Stats
   @Column(DataTypes.UUID) lastSnapshotId?: string;
+  @Column(DataTypes.UUID) lastSuccessfulSnapshotId?: string;
+  @Column(DataTypes.UUID) downtimeFirstSnapshotId?: string;
   @Column isOnline?: boolean;
   @Column lastCheckDate?: Date;
+  @Required @Default(DataTypes.NOW) @Column nextCheckDate: Date;
+  @Required @Default(0) @Column failedCheckCount: number;
   @Column(DataTypes.TEXT) error?: string;
   @Column deploymentCount?: number;
   @Column leaseCount?: number;
@@ -55,4 +59,6 @@ export class Provider extends Model {
   @HasMany(() => ProviderAttributeSignature, "provider") providerAttributeSignatures: ProviderAttributeSignature[];
   @HasMany(() => ProviderSnapshot, "owner") providerSnapshots: ProviderSnapshot[];
   @BelongsTo(() => ProviderSnapshot, "lastSnapshotId") lastSnapshot: ProviderSnapshot;
+  @BelongsTo(() => ProviderSnapshot, "lastSuccessfulSnapshotId") lastSuccessfulSnapshot: ProviderSnapshot;
+  @BelongsTo(() => ProviderSnapshot, "downtimeFirstSnapshotId") downtimeFirstSnapshot: ProviderSnapshot;
 }

--- a/shared/dbSchemas/akash/providerSnapshot.ts
+++ b/shared/dbSchemas/akash/providerSnapshot.ts
@@ -8,13 +8,15 @@ import { ProviderSnapshotNode } from "./providerSnapshotNode";
   indexes: [
     { unique: false, fields: ["owner"] },
     { unique: false, fields: ["owner", "checkDate"] },
-    { name: "provider_snapshot_id_where_isonline_and_islastofday", unique: false, fields: ["id"], where: { isOnline: true, isLastOfDay: true } }
+    { name: "provider_snapshot_id_where_isonline_and_islastofday", unique: false, fields: ["id"], where: { isOnline: true, isLastOfDay: true } },
+    { name: "provider_snapshot_id_where_islastsuccessofday", unique: false, fields: ["id"], where: { isLastSuccessOfDay: true } }
   ]
 })
 export class ProviderSnapshot extends Model {
   @Required @PrimaryKey @Default(DataTypes.UUIDV4) @Column(DataTypes.UUID) id: string;
   @Required @Column owner: string;
   @Required @Default(false) @Column isLastOfDay: boolean;
+  @Required @Default(false) @Column isLastSuccessOfDay: boolean;
 
   // Stats
   @Required @Column isOnline: boolean;


### PR DESCRIPTION
## Improvements to the provider uptime tracking system #152 

- Added a grace period before treating a provider as completely offline. This will reflect in the following places:
  - `/internal/gpu-prices` endpoint used by the GPU Pricing page
  - `/internal/gpu` & `/internal/provider-versions` endpoints used for internal tracking
  - Network capacity tiles + historical graph (shown on https://stats.akash.network/)
  - Provider detail page in Cloudmos / Console
  
  The default grace period is **3h**, but this can be changed with the `ProviderUptimeGracePeriodMinutes` env var in the api.
- When a provider fails an uptime check, start retrying every minutes and slowly increase the interval based on the following table:

| Downtime Duration | Retry Frequency |
| - | - |
| < 15m | 1m |
| 15m - 1h | 5m |
| 1h - 6h | 15m |
| 6h - 24h | 30m |
| 24h - 7d | 1h |
| 7d+ | 24h |
- Merge the uptime bars when they occurs in the same 15m window (during retries) so that they each represent the same interval. Added an orange bar when a provider is up and down in the same 15m window.
![image](https://github.com/akash-network/cloudmos/assets/2829180/97682ea8-a60c-4d46-b158-dafd886b324e)
- Uptime percentage (1d,7d,30d) will now take into account the interval between each check. That way if a provider fails a check, but the retry is successful after 1m then it will only count for 1 minute of downtime.

 