### PR TITLE
Decrease retry intervals for provider uptime checks

### DIFF
--- a/packages/database/dbSchemas/akash/provider.ts
+++ b/packages/database/dbSchemas/akash/provider.ts
@@ -5,6 +5,7 @@ import { Required } from "../decorators/requiredDecorator";
 import { ProviderAttribute } from "./providerAttribute";
 import { ProviderAttributeSignature } from "./providerAttributeSignature";
 import { ProviderSnapshot } from "./providerSnapshot";
+import { AkashBlock } from "./akashBlock";
 
 @Table({
   modelName: "provider",
@@ -45,6 +46,7 @@ export class Provider extends Model {
   @HasMany(() => ProviderAttribute, "provider") providerAttributes: ProviderAttribute[];
   @HasMany(() => ProviderAttributeSignature, "provider") providerAttributeSignatures: ProviderAttributeSignature[];
   @HasMany(() => ProviderSnapshot, "owner") providerSnapshots: ProviderSnapshot[];
+  @BelongsTo(() => AkashBlock, "createdHeight") createdBlock: AkashBlock;
   @BelongsTo(() => ProviderSnapshot, "lastSnapshotId") lastSnapshot: ProviderSnapshot;
   @BelongsTo(() => ProviderSnapshot, "lastSuccessfulSnapshotId") lastSuccessfulSnapshot: ProviderSnapshot;
   @BelongsTo(() => ProviderSnapshot, "downtimeFirstSnapshotId") downtimeFirstSnapshot: ProviderSnapshot;


### PR DESCRIPTION
## Decrease retry intervals for provider uptime checks (#286)

This PR adjust the retry intervals to be more frequent when a provider goes offline. The goal is to detect earlier when a provider comes back online. The retry frequency is also capped to 5 min for new providers (< 7d) to give them more time to finish setting up their provider before the interval starts to increase.

### New Retry Intervals
| Downtime Duration | Retry Frequency
| - | - | 
| < 30m | 1m |
| 30m - 6h | 5m* |
| 6h - 24h | 15m |
| 24h - 7d | 30m |
| 7d - 30d | 1h |
| 30d+ | 24h |

_* 5min is the max retry interval for new providers (< 7d)_

### Old Retry Intervals (for comparison)
| Downtime Duration | Retry Frequency
| - | - | 
| < 15m | 1m |
| 15m - 1h | 5m |
| 1h - 6h | 15m |
| 6h - 24h | 30m |
| 24h - 7d | 1h |
| 7d+ | 24h |