### PR TITLE
refactor(observability): ensure logger can be configured with options and env

### DIFF
--- a/apps/api/mvm.lock
+++ b/apps/api/mvm.lock
@@ -3,6 +3,6 @@
     "@akashnetwork/database": "1.0.0",
     "@akashnetwork/env-loader": "1.0.1",
     "@akashnetwork/http-sdk": "1.0.8",
-    "@akashnetwork/logging": "1.0.1"
+    "@akashnetwork/logging": "2.0.0"
   }
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -105,7 +105,7 @@ function startScheduler() {
   scheduler.start();
 }
 
-const appLogger = new LoggerService({ context: "APP" });
+const appLogger = LoggerService.forContext("APP");
 
 /**
  * Initialize database

--- a/apps/api/src/billing/repositories/checkout-session/checkout-session.repository.ts
+++ b/apps/api/src/billing/repositories/checkout-session/checkout-session.repository.ts
@@ -12,7 +12,7 @@ export type CheckoutSessionsOutput = Table["$inferSelect"];
 
 @singleton()
 export class CheckoutSessionRepository extends BaseRepository<Table, CheckoutSessionsInput, CheckoutSessionsOutput> {
-  private readonly logger = new LoggerService({ context: CheckoutSessionRepository.name });
+  private readonly logger = LoggerService.forContext(CheckoutSessionRepository.name);
 
   constructor(
     @InjectPg() protected readonly pg: ApiPgDatabase,

--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
@@ -32,7 +32,7 @@ export class ManagedUserWalletService {
 
   private readonly HD_PATH = "m/44'/118'/0'/0";
 
-  private readonly logger = new LoggerService({ context: ManagedUserWalletService.name });
+  private readonly logger = LoggerService.forContext(ManagedUserWalletService.name);
 
   constructor(
     @InjectBillingConfig() private readonly config: BillingConfig,

--- a/apps/api/src/billing/services/master-signing-client/master-signing-client.service.ts
+++ b/apps/api/src/billing/services/master-signing-client/master-signing-client.service.ts
@@ -38,7 +38,7 @@ export class MasterSigningClientService {
     { cache: false, batchScheduleFn: callback => setTimeout(callback, this.config.MASTER_WALLET_BATCHING_INTERVAL_MS) }
   );
 
-  private readonly logger = new LoggerService({ context: this.loggerContext });
+  private readonly logger = LoggerService.forContext(this.loggerContext);
 
   constructor(
     private readonly config: BillingConfig,

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -11,7 +11,7 @@ import { SentryEventService } from "@src/core/services/sentry-event/sentry-event
 
 @singleton()
 export class RefillService {
-  private readonly logger = new LoggerService({ context: RefillService.name });
+  private readonly logger = LoggerService.forContext(RefillService.name);
 
   constructor(
     @InjectBillingConfig() private readonly config: BillingConfig,

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
@@ -9,7 +9,7 @@ import { WithTransaction } from "@src/core";
 
 @singleton()
 export class StripeWebhookService {
-  private readonly logger = new LoggerService({ context: StripeWebhookService.name });
+  private readonly logger = LoggerService.forContext(StripeWebhookService.name);
 
   constructor(
     private readonly stripe: StripeService,

--- a/apps/api/src/caching/helpers.ts
+++ b/apps/api/src/caching/helpers.ts
@@ -4,7 +4,7 @@ import { differenceInSeconds } from "date-fns";
 
 import MemoryCacheEngine from "./memoryCacheEngine";
 
-const logger = new LoggerService({ context: "Caching" });
+const logger = LoggerService.forContext("Caching");
 
 export const cacheEngine = new MemoryCacheEngine();
 const pendingRequests: { [key: string]: Promise<unknown> } = {};

--- a/apps/api/src/chain/services/block-http/block-http.service.spec.ts
+++ b/apps/api/src/chain/services/block-http/block-http.service.spec.ts
@@ -1,9 +1,9 @@
+import "@test/mocks/logger-service.mock";
+
 import { BlockHttpService as BlockHttpServiceCommon } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
 
 import { BlockHttpService } from "./block-http.service";
-
-jest.mock("@akashnetwork/logging");
 
 describe(BlockHttpService.name, () => {
   let service: BlockHttpService;

--- a/apps/api/src/console.ts
+++ b/apps/api/src/console.ts
@@ -45,7 +45,7 @@ program
     });
   });
 
-const logger = new LoggerService({ context: "CLI" });
+const logger = LoggerService.forContext("CLI");
 
 async function executeCliHandler(name: string, handler: () => Promise<void>) {
   await context.with(trace.setSpan(context.active(), tracer.startSpan(name)), async () => {

--- a/apps/api/src/core/providers/postgres.provider.ts
+++ b/apps/api/src/core/providers/postgres.provider.ts
@@ -10,7 +10,7 @@ import { config } from "@src/core/config";
 import { PostgresLoggerService } from "@src/core/services/postgres-logger/postgres-logger.service";
 import * as userSchemas from "@src/user/model-schemas";
 
-const logger = new LoggerService({ context: "POSTGRES" });
+const logger = LoggerService.forContext("POSTGRES");
 const migrationClient = postgres(config.POSTGRES_DB_URI, { max: 1, onnotice: logger.info.bind(logger) });
 const appClient = postgres(config.POSTGRES_DB_URI, { max: config.POSTGRES_MAX_CONNECTIONS, onnotice: logger.info.bind(logger) });
 

--- a/apps/api/src/core/services/error/error.service.spec.ts
+++ b/apps/api/src/core/services/error/error.service.spec.ts
@@ -1,11 +1,11 @@
+import "@test/mocks/logger-service.mock";
+
 import { LoggerService } from "@akashnetwork/logging";
 import { faker } from "@faker-js/faker";
 
 import { Sentry } from "@src/core/providers/sentry.provider";
 import { SentryEventService } from "@src/core/services/sentry-event/sentry-event.service";
 import { ErrorService } from "./error.service";
-
-jest.mock("@akashnetwork/logging");
 
 describe(ErrorService.name, () => {
   const sentryEventService = new SentryEventService();

--- a/apps/api/src/core/services/error/error.service.ts
+++ b/apps/api/src/core/services/error/error.service.ts
@@ -6,7 +6,7 @@ import { SentryEventService } from "@src/core/services/sentry-event/sentry-event
 
 @singleton()
 export class ErrorService {
-  private readonly logger = new LoggerService();
+  private readonly logger = LoggerService.forContext(ErrorService.name);
 
   constructor(
     @InjectSentry() private readonly sentry: Sentry,

--- a/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts
+++ b/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts
@@ -12,7 +12,7 @@ import { SentryEventService } from "@src/core/services/sentry-event/sentry-event
 
 @singleton()
 export class HonoErrorHandlerService {
-  private readonly logger = new LoggerService({ context: "ErrorHandler" });
+  private readonly logger = LoggerService.forContext("ErrorHandler");
 
   constructor(
     @InjectSentry() private readonly sentry: Sentry,

--- a/apps/api/src/core/services/http-logger/http-logger.service.ts
+++ b/apps/api/src/core/services/http-logger/http-logger.service.ts
@@ -6,7 +6,7 @@ import type { HonoInterceptor } from "@src/core/types/hono-interceptor.type";
 
 @singleton()
 export class HttpLoggerService implements HonoInterceptor {
-  private readonly logger = new LoggerService({ context: "HTTP" });
+  private readonly logger = LoggerService.forContext("HTTP");
 
   intercept() {
     return async (c: Context, next: Next) => {

--- a/apps/api/src/core/services/postgres-logger/postgres-logger.service.ts
+++ b/apps/api/src/core/services/postgres-logger/postgres-logger.service.ts
@@ -17,7 +17,7 @@ export class PostgresLoggerService implements LogWriter {
 
   constructor(options?: PostgresLoggerServiceOptions) {
     const orm = options?.orm || "drizzle";
-    this.logger = new LoggerService({ context: "POSTGRES", orm, database: options?.database });
+    this.logger = new LoggerService({ base: { context: "POSTGRES", orm, database: options?.database } });
     this.isDrizzle = orm === "drizzle";
     this.useFormat = options?.useFormat || false;
   }

--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
@@ -13,7 +13,7 @@ import { averageBlockTime } from "@src/utils/constants";
 
 @singleton()
 export class StaleManagedDeploymentsCleanerService {
-  private readonly logger = new LoggerService({ context: StaleManagedDeploymentsCleanerService.name });
+  private readonly logger = LoggerService.forContext(StaleManagedDeploymentsCleanerService.name);
 
   private readonly MAX_LIVE_BLOCKS = Math.floor((10 * secondsInMinute) / averageBlockTime);
 

--- a/apps/api/src/deployment/services/top-up-custodial-deployments/top-up-custodial-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-custodial-deployments/top-up-custodial-deployments.service.spec.ts
@@ -1,3 +1,5 @@
+import "@test/mocks/logger-service.mock";
+
 import { AllowanceHttpService, BalanceHttpService, Denom } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
 import { MsgExec } from "cosmjs-types/cosmos/authz/v1beta1/tx";
@@ -17,8 +19,6 @@ import { DeploymentGrantSeeder } from "@test/seeders/deployment-grant.seeder";
 import { DrainingDeploymentSeeder } from "@test/seeders/draining-deployment.seeder";
 import { FeesAuthorizationSeeder } from "@test/seeders/fees-authorization.seeder";
 import { stub } from "@test/services/stub";
-
-jest.mock("@akashnetwork/logging");
 
 describe(TopUpCustodialDeploymentsService.name, () => {
   const CURRENT_BLOCK_HEIGHT = 7481457;

--- a/apps/api/src/deployment/services/top-up-custodial-deployments/top-up-custodial-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-custodial-deployments/top-up-custodial-deployments.service.ts
@@ -30,7 +30,7 @@ export class TopUpCustodialDeploymentsService implements DeploymentsRefiller {
 
   private readonly MIN_FEES_AVAILABLE = 5000;
 
-  private readonly logger = new LoggerService({ context: TopUpCustodialDeploymentsService.name });
+  private readonly logger = LoggerService.forContext(TopUpCustodialDeploymentsService.name);
 
   constructor(
     private readonly topUpToolsService: TopUpToolsService,

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -1,3 +1,5 @@
+import "@test/mocks/logger-service.mock";
+
 import { faker } from "@faker-js/faker";
 
 import { BillingConfig } from "@src/billing/providers";
@@ -16,8 +18,6 @@ import { AkashAddressSeeder } from "@test/seeders/akash-address.seeder";
 import { DrainingDeploymentSeeder } from "@test/seeders/draining-deployment.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 import { stub } from "@test/services/stub";
-
-jest.mock("@akashnetwork/logging");
 
 describe(TopUpManagedDeploymentsService.name, () => {
   const CURRENT_BLOCK_HEIGHT = 7481457;

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -17,7 +17,7 @@ import { DeploymentsRefiller, TopUpDeploymentsOptions } from "@src/deployment/ty
 export class TopUpManagedDeploymentsService implements DeploymentsRefiller {
   private readonly CONCURRENCY = 10;
 
-  private readonly logger = new LoggerService({ context: TopUpManagedDeploymentsService.name });
+  private readonly logger = LoggerService.forContext(TopUpManagedDeploymentsService.name);
 
   constructor(
     private readonly userWalletRepository: UserWalletRepository,

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,6 @@
-import "./open-telemetry";
 import "reflect-metadata";
 import "@akashnetwork/env-loader";
+import "./open-telemetry";
 
 async function bootstrap() {
   /* eslint-disable @typescript-eslint/no-var-requires */

