### PR TITLE
chore: sets higher coverage for deploy-web

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,7 +7,7 @@ coverage:
         flags:
           - api
       deploy-web:
-        target: 9%
+        target: 14%
         flags:
           - deploy-web
       notifications:
@@ -25,7 +25,7 @@ coverage:
         flags:
           - api
       deploy-web:
-        target: 30%
+        target: 50%
         flags:
           - deploy-web
       notifications:


### PR DESCRIPTION
## Why

It's pretty easy to get 50% patch coverage, so increasing to improve reliability