### PR TITLE
chore(ci): utilizes docker cache in order to speed up image build when dependencies are not changed

### DIFF
--- a/packages/docker/Dockerfile.nextjs
+++ b/packages/docker/Dockerfile.nextjs
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7-labs
+
 FROM node:20-alpine AS base
 
 ARG WORKSPACE
@@ -16,12 +18,14 @@ ENV NODE_ENV development
 
 RUN apk add --no-cache libc6-compat
 
+COPY package*.json /app
+COPY /$WORKSPACE/package.json /app/$WORKSPACE/package.json
+COPY --parents /packages/*/package.json /app
+
+RUN npm ci
+
 COPY $WORKSPACE ./$WORKSPACE
 COPY /packages /app/packages
-COPY /$WORKSPACE/package*.json /app/$WORKSPACE
-COPY package*.json /app
-
-RUN npm install
 
 CMD ["npm", "run", "dev", "--workspace", "${WORKSPACE}"]
 

--- a/packages/docker/Dockerfile.node
+++ b/packages/docker/Dockerfile.node
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.7-labs
+
 FROM node:20-alpine AS base
 
 ARG GITHUB_PAT
@@ -9,12 +11,14 @@ WORKDIR /app
 
 FROM base AS development
 
+COPY package*.json /app
+COPY /$WORKSPACE/package.json /app/$WORKSPACE/package.json
+COPY --parents /packages/*/package.json /app
+
+RUN npm ci
+
 COPY /$WORKSPACE /app/$WORKSPACE
 COPY /packages /app/packages
-COPY /$WORKSPACE/package*.json /app/$WORKSPACE
-COPY package*.json /app
-
-RUN npm install
 
 CMD ["npm", "run", "dev", "--workspace", "${WORKSPACE}"]
 


### PR DESCRIPTION
## Why 

Currently there are 2 issues with docker files:
1. We use non-deterministic `npm install` 
2. We re-install dependencies on any file change

## What

1. Uses `npm ci` instead of `npm install` to have deterministic dependencies installation
2. Changes structure of dockerfiles to install dependencies only if one of package.json or package-lock files changes
3. Uses experimental `COPY --parents` syntax https://docs.docker.com/build/buildkit/dockerfile-release-notes/#170 to make it possible to copy all package.json from `packages` without explicitly listing them