### PR TITLE
feat: adds certificate validation on provider proxy

### DIFF
--- a/.github/workflows/docker-build-provider-proxy.yml
+++ b/.github/workflows/docker-build-provider-proxy.yml
@@ -1,10 +1,12 @@
-name: Provider Proxy CI
+name: Validate and Build Provider Proxy CI
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -21,6 +23,40 @@ jobs:
           filters: |
             provider-proxy:
               - 'apps/provider-proxy/**'
+              - 'packages/net/**'
+
+      - name: Setup Node.js
+        if: steps.filter.outputs.provider-proxy == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.14.0
+
+      - name: Restore root node_modules cache
+        if: steps.filter.outputs.provider-proxy == 'true'
+        uses: actions/cache@v4
+        id: cache
+        with:
+          path: |
+            node_modules
+            apps/provider-proxy/node_modules
+            packages/*/node_modules
+          key: provider-proxy-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.filter.outputs.provider-proxy == 'true' && steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Run static code analysis
+        if: steps.filter.outputs.provider-proxy == 'true'
+        run: npm run lint -w apps/provider-proxy
+
+      - name: Run unit tests
+        if: steps.filter.outputs.provider-proxy == 'true'
+        run: npm run test:unit --workspace=apps/provider-proxy
+
+      - name: Run functional tests
+        if: steps.filter.outputs.provider-proxy == 'true'
+        run: npm run test:functional --workspace=apps/provider-proxy
 
       - name: Build the Docker image
         if: steps.filter.outputs.provider-proxy == 'true'

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,7 +7,11 @@ if [[ "$CI" != "true" ]]; then
     npm run update-apps-local-deps -w packages/ui
     npm run update-apps-local-deps -w packages/network-store
     npm run update-apps-local-deps -w packages/logging
+    npm run update-apps-local-deps -w packages/net
     git add ./apps/*/mvm.lock
+
+    npm run generate -w packages/net
+    git add ./packages/net/src/generated
 
     npx lint-staged
 fi

