### PR TITLE
chore: ensure that changes to package.json installs new dependency in container

### DIFF
--- a/packages/docker/Dockerfile.node
+++ b/packages/docker/Dockerfile.node
@@ -22,7 +22,7 @@ FROM base AS development
 
 COPY --from=prepare /app .
 
-RUN npm ci && npm cache clean --force
+RUN npm ci --workspace $WORKSPACE && npm cache clean --force
 COPY $WORKSPACE ./$WORKSPACE
 COPY packages ./packages
 

--- a/packages/docker/docker-compose.dev.yml
+++ b/packages/docker/docker-compose.dev.yml
@@ -5,8 +5,6 @@ services:
     volumes:
       - ../../apps/api:/app/apps/api
       - ../../packages:/app/packages
-      - ../../package.json:/app/package.json
-      - ../../package-lock.json:/app/package-lock.json
       - /app/node_modules
       - /app/apps/api/node_modules
 
@@ -15,8 +13,6 @@ services:
       target: development
     volumes:
       - ../../apps/indexer:/app/apps/indexer
-      - ../../package.json:/app/package.json
-      - ../../package-lock.json:/app/package-lock.json
       - /app/node_modules
       - /app/apps/indexer/node_modules
 
@@ -25,8 +21,6 @@ services:
       target: development
     volumes:
       - ../../apps/deploy-web:/app/apps/deploy-web
-      - ../../package.json:/app/package.json
-      - ../../package-lock.json:/app/package-lock.json
       - /app/node_modules
       - /app/apps/deploy-web/node_modules
       - /app/apps/deploy-web/.next
@@ -37,8 +31,6 @@ services:
       target: development
     volumes:
       - ../../apps/provider-proxy:/app/apps/provider-proxy
-      - ../../package.json:/app/package.json
-      - ../../package-lock.json:/app/package-lock.json
       - /app/node_modules
       - /app/apps/provider-proxy/node_modules
       - ../../packages:/app/packages
@@ -48,8 +40,6 @@ services:
       target: development
     volumes:
       - ../../apps/stats-web:/app/apps/stats-web
-      - ../../package.json:/app/package.json
-      - ../../package-lock.json:/app/package-lock.json
       - /app/node_modules
       - /app/apps/stats-web/node_modules
       - /app/apps/stats-web/.next
@@ -59,8 +49,6 @@ services:
       target: development
     volumes:
       - ../../apps/provider-console:/app/apps/provider-console
-      - ../../package.json:/app/package.json
-      - ../../package-lock.json:/app/package-lock.json
       - /app/node_modules
       - /app/apps/provider-console/node_modules
       - /app/apps/provider-console/.next

--- a/packages/docker/script/dc.sh
+++ b/packages/docker/script/dc.sh
@@ -84,11 +84,11 @@ case "$COMMAND" in
     ;;
   up:dev)
     echo "Running: docker compose -p console $DOCKER_COMPOSE_FILES up $*"
-    docker compose -p console $DOCKER_COMPOSE_FILES up "$@" || { echo "Docker up:dev failed"; exit 1; }
+    docker compose -p console $DOCKER_COMPOSE_FILES up "$@" --renew-anon-volumes || { echo "Docker up:dev failed"; exit 1; }
     ;;
   up:prod)
     echo "Running: docker compose -p console $DOCKER_COMPOSE_FILES up $*"
-    docker compose -p console $DOCKER_COMPOSE_FILES up "$@" || { echo "Docker up:prod failed"; exit 1; }
+    docker compose -p console $DOCKER_COMPOSE_FILES up "$@" --renew-anon-volumes || { echo "Docker up:prod failed"; exit 1; }
     ;;
   *)
     echo "Unknown command: $COMMAND"


### PR DESCRIPTION
## Why

Relates to https://github.com/akash-network/console/issues/970

Currently `npm run dc:up:dev -- api` and `npm run dc:up:dev -- api --build` install new dependency on package.json change BUT this installation is lost because afterwards docker mounts anonymous volumes from previous build. And as a result container fails to start because of missing dependency.

This forces us to remove container, image and volumes to install the new dependency what is frustrating and takes time.

## What

1. removes mounting of package*.json files because these files are copied by docker during build phase. As we have caching of layers, new dependencies will be installed only if package*.json are changed. And this is what we need
2. adds `--renew-anon-volumes` to development related docker-compose calls, to ensure that node_modules installed during build phase are not replaced by content of anonymous volume from prev build.

After these changes are merged, it's enough to call `npm run dc:up:dev -- api --build` every time we need to spin up container and it will properly install dependencies

## Additional notes

There is a better alternative, using `docker compose up --watch`. This actually could help us not to rebuild container manually when new dependency is installed! But it requires more testing and investigation. That's why keeping it old way for now