### PR TITLE
fix(config): increase nginx large header buffer limit

### DIFF
--- a/apps/deploy-web/nginx.conf
+++ b/apps/deploy-web/nginx.conf
@@ -21,6 +21,8 @@ http {
         ssl_certificate /etc/nginx/ssl/my_ssl_cert.crt;
         ssl_certificate_key /etc/nginx/ssl/my_ssl_key.key;
 
+        large_client_header_buffers 4 16k;
+
         location / {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;


### PR DESCRIPTION
The Auth0 cookies combined with others can sometime exceed the default 8k limit of the nginx reverse proxy causing `400 Bad Request` with `Request Header Or Cookie Too Large` . This change increases the limit to 16k.