### PR TITLE
chore(ci): passes GITHUB_TOKEN secret to reusable workflow

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -89,5 +89,6 @@ jobs:
       - name: Build Docker image
         env:
           DEPLOYMENT_ENV: ${{ inputs.deployment-env }}
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }} # used by console-api to fetch Akash templates
         run: |
           ./packages/docker/script/build.sh -r ${{ env.registry }} -t ${{ env.tag }} -a ${{ env.app }} ${{ env.force_build }}


### PR DESCRIPTION
## Why

Need to pass custom env variable to console-api build

## What

passes GITHUB_TOKEN secret to reusable workflow for all apps. later it will be changed in #971 