### PR TITLE
chore: improves cache utilization in docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
-**/node_modules
-**/data
+**/node_modules/**
+**/data/**
 **/npm-debug.log
 **/.git
 
@@ -8,11 +8,6 @@
 **/.env.test
 **/.env.*.local
 **/.env.*.test
-
-apps/indexer/.env*
-apps/landing/.env*
-apps/provider-console/.env*
-apps/provider-proxy/.env*
 
 **/.next
 *.md

--- a/apps/api/webpack.prod.js
+++ b/apps/api/webpack.prod.js
@@ -18,7 +18,7 @@ module.exports = {
     extensions: [".ts", ".js"],
     alias: hq.get("webpack")
   },
-  externals: [nodeExternals(), { "winston-transport": "commonjs winston-transport" }],
+  externals: [nodeExternals()],
   module: {
     rules: [
       {

--- a/apps/deploy-web/.dockerignore
+++ b/apps/deploy-web/.dockerignore
@@ -5,3 +5,4 @@ npm-debug.log
 README.md
 .next
 .git
+./tests/fixture/testdata

--- a/packages/docker/Dockerfile.nextjs
+++ b/packages/docker/Dockerfile.nextjs
@@ -12,17 +12,24 @@ ENV NEXT_TELEMETRY_DISABLED 1
 
 WORKDIR /app
 
+FROM base as prepare
+
+COPY package*.json /app
+COPY /$WORKSPACE/package.json /app/$WORKSPACE/package.json
+COPY --parents /packages/*/package.json /app
+# reset app version to 1.0.0 to avoid cache busting after every release
+RUN npm version --allow-same-version 1.0.0 -w $WORKSPACE --no-workspaces-update && \
+    npm install --package-lock-only
+
 FROM base AS development
 
 ENV NODE_ENV development
 
 RUN apk add --no-cache libc6-compat
 
-COPY package*.json /app
-COPY /$WORKSPACE/package.json /app/$WORKSPACE/package.json
-COPY --parents /packages/*/package.json /app
+COPY --from=prepare /app .
 
-RUN npm ci
+RUN npm ci && npm cache clean --force
 
 COPY $WORKSPACE ./$WORKSPACE
 COPY /packages /app/packages
@@ -45,6 +52,8 @@ ENV APP_USER app
 RUN addgroup --system --gid $APP_GROUP_ID $APP_GROUP \
     && adduser --system --uid $APP_GROUP_ID $APP_USER
 
+COPY --from=builder /app/$WORKSPACE/package.json ./$WORKSPACE/package.json
+COPY --from=builder /app/package*.json .
 COPY --from=builder /app/$WORKSPACE/env ./$WORKSPACE/env
 COPY --from=builder /app/$WORKSPACE/public ./$WORKSPACE/public
 COPY --from=builder /app/$WORKSPACE/.next/standalone ./

--- a/packages/docker/Dockerfile.node
+++ b/packages/docker/Dockerfile.node
@@ -9,16 +9,22 @@ ENV HUSKY 0
 
 WORKDIR /app
 
+FROM base AS prepare
+
+COPY package*.json /app/
+COPY $WORKSPACE/package.json /app/$WORKSPACE/
+COPY --parents packages/*/package.json /app
+# reset app version to 1.0.0 to avoid cache busting after every release
+RUN npm version --allow-same-version 1.0.0 -w $WORKSPACE --no-workspaces-update && \
+    npm install --package-lock-only
+
 FROM base AS development
 
-COPY package*.json /app
-COPY /$WORKSPACE/package.json /app/$WORKSPACE/package.json
-COPY --parents /packages/*/package.json /app
+COPY --from=prepare /app .
 
-RUN npm ci
-
-COPY /$WORKSPACE /app/$WORKSPACE
-COPY /packages /app/packages
+RUN npm ci && npm cache clean --force
+COPY $WORKSPACE ./$WORKSPACE
+COPY packages ./packages
 
 CMD ["npm", "run", "dev", "--workspace", "${WORKSPACE}"]
 
@@ -37,14 +43,9 @@ RUN addgroup --system --gid $APP_GROUP_ID $APP_GROUP \
     && adduser --system --uid $APP_GROUP_ID --ingroup $APP_GROUP $APP_USER
 
 COPY --from=builder /app/package*.json /app/
-COPY --from=builder /app/$WORKSPACE/package.json /app/$WORKSPACE/package.json
-COPY --from=builder --parents /app/packages/*/package.json /app
-
-RUN npm ci --workspace $WORKSPACE --omit=dev
-
+COPY --from=builder /app/$WORKSPACE/package.json /app/$WORKSPACE/
 COPY --from=builder /app/$WORKSPACE/dist /app/$WORKSPACE/dist
-COPY --from=builder /app/$WORKSPACE/env/* /app/$WORKSPACE/env/
-COPY --from=builder /app/packages /app/packages
+COPY --from=builder /app/$WORKSPACE/env /app/$WORKSPACE/env
 
 RUN find /app -name node_modules -prune -o -type f -exec chown $APP_USER:$APP_GROUP '{}' \;
 RUN apk add --no-cache libcap; \


### PR DESCRIPTION
## Why

Very often we need to install npm dependencies, this is time consuming and currently we refetch dependencies on every release of the every app. Basically every change in package.json invalidates docker caching mostly because of package version change. However the actual dependencies are not frequently changed. 

This both speeds up local dev rebuild and GHA builds. For local I use:

```
npm run dc:up:dev -- api deploy-web --build --force-recreate
```

after this changes it's super fast, so I can be sure that my node_modules are up to date with the latest package.json changes

## What

1. Removes unused external dependency in API's webpack file
2. Updates Dockerfiles to ignore version change and reuse cached layers 
3. Cleans npm cache to reduce docker image size
4. Removes ./packages from `Dockerfile.node` because we compile bundle in dist
5. Reduces docker image sizes