### PR TITLE
refactor: enables strict types for ui package

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     ],
     "package.json": [
       "node_modules/.bin/sort-package-json"
+    ],
+    "./packages/ui/**/*.ts": [
+      "npm run validate:types -w packages/ui"
     ]
   },
   "dependencies": {

--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -8,10 +8,5 @@
     "css": "styles/globals.css",
     "baseColor": "slate",
     "cssVariables": true
-  },
-  "aliases": {
-    "components": "@/components",
-    "hooks": "@/hooks",
-    "utils": "@utils/cn"
   }
 }

--- a/packages/ui/context/CustomSnackbarProvider/CustomSnackbarProvider.tsx
+++ b/packages/ui/context/CustomSnackbarProvider/CustomSnackbarProvider.tsx
@@ -24,7 +24,7 @@ const StyledMaterialDesignContent = styled(MaterialDesignContent)(() => {
   };
 });
 
-export const CustomSnackbarProvider = ({ children }) => {
+export const CustomSnackbarProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const notistackRef = useRef<SnackbarProvider>(null);
   const onClickDismiss = (key: SnackbarKey) => () => {
     notistackRef.current?.closeSnackbar(key);

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,7 +15,8 @@
   },
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
     "@mui/material": "^5.15.20",

--- a/packages/ui/tsconfig.build.json
+++ b/packages/ui/tsconfig.build.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "moduleResolution": "bundler",
-    "paths": {
-      "@/*": ["./*"]
-    },
+    "strict": true,
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
## Why 

To iteratively migrate to strict types

## What 

Migrates @akasnetwork/ui to strict types. Also removes "@/" aliases which are unused which are do not work in the current setup because those packages do not have own distribution. Moreover usage of such aliases causes errors on application level because app related tsconfig is in charge to resolve aliases

