### PR TITLE
feat(billing): handle tx errors

### DIFF
--- a/apps/api/src/billing/routes/sign-and-broadcast-tx/sign-and-broadcast-tx.router.ts
+++ b/apps/api/src/billing/routes/sign-and-broadcast-tx/sign-and-broadcast-tx.router.ts
@@ -11,7 +11,13 @@ export const SignTxRequestInputSchema = z.object({
     messages: z
       .array(
         z.object({
-          typeUrl: z.string(),
+          typeUrl: z.enum([
+            "/akash.deployment.v1beta3.MsgCreateDeployment",
+            "/akash.cert.v1beta3.MsgCreateCertificate",
+            "/akash.market.v1beta4.MsgCreateLease",
+            "/akash.deployment.v1beta3.MsgUpdateDeployment",
+            "/akash.deployment.v1beta3.MsgCloseDeployment"
+          ]),
           value: z.string()
         })
       )

--- a/apps/api/src/billing/services/chain-error/chain-error.service.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.ts
@@ -1,0 +1,49 @@
+import type { EncodeObject } from "@cosmjs/proto-signing";
+import createError from "http-errors";
+import { singleton } from "tsyringe";
+
+@singleton()
+export class ChainErrorService {
+  private readonly ERRORS = {
+    "insufficient funds": {
+      code: 400,
+      message: "Insufficient funds"
+    }
+  };
+
+  private MESSAGE_ERROR_TITLES: Record<string, string> = {
+    "/akash.deployment.v1beta3.MsgCreateDeployment": "Failed to create deployment"
+  };
+
+  public toAppError(error: Error, messages: readonly EncodeObject[]) {
+    const clues = Object.keys(this.ERRORS) as (keyof typeof this.ERRORS)[];
+
+    const clue = clues.find(clue => error.message.includes(clue));
+
+    if (!clue) {
+      return error;
+    }
+
+    const messagePrefix = this.getMessagePrefix(error, messages);
+    const { message, code } = this.ERRORS[clue];
+    const prefixedMessage = messagePrefix ? `${messagePrefix}: ${message}` : message;
+
+    return createError(code, prefixedMessage, { originalError: error });
+  }
+
+  private getMessagePrefix(error: Error, messages: readonly EncodeObject[]) {
+    const messageIndexStr = error.message.match(/message index: (\d+)/)?.[1];
+    if (!messageIndexStr) {
+      return "";
+    }
+
+    const messageIndex = parseInt(messageIndexStr);
+    const messageType = messages[messageIndex]?.typeUrl;
+
+    if (!messageType) {
+      return "";
+    }
+
+    return messageType in this.MESSAGE_ERROR_TITLES ? this.MESSAGE_ERROR_TITLES[messageType] : "";
+  }
+}

--- a/apps/api/src/billing/services/tx-signer/tx-signer.service.ts
+++ b/apps/api/src/billing/services/tx-signer/tx-signer.service.ts
@@ -12,6 +12,7 @@ import { InjectTypeRegistry } from "@src/billing/providers/type-registry.provide
 import { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
 import { MasterWalletService } from "@src/billing/services";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { ChainErrorService } from "../chain-error/chain-error.service";
 
 type StringifiedEncodeObject = Omit<EncodeObject, "value"> & { value: string };
 type SimpleSigningStargateClient = {
@@ -30,7 +31,8 @@ export class TxSignerService {
     private readonly userWalletRepository: UserWalletRepository,
     private readonly masterWalletService: MasterWalletService,
     private readonly balancesService: BalancesService,
-    private readonly authService: AuthService
+    private readonly authService: AuthService,
+    private readonly chainErrorService: ChainErrorService
   ) {}
 
   async signAndBroadcast(userId: UserWalletOutput["userId"], messages: StringifiedEncodeObject[]) {
@@ -65,16 +67,19 @@ export class TxSignerService {
       registry: this.registry
     });
     const walletAddress = (await wallet.getAccounts())[0].address;
-    const { GAS_SAFETY_MULTIPLIER } = this.config;
     const granter = await this.masterWalletService.getFirstAddress();
 
     return {
-      async signAndBroadcast(messages: readonly EncodeObject[]) {
-        const gasEstimation = await client.simulate(walletAddress, messages, "managed wallet gas estimation");
-        const estimatedGas = Math.round(gasEstimation * GAS_SAFETY_MULTIPLIER);
-        const fee = calculateFee(estimatedGas, GasPrice.fromString("0.025uakt"));
+      signAndBroadcast: async (messages: readonly EncodeObject[]) => {
+        try {
+          const gasEstimation = await client.simulate(walletAddress, messages, "managed wallet gas estimation");
+          const estimatedGas = Math.round(gasEstimation * this.config.GAS_SAFETY_MULTIPLIER);
+          const fee = calculateFee(estimatedGas, GasPrice.fromString("0.025uakt"));
 
-        return await client.signAndBroadcast(walletAddress, messages, { ...fee, granter }, "managed wallet tx");
+          return await client.signAndBroadcast(walletAddress, messages, { ...fee, granter }, "managed wallet tx");
+        } catch (error) {
+          throw this.chainErrorService.toAppError(error, messages);
+        }
       }
     };
   }

--- a/apps/api/src/core/services/logger/logger.service.ts
+++ b/apps/api/src/core/services/logger/logger.service.ts
@@ -38,8 +38,15 @@ export class LoggerService {
 
   protected toLoggableInput(message: any) {
     if (isHttpError(message)) {
-      return { status: message.status, message: message.message, stack: message.stack, data: message.data };
+      const loggableInput = { status: message.status, message: message.message, stack: message.stack, data: message.data };
+      return "originalError" in message
+        ? {
+            ...loggableInput,
+            originalError: message.stack
+          }
+        : loggableInput;
     }
+
     if (message instanceof Error) {
       return message.stack;
     }

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit.tsx
@@ -267,9 +267,8 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({ editedManifest, s
       } else {
         setIsCreatingDeployment(false);
       }
-    } catch (error) {
+    } finally {
       setIsCreatingDeployment(false);
-      throw error;
     }
   }
 


### PR DESCRIPTION
So far only added 1 error to handle as the range of possible errors we'd want to show to a user with a managed wallet is limited compared to the ones with custodial, but we can add more as we go. 