### PR TITLE
Fixed wrong zod type in leases duration endpoint

### DIFF
--- a/api/src/routes/internal/leasesDuration.ts
+++ b/api/src/routes/internal/leasesDuration.ts
@@ -14,7 +14,7 @@ const route = createRoute({
       owner: z.string().openapi({ example: openApiExampleAddress })
     }),
     query: z.object({
-      dseq: z.number().optional(),
+      dseq: z.string().optional().openapi({ type: "number" }),
       startDate: z.string().optional().openapi({ format: "YYYY-MM-DD" }),
       endDate: z.string().optional().openapi({ format: "YYYY-MM-DD" })
     })


### PR DESCRIPTION
Fixed wrong zod type in leases duration endpoint. Query param types should always be strings.