### PR TITLE
feat(deploy-web): enable console migration banner

### DIFF
--- a/deploy-web/src/components/layout/Header.tsx
+++ b/deploy-web/src/components/layout/Header.tsx
@@ -100,7 +100,7 @@ export const Header: React.FunctionComponent<Props> = ({ isMobileOpen, handleDra
               <Link href="https://console.akash.network" target="_blank" className={classes.bannerLink}>
                 console.akash.network
               </Link>{" "}
-              soon. All user data will be migrated. Please try out Console and let us know if you run into any issues.
+              soon. Please try out Console and let us know if you run into any issues.
             </Typography>
           </Box>
         )}

--- a/deploy-web/src/utils/constants.ts
+++ b/deploy-web/src/utils/constants.ts
@@ -16,7 +16,7 @@ export const drawerWidth = 240;
 export const closedDrawerWidth = 58;
 export const accountBarHeight = 58;
 // Rebrand Banner
-export const hasBanner = false;
+export const hasBanner = true;
 export const bannerHeight = 30;
 export const bannerHeightSm = 80;
 


### PR DESCRIPTION
PR to enable the migration banner on Cloudmos. The banner was previously added in #191 in a disabled state.

![image](https://github.com/akash-network/cloudmos/assets/2829180/81a16b35-685f-45a1-a766-6045cfb030a5)
