### PR TITLE
feat(docs): Indexer reference / Migration Clean-Up

### DIFF
--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -51,7 +51,7 @@ Tasks can be configured to report their execution to healthcheck endpoints autom
 
 ## Data Flow
 
-![Index Data Flow](../indexer-flow.drawio.png)
+![Index Data Flow](indexer-flow.drawio.png)
 
 ### **Step #1 - Download Blocks**
 

--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -53,7 +53,7 @@ Tasks can be configured to report their execution to healthcheck endpoints autom
 
 ![Index Data Flow](/indexer-flow.drawio.png)
 
-## Database Migrations
+### Database Migrations
 
 If you are running from an old database snapshot, you may need to run database migrations to ensure your schema is up to date. See [UPGRADE.md](./UPGRADE.md) for migration instructions.
 

--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -51,7 +51,7 @@ Tasks can be configured to report their execution to healthcheck endpoints autom
 
 ## Data Flow
 
-![Index Data Flow](indexer-flow.drawio.png)
+![Index Data Flow](/indexer-flow.drawio.png)
 
 ### **Step #1 - Download Blocks**
 

--- a/apps/indexer/README.md
+++ b/apps/indexer/README.md
@@ -53,6 +53,10 @@ Tasks can be configured to report their execution to healthcheck endpoints autom
 
 ![Index Data Flow](/indexer-flow.drawio.png)
 
+## Database Migrations
+
+If you are running from an old database snapshot, you may need to run database migrations to ensure your schema is up to date. See [UPGRADE.md](./UPGRADE.md) for migration instructions.
+
 ### **Step #1 - Download Blocks**
 
 Using our [nodeAccessor](./src/chain/nodeAccessor.ts) missing blocks are downloaded from RPC nodes. A list of rpc node is setup in the [chainDefinition](../shared/chainDefinitions.ts#L39) file and their status is then kept updated (earliest/latest available block, rate limiting, etc). The blocks are saved on disk inside a leveldb database (see [File Structure](#block-cache-structure)).


### PR DESCRIPTION
- Fixed README indexer image
- Added note for running migrations (I missed this in initial setup) - `UPGRADE.md`