### PR TITLE
fix: ensure balances are not fetched before chain node API is selected

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/BidGroup.tsx
+++ b/apps/deploy-web/src/components/new-deployment/BidGroup.tsx
@@ -11,7 +11,7 @@ import { deploymentGroupResourceSum, getStorageAmount } from "@src/utils/deploym
 import { FormPaper } from "../sdl/FormPaper";
 import { LabelValueOld } from "../shared/LabelValueOld";
 import { SpecDetail } from "../shared/SpecDetail";
-import { BidRow } from "./BidRow";
+import { BidRow } from "./BidRow/BidRow";
 
 type Props = {
   bids: Array<BidDto>;
@@ -120,12 +120,11 @@ export const BidGroup: React.FunctionComponent<Props> = ({
         </TableHeader>
 
         <TableBody>
-          {fBids.map((bid, i) => {
+          {fBids.map(bid => {
             const provider = providers && providers.find(x => x.owner === bid.provider);
             const showBid = provider?.isValidVersion && (!isSendingManifest || selectedBid?.id === bid.id);
             return (showBid || selectedNetworkId !== MAINNET_ID) && provider ? (
               <BidRow
-                testIndex={i}
                 key={bid.id}
                 bid={bid}
                 provider={provider}

--- a/apps/deploy-web/src/components/new-deployment/BidRow/BidRow.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/BidRow/BidRow.spec.tsx
@@ -1,0 +1,130 @@
+import type { RadioGroupItem } from "@akashnetwork/ui/components";
+import { QueryClientProvider } from "@tanstack/react-query";
+
+import { LocalNoteProvider } from "@src/context/LocalNoteProvider/LocalNoteContext";
+import { ServicesProvider } from "@src/context/ServicesProvider/ServicesProvider";
+import { queryClient } from "@src/queries/queryClient";
+import type { ProviderProxyService } from "@src/services/provider-proxy/provider-proxy.service";
+import type { BidDto } from "@src/types/deployment";
+import type { ApiProviderList } from "@src/types/provider";
+import { udenomToDenom } from "@src/utils/mathHelpers";
+import { BidRow, COMPONENTS } from "./BidRow";
+
+import { render } from "@testing-library/react";
+import { buildDeploymentBid } from "@tests/seeders/deploymentBid";
+import { buildProvider } from "@tests/seeders/provider";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe(BidRow.name, () => {
+  it("displays bid details", () => {
+    const provider = buildProvider({
+      hostUri: "https://provider-host-uri",
+      uptime7d: 0.9
+    });
+    const bid = buildDeploymentBid({
+      price: {
+        denom: "uakt",
+        amount: "1280000000000000000"
+      },
+      provider: provider.owner
+    });
+    const components = {
+      PricePerMonth: jest.fn(),
+      ProviderName: jest.fn(),
+      Uptime: jest.fn(),
+      RadioGroupItem: jest.fn() as unknown as typeof RadioGroupItem
+    };
+    const { getByText } = setup({
+      bid,
+      provider,
+      components
+    });
+
+    expect(components.PricePerMonth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        denom: bid.price.denom,
+        perBlockValue: udenomToDenom(bid.price.amount, 10)
+      }),
+      {}
+    );
+    expect(components.ProviderName).toHaveBeenCalledWith({ provider }, {});
+    expect(components.Uptime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: provider.uptime7d
+      }),
+      {}
+    );
+    expect(getByText(`${provider.ipRegionCode}, ${provider.ipCountryCode}`)).toBeInTheDocument();
+    expect(components.RadioGroupItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: bid.id,
+        id: bid.id,
+        disabled: false,
+        "aria-label": provider.name
+      }),
+      {}
+    );
+  });
+
+  it("does not display RadioGroupItem when disabled or bid closed", () => {
+    const provider = buildProvider({
+      hostUri: "https://provider-host-uri",
+      uptime7d: 0.9
+    });
+    let bid = buildDeploymentBid({ provider: provider.owner });
+    const components = {
+      RadioGroupItem: jest.fn() as typeof RadioGroupItem
+    };
+    setup({
+      bid,
+      provider,
+      components,
+      disabled: true
+    });
+    expect(components.RadioGroupItem).not.toHaveBeenCalled();
+
+    bid = buildDeploymentBid({ provider: provider.owner, state: "closed" });
+    setup({
+      bid,
+      provider,
+      components
+    });
+    expect(components.RadioGroupItem).not.toHaveBeenCalled();
+  });
+
+  function setup(
+    props: Partial<{
+      bid: BidDto;
+      selectedBid: BidDto;
+      handleBidSelected: (bid: BidDto) => void;
+      disabled: boolean;
+      provider: ApiProviderList;
+      isSendingManifest: boolean;
+      components?: Partial<typeof COMPONENTS>;
+    }>
+  ) {
+    const providerProxy = () =>
+      ({
+        fetchProviderUrl: jest.fn(() => {
+          return new Promise(() => {});
+        })
+      }) as unknown as ProviderProxyService;
+    return render(
+      <ServicesProvider services={{ providerProxy }}>
+        <QueryClientProvider client={queryClient}>
+          <LocalNoteProvider>
+            <BidRow
+              bid={props?.bid ?? buildDeploymentBid()}
+              selectedBid={props?.selectedBid}
+              handleBidSelected={props?.handleBidSelected || (() => {})}
+              disabled={props?.disabled ?? false}
+              provider={props?.provider ?? buildProvider()}
+              isSendingManifest={props?.isSendingManifest ?? false}
+              components={MockComponents(COMPONENTS, props?.components)}
+            />
+          </LocalNoteProvider>
+        </QueryClientProvider>
+      </ServicesProvider>
+    );
+  }
+});

--- a/apps/deploy-web/src/components/new-deployment/BidRow/BidRow.tsx
+++ b/apps/deploy-web/src/components/new-deployment/BidRow/BidRow.tsx
@@ -12,24 +12,51 @@ import type { ApiProviderList } from "@src/types/provider";
 import { getGpusFromAttributes } from "@src/utils/deploymentUtils";
 import { hasSomeParentTheClass } from "@src/utils/domUtils";
 import { udenomToDenom } from "@src/utils/mathHelpers";
-import { AuditorButton } from "../providers/AuditorButton";
-import { Uptime } from "../providers/Uptime";
-import { CopyTextToClipboardButton } from "../shared/CopyTextToClipboardButton";
-import { FavoriteButton } from "../shared/FavoriteButton";
-import { PriceEstimateTooltip } from "../shared/PriceEstimateTooltip";
-import { PricePerMonth } from "../shared/PricePerMonth";
-import { ProviderName } from "../shared/ProviderName";
+import { AuditorButton } from "../../providers/AuditorButton";
+import { Uptime } from "../../providers/Uptime";
+import { CopyTextToClipboardButton } from "../../shared/CopyTextToClipboardButton";
+import { FavoriteButton } from "../../shared/FavoriteButton";
+import { PriceEstimateTooltip } from "../../shared/PriceEstimateTooltip";
+import { PricePerMonth } from "../../shared/PricePerMonth";
+import { ProviderName } from "../../shared/ProviderName";
+
 type Props = {
-  testIndex: number;
   bid: BidDto;
-  selectedBid: BidDto;
+  selectedBid?: BidDto | null;
   handleBidSelected: (bid: BidDto) => void;
   disabled: boolean;
   provider: ApiProviderList;
   isSendingManifest: boolean;
+  components?: typeof COMPONENTS;
 };
 
-export const BidRow: React.FunctionComponent<Props> = ({ testIndex, bid, selectedBid, handleBidSelected, disabled, provider, isSendingManifest }) => {
+export const COMPONENTS = {
+  Badge,
+  CustomTooltip,
+  RadioGroup,
+  RadioGroupItem,
+  Spinner,
+  TableCell,
+  TableRow,
+  PricePerMonth,
+  PriceEstimateTooltip,
+  FavoriteButton,
+  ProviderName,
+  CopyTextToClipboardButton,
+  CloudXmark,
+  Uptime,
+  AuditorButton
+};
+
+export const BidRow: React.FunctionComponent<Props> = ({
+  bid,
+  selectedBid,
+  handleBidSelected,
+  disabled,
+  provider,
+  isSendingManifest,
+  components: c = COMPONENTS
+}) => {
   const { favoriteProviders, updateFavoriteProviders } = useLocalNotes();
   const isFavorite = favoriteProviders.some(x => provider.owner === x);
   const isCurrentBid = selectedBid?.id === bid.id;
@@ -66,25 +93,24 @@ export const BidRow: React.FunctionComponent<Props> = ({ testIndex, bid, selecte
   };
 
   return (
-    <TableRow
+    <c.TableRow
       key={bid.id}
       className={cn("bid-list-row [&>td]:px-2 [&>td]:py-1", {
         ["cursor-pointer hover:bg-muted-foreground/10"]: bid.state === "open",
         [`border bg-green-100 dark:bg-green-900`]: isCurrentBid
       })}
       onClick={onRowClick}
-      data-testid={`bid-list-row-${testIndex}`}
     >
-      <TableCell align="center">
+      <c.TableCell align="center">
         <div className="flex items-center justify-center whitespace-nowrap">
-          <PricePerMonth denom={bid.price.denom} perBlockValue={udenomToDenom(bid.price.amount, 10)} className="text-xl" />
-          <PriceEstimateTooltip denom={bid.price.denom} value={bid.price.amount} />
+          <c.PricePerMonth denom={bid.price.denom} perBlockValue={udenomToDenom(bid.price.amount, 10)} className="text-xl" />
+          <c.PriceEstimateTooltip denom={bid.price.denom} value={bid.price.amount} />
         </div>
-      </TableCell>
+      </c.TableCell>
 
-      <TableCell align="center">
+      <c.TableCell align="center">
         {provider.ipRegion && provider.ipCountry ? (
-          <CustomTooltip
+          <c.CustomTooltip
             title={
               <>
                 {provider.ipRegion}, {provider.ipCountry}
@@ -94,69 +120,69 @@ export const BidRow: React.FunctionComponent<Props> = ({ testIndex, bid, selecte
             <div>
               {provider.ipRegionCode}, {provider.ipCountryCode}
             </div>
-          </CustomTooltip>
+          </c.CustomTooltip>
         ) : (
           <div>-</div>
         )}
-      </TableCell>
+      </c.TableCell>
 
-      <TableCell align="center" className="font-bold">
-        {provider.uptime7d ? <Uptime value={provider.uptime7d} /> : <div>-</div>}
-      </TableCell>
+      <c.TableCell align="center" className="font-bold">
+        {provider.uptime7d ? <c.Uptime value={provider.uptime7d} /> : <div>-</div>}
+      </c.TableCell>
 
-      <TableCell align="left">
+      <c.TableCell align="left">
         <div className="flex items-center">
-          <FavoriteButton isFavorite={isFavorite} onClick={onStarClick} />
+          <c.FavoriteButton isFavorite={isFavorite} onClick={onStarClick} />
           <div className="ml-2">
-            <ProviderName provider={provider} />
+            <c.ProviderName provider={provider} />
           </div>
           <div className="pl-2">
-            <CopyTextToClipboardButton value={provider.name ?? provider.hostUri} />
+            <c.CopyTextToClipboardButton value={provider.name ?? provider.hostUri} />
           </div>
         </div>
-      </TableCell>
+      </c.TableCell>
 
       {gpuModels.length > 0 && (
-        <TableCell align="center">
+        <c.TableCell align="center">
           <div className="space-x">
             {gpuModels.map(gpu => (
-              <Badge key={`${gpu.vendor}-${gpu.model}`} className={cn("px-1 py-0 text-xs")} variant="default">
+              <c.Badge key={`${gpu.vendor}-${gpu.model}`} className={cn("px-1 py-0 text-xs")} variant="default">
                 {gpu.vendor}-{gpu.model}
-              </Badge>
+              </c.Badge>
             ))}
           </div>
-        </TableCell>
+        </c.TableCell>
       )}
 
-      <TableCell align="center">
+      <c.TableCell align="center">
         {provider.isAudited ? (
           <div className="flex items-center justify-center">
             <span className="text-sm text-muted-foreground">Yes</span>
             <div className="ml-1">
-              <AuditorButton provider={provider} />
+              <c.AuditorButton provider={provider} />
             </div>
           </div>
         ) : (
           <div className="flex items-center justify-center">
             <span className="text-sm text-muted-foreground">No</span>
 
-            <CustomTooltip title={<>This provider is not audited, which may result in a lesser quality experience.</>}>
+            <c.CustomTooltip title={<>This provider is not audited, which may result in a lesser quality experience.</>}>
               <WarningTriangle className="ml-2 text-sm text-orange-600" />
-            </CustomTooltip>
+            </c.CustomTooltip>
           </div>
         )}
-      </TableCell>
+      </c.TableCell>
 
-      <TableCell align="center">
+      <c.TableCell align="center">
         <div className="flex h-[38px] items-center justify-center">
           {isLoadingStatus && (
             <div className="flex items-center justify-center">
-              <Spinner size="small" />
+              <c.Spinner size="small" />
             </div>
           )}
           {!isLoadingStatus && !!error && !isSendingManifest && (
             <div className="mt-2 flex items-center space-x-2">
-              <CloudXmark className="text-xs text-primary" />
+              <c.CloudXmark className="text-xs text-primary" />
               <span className="text-sm text-muted-foreground">OFFLINE</span>
             </div>
           )}
@@ -165,32 +191,32 @@ export const BidRow: React.FunctionComponent<Props> = ({ testIndex, bid, selecte
             <>
               {bid.state !== "open" || disabled ? (
                 <div className="flex items-center justify-center">
-                  <Badge color={bid.state === "active" ? "success" : "error"} className="h-4 text-xs">
+                  <c.Badge color={bid.state === "active" ? "success" : "error"} className="h-4 text-xs">
                     {bid.state}
-                  </Badge>
+                  </c.Badge>
                 </div>
               ) : (
-                <RadioGroup>
-                  <RadioGroupItem
+                <c.RadioGroup>
+                  <c.RadioGroupItem
                     value={bid.id}
                     id={bid.id}
                     checked={isCurrentBid}
                     onChange={() => handleBidSelected(bid)}
                     disabled={bid.state !== "open" || disabled}
-                    data-testid={`bid-list-row-radio-${testIndex}`}
+                    aria-label={provider.name ?? provider.hostUri}
                   />
-                </RadioGroup>
+                </c.RadioGroup>
               )}
             </>
           )}
 
           {isSendingManifest && isCurrentBid && (
             <div className="flex items-center justify-center whitespace-nowrap">
-              <Badge variant="success">Deploying! 🚀</Badge>
+              <c.Badge variant="success">Deploying! 🚀</c.Badge>
             </div>
           )}
         </div>
-      </TableCell>
-    </TableRow>
+      </c.TableCell>
+    </c.TableRow>
   );
 };

--- a/apps/deploy-web/src/pages/_app.tsx
+++ b/apps/deploy-web/src/pages/_app.tsx
@@ -18,7 +18,6 @@ import NProgress from "nprogress";
 
 import GoogleAnalytics from "@src/components/layout/CustomGoogleAnalytics";
 import { CustomIntlProvider } from "@src/components/layout/CustomIntlProvider";
-import { Loading } from "@src/components/layout/Layout";
 import { PageHead } from "@src/components/layout/PageHead";
 import { ClientOnlyTurnstile } from "@src/components/turnstile/Turnstile";
 import { UserProviders } from "@src/components/user/UserProviders";
@@ -69,7 +68,7 @@ const App: React.FunctionComponent<Props> = props => {
   }, []);
 
   if (hasInjectedConfig() && !isResolvedConfig) {
-    return <Loading text="Loading config..." />;
+    return null;
   }
 
   return (

--- a/apps/deploy-web/src/queries/useBalancesQuery.ts
+++ b/apps/deploy-web/src/queries/useBalancesQuery.ts
@@ -10,7 +10,7 @@ export function useBalances(address?: string, options?: Omit<UseQueryOptions<Bal
   return useQuery({
     queryKey: QueryKeys.getBalancesKey(address) as QueryKey,
     queryFn: () => (address ? di.walletBalancesService.getBalances(address) : null),
-    enabled: !!address,
+    enabled: !!address && !!di.authzHttpService.getUri(),
     ...options
   });
 }

--- a/apps/deploy-web/tests/deploy-hello-world.spec.ts
+++ b/apps/deploy-web/tests/deploy-hello-world.spec.ts
@@ -3,6 +3,7 @@ import { test } from "./fixture/context-with-extension";
 import { testEnvConfig } from "./fixture/test-env.config";
 import { connectWalletViaLeap, setupWallet } from "./fixture/wallet-setup";
 import { DeployHelloWorldPage } from "./pages/DeployHelloWorldPage";
+import { isWalletConnected } from "./uiState/isWalletConnected";
 
 test("deploy hello world", async ({ context, page }) => {
   test.setTimeout(300_000);
@@ -11,7 +12,10 @@ test("deploy hello world", async ({ context, page }) => {
   await page.goto(testEnvConfig.BASE_URL);
   await connectWalletViaLeap(context, page);
   await selectChainNetwork(page, "sandbox");
-  await connectWalletViaLeap(context, page);
+
+  if (!(await isWalletConnected(page))) {
+    await connectWalletViaLeap(context, page);
+  }
 
   const helloWorldPage = new DeployHelloWorldPage(context, page, "new-deployment", "hello-world-card");
 

--- a/apps/deploy-web/tests/fixture/wallet-setup.ts
+++ b/apps/deploy-web/tests/fixture/wallet-setup.ts
@@ -2,9 +2,9 @@ import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import type { BrowserContext, Page } from "@playwright/test";
 import { selectors } from "@playwright/test";
 
+import { isWalletConnected } from "../uiState/isWalletConnected";
 import { restoreExtensionStorage } from "./context-with-extension";
 import { testEnvConfig } from "./test-env.config";
-
 const WALLET_PASSWORD = "12345678";
 
 export async function setupWallet(context: BrowserContext, page: Page) {
@@ -47,7 +47,7 @@ export async function connectWalletViaLeap(context: BrowserContext, page: Page) 
     }
   }
 
-  await page.getByLabel("Connected wallet name and balance").waitFor({ state: "visible" });
+  await isWalletConnected(page);
 }
 
 async function importWalletToLeap(context: BrowserContext, page: Page) {
@@ -61,7 +61,6 @@ async function importWalletToLeap(context: BrowserContext, page: Page) {
     throw new Error("TEST_WALLET_MNEMONIC should have 12 words");
   }
 
-  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
   await page.getByText(/recovery phrase/i).click();
 
   try {

--- a/apps/deploy-web/tests/pages/DeployBasePage.tsx
+++ b/apps/deploy-web/tests/pages/DeployBasePage.tsx
@@ -43,8 +43,8 @@ export class DeployBasePage {
     await this.page.getByTestId("deposit-modal-continue-button").click();
   }
 
-  async createLease() {
-    await this.page.getByTestId("bid-list-row-radio-0").click();
+  async createLease(providerName = "provider.europlots-sandbox.com") {
+    await this.page.getByLabel(providerName).click();
     await this.page.getByTestId("create-lease-button").click();
   }
 

--- a/apps/deploy-web/tests/seeders/deployment.ts
+++ b/apps/deploy-web/tests/seeders/deployment.ts
@@ -3,9 +3,9 @@ import type { DeepPartial } from "cosmjs-types/helpers";
 import { merge } from "lodash";
 
 import type { RpcDeployment } from "@src/types/deployment";
-
+import { genWalletAddress } from "./wallet";
 export function buildRpcDeployment(overrides?: DeepPartial<RpcDeployment>): RpcDeployment {
-  const walletAddress = overrides?.deployment?.deployment_id?.owner || `akash${faker.string.alphanumeric({ length: 39 })}`;
+  const walletAddress = overrides?.deployment?.deployment_id?.owner || genWalletAddress();
   const dseq = overrides?.deployment?.deployment_id?.dseq || faker.string.numeric({ length: 6 }).toString();
   return merge(
     {

--- a/apps/deploy-web/tests/seeders/deploymentBid.ts
+++ b/apps/deploy-web/tests/seeders/deploymentBid.ts
@@ -1,0 +1,46 @@
+import type { BidDto } from "@src/types/deployment";
+import { genWalletAddress } from "./wallet";
+
+export function buildDeploymentBid(overrides?: Partial<BidDto>): BidDto {
+  return {
+    id: "1",
+    owner: genWalletAddress(),
+    provider: genWalletAddress(),
+    dseq: "1",
+    gseq: 1,
+    oseq: 1,
+    price: {
+      denom: "uakt",
+      amount: "1000000000000000000"
+    },
+    state: "open",
+    resourcesOffer: [
+      {
+        resources: {
+          cpu: {
+            units: {
+              val: "0.1"
+            },
+            attributes: []
+          },
+          gpu: {
+            units: {
+              val: "1"
+            },
+            attributes: []
+          },
+          memory: {
+            quantity: {
+              val: "1024"
+            },
+            attributes: []
+          },
+          storage: [],
+          endpoints: []
+        },
+        count: 1
+      }
+    ],
+    ...overrides
+  };
+}

--- a/apps/deploy-web/tests/seeders/provider.ts
+++ b/apps/deploy-web/tests/seeders/provider.ts
@@ -1,10 +1,10 @@
 import { faker } from "@faker-js/faker";
 
 import type { ApiProviderDetail } from "@src/types/provider";
-
+import { genWalletAddress } from "./wallet";
 export function buildProvider(overrides?: Partial<ApiProviderDetail>): ApiProviderDetail {
   return {
-    owner: `akash${faker.string.alphanumeric({ length: 39 })}`,
+    owner: genWalletAddress(),
     name: `${faker.internet.domainWord()}.${faker.internet.domainWord()}.${faker.internet.domainName()}`,
     hostUri: `https://${faker.internet.domainName()}:8443`,
     createdHeight: faker.number.int({ min: 100000, max: 500000 }),

--- a/apps/deploy-web/tests/seeders/wallet.ts
+++ b/apps/deploy-web/tests/seeders/wallet.ts
@@ -1,0 +1,3 @@
+import { faker } from "@faker-js/faker";
+
+export const genWalletAddress = () => `akash${faker.string.alphanumeric({ length: 39 })}`;

--- a/apps/deploy-web/tests/uiState/isWalletConnected.ts
+++ b/apps/deploy-web/tests/uiState/isWalletConnected.ts
@@ -1,0 +1,9 @@
+import type { Page } from "@playwright/test";
+
+export async function isWalletConnected(page: Page) {
+  return page
+    .getByLabel("Connected wallet name and balance")
+    .waitFor({ state: "visible" })
+    .then(() => true)
+    .catch(() => false);
+}


### PR DESCRIPTION
## Why

Balances are currently fetched from the app base url because api endpoint is undefined. This is a bug introduced by me recently

## What

1. Ensure that balances are not fetched until chain node API url is resolved
2. Uses europlots provider for e2e testing
3. shows nothing when there is injected config which is not validated otherwise nextjs shows a hydration error (that server and client returns different html)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a utility to generate standardized wallet addresses for testing.
  - Introduced a utility to check wallet connection status in UI tests.
  - Added a new test seeder for generating mock deployment bids.
  - Added tests for the BidRow component.

- **Bug Fixes**
  - Prevented redundant wallet connection attempts during tests.
  - Improved logic for enabling balance queries, requiring both address and service URI.

- **Refactor**
  - Refactored the BidRow component to support dependency injection for UI components and updated its props.
  - Simplified and optimized service worker detection and page reuse in test fixtures.
  - Updated test seeders to use the new wallet address generator.

- **Chores**
  - Removed loading UI during configuration resolution, resulting in a blank screen during that phase.
  - Improved test reliability and maintainability by updating test utilities and fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->