### PR TITLE
fix: ensures provider-proxy has valid blockchain API_URL on sandbox env

### DIFF
--- a/apps/provider-proxy/src/services/ProviderService.ts
+++ b/apps/provider-proxy/src/services/ProviderService.ts
@@ -17,7 +17,12 @@ export class ProviderService {
       "pagination.limit": "1"
     });
 
-    const response = await httpRetry(() => this.fetch(`${this.getChainBaseUrl(network)}/akash/cert/v1beta3/certificates/list?${queryParams}`), {
+    const baseUrl = this.getChainBaseUrl(network);
+    if (!baseUrl) {
+      throw new Error(`No API URL provided for network ${network}`);
+    }
+
+    const response = await httpRetry(() => this.fetch(`${baseUrl}/akash/cert/v1beta3/certificates/list?${queryParams}`), {
       retryIf: response => response.status > 500
     });
 

--- a/apps/provider-proxy/src/services/WebsocketServer.ts
+++ b/apps/provider-proxy/src/services/WebsocketServer.ts
@@ -191,10 +191,10 @@ export class WebsocketServer {
         .catch(error => {
           options.logger?.error({
             message: "Could not validate SSL certificate",
-            error,
             chainNetwork: options.chainNetwork,
             providerAddress: options.providerAddress
           });
+          options.logger?.error(error);
           return {
             ok: false,
             code: "serverError"

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
     },
     "apps/api": {
       "name": "@akashnetwork/console-api",
-      "version": "2.69.3",
+      "version": "2.70.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
@@ -232,7 +232,7 @@
     },
     "apps/deploy-web": {
       "name": "@akashnetwork/console-web",
-      "version": "2.56.0",
+      "version": "2.57.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
@@ -42072,7 +42072,7 @@
     },
     "packages/http-sdk": {
       "name": "@akashnetwork/http-sdk",
-      "version": "1.1.4",
+      "version": "1.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.7.2",
@@ -42259,7 +42259,10 @@
     "packages/net": {
       "name": "@akashnetwork/net",
       "version": "0.0.2",
-      "license": "ISC"
+      "license": "ISC",
+      "devDependencies": {
+        "jest": "^29.7.0"
+      }
     },
     "packages/network-store": {
       "name": "@akashnetwork/network-store",

--- a/packages/docker/docker-compose.dev.yml
+++ b/packages/docker/docker-compose.dev.yml
@@ -32,6 +32,17 @@ services:
       - /app/apps/deploy-web/.next
       - ../../packages:/app/packages
 
+  provider-proxy:
+    build:
+      target: development
+    volumes:
+      - ../../apps/provider-proxy:/app/apps/provider-proxy
+      - ../../package.json:/app/package.json
+      - ../../package-lock.json:/app/package-lock.json
+      - /app/node_modules
+      - /app/apps/provider-proxy/node_modules
+      - ../../packages:/app/packages
+
   stats-web:
     build:
       target: development

--- a/packages/net/jest.config.ts
+++ b/packages/net/jest.config.ts
@@ -1,0 +1,8 @@
+import type { Config } from "jest";
+
+export default {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/src/**/*.spec.ts"],
+  verbose: true
+} satisfies Config;

--- a/packages/net/package.json
+++ b/packages/net/package.json
@@ -9,6 +9,11 @@
     "format": "prettier --write ./*.{ts,json} **/*.{ts,json}",
     "generate": "ts-node scripts/generate.ts",
     "lint": "eslint .",
+    "test": "npm run generate && jest",
+    "test:cov": "npm run test -- --coverage",
     "validate:types": "tsc --noEmit && echo"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/packages/net/src/NetConfig/NetConfig.spec.ts
+++ b/packages/net/src/NetConfig/NetConfig.spec.ts
@@ -1,0 +1,21 @@
+import { netConfigData } from "../generated/netConfigData";
+import { NetConfig, type SupportedChainNetworks } from "./NetConfig";
+
+describe("NetConfig", () => {
+  it.each(Object.keys(netConfigData))("provides base API URL for chain network '%s'", network => {
+    const netConfig = setup();
+    expect(netConfig.getBaseAPIUrl(network as SupportedChainNetworks)).toBeDefined();
+  });
+
+  it("returns supported networks", () => {
+    const netConfig = setup();
+    const allNetworks = Object.keys(netConfigData);
+    const hasSupportedNetworks = netConfig.getSupportedNetworks().every(network => allNetworks.includes(network));
+
+    expect(hasSupportedNetworks).toBe(true);
+  });
+
+  function setup() {
+    return new NetConfig();
+  }
+});

--- a/packages/net/src/NetConfig/NetConfig.ts
+++ b/packages/net/src/NetConfig/NetConfig.ts
@@ -1,10 +1,11 @@
-import { netConfigData } from "./generated/netConfigData";
+import { netConfigData } from "../generated/netConfigData";
 
 export type SupportedChainNetworks = keyof typeof netConfigData;
 
 export class NetConfig {
   getBaseAPIUrl(network: SupportedChainNetworks): string {
-    return netConfigData[network].apiUrls[1];
+    const apiUrls = netConfigData[network].apiUrls;
+    return apiUrls.length > 1 ? apiUrls[1] : apiUrls[0];
   }
 
   getSupportedNetworks(): SupportedChainNetworks[] {

--- a/packages/net/src/index.ts
+++ b/packages/net/src/index.ts
@@ -1,4 +1,4 @@
-import { NetConfig } from "./NetConfig";
+import { NetConfig } from "./NetConfig/NetConfig";
 
 export const netConfig = new NetConfig();
-export type { SupportedChainNetworks } from "./NetConfig";
+export type { SupportedChainNetworks } from "./NetConfig/NetConfig";


### PR DESCRIPTION
## Why

After recent changes, provider proxy cannot validate provider's certificates on sandbox chain

## What 

1. ensures provider-proxy has valid blockchain API_URL on sandbox env
2. separately logs error otherwise it's just serialized as empty object '{}'
3. updates docker-compose.dev file to support automatic updates for provider-proxy