### PR TITLE
fix: extracts injected config into a hook

### DIFF
--- a/.github/actions/console-web-ui-testing/action.yml
+++ b/.github/actions/console-web-ui-testing/action.yml
@@ -75,6 +75,14 @@ runs:
             pr = response.data[0];
           }
 
+          if (!pr.merged_by) {
+            pr = await github.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+          }
+
           console.dir(pr, { depth: null });
           core.setOutput('number', pr.number);
           core.setOutput('title', pr.title);

--- a/apps/deploy-web/src/hooks/useInjectedConfig.spec.ts
+++ b/apps/deploy-web/src/hooks/useInjectedConfig.spec.ts
@@ -1,0 +1,36 @@
+import { setTimeout as wait } from "node:timers/promises";
+
+import { useInjectedConfig } from "./useInjectedConfig";
+
+import { act, renderHook } from "@testing-library/react";
+
+describe(useInjectedConfig.name, () => {
+  it("returns null config and isLoaded=true when no injected config exists", () => {
+    const hasConfig = jest.fn().mockReturnValue(false);
+    const decodeConfig = jest.fn().mockResolvedValue(null);
+    const { result } = renderHook(() =>
+      useInjectedConfig({
+        hasConfig,
+        decodeConfig
+      })
+    );
+
+    expect(result.current).toEqual({ config: null, isLoaded: true });
+    expect(decodeConfig).not.toHaveBeenCalled();
+  });
+
+  it("returns decoded config and isLoaded=true when injected config exists", async () => {
+    const mockConfig = { NEXT_PUBLIC_TURNSTILE_ENABLED: true };
+    const { result } = renderHook(() =>
+      useInjectedConfig({
+        hasConfig: () => true,
+        decodeConfig: () => Promise.resolve(mockConfig)
+      })
+    );
+    expect(result.current).toEqual({ config: null, isLoaded: false });
+
+    await act(() => wait(0));
+
+    expect(result.current).toEqual({ config: mockConfig, isLoaded: true });
+  });
+});

--- a/apps/deploy-web/src/hooks/useInjectedConfig.ts
+++ b/apps/deploy-web/src/hooks/useInjectedConfig.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+
+import type { BrowserEnvConfig } from "@src/config/env-config.schema";
+import { decodeInjectedConfig, hasInjectedConfig } from "@src/services/decodeInjectedConfig/decodeInjectedConfig";
+
+/**
+ * This hook is used to get the injected and verified config from the window object.
+ */
+export function useInjectedConfig({
+  decodeConfig = decodeInjectedConfig,
+  hasConfig = hasInjectedConfig
+}: InjectedConfigHookProps = {}): InjectedConfigHookResult {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [config, setConfig] = useState<Partial<BrowserEnvConfig> | null>(null);
+
+  useEffect(() => {
+    if (hasConfig()) {
+      decodeConfig()
+        .then(setConfig)
+        .finally(() => setIsLoaded(true));
+    } else {
+      setIsLoaded(true);
+    }
+  }, []);
+
+  return { config, isLoaded };
+}
+
+/**
+ * Cannot use DI in this hook directly because we need to use it at the very beginning of the app
+ */
+export interface InjectedConfigHookProps {
+  decodeConfig?: typeof decodeInjectedConfig;
+  hasConfig?: typeof hasInjectedConfig;
+}
+
+export interface InjectedConfigHookResult {
+  config: Partial<BrowserEnvConfig> | null;
+  isLoaded: boolean;
+}

--- a/apps/deploy-web/src/pages/_app.tsx
+++ b/apps/deploy-web/src/pages/_app.tsx
@@ -2,7 +2,7 @@ import "@akashnetwork/ui/styles";
 import "nprogress/nprogress.css";
 import "../styles/index.css";
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { TooltipProvider } from "@akashnetwork/ui/components";
 import { CustomSnackbarProvider, PopupProvider } from "@akashnetwork/ui/context";
 import { cn } from "@akashnetwork/ui/utils";
@@ -21,7 +21,6 @@ import { CustomIntlProvider } from "@src/components/layout/CustomIntlProvider";
 import { PageHead } from "@src/components/layout/PageHead";
 import { ClientOnlyTurnstile } from "@src/components/turnstile/Turnstile";
 import { UserProviders } from "@src/components/user/UserProviders";
-import type { BrowserEnvConfig } from "@src/config/browser-env.config";
 import { browserEnvConfig } from "@src/config/browser-env.config";
 import { BackgroundTaskProvider } from "@src/context/BackgroundTaskProvider";
 import { CertificateProvider } from "@src/context/CertificateProvider";
@@ -34,11 +33,11 @@ import { PricingProvider } from "@src/context/PricingProvider/PricingProvider";
 import { ServicesProvider } from "@src/context/ServicesProvider";
 import { SettingsProvider } from "@src/context/SettingsProvider";
 import { WalletProvider } from "@src/context/WalletProvider";
