### PR TITLE
Improve error handling in api

### DIFF
--- a/apps/api/src/services/external/githubService.ts
+++ b/apps/api/src/services/external/githubService.ts
@@ -1,5 +1,6 @@
 import { Octokit } from "@octokit/rest";
 import axios from "axios";
+import minutesToSeconds from "date-fns/minutesToSeconds";
 
 import { cacheKeys, cacheResponse } from "@src/caching/helpers";
 import { Auditor, ProviderAttributesSchema } from "@src/types/provider";
@@ -22,19 +23,25 @@ export function getOctokit() {
 export const getProviderAttributesSchema = async (): Promise<ProviderAttributesSchema> => {
   // Fetching provider attributes schema
   const response = await cacheResponse(
-    30,
+    minutesToSeconds(5),
     cacheKeys.getProviderAttributesSchema,
-    async () => await axios.get<ProviderAttributesSchema>("https://raw.githubusercontent.com/akash-network/console/main/config/provider-attributes.json")
+    async () => await axios.get<ProviderAttributesSchema>("https://raw.githubusercontent.com/akash-network/console/main/config/provider-attributes.json"),
+    true
   );
 
   return response.data;
 };
 
 export async function getAuditors() {
-  const response = await cacheResponse(60 * 5, cacheKeys.getAuditors, async () => {
-    const res = await axios.get<Auditor[]>("https://raw.githubusercontent.com/akash-network/console/main/config/auditors.json");
-    return res.data;
-  });
+  const response = await cacheResponse(
+    minutesToSeconds(5),
+    cacheKeys.getAuditors,
+    async () => {
+      const res = await axios.get<Auditor[]>("https://raw.githubusercontent.com/akash-network/console/main/config/auditors.json");
+      return res.data;
+    },
+    true
+  );
 
   return response;
 }


### PR DESCRIPTION
- If a query fail in `cacheResponse` and the `keepCache` param was not used, re-throw the exception instead of catching and returning undefined. This prevents a second error from happening further in the flow because of the undefined value.
- Increased the caching time for `provider-attributes.json` from 30s to 5min. Also enabled the `keepCache` param for both queries in `githubService.ts` so that the old cached version is returned if the query fails.
- Use the new logger in the caching helper
- Added parameter validation in the address deployments endpoint