### PR TITLE
feat: improves error logging for AggregateError

### DIFF
--- a/packages/logging/src/servicies/logger/logger.service.spec.ts
+++ b/packages/logging/src/servicies/logger/logger.service.spec.ts
@@ -109,7 +109,24 @@ describe("LoggerService", () => {
     });
 
     describe("prototype.toLoggableInput", () => {
-      it("should return status, message, stack, and data for HttpError", () => {
+      it("should return detailed information about HttpError", () => {
+        const httpError = createHttpError(404, {
+          status: 404,
+          message: "Not found",
+          stack: "stack trace",
+          data: { key: "value" }
+        });
+
+        const loggable = loggerService["toLoggableInput"](httpError);
+        expect(loggable).toEqual({
+          status: 404,
+          message: "Not found",
+          stack: "stack trace",
+          data: { key: "value" }
+        });
+      });
+
+      it("should return detailed stack trace information about cause, errors, and original error for HttpError", () => {
         const httpError = createHttpError(404, {
           status: 404,
           message: "Not found",
@@ -123,7 +140,7 @@ describe("LoggerService", () => {
         expect(loggable).toEqual({
           status: 404,
           message: "Not found",
-          stack: expect.stringContaining("stack trace\n\nCaused by:\nError: Cause error"),
+          stack: expect.stringContaining("stack trace\n\nCaused by:\n  Error: Cause error"),
           data: { key: "value" },
           originalError: expect.stringContaining("Error: Original error")
         });

--- a/packages/logging/src/servicies/logger/logger.service.ts
+++ b/packages/logging/src/servicies/logger/logger.service.ts
@@ -4,6 +4,7 @@ import { gcpLogOptions } from "pino-cloud-logging";
 import type { PinoPretty } from "pino-pretty";
 
 import { Config, config as envConfig } from "../../config";
+import { collectFullErrorStack } from "../../utils/collect-full-error-stack/collect-full-error-stack";
 
 export type Logger = Pick<pino.Logger, "info" | "error" | "warn" | "debug">;
 
@@ -143,17 +144,4 @@ export class LoggerService implements Logger {
 
 function hasOwn<T extends object, U extends PropertyKey>(obj: T, key: U): obj is T & { [k in U]: unknown } {
   return Object.prototype.hasOwnProperty.call(obj, key);
-}
-
-function collectFullErrorStack(error: Error) {
-  let currentError = error;
-  const stack: string[] = [];
-  while (currentError) {
-    stack.push(currentError.stack!);
-    currentError = (currentError as unknown as { cause: Error }).cause;
-    if (currentError) {
-      stack.push("\nCaused by:");
-    }
-  }
-  return stack.join("\n");
 }

--- a/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.spec.ts
+++ b/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.spec.ts
@@ -1,0 +1,84 @@
+import { collectFullErrorStack, ErrorWithCause } from "./collect-full-error-stack";
+
+describe(collectFullErrorStack.name, () => {
+  it("returns empty string for falsy value", () => {
+    expect(collectFullErrorStack(undefined)).toBe("");
+    expect(collectFullErrorStack(null)).toBe("");
+  });
+
+  it("returns basic stack", () => {
+    const error = new Error("test error");
+    const result = collectFullErrorStack(error);
+    expect(result).toBe(error.stack);
+  });
+
+  it("returns error stacktrace with its cause stacktrace", () => {
+    const causeError = new Error("cause error");
+    const mainError = new Error("main error");
+    (mainError as unknown as ErrorWithCause).cause = causeError;
+
+    const result = collectFullErrorStack(mainError);
+
+    expect(result).toContain("main error");
+    expect(result).toContain("Caused by:");
+    expect(result).toContain("cause error");
+  });
+
+  it("returns nested causes stacktrace", () => {
+    const deepError = new Error("deep error");
+    const middleError = new Error("middle error");
+    const topError = new Error("top error");
+
+    (middleError as unknown as ErrorWithCause).cause = deepError;
+    (topError as unknown as ErrorWithCause).cause = middleError;
+
+    const result = collectFullErrorStack(topError);
+
+    expect(result).toContain("top error");
+    expect(result).toContain("middle error");
+    expect(result).toContain("deep error");
+    expect(result.match(/Caused by:/g)?.length).toBe(2);
+  });
+
+  it("returns error array stacktrace", () => {
+    const error1 = new Error("error 1");
+    const error2 = new Error("error 2");
+    const mainError = new Error("main error");
+    (mainError as unknown as ErrorWithCause).errors = [error1, error2];
+
+    const result = collectFullErrorStack(mainError);
+
+    expect(result).toContain("main error");
+    expect(result).toContain("Errors:");
+    expect(result).toContain("error 1");
+    expect(result).toContain("error 2");
+  });
+
+  it("returns stacktrace with indent", () => {
+    const error = new Error("test error");
+    const result = collectFullErrorStack(error, 2);
+
+    const lines = result.split("\n");
+    lines.forEach(line => {
+      expect(line).toMatch(/^ {2}/);
+    });
+  });
+
+  it("returns cause and errors array stacktraces", () => {
+    const causeError = new Error("cause error");
+    const error1 = new Error("error 1");
+    const error2 = new Error("error 2");
+    const mainError = new Error("main error");
+
+    (mainError as unknown as ErrorWithCause).cause = causeError;
+    (mainError as unknown as ErrorWithCause).errors = [error1, error2];
+
+    const result = collectFullErrorStack(mainError);
+
+    expect(result).toContain("main error");
+    expect(result).toContain("Caused by:\n  Error: cause error");
+    expect(result).toContain("Errors:");
+    expect(result).toContain("error 1");
+    expect(result).toContain("error 2");
+  });
+});

--- a/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.ts
+++ b/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.ts
@@ -1,0 +1,19 @@
+export function collectFullErrorStack(error: Error | undefined | null, indent = 0): string {
+  const currentError = error as unknown as ErrorWithCause;
+  if (!currentError) return "";
+
+  const stack: string[] = [currentError.stack!];
+
+  if (currentError.cause) {
+    stack.push("\nCaused by:", collectFullErrorStack(currentError.cause, indent + 2));
+  }
+
+  if (currentError.errors?.length) {
+    const errorStacks = currentError.errors.map(error => collectFullErrorStack(error, indent + 2));
+    stack.push("\nErrors:", ...errorStacks);
+  }
+
+  return stack.join("\n").replace(/^/gm, " ".repeat(indent));
+}
+
+export type ErrorWithCause = Error & { cause?: ErrorWithCause; errors?: ErrorWithCause[] };


### PR DESCRIPTION
## Why

Currently `AggregateError` is not expanded in logs, we need to expand it to understand the full stack trace

## What

expands `AggregateError` for better error logging