### PR TITLE
fix: ensure certificates validator is not blocked by more than 2 requests

### DIFF
--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "rm -rf dist/* && npx tsc && esbuild server.ts --bundle --sourcemap --platform=node --target=node20.14.0 --outdir=dist",
     "dev": "nodemon server.ts",
+    "dev:inspect": "nodemon --exec node --inspect -r ts-node/register server.ts",
     "dev-nodc": "npm run dev",
     "format": "prettier --write ./*.{ts,js,json} **/*.{ts,js,json}",
     "lint": "eslint .",
@@ -23,7 +24,6 @@
   "dependencies": {
     "@akashnetwork/logging": "*",
     "@akashnetwork/net": "*",
-    "async-sema": "^3.1.1",
     "bech32": "^2.0.0",
     "cors": "^2.8.5",
     "express": "^4.18.2",

--- a/apps/provider-proxy/test/services/CertificateValidator.spec.ts
+++ b/apps/provider-proxy/test/services/CertificateValidator.spec.ts
@@ -1,4 +1,5 @@
 import { X509Certificate } from "crypto";
+import { setTimeout } from "timers/promises";
 
 import { CertificateValidator, CertificateValidatorIntrumentation, CertValidationResultError } from "../../src/services/CertificateValidator";
 import { ProviderService } from "../../src/services/ProviderService";
@@ -159,10 +160,16 @@ describe(CertificateValidator.name, () => {
       commonName: "akash1rk090a6mq9gvm0h6ljf8kz8mrxglwwxsk4srxh",
       serialNumber: "177831BE7F249E66"
     });
-    const getCertificate = jest.fn(async () => cert);
+    const getCertificate = jest.fn(() => setTimeout(20, cert));
     const validator = setup({ getCertificate });
 
-    const results = await Promise.all([validator.validate(cert, "mainnet", "provider"), validator.validate(cert, "mainnet", "provider")]);
+    const results = await Promise.all([
+      // keep-newline
+      validator.validate(cert, "mainnet", "provider"),
+      validator.validate(cert, "mainnet", "provider"),
+      validator.validate(cert, "mainnet", "provider"),
+      validator.validate(cert, "mainnet", "provider")
+    ]);
 
     expect(getCertificate).toHaveBeenCalledTimes(1);
     expect(results[0].ok).toBe(true);

--- a/package-lock.json
+++ b/package-lock.json
@@ -230,7 +230,7 @@
     },
     "apps/deploy-web": {
       "name": "@akashnetwork/console-web",
-      "version": "2.42.0",
+      "version": "2.42.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
@@ -644,7 +644,6 @@
       "dependencies": {
         "@akashnetwork/logging": "*",
         "@akashnetwork/net": "*",
-        "async-sema": "^3.1.1",
         "bech32": "^2.0.0",
         "cors": "^2.8.5",
         "express": "^4.18.2",


### PR DESCRIPTION
## Why

If there are more than 2 requests sent to validate certificates, the last one will not be processed and will hang forever. This happens because I incorrectly used `async-sema`, it appears that `new Sema(1)` works not in the same way as `async-lock`. In case with semaphore, it needs to be released the same amount of times it was locked to unblock all pending tasks.

refs #170

## What

Despite the fact that I know the reason behind this issue, I think that it makes no sense to complicate stuff with semaphore. That's why I just replaced the logic with additional tmp promises cache which works in clear and reliable way 😃 