### PR TITLE
fix: improves logging of dashboard data date field and changes it to …

### DIFF
--- a/apps/api/src/services/db/statsService.ts
+++ b/apps/api/src/services/db/statsService.ts
@@ -1,6 +1,6 @@
 import { AkashBlock as Block } from "@akashnetwork/database/dbSchemas/akash";
 import { Day } from "@akashnetwork/database/dbSchemas/base";
-import { format, subHours } from "date-fns";
+import { isSameDay, subHours } from "date-fns";
 import { Op, QueryTypes } from "sequelize";
 
 import { cacheKeys, cacheResponse } from "@src/caching/helpers";
@@ -285,12 +285,15 @@ export const getProviderGraphData = async (dataName: ProviderStatsKey) => {
 const removeLastAroundMidnight = (stats: ProviderStats[]) => {
   const now = new Date();
   const isFirstFifteenMinuesOfDay = now.getHours() === 0 && now.getMinutes() <= 15;
-  const dateToday = format(now, "yyyy-MM-dd");
   const lastItem = stats.length > 0 ? stats[stats.length - 1] : null;
-  const lastItemIsForToday = typeof lastItem?.date === "string" && lastItem.date.startsWith(dateToday);
   if (lastItem && typeof lastItem.date !== "string") {
-    console.error(`removeLastAroundMidnight: lastItem.date is not a string: ${JSON.stringify(lastItem, null, 2)}`);
+    console.error(
+      `removeLastAroundMidnight: lastItem.date is not a string: ` +
+        `type = ${typeof lastItem.date} value = ${lastItem.date} constructor = ${(lastItem.date as any)?.constructor?.name}` +
+        JSON.stringify(lastItem)
+    );
   }
+  const lastItemIsForToday = lastItem && isSameDay(lastItem.date, now);
   if (isFirstFifteenMinuesOfDay && lastItemIsForToday) {
     return stats.slice(0, stats.length - 1);
   }

--- a/apps/api/src/types/graph.ts
+++ b/apps/api/src/types/graph.ts
@@ -1,7 +1,7 @@
 export type ProviderStatsKey = keyof Omit<ProviderStats, "date">;
 
 export type ProviderStats = {
-  date: string;
+  date: Date;
   count: number;
   cpu: string;
   gpu: string;


### PR DESCRIPTION
## Why

Currently we do not have full information in logs about the issue with `date` field being not a string:

```
removeLastAroundMidnight: lastItem.date is not a string: {
"
```

Very likely all information is missed because `console.error` doesn't use structural logging and everything after newline was just lost. So, I tested this locally and I got runtime value which is an instance of `Date`.

## What

Having no clue how it's possible that somebody typed date as a string when in reality it's a `Date` instance, I decided to use `isSameDay` from date-fns and keep logs that proves it's not a string even in production. `isSameDay` works with `number | string | Date`, so it covers pretty much all possible values for `date` property