### PR TITLE
Fix predictedClosedHeight prediction for multi-lease deployments

### DIFF
--- a/indexer/src/indexers/akashStatsIndexer.ts
+++ b/indexer/src/indexers/akashStatsIndexer.ts
@@ -597,7 +597,7 @@ export class AkashStatsIndexer extends Indexer {
       deployment.closedHeight = height;
       await deployment.save({ transaction: blockGroupTransaction });
     } else {
-      const predictedClosedHeight = deployment.balance / (blockRate - lease.price);
+      const predictedClosedHeight = Math.ceil((deployment.lastWithdrawHeight || lease.createdHeight) + deployment.balance / (blockRate - lease.price));
       await Lease.update({ predictedClosedHeight: predictedClosedHeight }, { where: { deploymentId: deployment.id }, transaction: blockGroupTransaction });
     }
   }


### PR DESCRIPTION
`invalid input syntax for type bigint: "922.3056880849911"`

There was an error when calculating `predictedClosedHeight` for multi-lease deployments when the owner was the one closing only one of the leases. The result of the calculation was not rounded and on top of that the logic was wrong causing the `predictedClosedHeight` to be earlier that reality.

I modified the calculation to match what we do when it's the provider that closes the lease.