### PR TITLE
fix: ensure that akash prebuilt templates exist in the final docker image

### DIFF
--- a/apps/api/scripts/buildAkashTemplatesCache.ts
+++ b/apps/api/scripts/buildAkashTemplatesCache.ts
@@ -9,7 +9,7 @@ if (!githubPAT) {
   process.exit(1);
 }
 
-getTemplateGallery({ githubPAT, dataFolderPath: "./data" }).catch(err => {
+getTemplateGallery({ githubPAT, dataFolderPath: "./dist/.data" }).catch(err => {
   console.error("Encountered an error trying to warm up Akash templates cache");
   console.error(err);
   process.exit(1);

--- a/apps/api/src/utils/constants.ts
+++ b/apps/api/src/utils/constants.ts
@@ -6,7 +6,7 @@ export const averageHoursInAMonth = averageDaysInMonth * 24;
 export const averageBlockCountInAMonth = (averageDaysInMonth * 24 * 60 * 60) / averageBlockTime;
 export const averageBlockCountInAnHour = (60 * 60) / averageBlockTime;
 
-export const dataFolderPath = "./data";
+export const dataFolderPath = "./dist/.data";
 
 // Open API examples
 export const openApiExampleAddress = "akash13265twfqejnma6cc93rw5dxk4cldyz2zyy8cdm";

--- a/packages/docker/Dockerfile.node
+++ b/packages/docker/Dockerfile.node
@@ -36,15 +36,17 @@ ENV APP_USER app
 RUN addgroup --system --gid $APP_GROUP_ID $APP_GROUP \
     && adduser --system --uid $APP_GROUP_ID --ingroup $APP_GROUP $APP_USER
 
+COPY --from=builder /app/package*.json /app/
+COPY --from=builder /app/$WORKSPACE/package.json /app/$WORKSPACE/package.json
+COPY --from=builder --parents /app/packages/*/package.json /app
+
+RUN npm ci --workspace $WORKSPACE --omit=dev
+
 COPY --from=builder /app/$WORKSPACE/dist /app/$WORKSPACE/dist
 COPY --from=builder /app/$WORKSPACE/env/* /app/$WORKSPACE/env/
 COPY --from=builder /app/packages /app/packages
-COPY --from=builder /app/package.json /app/package.json
-COPY --from=builder /app/package-lock.json /app/package-lock.json
-COPY --from=builder /app/$WORKSPACE/package.json /app/$WORKSPACE/package.json
 
-RUN chown -R $APP_USER:$APP_GROUP /app
-RUN npm ci --workspace $WORKSPACE --omit=dev
+RUN find /app -name node_modules -prune -o -type f -exec chown $APP_USER:$APP_GROUP '{}' \;
 RUN apk add --no-cache libcap; \
     setcap cap_net_bind_service=+ep `readlink -f \`which node\``
 


### PR DESCRIPTION
## Why

prebuilt templates are not copied to final docker image right now. ref #917 

## What

1. ensure that akash prebuilt templates exist in the final docker image
2. optimize production build to install deps only if they are changed