### PR TITLE
refactor: enables strict types for net & network-store package

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,12 @@
     ],
     "./packages/ui/**/*.ts": [
       "npm run validate:types -w packages/ui"
+    ],
+    "./packages/net/**/*.ts": [
+      "npm run validate:types -w packages/net"
+    ],
+    "./packages/network-store/**/*.ts": [
+      "npm run validate:types -w packages/network-store"
     ]
   },
   "dependencies": {

--- a/packages/net/package.json
+++ b/packages/net/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "format": "prettier --write ./*.{ts,json} **/*.{ts,json}",
     "generate": "ts-node scripts/generate.ts",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "validate:types": "tsc --noEmit && echo"
   }
 }

--- a/packages/net/tsconfig.build.json
+++ b/packages/net/tsconfig.build.json
@@ -2,10 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "noImplicitAny": true,
-    "paths": {
-      "@src/*": ["./src/*"],
-      "@test/*": ["./test/*"]
-    }
+    "strict": true
   },
   "extends": "@akashnetwork/dev-config/tsconfig.base-node.json"
 }

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -8,7 +8,8 @@
   "main": "src/index.ts",
   "scripts": {
     "format": "prettier --write ./*.{ts,json} **/*.{ts,json}",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
     "axios": "^1.7.2",

--- a/packages/network-store/src/network.store.ts
+++ b/packages/network-store/src/network.store.ts
@@ -21,11 +21,16 @@ interface NetworksStore {
 
 const networkIds = INITIAL_NETWORKS_CONFIG.map(({ id }) => id);
 
+interface NetworkError {
+  network: Network;
+  error: unknown;
+}
+
 class NetworkStoreVersionsInitError extends Error {
   errors: Error[];
-  constructor(errors: { network: Network; error: Error }[]) {
+  constructor(errors: NetworkError[]) {
     super(`Failed to fetch network versions: ${errors.map(({ network }) => network.id).join(", ")}`);
-    this.errors = errors.map(({ error }) => error);
+    this.errors = errors.map(({ error }) => error as Error);
   }
 }
 
@@ -104,7 +109,7 @@ export class NetworkStore {
   }
 
   private async initiateNetworks() {
-    const errors: { network: Network; error: Error }[] = [];
+    const errors: NetworkError[] = [];
     const networks = await Promise.all(
       cloneDeep(INITIAL_NETWORKS_CONFIG).map(async network => {
         try {

--- a/packages/network-store/tsconfig.build.json
+++ b/packages/network-store/tsconfig.build.json
@@ -2,10 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "noImplicitAny": true,
-    "paths": {
-      "@src/*": ["./src/*"],
-      "@test/*": ["./test/*"]
-    }
+    "strict": true
   },
   "extends": "@akashnetwork/dev-config/tsconfig.base-node.json"
 }


### PR DESCRIPTION
## Why 

To iteratively migrate to strict types

## What 

Migrates @akasnetwork/net to strict types.

