### PR TITLE
chore: adds additional check for release workflows

### DIFF
--- a/.github/workflows/console-api-release.yml
+++ b/.github/workflows/console-api-release.yml
@@ -18,6 +18,7 @@ jobs:
   build:
     needs: release
     name: Build Docker image
+    if: needs.release.outputs.git_tag != ''
     uses: ./.github/workflows/reusable-build-image.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/console-api-validate-n-build.yml
+++ b/.github/workflows/console-api-validate-n-build.yml
@@ -3,14 +3,8 @@ name: API CI
 on:
   pull_request:
     branches: ["main"]
-    paths:
-      - "apps/api/**"
-      - "packages/**"
   push:
     branches: ["main"]
-    paths:
-      - "apps/api/**"
-      - "packages/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/console-web-docker-build.yml
+++ b/.github/workflows/console-web-docker-build.yml
@@ -3,14 +3,8 @@ name: Deploy Web CI
 on:
   pull_request:
     branches: ["main"]
-    paths:
-      - "apps/deploy-web/**"
-      - "packages/**"
   push:
     branches: ["main"]
-    paths:
-      - "apps/deploy-web/**"
-      - "packages/**"
 
 
 jobs:

--- a/.github/workflows/console-web-release.yml
+++ b/.github/workflows/console-web-release.yml
@@ -18,6 +18,7 @@ jobs:
   build-beta:
     needs: release
     name: Build Beta Docker image
+    if: needs.release.outputs.git_tag != ''
     uses: ./.github/workflows/reusable-build-image.yml
     secrets: inherit
     permissions:
@@ -30,6 +31,7 @@ jobs:
   deploy-beta:
     needs: build-beta
     name: Deploy to beta sandbox
+    if: needs.build-beta.outputs.base_image_tag != ''
     uses: ./.github/workflows/reusable-deploy-k8s.yml
     secrets: inherit
     with:

--- a/.github/workflows/indexer-docker-build.yml
+++ b/.github/workflows/indexer-docker-build.yml
@@ -3,14 +3,8 @@ name: Indexer CI
 on:
   push:
     branches: ["main"]
-    paths:
-      - "apps/indexer/**"
-      - "packages/**"
   pull_request:
     branches: ["main"]
-    paths:
-      - "apps/indexer/**"
-      - "packages/**"
 
 jobs:
   should-validate:

--- a/.github/workflows/notifications-validate-n-build.yml
+++ b/.github/workflows/notifications-validate-n-build.yml
@@ -3,14 +3,8 @@ name: Notifications CI
 on:
   pull_request:
     branches: ["main"]
-    paths:
-      - "apps/notifications/**"
-      - "packages/**"
   push:
     branches: ["main"]
-    paths:
-      - "apps/notifications/**"
-      - "packages/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/provider-console-docker-build.yml
+++ b/.github/workflows/provider-console-docker-build.yml
@@ -3,14 +3,8 @@ name: Provider Console CI
 on:
   pull_request:
     branches: ["main"]
-    paths:
-      - "apps/provider-console/**"
-      - "packages/**"
   push:
     branches: ["main"]
-    paths:
-      - "apps/provider-console/**"
-      - "packages/**"
 jobs:
   should-validate:
     name: Decide Whether to Validate

--- a/.github/workflows/provider-console-release.yml
+++ b/.github/workflows/provider-console-release.yml
@@ -18,6 +18,7 @@ jobs:
   build-beta:
     needs: release
     name: Build Beta Docker image
+    if: needs.release.outputs.git_tag != ''
     uses: ./.github/workflows/reusable-build-image.yml
     secrets: inherit
     permissions:
@@ -30,6 +31,7 @@ jobs:
   build-prod:
     needs: release
     name: Build Prod Docker image
+    if: needs.release.outputs.git_tag != ''
     uses: ./.github/workflows/reusable-build-image.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/provider-proxy-docker-build.yml
+++ b/.github/workflows/provider-proxy-docker-build.yml
@@ -3,14 +3,8 @@ name: Provider Proxy CI
 on:
   pull_request:
     branches: ["main"]
-    paths:
-      - "apps/provider-proxy/**"
-      - "packages/**"
   push:
     branches: ["main"]
-    paths:
-      - "apps/provider-proxy/**"
-      - "packages/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/provider-proxy-release.yml
+++ b/.github/workflows/provider-proxy-release.yml
@@ -19,6 +19,7 @@ jobs:
   build:
     needs: release
     name: Build Docker image
+    if: needs.release.outputs.git_tag != ''
     uses: ./.github/workflows/reusable-build-image.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/reusable-create-github-release.yml
+++ b/.github/workflows/reusable-create-github-release.yml
@@ -61,9 +61,9 @@ jobs:
             exit 1
           fi
 
-          has_tag=$(git rev-parse "$git_tag" >/dev/null 2>&1 && echo "true" || echo "false")
+          tag_exists=$(git rev-parse "$git_tag" >/dev/null 2>&1 && echo "true" || echo "false")
 
-          if [ "$has_tag" = "false" ]; then
+          if [ "$tag_exists" = "false" ]; then
             echo "git_tag=$git_tag" >> $GITHUB_OUTPUT
             echo "git_tag=$git_tag"
 

--- a/.github/workflows/stats-web-docker-build.yml
+++ b/.github/workflows/stats-web-docker-build.yml
@@ -3,14 +3,8 @@ name: Stats Web CI
 on:
   push:
     branches: ["main"]
-    paths:
-      - "apps/stats-web/**"
-      - "packages/**"
   pull_request:
     branches: ["main"]
-    paths:
-      - "apps/stats-web/**"
-      - "packages/**"
 
 jobs:
   should-validate:

--- a/.github/workflows/stats-web-release.yml
+++ b/.github/workflows/stats-web-release.yml
@@ -18,6 +18,7 @@ jobs:
   build-beta:
     needs: release
     name: Build Beta Docker image
+    if: needs.release.outputs.git_tag != ''
     uses: ./.github/workflows/reusable-build-image.yml
     secrets: inherit
     permissions:
@@ -30,6 +31,7 @@ jobs:
   build-prod:
     needs: release
     name: Build Prod Docker image
+    if: needs.release.outputs.git_tag != ''
     uses: ./.github/workflows/reusable-build-image.yml
     secrets: inherit
     permissions:


### PR DESCRIPTION
## Why

After PR merge release workflows are executed by gh and all they fail -> https://github.com/akash-network/console/actions/runs/14514026487

## What

1. Adds `if` condition to build stage in release workflow
2. Removes paths filters because then required workflows are not executed and gh waits for them to run but they were filtered out by paths...