### PR TITLE
chore(dx): ensure that commits with "refactor" and "perf" type cause release version change

### DIFF
--- a/packages/releaser/.release-it.js
+++ b/packages/releaser/.release-it.js
@@ -1,16 +1,28 @@
 const { addBangNotes } = require("conventional-changelog-conventionalcommits/utils");
-const { DEFAULT_COMMIT_TYPES } = require("conventional-changelog-conventionalcommits");
 
 const version = "${version}";
 const packageName = process.env.npm_package_name;
 const scope = packageName.split("/")[1];
+const COMMIT_TYPES = [
+  { type: "feat", section: "Features" },
+  { type: "fix", section: "Bug Fixes" },
+  { type: "refactor", section: "Code Refactoring" },
+  { type: "perf", section: "Performance Improvements" },
+  { type: "test",  hidden: true },
+  { type: "chore", hidden: true },
+  { type: "docs",  hidden: true },
+  { type: "style", hidden: true },
+];
 
 module.exports = {
   plugins: {
     "@release-it/conventional-changelog": {
       path: ".",
       infile: "CHANGELOG.md",
-      preset: "conventionalcommits",
+      preset: {
+        name: "conventionalcommits",
+        types: COMMIT_TYPES,
+      },
       gitRawCommitsOpts: {
         path: "."
       },
@@ -21,7 +33,7 @@ module.exports = {
         let features = 0;
 
         commits.forEach(commit => {
-          const isHiddenType = DEFAULT_COMMIT_TYPES.find(type => type.type === commit.type)?.hidden || false;
+          const isHiddenType = COMMIT_TYPES.find(type => type.type === commit.type)?.hidden || false;
           addBangNotes(commit);
           if (commit.notes.length > 0) {
             breakings += commit.notes.length;


### PR DESCRIPTION
## Why

Sometimes we may have changes that from end user perspective is not a feature and not a bugfix but we still want it to be released. It may be either performance improvement or some small adjustments to prepare for bigger refactoring. In this case, the commit type should be "refactor" but the issue is that by default "refactor" commits do not trigger release (version bump and excluded from changelog). This is what happened with PR https://github.com/akash-network/console/pull/634

That's why I suggest to include "refactor" and "perf" commits to release

## What

Includes "refactor" and "perf" commits to release. 

Tested locally, this is an example of this change:

```md
Changelog:
## [2.28.3](https://github.com/akash-network/console/compare/console-web/v2.28.2...console-web/v2.28.3) (2025-01-16)

### Code Refactoring
* **template:** replaces /v1/templates with /v1/templates-list ([dcc986c](https://github.com/akash-network/console/commit/dcc986cc4718fc0a4b9463d3d780a5b70f9e6cd9)), closes [#477](https://github.com/akash-network/console/issues/477)
```
 



