### PR TITLE
chore: removes auto install

### DIFF
--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -15,7 +15,7 @@
     "release": "release-it",
     "start": "next start",
     "test:cov": "NODE_ENV=test DEPLOYMENT_ENV=staging jest --coverage",
-    "test:e2e": "playwright install && playwright test",
+    "test:e2e": "playwright test",
     "test:unit": "NODE_ENV=test DEPLOYMENT_ENV=staging jest",
     "type-check": "tsc"
   },


### PR DESCRIPTION
## Why

`playwright install` installs all browsers, we can perform testing only in Chromium. It means running this command has no sense. For local development people will see an error with a hint to run `playwright install` and will solve this issue once and forever

## What

removes auto install