### PR TITLE
fix(api): improve template link detection

### DIFF
--- a/apps/api/src/services/external/templateReposService.ts
+++ b/apps/api/src/services/external/templateReposService.ts
@@ -545,17 +545,20 @@ function getLinuxServerTemplateSummary(readme: string) {
 // Replaces local links with absolute links
 function replaceLinks(markdown: string, owner: string, repo: string, version: string, folder: string) {
   let newMarkdown = markdown;
-  const linkRegex = /!?\[([^[]+)\]\((.*?)\)/gm;
+  const linkRegex = /!?\[([^[]*)\]\((.*?)\)/gm;
   const matches = newMarkdown.matchAll(linkRegex);
   for (const match of matches) {
-    const url = match[2].startsWith("/") ? match[2].substring(1) : match[2];
+    const originalUrl = match[2];
+    const url = originalUrl.replace(/^\.?\//, "");
+
     if (isUrlAbsolute(url)) continue;
+
     const isPicture = match[0].startsWith("!");
     const absoluteUrl = isPicture
       ? `https://raw.githubusercontent.com/${owner}/${repo}/${version}/${folder}/` + url
       : `https://github.com/${owner}/${repo}/blob/${version}/${folder}/` + url;
 
-    newMarkdown = newMarkdown.split("(" + url + ")").join("(" + absoluteUrl + ")");
+    newMarkdown = newMarkdown.split("(" + originalUrl + ")").join("(" + absoluteUrl + ")");
   }
 
   return newMarkdown;

--- a/apps/deploy-web/src/pages/templates/[templateId]/index.tsx
+++ b/apps/deploy-web/src/pages/templates/[templateId]/index.tsx
@@ -24,6 +24,12 @@ export async function getServerSideProps({ params }) {
   const templates = categories.flatMap(x => x.templates);
   const template = templates.find(x => x.id === params?.templateId);
 
+  if (!template) {
+    return {
+      notFound: true
+    };
+  }
+
   return {
     props: {
       templateId: params?.templateId,


### PR DESCRIPTION
- Link detection was not working for images without description (ex: `![](./packetstream.png)`). This caused some templates to have missing relative images.
- Improved relative url cleanup. This didn't cause issues, but some urls kept an unecessary `.` in the url. Ex: `https://github.com/[...]/invoke-ai-cpu/./docker`
- Return status code 404 when a template is not found (instead of 500)