### PR TITLE
feat(billing): rename POST /v1/wallets to POST /v1/start-trial

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -73,8 +73,8 @@ if (BILLING_ENABLED === "true") {
   const { AuthInterceptor } = require("./auth/services/auth.interceptor");
   appHono.use(container.resolve<HonoInterceptor>(AuthInterceptor).intercept());
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { createWalletRouter, getWalletListRouter, signAndBroadcastTxRouter, checkoutRouter, stripeWebhook } = require("./billing");
-  appHono.route("/", createWalletRouter);
+  const { startTrialRouter, getWalletListRouter, signAndBroadcastTxRouter, checkoutRouter, stripeWebhook } = require("./billing");
+  appHono.route("/", startTrialRouter);
   appHono.route("/", getWalletListRouter);
   appHono.route("/", signAndBroadcastTxRouter);
   appHono.route("/", checkoutRouter);

--- a/apps/api/src/billing/controllers/wallet/wallet.controller.ts
+++ b/apps/api/src/billing/controllers/wallet/wallet.controller.ts
@@ -3,7 +3,7 @@ import { Lifecycle, scoped } from "tsyringe";
 
 import { Protected } from "@src/auth/services/auth.service";
 import type { WalletListOutputResponse, WalletOutputResponse } from "@src/billing/http-schemas/wallet.schema";
-import type { CreateWalletRequestInput, SignTxRequestInput, SignTxResponseOutput } from "@src/billing/routes";
+import type { SignTxRequestInput, SignTxResponseOutput, StartTrialRequestInput } from "@src/billing/routes";
 import { GetWalletQuery } from "@src/billing/routes/get-wallet-list/get-wallet-list.router";
 import { WalletInitializerService } from "@src/billing/services";
 import { RefillService } from "@src/billing/services/refill/refill.service";
@@ -22,7 +22,7 @@ export class WalletController {
 
   @WithTransaction()
   @Protected([{ action: "create", subject: "UserWallet" }])
-  async create({ data: { userId } }: CreateWalletRequestInput): Promise<WalletOutputResponse> {
+  async create({ data: { userId } }: StartTrialRequestInput): Promise<WalletOutputResponse> {
     return {
       data: await this.walletInitializer.initializeAndGrantTrialLimits(userId)
     };

--- a/apps/api/src/billing/routes/checkout/checkout.router.ts
+++ b/apps/api/src/billing/routes/checkout/checkout.router.ts
@@ -8,7 +8,7 @@ const route = createRoute({
   method: "get",
   path: "/v1/checkout",
   summary: "Creates a stripe checkout session and redirects to checkout",
-  tags: ["Wallets"],
+  tags: ["Wallet"],
   request: {},
   responses: {
     301: {

--- a/apps/api/src/billing/routes/get-wallet-list/get-wallet-list.router.ts
+++ b/apps/api/src/billing/routes/get-wallet-list/get-wallet-list.router.ts
@@ -16,7 +16,7 @@ const route = createRoute({
   method: "get",
   path: "/v1/wallets",
   summary: "Get a list of wallets",
-  tags: ["Wallets"],
+  tags: ["Wallet"],
   request: {
     query: GetWalletRequestQuerySchema
   },

--- a/apps/api/src/billing/routes/index.ts
+++ b/apps/api/src/billing/routes/index.ts
@@ -1,4 +1,4 @@
-export * from "@src/billing/routes/create-wallet/create-wallet.router";
+export * from "@src/billing/routes/start-trial/start-trial.router";
 export * from "@src/billing/routes/get-wallet-list/get-wallet-list.router";
 export * from "@src/billing/routes/checkout/checkout.router";
 export * from "@src/billing/routes/sign-and-broadcast-tx/sign-and-broadcast-tx.router";

--- a/apps/api/src/billing/routes/sign-and-broadcast-tx/sign-and-broadcast-tx.router.ts
+++ b/apps/api/src/billing/routes/sign-and-broadcast-tx/sign-and-broadcast-tx.router.ts
@@ -41,7 +41,7 @@ const route = createRoute({
   method: "post",
   path: "/v1/tx",
   summary: "Signs a transaction via a user managed wallet",
-  tags: ["Wallets"],
+  tags: ["Wallet"],
   request: {
     body: {
       content: {

--- a/apps/api/src/billing/routes/start-trial/start-trial.router.ts
+++ b/apps/api/src/billing/routes/start-trial/start-trial.router.ts
@@ -6,24 +6,24 @@ import { WalletController } from "@src/billing/controllers/wallet/wallet.control
 import { WalletResponseOutputSchema } from "@src/billing/http-schemas/wallet.schema";
 import { OpenApiHonoHandled } from "@src/core/services/open-api-hono-handled/open-api-hono-handled";
 
-export const CreateWalletRequestInputSchema = z.object({
+export const StartTrialRequestInputSchema = z.object({
   data: z.object({
     userId: z.string().openapi({})
   })
 });
 
-export type CreateWalletRequestInput = z.infer<typeof CreateWalletRequestInputSchema>;
+export type StartTrialRequestInput = z.infer<typeof StartTrialRequestInputSchema>;
 
 const route = createRoute({
   method: "post",
-  path: "/v1/wallets",
+  path: "/v1/start-trial",
   summary: "Creates a managed wallet for a user",
-  tags: ["Wallets"],
+  tags: ["Wallet"],
   request: {
     body: {
       content: {
         "application/json": {
-          schema: CreateWalletRequestInputSchema
+          schema: StartTrialRequestInputSchema
         }
       }
     }
@@ -39,8 +39,8 @@ const route = createRoute({
     }
   }
 });
-export const createWalletRouter = new OpenApiHonoHandled();
+export const startTrialRouter = new OpenApiHonoHandled();
 
-createWalletRouter.openapi(route, async function routeCreateWallet(c) {
+startTrialRouter.openapi(route, async function routeStartTrial(c) {
   return c.json(await container.resolve(WalletController).create(c.req.valid("json")), 200);
 });

--- a/apps/api/test/functional/start-trial.spec.ts
+++ b/apps/api/test/functional/start-trial.spec.ts
@@ -10,7 +10,7 @@ import { ApiPgDatabase, POSTGRES_DB, resolveTable } from "@src/core";
 
 jest.setTimeout(20000);
 
-describe("wallets", () => {
+describe("start trial", () => {
   const userWalletsTable = resolveTable("UserWallets");
   const config = container.resolve<BillingConfig>(BILLING_CONFIG);
   const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
@@ -22,7 +22,7 @@ describe("wallets", () => {
     await dbService.cleanAll();
   });
 
-  describe("POST /v1/wallets", () => {
+  describe("POST /v1/start-trial", () => {
     it("should create a wallet for a user", async () => {
       const userResponse = await app.request("/v1/anonymous-users", {
         method: "POST",
@@ -33,7 +33,7 @@ describe("wallets", () => {
         token
       } = await userResponse.json();
       const headers = new Headers({ "Content-Type": "application/json", authorization: `Bearer ${token}` });
-      const createWalletResponse = await app.request("/v1/wallets", {
+      const createWalletResponse = await app.request("/v1/start-trial", {
         method: "POST",
         body: JSON.stringify({ data: { userId } }),
         headers
@@ -102,7 +102,7 @@ describe("wallets", () => {
     });
 
     it("should throw 401 provided no auth header ", async () => {
-      const createWalletResponse = await app.request("/v1/wallets", {
+      const createWalletResponse = await app.request("/v1/start-trial", {
         method: "POST",
         body: JSON.stringify({ data: { userId: faker.string.uuid() } }),
         headers: new Headers({ "Content-Type": "application/json" })

--- a/apps/api/test/services/wallet-testing.service.ts
+++ b/apps/api/test/services/wallet-testing.service.ts
@@ -5,7 +5,7 @@ export class WalletTestingService {
 
   async createUserAndWallet() {
     const { user, token } = await this.createUser();
-    const walletResponse = await this.app.request("/v1/wallets", {
+    const walletResponse = await this.app.request("/v1/start-trial", {
       method: "POST",
       body: JSON.stringify({
         data: { userId: user.id }

--- a/packages/http-sdk/src/managed-wallet-http/managed-wallet-http.service.ts
+++ b/packages/http-sdk/src/managed-wallet-http/managed-wallet-http.service.ts
@@ -10,7 +10,7 @@ export interface ApiWalletOutput {
 
 export class ManagedWalletHttpService extends ApiHttpService {
   async createWallet(userId: string) {
-    return this.addWalletEssentials(this.extractApiData(await this.post<ApiWalletOutput>("v1/wallets", { data: { userId } })));
+    return this.addWalletEssentials(this.extractApiData(await this.post<ApiWalletOutput>("v1/start-trial", { data: { userId } })));
   }
 
   async getWallet(userId: string) {


### PR DESCRIPTION
The main purpose for the change - target the endpoint for rate limiting with Cloudflare. However this actually makes sense from app standpoint as this endpoint does more than just wallet creation - it also grants trial allowances. So this is a business workflow that should better be called respectively.