### PR TITLE
refactor: replaces express with hono in provider-proxy

### DIFF
--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -24,9 +24,11 @@
   "dependencies": {
     "@akashnetwork/logging": "*",
     "@akashnetwork/net": "*",
+    "@hono/node-server": "^1.13.8",
+    "@hono/zod-openapi": "^0.18.4",
+    "async-sema": "^3.1.1",
     "bech32": "^2.0.0",
-    "cors": "^2.8.5",
-    "express": "^4.18.2",
+    "hono": "^4.6.20",
     "lru-cache": "^11.0.2",
     "uuid": "^9.0.0",
     "ws": "^7.5.9"

--- a/apps/provider-proxy/src/container.ts
+++ b/apps/provider-proxy/src/container.ts
@@ -29,5 +29,6 @@ export const container = {
   providerProxy,
   certificateValidator,
   httpLogger,
-  createWsLogger
+  createWsLogger,
+  netConfig
 };

--- a/apps/provider-proxy/src/routes/proxyProviderRequest.ts
+++ b/apps/provider-proxy/src/routes/proxyProviderRequest.ts
@@ -1,46 +1,101 @@
-import { NextFunction, Request as ExpressRequest, Response as ExpressResponse } from "express";
+import { SupportedChainNetworks } from "@akashnetwork/net";
+import { createRoute, z } from "@hono/zod-openapi";
+import { bech32 } from "bech32";
+import { Context, TypedResponse } from "hono";
+import { ClientErrorStatusCode } from "hono/utils/http-status";
+import { Readable } from "stream";
 
 import { container } from "../container";
 import { httpRetry } from "../utils/retry";
 
-const DEFAULT_TIMEOUT = 5_000;
-export async function proxyProviderRequest(req: ExpressRequest, incommingResponse: ExpressResponse, next: NextFunction): Promise<void> {
-  const { certPem, keyPem, method, body, url, network, providerAddress, timeout } = req.body;
+const RequestPayload = z.object({
+  certPem: z.string().optional(),
+  keyPem: z.string().optional(),
+  method: z.enum(["GET", "POST", "PUT", "DELETE"]),
+  url: z.string().url(),
+  body: z.string().optional(),
+  network: z.enum(container.netConfig.getSupportedNetworks() as [SupportedChainNetworks]).describe("Blockchain network"),
+  providerAddress: z
+    .string()
+    .refine(v => !!bech32.decodeUnsafe(v), "is not bech32 address")
+    .describe("Bech32 representation of provider wallet address"),
+  timeout: z.number().optional()
+});
 
-  try {
-    const proxyResult = await httpRetry(
-      () =>
-        container.providerProxy.connect(url, {
-          method,
-          body,
-          cert: certPem,
-          key: keyPem,
-          network,
-          providerAddress,
-          timeout: Number(timeout || DEFAULT_TIMEOUT) || DEFAULT_TIMEOUT
-        }),
-      {
-        retryIf: result => result.ok && (!result.response.statusCode || result.response.statusCode > 500)
+export const proxyRoute = createRoute({
+  method: "post",
+  path: "/",
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: RequestPayload
+        }
       }
-    );
-
-    if (proxyResult.ok === false && proxyResult.code === "insecureConnection") {
-      incommingResponse.status(400);
-      incommingResponse.send("Could not establish tls connection since server responded with non-tls response");
-      return;
     }
-
-    if (proxyResult.ok === false && proxyResult.code === "invalidCertificate") {
-      incommingResponse.status(495); // https://http.dev/495
-      incommingResponse.send(`Invalid certificate error: ${proxyResult.reason}`);
-      return;
+  },
+  responses: {
+    400: {
+      content: {
+        "text/plain": {
+          schema: z.string()
+        }
+      },
+      description: "Returned if it's not possible to establish secure connection with proxied host"
+    },
+    495: {
+      // https://http.dev/495
+      content: {
+        "text/plain": {
+          schema: z.string()
+        }
+      },
+      description: "Returned if host SSL certificate is invalid"
     }
-
-    Object.keys(proxyResult.response.headers).forEach(header => {
-      incommingResponse.setHeader(header, proxyResult.response.headers[header] || "");
-    });
-    proxyResult.response.pipe(incommingResponse).on("error", next);
-  } catch (error) {
-    next(error);
   }
+});
+
+const DEFAULT_TIMEOUT = 5_000;
+export async function proxyProviderRequest(ctx: Context): Promise<Response | TypedResponse<string>> {
+  const { certPem, keyPem, method, body, url, network, providerAddress, timeout } = await ctx.req.json<z.infer<typeof RequestPayload>>();
+
+  const proxyResult = await httpRetry(
+    () =>
+      container.providerProxy.connect(url, {
+        method,
+        body,
+        cert: certPem,
+        key: keyPem,
+        network,
+        providerAddress,
+        timeout: Number(timeout || DEFAULT_TIMEOUT) || DEFAULT_TIMEOUT
+      }),
+    {
+      retryIf: result => result.ok && (!result.response.statusCode || result.response.statusCode > 500)
+    }
+  );
+
+  if (proxyResult.ok === false && proxyResult.code === "insecureConnection") {
+    return ctx.text("Could not establish tls connection since server responded with non-tls response", 400);
+  }
+
+  if (proxyResult.ok === false && proxyResult.code === "invalidCertificate") {
+    return ctx.text(`Invalid certificate error: ${proxyResult.reason}`, 495 as ClientErrorStatusCode);
+  }
+
+  const headers = new Headers();
+  Object.keys(proxyResult.response.headers).forEach(header => {
+    const value = proxyResult.response.headers[header];
+    if (Array.isArray(value)) {
+      value.forEach(v => headers.set(header, v));
+    } else {
+      headers.set(header, value);
+    }
+  });
+
+  return new Response(Readable.toWeb(proxyResult.response), {
+    status: proxyResult.response.statusCode,
+    statusText: proxyResult.response.statusMessage,
+    headers
+  });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -644,9 +644,11 @@
       "dependencies": {
         "@akashnetwork/logging": "*",
         "@akashnetwork/net": "*",
+        "@hono/node-server": "^1.13.8",
+        "@hono/zod-openapi": "^0.18.4",
+        "async-sema": "^3.1.1",
         "bech32": "^2.0.0",
-        "cors": "^2.8.5",
-        "express": "^4.18.2",
+        "hono": "^4.6.20",
         "lru-cache": "^11.0.2",
         "uuid": "^9.0.0",
         "ws": "^7.5.9"
@@ -1063,6 +1065,35 @@
         "node": ">=18"
       }
     },
+    "apps/provider-proxy/node_modules/@hono/node-server": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.13.8.tgz",
+      "integrity": "sha512-fsn8ucecsAXUoVxrUil0m13kOEq4mkX4/4QozCqmY+HpGfKl74OYSn8JcMA8GnG0ClfdRI4/ZSeG7zhFaVg+wg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "apps/provider-proxy/node_modules/@hono/zod-openapi": {
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/@hono/zod-openapi/-/zod-openapi-0.18.4.tgz",
+      "integrity": "sha512-6NHMHU96Hh32B1yDhb94Z4Z5/POsmEu2AXpWLWcBq9arskRnOMt2752yEoXoADV8WUAc7H1IkNaQHGj1ytXbYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@asteasolutions/zod-to-openapi": "^7.1.0",
+        "@hono/zod-validator": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "hono": ">=4.3.6",
+        "zod": "3.*"
+      }
+    },
     "apps/provider-proxy/node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
