### PR TITLE
refactor: refactors part of deploy-web to strict typescript types

### DIFF
--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -16,7 +16,8 @@
     "start": "next start",
     "test:cov": "NODE_ENV=test DEPLOYMENT_ENV=staging jest --coverage",
     "test:unit": "NODE_ENV=test DEPLOYMENT_ENV=staging jest",
-    "type-check": "tsc"
+    "type-check": "tsc",
+    "validate:types-strict": "tsc -p tsconfig.strict.json && echo"
   },
   "dependencies": {
     "@akashnetwork/akash-api": "^1.3.0",

--- a/apps/deploy-web/src/components/api-keys/CreateApiKeyModal.tsx
+++ b/apps/deploy-web/src/components/api-keys/CreateApiKeyModal.tsx
@@ -83,7 +83,7 @@ export const CreateApiKeyModal = ({ isOpen, onClose }: Props) => {
     enqueueSnackbar(<Snackbar title="Copied to clipboard!" iconVariant="success" />, { variant: "success", autoHideDuration: 1500 });
   };
 
-  const createApiKeyTracked = async ({ name }) => {
+  const createApiKeyTracked = async ({ name }: { name: string }) => {
     analyticsService.track("create_api_key", {
       category: "settings",
       label: "Create API key"

--- a/apps/deploy-web/src/components/authorizations/AllowanceModal.tsx
+++ b/apps/deploy-web/src/components/authorizations/AllowanceModal.tsx
@@ -47,7 +47,7 @@ export const AllowanceModal: React.FunctionComponent<Props> = ({ editingAllowanc
   const { amount, granteeAddress, expiration } = watch();
   const denomData = useDenomData(UAKT_DENOM);
 
-  const onDepositClick = event => {
+  const onDepositClick = (event: React.MouseEvent) => {
     event.preventDefault();
     formRef.current?.dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
   };
@@ -76,7 +76,7 @@ export const AllowanceModal: React.FunctionComponent<Props> = ({ editingAllowanc
     }
   };
 
-  function handleDocClick(ev, url: string) {
+  function handleDocClick(ev: React.MouseEvent<object>, url: string) {
     ev.preventDefault();
 
     window.open(url, "_blank");

--- a/apps/deploy-web/src/components/authorizations/GrantModal.tsx
+++ b/apps/deploy-web/src/components/authorizations/GrantModal.tsx
@@ -71,7 +71,7 @@ export const GrantModal: React.FunctionComponent<Props> = ({ editingGrant, addre
   const denom = token === "akt" ? UAKT_DENOM : usdcDenom;
   const denomData = useDenomData(denom);
 
-  const onDepositClick = event => {
+  const onDepositClick = (event: React.MouseEvent) => {
     event.preventDefault();
     formRef.current?.dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
   };

--- a/apps/deploy-web/src/components/layout/Sidebar.tsx
+++ b/apps/deploy-web/src/components/layout/Sidebar.tsx
@@ -15,7 +15,7 @@ import Link from "next/link";
 
 import { useWallet } from "@src/context/WalletProvider";
 import sdlStore from "@src/store/sdlStore";
-import { ISidebarGroupMenu } from "@src/types";
+import { ISidebarGroupMenu, ISidebarRoute } from "@src/types";
 import { UrlService } from "@src/utils/urlUtils";
 import { MobileSidebarUser } from "./MobileSidebarUser";
 import { ModeToggle } from "./ModeToggle";
@@ -45,7 +45,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
   const wallet = useWallet();
 
   const mainRoutes = useMemo(() => {
-    const routes = [
+    const routes: ISidebarRoute[] = [
       {
         title: "Home",
         icon: props => <Home {...props} />,
@@ -107,7 +107,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
     [mainRoutes]
   );
 
-  const extraRoutes = [
+  const extraRoutes: ISidebarGroupMenu[] = [
     {
       hasDivider: false,
       routes: [

--- a/apps/deploy-web/src/components/new-deployment/BidCountdownTimer.tsx
+++ b/apps/deploy-web/src/components/new-deployment/BidCountdownTimer.tsx
@@ -17,7 +17,7 @@ const time = 5 * 60;
 export const BidCountdownTimer: React.FunctionComponent<Props> = ({ height }) => {
   const [timeLeft, setTimeLeft] = useState(time); // Set the initial time in seconds
   const [isTimerInit, setIsTimerInit] = useState(false);
-  const { data: block, refetch: getBlock } = useBlock(height, {
+  const { data: block, refetch: getBlock } = useBlock(height || "", {
     disabled: true,
     onSuccess: block => {
       const date = new Date(block.block.header.time);

--- a/apps/deploy-web/src/components/new-deployment/BidGroup.tsx
+++ b/apps/deploy-web/src/components/new-deployment/BidGroup.tsx
@@ -53,7 +53,7 @@ export const BidGroup: React.FunctionComponent<Props> = ({
     if (currentGroup) {
       const resourcesSum = {
         cpuAmount: deploymentGroupResourceSum(currentGroup, r => parseInt(r.cpu.units.val) / 1000),
-        gpuAmount: deploymentGroupResourceSum(currentGroup, r => parseInt(r.gpu?.units?.val || 0)),
+        gpuAmount: deploymentGroupResourceSum(currentGroup, r => parseInt(r.gpu?.units?.val || "0")),
         memoryAmount: deploymentGroupResourceSum(currentGroup, r => parseInt(r.memory.quantity.val)),
         storageAmount: deploymentGroupResourceSum(currentGroup, r => getStorageAmount(r))
       };

--- a/apps/deploy-web/src/context/CertificateProvider/CertificateProviderContext.tsx
+++ b/apps/deploy-web/src/context/CertificateProvider/CertificateProviderContext.tsx
@@ -49,7 +49,7 @@ type ContextType = {
   validCertificates: Array<ChainCertificate>;
   setValidCertificates: React.Dispatch<React.SetStateAction<ChainCertificate[]>>;
   localCerts: Array<LocalCert> | null;
-  setLocalCerts: React.Dispatch<React.SetStateAction<LocalCert[]>>;
+  setLocalCerts: React.Dispatch<React.SetStateAction<LocalCert[] | null>>;
   createCertificate: () => Promise<void>;
   isCreatingCert: boolean;
   regenerateCertificate: () => Promise<void>;
@@ -59,7 +59,7 @@ type ContextType = {
 
 const CertificateProviderContext = React.createContext<ContextType>({} as ContextType);
 
-export const CertificateProvider = ({ children }) => {
+export const CertificateProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isCreatingCert, setIsCreatingCert] = useState(false);
   const [validCertificates, setValidCertificates] = useState<Array<ChainCertificate>>([]);
   const [selectedCertificate, setSelectedCertificate] = useState<ChainCertificate | null>(null);

--- a/apps/deploy-web/src/context/ChainParamProvider/ChainParamProvider.tsx
+++ b/apps/deploy-web/src/context/ChainParamProvider/ChainParamProvider.tsx
@@ -20,7 +20,7 @@ type ContextType = {
 
 const ChainParamContext = React.createContext<ContextType>({} as ContextType);
 
-export const ChainParamProvider = ({ children }) => {
+export const ChainParamProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { isSettingsInit } = useSettings();
   const { data: depositParams, refetch: getDepositParams } = useDepositParams({ enabled: false });
   const usdcDenom = useUsdcDenom();

--- a/apps/deploy-web/src/context/PricingProvider/PricingProvider.tsx
+++ b/apps/deploy-web/src/context/PricingProvider/PricingProvider.tsx
@@ -20,7 +20,7 @@ type ContextType = {
 
 const PricingProviderContext = React.createContext<ContextType>({} as ContextType);
 
-export const PricingProvider = ({ children }) => {
+export const PricingProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { data: marketData, isLoading } = useMarketData({ refetchInterval: 60_000 });
   const usdcIbcDenom = useUsdcDenom();
 

--- a/apps/deploy-web/src/context/SettingsProvider/SettingsProviderContext.tsx
+++ b/apps/deploy-web/src/context/SettingsProvider/SettingsProviderContext.tsx
@@ -197,7 +197,7 @@ export const SettingsProvider: FCWithChildren = ({ children }) => {
     return fastestNode;
   };
 
-  const updateSettings = newSettings => {
+  const updateSettings = (newSettings: any) => {
     setSettings(prevSettings => {
       clearQueries(prevSettings, newSettings);
       setLocalStorageItem("settings", JSON.stringify(newSettings));
@@ -206,7 +206,7 @@ export const SettingsProvider: FCWithChildren = ({ children }) => {
     });
   };
 
-  const clearQueries = (prevSettings, newSettings) => {
+  const clearQueries = (prevSettings: Settings, newSettings: Settings) => {
     if (prevSettings.apiEndpoint !== newSettings.apiEndpoint || (prevSettings.isCustomNode && !newSettings.isCustomNode)) {
       // Cancel and remove queries from cache if the api endpoint is changed
       queryClient.resetQueries();

--- a/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
@@ -64,7 +64,7 @@ const MESSAGE_STATES: Record<string, LoadingState> = {
   "/akash.deployment.v1beta3.MsgDepositDeployment": "depositingDeployment"
 };
 
-export const WalletProvider = ({ children }) => {
+export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isWalletLoaded, setIsWalletLoaded] = useState<boolean>(true);
   const [loadingState, setLoadingState] = useState<LoadingState | undefined>(undefined);
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
@@ -225,7 +225,7 @@ export const WalletProvider = ({ children }) => {
       });
 
       return true;
-    } catch (err) {
+    } catch (err: any) {
       console.error(err);
 
       if (axios.isAxiosError(err) && err.response?.status !== 500) {
@@ -248,7 +248,7 @@ export const WalletProvider = ({ children }) => {
               const codeSpace = match[2];
 
               if (codeSpace === "sdk" && code in ERROR_MESSAGES) {
-                errorMsg = ERROR_MESSAGES[code];
+                errorMsg = ERROR_MESSAGES[code as keyof typeof ERROR_MESSAGES];
               }
             }
 
@@ -331,7 +331,7 @@ export function useWallet() {
   return { ...React.useContext(WalletProviderContext) };
 }
 
-const TransactionSnackbarContent = ({ snackMessage, transactionHash }) => {
+const TransactionSnackbarContent: React.FC<{ snackMessage: string; transactionHash: string }> = ({ snackMessage, transactionHash }) => {
   const selectedNetworkId = networkStore.useSelectedNetworkId();
   const txUrl = transactionHash && `${browserEnvConfig.NEXT_PUBLIC_STATS_APP_URL}/transactions/${transactionHash}?network=${selectedNetworkId}`;
 

--- a/apps/deploy-web/src/hooks/useDenom.ts
+++ b/apps/deploy-web/src/hooks/useDenom.ts
@@ -2,11 +2,11 @@ import { USDC_IBC_DENOMS } from "@src/config/denom.config";
 import networkStore from "@src/store/networkStore";
 
 export const useUsdcDenom = () => {
-  return USDC_IBC_DENOMS[networkStore.selectedNetworkId];
+  return USDC_IBC_DENOMS[networkStore.selectedNetworkId as keyof typeof USDC_IBC_DENOMS];
 };
 
 export const getUsdcDenom = () => {
-  return USDC_IBC_DENOMS[networkStore.selectedNetworkId];
+  return USDC_IBC_DENOMS[networkStore.selectedNetworkId as keyof typeof USDC_IBC_DENOMS];
 };
 
 export const useSdlDenoms = () => {

--- a/apps/deploy-web/src/queries/useAnonymousUserQuery.ts
+++ b/apps/deploy-web/src/queries/useAnonymousUserQuery.ts
@@ -30,7 +30,7 @@ export function useAnonymousUserQuery(id?: string, options?: { enabled?: boolean
       const token = "token" in rest ? rest.token : undefined;
       setUserState({ user: fetched, token, isLoading: false });
     } catch (error) {
-      setUserState({ isLoading: false, error });
+      setUserState({ isLoading: false, error: error as Error | AxiosError });
       Sentry.captureException(error);
     }
   });

--- a/apps/deploy-web/src/queries/useApiKeysQuery.ts
+++ b/apps/deploy-web/src/queries/useApiKeysQuery.ts
@@ -35,7 +35,8 @@ export function useCreateApiKey() {
       }),
     {
       onSuccess: _response => {
-        queryClient.setQueryData(QueryKeys.getApiKeysKey(user?.userId ?? ""), (oldData: ApiKeyResponse[]) => {
+        queryClient.setQueryData(QueryKeys.getApiKeysKey(user?.userId ?? ""), (oldData: ApiKeyResponse[] | undefined) => {
+          if (!oldData) return [_response];
           return [...oldData, _response];
         });
       }

--- a/apps/deploy-web/src/queries/useBalancesQuery.ts
+++ b/apps/deploy-web/src/queries/useBalancesQuery.ts
@@ -60,9 +60,9 @@ async function getBalances(apiEndpoint: string, address?: string): Promise<Balan
   };
 }
 
-export function useBalances(address?: string, options?: Omit<UseQueryOptions<Balances, Error, any, QueryKey>, "queryKey" | "queryFn">) {
+export function useBalances(address?: string, options?: Omit<UseQueryOptions<Balances | undefined>, "queryKey" | "queryFn">) {
   const { settings } = useSettings();
-  return useQuery(QueryKeys.getBalancesKey(address), () => getBalances(settings.apiEndpoint, address), {
+  return useQuery(QueryKeys.getBalancesKey(address) as QueryKey, () => getBalances(settings.apiEndpoint, address), {
     enabled: !!address,
     ...options
   });

--- a/apps/deploy-web/src/queries/useBlocksQuery.ts
+++ b/apps/deploy-web/src/queries/useBlocksQuery.ts
@@ -7,13 +7,13 @@ import { ApiUrlService } from "@src/utils/apiUtils";
 import { QueryKeys } from "./queryKeys";
 
 // Block
-async function getBlock(apiEndpoint, id) {
+async function getBlock(apiEndpoint: string, id: string) {
   const response = await axios.get(ApiUrlService.block(apiEndpoint, id));
 
   return response.data;
 }
 
-export function useBlock(id, options = {}) {
+export function useBlock(id: string, options = {}) {
   const { settings } = useSettings();
   return useQuery(QueryKeys.getBlockKey(id), () => getBlock(settings.apiEndpoint, id), {
     refetchInterval: false,

--- a/apps/deploy-web/src/queries/useManagedWalletQuery.ts
+++ b/apps/deploy-web/src/queries/useManagedWalletQuery.ts
@@ -1,13 +1,13 @@
 import { QueryKey, useMutation, useQuery, useQueryClient, UseQueryOptions } from "react-query";
-import { ApiWalletOutput } from "@akashnetwork/http-sdk";
+import { ApiManagedWalletOutput } from "@akashnetwork/http-sdk";
 
 import { managedWalletHttpService } from "@src/services/managed-wallet-http/managed-wallet-http.service";
 
 const MANAGED_WALLET = "MANAGED_WALLET";
 
-export function useManagedWalletQuery(userId?: string, options?: Omit<UseQueryOptions<ApiWalletOutput, Error, any, QueryKey>, "queryKey" | "queryFn">) {
+export function useManagedWalletQuery(userId?: string, options?: Omit<UseQueryOptions<ApiManagedWalletOutput | undefined>, "queryKey" | "queryFn">) {
   return useQuery(
-    [MANAGED_WALLET, userId],
+    [MANAGED_WALLET, userId || ""] as QueryKey,
     async () => {
       if (userId) {
         return await managedWalletHttpService.getWallet(userId);

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -146,7 +146,7 @@ export class AnalyticsService {
 
     for (const key in user) {
       if (key !== "id") {
-        event.set(AMPLITUDE_USER_PROPERTIES_MAP[key] || AMPLITUDE_USER_PROPERTIES_MAP, user[key]);
+        event.set(AMPLITUDE_USER_PROPERTIES_MAP[key as keyof AnalyticsUser] || key, String(user[key as keyof typeof user]));
       }
     }
 
@@ -169,7 +169,7 @@ export class AnalyticsService {
     }
   }
 
-  trackSwitch(eventName: "connect_wallet", value: "managed" | "custodial", target?: AnalyticsTarget);
+  trackSwitch(eventName: "connect_wallet", value: "managed" | "custodial", target?: AnalyticsTarget): void;
   trackSwitch(eventName: any, value: any, target?: AnalyticsTarget) {
     if (!isBrowser) {
       return;
@@ -209,7 +209,7 @@ export class AnalyticsService {
       return [`${eventName}_${eventProperties.tab}`, eventProperties];
     }
 
-    return [GA_EVENTS[eventName] || eventName, eventProperties];
+    return [GA_EVENTS[eventName as keyof typeof GA_EVENTS] || eventName, eventProperties];
   }
 
   private shouldSampleUser(userId: string): boolean {

--- a/apps/deploy-web/src/services/managed-wallet-http/managed-wallet-http.service.ts
+++ b/apps/deploy-web/src/services/managed-wallet-http/managed-wallet-http.service.ts
@@ -1,4 +1,4 @@
-import { ApiWalletOutput, ManagedWalletHttpService as ManagedWalletHttpServiceOriginal } from "@akashnetwork/http-sdk";
+import { ApiManagedWalletOutput, ApiWalletOutput, ManagedWalletHttpService as ManagedWalletHttpServiceOriginal } from "@akashnetwork/http-sdk";
 import { AxiosRequestConfig } from "axios";
 
 import { browserEnvConfig } from "@src/config/browser-env.config";
@@ -31,7 +31,7 @@ class ManagedWalletHttpService extends ManagedWalletHttpServiceOriginal {
     }
   }
 
-  async getWallet(userId: string) {
+  async getWallet(userId: string): Promise<ApiManagedWalletOutput> {
     const [wallet] = this.extractApiData(await this.get<ApiWalletOutput[]>("v1/wallets", { params: this.getWalletListParams(userId) }));
 
     this.clearSessionResults();

--- a/apps/deploy-web/src/types/deployment.ts
+++ b/apps/deploy-web/src/types/deployment.ts
@@ -56,9 +56,9 @@ export interface RpcDeployment {
   escrow_account: EscrowAccount;
 }
 
-type DeploymentGroup = DeploymentGroup_v2 | DeploymentGroup_v3;
+export type DeploymentGroup = DeploymentGroup_v2 | DeploymentGroup_v3;
 
-interface DeploymentResource_V2 {
+export interface DeploymentResource_V2 {
   cpu: {
     units: {
       val: string;
@@ -89,7 +89,7 @@ interface DeploymentResource_V2 {
     sequence_number: number;
   }>;
 }
-interface DeploymentResource_V3 extends DeploymentResource_V2 {}
+export interface DeploymentResource_V3 extends DeploymentResource_V2 {}
 
 interface DeploymentGroup_v2 {
   group_id: {

--- a/apps/deploy-web/src/types/index.ts
+++ b/apps/deploy-web/src/types/index.ts
@@ -22,7 +22,7 @@ export type ISidebarGroupMenu = {
 
 export type ISidebarRoute = {
   title: string;
-  icon: any;
+  icon?: (props: Record<string, unknown>) => React.ReactNode;
   url: string;
   activeRoutes: string[];
   isNew?: boolean;

--- a/apps/deploy-web/src/utils/TransactionMessageData.ts
+++ b/apps/deploy-web/src/utils/TransactionMessageData.ts
@@ -85,7 +85,7 @@ export class TransactionMessageData {
     return message;
   }
 
-  static getCreateDeploymentMsg(deploymentData) {
+  static getCreateDeploymentMsg(deploymentData: Record<string, any>) {
     const message = {
       typeUrl: TransactionMessageData.Types.MSG_CREATE_DEPLOYMENT,
       value: {
@@ -100,7 +100,7 @@ export class TransactionMessageData {
     return message;
   }
 
-  static getUpdateDeploymentMsg(deploymentData) {
+  static getUpdateDeploymentMsg(deploymentData: Record<string, any>) {
     const message = {
       typeUrl: TransactionMessageData.Types.MSG_UPDATE_DEPLOYMENT,
       value: {

--- a/apps/deploy-web/src/utils/apiUtils.ts
+++ b/apps/deploy-web/src/utils/apiUtils.ts
@@ -128,8 +128,8 @@ export class ApiUrlService {
 // TODO: implement proper pagination on clients
 //   Issue: https://github.com/akash-network/console/milestone/7
 export async function loadWithPagination<T>(baseUrl: string, dataKey: string, limit: number, httpClient = axios) {
-  let items = [];
-  let nextKey = null;
+  let items: T[] = [];
+  let nextKey: string | null = null;
   // let callCount = 1;
   // let totalCount = null;
 

--- a/apps/deploy-web/src/utils/deploymentData/helpers.ts
+++ b/apps/deploy-web/src/utils/deploymentData/helpers.ts
@@ -4,7 +4,7 @@ import { NetworkId } from "@akashnetwork/akashjs/build/types/network";
 import axios from "axios";
 
 export class CustomValidationError extends Error {
-  constructor(message) {
+  constructor(message: string) {
     super(message);
     this.name = "CustomValidationError";
   }
@@ -46,7 +46,7 @@ export function parseSizeStr(str: string) {
     if (suffix) {
       const suffixPos = str.length - suffix.length;
       const numberStr = str.substring(0, suffixPos);
-      return (parseFloat(numberStr) * specSuffixes[suffix]).toString();
+      return (parseFloat(numberStr) * specSuffixes[suffix as keyof typeof specSuffixes]).toString();
     } else {
       return parseFloat(str);
     }

--- a/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
+++ b/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
@@ -10,11 +10,11 @@ export const ENDPOINT_NAME_VALIDATION_REGEX = /^[a-z]+[-_\da-z]+$/;
 const TRIAL_ATTRIBUTE = "console/trials";
 const AUDITOR = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
 
-export function getManifest(yamlJson, asString: boolean) {
+export function getManifest(yamlJson: any, asString: boolean) {
   return Manifest(yamlJson, "beta3", networkStore.selectedNetworkId, asString);
 }
 
-export async function getManifestVersion(yamlJson) {
+export async function getManifestVersion(yamlJson: any) {
   const version = await ManifestVersion(yamlJson, "beta3", networkStore.selectedNetworkId);
 
   return Buffer.from(version).toString("base64");
@@ -76,7 +76,7 @@ ${result}`;
 
 // Attributes is a key value pair object, but we store it as an array of objects with key and value
 function mapProviderAttributes(attributes: Attribute[]) {
-  return attributes?.reduce((acc, curr) => ((acc[curr.key] = curr.value), acc), {});
+  return attributes?.reduce<Record<string, string>>((acc, curr) => ((acc[curr.key] = curr.value), acc), {});
 }
 
 export async function NewDeploymentData(
@@ -110,7 +110,7 @@ export async function NewDeploymentData(
       deposit: _deposit,
       depositor: depositorAddress || fromAddress
     };
-  } catch (e) {
+  } catch (e: any) {
     const error = new CustomValidationError(e.message);
     error.stack = e.stack;
     throw error;

--- a/apps/deploy-web/src/utils/domUtils.ts
+++ b/apps/deploy-web/src/utils/domUtils.ts
@@ -1,5 +1,5 @@
 // returns true if the element or one of its parents has the class classname
-export function hasSomeParentTheClass(element: HTMLElement, classname: string) {
+export function hasSomeParentTheClass(element: HTMLElement, classname: string): boolean {
   if (element.className?.split && element.className.split(" ").indexOf(classname) >= 0) return true;
-  return element.parentNode && hasSomeParentTheClass(element.parentNode as HTMLElement, classname);
+  return !!element.parentNode && hasSomeParentTheClass(element.parentNode as HTMLElement, classname);
 }

--- a/apps/deploy-web/src/utils/localStorage.ts
+++ b/apps/deploy-web/src/utils/localStorage.ts
@@ -5,7 +5,7 @@ import { gt, neq } from "semver";
 
 const { publicRuntimeConfig } = getConfig();
 
-const migrations = {
+const migrations: Record<string, () => void> = {
   "0.14.0": () => {}
 };
 

--- a/apps/deploy-web/src/utils/proto/index.ts
+++ b/apps/deploy-web/src/utils/proto/index.ts
@@ -8,7 +8,7 @@ const commonTypes = { ...v1beta3, ...v1beta4 };
 const mainnetTypes = commonTypes;
 const sandboxTypes = commonTypes;
 
-export let protoTypes;
+export let protoTypes: typeof commonTypes | typeof mainnetTypes | typeof sandboxTypes;
 
 export function initProtoTypes() {
   switch (networkStore.selectedNetworkId) {

--- a/apps/deploy-web/src/utils/providerAttributes/helpers.ts
+++ b/apps/deploy-web/src/utils/providerAttributes/helpers.ts
@@ -18,8 +18,8 @@ export const mapFormValuesToAttributes = (data: z.infer<typeof providerAttribute
   const attributes: { key: string; value: string }[] = [];
 
   Object.keys(data).forEach(key => {
-    const value = data[key];
-    const attribute = providerAttributesSchema[key] as ProviderAttributeSchemaDetail;
+    const value = data[key as keyof typeof data];
+    const attribute = providerAttributesSchema[key as keyof ProviderAttributesSchema] as ProviderAttributeSchemaDetail;
     if (attribute && value) {
       switch (attribute.type) {
         case "string":
@@ -29,7 +29,9 @@ export const mapFormValuesToAttributes = (data: z.infer<typeof providerAttribute
           break;
         case "option":
           // eslint-disable-next-line no-case-declarations
-          const attributeValue = attribute.values?.find(v => v.key === value.key);
+          const detailValue = value as unknown as ProviderAttributeSchemaDetailValue;
+          // eslint-disable-next-line no-case-declarations
+          const attributeValue = attribute.values?.find(v => v.key === detailValue.key);
           attributes.push({ key: attribute.key, value: `${attributeValue?.key}` });
           break;
         case "multiple-option":

--- a/apps/deploy-web/src/utils/providerUtils.ts
+++ b/apps/deploy-web/src/utils/providerUtils.ts
@@ -22,7 +22,7 @@ export function providerStatusToDto(providerStatus: ProviderStatus, providerVers
   };
 }
 
-export function getNetworkCapacityDto(networkCapacity) {
+export function getNetworkCapacityDto(networkCapacity: any) {
   return {
     ...networkCapacity,
     activeCPU: networkCapacity.activeCPU / 1000,

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -1,7 +1,7 @@
 import yaml from "js-yaml";
 import { nanoid } from "nanoid";
 
-import { ExposeType, ProfileGpuModelType,ServiceType } from "@src/types";
+import { ExposeType, ProfileGpuModelType, ServiceType } from "@src/types";
 import { CustomValidationError } from "../deploymentData";
 import { capitalizeFirstLetter } from "../stringUtils";
 import { defaultHttpOptions } from "./data";
@@ -10,6 +10,7 @@ export const importSimpleSdl = (yamlStr: string) => {
   try {
     const yamlJson = yaml.load(yamlStr) as any;
     const services: ServiceType[] = [];
+    if (!yamlJson.services) return services;
 
     const sortedServicesNames = Object.keys(yamlJson.services).sort();
     sortedServicesNames.forEach(svcName => {
@@ -20,14 +21,14 @@ export const importSimpleSdl = (yamlStr: string) => {
         title: svcName,
         image: svc.image,
         hasCredentials: !!svc.credentials,
-        credentials: svc.credentials,
+        credentials: svc.credentials
       };
 
       const compute = yamlJson.profiles.compute[svcName];
       const storages = compute.resources.storage.map ? compute.resources.storage : [compute.resources.storage];
-      const persistentStorage = storages.find(s => s.attributes?.persistent === true);
+      const persistentStorage = storages.find((s: any) => s.attributes?.persistent === true);
       const hasPersistentStorage = !!persistentStorage;
-      const ephStorage = storages.find(s => !s.attributes);
+      const ephStorage = storages.find((s: any) => !s.attributes);
       const persistentStorageName = hasPersistentStorage ? persistentStorage.name : "data";
 
       // TODO validation
@@ -59,12 +60,12 @@ export const importSimpleSdl = (yamlStr: string) => {
       };
 
       // Env
-      service.env = svc.env?.map(e => ({ id: nanoid(), key: e.split("=")[0], value: e.split("=")[1] })) || [];
+      service.env = svc.env?.map((e: any) => ({ id: nanoid(), key: e.split("=")[0], value: e.split("=")[1] })) || [];
 
       // Expose
       service.expose = [];
-      svc.expose?.forEach(expose => {
-        const isGlobal = expose.to.find(t => t.global);
+      svc.expose?.forEach((expose: any) => {
+        const isGlobal = expose.to.find((t: any) => t.global);
 
         const _expose: ExposeType = {
           id: nanoid(),
@@ -72,8 +73,8 @@ export const importSimpleSdl = (yamlStr: string) => {
           as: expose.as || 80,
           proto: expose.proto === "tcp" ? expose.proto : "http",
           global: !!isGlobal,
-          to: expose.to.filter(t => t.global === undefined).map(t => ({ id: nanoid(), value: t.service })),
-          accept: expose.accept?.map(a => ({ id: nanoid(), value: a })) || [],
+          to: expose.to.filter((t: any) => t.global === undefined).map((t: any) => ({ id: nanoid(), value: t.service })),
+          accept: expose.accept?.map((a: string) => ({ id: nanoid(), value: a })) || [],
           ipName: isGlobal?.ip ? isGlobal.ip : "",
           hasCustomHttpOptions: !!expose.http_options,
           httpOptions: {
@@ -110,8 +111,8 @@ export const importSimpleSdl = (yamlStr: string) => {
           denom: placementPricing.denom
         },
         signedBy: {
-          anyOf: placement.signedBy && placement.signedBy?.anyOf ? placement.signedBy.anyOf.map(x => ({ id: nanoid(), value: x })) : [],
-          allOf: placement.signedBy && placement.signedBy?.allOf ? placement.signedBy.allOf.map(x => ({ id: nanoid(), value: x })) : []
+          anyOf: placement.signedBy && placement.signedBy?.anyOf ? placement.signedBy.anyOf.map((x: string) => ({ id: nanoid(), value: x })) : [],
+          allOf: placement.signedBy && placement.signedBy?.allOf ? placement.signedBy.allOf.map((x: string) => ({ id: nanoid(), value: x })) : []
         },
         attributes: placement.attributes
           ? Object.keys(placement.attributes).map(attKey => {

--- a/apps/deploy-web/src/utils/sdl/transformCustomSdlFields.ts
+++ b/apps/deploy-web/src/utils/sdl/transformCustomSdlFields.ts
@@ -84,7 +84,7 @@ function ensureServiceCount(input: ServiceType) {
 }
 
 function mapImage(input: ServiceType) {
-  const image = SSH_VM_IMAGES[input.image];
+  const image = SSH_VM_IMAGES[input.image as keyof typeof SSH_VM_IMAGES];
 
   if (!image) {
     return input;

--- a/apps/deploy-web/src/utils/timer.ts
+++ b/apps/deploy-web/src/utils/timer.ts
@@ -1,5 +1,5 @@
 export const Timer = (ms: number) => {
-  let id;
+  let id: ReturnType<typeof setTimeout> | number;
 
   const start = () =>
     new Promise(resolve => {

--- a/apps/deploy-web/src/utils/urlUtils.ts
+++ b/apps/deploy-web/src/utils/urlUtils.ts
@@ -96,7 +96,7 @@ export function removeEmptyFilters(obj: { [key: string]: string }) {
   return copy;
 }
 
-export function handleDocClick(ev, url) {
+export function handleDocClick(ev: React.MouseEvent<any>, url: string): void {
   ev.preventDefault();
 
   window.open(url, "_blank");

--- a/apps/deploy-web/tsconfig.strict.json
+++ b/apps/deploy-web/tsconfig.strict.json
@@ -1,0 +1,32 @@
+{
+  "extends": "./tsconfig.build.json",
+  "include": [
+    "next-env.d.ts",
+    "**/*.d.ts",
+    "./src/types/**/*.ts",
+    "./src/utils/**/*.ts",
+    "./src/store/**/*.ts",
+    "src/context/CertificateProvider/CertificateProviderContext.tsx",
+    "src/context/SettingsProvider/SettingsProviderContext.tsx",
+    "src/context/PricingProvider/PricingProvider.tsx",
+    "src/context/SettingsProvider/SettingsProviderContext.tsx",
+    "src/context/WalletProvider/WalletProvider.tsx",
+    "src/hooks/useDenom.ts",
+    "src/queries/useAnonymousUserQuery.ts",
+    "src/queries/useApiKeysQuery.ts",
+    "src/queries/useBalancesQuery.ts",
+    "src/queries/useBlocksQuery.ts",
+    "src/queries/useManagedWalletQuery.ts",
+    "src/services/managed-wallet-http/managed-wallet-http.service.ts",
+    "src/services/analytics/analytics.service.ts",
+    "src/components/layout/Sidebar.tsx",
+    "src/components/api-keys/CreateApiKeyModal.tsx",
+    "src/components/authorizations/AllowanceModal.tsx",
+    "src/components/authorizations/GrantModal.tsx",
+  ],
+  "compilerOptions": {
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     ],
     "./packages/database/**/*.ts": [
       "npm run validate:types -w packages/database"
+    ],
+    "./apps/deploy-web/src/utils/**/*.ts": [
+      "npm run validate:types-strict -w apps/deploy-web"
     ]
   },
   "dependencies": {

--- a/packages/http-sdk/src/managed-wallet-http/managed-wallet-http.service.ts
+++ b/packages/http-sdk/src/managed-wallet-http/managed-wallet-http.service.ts
@@ -19,7 +19,7 @@ export class ManagedWalletHttpService extends ApiHttpService {
     return wallet && this.addWalletEssentials(wallet);
   }
 
-  protected addWalletEssentials(input: ApiWalletOutput): ApiWalletOutput & { username: "Managed Wallet"; isWalletConnected: true } {
+  protected addWalletEssentials(input: ApiWalletOutput): ApiManagedWalletOutput {
     return {
       ...input,
       username: "Managed Wallet",
@@ -27,3 +27,5 @@ export class ManagedWalletHttpService extends ApiHttpService {
     };
   }
 }
+
+export type ApiManagedWalletOutput = ApiWalletOutput & { username: "Managed Wallet"; isWalletConnected: true };


### PR DESCRIPTION
## Why 

to improve quality of the project and reliance on existing tools. To catch bugs at early stage

## What

1. introduced `tsconfig.strict.json` which includes only those files which were refactored and should adhere to strict type policy which is checked by lint-staged in case there are changes in those files
2. lint-staged validation check which ensures that refactored files do not degrade into prev state
3. types changes/additions

## Additional notes

If file inside tsconfig.strict.json references file which is not in tsconfig.strict.json that file will be type checked as well. There is no way to workaround this, that's why it's possible to refactor only the whole import subtree. The easiest way to do it is to refactor from bottom to top, starting from files which has the least imports. In case of modular structure, it's possible to refactor the whole module at once as well because it follows bottom-up approach