### PR TITLE
refactor: enables strict ts mode for logging package

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     ],
     "./packages/http-sdk/**/*.ts": [
       "npm run validate:types -w packages/http-sdk"
+    ],
+    "./packages/logging/**/*.ts": [
+      "npm run validate:types -w packages/logging"
     ]
   },
   "dependencies": {

--- a/packages/logging/jest.config.js
+++ b/packages/logging/jest.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-    preset: "ts-jest",
-    testEnvironment: "node",
-    testMatch: ["**/src/**/*.spec.ts"],
-    verbose: true,
-  };
-  

--- a/packages/logging/jest.config.ts
+++ b/packages/logging/jest.config.ts
@@ -1,0 +1,8 @@
+import type { Config } from "jest";
+
+export default {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/src/**/*.spec.ts"],
+  verbose: true
+} satisfies Config;

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "format": "prettier --write ./*.{ts,json} **/*.{ts,json}",
     "lint": "eslint .",
-    "test": "jest"
+    "test": "jest",
+    "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/logging/src/servicies/logger/logger.service.ts
+++ b/packages/logging/src/servicies/logger/logger.service.ts
@@ -29,7 +29,7 @@ export class LoggerService implements Logger {
     return new LoggerService().setContext(context);
   }
 
-  static mixin: (mergeObject: object) => object;
+  static mixin?: (mergeObject: object) => object;
 
   protected pino: pino.Logger;
 
@@ -51,7 +51,10 @@ export class LoggerService implements Logger {
       return pino(options, pretty);
     }
 
-    return pino(gcpLogOptions(options as any));
+    // pino-cloud-logging uses pino@8.x but we are using pino@9.x
+    const gcpOptions = gcpLogOptions(options as any);
+    // pino-cloud-logging uses pino@8.x but we are using pino@9.x
+    return pino(gcpOptions as any);
   }
 
   private getPrettyIfPresent(): PinoPretty.PrettyStream | undefined {

--- a/packages/logging/tsconfig.build.json
+++ b/packages/logging/tsconfig.build.json
@@ -2,14 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "noImplicitAny": true,
-    "paths": {
-      "@src/*": [
-        "./src/*"
-      ],
-      "@test/*": [
-        "./test/*"
-      ]
-    }
+    "strict": true
   },
   "extends": "@akashnetwork/dev-config/tsconfig.base-node.json"
 }


### PR DESCRIPTION
## Why 

To iteratively migrate to strict types

## What 

Migrates @akasnetwork/logging to strict types.

