### PR TITLE
chore(release): update the way mvm files update is called

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,8 @@
 if [[ "$CI" != "true" ]]; then
-    turbo update-apps-local-deps \
-        --filter=./packages/database \
-        --filter=./packages/env-loader \
-        --filter=./packages/http-sdk \
-        --filter=./packages/ui
+    npm run update-apps-local-deps -w packages/database
+    npm run update-apps-local-deps -w packages/env-loader
+    npm run update-apps-local-deps -w packages/http-sdk
+    npm run update-apps-local-deps -w packages/ui
+    npm run update-apps-local-deps -w packages/network-store
     git add ./apps/*/mvm.lock
 fi

--- a/apps/api/mvm.lock
+++ b/apps/api/mvm.lock
@@ -3,8 +3,5 @@
     "@akashnetwork/database": "1.0.0",
     "@akashnetwork/env-loader": "1.0.1",
     "@akashnetwork/http-sdk": "1.0.7"
-  },
-  "devDependencies": {
-    "@akashnetwork/dev-config": "1.0.0"
   }
 }

--- a/apps/deploy-web/mvm.lock
+++ b/apps/deploy-web/mvm.lock
@@ -2,6 +2,7 @@
   "dependencies": {
     "@akashnetwork/env-loader": "1.0.1",
     "@akashnetwork/http-sdk": "1.0.7",
+    "@akashnetwork/network-store": "1.0.0",
     "@akashnetwork/ui": "1.0.0"
   },
   "devDependencies": {

--- a/apps/stats-web/mvm.lock
+++ b/apps/stats-web/mvm.lock
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@akashnetwork/network-store": "1.0.0",
     "@akashnetwork/ui": "1.0.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
     },
     "apps/api": {
       "name": "@akashnetwork/console-api",
-      "version": "2.23.4",
+      "version": "2.24.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
@@ -270,7 +270,7 @@
     },
     "apps/deploy-web": {
       "name": "@akashnetwork/console-web",
-      "version": "2.16.2",
+      "version": "2.17.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
@@ -39467,7 +39467,8 @@
         "lodash": "^4.17.21"
       },
       "devDependencies": {
-        "@akashnetwork/akashjs": "^0.10.0"
+        "@akashnetwork/akashjs": "^0.10.0",
+        "@b12k/mvm": "^0.0.10"
       }
     },
     "packages/releaser": {

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -8,13 +8,15 @@
   "main": "src/index.ts",
   "scripts": {
     "format": "prettier --write ./*.{ts,json} **/*.{ts,json}",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "update-apps-local-deps": "mvm-update"
   },
   "dependencies": {
     "axios": "^1.7.2",
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@b12k/mvm": "^0.0.10",
     "@akashnetwork/akashjs": "^0.10.0"
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -8,9 +8,6 @@
       "dependsOn": ["//#dc:up:db"],
       "env": ["SKIP_DB"]
     },
-    "//#dc:up:db": {},
-    "update-apps-local-deps": {
-      "outputs": ["mvm.lock"]
-    }
+    "//#dc:up:db": {}
   }
 }


### PR DESCRIPTION
For some reason calling via turbo empties mvm files. Replaced with individual calls