### PR TITLE
chore: improves constructor types of BaseRepository in api

### DIFF
--- a/apps/api/src/core/repositories/base.repository.ts
+++ b/apps/api/src/core/repositories/base.repository.ts
@@ -1,6 +1,6 @@
 import { AnyAbility } from "@casl/ability";
 import { and, DBQueryConfig, eq, inArray, sql } from "drizzle-orm";
-import { PgTableWithColumns } from "drizzle-orm/pg-core/table";
+import { PgTableWithColumns } from "drizzle-orm/pg-core";
 import { SQL } from "drizzle-orm/sql/sql";
 import first from "lodash/first";
 
@@ -32,8 +32,8 @@ export abstract class BaseRepository<
     return this.txManager.getPgTx() || this.pg;
   }
 
-  get queryCursor() {
-    return this.cursor.query[this.tableName] as unknown as T;
+  get queryCursor(): T {
+    return this.cursor.query[this.tableName];
   }
 
   protected constructor(
@@ -41,7 +41,7 @@ export abstract class BaseRepository<
     protected readonly table: T,
     protected readonly txManager: TxService,
     protected readonly entityName: string,
-    protected readonly tableName: keyof ApiPgTables
+    protected readonly tableName: TableNameInSchema<T>
   ) {}
 
   protected withAbility(ability: AnyAbility, action: Parameters<AnyAbility["can"]>[0]) {
@@ -194,3 +194,8 @@ export abstract class BaseRepository<
     return payload as Output;
   }
 }
+
+type TableName<T extends PgTableWithColumns<any>> = T extends PgTableWithColumns<infer TableConfig> ? TableConfig["name"] : never;
+type TableNameInSchema<T extends PgTableWithColumns<any>> = {
+  [K in keyof ApiPgTables as TableName<ApiPgTables[K]>]: K;
+}[TableName<T>];

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -9,10 +9,10 @@ export const netConfigData = {
     ],
     rpcUrls: [
       "https://rpc.akashnet.net:443",
-      "https://rpc.akash.forbole.com:443",
       "https://rpc-akash.ecostake.com:443",
       "https://akash-rpc.polkachu.com:443",
-      "https://akash.c29r3.xyz:443/rpc"
+      "https://akash.c29r3.xyz:443/rpc",
+      "https://akash-rpc.europlots.com:443"
     ]
   },
   sandbox: {


### PR DESCRIPTION
## Why

To make coding less error prone. Last parameter is now corresponds to the table type which is passed as the 2nd argument:

<img width="1026" alt="Screenshot 2025-02-10 at 17 41 38" src="https://github.com/user-attachments/assets/99999a75-7fe8-4f96-b67c-16de14e72233" />

## What

improves constructor types of BaseRepository in api 
