### PR TITLE
fix: disables nodejs auto family selection

### DIFF
--- a/packages/docker/Dockerfile.nextjs
+++ b/packages/docker/Dockerfile.nextjs
@@ -5,6 +5,9 @@ FROM node:22.14-alpine AS base
 ARG WORKSPACE
 ENV WORKSPACE $WORKSPACE
 
+# see https://r1ch.net/blog/node-v20-aggregateeerror-etimedout-happy-eyeballs and https://github.com/nodejs/node/issues/54359
+ARG NODE_OPTIONS="--no-network-family-autoselection"
+
 ARG DEPLOYMENT_ENV
 ENV DEPLOYMENT_ENV $DEPLOYMENT_ENV
 
@@ -33,6 +36,8 @@ RUN npm ci && npm cache clean --force
 
 COPY $WORKSPACE ./$WORKSPACE
 COPY /packages /app/packages
+
+ENV NODE_OPTIONS=$NODE_OPTIONS
 
 CMD ["npm", "run", "dev", "--workspace", "${WORKSPACE}"]
 
@@ -64,6 +69,8 @@ RUN chown -R $APP_USER:$APP_GROUP /app
 WORKDIR /app/$WORKSPACE
 
 USER $APP_USER
+
+ENV NODE_OPTIONS=$NODE_OPTIONS
 
 CMD ["node", "server.js"]
 

--- a/packages/docker/Dockerfile.node
+++ b/packages/docker/Dockerfile.node
@@ -2,6 +2,8 @@
 
 FROM node:22.14-alpine AS base
 
+# see https://r1ch.net/blog/node-v20-aggregateeerror-etimedout-happy-eyeballs and https://github.com/nodejs/node/issues/54359
+ARG NODE_OPTIONS="--no-network-family-autoselection"
 ARG GITHUB_PAT
 ARG WORKSPACE
 ENV WORKSPACE $WORKSPACE
@@ -25,6 +27,8 @@ COPY --from=prepare /app .
 RUN npm ci --workspace $WORKSPACE && npm cache clean --force
 COPY $WORKSPACE ./$WORKSPACE
 COPY packages ./packages
+
+ENV NODE_OPTIONS=$NODE_OPTIONS
 
 CMD ["npm", "run", "dev", "--workspace", "${WORKSPACE}"]
 
@@ -63,6 +67,8 @@ RUN wget -q -t3 'https://packages.doppler.com/public/cli/rsa.8004D9FF50437357.ke
 USER $APP_USER
 
 WORKDIR /app/$WORKSPACE
+
+ENV NODE_OPTIONS=$NODE_OPTIONS
 
 CMD ["npm", "run", "prod"]
 

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -1,13 +1,13 @@
 export const netConfigData = {
-  mainnet: {
-    version: "0.38.0",
-    apiUrls: [
+  "mainnet": {
+    "version": "0.38.0",
+    "apiUrls": [
       "https://api.akashnet.net:443",
       "https://akash-api.polkachu.com:443",
       "https://akash.c29r3.xyz:443/api",
       "https://akash-api.global.ssl.fastly.net:443"
     ],
-    rpcUrls: [
+    "rpcUrls": [
       "https://rpc.akashnet.net:443",
       "https://rpc-akash.ecostake.com:443",
       "https://akash-rpc.polkachu.com:443",
@@ -15,14 +15,24 @@ export const netConfigData = {
       "https://akash-rpc.europlots.com:443"
     ]
   },
-  sandbox: {
-    version: "0.38.0",
-    apiUrls: ["https://api.sandbox-01.aksh.pw:443"],
-    rpcUrls: ["https://rpc.sandbox-01.aksh.pw:443"]
+  "sandbox": {
+    "version": "0.38.0",
+    "apiUrls": [
+      "https://api.sandbox-01.aksh.pw:443"
+    ],
+    "rpcUrls": [
+      "https://rpc.sandbox-01.aksh.pw:443"
+    ]
   },
   "testnet-02": {
-    version: "0.23.1-rc0",
-    apiUrls: ["https://api.testnet-02.aksh.pw:443", "https://akash-testnet-rest.cosmonautstakes.com:443"],
-    rpcUrls: ["https://rpc.testnet-02.aksh.pw:443", "https://akash-testnet-rpc.cosmonautstakes.com:443"]
+    "version": "0.23.1-rc0",
+    "apiUrls": [
+      "https://api.testnet-02.aksh.pw:443",
+      "https://akash-testnet-rest.cosmonautstakes.com:443"
+    ],
+    "rpcUrls": [
+      "https://rpc.testnet-02.aksh.pw:443",
+      "https://akash-testnet-rpc.cosmonautstakes.com:443"
+    ]
   }
-};
+}


### PR DESCRIPTION
## Why

From time to time we get ETIMEDOUT errors in logs and potentially this is caused by [nodejs bug](https://github.com/nodejs/node/issues/54359). Some information about it described in this [blog post](https://r1ch.net/blog/node-v20-aggregateeerror-etimedout-happy-eyeballs)

## What

Increases `--no-network-family-autoselection`