### PR TITLE
Improve validation and error handling

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -36,7 +36,7 @@
     "@akashnetwork/database": "*",
     "@akashnetwork/http-sdk": "*",
     "@casl/ability": "^6.7.1",
-    "@chain-registry/assets": "^0.7.1",
+    "@chain-registry/assets": "^1.64.79",
     "@cosmjs/amino": "^0.32.4",
     "@cosmjs/crypto": "^0.32.4",
     "@cosmjs/encoding": "^0.32.4",

--- a/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts
+++ b/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts
@@ -39,8 +39,12 @@ export class HonoErrorHandlerService {
   }
 
   private async reportError<E extends Env = any>(error: Error, c: Context<E>): Promise<void> {
-    const id = this.sentry.captureEvent(await this.getSentryEvent(error, c));
-    this.logger.info({ event: "SENTRY_EVENT_REPORTED", id });
+    try {
+      const id = this.sentry.captureEvent(await this.getSentryEvent(error, c));
+      this.logger.info({ event: "SENTRY_EVENT_REPORTED", id });
+    } catch (e) {
+      this.logger.error(e);
+    }
   }
 
   private async getSentryEvent<E extends Env = any>(error: Error, c: Context<E>): Promise<Event> {
@@ -48,7 +52,7 @@ export class HonoErrorHandlerService {
       method: c.req.method,
       url: c.req.url,
       headers: omit(Object.fromEntries(c.req.raw.headers), ["x-anonymous-user-id"]),
-      body: await c.req.json()
+      body: await this.getSentryEventRequestBody(c)
     });
     const currentSpan = trace.getSpan(context.active());
 
@@ -64,5 +68,19 @@ export class HonoErrorHandlerService {
     }
 
     return event;
+  }
+
+  private async getSentryEventRequestBody<E extends Env = any>(c: Context<E>) {
+    switch (c.req.header("content-type")) {
+      case "text/plain":
+        return await c.req.text();
+      case "application/json":
+        return await c.req.json();
+      case "application/x-www-form-urlencoded":
+      case "multipart/form-data":
+        return await c.req.parseBody();
+      default:
+        return undefined;
+    }
   }
 }

--- a/apps/api/src/routes/internal/leasesDuration.ts
+++ b/apps/api/src/routes/internal/leasesDuration.ts
@@ -15,7 +15,7 @@ const route = createRoute({
       owner: z.string().openapi({ example: openApiExampleAddress })
     }),
     query: z.object({
-      dseq: z.string().optional().openapi({ type: "number" }),
+      dseq: z.string().regex(/^\d+$/, "Invalid dseq, must be a positive integer").optional().openapi({ type: "integer" }),
       startDate: z.string().optional().openapi({ format: "YYYY-MM-DD" }),
       endDate: z.string().optional().openapi({ format: "YYYY-MM-DD" })
     })
