### PR TITLE
fix: ensures that stats.date is a string

### DIFF
--- a/apps/api/src/services/db/statsService.ts
+++ b/apps/api/src/services/db/statsService.ts
@@ -286,7 +286,11 @@ const removeLastAroundMidnight = (stats: ProviderStats[]) => {
   const now = new Date();
   const isFirstFifteenMinuesOfDay = now.getHours() === 0 && now.getMinutes() <= 15;
   const dateToday = format(now, "yyyy-MM-dd");
-  const lastItemIsForToday = stats.length > 0 && stats[stats.length - 1].date.startsWith(dateToday);
+  const lastItem = stats.length > 0 ? stats[stats.length - 1] : null;
+  const lastItemIsForToday = typeof lastItem?.date === "string" && lastItem.date.startsWith(dateToday);
+  if (lastItem && typeof lastItem.date !== "string") {
+    console.error(`removeLastAroundMidnight: lastItem.date is not a string: ${JSON.stringify(lastItem, null, 2)}`);
+  }
   if (isFirstFifteenMinuesOfDay && lastItemIsForToday) {
     return stats.slice(0, stats.length - 1);
   }


### PR DESCRIPTION
## Why

log entry 
```
stats[(stats.length - 1)].date.startsWith is not a function
    at removeLastAroundMidnight (/app/apps/api/dist/server.js:76722:81)
    at /app/apps/api/dist/server.js:76657:16
    at Generator.next (<anonymous>)
    at fulfilled (/app/apps/api/dist/server.js:76481:58)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)", "event":"Failed to fetch ", 
```

## What

Ensures this error cannot happen in runtime