### PR TITLE
fix(indexer): fix indexer bugs affecting zombie leases calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The database schemas is defined using [sequelize-typescript](https://github.com/
 |indexInBlock|integer
 |isProcessed|boolean|`false` when inserted into the database and then set to `true` once the indexers have processed the message.
 |isNotificationProcessed|boolean|`false` when inserted into the database and then set to true once it has been checked for existing alerts. (BlockSpy specific)
-|amount|bigint|Amount of the transfer if token were transferred. ex: `MsgSend` or `MsgDelegate`
+|amount|decimal|Amount of the transfer if token were transferred. ex: `MsgSend` or `MsgDelegate`
 |data|bytes|Protobuf encoded data of the message
 |relatedDeploymentId|uuid|If the message is deployment related (ex: `MsgCloseLease`) this will be set to the related deployment. See [Deployment](#deployment)
 
@@ -313,7 +313,7 @@ Created for each days (UTC based), simplifies querying for daily stats.
 |providerAddress|varchar
 |createdHeight|integer|Height of the lease creation. Happens when a bid is accepted with `MsgCreateLease`.
 |closedHeight|integer|Height at which the lease is closed on-chain. Happens from `MsgCloseLease`, `MsgCloseHeight` or if the deployment become overdrawn during an account settlement. 
-|predictedClosedHeight|bigint|Height at which the lease should theoretically expire. This is calculated based on the balance and price. It will usually not match the `closedHeight` since leases can be closed early (`MsgCloseLease` & `MsgCloseBid`) or closed late since the closing wont happen until the provider does a `MsgWithdrawLease`
+|predictedClosedHeight|decimal|Height at which the lease should theoretically expire. This is calculated based on the balance and price. It will usually not match the `closedHeight` since leases can be closed early (`MsgCloseLease` & `MsgCloseBid`) or closed late since the closing wont happen until the provider does a `MsgWithdrawLease`
 |price|double|Lease price as uakt/block
 |withdrawnAmount|double|Withdrawn amount as of now for this lease. Updated on account settlement (create,withdraw,close).
 |cpuUnits|integer|Thousandth of CPU

--- a/apps/api/src/routes/v1/addresses/transactions.ts
+++ b/apps/api/src/routes/v1/addresses/transactions.ts
@@ -44,7 +44,7 @@ const route = createRoute({
                 error: z.string().nullable(),
                 gasUsed: z.number(),
                 gasWanted: z.number(),
-                fee: z.number(), // TODO CHECK
+                fee: z.number(),
                 memo: z.string().nullable(),
                 isSigner: z.boolean(),
                 messages: z.array(

--- a/apps/api/src/services/db/blocksService.ts
+++ b/apps/api/src/services/db/blocksService.ts
@@ -67,7 +67,7 @@ export async function getBlock(height: number) {
       hash: tx.hash,
       isSuccess: !tx.hasProcessingError,
       error: tx.hasProcessingError ? tx.log : null,
-      fee: tx.fee,
+      fee: parseInt(tx.fee),
       datetime: block.datetime,
       messages: tx.messages.map(message => ({
         id: message.id,

--- a/apps/api/src/services/db/blocksService.ts
+++ b/apps/api/src/services/db/blocksService.ts
@@ -72,7 +72,7 @@ export async function getBlock(height: number) {
       messages: tx.messages.map(message => ({
         id: message.id,
         type: message.type,
-        amount: message.amount
+        amount: parseInt(message.amount)
       }))
     }))
   };

--- a/apps/api/src/services/db/transactionsService.ts
+++ b/apps/api/src/services/db/transactionsService.ts
@@ -38,7 +38,7 @@ export async function getTransactions(limit: number) {
     messages: tx.messages.map(msg => ({
       id: msg.id,
       type: msg.type,
-      amount: msg.amount
+      amount: parseInt(msg.amount)
     }))
   }));
 }

--- a/apps/api/src/services/db/transactionsService.ts
+++ b/apps/api/src/services/db/transactionsService.ts
@@ -33,7 +33,7 @@ export async function getTransactions(limit: number) {
     error: tx.hasProcessingError ? tx.log : null,
     gasUsed: tx.gasUsed,
     gasWanted: tx.gasWanted,
-    fee: tx.fee,
+    fee: parseInt(tx.fee),
     memo: tx.memo,
     messages: tx.messages.map(msg => ({
       id: msg.id,
@@ -84,7 +84,7 @@ export async function getTransaction(hash: string): Promise<ApiTransactionRespon
     error: tx.hasProcessingError ? tx.log : null,
     gasUsed: tx.gasUsed,
     gasWanted: tx.gasWanted,
-    fee: tx.fee,
+    fee: parseInt(tx.fee),
     memo: tx.memo,
     messages: messages.map(msg => ({
       id: msg.id,
@@ -138,7 +138,7 @@ export async function getTransactionByAddress(address: string, skip: number, lim
       error: tx.hasProcessingError ? tx.log : null,
       gasUsed: tx.gasUsed,
       gasWanted: tx.gasWanted,
-      fee: tx.fee,
+      fee: parseInt(tx.fee),
       memo: tx.memo,
       isSigner: tx.addressReferences.some(ar => ar.type === "Signer"),
       messages: tx.messages.map(msg => ({

--- a/apps/indexer/UPGRADE.md
+++ b/apps/indexer/UPGRADE.md
@@ -264,3 +264,44 @@ FROM "created_msg" cm
 LEFT JOIN "update_msg" um ON um."address"=cm."address"
 WHERE cm."address"=p."owner";
 ```
+
+## v1.4.1
+
+Add columns on the provider to keep track track of uptime ([PR #20](https://github.com/akash-network/console/pull/20))
+
+```
+ALTER TABLE public.provider ADD COLUMN "uptime1d" double precision DEFAULT 0;
+ALTER TABLE public.provider ADD COLUMN "uptime7d" double precision DEFAULT 0;
+ALTER TABLE public.provider ADD COLUMN "uptime30d" double precision DEFAULT 0;
+```
+
+
+## v1.4.0
+
+Add columns to keep track of USD spending overtime ([PR #16](https://github.com/akash-network/console/pull/16))
+
+```
+ALTER TABLE IF EXISTS public.day
+    ADD COLUMN "aktPriceChanged" boolean NOT NULL DEFAULT true;
+ALTER TABLE IF EXISTS public.block
+    ADD COLUMN "totalUUsdSpent" double precision;
+    
+CREATE INDEX IF NOT EXISTS block_totaluusdspent_is_null
+    ON public.block USING btree
+    (height ASC NULLS LAST)
+    TABLESPACE pg_default
+    WHERE "totalUUsdSpent" IS NULL;
+```
+
+## v1.3.0
+
+Add columns to support multi-denom deployments ([PR #5](https://github.com/akash-network/console/pull/5))
+
+```
+ALTER TABLE public.block ADD COLUMN "totalUUsdcSpent" double precision DEFAULT 0;
+ALTER TABLE public.block ALTER COLUMN "totalUUsdcSpent" DROP DEFAULT;
+ALTER TABLE public.deployment ADD COLUMN denom character varying(255) DEFAULT 'uakt' COLLATE pg_catalog."default" NOT NULL;
+ALTER TABLE public.deployment ALTER COLUMN denom DROP DEFAULT;
+ALTER TABLE public.lease ADD COLUMN denom character varying(255) DEFAULT 'uakt' COLLATE pg_catalog."default" NOT NULL;
+ALTER TABLE public.lease ALTER COLUMN denom DROP DEFAULT;
+```

--- a/apps/indexer/UPGRADE.md
+++ b/apps/indexer/UPGRADE.md
@@ -295,7 +295,7 @@ CREATE INDEX IF NOT EXISTS block_totaluusdspent_is_null
 
 ## v1.3.0
 
-Add columns to support multi-denom deployments ([PR #5](https://github.com/akash-network/console/pull/5))
+Add columns to support multi-denom deployments ([PR #5](https://github.com/akash-network/console/pull/5)) and change fee type to numeric ([PR #40 in old repo](https://github.com/maxmaxlabs/cloudmos-mono/pull/40))
 
 ```
 ALTER TABLE public.block ADD COLUMN "totalUUsdcSpent" double precision DEFAULT 0;
@@ -304,4 +304,7 @@ ALTER TABLE public.deployment ADD COLUMN denom character varying(255) DEFAULT 'u
 ALTER TABLE public.deployment ALTER COLUMN denom DROP DEFAULT;
 ALTER TABLE public.lease ADD COLUMN denom character varying(255) DEFAULT 'uakt' COLLATE pg_catalog."default" NOT NULL;
 ALTER TABLE public.lease ALTER COLUMN denom DROP DEFAULT;
+
+ALTER TABLE IF EXISTS public.transaction
+    ALTER COLUMN "fee" TYPE numeric(30,0);
 ```

--- a/apps/indexer/src/chain/chainSync.ts
+++ b/apps/indexer/src/chain/chainSync.ts
@@ -219,7 +219,7 @@ async function insertBlocks(startHeight: number, endHeight: number) {
         height: i,
         msgCount: msgs.length,
         index: txIndex,
-        fee: decodedTx.authInfo.fee.amount.length > 0 ? parseInt(decodedTx.authInfo.fee.amount[0].amount) : 0,
+        fee: decodedTx.authInfo.fee.amount.length > 0 ? decodedTx.authInfo.fee.amount[0].amount : "0",
         memo: decodedTx.body.memo,
         hasProcessingError: !!txJson.code,
         log: txJson.code ? txJson.log : null,

--- a/apps/indexer/src/indexers/akashStatsIndexer.ts
+++ b/apps/indexer/src/indexers/akashStatsIndexer.ts
@@ -116,7 +116,8 @@ export class AkashStatsIndexer extends Indexer {
       "/akash.market.v1beta4.MsgCreateLease": this.handleCreateLease,
       "/akash.market.v1beta4.MsgCloseLease": this.handleCloseLease,
       "/akash.market.v1beta4.MsgCreateBid": this.handleCreateBidV4,
-      "/akash.market.v1beta4.MsgCloseBid": this.handleCloseBid
+      "/akash.market.v1beta4.MsgCloseBid": this.handleCloseBid,
+      "/akash.market.v1beta4.MsgWithdrawLease": this.handleWithdrawLease
     };
   }
 
@@ -554,7 +555,10 @@ export class AkashStatsIndexer extends Indexer {
       { transaction: blockGroupTransaction }
     );
 
-    await Lease.update({ predictedClosedHeight: predictedClosedHeight.toString() }, { where: { deploymentId: deploymentId }, transaction: blockGroupTransaction });
+    await Lease.update(
+      { predictedClosedHeight: predictedClosedHeight.toString() },
+      { where: { deploymentId: deploymentId }, transaction: blockGroupTransaction }
+    );
 
     msg.relatedDeploymentId = deploymentId;
 
@@ -599,7 +603,10 @@ export class AkashStatsIndexer extends Indexer {
       await deployment.save({ transaction: blockGroupTransaction });
     } else {
       const predictedClosedHeight = Math.ceil((deployment.lastWithdrawHeight || lease.createdHeight) + deployment.balance / (blockRate - lease.price));
-      await Lease.update({ predictedClosedHeight: predictedClosedHeight.toString() }, { where: { deploymentId: deployment.id }, transaction: blockGroupTransaction });
+      await Lease.update(
+        { predictedClosedHeight: predictedClosedHeight.toString() },
+        { where: { deploymentId: deployment.id }, transaction: blockGroupTransaction }
+      );
     }
   }
 
@@ -708,7 +715,10 @@ export class AkashStatsIndexer extends Indexer {
         await deployment.save({ transaction: blockGroupTransaction });
       } else {
         const predictedClosedHeight = Math.ceil((deployment.lastWithdrawHeight || lease.createdHeight) + deployment.balance / (blockRate - lease.price));
-        await Lease.update({ predictedClosedHeight: predictedClosedHeight.toString() }, { where: { deploymentId: deployment.id }, transaction: blockGroupTransaction });
+        await Lease.update(
+          { predictedClosedHeight: predictedClosedHeight.toString() },
+          { where: { deploymentId: deployment.id }, transaction: blockGroupTransaction }
+        );
       }
     }
 
@@ -768,7 +778,7 @@ export class AkashStatsIndexer extends Indexer {
   }
 
   private async handleWithdrawLease(
-    decodedMessage: v1beta1.MsgWithdrawLease | v1beta2.MsgWithdrawLease | v1beta3.MsgWithdrawLease,
+    decodedMessage: v1beta1.MsgWithdrawLease | v1beta2.MsgWithdrawLease | v1beta3.MsgWithdrawLease | v1beta4.MsgWithdrawLease,
     height: number,
     blockGroupTransaction: DbTransaction,
     msg: Message

--- a/apps/indexer/src/indexers/akashStatsIndexer.ts
+++ b/apps/indexer/src/indexers/akashStatsIndexer.ts
@@ -206,7 +206,7 @@ export class AkashStatsIndexer extends Indexer {
       transaction: blockGroupTransaction
     });
 
-    return leases.map(x => x.predictedClosedHeight);
+    return leases.map(x => parseInt(x.predictedClosedHeight));
   }
 
   @benchmark.measureMethodAsync
@@ -540,7 +540,7 @@ export class AkashStatsIndexer extends Indexer {
         gseq: decodedMessage.bidId.gseq,
         providerAddress: decodedMessage.bidId.provider,
         createdHeight: height,
-        predictedClosedHeight: predictedClosedHeight,
+        predictedClosedHeight: predictedClosedHeight.toString(),
         price: bid.price,
         denom: deployment.denom,
 
@@ -554,7 +554,7 @@ export class AkashStatsIndexer extends Indexer {
       { transaction: blockGroupTransaction }
     );
 
-    await Lease.update({ predictedClosedHeight: predictedClosedHeight }, { where: { deploymentId: deploymentId }, transaction: blockGroupTransaction });
+    await Lease.update({ predictedClosedHeight: predictedClosedHeight.toString() }, { where: { deploymentId: deploymentId }, transaction: blockGroupTransaction });
 
     msg.relatedDeploymentId = deploymentId;
 
@@ -599,7 +599,7 @@ export class AkashStatsIndexer extends Indexer {
       await deployment.save({ transaction: blockGroupTransaction });
     } else {
       const predictedClosedHeight = Math.ceil((deployment.lastWithdrawHeight || lease.createdHeight) + deployment.balance / (blockRate - lease.price));
-      await Lease.update({ predictedClosedHeight: predictedClosedHeight }, { where: { deploymentId: deployment.id }, transaction: blockGroupTransaction });
+      await Lease.update({ predictedClosedHeight: predictedClosedHeight.toString() }, { where: { deploymentId: deployment.id }, transaction: blockGroupTransaction });
     }
   }
 
@@ -708,7 +708,7 @@ export class AkashStatsIndexer extends Indexer {
         await deployment.save({ transaction: blockGroupTransaction });
       } else {
         const predictedClosedHeight = Math.ceil((deployment.lastWithdrawHeight || lease.createdHeight) + deployment.balance / (blockRate - lease.price));
-        await Lease.update({ predictedClosedHeight: predictedClosedHeight }, { where: { deploymentId: deployment.id }, transaction: blockGroupTransaction });
+        await Lease.update({ predictedClosedHeight: predictedClosedHeight.toString() }, { where: { deploymentId: deployment.id }, transaction: blockGroupTransaction });
       }
     }
 
@@ -760,7 +760,7 @@ export class AkashStatsIndexer extends Indexer {
       .reduce((a, b) => a + b, 0);
 
     for (const lease of deployment.leases.filter(x => !x.closedHeight)) {
-      lease.predictedClosedHeight = Math.ceil((deployment.lastWithdrawHeight || lease.createdHeight) + deployment.balance / blockRate);
+      lease.predictedClosedHeight = Math.ceil((deployment.lastWithdrawHeight || lease.createdHeight) + deployment.balance / blockRate).toString();
       await lease.save({ transaction: blockGroupTransaction });
     }
 

--- a/apps/indexer/src/shared/utils/coin.ts
+++ b/apps/indexer/src/shared/utils/coin.ts
@@ -1,14 +1,14 @@
 import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
 
-export function getAmountFromCoinArray(coins: Coin[], denom: string): number {
+export function getAmountFromCoinArray(coins: Coin[], denom: string): string {
   const coin = coins.find(coin => coin.denom === denom);
-  return coin ? parseInt(coin.amount) : 0;
+  return coin ? coin.amount : "0";
 }
 
-export function getAmountFromCoin(coin: Coin, denom?: string): number {
+export function getAmountFromCoin(coin: Coin, denom?: string): string {
   if (denom && coin.denom !== denom) {
-    return 0;
+    return "0";
   }
 
-  return parseInt(coin.amount);
+  return coin.amount;
 }

--- a/packages/database/dbSchemas/akash/lease.ts
+++ b/packages/database/dbSchemas/akash/lease.ts
@@ -27,7 +27,7 @@ export class Lease extends Model {
   @Required @Column providerAddress: string;
   @Required @Column createdHeight: number;
   @Column closedHeight?: number;
-  @Required @Column(DataTypes.DECIMAL(30, 0)) predictedClosedHeight: number;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) predictedClosedHeight: string;
   @Required @Column(DataTypes.DOUBLE) price: number;
   @Required @Default(0) @Column(DataTypes.DOUBLE) withdrawnAmount: number;
   @Required @Column denom: string;

--- a/packages/database/dbSchemas/base/message.ts
+++ b/packages/database/dbSchemas/base/message.ts
@@ -29,7 +29,7 @@ export class Message extends Model {
   @Required @Column indexInBlock: number;
   @Required @Default(false) @Column isProcessed: boolean;
   @Required @Default(false) @Column isNotificationProcessed: boolean;
-  @Column(DataTypes.DECIMAL(30, 0)) amount?: number;
+  @Column(DataTypes.DECIMAL(30, 0)) amount?: string;
   @Required @Column(DataTypes.BLOB) data: Uint8Array;
 
   @BelongsTo(() => Transaction, "txId") transaction: Transaction;

--- a/packages/database/dbSchemas/base/transaction.ts
+++ b/packages/database/dbSchemas/base/transaction.ts
@@ -24,7 +24,7 @@ export class Transaction extends Model {
   @Column multisigThreshold?: number;
   @Required @Column gasUsed: number;
   @Required @Column gasWanted: number;
-  @Required @Column(DataTypes.DECIMAL(30, 0)) fee: number;
+  @Required @Column(DataTypes.DECIMAL(30, 0)) fee: string;
   @Required @Column(DataTypes.TEXT) memo: string;
   @Required @Default(false) @Column isProcessed: boolean;
   @Required @Default(false) @Column hasProcessingError: boolean;


### PR DESCRIPTION
## Bug 1 : Wrong type for decimal columns
Three columns were recently changed from `bigint` type to `decimal`. Those changes were applied to the database, but the typings were not updated accordingly. Sequelize handle `decimal` columns as string which caused some undetected issues in the indexer.
- #215 
- #276 
- https://github.com/maxmaxlabs/cloudmos-mono/pull/40

This PR sets the correct type (`string`) and adjust the code accordingly to restore the expected behavior. Calculations are still done using js `numbers` which could cause issues due to floating point inaccuracy. The [BigInt](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/BigInt) type could be used in the future to improve that.

## Bug 2 : Missing v1beta4 handler for MsgWithdrawLease
There was a missing handler for the v1beta4 version of MsgWithdrawLease. This means MsgWithdrawLease messages have not been processed since Nov 20, 2023. This resulted in the leases `predictedClosedHeight` being incorrectly updated. This PR adds the missing handler.

## Impact & Resolution
Those 2 bugs affected the calculations of leased resources and spent amount when zombie leases occurs. However, since zombie leases issues are mostly mitigated now, **the effect it had on reported stats is minimal (<0.001%)**. The fixes will be released shortly to prevent any more impact.
