### PR TITLE
chore: sets es2022 compilation target for console-api

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,4 +2,8 @@
   "exclude": ["node_modules", "dist", "test"],
   "extends": "./tsconfig.build.json",
   "include": ["src/**/*", "../../packages/logging/src/types/pino-fluentd.d.ts"],
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false
+  }
 }

--- a/apps/api/webpack.prod.js
+++ b/apps/api/webpack.prod.js
@@ -10,6 +10,7 @@ module.exports = {
   entry: "./src/index.ts",
   mode: NODE_ENV,
   target: "node",
+  devtool: "source-map",
   output: {
     path: path.resolve(__dirname, "dist"),
     filename: "server.js"


### PR DESCRIPTION
## Why

console-api uses ES6 (ES2015) compilation target which is old nowadays. We are using latest nodejs LTS (v22) which supports ES2022.

This makes compiled version to use native JS features instead of falling back on polyfills and transformations (for example, now we will use native async/await instead of generator wrapper what will simplify stacktrace and ease debugging)

## What

Sets compilation target in console-api to ES2022. But [set `useDefineForClassFields` to `false` ](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier) because it requires changes in sequelize models definitions.
added devtool for production code for better stacktraces

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Updated TypeScript configuration to target ES2022 for API compilation.
  - Enabled source map generation in production builds to improve debugging capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->