### PR TITLE
fix(lease): safely render lease ips

### DIFF
--- a/deploy-web/src/components/deployments/LeaseRow.tsx
+++ b/deploy-web/src/components/deployments/LeaseRow.tsx
@@ -390,7 +390,8 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(({ lease, setActi
             <LabelValueOld label="IP(s):" />
             <ul className="mt-2 space-y-2">
               {servicesNames
-                .flatMap(n => leaseStatus.ips[n])
+                .flatMap(service => leaseStatus.ips[service])
+                .filter(Boolean)
                 .map((ip, i) => (
                   <li key={`${ip.IP}${ip.ExternalPort}`} className="flex items-center">
                     <Link className="inline-flex items-center space-x-2 text-sm" href={`http://${ip.IP}:${ip.ExternalPort}`} target="_blank">


### PR DESCRIPTION
In the giver use case only one of the services was using IPs. Status IPs looked like:

```
{
  ips: { node: [ [Object], [Object] ] }
}

```

So another service `postgres` had underlined IPs as returned by the `flatMap`