### PR TITLE
feat(analytics): add financial endpoint

### DIFF
--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -1,4 +1,4 @@
-import { eq, inArray, lte } from "drizzle-orm";
+import { count, eq, inArray, lte } from "drizzle-orm";
 import first from "lodash/first";
 import omit from "lodash/omit";
 import pick from "lodash/pick";
@@ -71,6 +71,11 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
   async findByUserId(userId: UserWalletOutput["userId"] | UserWalletOutput["userId"][]) {
     const where = Array.isArray(userId) ? inArray(this.table.userId, userId) : eq(this.table.userId, userId);
     return this.toOutputList(await this.cursor.query.UserWallets.findMany({ where: this.whereAccessibleBy(where) }));
+  }
+
+  async payingUserCount() {
+    const [{ count: payingUserCount }] = await this.cursor.select({ count: count() }).from(this.table).where(eq(this.table.isTrialing, false));
+    return payingUserCount;
   }
 
   protected toOutput(dbOutput: DbUserWalletOutput): UserWalletOutput {

--- a/apps/api/src/billing/services/financial-stats/financial-stats.service.ts
+++ b/apps/api/src/billing/services/financial-stats/financial-stats.service.ts
@@ -8,7 +8,7 @@ import { USDC_IBC_DENOMS } from "@src/billing/config/network.config";
 import { BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { UserWalletRepository } from "@src/billing/repositories";
 import { chainDb } from "@src/db/dbConnection";
-import { RestCosmosBankBalancesResponse, CosmosDistributionCommunityPoolResponse } from "@src/types/rest";
+import { CosmosDistributionCommunityPoolResponse, RestCosmosBankBalancesResponse } from "@src/types/rest";
 import { apiNodeUrl } from "@src/utils/constants";
 
 @singleton()

--- a/apps/api/src/billing/services/financial-stats/financial-stats.service.ts
+++ b/apps/api/src/billing/services/financial-stats/financial-stats.service.ts
@@ -1,0 +1,105 @@
+import { Provider } from "@akashnetwork/database/dbSchemas/akash";
+import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
+import axios from "axios";
+import { Op, QueryTypes } from "sequelize";
+import { singleton } from "tsyringe";
+
+import { USDC_IBC_DENOMS } from "@src/billing/config/network.config";
+import { BillingConfig, InjectBillingConfig } from "@src/billing/providers";
+import { UserWalletRepository } from "@src/billing/repositories";
+import { chainDb } from "@src/db/dbConnection";
+import { RestCosmosBankBalancesResponse, CosmosDistributionCommunityPoolResponse } from "@src/types/rest";
+import { apiNodeUrl } from "@src/utils/constants";
+
+@singleton()
+export class FinancialStatsService {
+  constructor(
+    @InjectBillingConfig() private readonly config: BillingConfig,
+    private readonly userWalletRepository: UserWalletRepository
+  ) {}
+
+  async getPayingUserCount() {
+    return this.userWalletRepository.payingUserCount();
+  }
+
+  async getMasterWalletBalanceUsdc() {
+    const wallet = await DirectSecp256k1HdWallet.fromMnemonic(this.config.MASTER_WALLET_MNEMONIC, { prefix: "akash" });
+    const [account] = await wallet.getAccounts();
+
+    return this.getWalletBalances(account.address, USDC_IBC_DENOMS.mainnetId);
+  }
+
+  private async getWalletBalances(address: string, denom: string) {
+    const response = await axios.get<RestCosmosBankBalancesResponse>(`${apiNodeUrl}/cosmos/bank/v1beta1/balances/${address}?pagination.limit=1000`);
+    return parseFloat(response.data.balances.find(b => b.denom === denom)?.amount || "0");
+  }
+
+  async getAkashPubProviderBalances() {
+    const akashPubProviders = await Provider.findAll({
+      where: {
+        hostUri: { [Op.like]: "%akash.pub:8443" }
+      }
+    });
+
+    const balances = await Promise.all(
+      akashPubProviders.map(async p => {
+        const balance = await this.getWalletBalances(p.owner, USDC_IBC_DENOMS.mainnetId);
+        return { provider: p.hostUri, balanceUsdc: balance / 1_000_000 };
+      })
+    );
+
+    return balances;
+  }
+
+  async getCommunityPoolUsdc() {
+    const communityPoolData = await axios.get<CosmosDistributionCommunityPoolResponse>(`${apiNodeUrl}/cosmos/distribution/v1beta1/community_pool`);
+    return parseFloat(communityPoolData.data.pool.find(x => x.denom === USDC_IBC_DENOMS.mainnetId)?.amount || "0");
+  }
+
+  async getProviderRevenues() {
+    const results = await chainDb.query<{ hostUri: string; usdEarned: string }>(
+      `
+  WITH trial_deployments_ids AS (
+      SELECT DISTINCT m."relatedDeploymentId" AS "deployment_id"
+      FROM "transaction" t
+      INNER JOIN message m ON m."txId"=t.id
+      WHERE t."memo"='managed wallet tx' AND m.type='/akash.market.v1beta4.MsgCreateLease' AND t.height > 18515430 AND m.height > 18515430 -- 18515430 is height on trial launch (2024-10-17)
+  ),
+  trial_leases AS (
+      SELECT 
+          l.owner AS "owner",
+          l."createdHeight",
+          l."closedHeight",
+          l."providerAddress",
+          l.denom AS denom,
+          l.price AS price,
+          LEAST((SELECT MAX(height) FROM block), COALESCE(l."closedHeight",l."predictedClosedHeight")) - l."createdHeight" AS duration
+      FROM trial_deployments_ids
+      INNER JOIN deployment d ON d.id="deployment_id"
+      INNER JOIN lease l ON l."deploymentId"=d."id"
+      WHERE l.denom='uusdc'
+  ),
+  billed_leases AS (
+      SELECT
+          l.owner,
+          p."hostUri",
+          ROUND(l.duration * l.price::numeric / 1000000, 2) AS "Spent USD"
+      FROM trial_leases l
+      INNER JOIN provider p ON p.owner=l."providerAddress"
+  )
+  SELECT
+      "hostUri",
+      SUM("Spent USD") AS "usdEarned"
+  FROM billed_leases
+  GROUP BY "hostUri"
+  ORDER BY SUM("Spent USD") DESC
+      `,
+      { type: QueryTypes.SELECT }
+    );
+
+    return results.map(p => ({
+      provider: p.hostUri,
+      usdEarned: parseFloat(p.usdEarned)
+    }));
+  }
+}

--- a/apps/api/src/routers/internalRouter.ts
+++ b/apps/api/src/routers/internalRouter.ts
@@ -1,6 +1,7 @@
 import { swaggerUI } from "@hono/swagger-ui";
 import { OpenAPIHono } from "@hono/zod-openapi";
 
+import { privateMiddleware } from "@src/middlewares/privateMiddleware";
 import { env } from "@src/utils/env";
 import routes from "../routes/internal";
 
@@ -19,5 +20,7 @@ internalRouter.doc(`/doc`, {
 const swaggerInstance = swaggerUI({ url: `/internal/doc` });
 
 internalRouter.get(`/swagger`, swaggerInstance);
+
+internalRouter.use("/financial", privateMiddleware);
 
 routes.forEach(route => internalRouter.route(`/`, route));

--- a/apps/api/src/routes/internal/financial.ts
+++ b/apps/api/src/routes/internal/financial.ts
@@ -1,0 +1,44 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi";
+import { container } from "tsyringe";
+
+import { FinancialStatsService } from "@src/billing/services/financial-stats/financial-stats.service";
+
+const route = createRoute({
+  method: "get",
+  path: "/financial",
+  summary: "Financial stats for trial usage",
+  responses: {
+    200: {
+      description: "Financial stats for trial usage",
+      content: {
+        "application/json": {
+          schema: z.object({})
+        }
+      }
+    }
+  }
+});
+
+export default new OpenAPIHono().openapi(route, async c => {
+  const financialStatsService = container.resolve(FinancialStatsService);
+
+  const [masterBalanceUsdc, providerRevenues, communityPoolUsdc, akashPubProviderBalances, payingUserCount] = await Promise.all([
+    financialStatsService.getMasterWalletBalanceUsdc(),
+    financialStatsService.getProviderRevenues(),
+    financialStatsService.getCommunityPoolUsdc(),
+    financialStatsService.getAkashPubProviderBalances(),
+    financialStatsService.getPayingUserCount()
+  ]);
+
+  const readyToRecycle = akashPubProviderBalances.map(x => x.balanceUsdc).reduce((a, b) => a + b, 0);
+
+  return c.json({
+    date: new Date(),
+    trialBalanceUsdc: masterBalanceUsdc / 1_000_000,
+    communityPoolUsdc: communityPoolUsdc / 1_000_000,
+    readyToRecycle,
+    payingUserCount,
+    akashPubProviderBalances,
+    providerRevenues: providerRevenues
+  });
+});

--- a/apps/api/src/routes/internal/index.ts
+++ b/apps/api/src/routes/internal/index.ts
@@ -4,5 +4,6 @@ import gpuPrices from "../v1/gpuPrices";
 import leasesDuration from "../v1/leasesDuration";
 import providerDashboard from "../v1/providerDashboard";
 import providerVersions from "../v1/providerVersions";
+import financial from "./financial";
 
-export default [providerVersions, gpu, leasesDuration, gpuModels, gpuPrices, providerDashboard];
+export default [providerVersions, gpu, leasesDuration, gpuModels, gpuPrices, providerDashboard, financial];

--- a/apps/api/src/types/rest/index.ts
+++ b/apps/api/src/types/rest/index.ts
@@ -7,5 +7,6 @@ export * from "./cosmosGovProposalResponse";
 export * from "./cosmosGovProposalsTallyResponse";
 export * from "./cosmosBankBalancesResponse";
 export * from "./cosmosStakingDelegationsResponse";
+export * from "./cosmosDistributionCommunityPoolResponse";
 export * from "./cosmosDistributionDelegatorsRewardsResponse";
 export * from "./cosmosStakingDelegatorsRedelegationsResponse";

--- a/apps/provider-console/src/pages/dashboard/index.tsx
+++ b/apps/provider-console/src/pages/dashboard/index.tsx
@@ -12,11 +12,11 @@ import { Layout } from "@src/components/layout/Layout";
 import { ProviderActionList } from "@src/components/shared/ProviderActionList";
 import { Title } from "@src/components/shared/Title";
 import { withAuth } from "@src/components/shared/withAuth";
+import { useSelectedChain } from "@src/context/CustomChainProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useAKTData } from "@src/queries";
 import { useProviderActions, useProviderDashboard, useProviderDetails } from "@src/queries/useProviderQuery";
 import { formatUUsd } from "@src/utils/formatUsd";
-import { useSelectedChain } from "@src/context/CustomChainProvider";
 
 const OfflineWarningBanner: React.FC = () => (
   <div className="mb-4 rounded-md bg-yellow-100 p-4 text-yellow-700">


### PR DESCRIPTION
Add `/internal/financial` endpoint to track trial usage. The endpoint is protected using the existing `privateMiddleware` requiring a `token` query param if the `SECRET_TOKEN` env var is set.