### PR TITLE
feat: add nginx proxying with ssl to api & provider-proxy

### DIFF
--- a/apps/api/nginx.conf
+++ b/apps/api/nginx.conf
@@ -1,0 +1,33 @@
+# nginx.conf
+
+events {
+}
+
+http {
+    server {
+        # Redirect HTTP requests to HTTPS.
+        listen 80;
+        return 307 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+
+        server_tokens off;
+
+        ssl_certificate /etc/nginx/ssl/my_ssl_cert.crt;
+        ssl_certificate_key /etc/nginx/ssl/my_ssl_key.key;
+
+        location / {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Ssl on;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+            proxy_pass http://127.0.0.1:3000;
+            proxy_buffers 8 16k;
+            proxy_buffer_size 16k;
+            proxy_cookie_path / "/; HTTPOnly; Secure";
+        }
+    }
+}

--- a/apps/provider-proxy/nginx.conf
+++ b/apps/provider-proxy/nginx.conf
@@ -1,0 +1,33 @@
+# nginx.conf
+
+events {
+}
+
+http {
+    server {
+        # Redirect HTTP requests to HTTPS.
+        listen 80;
+        return 307 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+
+        server_tokens off;
+
+        ssl_certificate /etc/nginx/ssl/my_ssl_cert.crt;
+        ssl_certificate_key /etc/nginx/ssl/my_ssl_key.key;
+
+        location / {
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+            proxy_set_header X-Forwarded-Ssl on;
+            proxy_set_header Host $http_host;
+            proxy_redirect off;
+            proxy_pass http://127.0.0.1:3000;
+            proxy_buffers 8 16k;
+            proxy_buffer_size 16k;
+            proxy_cookie_path / "/; HTTPOnly; Secure";
+        }
+    }
+}

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -3,7 +3,7 @@ services:
     image: console-api:${API_TAG:-latest}
     build:
       dockerfile: docker/Dockerfile.node
-      target: production
+      target: production-nginx
       args:
         WORKSPACE: apps/api
 
@@ -19,7 +19,7 @@ services:
     image: console-provider-proxy:${PROVIDER_PROXY_TAG:-latest}
     build:
       dockerfile: docker/Dockerfile.node
-      target: production
+      target: production-nginx
       args:
         WORKSPACE: apps/provider-proxy
 

--- a/docker/Dockerfile.node
+++ b/docker/Dockerfile.node
@@ -47,3 +47,17 @@ USER $APP_USER
 WORKDIR /app/$WORKSPACE
 
 CMD ["node", "dist/server.js"]
+
+FROM production AS production-nginx
+
+USER root
+
+RUN apk add --no-cache libcap nginx openssl \
+    && setcap cap_net_bind_service=+ep `readlink -f \`which node\`` \
+    && mkdir -p /etc/nginx/ssl \
+    && openssl req -x509 -newkey rsa:4096 -sha256 -nodes -keyout /etc/nginx/ssl/my_ssl_key.key -out /etc/nginx/ssl/my_ssl_cert.crt -subj "/CN=akash.network" -days 600 \
+    && nginx -t
+
+COPY $WORKSPACE/nginx.conf /etc/nginx/nginx.conf
+
+CMD sed -i "s/127.0.0.1/$(hostname -i)/" /etc/nginx/nginx.conf && sed -i "s/:3000/:$PORT/" /etc/nginx/nginx.conf && nginx && node dist/server.js


### PR DESCRIPTION
Add nginx proxying to the api & provider console enabling https