### PR TITLE
fix: ensure that provider proxy does not reuse Tls session in case of invalid certificate

### DIFF
--- a/apps/provider-proxy/src/routes/proxyProviderRequest.ts
+++ b/apps/provider-proxy/src/routes/proxyProviderRequest.ts
@@ -24,7 +24,13 @@ export async function proxyProviderRequest(req: ExpressRequest, incommingRespons
       }
     );
 
-    if (proxyResult.ok === false) {
+    if (proxyResult.ok === false && proxyResult.code === "insecureConnection") {
+      incommingResponse.status(400);
+      incommingResponse.send("Could not establish tls connection since server responded with non-tls response");
+      return;
+    }
+
+    if (proxyResult.ok === false && proxyResult.code === "invalidCertificate") {
       incommingResponse.status(495); // https://http.dev/495
       incommingResponse.send(`Invalid certificate error: ${proxyResult.reason}`);
       return;

--- a/apps/provider-proxy/src/services/ProviderService.ts
+++ b/apps/provider-proxy/src/services/ProviderService.ts
@@ -12,7 +12,7 @@ export class ProviderService {
     const queryParams = new URLSearchParams({
       "filter.state": "valid",
       "filter.owner": providerAddress,
-      "filter.serial": serialNumber,
+      "filter.serial": BigInt(`0x${serialNumber}`).toString(10),
       "pagination.limit": "1"
     });
 

--- a/apps/provider-proxy/test/seeders/createX509CertPair.ts
+++ b/apps/provider-proxy/test/seeders/createX509CertPair.ts
@@ -6,7 +6,7 @@ export function createX509CertPair(options: CertificateOptions = {}): CertPair {
   const cert = pki.createCertificate();
 
   cert.publicKey = keys.publicKey;
-  cert.serialNumber = options.serialNumber ?? "01";
+  cert.serialNumber = options.serialNumber ?? "177831BE7F249E66";
   cert.validity.notBefore = options.validFrom || new Date();
   cert.validity.notAfter = options.validTo || nextDay(cert.validity.notBefore);
 

--- a/apps/provider-proxy/test/services/ProviderService.spec.ts
+++ b/apps/provider-proxy/test/services/ProviderService.spec.ts
@@ -7,11 +7,13 @@ describe(ProviderService.name, () => {
       const service = setup({ getCertificates });
 
       getCertificates.mockReturnValueOnce(new Response(JSON.stringify({ certificates: [] }), { status: 200 }));
-      expect(await service.hasCertificate("sandbox", "provider", "serial123")).toBe(false);
-      expect(getCertificates).toHaveBeenCalledWith(expect.stringMatching(/(pagination.limit=10|filter.owner=provider|filter.serial=serial123)/));
+      expect(await service.hasCertificate("sandbox", "provider", "177831BE7F249E66")).toBe(false);
+      expect(getCertificates).toHaveBeenCalledWith(expect.stringContaining("pagination.limit=1"));
+      expect(getCertificates).toHaveBeenCalledWith(expect.stringContaining("filter.owner=provider"));
+      expect(getCertificates).toHaveBeenCalledWith(expect.stringContaining("filter.serial=1691156354324274790"));
 
       getCertificates.mockReturnValueOnce(new Response(JSON.stringify({ certificates: [{}] }), { status: 200 }));
-      expect(await service.hasCertificate("sandbox", "provider", "serial321")).toBe(true);
+      expect(await service.hasCertificate("sandbox", "provider", "17B85C634EF9EB05")).toBe(true);
     });
 
     it("retries certificates request if it fails with response.status > 500", async () => {
@@ -21,7 +23,7 @@ describe(ProviderService.name, () => {
       getCertificates.mockReturnValueOnce(new Response(JSON.stringify("Server error"), { status: 502 }));
       getCertificates.mockReturnValueOnce(new Response(JSON.stringify("Server error"), { status: 502 }));
       getCertificates.mockReturnValueOnce(new Response(JSON.stringify({ certificates: [{}] }), { status: 200 }));
-      expect(await service.hasCertificate("sandbox", "provider", "serial321")).toBe(true);
+      expect(await service.hasCertificate("sandbox", "provider", "17B85C634EF9EB05")).toBe(true);
       expect(getCertificates).toHaveBeenCalledTimes(3);
     });
 
@@ -30,7 +32,7 @@ describe(ProviderService.name, () => {
       const service = setup({ getCertificates });
 
       getCertificates.mockReturnValue(new Response(JSON.stringify("Server error"), { status: 502 }));
-      expect(await service.hasCertificate("sandbox", "provider", "serial321")).toBe(false);
+      expect(await service.hasCertificate("sandbox", "provider", "17B85C634EF9EB05")).toBe(false);
       expect(getCertificates).toHaveBeenCalledTimes(1 + 5);
     }, 7_000);
 
@@ -39,7 +41,7 @@ describe(ProviderService.name, () => {
       const service = setup({ getCertificates });
 
       getCertificates.mockReturnValueOnce(new Response(JSON.stringify("Server error"), { status: 500 }));
-      expect(await service.hasCertificate("sandbox", "provider", "serial321")).toBe(false);
+      expect(await service.hasCertificate("sandbox", "provider", "17B85C634EF9EB05")).toBe(false);
       expect(getCertificates).toHaveBeenCalledTimes(1);
     });
   });

--- a/apps/provider-proxy/test/setup/chainApiServer.ts
+++ b/apps/provider-proxy/test/setup/chainApiServer.ts
@@ -25,14 +25,15 @@ export function mockOnChainCertificates(certificates: X509Certificate[], options
       }
 
       const url = new URL(`http://localhost${req.url || "/"}`);
+      const serialNumber = BigInt(url.searchParams.get("filter.serial")!).toString(16).toUpperCase();
 
       res.writeHead(200, "OK");
       res.end(
         JSON.stringify({
           certificates: certificates
-            .filter(cert => cert.serialNumber === url.searchParams.get("filter.serial"))
+            .filter(cert => cert.serialNumber === serialNumber)
             .map(cert => ({
-              serial: cert.serialNumber,
+              serial: BigInt(`0x${cert.serialNumber}`).toString(10),
               certificate: {
                 cert: btoa(cert.toJSON()),
                 pubkey: cert.publicKey.export({ type: "pkcs1", format: "pem" })


### PR DESCRIPTION
## Why

bug,  refs #170 

## What

1. converts base16 certificate serial number to base10 number before fetching certificates from chain
2. ensure that TLS session is not reused in case certificate is invalid
3. adds proper check on `TLSSocket` instead of type casting