### PR TITLE
chore: adds flags to codecov default

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,16 +1,7 @@
-github_checks:
-  annotations: true
-
 coverage:
   status:
     project:
-      default:
-        target: auto
-        branches:
-          - main
-        if_ci_failed: error
-        informational: false
-        only_pulls: false
+      default: off
       api:
         target: 80%
         flags:
@@ -19,34 +10,16 @@ coverage:
         target: auto
         flags:
           - deploy-web
-      indexer:
-        target: 0%
-        flags:
-          - indexer
       notifications:
         target: 80%
         flags:
           - notifications
-      provider-console:
-        target: 0%
-        flags:
-          - provider-console
       provider-proxy:
         target: 80%
         flags:
           - provider-proxy
-      stats-web:
-        target: 0%
-        flags:
-          - stats-web
     patch:
-      default:
-        target: auto
-        branches:
-          - main
-        if_ci_failed: error
-        informational: false
-        only_pulls: false
+      default: off
       api:
         target: 80%
         flags:
@@ -55,46 +28,51 @@ coverage:
         target: 30%
         flags:
           - deploy-web
-      indexer:
-        target: 0%
-        flags:
-          - indexer
       notifications:
         target: 80%
         flags:
           - notifications
-      provider-console:
-        target: 0%
-        flags:
-          - provider-console
       provider-proxy:
         target: 80%
         flags:
           - provider-proxy
-      stats-web:
-        target: 0%
-        flags:
-          - stats-web
 
 flags:
   api:
+    carryforward: true
     paths:
       - apps/api/
   deploy-web:
+    carryforward: true
     paths:
       - apps/deploy-web/
   indexer:
+    carryforward: true
     paths:
       - apps/indexer/
   notifications:
+    carryforward: true
     paths:
       - apps/notifications/
   provider-console:
+    carryforward: true
     paths:
       - apps/provider-console/
   provider-proxy:
+    carryforward: true
     paths:
       - apps/provider-proxy/
   stats-web:
+    carryforward: true
     paths:
       - apps/stats-web/
+
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: true
+  require_base: yes
+  require_head: yes
+  branches:
+    - main
+  show_carryforward_flags: true

--- a/.github/workflows/all-trigger-coverage.yml
+++ b/.github/workflows/all-trigger-coverage.yml
@@ -1,0 +1,18 @@
+name: Triggers coverage check for files that do not require coverage
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - 'apps/**'
+      - 'packages/**'
+
+jobs:
+  trigger-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: codecov/codecov-action@v5
+        with:
+          directory: ./coverage
+          token: ${{ secrets.CODECOV_TOKEN }}
+          run_command: empty-upload


### PR DESCRIPTION
## Why

our project coverage looks strange -> https://app.codecov.io/github/akash-network/console . It has spikes, which is obviously impossible 😄 . I have an assumption that with every PR we currently re-write project coverage, instead of accumulating it. Probably this happens because we are in monorepo and using flags

<img width="1409" alt="Screenshot 2025-04-16 at 13 27 02" src="https://github.com/user-attachments/assets/2ed75e50-83d6-4e12-81bd-aa76586b04bc" />

## What

adds all flags to codecov default project section