### PR TITLE
refactor: moves ProviderRawData and its unit tests under a single folder

### DIFF
--- a/apps/deploy-web/jest.config.ts
+++ b/apps/deploy-web/jest.config.ts
@@ -9,7 +9,7 @@ const styleMockPath = "<rootDir>/../../node_modules/next/dist/build/jest/__mocks
 const getConfig = createJestConfig({
   testEnvironment: "jsdom",
   collectCoverageFrom: ["<rootDir>/src/**/*.{js,ts,tsx}"],
-  testMatch: ["<rootDir>/tests/unit/**/*.spec.{tsx,ts}", "<rootDir>/src/**/*.spec.{tsx,ts}"],
+  testMatch: ["<rootDir>/src/**/*.spec.{tsx,ts}"],
   transform: {
     "\\.tsx?$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.json" }]
   },

--- a/apps/deploy-web/src/components/providers/ProviderRawData/ProviderRawData.spec.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderRawData/ProviderRawData.spec.tsx
@@ -1,15 +1,15 @@
 import { QueryClientProvider } from "react-query";
 import { AxiosStatic } from "axios";
 
-import { COMPONENTS, ProviderRawData } from "@src/components/providers/ProviderRawData";
+import { COMPONENTS, ProviderRawData } from "@src/components/providers/ProviderRawData/ProviderRawData";
 import { ServicesProvider } from "@src/context/ServicesProvider";
 import { queryClient } from "@src/queries";
 import { ProviderProxyService } from "@src/services/provider-proxy/provider-proxy.service";
 import { ApiProviderDetail } from "@src/types/provider";
-import { buildProvider } from "../seeders/provider";
-import { MockComponents } from "./mocks";
 
 import { act, render } from "@testing-library/react";
+import { buildProvider } from "@tests/seeders/provider";
+import { MockComponents } from "@tests/unit/mocks";
 
 describe(ProviderRawData.name, () => {
   it("renders", async () => {

--- a/apps/deploy-web/src/components/providers/ProviderRawData/ProviderRawData.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderRawData/ProviderRawData.tsx
@@ -7,9 +7,9 @@ import { useAllLeases } from "@src/queries/useLeaseQuery";
 import { useProviderDetail, useProviderStatus } from "@src/queries/useProvidersQuery";
 import { ApiProviderList, ClientProviderDetailWithStatus } from "@src/types/provider";
 import { domainName, UrlService } from "@src/utils/urlUtils";
-import Layout from "../layout/Layout";
-import { CustomNextSeo } from "../shared/CustomNextSeo";
-import ProviderDetailLayout, { ProviderDetailTabs } from "./ProviderDetailLayout";
+import Layout from "../../layout/Layout";
+import { CustomNextSeo } from "../../shared/CustomNextSeo";
+import ProviderDetailLayout, { ProviderDetailTabs } from "../ProviderDetailLayout";
 
 export const COMPONENTS = {
   Layout,

--- a/apps/deploy-web/src/pages/providers/[owner]/raw/index.tsx
+++ b/apps/deploy-web/src/pages/providers/[owner]/raw/index.tsx
@@ -1,4 +1,4 @@
-import { ProviderRawData } from "@src/components/providers/ProviderRawData";
+import { ProviderRawData } from "@src/components/providers/ProviderRawData/ProviderRawData";
 
 type Props = {
   owner: string;


### PR DESCRIPTION
## Why

To keep related code together

## What

moves ProviderRawData and its unit tests under a single folder