+import { useInjectedConfig } from "@src/hooks/useInjectedConfig";
 import { getServerSidePropsWithServices } from "@src/lib/nextjs/getServerSidePropsWithServices";
 import { queryClient } from "@src/queries";
 import { prefetchFeatureFlags } from "@src/queries/featureFlags";
 import { serverApiUrlService } from "@src/services/api-url/server-api-url.service";
-import { decodeInjectedConfig, hasInjectedConfig } from "@src/services/decodeInjectedConfig/decodeInjectedConfig";
 import { store } from "@src/store/global-store";
 
 interface Props extends AppProps {
@@ -56,20 +55,7 @@ Router.events.on("routeChangeError", () => NProgress.done());
 
 const App: React.FunctionComponent<Props> = props => {
   const { Component, pageProps } = props;
-  const [isResolvedConfig, setIsResolvedConfig] = useState(false);
-  const [config, setConfig] = useState<Partial<BrowserEnvConfig> | null>(null);
-
-  useEffect(() => {
-    if (hasInjectedConfig()) {
-      decodeInjectedConfig()
-        .then(setConfig)
-        .finally(() => setIsResolvedConfig(true));
-    }
-  }, []);
-
-  if (hasInjectedConfig() && !isResolvedConfig) {
-    return null;
-  }
+  const { config } = useInjectedConfig();
 
   return (
     <FlagProvider>

--- a/apps/deploy-web/src/services/decodeInjectedConfig/decodeInjectedConfig.spec.ts
+++ b/apps/deploy-web/src/services/decodeInjectedConfig/decodeInjectedConfig.spec.ts
@@ -14,12 +14,10 @@ describe(decodeInjectedConfig.name, () => {
   });
 
   it("returns null if public key is not provided", async () => {
-    const config = await decodeInjectedConfig(undefined);
+    let config = await decodeInjectedConfig(undefined);
     expect(config).toBeNull();
-  });
 
-  it("returns null if no config is injected", async () => {
-    const config = await decodeInjectedConfig();
+    config = await decodeInjectedConfig();
     expect(config).toBeNull();
   });
 

--- a/apps/deploy-web/tests/fixture/base-test.ts
+++ b/apps/deploy-web/tests/fixture/base-test.ts
@@ -19,9 +19,15 @@ export async function injectUIConfig(page: Page) {
   }
 
   const uiConfig = await getSignedConfig(testEnvConfig.UI_CONFIG_SIGNATURE_PRIVATE_KEY);
-  await page.addInitScript(config => {
-    (window as any).__AK_INJECTED_CONFIG__ = config;
-  }, uiConfig);
+  await page.addInitScript(
+    stringifiedConfig => {
+      const { uiConfig, expectedBaseUrl } = JSON.parse(stringifiedConfig);
+      if (window.location.href.startsWith(expectedBaseUrl)) {
+        (window as any).__AK_INJECTED_CONFIG__ = uiConfig;
+      }
+    },
+    JSON.stringify({ uiConfig, expectedBaseUrl: testEnvConfig.BASE_URL })
+  );
 }
 
 const signedConfigCache = new Map<string, string>();

--- a/apps/deploy-web/tests/fixture/context-with-extension.ts
+++ b/apps/deploy-web/tests/fixture/context-with-extension.ts
@@ -37,6 +37,7 @@ export const test = baseTest.extend<{
     });
 
     await use(context);
+    await context.close();
   },
   extensionId: async ({ context }, use) => {
     let [background] = context.serviceWorkers();
@@ -48,6 +49,12 @@ export const test = baseTest.extend<{
     await use(extensionId);
   },
   page: async ({ context, extensionId }, use) => {
+    try {
+      await context.waitForEvent("page", { timeout: 5000 });
+    } catch {
+      // ignore timeout error
+    }
+
     const extUrl = `chrome-extension://${extensionId}/index.html`;
     let extPage = context.pages().find(page => page.url().startsWith(extUrl));
 


### PR DESCRIPTION
## Why

React renders `<main>` tag 2 times when config is injected (during e2e testing)

## What

1. extracts injected config into a hook
2. inject verified config only on console page urls
3. wait for extension page to open in order to prevent unexpected "target, page, context or browser has been closed" error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new React hook to manage and retrieve injected configuration within the app.

- **Refactor**
  - Simplified configuration handling in the main app by replacing local state logic with the new hook.

- **Bug Fixes**
  - Improved test fixture to ensure configuration is injected only when the page URL matches the expected base URL.
  - Enhanced browser context management in test fixtures for more reliable cleanup and asynchronous page handling.

- **Tests**
  - Added comprehensive tests for the new configuration hook.
  - Consolidated and improved tests for configuration decoding logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->