### PR TITLE
fix(billing): handle insufficient funds error for user and master wallet

### DIFF
--- a/apps/api/src/billing/config/index.ts
+++ b/apps/api/src/billing/config/index.ts
@@ -1,7 +1,11 @@
 import { envConfig } from "./env.config";
 import { USDC_IBC_DENOMS } from "./network.config";
 
+export const appConfig = {
+  USDC_IBC_DENOMS
+};
+
 export const config = {
   ...envConfig,
-  USDC_IBC_DENOMS
+  ...appConfig
 };

--- a/apps/api/src/billing/services/billing-config/billing-config.service.ts
+++ b/apps/api/src/billing/services/billing-config/billing-config.service.ts
@@ -1,11 +1,12 @@
 import { singleton } from "tsyringe";
 
+import { appConfig } from "@src/billing/config";
 import { envSchema } from "@src/billing/config/env.config";
 import { ConfigService } from "@src/core/services/config/config.service";
 
 @singleton()
-export class BillingConfigService extends ConfigService<typeof envSchema, unknown> {
+export class BillingConfigService extends ConfigService<typeof envSchema, typeof appConfig> {
   constructor() {
-    super({ envSchema });
+    super({ envSchema, config: appConfig });
   }
 }

--- a/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
@@ -1,0 +1,127 @@
+import type { BalanceHttpService } from "@akashnetwork/http-sdk";
+import type { EncodeObject } from "@cosmjs/proto-signing";
+import { BadRequest, ServiceUnavailable } from "http-errors";
+import type { MockProxy } from "jest-mock-extended";
+import { mock } from "jest-mock-extended";
+
+import type { Wallet } from "@src/billing/lib/wallet/wallet";
+import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { ChainErrorService } from "./chain-error.service";
+
+const USDC_IBC_DENOMS = {
+  mainnetId: "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1",
+  sandboxId: "ibc/12C6A0C374171B595A0A9E18B83FA09D295FB1F2D8C6DAA3AC28683471752D84"
+};
+
+describe(ChainErrorService.name, () => {
+  describe("toAppError", () => {
+    const encodeMessages: EncodeObject[] = [];
+
+    it("returns the original Error when no clue is found", async () => {
+      const { service } = setup();
+      const err = new Error("just some random failure");
+      const result = await service.toAppError(err, encodeMessages);
+      expect(result).toBe(err);
+    });
+
+    it("returns 503 when master wallet balance is less than required in uakt", async () => {
+      const { service, balanceHttpService } = setup();
+      const denom = "uakt";
+      const err = new Error(`insufficient funds: 10${denom} is smaller than 20${denom}`);
+      balanceHttpService.getBalance.mockResolvedValue({ amount: 5, denom: "uakt" });
+
+      const appErr = await service.toAppError(err, encodeMessages);
+      expect(appErr).toBeInstanceOf(ServiceUnavailable);
+      expect(appErr.message).toBe("Service temporarily unavailable");
+    });
+
+    it("returns 503 when master wallet balance is less than required in mainnet USDC", async () => {
+      const { service, balanceHttpService } = setup();
+      const denom = USDC_IBC_DENOMS.mainnetId;
+      const err = new Error(`insufficient funds: 10${denom} is smaller than 20${denom}`);
+      balanceHttpService.getBalance.mockResolvedValue({ amount: 5, denom: "ibc/12C6A0C374171B595A0A9E18B83FA09D295FB1F2D8C6DAA3AC28683471752D84" });
+
+      const appErr = await service.toAppError(err, encodeMessages);
+      expect(appErr).toBeInstanceOf(ServiceUnavailable);
+      expect(appErr.message).toBe("Service temporarily unavailable");
+    });
+
+    it("returns 503 when master wallet balance is less than required in sandbox USDC", async () => {
+      const { service, balanceHttpService } = setup();
+      const denom = USDC_IBC_DENOMS.sandboxId;
+      const err = new Error(`insufficient funds: 10${denom} is smaller than 20${denom}`);
+      balanceHttpService.getBalance.mockResolvedValue({ amount: 5, denom: "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1" });
+
+      const appErr = await service.toAppError(err, encodeMessages);
+      expect(appErr).toBeInstanceOf(ServiceUnavailable);
+      expect(appErr.message).toBe("Service temporarily unavailable");
+    });
+
+    it("returns 400 when master wallet balance is more than required in uakt", async () => {
+      const { service, balanceHttpService } = setup();
+      const denom = "uakt";
+      const err = new Error(`insufficient funds: 10${denom} is smaller than 20${denom}`);
+      balanceHttpService.getBalance.mockResolvedValue({ amount: 20, denom: "uakt" });
+
+      const appErr = await service.toAppError(err, encodeMessages);
+      expect(appErr).toBeInstanceOf(BadRequest);
+      expect(appErr.message).toBe("Insufficient funds");
+    });
+
+    it("returns 400 when master wallet balance is more than required in mainnet USDC", async () => {
+      const { service, balanceHttpService } = setup();
+      const denom = USDC_IBC_DENOMS.mainnetId;
+      const err = new Error(`insufficient funds: 10${denom} is smaller than 20${denom}`);
+      balanceHttpService.getBalance.mockResolvedValue({ amount: 20, denom: "ibc/12C6A0C374171B595A0A9E18B83FA09D295FB1F2D8C6DAA3AC28683471752D84" });
+
+      const appErr = await service.toAppError(err, encodeMessages);
+      expect(appErr).toBeInstanceOf(BadRequest);
+      expect(appErr.message).toBe("Insufficient funds");
+    });
+
+    it("returns 400 when master wallet balance is more than required in sandbox USDC", async () => {
+      const { service, balanceHttpService } = setup();
+      const denom = USDC_IBC_DENOMS.sandboxId;
+      const err = new Error(`insufficient funds: 10${denom} is smaller than 20${denom}`);
+      balanceHttpService.getBalance.mockResolvedValue({ amount: 20, denom: "ibc/12C6A0C374171B595A0A9E18B83FA09D295FB1F2D8C6DAA3AC28683471752D84" });
+
+      const appErr = await service.toAppError(err, encodeMessages);
+      expect(appErr).toBeInstanceOf(BadRequest);
+      expect(appErr.message).toBe("Insufficient funds");
+    });
+
+    it("returns 400 for an unsupported IBС denom", async () => {
+      const { service, balanceHttpService } = setup();
+      const denom = "ibc/UNKNOWN";
+      const err = new Error(`insufficient funds: 10${denom} is smaller than 20${denom}`);
+      balanceHttpService.getBalance.mockResolvedValue({ amount: 0, denom: "uakt" });
+
+      const appErr = await service.toAppError(err, encodeMessages);
+      expect(appErr).toBeInstanceOf(BadRequest);
+      expect(appErr.message).toBe("Insufficient funds");
+    });
+  });
+
+  function setup(): {
+    balanceHttpService: MockProxy<BalanceHttpService>;
+    billingConfigService: MockProxy<BillingConfigService>;
+    masterWallet: MockProxy<Wallet>;
+    service: ChainErrorService;
+  } {
+    const balanceHttpService = mock<BalanceHttpService>();
+    const billingConfigService = mock<BillingConfigService>();
+    const masterWallet = mock<Wallet>();
+
+    (billingConfigService.get as jest.Mock).mockImplementation((key: string) => {
+      if (key === "USDC_IBC_DENOMS") return USDC_IBC_DENOMS;
+      if (key === "DEPLOYMENT_GRANT_DENOM") return "uakt";
+      return undefined;
+    });
+
+    masterWallet.getFirstAddress.mockResolvedValue("test-address");
+
+    const service = new ChainErrorService(balanceHttpService, billingConfigService, masterWallet);
+
+    return { balanceHttpService, billingConfigService, masterWallet, service };
+  }
+});

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -80,7 +80,7 @@ export class ManagedSignerService {
 
       return result;
     } catch (error) {
-      throw this.chainErrorService.toAppError(error, messages);
+      throw await this.chainErrorService.toAppError(error, messages);
     }
   }
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -28,7 +28,7 @@ jest.mock("@akashnetwork/logging", () => ({
 
 describe(TopUpManagedDeploymentsService.name, () => {
   let managedSignerService: jest.Mocked<ManagedSignerService>;
-  let billingConfig: MockConfigService<{ DEPLOYMENT_GRANT_DENOM: string }>;
+  let billingConfig: MockConfigService<{ DEPLOYMENT_GRANT_DENOM: string; USDC_IBC_DENOMS: { mainnetId: string; sandboxId: string } }>;
   let drainingDeploymentService: jest.Mocked<DrainingDeploymentService>;
   let managedMasterWallet: jest.Mocked<Wallet>;
   let rpcMessageService: RpcMessageService;
@@ -43,8 +43,12 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
   beforeEach(() => {
     managedSignerService = stub<ManagedSignerService>({ executeManagedTx: jest.fn() });
-    billingConfig = new MockConfigService<{ DEPLOYMENT_GRANT_DENOM: string }>({
-      DEPLOYMENT_GRANT_DENOM
+    billingConfig = new MockConfigService<{ DEPLOYMENT_GRANT_DENOM: string; USDC_IBC_DENOMS: { mainnetId: string; sandboxId: string } }>({
+      DEPLOYMENT_GRANT_DENOM,
+      USDC_IBC_DENOMS: {
+        mainnetId: DEPLOYMENT_GRANT_DENOM,
+        sandboxId: DEPLOYMENT_GRANT_DENOM
+      }
     });
     drainingDeploymentService = stub<DrainingDeploymentService>({
       paginate: jest.fn(),

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -1,13 +1,13 @@
 export const netConfigData = {
-  "mainnet": {
-    "version": "0.38.0",
-    "apiUrls": [
+  mainnet: {
+    version: "0.38.0",
+    apiUrls: [
       "https://api.akashnet.net:443",
       "https://akash-api.polkachu.com:443",
       "https://akash.c29r3.xyz:443/api",
       "https://akash-api.global.ssl.fastly.net:443"
     ],
-    "rpcUrls": [
+    rpcUrls: [
       "https://rpc.akashnet.net:443",
       "https://rpc-akash.ecostake.com:443",
       "https://akash-rpc.polkachu.com:443",
@@ -15,24 +15,14 @@ export const netConfigData = {
       "https://akash-rpc.europlots.com:443"
     ]
   },
-  "sandbox": {
-    "version": "0.38.0",
-    "apiUrls": [
-      "https://api.sandbox-01.aksh.pw:443"
-    ],
-    "rpcUrls": [
-      "https://rpc.sandbox-01.aksh.pw:443"
-    ]
+  sandbox: {
+    version: "0.38.0",
+    apiUrls: [""],
+    rpcUrls: ["https://rpc.sandbox-01.aksh.pw:443"]
   },
   "testnet-02": {
-    "version": "0.23.1-rc0",
-    "apiUrls": [
-      "https://api.testnet-02.aksh.pw:443",
-      "https://akash-testnet-rest.cosmonautstakes.com:443"
-    ],
-    "rpcUrls": [
-      "https://rpc.testnet-02.aksh.pw:443",
-      "https://akash-testnet-rpc.cosmonautstakes.com:443"
-    ]
+    version: "0.23.1-rc0",
+    apiUrls: ["https://api.testnet-02.aksh.pw:443", "https://akash-testnet-rest.cosmonautstakes.com:443"],
+    rpcUrls: ["https://rpc.testnet-02.aksh.pw:443", "https://akash-testnet-rpc.cosmonautstakes.com:443"]
   }
-}
+};

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -17,7 +17,7 @@ export const netConfigData = {
   },
   sandbox: {
     version: "0.38.0",
-    apiUrls: [""],
+    apiUrls: ["https://api.sandbox-01.aksh.pw:443"],
     rpcUrls: ["https://rpc.sandbox-01.aksh.pw:443"]
   },
   "testnet-02": {


### PR DESCRIPTION
This PR fixes #1107 

It introduces method helpers to ChainErrorService of billing for parsing error messages of the following format:

`Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 1: 1999472uakt is smaller than 5000000uakt: insufficient funds [cosmos/cosmos-sdk@v0.45.16/x/bank/keeper/send.go:186] With gas wanted: '0' and gas used: '145584' : unknown request`

Where `uakt` can also be one of the two denomination values from the `USDC_IBC_DENOMS` config, and `1999472` and `5000000` can be any numbers. We then check the balance of user master wallet and if it's indeed less than the amount required (5000000 in this case) then we throw 503 instead of 400. Otherwise, we throw  400.

This PR also adds unit tests for the ChainErrorService functionality.