### PR TITLE
fix(provider): fix indexing of provider attribute unsign txs

### DIFF
--- a/apps/indexer/src/indexers/akashStatsIndexer.ts
+++ b/apps/indexer/src/indexers/akashStatsIndexer.ts
@@ -939,14 +939,24 @@ export class AkashStatsIndexer extends Indexer {
     height: number,
     blockGroupTransaction: DbTransaction
   ) {
-    await ProviderAttributeSignature.destroy({
-      where: {
-        provider: decodedMessage.owner,
-        auditor: decodedMessage.auditor,
-        key: { [Op.in]: decodedMessage.keys }
-      },
-      transaction: blockGroupTransaction
-    });
+    if (decodedMessage.keys.length > 0) {
+      await ProviderAttributeSignature.destroy({
+        where: {
+          provider: decodedMessage.owner,
+          auditor: decodedMessage.auditor,
+          key: { [Op.in]: decodedMessage.keys }
+        },
+        transaction: blockGroupTransaction
+      });
+    } else {
+      await ProviderAttributeSignature.destroy({
+        where: {
+          provider: decodedMessage.owner,
+          auditor: decodedMessage.auditor
+        },
+        transaction: blockGroupTransaction
+      });
+    }
   }
 
   seed(): Promise<void> {


### PR DESCRIPTION
When a `MsgDeleteProviderAttributes` tx doesn't include any keys, every attribute should be unsigned. This PR fixes the indexer implementation which was previously unsigning no attributes.