### PR TITLE
chore: enhance build image tag error

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -63,7 +63,7 @@ jobs:
             echo "registry=${{ vars.PROVIDER_PROXY_REGISTRY }}" >> $GITHUB_ENV
             echo "app=provider-proxy" >> $GITHUB_ENV
           else
-            echo "Error: Unknown tag format"
+            echo "Error: Unknown tag format = $tag"
             exit 1
           fi
 


### PR DESCRIPTION
## Why

GHA failed with unknown tag message and there is no way to see what this tag actually is. Example https://github.com/akash-network/console/actions/runs/13031603855/job/36352316958

## What 

enhance build image tag error to see invalid/unknown tag