### PR TITLE
chore: renames workflows to have shorter name

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,9 +1,55 @@
 coverage:
   status:
     patch:
-      default:
-        target: 50%
-        threshold: 1%
-        if_ci_failed: error
-        if_not_found: error
-        informational: false
+      default: off
+      api:
+        target: 80%
+        flags:
+          - api
+      deploy-web:
+        target: 30%
+        flags:
+          - deploy-web
+      indexer:
+        target: 0%
+        flags:
+          - indexer
+      notifications:
+        target: 80%
+        flags:
+          - notifications
+      provider-console:
+        target: 0%
+        flags:
+          - provider-console
+      provider-proxy:
+        target: 80%
+        flags:
+          - provider-proxy
+      stats-web:
+        target: 0%
+        flags:
+          - stats-web
+
+flags:
+  api:
+    paths:
+      - apps/api/
+  deploy-web:
+    paths:
+      - apps/deploy-web/
+  indexer:
+    paths:
+      - apps/indexer/
+  notifications:
+    paths:
+      - apps/notifications/
+  provider-console:
+    paths:
+      - apps/provider-console/
+  provider-proxy:
+    paths:
+      - apps/provider-proxy/
+  stats-web:
+    paths:
+      - apps/stats-web/

--- a/.github/workflows/console-api-validate-n-build.yml
+++ b/.github/workflows/console-api-validate-n-build.yml
@@ -1,4 +1,4 @@
-name: Validate and Build API
+name: API CI
 
 on:
   pull_request:

--- a/.github/workflows/notifications-validate-n-build.yml
+++ b/.github/workflows/notifications-validate-n-build.yml
@@ -1,4 +1,4 @@
-name: Validate and Build Notifications
+name: Notifications CI
 
 on:
   pull_request:

--- a/.github/workflows/provider-console-docker-build.yml
+++ b/.github/workflows/provider-console-docker-build.yml
@@ -1,4 +1,4 @@
-name: Deploy Provider Console CI
+name: Provider Console CI
 
 on:
   pull_request:

--- a/.github/workflows/provider-proxy-docker-build.yml
+++ b/.github/workflows/provider-proxy-docker-build.yml
@@ -1,4 +1,4 @@
-name: Validate and Build Provider Proxy CI
+name: Provider Proxy CI
 
 on:
   pull_request:


### PR DESCRIPTION
## Why

to make it easier to navigate in failed/skipped/successful github checks

## What

renames workflows to have shorter names