@@ -1125,6 +1156,15 @@
         "@esbuild/win32-arm64": "0.24.2",
         "@esbuild/win32-ia32": "0.24.2",
         "@esbuild/win32-x64": "0.24.2"
+      }
+    },
+    "apps/provider-proxy/node_modules/hono": {
+      "version": "4.6.20",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.6.20.tgz",
+      "integrity": "sha512-5qfNQeaIptMaJKyoJ6N/q4gIq0DBp2FCRaLNuUI3LlJKL4S37DY/rLL1uAxA4wrPB39tJ3s+f7kgI79O4ScSug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "apps/provider-proxy/node_modules/lru-cache": {
@@ -20006,18 +20046,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
-    "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",

--- a/packages/net/src/NetConfig.ts
+++ b/packages/net/src/NetConfig.ts
@@ -6,4 +6,8 @@ export class NetConfig {
   getBaseAPIUrl(network: SupportedChainNetworks): string {
     return netConfigData[network].apiUrls[0];
   }
+
+  getSupportedNetworks(): SupportedChainNetworks[] {
+    return Object.keys(netConfigData) as SupportedChainNetworks[];
+  }
 }


### PR DESCRIPTION
## Why

1. To keep stack consistent and to better utilize existing tools
2. hono is faster than express
4. hono supports http2 server in nodejs. And this may be interesting for us because grpc works on top of http2 and potentially we may use provider-proxy to do SSL cert validation and proxy grpc requests. This potentially may be a good point for grpc-web integration

refs #170 

## What

Rewrites provider-proxy to hono