### PR TITLE
feat(deploy-web): add localstorage export page

### DIFF
--- a/.github/workflows/docker-build-deploy-web.yml
+++ b/.github/workflows/docker-build-deploy-web.yml
@@ -2,9 +2,9 @@ name: Deploy Web CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "features/temp-cloudmos-maintain"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "features/temp-cloudmos-maintain"]
 
 jobs:
   build:

--- a/deploy-web/src/pages/_app.tsx
+++ b/deploy-web/src/pages/_app.tsx
@@ -46,7 +46,7 @@ Router.events.on("routeChangeError", () => NProgress.done());
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
 
-const App: React.FunctionComponent<Props> = ({ Component, pageProps, emotionCache = clientSideEmotionCache }) => {
+const App: React.FunctionComponent<Props> = ({ Component, pageProps, emotionCache = clientSideEmotionCache, router }) => {
   usePreviousRoute();
 
   useEffect(() => {
@@ -62,6 +62,11 @@ const App: React.FunctionComponent<Props> = ({ Component, pageProps, emotionCach
       return { width: this.offsetWidth, height: this.offsetHeight };
     };
   }, []);
+
+  // Do not wrap with layout if standalone page
+  if (router.pathname.startsWith("/standalone/")) {
+    return <Component {...pageProps} />;
+  }
 
   return (
     <>

--- a/deploy-web/src/pages/standalone/localstorage-export.tsx
+++ b/deploy-web/src/pages/standalone/localstorage-export.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { extractLocalStorageData } from "@src/utils/localStorage";
+import { useEffect } from "react";
+
+const validExternalDomain = "https://console.akash.network";
+
+export default function Page() {
+  useEffect(() => {
+    exportLocalStorageData();
+  }, []);
+
+  function exportLocalStorageData() {
+    if (window.parent === window) {
+      console.log(`${window.location.origin} => No parent window found`);
+      return;
+    }
+
+    const data = extractLocalStorageData();
+
+    console.log(`${window.location.origin} => Sending localstorage data to ${validExternalDomain}`);
+    window.parent.postMessage(data, { targetOrigin: validExternalDomain });
+  }
+
+  return (
+    <div>
+      <p>Exporting local storage data to {validExternalDomain}</p>
+    </div>
+  );
+}

--- a/deploy-web/src/utils/localStorage.ts
+++ b/deploy-web/src/utils/localStorage.ts
@@ -1,6 +1,6 @@
 import getConfig from "next/config";
 import { gt, neq } from "semver";
-import { mainnetId } from "./constants";
+import { mainnetId, sandboxId, testnetId } from "./constants";
 const { publicRuntimeConfig } = getConfig();
 
 const migrations = {
@@ -44,3 +44,12 @@ export const migrateLocalStorage = () => {
   // Update the latestUpdatedVersion
   localStorage.setItem("latestUpdatedVersion", currentVersion);
 };
+
+export function extractLocalStorageData() {
+  const networks = [mainnetId, testnetId, sandboxId];
+
+  const allKeys = Object.keys(localStorage);
+  const filteredKeys = allKeys.filter(key => networks.some(network => key.startsWith(network + "/")));
+
+  return filteredKeys.reduce((acc, key) => ({ ...acc, [key]: localStorage.getItem(key) }), {} as { [key: string]: string });
+}


### PR DESCRIPTION
# Automatic localstorage migration from Cloudmos to Console

Added a page under `/standalone/localstorage-export` that will be used to automatically import the localstorage data from Cloudmos into Console. The page will be opened on Console in an iframe and the data will be transferred using the `window.postMessage` method.

Matching PR for Console side: https://github.com/akash-network/cloudmos/pull/196

The exported data include:
- Settings
- Certificates
- Deployment Names & SDLs
- Provider Favorites

## Security Concerns ⚠️ 

The exported data contains sensitive information so we must make sure it is handled securely.
To make sure the data does not end up on the wrong domain we pass the `targetOrigin` property to `postMessage`. The browser will make sure the message is only dispatched if the parent window has the correct origin `https://console.akash.network`.

[`postMessage` documentation](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#security_concerns)

Once the majority of users have migrated to Console, we could remove this page to mitigate any future security risk. We could also change it be opened as a popup instead and require user approval before sending the data.