### PR TITLE
fix(deploy-web): fix localstorage auto-import url

### DIFF
--- a/.github/workflows/docker-build-stats-web.yml
+++ b/.github/workflows/docker-build-stats-web.yml
@@ -2,9 +2,9 @@ name: Stats Web CI
 
 on:
   push:
-    branches: ["main", "collab-rebrand"]
+    branches: ["main"]
   pull_request:
-    branches: ["main", "collab-rebrand"]
+    branches: ["main"]
 
 jobs:
   build:

--- a/deploy-web/Dockerfile
+++ b/deploy-web/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:18 AS base
-# Pinned to 3.18 to avoid this issue: https://github.com/nodejs/docker-node/issues/2009
 
 # Install dependencies only when needed
 FROM base AS deps
@@ -51,10 +50,10 @@ RUN setcap cap_net_bind_service=+ep `readlink -f \`which node\``
 
 USER nextjs
 
-EXPOSE 3001
-# EXPOSE 80
+#EXPOSE 3001
+EXPOSE 80
 
-ENV PORT 3001
-# ENV PORT 80
+#ENV PORT 3001
+ENV PORT 80
 
 CMD ["node", "server.js"]

--- a/deploy-web/src/context/SettingsProvider/SettingsProviderContext.tsx
+++ b/deploy-web/src/context/SettingsProvider/SettingsProviderContext.tsx
@@ -356,7 +356,7 @@ export function SettingsProvider({ children }: React.PropsWithChildren<{}>) {
       {children}
 
       {/* iframe for localstorage automatic import */}
-      {isSettingsInit && <iframe ref={iframeRef} className="hidden" src={`${autoImportOrigin}/standalone/localstorage-import`} width={0} height={0} />}
+      {isSettingsInit && <iframe ref={iframeRef} className="hidden" src={`${autoImportOrigin}/standalone/localstorage-export`} width={0} height={0} />}
     </SettingsProviderContext.Provider>
   );
 }


### PR DESCRIPTION
- Fix wrong url for localstorage auto-import (from cloudmos)
- Change Dockerfile to use port 80
- Remove `collab-rebrand` from the stats website github workflow