### PR TITLE
chore(ci): adds coverage report for provider proxy

### DIFF
--- a/.github/workflows/docker-build-provider-proxy.yml
+++ b/.github/workflows/docker-build-provider-proxy.yml
@@ -50,14 +50,18 @@ jobs:
         if: steps.filter.outputs.provider-proxy == 'true'
         run: npm run lint -w apps/provider-proxy
 
-      - name: Run unit tests
+      - name: Run tests
         if: steps.filter.outputs.provider-proxy == 'true'
-        run: npm run test:unit --workspace=apps/provider-proxy
-
-      - name: Run functional tests
-        if: steps.filter.outputs.provider-proxy == 'true'
-        run: npm run test:functional --workspace=apps/provider-proxy
+        run: npm run test:cov --workspace=apps/provider-proxy
 
       - name: Build the Docker image
         if: steps.filter.outputs.provider-proxy == 'true'
         run: packages/docker/script/dc.sh build provider-proxy
+
+      - name: Upload Test Coverage
+        if: steps.filter.outputs.provider-proxy == 'true'
+        uses: codecov/codecov-action@v5
+        with:
+          directory: ./apps/provider-proxy/coverage
+          flags: provider-proxy
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/validate-n-build-api.yml
+++ b/.github/workflows/validate-n-build-api.yml
@@ -63,6 +63,7 @@ jobs:
         run: packages/docker/script/dc.sh build api
 
       - name: Upload Test Coverage
+        if: steps.filter.outputs.api == 'true'
         uses: codecov/codecov-action@v5
         with:
           directory: ./apps/api/coverage

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -13,5 +13,10 @@ if [[ "$CI" != "true" ]]; then
     npm run generate -w packages/net
     git add ./packages/net/src/generated
 
+    echo ""
+    echo "Checking if package-lock.json and package.json are in sync..."
+    echo ""
+    npm ci --dry-run --ignore-scripts > /dev/null
+
     npx lint-staged
 fi

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -14,6 +14,7 @@
     "prod": "node ./dist/server.js",
     "release": "release-it",
     "start": "npm run build && node ./dist/server.js",
+    "test:cov": "jest --selectProjects unit functional --coverage",
     "test:functional": "jest --selectProjects functional",
     "test:functional:cov": "jest --selectProjects functional --coverage",
     "test:functional:watch": "jest --selectProjects functional --watch",

--- a/package-lock.json
+++ b/package-lock.json
@@ -565,7 +565,8 @@
       "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A=="
     },
     "apps/provider-console": {
-      "version": "0.1.1",
+      "name": "@akashnetwork/provider-console",
+      "version": "1.0.0",
       "dependencies": {
         "@akashnetwork/releaser": "*",
         "@akashnetwork/ui": "*",
@@ -33194,7 +33195,7 @@
       "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.1.tgz",
       "integrity": "sha512-/XJ368cyBJ7fzLMwLKv1e4vLxOju2MNAIokcr7meSaNcVbWz/CPcW22cP04mwxOErdA5mwjA8Q6w/cdAQxVn7Q=="
     },
-    "node_modules/provider-console": {
+    "node_modules/@akashnetwork/provider-console": {
       "resolved": "apps/provider-console",
       "link": true
     },


### PR DESCRIPTION
## Why

to know what is covered and what requires improvement

## What

1. adds coverage report for provider proxy
2. adds precommit hook to check that package.json and package-lock.json are in sync
3. fixes issue of provider-console name in package-lock what prevent `npm ci` to install deps