### PR TITLE
fix(api): fix swagger server list (#192)

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -22,6 +22,7 @@ When running the api locally the following environment variables can be set in a
 |-|-|-
 Network|`mainnet` or `testnet`|Specify if the api should be in mainnet or testnet mode. Default: `mainnet`.
 RestApiNodeUrl|ex: `"https://api.akashnet.net"`|Rest api to use. Will default to `"https://rest.cosmos.directory/akash"` for mainnet and `"https://api.testnet-02.aksh.pw:443"` for testnet.
+ServerOrigin|ex: `http://localhost:3080`|Origin of the api server. Will be used to populate the swagger server list.
 HealthchecksEnabled|`true` or `false`|Specify if the [Scheduler](./src/index.ts#L42) should send health check pings.
 SentryDSN|ex: `"https://1234...789@z645.ingest.sentry.io/1234"`|[Sentry DSN](https://docs.sentry.io/product/sentry-basics/dsn-explainer/) used when [initializing](./src/index.ts#L29) Sentry
 AkashDatabaseCS|ex: `postgres://user:password@localhost:5432/cloudmos-akash`|Akash Database Connection String

--- a/api/src/routers/apiRouter.ts
+++ b/api/src/routers/apiRouter.ts
@@ -1,21 +1,16 @@
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { swaggerUI } from "@hono/swagger-ui";
 import routesV1 from "../routes/v1";
-import { isProd } from "@src/utils/constants";
+import { env } from "@src/utils/env";
 
 export const apiRouter = new OpenAPIHono();
 
 function registerApiVersion(version: string, baseRouter: OpenAPIHono, versionRoutes: OpenAPIHono[]) {
   const versionRouter = new OpenAPIHono();
 
-  const servers = [{ url: `https://api.cloudmos.io/${version}`, description: "Production" }];
-  if (!isProd) {
-    servers.unshift({ url: `http://localhost:3080/${version}`, description: "Localhost" });
-  }
-
   versionRouter.doc(`/doc`, {
     openapi: "3.0.0",
-    servers: servers,
+    servers: [{ url: `${env.ServerOrigin}/${version}` }],
     info: {
       title: "Cloudmos API",
       description: "Access Akash data from our indexer",

--- a/api/src/routers/internalRouter.ts
+++ b/api/src/routers/internalRouter.ts
@@ -1,18 +1,13 @@
-import { isProd } from "@src/utils/constants";
 import { OpenAPIHono } from "@hono/zod-openapi";
 import { swaggerUI } from "@hono/swagger-ui";
 import routes from "../routes/internal";
+import { env } from "@src/utils/env";
 
 export const internalRouter = new OpenAPIHono();
 
-const servers = [{ url: `https://api.cloudmos.io/internal`, description: "Production" }];
-if (!isProd) {
-  servers.unshift({ url: `http://localhost:3080/internal`, description: "Localhost" });
-}
-
 internalRouter.doc(`/doc`, {
   openapi: "3.0.0",
-  servers: servers,
+  servers: [{ url: `${env.ServerOrigin}/internal` }],
   info: {
     title: "Cloudmos Internal API",
     description: "APIs for internal use that are not part of the public API. There is no garantees of stability or backward compatibility.",

--- a/api/src/utils/env.ts
+++ b/api/src/utils/env.ts
@@ -17,6 +17,7 @@ export const env = z
     UserDatabaseCS: z.string().optional(),
     Network: z.string().default("mainnet"),
     RestApiNodeUrl: z.string().optional(),
+    ServerOrigin: z.string().optional().default("http://localhost:3080"),
     AkashlyticsGithubPAT: z.string().optional(),
     Auth0JWKSUri: z.string().optional(),
     Auth0Audience: z.string().optional(),


### PR DESCRIPTION
Added the `ServerOrigin` env var that needs to be set to the api server origin (ex: `https://api.cloudmos.io`). This is now used for the swagger server list.

Fixes: #192 