@@ -61,10 +61,6 @@ export default new OpenAPIHono().openapi(route, async c => {
   let endTime: Date = new Date("2100-01-01");
 
   const { dseq, startDate, endDate } = c.req.query();
-
-  if (dseq && isNaN(parseInt(dseq))) {
-    return c.text("Invalid dseq", 400);
-  }
 
   if (startDate) {
     if (!startDate.match(dateFormat)) return c.text("Invalid start date, must be in the following format: YYYY-MM-DD", 400);

--- a/apps/api/src/routes/v1/deployments/byOwnerDseq.ts
+++ b/apps/api/src/routes/v1/deployments/byOwnerDseq.ts
@@ -15,8 +15,9 @@ const route = createRoute({
         description: "Owner's Address",
         example: openApiExampleAddress
       }),
-      dseq: z.string().optional().openapi({
+      dseq: z.string().regex(/^\d+$/, "Invalid dseq, must be a positive integer").openapi({
         description: "Deployment DSEQ",
+        type: "integer",
         example: "1000000"
       })
     })
@@ -72,10 +73,6 @@ const route = createRoute({
 });
 
 export default new OpenAPIHono().openapi(route, async c => {
-  if (isNaN(parseInt(c.req.valid("param").dseq))) {
-    return c.text("Invalid dseq.", 400);
-  }
-
   if (!isValidBech32Address(c.req.valid("param").owner, "akash")) {
     return c.text("Invalid address", 400);
   }

--- a/apps/api/src/utils/coin.ts
+++ b/apps/api/src/utils/coin.ts
@@ -1,48 +1,55 @@
 import { asset_lists } from "@chain-registry/assets";
-import * as Sentry from "@sentry/node";
 import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
 
+import { LoggerService } from "@src/core";
+
+const logger = new LoggerService({ context: "CoinUtil" });
+
 export function coinToAsset(coin: Coin) {
-  try {
-    if (coin.denom === "uakt") {
+  if (coin.denom === "uakt") {
+    return {
+      symbol: "AKT",
+      logoUrl: "https://console.akash.network/images/akash-logo.svg",
+      amount: parseInt(coin.amount) / 1_000_000
+    };
+  } else if (coin.denom === "akt") {
+    return {
+      symbol: "AKT",
+      logoUrl: "https://console.akash.network/images/akash-logo.svg",
+      amount: parseFloat(coin.amount)
+    };
+  } else {
+    const akashChain = asset_lists.find(c => c.chain_name === "akash");
+    const ibcAsset = akashChain.assets.find(a => a.base === coin.denom);
+
+    if (!ibcAsset) {
+      logger.info(`Unknown asset ${coin.denom}`);
+
       return {
-        symbol: "AKT",
-        logoUrl: "https://console.akash.network/images/akash-logo.svg",
-        amount: parseInt(coin.amount) / 1_000_000
-      };
-    } else if (coin.denom === "akt") {
-      return {
-        symbol: "AKT",
-        logoUrl: "https://console.akash.network/images/akash-logo.svg",
+        ibcToken: coin.denom,
         amount: parseFloat(coin.amount)
       };
-    } else {
-      const akashChain = asset_lists.find(c => c.chain_name === "akash");
-      const ibcAsset = akashChain.assets.find(a => a.base === coin.denom);
+    }
 
-      if (!ibcAsset) throw new Error(`Unknown asset ${coin.denom}`);
+    const displayAsset = ibcAsset.denom_units.find(d => d.denom === ibcAsset.display);
 
-      const displayAsset = ibcAsset.denom_units.find(d => d.denom === ibcAsset.display);
-
-      if (!displayAsset) throw new Error(`Unable to find display asset for ${coin.denom}`);
-
-      const displayAmount = parseInt(coin.amount) / Math.pow(10, displayAsset.exponent);
+    if (!displayAsset) {
+      logger.info(`Unable to find display asset for ${coin.denom}`);
 
       return {
-        symbol: ibcAsset.symbol,
         ibcToken: coin.denom,
-        logoUrl: ibcAsset.logo_URIs?.svg || ibcAsset?.logo_URIs?.png,
-        description: ibcAsset?.description,
-        amount: displayAmount
+        amount: parseFloat(coin.amount)
       };
     }
-  } catch (err) {
-    console.error(err);
-    Sentry.captureException(err);
+
+    const displayAmount = parseInt(coin.amount) / Math.pow(10, displayAsset.exponent);
 
     return {
+      symbol: ibcAsset.symbol,
       ibcToken: coin.denom,
-      amount: parseFloat(coin.amount)
+      logoUrl: ibcAsset.logo_URIs?.svg || ibcAsset?.logo_URIs?.png,
+      description: ibcAsset?.description,
+      amount: displayAmount
     };
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@akashnetwork/database": "*",
         "@akashnetwork/http-sdk": "*",
         "@casl/ability": "^6.7.1",
-        "@chain-registry/assets": "^0.7.1",
+        "@chain-registry/assets": "^1.64.79",
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
@@ -2979,133 +2979,17 @@
       }
     },
     "node_modules/@chain-registry/assets": {
-      "version": "0.7.1",
-      "license": "SEE LICENSE IN LICENSE",
+      "version": "1.64.79",
+      "resolved": "https://registry.npmjs.org/@chain-registry/assets/-/assets-1.64.79.tgz",
+      "integrity": "sha512-16rep8YPOfqYs0Di6yoWG7cQeBwS6bqdZX6Cf6l6rn57g1F3UrI9rsC41d/RnWBDZf4onsRJ/wjiqVrzJ3rjFg==",
       "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@chain-registry/types": "^0.6.0"
+        "@chain-registry/types": "^0.45.62"
       }
     },
     "node_modules/@chain-registry/assets/node_modules/@chain-registry/types": {
-      "version": "0.6.0",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "@keplr-wallet/cosmos": "^0.10.3",
-        "@keplr-wallet/crypto": "^0.10.11"
-      }
-    },
-    "node_modules/@chain-registry/assets/node_modules/@cosmjs/crypto": {
-      "version": "0.24.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.24.1",
-        "@cosmjs/math": "^0.24.1",
-        "@cosmjs/utils": "^0.24.1",
-        "bip39": "^3.0.2",
-        "bn.js": "^4.11.8",
-        "elliptic": "^6.5.3",
-        "js-sha3": "^0.8.0",
-        "libsodium-wrappers": "^0.7.6",
-        "pbkdf2": "^3.1.1",
-        "ripemd160": "^2.0.2",
-        "sha.js": "^2.4.11",
-        "unorm": "^1.5.0"
-      }
-    },
-    "node_modules/@chain-registry/assets/node_modules/@cosmjs/encoding": {
-      "version": "0.24.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@chain-registry/assets/node_modules/@cosmjs/launchpad": {
-      "version": "0.24.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.24.1",
-        "@cosmjs/encoding": "^0.24.1",
-        "@cosmjs/math": "^0.24.1",
-        "@cosmjs/utils": "^0.24.1",
-        "axios": "^0.21.1",
-        "fast-deep-equal": "^3.1.3"
-      }
-    },
-    "node_modules/@chain-registry/assets/node_modules/@cosmjs/launchpad/node_modules/axios": {
-      "version": "0.21.4",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
-    "node_modules/@chain-registry/assets/node_modules/@cosmjs/math": {
-      "version": "0.24.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^4.11.8"
-      }
-    },
-    "node_modules/@chain-registry/assets/node_modules/@cosmjs/utils": {
-      "version": "0.24.1",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@chain-registry/assets/node_modules/@keplr-wallet/cosmos": {
-      "version": "0.10.24",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/launchpad": "^0.24.0-alpha.25",
-        "@ethersproject/address": "^5.6.0",
-        "@keplr-wallet/crypto": "0.10.24",
-        "@keplr-wallet/proto-types": "0.10.24",
-        "@keplr-wallet/types": "0.10.24",
-        "@keplr-wallet/unit": "0.10.24",
-        "axios": "^0.27.2",
-        "bech32": "^1.1.4",
-        "buffer": "^6.0.3",
-        "long": "^4.0.0",
-        "protobufjs": "^6.11.2"
-      }
-    },
-    "node_modules/@chain-registry/assets/node_modules/@keplr-wallet/crypto": {
-      "version": "0.10.24",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bip32": "^2.0.6",
-        "bip39": "^3.0.3",
-        "bs58check": "^2.1.2",
-        "buffer": "^6.0.3",
-        "crypto-js": "^4.0.0",
-        "elliptic": "^6.5.3",
-        "sha.js": "^2.4.11"
-      }
-    },
-    "node_modules/@chain-registry/assets/node_modules/@keplr-wallet/proto-types": {
-      "version": "0.10.24",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "long": "^4.0.0",
-        "protobufjs": "^6.11.2"
-      }
-    },
-    "node_modules/@chain-registry/assets/node_modules/@keplr-wallet/unit": {
-      "version": "0.10.24",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@keplr-wallet/types": "0.10.24",
-        "big-integer": "^1.6.48",
-        "utility-types": "^3.10.0"
-      }
-    },
-    "node_modules/@chain-registry/assets/node_modules/bn.js": {
-      "version": "4.12.0",
-      "license": "MIT"
-    },
-    "node_modules/@chain-registry/assets/node_modules/long": {
-      "version": "4.0.0",
-      "license": "Apache-2.0"
+      "version": "0.45.62",
+      "resolved": "https://registry.npmjs.org/@chain-registry/types/-/types-0.45.62.tgz",
+      "integrity": "sha512-q7AGNgNGKF+hXb/ED67g3jypm+k7nTLVnQ1nEsdq64LeWMfJA9rmkI3a1PAhZq2rx7PBMM2UWKS2BsX+DI+syg=="
     },
     "node_modules/@chain-registry/client": {
       "version": "1.48.57",
@@ -6271,45 +6155,6 @@
         "@swc/helpers": "^0.5.0"
       }
     },