--- a/apps/provider-proxy/jest.config.js
+++ b/apps/provider-proxy/jest.config.js
@@ -11,7 +11,8 @@ module.exports = {
     {
       displayName: "unit",
       ...common,
-      testMatch: ["<rootDir>/src/**/*.spec.ts"]
+      testMatch: ["<rootDir>/test/**/*.spec.ts"],
+      testPathIgnorePatterns: ["/node_modules", "test/functional"]
     },
     {
       displayName: "functional",

--- a/apps/provider-proxy/mvm.lock
+++ b/apps/provider-proxy/mvm.lock
@@ -1,4 +1,7 @@
 {
+  "dependencies": {
+    "@akashnetwork/net": "0.0.1"
+  },
   "devDependencies": {
     "@akashnetwork/dev-config": "1.0.0"
   }

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -6,8 +6,8 @@
   "author": "Akash Network",
   "main": "main.js",
   "scripts": {
-    "build": "npx tsc",
-    "dev": "npm run start",
+    "build": "rm -rf dist/* && npx tsc && esbuild server.ts --bundle --sourcemap --platform=node --target=node20.14.0 --outdir=dist",
+    "dev": "nodemon server.ts",
     "dev-nodc": "npm run start",
     "format": "prettier --write ./*.{ts,js,json} **/*.{ts,js,json}",
     "lint": "eslint .",
@@ -15,13 +15,15 @@
     "start": "npm run build && node ./dist/server.js",
     "test:functional": "jest --selectProjects functional",
     "test:functional:cov": "jest --selectProjects functional --coverage",
-    "test:functional:watch": "jest --selectProjects functional --watch"
+    "test:functional:watch": "jest --selectProjects functional --watch",
+    "test:unit": "jest --selectProjects unit"
   },
   "dependencies": {
-    "axios": "^1.7.2",
+    "@akashnetwork/net": "*",
+    "bech32": "^2.0.0",
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "node-fetch": "^2.6.9",
+    "lru-cache": "^11.0.2",
     "uuid": "^9.0.0",
     "ws": "^7.5.9"
   },
@@ -29,14 +31,17 @@
     "@akashnetwork/dev-config": "*",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.16",
-    "@types/node-fetch": "^2.6.2",
+    "@types/node-forge": "^1.3.11",
     "@types/uuid": "^9.0.0",
     "@types/ws": "^8.5.4",
     "@typescript-eslint/eslint-plugin": "^7.12.0",
+    "esbuild": "^0.24.2",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.3",
     "eslint-plugin-simple-import-sort": "^12.1.0",
     "jest": "^29.7.0",
+    "node-forge": "^1.3.1",
+    "nodemon": "^3.1.9",
     "prettier": "^3.3.0",
     "prettier-plugin-tailwindcss": "^0.6.1",
     "typescript": "5.1.3"

--- a/apps/provider-proxy/src/app.ts
+++ b/apps/provider-proxy/src/app.ts
@@ -16,6 +16,7 @@ const whitelist = [
   "https://console-beta.akash.network"
 ];
 
+app.disable("x-powered-by");
 app.use(
   cors({
     origin: function (origin, callback) {

--- a/apps/provider-proxy/src/container.ts
+++ b/apps/provider-proxy/src/container.ts
@@ -1,7 +1,21 @@
+import { netConfig, SupportedChainNetworks } from "@akashnetwork/net";
+
 import { ProviderProxy } from "./services/ProviderProxy";
+import { ProviderService } from "./services/ProviderService";
 import { WebsocketStats } from "./services/WebsocketStats";
 
+const wsStats = new WebsocketStats();
+const providerService = new ProviderService((network: SupportedChainNetworks) => {
+  // TEST_CHAIN_NETWORK_URL is hack for functional tests
+  // there is no good way to mock external server in nodejs
+  // both nock and msw do not work well when I need to use low level API like X509 certificate validation
+  // for some reason when those libraries are used I receive MockSocket instead of TLSSocket
+  // @see https://github.com/mswjs/msw/discussions/2416
+  return process.env.TEST_CHAIN_NETWORK_URL || netConfig.getBaseAPIUrl(network);
+}, fetch);
+const providerProxy = new ProviderProxy(Date.now, providerService);
+
 export const container = {
-  wsStats: new WebsocketStats(),
-  providerProxy: new ProviderProxy()
+  wsStats,
+  providerProxy
 };

--- a/apps/provider-proxy/src/services/ProviderProxy.ts
+++ b/apps/provider-proxy/src/services/ProviderProxy.ts
@@ -1,24 +1,118 @@
+import { SupportedChainNetworks } from "@akashnetwork/net";
+import { X509Certificate } from "crypto";
+import { IncomingMessage } from "http";
 import https, { RequestOptions } from "https";
-import fetch, { BodyInit, Headers, Response } from "node-fetch";
+import { LRUCache } from "lru-cache";
+import { TLSSocket } from "tls";
+
+import { CertValidationResultError, validateCertificate } from "../utils/validateCertificate";
+import { ProviderService } from "./ProviderService";
 
 export class ProviderProxy {
-  fetch(url: string, options: FetchOptions): Promise<Response> {
-    const httpsAgent = new https.Agent({
-      cert: options.cert,
-      key: options.key,
-      rejectUnauthorized: false
-    });
+  private readonly knownCertificatesCache = new LRUCache<string, boolean>({
+    max: 100_000,
+    ttl: 30 * 60 * 1000
+  });
 
-    return fetch(url, {
-      method: options.method,
-      body: options.body,
-      headers: new Headers(options.headers),
-      agent: httpsAgent
+  constructor(
+    private readonly now: () => number,
+    private readonly providerService: ProviderService
+  ) {}
+
+  connect(url: string, options: ProxyConnectOptions): Promise<ProxyConnectionResult> {
+    return new Promise<ProxyConnectionResult>((resolve, reject) => {
+      const req = https.request(
+        url,
+        {
+          method: options.method,
+          headers: {
+            "Content-Type": "application/json",
+            ...options.headers
+          },
+          timeout: options.timeout,
+          cert: options.cert,
+          key: options.key,
+          rejectUnauthorized: false
+        },
+        async res => {
+          try {
+            res.setEncoding("utf8");
+            const socket = res.socket as TLSSocket;
+            const serverCert = socket.getPeerX509Certificate();
+            // @see https://nodejs.org/api/tls.html#session-resumption
+            // for servers which support TLS session resumption, handshake phase is skipped for subsequent requests
+            // to improve performance and in this case certicate is not available because it is not requested.
+            // There is a way to disable session resumption but it will hurt performance.
+            // To disable either create a new `https.Agent` for every request or reduce session related options in it
+            // sessionTimeout & maxCachedSessions. In that case, we will do TLS handshake on every request and
+            // will receive certificate for every request
+            const didHandshake = !!serverCert;
+
+            if (didHandshake && options.network && options.providerAddress) {
+              const validationResult = validateCertificate(serverCert, this.now());
+              if (validationResult.ok === false) {
+                req.destroy();
+                return resolve({ ok: false, code: "invalidCertificate", reason: validationResult.code });
+              }
+
+              const isKnown = await this.isKnownCertificate(serverCert, options.network, options.providerAddress);
+              if (!isKnown) {
+                req.destroy();
+                return resolve({ ok: false, code: "invalidCertificate", reason: "unknownCertificate" });
+              }
+            }
+
+            resolve({ ok: true, response: res });
+          } catch (error) {
+            reject(error);
+          }
+        }
+      );
+
+      if (!req.reusedSocket) {
+        req.on("error", (error: (Error & { code: string }) | undefined) => {
+          reject(error);
+        });
+        req.on("timeout", () => {
+          // here we are just notified that response take more than specified in request options timeout
+          // then we manually destroy request and it drops connection and
+          // on('error') handler is called with Error code = ECONNRESET
+          req.destroy();
+        });
+      }
+
+      if (options.body) req.write(options.body);
+      req.end();
     });
+  }
+
+  private async isKnownCertificate(cert: X509Certificate, network: SupportedChainNetworks, providerAddress: string): Promise<boolean> {
+    const key = `${network}.${providerAddress}.${cert.serialNumber}`;
+
+    if (!this.knownCertificatesCache.has(key)) {
+      const hasCertificate = await this.providerService.hasCertificate(network, providerAddress, cert.serialNumber);
+      this.knownCertificatesCache.set(key, hasCertificate);
+      return hasCertificate;
+    }
+
+    return this.knownCertificatesCache.get(key);
   }
 }
 
-export interface FetchOptions extends Pick<RequestOptions, "cert" | "key" | "method"> {
+export interface ProxyConnectOptions extends Pick<RequestOptions, "cert" | "key" | "method"> {
   body?: BodyInit;
   headers?: Record<string, string>;
+  network: SupportedChainNetworks;
+  timeout?: number;
+  /** provider wallet address */
+  providerAddress: string;
 }
+
+export type ProxyConnectionResult = ProxyConnectionResultSuccess | ProxyConnectionResultError;
+
+interface ProxyConnectionResultSuccess {
+  ok: true;
+  response: IncomingMessage;
+}
+
+type ProxyConnectionResultError = { ok: false; code: "invalidCertificate"; reason: CertValidationResultError["code"] | "unknownCertificate" };

--- a/apps/provider-proxy/src/services/ProviderService.ts
+++ b/apps/provider-proxy/src/services/ProviderService.ts
@@ -1,0 +1,34 @@
+import { SupportedChainNetworks } from "@akashnetwork/net";
+
+import { httpRetry } from "../utils/retry";
+
+export class ProviderService {
+  constructor(
+    private readonly getChainBaseUrl: (network: SupportedChainNetworks) => string,
+    private readonly fetch: typeof global.fetch
+  ) {}
+
+  async hasCertificate(network: SupportedChainNetworks, providerAddress: string, serialNumber: string): Promise<boolean> {
+    const queryParams = new URLSearchParams({
+      "filter.state": "valid",
+      "filter.owner": providerAddress,
+      "filter.serial": serialNumber,
+      "pagination.limit": "1"
+    });
+
+    const response = await httpRetry(() => this.fetch(`${this.getChainBaseUrl(network)}/akash/cert/v1beta3/certificates/list?${queryParams}`), {
+      retryIf: response => response.status > 500
+    });
+
+    if (response.status >= 200 && response.status < 300) {
+      const body = (await response.json()) as KnownCertificatesResponseBody;
+      return body.certificates.length === 1;
+    }
+
+    return false;
+  }
+}
+
+interface KnownCertificatesResponseBody {
+  certificates: unknown[];
+}

--- a/apps/provider-proxy/src/utils/retry.ts
+++ b/apps/provider-proxy/src/utils/retry.ts
@@ -1,0 +1,49 @@
+import { setTimeout } from "timers/promises";
+
+export const httpRetry = <T>(callback: () => Promise<T>, options: HttpRetryOptions<T>): Promise<T> => {
+  return retryWithBackoff(callback, options.retryIf, options.maxRetries || 5, 0);
+};
+
+export interface HttpRetryOptions<T> {
+  retryIf: (response: T) => boolean;
+  maxRetries?: number;
+}
+
+async function retryWithBackoff<T>(
+  callback: () => Promise<T>,
+  shouldRetryOnResponse: HttpRetryOptions<T>["retryIf"],
+  maxRetries: number,
+  attempt: number
+): Promise<T> {
+  try {
+    if (attempt > 0) {
+      // (2 ** 1) * 100 = 200 ms
+      // (2 ** 2) * 100 = 400 ms
+      // (2 ** 3) * 100 = 800 ms
+      // (2 ** 4) * 100 = 1600 ms
+      // (2 ** 5) * 100 = 3200 ms
+      await setTimeout(2 ** attempt * 100);
+    }
+    const response = await callback();
+
+    if (attempt < maxRetries && shouldRetryOnResponse(response)) {
+      return retryWithBackoff(callback, shouldRetryOnResponse, maxRetries, attempt + 1);
+    }
+    return response;
+  } catch (error: unknown) {
+    if (attempt < maxRetries && canRetryOnError(error)) {
+      return retryWithBackoff(callback, shouldRetryOnResponse, maxRetries, attempt + 1);
+    } else {
+      throw error;
+    }
+  }
+}
+
+const isRetriableError = (code: string) => code === "ECONNREFUSED" || code === "ECONNRESET" || code === "ERR_TLS_SESSION_REJECTED";
+function canRetryOnError(error: unknown): boolean {
+  if (!error) return false;
+  if (Object.hasOwn(error as Error, "code")) return isRetriableError((error as { code: string }).code);
+
+  const errorCode = ((error as Error).cause as { code: string })?.code;
+  return isRetriableError(errorCode);
+}

--- a/apps/provider-proxy/src/utils/validateCertificate.ts
+++ b/apps/provider-proxy/src/utils/validateCertificate.ts
@@ -1,0 +1,56 @@
+import { bech32 } from "bech32";
+import { X509Certificate } from "crypto";
+
+export function validateCertificate(cert: X509Certificate, now: number): CertValidationResult {
+  if (new Date(cert.validFrom).getTime() > now) {
+    return {
+      ok: false,
+      code: "validInFuture"
+    };
+  }
+
+  if (new Date(cert.validTo).getTime() < now) {
+    return {
+      ok: false,
+      code: "expired"
+    };
+  }
+
+  if (!cert.serialNumber?.trim()) {
+    return {
+      ok: false,
+      code: "invalidSerialNumber"
+    };
+  }
+
+  if (cert.issuer !== cert.subject) {
+    return {
+      ok: false,
+      code: "notSelfSigned"
+    };
+  }
+
+  const commonName = parseCertSubject(cert.subject, "CN");
+  if (!commonName || !bech32.decodeUnsafe(commonName)) {
+    return {
+      ok: false,
+      code: "CommonNameIsNotBech32"
+    };
+  }
+
+  return { ok: true };
+}
+
+export type CertValidationResult = CertValidationResultError | { ok: true };
+export type CertValidationResultError = { ok: false; code: "validInFuture" | "expired" | "invalidSerialNumber" | "notSelfSigned" | "CommonNameIsNotBech32" };
+
+function parseCertSubject(subject: string, attr: string): string | null {
+  const attrPrefix = `${attr}=`;
+  const index = subject.indexOf(attrPrefix);
+  if (index === -1) return null;
+
+  const endIndex = subject.indexOf("\n", index);
+  if (endIndex === -1) return subject.slice(index);
+
+  return subject.slice(index + attrPrefix.length, endIndex);
+}

--- a/apps/provider-proxy/test/functional/provider-proxy.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy.spec.ts
@@ -1,29 +1,265 @@
+import { SupportedChainNetworks } from "@akashnetwork/net";
+import { bech32 } from "bech32";
+import { setTimeout } from "timers/promises";
+
+import { createX509CertPair } from "../seeders/createX509CertPair";
 import { request } from "../setup/apiClient";
+import { mockOnChainCertificates, stopChainAPIServer } from "../setup/chainApiServer";
+import { startProviderServer, stopProviderServer } from "../setup/providerServer";
 
 describe("Provider proxy", () => {
-  it("should proxy request if provider uses self-signed certificate", async () => {
+  const network: SupportedChainNetworks = "sandbox";
+  const ONE_HOUR = 60 * 60 * 1000;
+
+  afterEach(() => {
+    stopProviderServer();
+    stopChainAPIServer();
+  });
+
+  it("proxies request if provider uses self-signed certificate which is available on chain", async () => {
+    const providerAddress = generateBech32();
+    const validCertPair = createX509CertPair({ commonName: providerAddress, validFrom: new Date(Date.now() - ONE_HOUR), serialNumber: Date.now().toString() });
+
+    await mockOnChainCertificates([validCertPair.cert]);
+    const providerUrl = await startProviderServer(validCertPair);
+
     const response = await request("/", {
       method: "POST",
       body: JSON.stringify({
         method: "GET",
-        url: "https://provider.tevuicdasialmareny.es:8443/status"
+        url: `${providerUrl}/200.txt`,
+        providerAddress,
+        network
       })
     });
 
-    const body = await response.json();
-    expect(body.cluster_public_hostname).toBe("provider.tevuicdasialmareny.es");
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("text/plain");
+
+    const body = await response.text();
+    expect(body).toBe("Hello, World!");
   });
 
-  it("should proxy request if provider uses trusted CA issued certificate", async () => {
+  it("proxies headers from remote provider host", async () => {
+    const providerAddress = generateBech32();
+    const validCertPair = createX509CertPair({ commonName: providerAddress, validFrom: new Date(Date.now() - ONE_HOUR) });
+
+    await mockOnChainCertificates([validCertPair.cert]);
+    const providerUrl = await startProviderServer(validCertPair);
+
     const response = await request("/", {
       method: "POST",
       body: JSON.stringify({
         method: "GET",
-        url: "https://api.cloudmos.io/internal/gpu-prices"
+        url: `${providerUrl}/headers.json`,
+        providerAddress,
+        network
       })
     });
 
-    const body = await response.json();
-    expect(body.availability).toBeTruthy();
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("x-custom-header")).toBe("test");
+
+    const body = await response.text();
+    expect(body).toBe(JSON.stringify({ ok: true }));
   });
+
+  it("can work without chain API by using cached certificates", async () => {
+    const providerAddress = generateBech32();
+    const validCertPair = createX509CertPair({ commonName: providerAddress, validFrom: new Date(Date.now() - ONE_HOUR) });
+
+    const chainServer = await mockOnChainCertificates([validCertPair.cert]);
+    const providerUrl = await startProviderServer(validCertPair);
+
+    let response = await request("/", {
+      method: "POST",
+      body: JSON.stringify({
+        method: "GET",
+        url: `${providerUrl}/200.txt`,
+        providerAddress,
+        network
+      })
+    });
+    chainServer.close();
+
+    response = await request("/", {
+      method: "POST",
+      body: JSON.stringify({
+        method: "GET",
+        url: `${providerUrl}/200.txt`,
+        providerAddress,
+        network
+      })
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = await response.text();
+    expect(body).toBe("Hello, World!");
+  });
+
+  it("responds with 495 error if certificate is not on chain", async () => {
+    const providerAddress = generateBech32();
+    const validCertPair = createX509CertPair({ commonName: providerAddress, validFrom: new Date(Date.now() - ONE_HOUR) });
+
+    await mockOnChainCertificates([
+      createX509CertPair({
+        commonName: providerAddress,
+        validFrom: new Date(Date.now() + ONE_HOUR),
+        serialNumber: Date.now().toString()
+      }).cert
+    ]);
+    const providerUrl = await startProviderServer(validCertPair);
+
+    const response = await request("/", {
+      method: "POST",
+      body: JSON.stringify({
+        method: "GET",
+        url: `${providerUrl}/200.txt`,
+        providerAddress,
+        network
+      })
+    });
+
+    expect(response.status).toBe(495);
+
+    const body = await response.text();
+    expect(body).toContain("unknownCertificate");
+  });
+
+  it("responds with 495 error if server uses invalid certificate", async () => {
+    const providerAddress = generateBech32();
+    const validCertPair = createX509CertPair({
+      commonName: providerAddress,
+      validFrom: new Date(Date.now() - 24 * ONE_HOUR),
+      validTo: new Date(Date.now() - ONE_HOUR)
+    });
+
+    await mockOnChainCertificates([createX509CertPair({ commonName: providerAddress, validFrom: new Date(Date.now() + ONE_HOUR) }).cert, validCertPair.cert]);
+    const providerUrl = await startProviderServer(validCertPair);
+
+    const response = await request("/", {
+      method: "POST",
+      body: JSON.stringify({
+        method: "GET",
+        url: `${providerUrl}/200.txt`,
+        providerAddress,
+        network
+      })
+    });
+
+    expect(response.status).toBe(495);
+
+    const body = await response.text();
+    expect(body).toContain("expired");
+  });
+
+  it("retries fetching chain certificates if chain API is unavailable", async () => {
+    const providerAddress = generateBech32();
+    const validCertPair = createX509CertPair({
+      commonName: providerAddress
+    });
+
+    const providerUrl = await startProviderServer(validCertPair);
+
+    process.env.TEST_CHAIN_NETWORK_URL = "http://localhost:31234";
+    const responsePromise = request("/", {
+      method: "POST",
+      body: JSON.stringify({
+        method: "GET",
+        url: `${providerUrl}/200.txt`,
+        providerAddress,
+        network
+      })
+    });
+    await setTimeout(200);
+    await mockOnChainCertificates([validCertPair.cert]);
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toBe("Hello, World!");
+  });
+
+  it("retries if chain API responds with 5xx request", async () => {
+    const providerAddress = generateBech32();
+    const validCertPair = createX509CertPair({
+      commonName: providerAddress
+    });
+
+    const providerUrl = await startProviderServer(validCertPair);
+    await mockOnChainCertificates([validCertPair.cert], {
+      respondWithOnceWith: 502
+    });
+
+    const response = await request("/", {
+      method: "POST",
+      body: JSON.stringify({
+        method: "GET",
+        url: `${providerUrl}/200.txt`,
+        providerAddress,
+        network
+      })
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toBe("Hello, World!");
+  });
+
+  it("retries on provider host returning 5xx", async () => {
+    const providerAddress = generateBech32();
+    const validCertPair = createX509CertPair({
+      commonName: providerAddress
+    });
+
+    const providerUrl = await startProviderServer(validCertPair);
+    await mockOnChainCertificates([validCertPair.cert]);
+
+    const response = await request("/", {
+      method: "POST",
+      body: JSON.stringify({
+        method: "GET",
+        url: `${providerUrl}/5xx-once`,
+        providerAddress,
+        network
+      })
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toBe("Success");
+  });
+
+  it("retries on provider host being slow", async () => {
+    const providerAddress = generateBech32();
+    const validCertPair = createX509CertPair({
+      commonName: providerAddress
+    });
+
+    const providerUrl = await startProviderServer(validCertPair);
+    await mockOnChainCertificates([validCertPair.cert]);
+
+    const response = await request("/", {
+      method: "POST",
+      body: JSON.stringify({
+        method: "GET",
+        url: `${providerUrl}/slow-once`,
+        providerAddress,
+        network,
+        timeout: 200
+      })
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toBe("Fast");
+  });
+
+  let index = 0;
+  function generateBech32() {
+    const words = bech32.toWords(Buffer.from("foobar2", "utf8"));
+    return bech32.encode(`test${++index}`, words);
+  }
 });

--- a/apps/provider-proxy/test/seeders/createX509CertPair.ts
+++ b/apps/provider-proxy/test/seeders/createX509CertPair.ts
@@ -1,0 +1,44 @@
+import { X509Certificate } from "crypto";
+import { pki } from "node-forge";
+
+export function createX509CertPair(options: CertificateOptions = {}): CertPair {
+  const keys = pki.rsa.generateKeyPair(2048);
+  const cert = pki.createCertificate();
+
+  cert.publicKey = keys.publicKey;
+  cert.serialNumber = options.serialNumber ?? "01";
+  cert.validity.notBefore = options.validFrom || new Date();
+  cert.validity.notAfter = options.validTo || nextDay(cert.validity.notBefore);
+
+  const attrs = [
+    { name: "commonName", value: options?.commonName ?? "example.org" },
+    { name: "countryName", value: "US" },
+    { shortName: "ST", value: "Virginia" }
+  ];
+  cert.setSubject(attrs);
+  cert.setIssuer(attrs);
+  cert.sign(keys.privateKey);
+
+  return {
+    cert: new X509Certificate(pki.certificateToPem(cert)),
+    key: pki.privateKeyToPem(keys.privateKey)
+  };
+}
+
+export interface CertPair {
+  key: string;
+  cert: X509Certificate;
+}
+
+export interface CertificateOptions {
+  validFrom?: Date;
+  validTo?: Date;
+  serialNumber?: string;
+  commonName?: string;
+}
+
+function nextDay(from: Date) {
+  const date = new Date(from.getTime());
+  date.setDate(date.getDate() + 1);
+  return date;
+}

--- a/apps/provider-proxy/test/services/ProviderService.spec.ts
+++ b/apps/provider-proxy/test/services/ProviderService.spec.ts
@@ -1,0 +1,57 @@
+import { ProviderService } from "../../src/services/ProviderService";
+
+describe(ProviderService.name, () => {
+  describe("hasCertificate", () => {
+    it("returns true if there is exactly 1 certificate for provided certificate", async () => {
+      const getCertificates = jest.fn();
+      const service = setup({ getCertificates });
+
+      getCertificates.mockReturnValueOnce(new Response(JSON.stringify({ certificates: [] }), { status: 200 }));
+      expect(await service.hasCertificate("sandbox", "provider", "serial123")).toBe(false);
+      expect(getCertificates).toHaveBeenCalledWith(expect.stringMatching(/(pagination.limit=10|filter.owner=provider|filter.serial=serial123)/));
+
+      getCertificates.mockReturnValueOnce(new Response(JSON.stringify({ certificates: [{}] }), { status: 200 }));
+      expect(await service.hasCertificate("sandbox", "provider", "serial321")).toBe(true);
+    });
+
+    it("retries certificates request if it fails with response.status > 500", async () => {
+      const getCertificates = jest.fn();
+      const service = setup({ getCertificates });
+
+      getCertificates.mockReturnValueOnce(new Response(JSON.stringify("Server error"), { status: 502 }));
+      getCertificates.mockReturnValueOnce(new Response(JSON.stringify("Server error"), { status: 502 }));
+      getCertificates.mockReturnValueOnce(new Response(JSON.stringify({ certificates: [{}] }), { status: 200 }));
+      expect(await service.hasCertificate("sandbox", "provider", "serial321")).toBe(true);
+      expect(getCertificates).toHaveBeenCalledTimes(3);
+    });
+
+    it("retries certificate request 5 times and then fails in case of response.status > 500", async () => {
+      const getCertificates = jest.fn();
+      const service = setup({ getCertificates });
+
+      getCertificates.mockReturnValue(new Response(JSON.stringify("Server error"), { status: 502 }));
+      expect(await service.hasCertificate("sandbox", "provider", "serial321")).toBe(false);
+      expect(getCertificates).toHaveBeenCalledTimes(1 + 5);
+    }, 7_000);
+
+    it("returns false if certificates request fails with 500 and do not retry", async () => {
+      const getCertificates = jest.fn();
+      const service = setup({ getCertificates });
+
+      getCertificates.mockReturnValueOnce(new Response(JSON.stringify("Server error"), { status: 500 }));
+      expect(await service.hasCertificate("sandbox", "provider", "serial321")).toBe(false);
+      expect(getCertificates).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  function setup(props: Props) {
+    return new ProviderService(
+      () => "/",
+      (...args) => Promise.resolve(props.getCertificates(...args))
+    );
+  }
+
+  interface Props {
+    getCertificates(...args: unknown[]): Response;
+  }
+});

--- a/apps/provider-proxy/test/services/validateCertificate.spec.ts
+++ b/apps/provider-proxy/test/services/validateCertificate.spec.ts
@@ -1,0 +1,67 @@
+import { X509Certificate } from "crypto";
+
+import { CertValidationResultError, validateCertificate } from "../../src/utils/validateCertificate";
+import { createX509CertPair } from "../seeders/createX509CertPair";
+
+describe(validateCertificate.name, () => {
+  const ONE_MINUTE = 60 * 1000;
+
+  it("returns error if certificate is issued for future use", () => {
+    const validFrom = new Date();
+    const { cert } = createX509CertPair({ validFrom });
+
+    const result = validateCertificate(cert, validFrom.getTime() - ONE_MINUTE) as CertValidationResultError;
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("validInFuture");
+  });
+
+  it("returns error if certificate expired", () => {
+    const validFrom = new Date();
+    const validTo = new Date(validFrom.getTime() + 60 * 1000);
+    const { cert } = createX509CertPair({ validFrom, validTo });
+
+    const result = validateCertificate(cert, validTo.getTime() + ONE_MINUTE) as CertValidationResultError;
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("expired");
+  });
+
+  it("returns error if certificate does not have serial number", () => {
+    const cert = Object.create(createX509CertPair().cert) as X509Certificate;
+    Object.defineProperty(cert, "serialNumber", { get: () => "" });
+
+    const result = validateCertificate(cert, Date.now()) as CertValidationResultError;
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("invalidSerialNumber");
+  });
+
+  it("returns error if certificate subject common name is not in bech32 format", () => {
+    const { cert } = createX509CertPair({ commonName: "test.com" });
+    const result = validateCertificate(cert, Date.now()) as CertValidationResultError;
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("CommonNameIsNotBech32");
+  });
+
+  it("returns error if certificate subject common name is not in bech32 format", () => {
+    const { cert } = createX509CertPair();
+    const result = validateCertificate(cert, Date.now()) as CertValidationResultError;
+
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("CommonNameIsNotBech32");
+  });
+
+  it("returns successful result if all criterias above are met", () => {
+    const { cert } = createX509CertPair({
+      validFrom: new Date(),
+      validTo: new Date(Date.now() + ONE_MINUTE),
+      commonName: "akash1rk090a6mq9gvm0h6ljf8kz8mrxglwwxsk4srxh",
+      serialNumber: "177831BE7F249E66"
+    });
+    const result = validateCertificate(cert, Date.now());
+
+    expect(result.ok).toBe(true);
+  });
+});

--- a/apps/provider-proxy/test/setup-functional-tests.ts
+++ b/apps/provider-proxy/test/setup-functional-tests.ts
@@ -4,6 +4,6 @@ beforeAll(async () => {
   await startServer();
 });
 
-afterAll(async () => {
+afterAll(() => {
   stopServer();
 });

--- a/apps/provider-proxy/test/setup/chainApiServer.ts
+++ b/apps/provider-proxy/test/setup/chainApiServer.ts
@@ -1,0 +1,59 @@
+import { X509Certificate } from "crypto";
+import http from "http";
+import { AddressInfo } from "net";
+
+let chainServer: http.Server | undefined;
+/**
+ * Cannot mock blockchain API using nock and msw that's why have a separate server
+ * @see https://github.com/mswjs/msw/discussions/2416
+ */
+export function mockOnChainCertificates(certificates: X509Certificate[], options?: ChainApiOptions) {
+  let isRespondedWithCustomStatus = false;
+  return new Promise<http.Server>(resolve => {
+    const server = http.createServer((req, res) => {
+      if (options?.respondWithOnceWith && !isRespondedWithCustomStatus) {
+        isRespondedWithCustomStatus = true;
+        res.writeHead(options?.respondWithOnceWith);
+        res.end();
+        return;
+      }
+
+      if (!req.url?.includes("/akash/cert/v1beta3/certificates/list")) {
+        res.writeHead(404, "Not Found");
+        res.end("");
+        return;
+      }
+
+      const url = new URL(`http://localhost${req.url || "/"}`);
+
+      res.writeHead(200, "OK");
+      res.end(
+        JSON.stringify({
+          certificates: certificates
+            .filter(cert => cert.serialNumber === url.searchParams.get("filter.serial"))
+            .map(cert => ({
+              serial: cert.serialNumber,
+              certificate: {
+                cert: btoa(cert.toJSON()),
+                pubkey: cert.publicKey.export({ type: "pkcs1", format: "pem" })
+              }
+            }))
+        })
+      );
+    });
+
+    server.listen(0, () => {
+      chainServer = server;
+      process.env.TEST_CHAIN_NETWORK_URL = `http://localhost:${(server.address() as AddressInfo).port}`;
+      resolve(server);
+    });
+  });
+}
+
+export function stopChainAPIServer(): void {
+  chainServer?.close();
+}
+
+export interface ChainApiOptions {
+  respondWithOnceWith?: number;
+}

--- a/apps/provider-proxy/test/setup/providerServer.ts
+++ b/apps/provider-proxy/test/setup/providerServer.ts
@@ -1,0 +1,73 @@
+import { RequestListener } from "http";
+import https, { ServerOptions } from "https";
+import { AddressInfo } from "net";
+import { setTimeout } from "timers/promises";
+
+import { CertPair } from "../seeders/createX509CertPair";
+
+let runningServer: https.Server | undefined;
+
+export function startProviderServer(pair: CertPair): Promise<string> {
+  return new Promise<string>(resolve => {
+    const options: ServerOptions = {
+      key: pair.key,
+      cert: pair.cert.toJSON()
+    };
+
+    const state: Record<string, any> = {};
+    const handlers: Record<string, RequestListener> = {
+      "/200.txt"(_, res) {
+        res.writeHead(200, "OK", { "Content-Type": "text/plain" });
+        res.end("Hello, World!");
+      },
+      "/headers.json"(_, res) {
+        res.writeHead(200, "OK", {
+          "Content-Type": "application/json",
+          "X-Custom-Header": "test"
+        });
+        res.end(JSON.stringify({ ok: true }));
+      },
+      async "/slow-once"(_, res) {
+        if (!state.wasSlow) {
+          state.wasSlow = true;
+          await setTimeout(1000);
+          res.writeHead(200);
+          res.end("Slow");
+          return;
+        }
+
+        res.writeHead(200, "OK", { "Content-Type": "text/plain" });
+        res.end("Fast");
+      },
+      "/5xx-once"(_, res) {
+        if (!state.returned5xx) {
+          state.returned5xx = true;
+          res.writeHead(502);
+          res.end();
+          return;
+        }
+
+        res.writeHead(200, "OK", { "Content-Type": "text/plain" });
+        res.end("Success");
+      }
+    };
+
+    const server = https.createServer(options, (req, res) => {
+      if (req.url && Object.hasOwn(handlers, req.url)) {
+        handlers[req.url](req, res);
+      } else {
+        res.writeHead(404, "Not found", { "Content-Type": "text/plain" });
+        res.end("Not Found");
+      }
+    });
+
+    server.listen(0, () => {
+      runningServer = server;
+      resolve(`https://localhost:${(server.address() as AddressInfo).port}`);
+    });
+  });
+}
+
+export function stopProviderServer() {
+  runningServer?.close();
+}

--- a/apps/provider-proxy/tsconfig.build.json
+++ b/apps/provider-proxy/tsconfig.build.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "outDir": "build"
+    "outDir": "build",
+    "target": "es2022"
   },
   "extends": "@akashnetwork/dev-config/tsconfig.base-node.json"
 }

--- a/apps/provider-proxy/tsconfig.json
+++ b/apps/provider-proxy/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "noEmit": true
   },
   "exclude": ["node_modules", "dist", "build", "test"],
   "extends": "./tsconfig.build.json"

--- a/package-lock.json
+++ b/package-lock.json
@@ -636,10 +636,11 @@
       "version": "1.0.12",
       "license": "Apache-2.0",
       "dependencies": {
-        "axios": "^1.7.2",
+        "@akashnetwork/net": "*",
+        "bech32": "^2.0.0",
         "cors": "^2.8.5",
         "express": "^4.18.2",
-        "node-fetch": "^2.6.9",
+        "lru-cache": "^11.0.2",
         "uuid": "^9.0.0",
         "ws": "^7.5.9"
       },
@@ -647,17 +648,411 @@
         "@akashnetwork/dev-config": "*",
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.16",
-        "@types/node-fetch": "^2.6.2",
+        "@types/node-forge": "^1.3.11",
         "@types/uuid": "^9.0.0",
         "@types/ws": "^8.5.4",
         "@typescript-eslint/eslint-plugin": "^7.12.0",
+        "esbuild": "^0.24.2",
         "eslint": "^8.57.0",
         "eslint-config-next": "^14.2.3",
         "eslint-plugin-simple-import-sort": "^12.1.0",
         "jest": "^29.7.0",
+        "node-forge": "^1.3.1",
+        "nodemon": "^3.1.9",
         "prettier": "^3.3.0",
         "prettier-plugin-tailwindcss": "^0.6.1",
         "typescript": "5.1.3"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/android-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/android-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/android-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/darwin-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/linux-arm": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/linux-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/linux-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/linux-loong64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/linux-s390x": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/linux-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/sunos-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/win32-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/win32-ia32": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/provider-proxy/node_modules/@esbuild/win32-x64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "apps/provider-proxy/node_modules/@types/uuid": {
@@ -665,6 +1060,128 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true
+    },
+    "apps/provider-proxy/node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
+    },
+    "apps/provider-proxy/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "apps/provider-proxy/node_modules/esbuild": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "apps/provider-proxy/node_modules/lru-cache": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+      "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "apps/provider-proxy/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "apps/provider-proxy/node_modules/nodemon": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.9.tgz",
+      "integrity": "sha512-hdr1oIb2p6ZSxu3PB2JWWYS7ZQ0qvaZsc3hK8DR8f02kRzc8rjYmxAIvdz+aYC+8F2IjNaB7HMcSDg8nQpJxyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "apps/provider-proxy/node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "apps/stats-web": {
       "name": "@akashnetwork/stats-web",
@@ -914,6 +1431,10 @@
     },
     "node_modules/@akashnetwork/logging": {
       "resolved": "packages/logging",
+      "link": true
+    },
+    "node_modules/@akashnetwork/net": {
+      "resolved": "packages/net",
       "link": true
     },
     "node_modules/@akashnetwork/network-store": {
@@ -5516,6 +6037,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.19.12",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.12.tgz",
@@ -5530,6 +6068,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
@@ -6419,9 +6974,10 @@
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.7.tgz",
-      "integrity": "sha512-m+Trk77mp54Zma6xLkLuY+mvanPxlE4A7yNKs2HBiyZ4UkVs28Mv5c/pgWrHeInx+USHeX/WEPzjrWrcJiQgjw==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.9.tgz",
+      "integrity": "sha512-BXvGj0ehzrngHTPTDqUoDT3NXL8U0RxUk2zJm2A66RhCEIWdtU1v6GuUqNAgArW4PQ9CinqIWyHdQgdwOj06zQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -15134,6 +15690,16 @@
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/node-forge": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
+      "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/node-gzip": {
@@ -30150,6 +30716,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
       "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -31310,7 +31877,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -40154,6 +40723,11 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
+    },
+    "packages/net": {
+      "name": "@akashnetwork/net",
+      "version": "0.0.1",
+      "license": "ISC"
     },
     "packages/network-store": {
       "name": "@akashnetwork/network-store",

--- a/packages/net/package.json
+++ b/packages/net/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@akashnetwork/net",
+  "version": "0.0.1",
+  "description": "",
+  "license": "ISC",
+  "author": "",
+  "main": "src/index.ts",
+  "scripts": {
+    "format": "prettier --write ./*.{ts,json} **/*.{ts,json}",
+    "generate": "ts-node scripts/generate.ts",
+    "lint": "eslint .",
+    "update-apps-local-deps": "mvm-update"
+  }
+}

--- a/packages/net/scripts/generate.ts
+++ b/packages/net/scripts/generate.ts
@@ -1,0 +1,38 @@
+import fsp from "fs/promises";
+import { join as joinPath, normalize } from "path";
+
+const PROJECT_DIR = normalize(joinPath(__dirname, "..", "..", ".."));
+const PACKAGE_DIR = normalize(joinPath(__dirname, ".."));
+const OUT_DIR = joinPath(PACKAGE_DIR, "src", "generated");
+const AKASH_NET_BASE = "https://raw.githubusercontent.com/akash-network/net/main";
+const networks = ["mainnet", "sandbox", "testnet-02"];
+
+async function main() {
+  console.log(`Generate network configuration: ${networks.join(", ")}`);
+  const config: Record<string, unknown> = {};
+  for (const network of networks) {
+    const baseConfigUrl = `${AKASH_NET_BASE}/${network}`;
+    const [apiUrls, rpcUrls, version] = await Promise.all([
+      fetchText(`${baseConfigUrl}/api-nodes.txt`),
+      fetchText(`${baseConfigUrl}/rpc-nodes.txt`),
+      fetchText(`${baseConfigUrl}/version.txt`)
+    ]);
+
+    config[network] = {
+      version: version.trim(),
+      apiUrls: apiUrls.trim().split("\n"),
+      rpcUrls: rpcUrls.trim().split("\n")
+    };
+  }
+
+  await fsp.mkdir(OUT_DIR, { recursive: true });
+  await fsp.writeFile(joinPath(OUT_DIR, "netConfigData.ts"), `export const netConfigData = ${JSON.stringify(config, null, 2)}`);
+
+  console.log(`Network configuration was written to ${OUT_DIR.replace(PROJECT_DIR, ".")}/net-config.ts`);
+}
+
+function fetchText(url: string): Promise<string> {
+  return fetch(url).then(res => res.text());
+}
+
+main().catch(console.error);

--- a/packages/net/src/NetConfig.ts
+++ b/packages/net/src/NetConfig.ts
@@ -1,0 +1,9 @@
+import { netConfigData } from "./generated/netConfigData";
+
+export type SupportedChainNetworks = keyof typeof netConfigData;
+
+export class NetConfig {
+  getBaseAPIUrl(network: SupportedChainNetworks): string {
+    return netConfigData[network].apiUrls[0];
+  }
+}

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -1,0 +1,28 @@
+export const netConfigData = {
+  mainnet: {
+    version: "0.36.0",
+    apiUrls: [
+      "https://api.akashnet.net:443",
+      "https://akash-api.polkachu.com:443",
+      "https://akash.c29r3.xyz:443/api",
+      "https://akash-api.global.ssl.fastly.net:443"
+    ],
+    rpcUrls: [
+      "https://rpc.akashnet.net:443",
+      "https://rpc.akash.forbole.com:443",
+      "https://rpc-akash.ecostake.com:443",
+      "https://akash-rpc.polkachu.com:443",
+      "https://akash.c29r3.xyz:443/rpc"
+    ]
+  },
+  sandbox: {
+    version: "0.36.0",
+    apiUrls: ["https://api.sandbox-01.aksh.pw:443"],
+    rpcUrls: ["https://rpc.sandbox-01.aksh.pw:443"]
+  },
+  "testnet-02": {
+    version: "0.23.1-rc0",
+    apiUrls: ["https://api.testnet-02.aksh.pw:443", "https://akash-testnet-rest.cosmonautstakes.com:443"],
+    rpcUrls: ["https://rpc.testnet-02.aksh.pw:443", "https://akash-testnet-rpc.cosmonautstakes.com:443"]
+  }
+};

--- a/packages/net/src/index.ts
+++ b/packages/net/src/index.ts
@@ -1,0 +1,4 @@
+import { NetConfig } from "./NetConfig";
+
+export const netConfig = new NetConfig();
+export type { SupportedChainNetworks } from "./NetConfig";

--- a/packages/net/tsconfig.build.json
+++ b/packages/net/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noImplicitAny": true,
+    "paths": {
+      "@src/*": ["./src/*"],
+      "@test/*": ["./test/*"]
+    }
+  },
+  "extends": "@akashnetwork/dev-config/tsconfig.base-node.json"
+}

--- a/packages/net/tsconfig.json
+++ b/packages/net/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "exclude": ["node_modules", "dist", "**/*spec.ts",  "scripts"],
+  "extends": "./tsconfig.build.json",
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Why

We need to validate provider self-signed certificate

## What 

1. Fetch provider certificates from chain and check whether SSL certificate returned by provider's host is one of those on chain 
2. adds `nodemon` for easier local development
3. removes unused packages
4. creates internal `@akasnetwork/net` package for sharing blockchain configuration
5. added unit and functional tests
6. modifies GHA for provider proxy to run both types of tests 
7. added esbuild to bundle internal packages together with provider-proxy

refs: #170 