### PR TITLE
fix(deploy-web): fix provider page

### DIFF
--- a/api/src/types/provider.ts
+++ b/api/src/types/provider.ts
@@ -21,6 +21,7 @@ export interface ProviderList {
   uptime30d: number;
   isValidVersion: boolean;
   isOnline: boolean;
+  lastOnlineDate: Date;
   isAudited: boolean;
   gpuModels: { vendor: string; model: string; ram: string; interface: string }[];
   activeStats: {

--- a/deploy-web/src/pages/providers/[owner]/index.tsx
+++ b/deploy-web/src/pages/providers/[owner]/index.tsx
@@ -91,7 +91,7 @@ const ProviderDetailPage: React.FunctionComponent<Props> = ({ owner, _provider }
   function groupUptimeChecksByPeriod(uptimeChecks: { isOnline: boolean; checkDate: string }[] = []) {
     const groupedSnapshots: { checkDate: Date; checks: boolean[] }[] = [];
 
-    const sortedUptimeChecks = uptimeChecks.toSorted((a, b) => new Date(a.checkDate).getTime() - new Date(b.checkDate).getTime());
+    const sortedUptimeChecks = [...uptimeChecks].sort((a, b) => new Date(a.checkDate).getTime() - new Date(b.checkDate).getTime());
 
     for (const snapshot of sortedUptimeChecks) {
       const recentGroup = groupedSnapshots.find(x => differenceInMinutes(new Date(snapshot.checkDate), x.checkDate) < 15);
@@ -113,7 +113,7 @@ const ProviderDetailPage: React.FunctionComponent<Props> = ({ owner, _provider }
   }
 
   const uptimePeriods = useMemo(() => groupUptimeChecksByPeriod(provider?.uptime || []), [provider?.uptime]);
-  const wasRecentlyOnline = provider && (provider.isOnline || (provider.lastCheckDate && new Date(provider.lastCheckDate) >= sub(new Date(), { hours: 24 })));
+  const wasRecentlyOnline = provider && (provider.isOnline || (provider.lastOnlineDate && new Date(provider.lastOnlineDate) >= sub(new Date(), { hours: 24 })));
 
   return (
     <Layout isLoading={isLoading}>
@@ -126,7 +126,7 @@ const ProviderDetailPage: React.FunctionComponent<Props> = ({ owner, _provider }
           </Box>
         )}
 
-        {provider && !wasRecentlyOnline && !isLoading && (
+        {provider && !wasRecentlyOnline && !isLoadingProvider && (
           <Alert
             variant="outlined"
             severity="warning"

--- a/deploy-web/src/types/provider.ts
+++ b/deploy-web/src/types/provider.ts
@@ -205,6 +205,7 @@ export interface ApiProviderList {
   uptime30d: number;
   isValidVersion: boolean;
   isOnline: boolean;
+  lastOnlineDate: string;
   isAudited: boolean;
   gpuModels: { vendor: string; model: string; ram: string; interface: string }[];
   activeStats: {


### PR DESCRIPTION
# Fix provider page issues introduced in recent release (#173)
- Fix the "inactive" warning not showing for all offline providers. (check `lastOnlineDate` instead of `lastCheckDate` for the 24h grace period)
- Replaced the `toSorted()` call for a `sort()` because `toSorted` is not supported in node 18 which is used in current docker image. This was causing the provider page to work during client navigation, but not during server-rendering.