### PR TITLE
fix: template fetch in deploy

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer.tsx
@@ -3,6 +3,7 @@ import { FC, useEffect, useState } from "react";
 import { useAtomValue } from "jotai";
 import { useRouter, useSearchParams } from "next/navigation";
 
+import { USER_TEMPLATE_CODE } from "@src/config/deploy.config";
 import { CI_CD_TEMPLATE_ID } from "@src/config/remote-deploy.config";
 import { useLocalNotes } from "@src/context/LocalNoteProvider";
 import { useSdlBuilder } from "@src/context/SdlBuilderProvider";
@@ -18,7 +19,6 @@ import { CreateLease } from "./CreateLease";
 import { ManifestEdit } from "./ManifestEdit";
 import { CustomizedSteppers } from "./Stepper";
 import { TemplateList } from "./TemplateList";
-import { USER_TEMPLATE_CODE } from "@src/config/deploy.config";
 
 export const NewDeploymentContainer: FC = () => {
   const [isGitProviderTemplate, setIsGitProviderTemplate] = useState<boolean>(false);
@@ -56,17 +56,14 @@ export const NewDeploymentContainer: FC = () => {
         })
       );
     } else {
-      if (isGitProvider) {
-        setIsGitProviderTemplate(true);
-      } else {
-        setIsGitProviderTemplate(false);
-      }
+      setIsGitProviderTemplate(!!isGitProvider);
     }
   }, [searchParams]);
 
   useEffect(() => {
     const templateId = searchParams?.get("templateId");
     const isCreating = !!activeStep && activeStep > getStepIndexByParam(RouteStep.chooseTemplate);
+
     if (!templates || (isCreating && !!editedManifest && !!templateId)) return;
 
     const template = getRedeployTemplate() || getGalleryTemplate() || deploySdl;
@@ -80,7 +77,9 @@ export const NewDeploymentContainer: FC = () => {
     if ("config" in template && (template.config?.ssh || (!template.config?.ssh && hasComponent("ssh")))) {
       toggleCmp("ssh");
     }
-    const isRemoteYamlImage = isImageInYaml(template?.content as string, getTemplateById(CI_CD_TEMPLATE_ID)?.deploy);
+
+    const cicdTemplate = getTemplateById(CI_CD_TEMPLATE_ID);
+    const isRemoteYamlImage = isImageInYaml(template?.content as string, cicdTemplate?.deploy);
     const queryStep = searchParams?.get("step");
     if (queryStep !== RouteStep.editDeployment) {
       if (isRemoteYamlImage) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
     },
     "apps/api": {
       "name": "@akashnetwork/console-api",
-      "version": "2.30.1",
+      "version": "2.32.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
@@ -224,7 +224,7 @@
     },
     "apps/deploy-web": {
       "name": "@akashnetwork/console-web",
-      "version": "2.22.1",
+      "version": "2.23.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",


### PR DESCRIPTION
The issue occurs when the console doesn't fully complete fetching the template, and the user clicks the GitHub CI/CD button immediately to deploy. This leads to malfunctions at times because the template hasn't been fully loaded in the background. To resolve this, we are working on disabling the Build and Deploy button until the template is fully loaded in the background. This Pr solves that..