-    "node_modules/@iov/crypto": {
-      "version": "2.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@iov/encoding": "^2.1.0",
-        "bip39": "^3.0.2",
-        "bn.js": "^4.11.8",
-        "elliptic": "^6.4.0",
-        "js-sha3": "^0.8.0",
-        "libsodium-wrappers": "^0.7.6",
-        "pbkdf2": "^3.0.16",
-        "ripemd160": "^2.0.2",
-        "sha.js": "^2.4.11",
-        "type-tagger": "^1.0.0",
-        "unorm": "^1.5.0"
-      }
-    },
-    "node_modules/@iov/crypto/node_modules/bn.js": {
-      "version": "4.12.0",
-      "license": "MIT"
-    },
-    "node_modules/@iov/encoding": {
-      "version": "2.1.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.3",
-        "bn.js": "^4.11.8",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@iov/encoding/node_modules/bn.js": {
-      "version": "4.12.0",
-      "license": "MIT"
-    },
-    "node_modules/@iov/utils": {
-      "version": "2.0.2",
-      "license": "Apache-2.0"
-    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "license": "ISC",
@@ -7470,119 +7315,6 @@
       "version": "0.12.28",
       "resolved": "https://registry.npmjs.org/@keplr-wallet/simple-fetch/-/simple-fetch-0.12.28.tgz",
       "integrity": "sha512-T2CiKS2B5n0ZA7CWw0CA6qIAH0XYI1siE50MP+i+V0ZniCGBeL+BMcDw64vFJUcEH+1L5X4sDAzV37fQxGwllA=="
-    },
-    "node_modules/@keplr-wallet/types": {
-      "version": "0.10.24",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/launchpad": "^0.24.0-alpha.25",
-        "@cosmjs/proto-signing": "^0.24.0-alpha.25",
-        "axios": "^0.27.2",
-        "long": "^4.0.0",
-        "secretjs": "^0.17.0"
-      }
-    },
-    "node_modules/@keplr-wallet/types/node_modules/@cosmjs/crypto": {
-      "version": "0.24.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.24.1",
-        "@cosmjs/math": "^0.24.1",
-        "@cosmjs/utils": "^0.24.1",
-        "bip39": "^3.0.2",
-        "bn.js": "^4.11.8",
-        "elliptic": "^6.5.3",
-        "js-sha3": "^0.8.0",
-        "libsodium-wrappers": "^0.7.6",
-        "pbkdf2": "^3.1.1",
-        "ripemd160": "^2.0.2",
-        "sha.js": "^2.4.11",
-        "unorm": "^1.5.0"
-      }
-    },
-    "node_modules/@keplr-wallet/types/node_modules/@cosmjs/encoding": {
-      "version": "0.24.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@keplr-wallet/types/node_modules/@cosmjs/launchpad": {
-      "version": "0.24.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.24.1",
-        "@cosmjs/encoding": "^0.24.1",
-        "@cosmjs/math": "^0.24.1",
-        "@cosmjs/utils": "^0.24.1",
-        "axios": "^0.21.1",
-        "fast-deep-equal": "^3.1.3"
-      }
-    },
-    "node_modules/@keplr-wallet/types/node_modules/@cosmjs/launchpad/node_modules/axios": {
-      "version": "0.21.4",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.14.0"
-      }
-    },
-    "node_modules/@keplr-wallet/types/node_modules/@cosmjs/math": {
-      "version": "0.24.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^4.11.8"
-      }
-    },
-    "node_modules/@keplr-wallet/types/node_modules/@cosmjs/proto-signing": {
-      "version": "0.24.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/launchpad": "^0.24.1",
-        "long": "^4.0.0",
-        "protobufjs": "~6.10.2"
-      }
-    },
-    "node_modules/@keplr-wallet/types/node_modules/@cosmjs/utils": {
-      "version": "0.24.1",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@keplr-wallet/types/node_modules/@types/node": {
-      "version": "13.13.52",
-      "license": "MIT"
-    },
-    "node_modules/@keplr-wallet/types/node_modules/bn.js": {
-      "version": "4.12.0",
-      "license": "MIT"
-    },
-    "node_modules/@keplr-wallet/types/node_modules/long": {
-      "version": "4.0.0",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@keplr-wallet/types/node_modules/protobufjs": {
-      "version": "6.10.3",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": "^13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
     },
     "node_modules/@keplr-wallet/unit": {
       "version": "0.12.28",
@@ -21555,6 +21287,7 @@
     "node_modules/axios": {
       "version": "0.27.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.14.9",
         "form-data": "^4.0.0"
@@ -22575,13 +22308,6 @@
       "version": "0.7.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/charenc": {
-      "version": "0.0.2",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -23968,13 +23694,6 @@
         }
       }
     },
