### PR TITLE
fix: fix top-up amount button spacing

### DIFF
--- a/apps/deploy-web/src/components/top-up-amount-picker/TopUpAmountPicker.tsx
+++ b/apps/deploy-web/src/components/top-up-amount-picker/TopUpAmountPicker.tsx
@@ -47,7 +47,7 @@ export const TopUpAmountPicker: FCWithChildren<TopUpAmountPickerProps> = ({ chil
               return (
                 <VerifiedLoginRequiredLink
                   key={price.unitAmount || "custom"}
-                  className={cn(buttonVariants({ variant: "default" }))}
+                  className={cn("mb-2", buttonVariants({ variant: "default" }))}
                   href={`/api/proxy/v1/checkout${price.isCustom ? "" : `?amount=${price.unitAmount}`}`}
                 >
                   {price.isCustom ? "Custom" : "$"}


### PR DESCRIPTION
closes #668

Before:
<img width="340" alt="Screenshot 2025-03-08 at 2 33 06" src="https://github.com/user-attachments/assets/04ec0d8f-1380-482e-bafe-c20690a5920e" />

After:
<img width="336" alt="Screenshot 2025-03-08 at 2 32 46" src="https://github.com/user-attachments/assets/1c7a1cc5-f56a-47a9-ba88-3abb995aff4a" />