--- a/apps/api/src/open-telemetry.ts
+++ b/apps/api/src/open-telemetry.ts
@@ -1,3 +1,5 @@
+import { LoggerService } from "@akashnetwork/logging";
+import { context, trace } from "@opentelemetry/api";
 import { registerInstrumentations } from "@opentelemetry/instrumentation";
 import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
@@ -7,3 +9,8 @@ new NodeTracerProvider().register();
 registerInstrumentations({
   instrumentations: [new HttpInstrumentation()]
 });
+
+LoggerService.mixin = () => {
+  const currentSpan = trace.getSpan(context.active());
+  return { ...currentSpan?.spanContext() };
+};

--- a/apps/api/src/routes/v1/dashboardData.ts
+++ b/apps/api/src/routes/v1/dashboardData.ts
@@ -8,9 +8,8 @@ import { getTransactions } from "@src/services/db/transactionsService";
 import { getChainStats } from "@src/services/external/apiNodeService";
 import { createLoggingExecutor } from "@src/utils/logging";
 
-
-const logger = new LoggerService({ context: "Dashboard" });
-const runOrLog = createLoggingExecutor(logger)
+const logger = LoggerService.forContext("Dashboard");
+const runOrLog = createLoggingExecutor(logger);
 
 const route = createRoute({
   method: "get",
@@ -167,8 +166,8 @@ export default new OpenAPIHono().openapi(route, async c => {
   const chainStats = {
     ...chainStatsQuery,
     height: latestBlocks && latestBlocks.length > 0 ? latestBlocks[0].height : undefined,
-    transactionCount: latestBlocks && latestBlocks.length > 0 ? latestBlocks[0].totalTransactionCount : undefined,
-  }
+    transactionCount: latestBlocks && latestBlocks.length > 0 ? latestBlocks[0].totalTransactionCount : undefined
+  };
 
   return c.json({
     chainStats,

--- a/apps/api/src/services/db/userDataService.ts
+++ b/apps/api/src/services/db/userDataService.ts
@@ -4,7 +4,7 @@ import pick from "lodash/pick";
 import { Transaction } from "sequelize";
 import { container } from "tsyringe";
 
-const logger = new LoggerService({ context: "UserDataService" });
+const logger = LoggerService.forContext("UserDataService");
 
 function randomIntFromInterval(min: number, max: number) {
   return Math.floor(Math.random() * (max - min + 1) + min);

--- a/apps/api/src/utils/coin.ts
+++ b/apps/api/src/utils/coin.ts
@@ -2,8 +2,7 @@ import { LoggerService } from "@akashnetwork/logging";
 import { asset_lists } from "@chain-registry/assets";
 import { Coin } from "cosmjs-types/cosmos/base/v1beta1/coin";
 
-
-const logger = new LoggerService({ context: "CoinUtil" });
+const logger = LoggerService.forContext("CoinUtil");
 
 export function coinToAsset(coin: Coin) {
   if (coin.denom === "uakt") {

--- a/apps/api/test/mocks/logger-service.mock.ts
+++ b/apps/api/test/mocks/logger-service.mock.ts
@@ -1,0 +1,17 @@
+jest.mock("@akashnetwork/logging", () => {
+  class LoggerService {
+    static forContext() {
+      return new LoggerService();
+    }
+
+    error() {}
+    debug() {}
+    info() {}
+  }
+
+  jest.spyOn(LoggerService.prototype, "error");
+  jest.spyOn(LoggerService.prototype, "debug");
+  jest.spyOn(LoggerService.prototype, "info");
+
+  return { LoggerService };
+});

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashnetwork/logging",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Package containing logging tools",
   "main": "src/index.ts",
   "scripts": {

--- a/packages/logging/src/servicies/logger/logger.service.spec.ts
+++ b/packages/logging/src/servicies/logger/logger.service.spec.ts
@@ -1,41 +1,20 @@
 import createHttpError from "http-errors";
 import pino from "pino";
-import pinoFluentd from "pino-fluentd";
-import pretty from "pino-pretty";
+import { gcpLogOptions } from "pino-cloud-logging";
 
 import { config } from "../../config";
 import { Logger, LoggerService } from "./logger.service";
 
 jest.mock("pino");
-jest.mock("pino-fluentd");
-jest.mock("pino-pretty");
+jest.mock("pino-cloud-logging");
+
+(gcpLogOptions as jest.Mock).mockImplementation(options => options);
 
 describe("LoggerService", () => {
-  let loggerService: LoggerService;
-  let mockLogger: jest.Mocked<Logger>;
   const defaultLogFormat = config.STD_OUT_LOG_FORMAT;
-  const defaultFluentdTag = config.FLUENTD_TAG;
-  const defaultFluentdHost = config.FLUENTD_HOST;
-  const defaultFluentdPort = config.FLUENTD_PORT;
-
-  beforeEach(() => {
-    mockLogger = {
-      info: jest.fn(),
-      error: jest.fn(),
-      warn: jest.fn(),
-      debug: jest.fn(),
-      child: jest.fn().mockReturnThis()
-    } as unknown as jest.Mocked<Logger>;
-
-    (pino as unknown as jest.Mock).mockReturnValue(mockLogger);
-    loggerService = new LoggerService();
-  });
 
   afterEach(() => {
     config.STD_OUT_LOG_FORMAT = defaultLogFormat;
-    config.FLUENTD_TAG = defaultFluentdTag;
-    config.FLUENTD_HOST = defaultFluentdHost;
-    config.FLUENTD_PORT = defaultFluentdPort;
     jest.clearAllMocks();
   });
 
@@ -43,80 +22,117 @@ describe("LoggerService", () => {
     it("should initialize pino with pretty formatting when STD_OUT_LOG_FORMAT is 'pretty'", () => {
       config.STD_OUT_LOG_FORMAT = "pretty";
       new LoggerService();
-      expect(pretty).toHaveBeenCalledWith({ sync: true });
+
+      expect(pino).toHaveBeenCalledWith({
+        level: "info",
+        mixin: undefined,
+        transport: { target: "pino-pretty", options: { colorize: true, sync: true } }
+      });
+      expect(gcpLogOptions).not.toHaveBeenCalled();
     });
 
     it("should initialize pino without pretty formatting for other formats", () => {
       config.STD_OUT_LOG_FORMAT = "json";
       new LoggerService();
-      expect(pretty).not.toHaveBeenCalled();
-      expect(pino).toHaveBeenCalled();
+
+      expect(pino).toHaveBeenCalledWith({ level: "info", mixin: undefined });
+      expect(gcpLogOptions).toHaveBeenCalled();
     });
 
-    it("should initialize fluentd if configuration is enabled", () => {
-      config.FLUENTD_HOST = "localhost";
-      config.FLUENTD_PORT = 24224;
-      config.FLUENTD_TAG = "app";
-
+    it("should initialize pino with global mixin", () => {
+      function globalMixin() {
+        return {};
+      }
+      LoggerService.mixin = globalMixin;
       new LoggerService();
-      expect(pinoFluentd).toHaveBeenCalledWith({
-        tag: config.FLUENTD_TAG,
-        host: config.FLUENTD_HOST,
-        port: config.FLUENTD_PORT,
-        "trace-level": config.LOG_LEVEL
-      });
+
+      expect(pino).toHaveBeenCalledWith({ level: "info", mixin: globalMixin });
+
+      LoggerService.mixin = undefined;
     });
 
-    it("should not initialize fluentd if configuration is missing", () => {
-      config.FLUENTD_HOST = "";
-      config.FLUENTD_PORT = 0;
-      config.FLUENTD_TAG = "";
+    it("should initialize pino with local mixin overriding global mixin", () => {
+      function globalMixin() {
+        return {};
+      }
+      function localMixin() {
+        return {};
+      }
+      LoggerService.mixin = globalMixin;
+      new LoggerService({ mixin: localMixin });
 
-      new LoggerService();
-      expect(pinoFluentd).not.toHaveBeenCalled();
+      expect(pino).toHaveBeenCalledWith({ level: "info", mixin: localMixin });
+
+      LoggerService.mixin = undefined;
+    });
+
+    it("should initialize pino with provided log level overriding global log level", () => {
+      new LoggerService({ level: "debug" });
+
+      expect(pino).toHaveBeenCalledWith({ level: "debug" });
+
+      LoggerService.mixin = undefined;
     });
   });
 
-  const methods: (keyof Logger)[] = ["info", "error", "warn", "debug"];
-  describe.each(methods)("prototype.%s", method => {
-    const logMessage = "Test message";
+  describe("methods", () => {
+    let loggerService: LoggerService;
+    let mockLogger: jest.Mocked<Logger>;
 
-    it(`should call pino.${method} on info method`, () => {
-      loggerService[method](logMessage);
-      expect(mockLogger[method]).toHaveBeenCalledWith(logMessage);
+    beforeEach(() => {
+      mockLogger = {
+        info: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+        debug: jest.fn(),
+        child: jest.fn().mockReturnThis()
+      } as unknown as jest.Mocked<Logger>;
+
+      (pino as unknown as jest.Mock).mockReturnValue(mockLogger);
+      loggerService = new LoggerService();
     });
-  });
 
-  describe("prototype.toLoggableInput", () => {
-    it("should return status, message, stack, and data for HttpError", () => {
-      const httpError = createHttpError(404, {
-        status: 404,
-        message: "Not found",
-        stack: "stack trace",
-        data: { key: "value" },
-        originalError: new Error("Original error")
-      });
+    const methods: (keyof Logger)[] = ["info", "error", "warn", "debug"];
+    describe.each(methods)("prototype.%s", method => {
+      const logMessage = "Test message";
 
-      const loggable = loggerService["toLoggableInput"](httpError);
-      expect(loggable).toEqual({
-        status: 404,
-        message: "Not found",
-        stack: "stack trace",
-        data: { key: "value" },
-        originalError: "stack trace"
+      it(`should call pino.${method} on info method`, () => {
+        loggerService[method](logMessage);
+        expect(mockLogger[method]).toHaveBeenCalledWith(logMessage);
       });
     });
 
-    it("should return stack for general Error instance", () => {
-      const error = new Error("Test error");
-      const loggable = loggerService["toLoggableInput"](error);
-      expect(loggable).toBe(error.stack);
-    });
+    describe("prototype.toLoggableInput", () => {
+      it("should return status, message, stack, and data for HttpError", () => {
+        const httpError = createHttpError(404, {
+          status: 404,
+          message: "Not found",
+          stack: "stack trace",
+          data: { key: "value" },
+          originalError: new Error("Original error")
+        });
 
-    it("should return the original message if it is not an error", () => {
-      const message = "Test message";
-      const loggable = loggerService["toLoggableInput"](message);
-      expect(loggable).toBe(message);
+        const loggable = loggerService["toLoggableInput"](httpError);
+        expect(loggable).toEqual({
+          status: 404,
+          message: "Not found",
+          stack: "stack trace",
+          data: { key: "value" },
+          originalError: "stack trace"
+        });
+      });
+
+      it("should return stack for general Error instance", () => {
+        const error = new Error("Test error");
+        const loggable = loggerService["toLoggableInput"](error);
+        expect(loggable).toBe(error.stack);
+      });
+
+      it("should return the original message if it is not an error", () => {
+        const message = "Test message";
+        const loggable = loggerService["toLoggableInput"](message);
+        expect(loggable).toBe(message);
+      });
     });
   });
 });

--- a/packages/logging/src/servicies/logger/logger.service.ts
+++ b/packages/logging/src/servicies/logger/logger.service.ts
@@ -1,78 +1,61 @@
-import { context, trace } from "@opentelemetry/api";
 import { isHttpError } from "http-errors";
-import pino, { Bindings, Logger as PinoLogger, LoggerOptions } from "pino";
+import pino from "pino";
 import { gcpLogOptions } from "pino-cloud-logging";
-import pinoFluentd from "pino-fluentd";
-import pretty from "pino-pretty";
-import { Writable } from "stream";
 
 import { config } from "../../config";
 
-export type Logger = Pick<PinoLogger, "info" | "error" | "warn" | "debug">;
+export type Logger = Pick<pino.Logger, "info" | "error" | "warn" | "debug">;
+
+interface Bindings extends pino.Bindings {
+  context?: string;
+}
+
+interface LoggerOptions extends pino.LoggerOptions {
+  base?: Bindings | null;
+}
 
 export class LoggerService implements Logger {
-  protected pino: Logger;
-
-  constructor(bindings?: Bindings) {
-    this.pino = this.initPino(bindings);
+  static forContext(context: string) {
+    return new LoggerService().setContext(context);
   }
 
-  private initPino(bindings?: Bindings): Logger {
-    const destinations: Writable[] = [];
+  static mixin: (mergeObject: object) => object;
 
+  protected pino: pino.Logger;
+
+  constructor(options?: LoggerOptions) {
+    this.pino = this.initPino(options);
+  }
+
+  private initPino(inputOptions: LoggerOptions = {}): pino.Logger {
     let options: LoggerOptions = {
       level: config.LOG_LEVEL,
-      mixin: () => {
-        const currentSpan = trace.getSpan(context.active());
-        return { ...currentSpan?.spanContext() };
-      }
+      mixin: LoggerService.mixin,
+      ...inputOptions
     };
 
-    if (config.STD_OUT_LOG_FORMAT === "pretty") {
-      destinations.push(pretty({ sync: true }));
+    if (typeof window === "undefined" && config.STD_OUT_LOG_FORMAT === "pretty") {
+      options.transport = {
+        target: "pino-pretty",
+        options: { colorize: true, sync: true }
+      };
     } else {
       options = gcpLogOptions(options as any) as LoggerOptions;
-      destinations.push(process.stdout);
     }
 
-    const fluentd = this.initFluentd();
-
-    if (fluentd) {
-      destinations.push(fluentd);
-    }
-
-    let instance = pino(options, this.combineDestinations(destinations));
-
-    if (bindings) {
-      instance = instance.child(bindings);
-    }
-
-    return instance;
+    return pino(options);
   }
 
-  private initFluentd(): Writable | undefined {
-    const isFluentdEnabled = !!(config.FLUENTD_HOST && config.FLUENTD_PORT && config.FLUENTD_TAG);
+  setContext(context: string) {
+    this.pino.setBindings({ context });
 
-    if (isFluentdEnabled) {
-      return pinoFluentd({
-        tag: config.FLUENTD_TAG,
-        host: config.FLUENTD_HOST,
-        port: config.FLUENTD_PORT,
-        "trace-level": config.LOG_LEVEL
-      });
-    }
+    return this;
   }
 
-  private combineDestinations(destinations: Writable[]): Writable {
-    return new Writable({
-      write(chunk, encoding, callback) {
-        for (const destination of destinations) {
-          destination.write(chunk, encoding);
-        }
+  bind(bindings: pino.Bindings) {
+    this.pino.setBindings(bindings);
 
-        callback();
-      }
-    });
+    return this;
   }
 
   info(message: any) {


### PR DESCRIPTION
This implementation ensures that all pino options can be passed to the LoggerService and would have higher prio comared to env configuration. Env configuration would still take effect.

Also it adds a couple of utility and factory methods.

refs #430