-    "node_modules/crypt": {
-      "version": "0.0.2",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/crypto-js": {
       "version": "4.2.0",
       "license": "MIT"
@@ -24015,10 +23734,6 @@
     },
     "node_modules/cuint": {
       "version": "0.2.2",
-      "license": "MIT"
-    },
-    "node_modules/curve25519-js": {
-      "version": "0.0.4",
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -31267,58 +30982,6 @@
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
       "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw=="
     },
-    "node_modules/js-crypto-env": {
-      "version": "0.3.2",
-      "license": "MIT"
-    },
-    "node_modules/js-crypto-hash": {
-      "version": "0.6.3",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "~5.4.3",
-        "hash.js": "~1.1.7",
-        "js-crypto-env": "^0.3.2",
-        "md5": "~2.2.1",
-        "sha3": "~2.1.0"
-      }
-    },
-    "node_modules/js-crypto-hash/node_modules/buffer": {
-      "version": "5.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
-      }
-    },
-    "node_modules/js-crypto-hkdf": {
-      "version": "0.7.3",
-      "license": "MIT",
-      "dependencies": {
-        "js-crypto-env": "^0.3.2",
-        "js-crypto-hmac": "^0.6.3",
-        "js-crypto-random": "^0.4.3",
-        "js-encoding-utils": "0.5.6"
-      }
-    },
-    "node_modules/js-crypto-hmac": {
-      "version": "0.6.3",
-      "license": "MIT",
-      "dependencies": {
-        "js-crypto-env": "^0.3.2",
-        "js-crypto-hash": "^0.6.3"
-      }
-    },
-    "node_modules/js-crypto-random": {
-      "version": "0.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "js-crypto-env": "^0.3.2"
-      }
-    },
-    "node_modules/js-encoding-utils": {
-      "version": "0.5.6",
-      "license": "MIT"
-    },
     "node_modules/js-sha256": {
       "version": "0.9.0",
       "license": "MIT"
@@ -33019,15 +32682,6 @@
         "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/md5": {
-      "version": "2.2.1",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "charenc": "~0.0.1",
-        "crypt": "~0.0.1",
-        "is-buffer": "~1.1.1"
-      }
-    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "license": "MIT",
@@ -33036,10 +32690,6 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
       }
