### PR TITLE
fix: shows wallet balance on intial rendering

### DIFF
--- a/.github/actions/console-web-ui-testing/action.yml
+++ b/.github/actions/console-web-ui-testing/action.yml
@@ -98,6 +98,7 @@ runs:
           core.setOutput('slack-user', userMapping[author] || "");
 
     - name: DEBUG
+      shell: bash
       env:
         PR_DETAILS: ${{ toJson(github.event.pull_request) }}
       run: echo "$PR_DETAILS"

--- a/apps/deploy-web/playwright.config.ts
+++ b/apps/deploy-web/playwright.config.ts
@@ -19,6 +19,8 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
+  timeout: 60 * 1000,
+  globalTimeout: process.env.CI ? 60 * 60 * 1000 : undefined,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/apps/deploy-web/src/queries/useBalancesQuery.ts
+++ b/apps/deploy-web/src/queries/useBalancesQuery.ts
@@ -66,7 +66,8 @@ export function useBalances(address?: string, options?: Omit<UseQueryOptions<Bal
   return useQuery({
     queryKey: QueryKeys.getBalancesKey(address) as QueryKey,
     queryFn: () => getBalances(settings.apiEndpoint, address),
-    enabled: !!address,
+    enabled: !!address && !!settings.apiEndpoint,
+
     ...options
   });
 }

--- a/apps/deploy-web/tests/deploy-hello-world.spec.ts
+++ b/apps/deploy-web/tests/deploy-hello-world.spec.ts
@@ -4,7 +4,7 @@ import { testEnvConfig } from "./fixture/test-env.config";
 import { connectWalletViaLeap, setupWallet } from "./fixture/wallet-setup";
 import { DeployHelloWorldPage } from "./pages/DeployHelloWorldPage";
 
-test("deploy hello world", async ({ context, extPage: page }) => {
+test("deploy hello world", async ({ context, page }) => {
   test.setTimeout(300_000);
 
   await setupWallet(context, page);

--- a/apps/deploy-web/tests/fixture/base-test.ts
+++ b/apps/deploy-web/tests/fixture/base-test.ts
@@ -1,22 +1,30 @@
-import type { Request, Route } from "@playwright/test";
-import { test } from "@playwright/test";
+import type { Page, Request, Route } from "@playwright/test";
+import { test as baseTest } from "@playwright/test";
 
 import { testEnvConfig } from "./test-env.config";
 
 export * from "@playwright/test";
 
-test.beforeEach(async ({ page }) => {
-  const uiTestsToken = testEnvConfig.UI_TESTS_TOKEN;
-  if (!uiTestsToken) return;
-
-  const addUITestsToken = async (route: Route, request: Request) => {
-    await route.continue({
-      headers: {
-        ...request.headers(),
-        "x-ui-tests-token": uiTestsToken
-      }
-    });
-  };
-  await page.route("**/api-mainnet/**", addUITestsToken);
-  await page.route("**/api-sandbox/**", addUITestsToken);
+export const test = baseTest.extend<{
+  page: Page;
+}>({
+  page: async ({ page }, use) => {
+    await addUITestsToken(page);
+    await use(page);
+  }
 });
+
+export async function addUITestsToken(page: Page) {
+  const uiTestsToken = testEnvConfig.UI_TESTS_TOKEN;
+
+  if (uiTestsToken) {
+    await page.route(`${testEnvConfig.BASE_URL}/api/config`, async (route: Route, request: Request) => {
+      await route.continue({
+        headers: {
+          ...request.headers(),
+          "x-ui-tests-token": uiTestsToken
+        }
+      });
+    });
+  }
+}

--- a/apps/deploy-web/tests/fixture/context-with-extension.ts
+++ b/apps/deploy-web/tests/fixture/context-with-extension.ts
@@ -5,7 +5,7 @@ import { nanoid } from "nanoid";
 import path from "path";
 import { setTimeout as delay } from "timers/promises";
 
-import { test as baseTest } from "./base-test";
+import { addUITestsToken, test as baseTest } from "./base-test";
 
 // @see https://github.com/microsoft/playwright/issues/14949
 export async function restoreExtensionStorage(page: Page): Promise<void> {
@@ -59,15 +59,14 @@ export const test = baseTest.extend<{
     const extensionId = background.url().split("/")[2];
     await use(extensionId);
   },
-  extPage: [
-    async ({ context, extensionId }, use) => {
-      const extPage = await context.newPage();
-      await extPage.goto(`chrome-extension://${extensionId}/index.html`);
-      await extPage.waitForLoadState("domcontentloaded");
-      await use(extPage);
-    },
-    { scope: "test" }
-  ]
+  page: async ({ context, extensionId }, use) => {
+    const extPage = await context.newPage();
+    await extPage.goto(`chrome-extension://${extensionId}/index.html`);
+    await extPage.waitForLoadState("domcontentloaded");
+    await addUITestsToken(extPage);
+
+    await use(extPage);
+  }
 });
 
 export const expect = test.expect;


### PR DESCRIPTION
## Why

bug

## What

1. Fixes wallet balance in header navigation because it's used in e2e tests and without this e2e tests fails
2. Fixes e2e testing custom action (added `shell` 🤦 )
3. Refactored e2e tests supportive code and increased timeouts (for some reason locally it take 30 secs to load https://console-beta....)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of balance queries by ensuring they only run when both the address and API endpoint are available.

- **Tests**
	- Introduced per-test and global timeouts to Playwright test configuration for better test execution control.
	- Refactored test fixtures to streamline page setup and token injection, replacing previous fixtures and hooks for improved consistency.
	- Updated test parameter naming for clarity and direct usage.

- **Chores**
	- Updated GitHub Actions workflow to explicitly use the Bash shell in debugging steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->