### PR TITLE
fix(stats): fixes syntax for api prod version

### DIFF
--- a/apps/api/src/services/db/providerStatusService.ts
+++ b/apps/api/src/services/db/providerStatusService.ts
@@ -28,25 +28,25 @@ export async function getNetworkCapacity() {
   const filteredProviders = uniqBy(providers, provider => provider.hostUri);
   const stats = filteredProviders.reduce(
     (all, provider) => {
-      stats.activeCPU += provider.lastSuccessfulSnapshot.activeCPU;
-      stats.pendingCPU += provider.lastSuccessfulSnapshot.pendingCPU;
-      stats.availableCPU += provider.lastSuccessfulSnapshot.availableCPU;
+      all.activeCPU += provider.lastSuccessfulSnapshot.activeCPU;
+      all.pendingCPU += provider.lastSuccessfulSnapshot.pendingCPU;
+      all.availableCPU += provider.lastSuccessfulSnapshot.availableCPU;
 
-      stats.activeGPU += provider.lastSuccessfulSnapshot.activeGPU;
-      stats.pendingGPU += provider.lastSuccessfulSnapshot.pendingGPU;
-      stats.availableGPU += provider.lastSuccessfulSnapshot.availableGPU;
+      all.activeGPU += provider.lastSuccessfulSnapshot.activeGPU;
+      all.pendingGPU += provider.lastSuccessfulSnapshot.pendingGPU;
+      all.availableGPU += provider.lastSuccessfulSnapshot.availableGPU;
 
-      stats.activeMemory += provider.lastSuccessfulSnapshot.activeMemory;
-      stats.pendingMemory += provider.lastSuccessfulSnapshot.pendingMemory;
-      stats.availableMemory += provider.lastSuccessfulSnapshot.availableMemory;
+      all.activeMemory += provider.lastSuccessfulSnapshot.activeMemory;
+      all.pendingMemory += provider.lastSuccessfulSnapshot.pendingMemory;
+      all.availableMemory += provider.lastSuccessfulSnapshot.availableMemory;
 
-      stats.activeEphemeralStorage += provider.lastSuccessfulSnapshot.activeEphemeralStorage;
-      stats.pendingEphemeralStorage += provider.lastSuccessfulSnapshot.pendingEphemeralStorage;
-      stats.availableEphemeralStorage += provider.lastSuccessfulSnapshot.availableEphemeralStorage;
+      all.activeEphemeralStorage += provider.lastSuccessfulSnapshot.activeEphemeralStorage;
+      all.pendingEphemeralStorage += provider.lastSuccessfulSnapshot.pendingEphemeralStorage;
+      all.availableEphemeralStorage += provider.lastSuccessfulSnapshot.availableEphemeralStorage;
 
-      stats.activePersistentStorage += provider.lastSuccessfulSnapshot.activePersistentStorage;
-      stats.pendingPersistentStorage += provider.lastSuccessfulSnapshot.pendingPersistentStorage;
-      stats.availablePersistentStorage += provider.lastSuccessfulSnapshot.availablePersistentStorage;
+      all.activePersistentStorage += provider.lastSuccessfulSnapshot.activePersistentStorage;
+      all.pendingPersistentStorage += provider.lastSuccessfulSnapshot.pendingPersistentStorage;
+      all.availablePersistentStorage += provider.lastSuccessfulSnapshot.availablePersistentStorage;
 
       return all;
     },


### PR DESCRIPTION
refs #645

## Why

after deploying changes to beta, it appeared that I used wrong variable in reduce which was not initialized and /network-capacity request failed with 500 error:

```json
{
    "severity": "ERROR",
    "@type": "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent",
    "time": "2025-01-21T11:01:46.704Z",
    "context": "ErrorHandler",
    "traceId": "7542356c94be395186f49cce02a27021",
    "spanId": "8a3f58664923dbca",
    "traceFlags": 1,
    "message": "ReferenceError: Cannot access 'stats' before initialization\n    at filteredProviders.reduce.activeCPU (/app/apps/api/dist/server.js:551416:13)\n    at Array.reduce (<anonymous>)\n    at /app/apps/api/dist/server.js:551415:41\n    at Generator.next (<anonymous>)\n    at fulfilled (/app/apps/api/dist/server.js:551379:58)\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)"
}
```

Stacktrace:
```
ReferenceError: Cannot access 'stats' before initialization
    at filteredProviders.reduce.activeCPU (/app/apps/api/dist/server.js:551416:13)
    at Array.reduce (<anonymous>)
    at /app/apps/api/dist/server.js:551415:41
    at Generator.next (<anonymous>)
    at fulfilled (/app/apps/api/dist/server.js:551379:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```