### PR TITLE
fix(deploy-web): fix duplicate persistent attribute for ram storage

### DIFF
--- a/deploy-web/package-lock.json
+++ b/deploy-web/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.0.3",
-        "@akashnetwork/akashjs": "^0.6.2",
+        "@akashnetwork/akashjs": "^0.6.3",
         "@auth0/nextjs-auth0": "^3.1.0",
         "@cosmjs/encoding": "^0.29.5",
         "@cosmjs/stargate": "^0.29.5",
@@ -133,9 +133,9 @@
       }
     },
     "node_modules/@akashnetwork/akashjs": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/akashjs/-/akashjs-0.6.2.tgz",
-      "integrity": "sha512-0MqgLCVvadaU0NOyntH/w5Vw6h7ix7ua8LQqKbWlgWin2PnNCDJhc8EHuU8D0qmkmdr97tVXWeKfEeq5Hplk/w==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/akashjs/-/akashjs-0.6.3.tgz",
+      "integrity": "sha512-tHAwxzXd+scoGK9HirQQVg/aV7IY6N+X4N/xB/g+4mEqB5uHdPjI+TnFIbRlupeHx+5Q2+nky1DUr5usKZbn6g==",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.0.2",
         "@cosmjs/launchpad": "^0.27.0",
@@ -24407,9 +24407,9 @@
       }
     },
     "@akashnetwork/akashjs": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/akashjs/-/akashjs-0.6.2.tgz",
-      "integrity": "sha512-0MqgLCVvadaU0NOyntH/w5Vw6h7ix7ua8LQqKbWlgWin2PnNCDJhc8EHuU8D0qmkmdr97tVXWeKfEeq5Hplk/w==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/akashjs/-/akashjs-0.6.3.tgz",
+      "integrity": "sha512-tHAwxzXd+scoGK9HirQQVg/aV7IY6N+X4N/xB/g+4mEqB5uHdPjI+TnFIbRlupeHx+5Q2+nky1DUr5usKZbn6g==",
       "requires": {
         "@akashnetwork/akash-api": "^1.0.2",
         "@cosmjs/launchpad": "^0.27.0",

--- a/deploy-web/package.json
+++ b/deploy-web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "^1.0.3",
-    "@akashnetwork/akashjs": "^0.6.2",
+    "@akashnetwork/akashjs": "^0.6.3",
     "@auth0/nextjs-auth0": "^3.1.0",
     "@cosmjs/encoding": "^0.29.5",
     "@cosmjs/stargate": "^0.29.5",


### PR DESCRIPTION
Bump akashjs version to 0.6.3 to fix duplicate `persistent` attribute issue with ram storage