### PR TITLE
fix: use placeholder in profile social inputs

### DIFF
--- a/apps/deploy-web/src/components/user/UserSettingsForm.tsx
+++ b/apps/deploy-web/src/components/user/UserSettingsForm.tsx
@@ -157,9 +157,7 @@ export const UserSettingsForm: RequiredUserConsumer = ({ user }) => {
                   <FormField
                     name="youtubeUsername"
                     control={control}
-                    render={({ field }) => (
-                      <FormInput {...field} disabled={isFormDisabled} className="w-full" startIcon={<div>https://www.youtube.com/c/</div>} />
-                    )}
+                    render={({ field }) => <FormInput {...field} disabled={isFormDisabled} className="w-full" placeholder="https://www.youtube.com/c/" />}
                   />
                 }
               />
@@ -169,7 +167,7 @@ export const UserSettingsForm: RequiredUserConsumer = ({ user }) => {
                   <FormField
                     name="twitterUsername"
                     control={control}
-                    render={({ field }) => <FormInput {...field} disabled={isFormDisabled} className="w-full" startIcon={<div>https://x.com/</div>} />}
+                    render={({ field }) => <FormInput {...field} disabled={isFormDisabled} className="w-full" placeholder="https://x.com/" />}
                   />
                 }
               />
@@ -179,7 +177,7 @@ export const UserSettingsForm: RequiredUserConsumer = ({ user }) => {
                   <FormField
                     name="githubUsername"
                     control={control}
-                    render={({ field }) => <FormInput {...field} disabled={isFormDisabled} className="w-full" startIcon={<div>https://github.com/</div>} />}
+                    render={({ field }) => <FormInput {...field} disabled={isFormDisabled} className="w-full" placeholder="https://github.com/" />}
                   />
                 }
               />


### PR DESCRIPTION
Fixes #1234 

I believe startIcon was meant to serve as placeholder in these cases, so I simply swapped them.

Before:

<img width="1461" alt="Screenshot 2025-04-30 at 23 07 10" src="https://github.com/user-attachments/assets/02d54efd-acd6-44ed-8d11-4a685bc8bef6" />

After:

<img width="1456" alt="Screenshot 2025-04-30 at 23 07 36" src="https://github.com/user-attachments/assets/1461a38d-72de-49e7-9336-327eef44911d" />
