### PR TITLE
Features/track persistent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,17 +353,6 @@ Created for each days (UTC based), simplifies querying for daily stats.
 |lastSuccessfulSnapshotId|uuid|Snapshot ID of the last successful check
 |downtimeFirstSnapshotId|uuid|Snapshot ID of the first failed check of the current downtime period. `NULL` if currently online.
 |error|text|`NULL` if the latest uptime check was successful, otherwise this will contain the error message.
-|deploymentCount|integer
-|leaseCount|integer
-|activeCPU|bigint|Thousandth of CPU
-|activeMemory|bigint|Memory in bytes
-|activeStorage|bigint|Storage in bytes
-|pendingCPU|bigint|Thousandth of CPU
-|pendingMemory|bigint|Memory in bytes
-|pendingStorage|bigint|Storage in bytes
-|availableCPU|bigint|Thousandth of CPU
-|availableMemory|bigint|Memory in bytes
-|availableStorage|bigint|Storage in bytes
 |akashVersion|varchar
 |cosmosSdkVersion|varchar
 |ip|varchar|IP obtained by resolving DNS for the `hostUri`
@@ -406,18 +395,21 @@ Similar to stats on the [Provider](#provider), but a new row is inserted for eve
 |isOnline|boolean|Indicates if this uptime check was successful
 |isLastOfDay|boolean|Indicates if this is the last snapshot of the day for this provider
 |checkDate|timestamp|Date & Time of this uptime check
-|error|text|`null` if the uptime check was successful, otherwise this wil contain the error message.
+|error|text|`null` if the uptime check was successful, otherwise this will contain the error message.
 |deploymentCount|integer
 |leaseCount|integer
 |activeCPU|bigint|Thousandth of CPU
 |activeMemory|bigint|Memory in bytes
-|activeStorage|bigint|Storage in bytes
+|activeEphemeralStorage|bigint|Ephemeral storage in bytes
+|activePersistentStorage|bigint|Persistent storage in bytes
 |pendingCPU|bigint|Thousandth of CPU
 |pendingMemory|bigint|Memory in bytes
-|pendingStorage|bigint|Storage in bytes
+|pendingEphemeralStorage|bigint|Ephemeral storage in bytes
+|pendingPersistentStorage|bigint|Persistent storage in bytes
 |availableCPU|bigint|Thousandth of CPU
 |availableMemory|bigint|Memory in bytes
-|availableStorage|bigint|Storage in bytes
+|availableEphemeralStorage|bigint|Ephemeral storage in bytes
+|availablePersistentStorage|bigint|Persistent storage in bytes
 
 ## ProviderSnapshotNodes
 
@@ -465,6 +457,18 @@ Store GPU informations for each [Provider Nodes](#providersnapshotnodes)
 |modelId|varchar|On the provider, this gets mapped to vendor, name, interface and memorySize based on [this file](https://github.com/akash-network/provider-configs/blob/main/devices/pcie/gpus.json).
 |interface|varchar|ex: `PCIe`
 |memorySize|varchar|ex: `24Gi`
+
+## ProviderSnapshotStorage
+
+Store persistent storage informations
+
+|Column|Type|Note
+|-|-|-
+|id|uuid
+|snapshotId|uuid|Snapshot ID
+|class|varchar|Storage class
+|allocatable|bigint|Storage in bytes
+|allocated|bigint|Storage in bytes
 
 ## Template
 

--- a/apps/api/src/caching/helpers.ts
+++ b/apps/api/src/caching/helpers.ts
@@ -42,7 +42,7 @@ export async function cacheResponse<T>(seconds: number, key: string, refreshRequ
         return data;
       })
       .catch(err => {
-        // console.log(`Error making cache request ${err}`);
+        console.error(`Error making cache request ${err}`);
         Sentry.captureException(err);
       })
       .finally(() => {

--- a/apps/api/src/services/db/statsService.ts
+++ b/apps/api/src/services/db/statsService.ts
@@ -207,7 +207,13 @@ export const getProviderGraphData = async (dataName: ProviderStatsKey) => {
         `SELECT d."date", (SUM("activeCPU") + SUM("pendingCPU") + SUM("availableCPU")) AS "cpu", (SUM("activeGPU") + SUM("pendingGPU") + SUM("availableGPU")) AS "gpu", (SUM("activeMemory") + SUM("pendingMemory") + SUM("availableMemory")) AS memory, (SUM("activeStorage") + SUM("pendingStorage") + SUM("availableStorage")) as storage, COUNT(*) as count
          FROM "day" d
          INNER JOIN (
-            SELECT DISTINCT ON("hostUri",DATE("checkDate")) DATE("checkDate") AS date, ps."activeCPU", ps."pendingCPU", ps."availableCPU", ps."activeGPU", ps."pendingGPU", ps."availableGPU", ps."activeMemory", ps."pendingMemory", ps."availableMemory", ps."activeStorage", ps."pendingStorage", ps."availableStorage", ps."isOnline"
+            SELECT DISTINCT ON("hostUri",DATE("checkDate")) 
+              DATE("checkDate") AS date, 
+              ps."activeCPU", ps."pendingCPU", ps."availableCPU", 
+              ps."activeGPU", ps."pendingGPU", ps."availableGPU", 
+              ps."activeMemory", ps."pendingMemory", ps."availableMemory", 
+              ps."activeEphemeralStorage" + COALESCE(ps."activePersistentStorage", 0) AS "activeStorage", ps."pendingEphemeralStorage" + COALESCE(ps."pendingPersistentStorage", 0) AS "pendingStorage", ps."availableEphemeralStorage" + COALESCE(ps."availablePersistentStorage", 0) AS "availableStorage", 
+              ps."isOnline"
             FROM "providerSnapshot" ps
             INNER JOIN "provider" ON "provider"."owner"=ps."owner"
             WHERE ps."isLastSuccessOfDay" = TRUE AND ps."checkDate" >= DATE(ps."checkDate")::timestamp + INTERVAL '1 day' - (:grace_duration * INTERVAL '1 minutes')

--- a/apps/api/src/utils/map/provider.ts
+++ b/apps/api/src/utils/map/provider.ts
@@ -22,8 +22,8 @@ export const mapProviderToList = (
     email: provider.email || getProviderAttributeValue("email", provider, providerAttributeSchema),
     website: provider.website || getProviderAttributeValue("website", provider, providerAttributeSchema),
     lastCheckDate: provider.lastCheckDate,
-    deploymentCount: provider.deploymentCount,
-    leaseCount: provider.leaseCount,
+    deploymentCount: lastSuccessfulSnapshot?.deploymentCount,
+    leaseCount: lastSuccessfulSnapshot?.leaseCount,
     cosmosSdkVersion: provider.cosmosSdkVersion,
     akashVersion: provider.akashVersion,
     ipRegion: provider.ipRegion,
@@ -33,22 +33,22 @@ export const mapProviderToList = (
     ipLat: provider.ipLat,
     ipLon: provider.ipLon,
     activeStats: {
-      cpu: provider.activeCPU,
-      gpu: provider.activeGPU,
-      memory: provider.activeMemory,
-      storage: provider.activeStorage
+      cpu: lastSuccessfulSnapshot?.activeCPU,
+      gpu: lastSuccessfulSnapshot?.activeGPU,
+      memory: lastSuccessfulSnapshot?.activeMemory,
+      storage: lastSuccessfulSnapshot?.activeEphemeralStorage + lastSuccessfulSnapshot?.activePersistentStorage
     },
     pendingStats: {
-      cpu: isValidVersion ? provider.pendingCPU : 0,
-      gpu: isValidVersion ? provider.pendingGPU : 0,
-      memory: isValidVersion ? provider.pendingMemory : 0,
-      storage: isValidVersion ? provider.pendingStorage : 0
+      cpu: isValidVersion ? lastSuccessfulSnapshot?.pendingCPU : 0,
+      gpu: isValidVersion ? lastSuccessfulSnapshot?.pendingGPU : 0,
+      memory: isValidVersion ? lastSuccessfulSnapshot?.pendingMemory : 0,
+      storage: isValidVersion ? lastSuccessfulSnapshot?.pendingEphemeralStorage + lastSuccessfulSnapshot?.pendingPersistentStorage : 0
     },
     availableStats: {
-      cpu: isValidVersion ? provider.availableCPU : 0,
-      gpu: isValidVersion ? provider.availableGPU : 0,
-      memory: isValidVersion ? provider.availableMemory : 0,
-      storage: isValidVersion ? provider.availableStorage : 0
+      cpu: isValidVersion ? lastSuccessfulSnapshot?.availableCPU : 0,
+      gpu: isValidVersion ? lastSuccessfulSnapshot?.availableGPU : 0,
+      memory: isValidVersion ? lastSuccessfulSnapshot?.availableMemory : 0,
+      storage: isValidVersion ? lastSuccessfulSnapshot?.availableEphemeralStorage + lastSuccessfulSnapshot?.availablePersistentStorage : 0
     },
     gpuModels: gpuModels,
     uptime1d: provider.uptime1d,

--- a/apps/deploy-web/src/components/settings/SettingsContainer.tsx
+++ b/apps/deploy-web/src/components/settings/SettingsContainer.tsx
@@ -10,11 +10,11 @@ import { LabelValue } from "@src/components/shared/LabelValue";
 import { useSelectedNetwork } from "@src/hooks/useSelectedNetwork";
 import Layout from "../layout/Layout";
 import { CertificateList } from "./CertificateList";
+import CloudmosImportPanel from "./CloudmosImportPanel";
 import { ColorModeSelect } from "./ColorModeSelect";
 import { SelectNetworkModal } from "./SelectNetworkModal";
 import { SettingsForm } from "./SettingsForm";
 import { SettingsLayout, SettingsTabs } from "./SettingsLayout";
-import CloudmosImportPanel from "./CloudmosImportPanel";
 
 export const SettingsContainer: React.FunctionComponent = () => {
   const [isSelectingNetwork, setIsSelectingNetwork] = useState(false);

--- a/apps/deploy-web/src/components/shared/Markdown.tsx
+++ b/apps/deploy-web/src/components/shared/Markdown.tsx
@@ -1,12 +1,12 @@
 "use client";
+import "highlight.js/styles/vs2015.css";
+
 import ReactMarkdown from "react-markdown";
 import { useTheme } from "next-themes";
 import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
 
 import { cn } from "@src/utils/styleUtils";
-
-import "highlight.js/styles/vs2015.css";
 
 type MarkdownProps = {
   children?: React.ReactNode | string;

--- a/apps/deploy-web/src/context/CustomChainProvider/CustomChainProvider.tsx
+++ b/apps/deploy-web/src/context/CustomChainProvider/CustomChainProvider.tsx
@@ -1,4 +1,7 @@
 "use client";
+import "@interchain-ui/react/styles";
+import "@interchain-ui/react/globalStyles";
+
 import { GasPrice } from "@cosmjs/stargate";
 import { wallets as cosmostation } from "@cosmos-kit/cosmostation-extension";
 import { wallets as keplr } from "@cosmos-kit/keplr";
@@ -9,9 +12,6 @@ import { useChain } from "@cosmos-kit/react";
 import { akash, akashSandbox, akashTestnet, assetLists } from "@src/chains";
 import { useSelectedNetwork } from "@src/hooks/useSelectedNetwork";
 import { customRegistry } from "@src/utils/customRegistry";
-
-import "@interchain-ui/react/styles";
-import "@interchain-ui/react/globalStyles";
 
 type Props = {
   children: React.ReactNode;

--- a/apps/deploy-web/src/context/SettingsProvider/SettingsProviderContext.tsx
+++ b/apps/deploy-web/src/context/SettingsProvider/SettingsProviderContext.tsx
@@ -154,14 +154,13 @@ export const SettingsProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
   /**
    * Load the node status from status rpc endpoint
-   * @param {*} nodeUrl
+   * @param {string} rpcUrl
    * @returns
    */
   const loadNodeStatus = async (rpcUrl: string) => {
     const start = performance.now();
-    let latency: number,
-      status: "active" | "inactive" = "inactive",
-      nodeStatus: NodeStatus | null = null;
+    let status: "active" | "inactive" = "inactive";
+    let nodeStatus: NodeStatus | null = null;
 
     try {
       const response = await axios.get(`${rpcUrl}/status`, { timeout: 10000 });
@@ -169,17 +168,16 @@ export const SettingsProvider: FC<{ children: ReactNode }> = ({ children }) => {
       status = "active";
     } catch (error) {
       status = "inactive";
-    } finally {
-      const end = performance.now();
-      latency = end - start;
-
-      // eslint-disable-next-line no-unsafe-finally
-      return {
-        latency,
-        status,
-        nodeInfo: nodeStatus
-      };
     }
+
+    const end = performance.now();
+    const latency = end - start;
+
+    return {
+      latency,
+      status,
+      nodeInfo: nodeStatus
+    };
   };
 
   /**

--- a/apps/deploy-web/src/lib/XTerm/XTerm.tsx
+++ b/apps/deploy-web/src/lib/XTerm/XTerm.tsx
@@ -1,4 +1,6 @@
 "use client";
+import "xterm/css/xterm.css";
+
 import { Ref, useEffect, useRef } from "react";
 import React from "react";
 import { useTheme } from "next-themes";
@@ -7,8 +9,6 @@ import { FitAddon } from "xterm-addon-fit";
 
 import { copyTextToClipboard } from "@src/utils/copyClipboard";
 import { cn } from "@src/utils/styleUtils";
-
-import "xterm/css/xterm.css";
 
 export interface IProps {
   /**

--- a/apps/deploy-web/src/pages/_app.tsx
+++ b/apps/deploy-web/src/pages/_app.tsx
@@ -1,3 +1,8 @@
+import "nprogress/nprogress.css"; //styles of nprogress
+import "@akashnetwork/ui/styles";
+import "../styles/index.css";
+import "@leapwallet/elements/styles.css";
+
 import React from "react";
 import { QueryClientProvider } from "react-query";
 import { TooltipProvider } from "@akashnetwork/ui/components";

--- a/apps/indexer/src/providers/statusEndpointHandlers/rest.ts
+++ b/apps/indexer/src/providers/statusEndpointHandlers/rest.ts
@@ -27,17 +27,21 @@ export async function fetchProviderStatusFromREST(provider: Provider, timeout: n
       activeCPU: activeResources.cpu,
       activeGPU: activeResources.gpu,
       activeMemory: activeResources.memory,
-      activeStorage: activeResources.storage,
+      activeEphemeralStorage: activeResources.storage,
+      activePersistentStorage: null,
       pendingCPU: pendingResources.cpu,
       pendingGPU: pendingResources.gpu,
       pendingMemory: pendingResources.memory,
-      pendingStorage: pendingResources.storage,
+      pendingEphemeralStorage: pendingResources.storage,
+      pendingPersistentStorage: null,
       availableCPU: availableResources.cpu,
       availableGPU: availableResources.gpu,
       availableMemory: availableResources.memory,
-      availableStorage: availableResources.storage
+      availableEphemeralStorage: availableResources.storage,
+      availablePersistentStorage: null
     },
-    nodes: []
+    nodes: [],
+    storage: []
   };
 }
 

--- a/apps/indexer/src/providers/statusEndpointHandlers/types.ts
+++ b/apps/indexer/src/providers/statusEndpointHandlers/types.ts
@@ -5,17 +5,24 @@ export type ProviderStatusInfo = {
     activeCPU: number;
     activeGPU: number;
     activeMemory: number;
-    activeStorage: number;
+    activeEphemeralStorage: number;
+    activePersistentStorage: number;
     pendingCPU: number;
     pendingGPU: number;
     pendingMemory: number;
-    pendingStorage: number;
+    pendingPersistentStorage: number;
+    pendingEphemeralStorage: number;
     availableCPU: number;
     availableGPU: number;
     availableMemory: number;
-    availableStorage: number;
+    availablePersistentStorage: number;
+    availableEphemeralStorage: number;
   };
-
+  storage: {
+    class: string;
+    allocatable: number;
+    allocated: number;
+  }[];
   nodes: {
     name: string;
     cpuAllocatable: number;

--- a/packages/database/chainDefinitions.ts
+++ b/packages/database/chainDefinitions.ts
@@ -15,7 +15,8 @@ import {
   ProviderSnapshot,
   ProviderSnapshotNode,
   ProviderSnapshotNodeCPU,
-  ProviderSnapshotNodeGPU
+  ProviderSnapshotNodeGPU,
+  ProviderSnapshotStorage
 } from "./dbSchemas/akash";
 import { Block, Message } from "./dbSchemas/base";
 dotenv.config({ path: ".env.local" });
@@ -79,7 +80,8 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
       ProviderSnapshot,
       ProviderSnapshotNode,
       ProviderSnapshotNodeCPU,
-      ProviderSnapshotNodeGPU
+      ProviderSnapshotNodeGPU,
+      ProviderSnapshotStorage
     ]
   },
   akashTestnet: {
@@ -111,7 +113,8 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
       ProviderSnapshot,
       ProviderSnapshotNode,
       ProviderSnapshotNodeCPU,
-      ProviderSnapshotNodeGPU
+      ProviderSnapshotNodeGPU,
+      ProviderSnapshotStorage
     ]
   },
   akashSandbox: {
@@ -143,7 +146,8 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
       ProviderSnapshot,
       ProviderSnapshotNode,
       ProviderSnapshotNodeCPU,
-      ProviderSnapshotNodeGPU
+      ProviderSnapshotNodeGPU,
+      ProviderSnapshotStorage
     ]
   },
   passage: {

--- a/packages/database/dbSchemas/akash/index.ts
+++ b/packages/database/dbSchemas/akash/index.ts
@@ -5,6 +5,7 @@ export { ProviderSnapshot } from "./providerSnapshot";
 export { ProviderSnapshotNode } from "./providerSnapshotNode";
 export { ProviderSnapshotNodeCPU } from "./providerSnapshotNodeCPU";
 export { ProviderSnapshotNodeGPU } from "./providerSnapshotNodeGPU";
+export { ProviderSnapshotStorage } from "./providerSnapshotStorage";
 export { ProviderAttribute } from "./providerAttribute";
 export { ProviderAttributeSignature } from "./providerAttributeSignature";
 export { Lease } from "./lease";

--- a/packages/database/dbSchemas/akash/provider.ts
+++ b/packages/database/dbSchemas/akash/provider.ts
@@ -30,8 +30,6 @@ export class Provider extends Model {
   @Required @Default(DataTypes.NOW) @Column nextCheckDate: Date;
   @Required @Default(0) @Column failedCheckCount: number;
   @Column(DataTypes.TEXT) error?: string;
-  @Column deploymentCount?: number;
-  @Column leaseCount?: number;
   @Column ip?: string;
   @Column ipRegion?: string;
   @Column ipRegionCode?: string;
@@ -39,18 +37,6 @@ export class Provider extends Model {
   @Column ipCountryCode?: string;
   @Column ipLat?: string;
   @Column ipLon?: string;
-  @Column(DataTypes.BIGINT) activeCPU?: number;
-  @Column(DataTypes.BIGINT) activeGPU?: number;
-  @Column(DataTypes.BIGINT) activeMemory?: number;
-  @Column(DataTypes.BIGINT) activeStorage?: number;
-  @Column(DataTypes.BIGINT) pendingCPU?: number;
-  @Column(DataTypes.BIGINT) pendingGPU?: number;
-  @Column(DataTypes.BIGINT) pendingMemory?: number;
-  @Column(DataTypes.BIGINT) pendingStorage?: number;
-  @Column(DataTypes.BIGINT) availableCPU?: number;
-  @Column(DataTypes.BIGINT) availableGPU?: number;
-  @Column(DataTypes.BIGINT) availableMemory?: number;
-  @Column(DataTypes.BIGINT) availableStorage?: number;
 
   @Column(DataTypes.DOUBLE) uptime1d?: number;
   @Column(DataTypes.DOUBLE) uptime7d?: number;

--- a/packages/database/dbSchemas/akash/providerSnapshot.ts
+++ b/packages/database/dbSchemas/akash/providerSnapshot.ts
@@ -3,6 +3,7 @@ import { Column, Default, HasMany, Model, PrimaryKey, Table } from "sequelize-ty
 
 import { Required } from "../decorators/requiredDecorator";
 import { ProviderSnapshotNode } from "./providerSnapshotNode";
+import { ProviderSnapshotStorage } from "./providerSnapshotStorage";
 
 @Table({
   modelName: "providerSnapshot",
@@ -28,15 +29,19 @@ export class ProviderSnapshot extends Model {
   @Column(DataTypes.BIGINT) activeCPU?: number;
   @Column(DataTypes.BIGINT) activeGPU?: number;
   @Column(DataTypes.BIGINT) activeMemory?: number;
-  @Column(DataTypes.BIGINT) activeStorage?: number;
+  @Column(DataTypes.BIGINT) activeEphemeralStorage?: number;
+  @Column(DataTypes.BIGINT) activePersistentStorage?: number;
   @Column(DataTypes.BIGINT) pendingCPU?: number;
   @Column(DataTypes.BIGINT) pendingGPU?: number;
   @Column(DataTypes.BIGINT) pendingMemory?: number;
-  @Column(DataTypes.BIGINT) pendingStorage?: number;
+  @Column(DataTypes.BIGINT) pendingEphemeralStorage?: number;
+  @Column(DataTypes.BIGINT) pendingPersistentStorage?: number;
   @Column(DataTypes.BIGINT) availableCPU?: number;
   @Column(DataTypes.BIGINT) availableGPU?: number;
   @Column(DataTypes.BIGINT) availableMemory?: number;
-  @Column(DataTypes.BIGINT) availableStorage?: number;
+  @Column(DataTypes.BIGINT) availableEphemeralStorage?: number;
+  @Column(DataTypes.BIGINT) availablePersistentStorage?: number;
 
   @HasMany(() => ProviderSnapshotNode, "snapshotId") nodes: ProviderSnapshotNode[];
+  @HasMany(() => ProviderSnapshotStorage, "snapshotId") storage: ProviderSnapshotStorage[];
 }

--- a/packages/database/dbSchemas/akash/providerSnapshotStorage.ts
+++ b/packages/database/dbSchemas/akash/providerSnapshotStorage.ts
@@ -1,0 +1,17 @@
+import { DataTypes } from "sequelize";
+import { Column, Default, Model, PrimaryKey, Table } from "sequelize-typescript";
+
+import { Required } from "../decorators/requiredDecorator";
+
+@Table({
+  modelName: "providerSnapshotStorage",
+  indexes: [{ unique: false, fields: ["snapshotId"] }]
+})
+export class ProviderSnapshotStorage extends Model {
+  @Required @PrimaryKey @Default(DataTypes.UUIDV4) @Column(DataTypes.UUID) id: string;
+  @Required @Column(DataTypes.UUID) snapshotId: string;
+
+  @Required @Column class: string;
+  @Required @Column(DataTypes.BIGINT) allocatable: number;
+  @Required @Column(DataTypes.BIGINT) allocated: number;
+}


### PR DESCRIPTION
## Track provider persistent storage
- Store persistent storage information in the new `ProviderSnapshotStorage` table
- Added columns for persistent storage to `ProviderSnapshot` and renamed the old ones to ephemeral.
- Removed all stats columns from the `Provider` table. We recently added `lastSnapshotId` & `lastSuccessfulSnapshotId` on the `Provider` table and it is easy to get the stats from there.

⚠️ I did not implement persistent storage tracking for the REST status endpoint since almost all active providers have already migrated to GRPC. 