### PR TITLE
Bugfixes/change predictredcloseheight type

### DIFF
--- a/indexer/UPGRADE.md
+++ b/indexer/UPGRADE.md
@@ -4,6 +4,16 @@ Some indexer updates changes the database schemas and an upgrade script must be 
 
 **It is recommended to stop the indexer before running any migration script.**
 
+## v1.8.2
+
+Change the type of the lease's `predictedClosedHeight` to allow larger values.
+```
+ALTER TABLE lease
+ALTER COLUMN "predictedClosedHeight"
+TYPE numeric(30,0)
+USING "predictedClosedHeight"::numeric(30,0);
+```
+
 ## v1.8.0
 
 Version 1.8.0 adds the necessary fields for improving the Akash provider uptime checks.

--- a/indexer/package-lock.json
+++ b/indexer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cloudmos-indexer",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cloudmos-indexer",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",

--- a/indexer/package.json
+++ b/indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudmos-indexer",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Indexer for any Cosmos based blockchain",
   "homepage": "https://github.com/akash-network/cloudmos",
   "bugs": {

--- a/shared/dbSchemas/akash/lease.ts
+++ b/shared/dbSchemas/akash/lease.ts
@@ -26,7 +26,7 @@ export class Lease extends Model {
   @Required @Column providerAddress: string;
   @Required @Column createdHeight: number;
   @Column closedHeight?: number;
-  @Required @Column(DataTypes.BIGINT) predictedClosedHeight: number;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) predictedClosedHeight: number;
   @Required @Column(DataTypes.DOUBLE) price: number;
   @Required @Default(0) @Column(DataTypes.DOUBLE) withdrawnAmount: number;
   @Required @Column denom: string;


### PR DESCRIPTION
Change the type of `predictedClosedHeight` from `bigint` to `numeric(30,0)`. 

This is to fix the indexer being blocked on [this tx](https://www.mintscan.io/akash/tx/E3F263D13356D283177A45A76625BAC0E317DB91E28EEEDB419A9B561BFB1BCC?height=16488231) because the price of the [selected bid](https://www.mintscan.io/akash/tx/C58A89E94CE127DF9333F91E2D79B316FEF71DA18D72950A17A47B88AD7838D9?height=16488228&sector=json) is `0.000000000000000069` uakt and that represent a predicted closed height of 7.24637681159422e+21 which is larger than the bigint max value.