### PR TITLE
feat: adjusts logic to send provider and chain details to provider proxy

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
@@ -42,7 +42,7 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
     data: leaseStatus,
     refetch: getLeaseStatus,
     isFetching: isLoadingStatus
-  } = useLeaseStatus(providerInfo?.hostUri || "", selectedLease as LeaseDto, {
+  } = useLeaseStatus(providerInfo, selectedLease as LeaseDto, {
     enabled: false
   });
   const currentUrl = useRef<string | null>(null);

--- a/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
@@ -54,7 +54,7 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
     data: leaseStatus,
     refetch: getLeaseStatus,
     isFetching: isLoadingStatus
-  } = useLeaseStatus(providerInfo?.hostUri || "", selectedLease as LeaseDto, {
+  } = useLeaseStatus(providerInfo, selectedLease as LeaseDto, {
     enabled: false
   });
   const { sendJsonMessage } = useWebSocket(browserEnvConfig.NEXT_PUBLIC_PROVIDER_PROXY_URL_WS, {

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate.tsx
@@ -11,10 +11,10 @@ import { LinearLoadingSkeleton } from "@src/components/shared/LinearLoadingSkele
 import { LinkTo } from "@src/components/shared/LinkTo";
 import ViewPanel from "@src/components/shared/ViewPanel";
 import { useCertificate } from "@src/context/CertificateProvider";
-import { LocalCert } from "@src/context/CertificateProvider/CertificateProviderContext";
 import { useSettings } from "@src/context/SettingsProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useProviderList } from "@src/queries/useProvidersQuery";
+import networkStore from "@src/store/networkStore";
 import { AnalyticsCategory, AnalyticsEvents } from "@src/types/analytics";
 import { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import { ApiProviderList } from "@src/types/provider";
@@ -122,9 +122,14 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     window.open("https://akash.network/docs/deployments/akash-cli/installation/#update-the-deployment", "_blank");
   }
 
+  const chainNetwork = networkStore.useSelectedNetworkId();
   async function sendManifest(providerInfo: ApiProviderList, manifest: any) {
     try {
-      return await sendManifestToProvider(providerInfo, manifest, deployment.dseq, localCert as LocalCert);
+      return await sendManifestToProvider(providerInfo, manifest, {
+        dseq: deployment.dseq,
+        localCert,
+        chainNetwork
+      });
     } catch (err) {
       enqueueSnackbar(<ManifestErrorSnackbar err={err} />, { variant: "error", autoHideDuration: null });
       throw err;

--- a/apps/deploy-web/src/components/new-deployment/BidRow.tsx
+++ b/apps/deploy-web/src/components/new-deployment/BidRow.tsx
@@ -38,7 +38,7 @@ export const BidRow: React.FunctionComponent<Props> = ({ testIndex, bid, selecte
     isLoading: isLoadingStatus,
     refetch: fetchProviderStatus,
     error
-  } = useProviderStatus(provider?.hostUri, {
+  } = useProviderStatus(provider, {
     enabled: false,
     retry: false
   });

--- a/apps/deploy-web/src/components/new-deployment/CreateLease.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease.tsx
@@ -23,13 +23,13 @@ import { useRouter } from "next/navigation";
 import { event } from "nextjs-google-analytics";
 import { useSnackbar } from "notistack";
 
-import { LocalCert } from "@src/context/CertificateProvider/CertificateProviderContext";
 import { useWallet } from "@src/context/WalletProvider";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useWhen } from "@src/hooks/useWhen";
 import { useBidList } from "@src/queries/useBidQuery";
 import { useDeploymentDetail } from "@src/queries/useDeploymentQuery";
 import { useProviderList } from "@src/queries/useProvidersQuery";
+import networkStore from "@src/store/networkStore";
 import { AnalyticsCategory, AnalyticsEvents } from "@src/types/analytics";
 import { BidDto } from "@src/types/deployment";
 import { RouteStep } from "@src/types/route-steps.type";
@@ -108,6 +108,7 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq }) => {
 
   useWhen(hasActiveBid, () => selectBid(activeBid));
 
+  const chainNetwork = networkStore.useSelectedNetworkId();
   const sendManifest = useCallback(async () => {
     setIsSendingManifest(true);
     const bidKeys = Object.keys(selectedBids);
@@ -141,7 +142,7 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq }) => {
         if (!provider) {
           throw new Error("Provider not found");
         }
-        await sendManifestToProvider(provider, mani, dseq, localCert as LocalCert);
+        await sendManifestToProvider(provider, mani, { dseq, localCert, chainNetwork });
       }
       router.replace(UrlService.deploymentDetails(dseq, "EVENTS", "events"));
     } catch (err) {
@@ -154,7 +155,7 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq }) => {
 
       setIsSendingManifest(false);
     }
-  }, [selectedBids, dseq, providers, localCert, isManaged, enqueueSnackbar, closeSnackbar, router]);
+  }, [selectedBids, dseq, providers, localCert, isManaged, enqueueSnackbar, closeSnackbar, router, chainNetwork]);
 
   // Filter bids
   useEffect(() => {

--- a/apps/deploy-web/src/components/providers/LeaseListContainer.tsx
+++ b/apps/deploy-web/src/components/providers/LeaseListContainer.tsx
@@ -5,7 +5,7 @@ import { useWallet } from "@src/context/WalletProvider";
 import { useAllLeases } from "@src/queries/useLeaseQuery";
 import { useProviderDetail, useProviderStatus } from "@src/queries/useProvidersQuery";
 import { LeaseDto } from "@src/types/deployment";
-import { ClientProviderDetailWithStatus } from "@src/types/provider";
+import { ApiProviderList, ClientProviderDetailWithStatus } from "@src/types/provider";
 import { domainName, UrlService } from "@src/utils/urlUtils";
 import Layout from "../layout/Layout";
 import { CustomNextSeo } from "../shared/CustomNextSeo";
@@ -32,7 +32,7 @@ export const LeaseListContainer: React.FunctionComponent<Props> = ({ owner }) =>
     data: providerStatus,
     isLoading: isLoadingStatus,
     refetch: getProviderStatus
-  } = useProviderStatus(provider?.hostUri || "", {
+  } = useProviderStatus(provider as ApiProviderList, {
     enabled: false,
     retry: false,
     onSuccess: () => {

--- a/apps/deploy-web/src/components/providers/ProviderDetail.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderDetail.tsx
@@ -44,7 +44,7 @@ export const ProviderDetail: React.FunctionComponent<Props> = ({ owner, _provide
   });
   const { data: leases, isFetching: isLoadingLeases, refetch: getLeases } = useAllLeases(address, { enabled: false });
   const { data: providerAttributesSchema, isFetching: isLoadingSchema } = useProviderAttributesSchema();
-  const { isLoading: isLoadingStatus, refetch: getProviderStatus } = useProviderStatus(provider?.hostUri || "", {
+  const { isLoading: isLoadingStatus, refetch: getProviderStatus } = useProviderStatus(provider, {
     enabled: true,
     retry: false,
     onSuccess: _providerStatus => {

--- a/apps/deploy-web/src/components/providers/ProviderRawData.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderRawData.tsx
@@ -5,7 +5,7 @@ import { DynamicReactJson } from "@src/components/shared/DynamicJsonView";
 import { useWallet } from "@src/context/WalletProvider";
 import { useAllLeases } from "@src/queries/useLeaseQuery";
 import { useProviderDetail, useProviderStatus } from "@src/queries/useProvidersQuery";
-import { ClientProviderDetailWithStatus } from "@src/types/provider";
+import { ApiProviderList, ClientProviderDetailWithStatus } from "@src/types/provider";
 import { domainName, UrlService } from "@src/utils/urlUtils";
 import Layout from "../layout/Layout";
 import { CustomNextSeo } from "../shared/CustomNextSeo";
@@ -30,7 +30,7 @@ export const ProviderRawData: React.FunctionComponent<Props> = ({ owner }) => {
     data: providerStatus,
     isLoading: isLoadingStatus,
     refetch: getProviderStatus
-  } = useProviderStatus(provider?.hostUri || "", {
+  } = useProviderStatus(provider as ApiProviderList, {
     enabled: false,
     retry: false,
     onSuccess: () => {

--- a/apps/deploy-web/src/config/env-config.schema.ts
+++ b/apps/deploy-web/src/config/env-config.schema.ts
@@ -46,7 +46,8 @@ export const serverEnvSchema = browserEnvSchema.extend({
   GITHUB_CLIENT_SECRET: z.string(),
   BITBUCKET_CLIENT_SECRET: z.string(),
   GITLAB_CLIENT_SECRET: z.string(),
-  NEXT_PUBLIC_CI_CD_IMAGE_NAME: z.string()
+  NEXT_PUBLIC_CI_CD_IMAGE_NAME: z.string(),
+  NEXT_PUBLIC_PROVIDER_PROXY_URL: z.string()
 });
 
 export type BrowserEnvConfig = z.infer<typeof browserEnvSchema>;

--- a/apps/deploy-web/src/context/ServicesProvider/index.tsx
+++ b/apps/deploy-web/src/context/ServicesProvider/index.tsx
@@ -1,0 +1,13 @@
+import React, { useContext } from "react";
+
+import { services as defaultServices } from "@src/services/http/http-browser.service";
+
+const ServicesContext = React.createContext(defaultServices);
+
+export const ServicesProvider: React.FC<{ children: React.ReactNode; services?: Partial<typeof defaultServices> }> = ({ children, services }) => {
+  return <ServicesContext.Provider value={{ ...defaultServices, ...services }}>{children}</ServicesContext.Provider>;
+};
+
+export function useServices() {
+  return useContext(ServicesContext);
+}

--- a/apps/deploy-web/src/hooks/useScopedFetchProviderUrl.ts
+++ b/apps/deploy-web/src/hooks/useScopedFetchProviderUrl.ts
@@ -1,0 +1,25 @@
+import { useCallback } from "react";
+import { AxiosResponse } from "axios";
+
+import { useServices } from "@src/context/ServicesProvider";
+import { ProviderIdentity, ProviderProxyPayload } from "@src/services/provider-proxy/provider-proxy.service";
+import networkStore from "@src/store/networkStore";
+
+export function useScopedFetchProviderUrl(provider: ProviderIdentity | undefined | null): ScopedFetchProviderUrl {
+  const chainNetwork = networkStore.useSelectedNetworkId();
+  const { providerProxy } = useServices();
+  return useCallback(
+    (url, options) => {
+      if (!provider) return new Promise(() => {});
+      return providerProxy.fetchProviderUrl(url, {
+        ...options,
+        chainNetwork,
+        providerIdentity: provider
+      });
+    },
+    [provider?.hostUri, provider?.owner, chainNetwork]
+  );
+}
+
+export type ScopedFetchProviderUrlOptions = Omit<ProviderProxyPayload, "chainNetwork" | "providerIdentity">;
+export type ScopedFetchProviderUrl = <T>(url: string, options?: ScopedFetchProviderUrlOptions) => Promise<AxiosResponse<T>>;

--- a/apps/deploy-web/src/pages/_app.tsx
+++ b/apps/deploy-web/src/pages/_app.tsx
@@ -27,6 +27,7 @@ import { CustomChainProvider } from "@src/context/CustomChainProvider";
 import { ColorModeProvider } from "@src/context/CustomThemeContext";
 import { LocalNoteProvider } from "@src/context/LocalNoteProvider";
 import { PricingProvider } from "@src/context/PricingProvider/PricingProvider";
+import { ServicesProvider } from "@src/context/ServicesProvider";
 import { SettingsProvider } from "@src/context/SettingsProvider";
 import { TemplatesProvider } from "@src/context/TemplatesProvider";
 import { WalletProvider } from "@src/context/WalletProvider";
@@ -73,7 +74,9 @@ const App: React.FunctionComponent<Props> = props => {
                                         <BackgroundTaskProvider>
                                           <TemplatesProvider>
                                             <LocalNoteProvider>
-                                              <Component {...pageProps} />
+                                              <ServicesProvider>
+                                                <Component {...pageProps} />
+                                              </ServicesProvider>
                                             </LocalNoteProvider>
                                           </TemplatesProvider>
                                         </BackgroundTaskProvider>

--- a/apps/deploy-web/src/services/http-factory/http-factory.service.ts
+++ b/apps/deploy-web/src/services/http-factory/http-factory.service.ts
@@ -1,21 +1,22 @@
-import { AuthHttpService, TxHttpService, UserHttpService } from "@akashnetwork/http-sdk";
+import { AuthHttpService, TemplateHttpService, TxHttpService, UserHttpService } from "@akashnetwork/http-sdk";
 import { StripeService } from "@akashnetwork/http-sdk/src/stripe/stripe.service";
-import { TemplateHttpService } from "@akashnetwork/http-sdk/src/template/template-http.service";
+import axios from "axios";
 import { event } from "nextjs-google-analytics";
 
-import type { BrowserEnvConfig, ServerEnvConfig } from "@src/config/env-config.schema";
 import { authService } from "@src/services/auth/auth.service";
 import { AnalyticsCategory, AnalyticsEvents } from "@src/types/analytics";
 import { customRegistry } from "@src/utils/customRegistry";
+import { ProviderProxyService } from "../provider-proxy/provider-proxy.service";
 
-export const createServices = (config: Pick<ServerEnvConfig, "BASE_API_MAINNET_URL"> | Pick<BrowserEnvConfig, "NEXT_PUBLIC_BASE_API_MAINNET_URL">) => {
-  const apiConfig = { baseURL: "BASE_API_MAINNET_URL" in config ? config.BASE_API_MAINNET_URL : config.NEXT_PUBLIC_BASE_API_MAINNET_URL };
+export const createServices = (config: ServicesConfig) => {
+  const apiConfig = { baseURL: config.BASE_API_MAINNET_URL };
 
   const user = new UserHttpService(apiConfig);
   const stripe = new StripeService(apiConfig);
   const tx = new TxHttpService(customRegistry, apiConfig);
   const template = new TemplateHttpService(apiConfig);
   const auth = new AuthHttpService(apiConfig);
+  const providerProxy = new ProviderProxyService({ baseURL: config.BASE_PROVIDER_PROXY_URL });
 
   user.interceptors.request.use(authService.withAnonymousUserHeader);
   stripe.interceptors.request.use(authService.withAnonymousUserHeader);
@@ -29,5 +30,10 @@ export const createServices = (config: Pick<ServerEnvConfig, "BASE_API_MAINNET_U
     return response;
   });
 
-  return { user, stripe, tx, template, auth };
+  return { user, stripe, tx, template, auth, providerProxy, axios };
 };
+
+export interface ServicesConfig {
+  BASE_API_MAINNET_URL: string;
+  BASE_PROVIDER_PROXY_URL: string;
+}

--- a/apps/deploy-web/src/services/http/http-browser.service.ts
+++ b/apps/deploy-web/src/services/http/http-browser.service.ts
@@ -1,7 +1,10 @@
 import { browserEnvConfig } from "@src/config/browser-env.config";
 import { createServices } from "@src/services/http-factory/http-factory.service";
 
-export const services = createServices(browserEnvConfig);
+export const services = createServices({
+  BASE_API_MAINNET_URL: browserEnvConfig.NEXT_PUBLIC_BASE_API_MAINNET_URL,
+  BASE_PROVIDER_PROXY_URL: browserEnvConfig.NEXT_PUBLIC_PROVIDER_PROXY_URL
+});
 
 export const userHttpService = services.user;
 export const stripeService = services.stripe;

--- a/apps/deploy-web/src/services/http/http-server.service.ts
+++ b/apps/deploy-web/src/services/http/http-server.service.ts
@@ -1,4 +1,7 @@
 import { serverEnvConfig } from "@src/config/server-env.config";
 import { createServices } from "@src/services/http-factory/http-factory.service";
 
-export const services = createServices(serverEnvConfig);
+export const services = createServices({
+  ...serverEnvConfig,
+  BASE_PROVIDER_PROXY_URL: serverEnvConfig.NEXT_PUBLIC_PROVIDER_PROXY_URL
+});

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
@@ -1,0 +1,38 @@
+import { HttpService } from "@akashnetwork/http-sdk";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+
+export class ProviderProxyService extends HttpService {
+  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
+    super(config);
+  }
+
+  fetchProviderUrl<T>(url: string, options: ProviderProxyPayload): Promise<AxiosResponse<T>> {
+    const { chainNetwork, providerIdentity, timeout, ...params } = options;
+    return this.post(
+      "/",
+      {
+        ...params,
+        method: options.method || "GET",
+        url: providerIdentity.hostUri + url,
+        providerAddress: providerIdentity.owner,
+        network: options.chainNetwork
+      },
+      { timeout }
+    );
+  }
+}
+
+export interface ProviderProxyPayload {
+  method?: "GET" | "POST" | "PUT" | "DELETE";
+  certPem?: string;
+  keyPem?: string;
+  body?: string;
+  timeout?: number;
+  chainNetwork: string;
+  providerIdentity: ProviderIdentity;
+}
+
+export interface ProviderIdentity {
+  owner: string;
+  hostUri: string;
+}

--- a/apps/deploy-web/src/utils/deploymentUtils.ts
+++ b/apps/deploy-web/src/utils/deploymentUtils.ts
@@ -1,47 +1,53 @@
-import axios from "axios";
+import { AxiosResponse } from "axios";
 
-import { browserEnvConfig } from "@src/config/browser-env.config";
 import { LocalCert } from "@src/context/CertificateProvider/CertificateProviderContext";
+import { services } from "@src/services/http/http-browser.service";
 import { ApiProviderList } from "@src/types/provider";
 import { wait } from "./timer";
 
-export const sendManifestToProvider = async (providerInfo: ApiProviderList, manifest: any, dseq: string, localCert: LocalCert) => {
+export interface SendManifestToProviderOptions {
+  dseq: string;
+  localCert?: LocalCert | null;
+  chainNetwork: string;
+}
+
+export const sendManifestToProvider = async (providerInfo: ApiProviderList | undefined | null, manifest: unknown, options: SendManifestToProviderOptions) => {
+  if (!providerInfo) return;
   console.log("Sending manifest to " + providerInfo?.owner);
 
   let jsonStr = JSON.stringify(manifest);
   jsonStr = jsonStr.replaceAll('"quantity":{"val', '"size":{"val');
 
-  // Waiting for 5 sec for provider to have lease
+  // Waiting for provider to have lease
   await wait(5000);
 
-  let response;
+  let response: AxiosResponse | undefined;
 
-  for (let i = 1; i <= 3; i++) {
+  for (let i = 1; i <= 3 && !response; i++) {
     console.log("Try #" + i);
     try {
       if (!response) {
-        response = await axios.post(browserEnvConfig.NEXT_PUBLIC_PROVIDER_PROXY_URL, {
+        response = await services.providerProxy.fetchProviderUrl(`/deployment/${options.dseq}/manifest`, {
           method: "PUT",
-          url: providerInfo.hostUri + "/deployment/" + dseq + "/manifest",
-          certPem: localCert?.certPem,
-          keyPem: localCert?.keyPem,
+          certPem: options.localCert?.certPem,
+          keyPem: options.localCert?.keyPem,
           body: jsonStr,
-          timeout: 60_000
+          timeout: 60_000,
+          providerIdentity: providerInfo,
+          chainNetwork: options.chainNetwork
         });
-
-        i = 3;
       }
     } catch (err) {
       if (err.includes && err.includes("no lease for deployment") && i < 3) {
         console.log("Lease not found, retrying...");
-        await wait(6000); // Waiting for 6 sec
+        await wait(6000);
       } else {
         throw new Error(err?.response?.data || err);
       }
     }
   }
 
-  // Waiting for 5 sec for provider to boot up workload
+  // Waiting for provider to boot up workload
   await wait(5000);
 
   return response;


### PR DESCRIPTION
## Why

refs #170 

## What

1. adds provide proxy service
2. adds `useScopedProviderProxy` which automatically uses selected chain network for subsequent provider proxy requests
3. adds `ServicesProvider` to make it possible to substitute them in unit tests later