### PR TITLE
fix: concurrent provider certs validation

### DIFF
--- a/apps/provider-proxy/src/services/CertificateValidator.ts
+++ b/apps/provider-proxy/src/services/CertificateValidator.ts
@@ -47,20 +47,29 @@ export class CertificateValidator {
   private async getProviderCertificate(cert: X509Certificate, network: SupportedChainNetworks, providerAddress: string): Promise<X509Certificate | null> {
     const key = `${network}.${providerAddress}.${cert.serialNumber}`;
 
+    if (this.knownCertificatesCache.has(key)) {
+      // no need to create lock as we have value in cache
+      return this.knownCertificatesCache.get(key);
+    }
+
     this.locks[key] ??= new Sema(1);
 
     try {
       await this.locks[key].acquire();
-      if (!this.knownCertificatesCache.has(key)) {
-        const certificate = await this.providerService.getCertificate(network, providerAddress, cert.serialNumber);
-        this.knownCertificatesCache.set(key, certificate);
-        return certificate;
+      if (this.knownCertificatesCache.has(key)) {
+        // no need to send request, another request put the value in cache
+        return this.knownCertificatesCache.get(key);
       }
 
-      return this.knownCertificatesCache.get(key);
+      const certificate = await this.providerService.getCertificate(network, providerAddress, cert.serialNumber);
+      this.knownCertificatesCache.set(key, certificate);
+
+      return certificate;
     } finally {
-      this.locks[key].release();
-      delete this.locks[key];
+      if (this.locks[key]) {
+        this.locks[key].release();
+        delete this.locks[key];
+      }
     }
   }
 }


### PR DESCRIPTION
## Why

when we have 2 concurrent requests 1 and 2,

`#1` goes into `finally` block and removes Sema instance and then `#2` goes into `finally` block and tries to release released Sema instance but that instance was removed by `#1`. refs #170 

## What

Checks whether lock exists in the hashmap of locks because it could be released and cleared by another validation request