### PR TITLE
chore: removes setting GITHUB_PAT env variable in docker build compose

### DIFF
--- a/packages/docker/docker-compose.build.yml
+++ b/packages/docker/docker-compose.build.yml
@@ -8,8 +8,6 @@ services:
       args:
         WORKSPACE: apps/api
         GITHUB_PAT: ${GITHUB_PAT}
-    environment:
-        GITHUB_PAT: ${GITHUB_PAT}
 
   indexer:
     image: ${INDEXER_REPO:-console-indexer}:${INDEXER_TAG:-latest}

--- a/packages/env-loader/src/index.js
+++ b/packages/env-loader/src/index.js
@@ -16,16 +16,12 @@ const config = path => {
     files.push(path);
   }
 };
-config("env/.env.local");
-config("env/.env");
 
-const deploymentEnv = process.env.DEPLOYMENT_ENV;
-
-if (deploymentEnv && deploymentEnv !== "local") {
-  config(`env/.env.${deploymentEnv}`);
+if (!process.env.DEPLOYMENT_ENV) {
+  config("../../.env.local");
 }
-
-const network = process.env.NETWORK;
-config(`env/.env.${network}`);
+config(`env/.env.${process.env.DEPLOYMENT_ENV}`);
+config(`env/.env.${process.env.NETWORK}`);
+config("env/.env");
 
 logger.info(`Loaded env files: ${files.join(", ")}`);


### PR DESCRIPTION
## Why

Docker sets this variable to an empty string if it's not available in host env vars. And this overwrites variable specified in `.env.local` because host env variable overwrites the same variable in config file. 

## What

1. removes setting GITHUB_PAT env variable in docker build compose
2. adds repository wide `.env.local` file to change some parameters globally for all apps
3. changes the order of files in order to get rid of one `if`

## Additional notes

I tested this with simple script in `apps/api`:

```ts
import "@akashnetwork/env-loader"
import { env } from "./utils/env"

console.log(env.GITHUB_PAT)
```

Then called it like this:

```sh
$ npx ts-node src/test-env.ts
{"level":30,"time":1741695665572,"pid":12770,"hostname":"Sergiis-MacBook-Pro.local","context":"ENV","msg":"Loaded env files: env/.env.local, env/.env, env/.env.sandbox"}
from .env.local

$ GITHUB_PAT=1 npx ts-node src/test-env.ts
{"level":30,"time":1741695689481,"pid":12793,"hostname":"Sergiis-MacBook-Pro.local","context":"ENV","msg":"Loaded env files: env/.env.local, env/.env, env/.env.sandbox"}
1

$ export GITHUB_PAT=global
$ npx ts-node src/test-env.ts             
{"level":30,"time":1741695707446,"pid":12814,"hostname":"Sergiis-MacBook-Pro.local","context":"ENV","msg":"Loaded env files: env/.env.local, env/.env, env/.env.sandbox"}
global

$ GITHUB_PAT= npx ts-node src/test22.ts 
{"level":30,"time":1741695745347,"pid":12834,"hostname":"Sergiis-MacBook-Pro.local","context":"ENV","msg":"Loaded env files: env/.env.local, env/.env, env/.env.sandbox"}
           # <--- empty string here
```