-    },
-    "node_modules/md5/node_modules/is-buffer": {
-      "version": "1.1.6",
-      "license": "MIT"
     },
     "node_modules/mdast-util-definitions": {
       "version": "5.1.2",
@@ -35657,10 +35307,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/miscreant": {
-      "version": "0.3.2",
-      "license": "MIT"
     },
     "node_modules/mixin-deep": {
       "version": "1.3.2",
@@ -40424,73 +40070,9 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
-    "node_modules/secretjs": {
-      "version": "0.17.8",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@iov/crypto": "2.1.0",
-        "@iov/encoding": "2.1.0",
-        "@iov/utils": "2.0.2",
-        "axios": "0.21.1",
-        "curve25519-js": "0.0.4",
-        "fast-deep-equal": "3.1.1",
-        "js-crypto-hkdf": "0.7.3",
-        "miscreant": "0.3.2",
-        "pako": "1.0.11",
-        "protobufjs": "6.11.3",
-        "secure-random": "1.1.2"
-      }
-    },
-    "node_modules/secretjs/node_modules/axios": {
-      "version": "0.21.1",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.10.0"
-      }
-    },
-    "node_modules/secretjs/node_modules/fast-deep-equal": {
-      "version": "3.1.1",
-      "license": "MIT"
-    },
-    "node_modules/secretjs/node_modules/long": {
-      "version": "4.0.0",
-      "license": "Apache-2.0"
-    },
-    "node_modules/secretjs/node_modules/pako": {
-      "version": "1.0.11",
-      "license": "(MIT AND Zlib)"
-    },
-    "node_modules/secretjs/node_modules/protobufjs": {
-      "version": "6.11.3",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.1",
-        "@types/node": ">=13.7.0",
-        "long": "^4.0.0"
-      },
-      "bin": {
-        "pbjs": "bin/pbjs",
-        "pbts": "bin/pbts"
-      }
-    },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/secure-random": {
-      "version": "1.1.2",
-      "license": "MIT"
     },
     "node_modules/selfsigned": {
       "version": "2.4.1",
@@ -40811,13 +40393,6 @@
       },
       "bin": {
         "sha.js": "bin.js"
-      }
-    },
-    "node_modules/sha3": {
-      "version": "2.1.4",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "6.0.3"
       }
     },
     "node_modules/shallow-clone": {
@@ -43201,10 +42776,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/type-tagger": {
-      "version": "1.0.0",
-      "license": "Apache-2.0"
-    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.2",
       "license": "MIT",
@@ -43590,13 +43161,6 @@
       "dependencies": {
         "@babel/runtime": "^7.6.2",
         "detect-node": "^2.0.4"
-      }
-    },
-    "node_modules/unorm": {
-      "version": "1.6.0",
-      "license": "MIT or GPL-2.0",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/unpipe": {


### PR DESCRIPTION
## Improved dseq validation
Improved dseq validation by making sure the string is a positive integer. The previous check was using `parseInt`, but some input that parses successfully are not valid dseq like negative numbers or numbers with leading/trailing spaces. I tried doing the validation with zod, but zod's coersion uses `Number()` which has the same pitfalls as `parseInt()`. 

Endpoints affected:
- `/v1/deployment/{owner}/{dseq}`
- `/internal/leases-duration/{owner}`

## Fixed body parsing during sentry error reporting
The [getSentryEvent](https://github.com/akash-network/console/blob/3430a089629e40019b90fa712d668279b9774982/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts#L46-L68) method in [hono-error-handler.service.ts](https://github.com/akash-network/console/blob/3430a089629e40019b90fa712d668279b9774982/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts) was calling `c.req.json()` no matter the request's `content-type`. That was failing when an exception was thrown inside an endpoint with no body. I added a `getSentryEventRequestBody` function that parses the body differently based on the `content-type` header.

Error that was previously thrown: `SyntaxError: Unexpected end of JSON input`

I also wrapped the `reportError()` call into a try/catch so that if the sentry reporting fail, the `{"error":"InternalServerError"}` response is still returned.

## No longer report an error when an ibc denom is not found
In the address endpoint we use `coinToAsset()` to looks if some additional information (symbol, logo, description, etc) is available in `@chain-registry/assets` for a specific asset. If an this information was not found we previously reported it as an error in sentry. The goal was to be notified of a potential update needed to the `@chain-registry/assets`. Making sure that the assets have all that additional information is out of scope as there is way too many denoms out there and even the `@chain-registry/assets` package does not include them all. On top of that this information was used inside the block explorer pages which we are no longer promoting. As such I removed the sentry reporting for this. I left a log so that we can always see which coin we are missing in the future if needed.

Endpoint affected: `/v1/addresses/{address}`