### PR TITLE
fix: ensure that deployment details are not fetched unless node api endpoint is not empty

### DIFF
--- a/apps/deploy-web/src/queries/useDeploymentQuery.ts
+++ b/apps/deploy-web/src/queries/useDeploymentQuery.ts
@@ -29,7 +29,7 @@ export function useDeploymentList(address: string, options) {
 
 // Deployment detail
 async function getDeploymentDetail(apiEndpoint: string, address: string, dseq: string) {
-  if (!address) return null;
+  if (!address || !apiEndpoint) return null;
 
   const response = await axios.get(ApiUrlService.deploymentDetail(apiEndpoint, address, dseq));
 


### PR DESCRIPTION
## Why

While app is loading `apiEndpoint` in settings returns undefined or empty string what results in sending Node API specific request on console web server

## What 

Ensure that deployment information is not fetched until apiEndpoint gets some value