### PR TITLE
refactor: moves trial authorization spending out of db transaction

### DIFF
--- a/apps/api/src/billing/controllers/wallet/wallet.controller.ts
+++ b/apps/api/src/billing/controllers/wallet/wallet.controller.ts
@@ -9,7 +9,6 @@ import { WalletInitializerService } from "@src/billing/services";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { RefillService } from "@src/billing/services/refill/refill.service";
 import { GetWalletOptions, WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
-import { WithTransaction } from "@src/core";
 import { Semaphore } from "@src/core/lib/semaphore.decorator";
 
 @scoped(Lifecycle.ResolutionScoped)
@@ -22,7 +21,6 @@ export class WalletController {
   ) {}
 
   @Semaphore()
-  @WithTransaction()
   @Protected([{ action: "create", subject: "UserWallet" }])
   async create({ data: { userId } }: StartTrialRequestInput): Promise<WalletOutputResponse> {
     return {

--- a/apps/api/src/billing/services/balances/balances.service.ts
+++ b/apps/api/src/billing/services/balances/balances.service.ts
@@ -1,10 +1,10 @@
 import { AuthzHttpService } from "@akashnetwork/http-sdk";
 import { singleton } from "tsyringe";
 
+import { Wallet } from "@src/billing/lib/wallet/wallet";
 import { BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { InjectWallet } from "@src/billing/providers/wallet.provider";
 import { UserWalletInput, UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
-import { Wallet } from "@src/billing/services";
 
 @singleton()
 export class BalancesService {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -9,10 +9,10 @@ import { Wallet } from "@src/billing/lib/wallet/wallet";
 import { InjectSigningClient } from "@src/billing/providers/signing-client.provider";
 import { InjectTypeRegistry } from "@src/billing/providers/type-registry.provider";
 import { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
-import { BalancesService } from "@src/billing/services/balances/balances.service";
-import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
-import { DedupeSigningClientService } from "@src/billing/services/dedupe-signing-client/dedupe-signing-client.service";
+import { BalancesService } from "../balances/balances.service";
+import { BillingConfigService } from "../billing-config/billing-config.service";
 import { ChainErrorService } from "../chain-error/chain-error.service";
+import { DedupeSigningClientService } from "../dedupe-signing-client/dedupe-signing-client.service";
 import { TrialValidationService } from "../trial-validation/trial-validation.service";
 
 type StringifiedEncodeObject = Omit<EncodeObject, "value"> & { value: string };

--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
@@ -8,9 +8,9 @@ import { singleton } from "tsyringe";
 import { Wallet } from "@src/billing/lib/wallet/wallet";
 import { BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { InjectWallet } from "@src/billing/providers/wallet.provider";
-import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
-import { RpcMessageService, SpendingAuthorizationMsgOptions } from "@src/billing/services/rpc-message-service/rpc-message.service";
-import { DryRunOptions } from "@src/core/types/console";
+import type { DryRunOptions } from "@src/core/types/console";
+import { ManagedSignerService } from "../managed-signer/managed-signer.service";
+import { RpcMessageService, SpendingAuthorizationMsgOptions } from "../rpc-message-service/rpc-message.service";
 
 interface SpendingAuthorizationOptions {
   address: string;
@@ -105,7 +105,7 @@ export class ManagedUserWalletService {
     return await this.managedSignerService.executeRootTx(messages);
   }
 
-  private async authorizeDeploymentSpending(options: SpendingAuthorizationMsgOptions) {
+  private async authorizeDeploymentSpending(options: any) {
     const deploymentAllowanceMsg = this.rpcMessageService.getDepositDeploymentGrantMsg(options);
     return await this.managedSignerService.executeRootTx([deploymentAllowanceMsg]);
   }

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
@@ -1,0 +1,127 @@
+import { mock } from "jest-mock-extended";
+import { container } from "tsyringe";
+
+import { AuthService } from "@src/auth/services/auth.service";
+import { UserWalletRepository } from "../../repositories/user-wallet/user-wallet.repository";
+import { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wallet.service";
+import { WalletInitializerService } from "./wallet-initializer.service";
+
+import { createChainWallet } from "@test/seeders/chain-wallet.seeder";
+import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+
+describe(WalletInitializerService.name, () => {
+  describe("initializeAndGrantTrialLimits", () => {
+    it("creates a new wallet and authorizes trial spending when no wallet exists", async () => {
+      const userId = "test-user-id";
+      const newWallet = UserWalletSeeder.create({ userId });
+      const chainWallet = createChainWallet();
+      const findWalletByUserId = jest.fn().mockImplementation(async () => null);
+      const createWallet = jest.fn().mockImplementation(async () => newWallet);
+      const createAndAuthorizeTrialSpending = jest.fn().mockImplementation(async () => chainWallet);
+      const updateWalletById = jest.fn().mockImplementation(async () => newWallet);
+
+      const di = setup({
+        findWalletByUserId,
+        createWallet,
+        createAndAuthorizeTrialSpending,
+        updateWalletById
+      });
+
+      await di.resolve(WalletInitializerService).initializeAndGrantTrialLimits(userId);
+
+      expect(findWalletByUserId).toHaveBeenCalledWith(userId);
+      expect(createWallet).toHaveBeenCalledWith({ userId });
+      expect(createAndAuthorizeTrialSpending).toHaveBeenCalledWith({ addressIndex: newWallet.id });
+      expect(updateWalletById).toHaveBeenCalledWith(
+        newWallet.id,
+        {
+          address: chainWallet.address,
+          deploymentAllowance: chainWallet.limits.deployment,
+          feeAllowance: chainWallet.limits.fees
+        },
+        expect.any(Object)
+      );
+    });
+
+    it("does not authorizes trial spending for existing wallet", async () => {
+      const userId = "test-user-id";
+      const existingWallet = UserWalletSeeder.create({ userId });
+      const findWalletByUserId = jest.fn().mockResolvedValue(existingWallet);
+      const createAndAuthorizeTrialSpending = jest.fn().mockResolvedValue(undefined);
+      const createWallet = jest.fn().mockResolvedValue(null);
+
+      const di = setup({
+        findWalletByUserId,
+        createAndAuthorizeTrialSpending,
+        createWallet
+      });
+
+      await di.resolve(WalletInitializerService).initializeAndGrantTrialLimits(userId);
+
+      expect(findWalletByUserId).toHaveBeenCalledWith(userId);
+      expect(createAndAuthorizeTrialSpending).not.toHaveBeenCalled();
+      expect(createWallet).not.toHaveBeenCalled();
+    });
+
+    it("throws an error when cannot authorize trial spending and deletes user wallet", async () => {
+      const userId = "test-user-id";
+      const findWalletByUserId = jest.fn().mockImplementation(async () => null);
+      const newWallet = UserWalletSeeder.create({ userId });
+      const createWallet = jest.fn().mockImplementation(async () => newWallet);
+      const deleteWalletById = jest.fn().mockImplementation(async () => null);
+      const createAndAuthorizeTrialSpending = jest.fn().mockRejectedValue(new Error("Failed to authorize trial"));
+
+      const di = setup({
+        findWalletByUserId,
+        createWallet,
+        deleteWalletById,
+        createAndAuthorizeTrialSpending
+      });
+
+      await expect(di.resolve(WalletInitializerService).initializeAndGrantTrialLimits(userId)).rejects.toThrow("Failed to authorize trial");
+      expect(createAndAuthorizeTrialSpending).toHaveBeenCalledWith({ addressIndex: newWallet.id });
+      expect(deleteWalletById).toHaveBeenCalledWith(newWallet.id);
+    });
+  });
+
+  function setup(input?: SetupInput) {
+    const di = container.createChildContainer();
+    di.registerInstance(
+      ManagedUserWalletService,
+      mock<ManagedUserWalletService>({
+        createAndAuthorizeTrialSpending: input?.createAndAuthorizeTrialSpending
+      })
+    );
+    di.registerInstance(
+      UserWalletRepository,
+      mock<UserWalletRepository>({
+        findOneByUserId: input?.findWalletByUserId,
+        updateById: input?.updateWalletById,
+        deleteById: input?.deleteWalletById ?? jest.fn(),
+        accessibleBy() {
+          return this;
+        },
+        create: input?.createWallet,
+        toPublic: value => value
+      })
+    );
+    di.registerInstance(
+      AuthService,
+      mock<AuthService>({
+        ability: {}
+      })
+    );
+
+    container.clearInstances();
+
+    return di;
+  }
+
+  interface SetupInput {
+    findWalletByUserId?: UserWalletRepository["findOneByUserId"];
+    updateWalletById?: UserWalletRepository["updateById"];
+    createWallet?: UserWalletRepository["create"];
+    deleteWalletById?: UserWalletRepository["deleteById"];
+    createAndAuthorizeTrialSpending?: ManagedUserWalletService["createAndAuthorizeTrialSpending"];
+  }
+});

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
@@ -14,10 +14,11 @@ export class WalletInitializerService {
 
   async initializeAndGrantTrialLimits(userId: UserWalletInput["userId"]): Promise<UserWalletPublicOutput> {
     let userWallet = await this.userWalletRepository.findOneByUserId(userId);
+    if (userWallet) return this.userWalletRepository.toPublic(userWallet);
 
-    if (!userWallet) {
-      userWallet = await this.userWalletRepository.accessibleBy(this.authService.ability, "create").create({ userId });
+    userWallet = await this.userWalletRepository.accessibleBy(this.authService.ability, "create").create({ userId });
 
+    try {
       const wallet = await this.walletManager.createAndAuthorizeTrialSpending({ addressIndex: userWallet.id });
       userWallet = await this.userWalletRepository.updateById(
         userWallet.id,
@@ -28,6 +29,9 @@ export class WalletInitializerService {
         },
         { returning: true }
       );
+    } catch (error) {
+      await this.userWalletRepository.deleteById(userWallet.id);
+      throw error;
     }
 
     return this.userWalletRepository.toPublic(userWallet);

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
@@ -2,7 +2,7 @@ import { singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
 import { UserWalletInput, UserWalletPublicOutput, UserWalletRepository } from "@src/billing/repositories";
-import { ManagedUserWalletService } from "@src/billing/services";
+import { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wallet.service";
 
 @singleton()
 export class WalletInitializerService {

--- a/apps/api/test/seeders/chain-wallet.seeder.ts
+++ b/apps/api/test/seeders/chain-wallet.seeder.ts
@@ -1,0 +1,20 @@
+import { faker } from "@faker-js/faker";
+
+import { AkashAddressSeeder } from "./akash-address.seeder";
+export function createChainWallet(input: Partial<ChainWallet> = {}): ChainWallet {
+  return {
+    address: input.address ?? AkashAddressSeeder.create(),
+    limits: {
+      deployment: input.limits?.deployment ?? faker.number.int({ min: 0, max: 1000000 }),
+      fees: input.limits?.fees ?? faker.number.int({ min: 0, max: 100 })
+    }
+  };
+}
+
+export interface ChainWallet {
+  address: string;
+  limits: {
+    deployment: number;
+    fees: number;
+  };
+}

--- a/packages/docker/script/dc.sh
+++ b/packages/docker/script/dc.sh
@@ -84,11 +84,11 @@ case "$COMMAND" in
     ;;
   up:dev)
     echo "Running: docker compose -p console $DOCKER_COMPOSE_FILES up $*"
-    docker compose -p console $DOCKER_COMPOSE_FILES up "$@" --renew-anon-volumes || { echo "Docker up:dev failed"; exit 1; }
+    docker compose -p console $DOCKER_COMPOSE_FILES up --renew-anon-volumes "$@" || { echo "Docker up:dev failed"; exit 1; }
     ;;
   up:prod)
     echo "Running: docker compose -p console $DOCKER_COMPOSE_FILES up $*"
-    docker compose -p console $DOCKER_COMPOSE_FILES up "$@" --renew-anon-volumes || { echo "Docker up:prod failed"; exit 1; }
+    docker compose -p console $DOCKER_COMPOSE_FILES up --renew-anon-volumes "$@" || { echo "Docker up:prod failed"; exit 1; }
     ;;
   *)
     echo "Unknown command: $COMMAND"


### PR DESCRIPTION
## Why

Because calling external service in transaction prolongs resource locking time and causes db to become slow

## What

1. moves trial authorization spending out of db transaction
2. moves docker compose options in front of service names to make it properly work with `npx dc up:dev -- deploy-web`