### PR TITLE
Treat missing denom as balance of 0 for Monitored Values

### DIFF
--- a/apps/indexer/src/monitors/addressBalanceMonitor.ts
+++ b/apps/indexer/src/monitors/addressBalanceMonitor.ts
@@ -19,10 +19,6 @@ export class AddressBalanceMonitor {
     const [targetAddress, targetToken] = monitoredValue.target.split("|");
     const balance = await this.getBalance(targetAddress, targetToken);
 
-    if (balance === null) {
-      throw new Error("Unable to get balance for " + monitoredValue.target);
-    }
-
     monitoredValue.value = balance.toString();
     monitoredValue.lastUpdateDate = new Date();
     await monitoredValue.save();
@@ -36,7 +32,7 @@ export class AddressBalanceMonitor {
     const balance = response.data.balances.find(x => x.denom === (denom || activeChain.udenom));
 
     if (!balance) {
-      return null;
+      return 0;
     }
 
     return parseInt(balance.amount);


### PR DESCRIPTION
If a wallet never received tokens of a specific denom the balance endpoint wont have it in the response. Instead of treating this as an error this change treat it as `0` which allow alert to still works.