### PR TITLE
feat(deploy-web): add localstorage auto-import from cloudmos

### DIFF
--- a/deploy-web/src/utils/localStorage.ts
+++ b/deploy-web/src/utils/localStorage.ts
@@ -24,7 +24,6 @@ export const migrateLocalStorage = () => {
     } else {
       // It's a brand new installation
       latestUpdatedVersion = currentVersion;
-      localStorage.setItem("selectedNetworkId", mainnetId);
     }
   }
 
@@ -45,4 +44,8 @@ export const migrateLocalStorage = () => {
 
   // Update the latestUpdatedVersion
   localStorage.setItem("latestUpdatedVersion", currentVersion);
+
+  if (!localStorage.getItem("selectedNetworkId")) {
+    localStorage.setItem("selectedNetworkId", mainnetId);
+  }
 };


### PR DESCRIPTION
# Automatic localstorage migration from Cloudmos to Console
This PR add the ability to auto-import localstorage data from Cloudmos into Console. An iframe loads the export page of cloudmos and then listen for a message event containing the data.

Matching PR for Cloudmos side: https://github.com/akash-network/cloudmos/pull/195

The imported data include:
- Settings
- Certificates
- Deployment Names & SDLs
- Provider Favorites

## Security Concerns ⚠️
Any websites can use `postMessage` to send us messages. In order to prevent injection of localstorage data from untrusted sources, the origin of messages are checked to only accept messages from `https://deploy.cloudmos.io`.