### PR TITLE
fix(notifications): allows alert pages to registered users only

### DIFF
--- a/apps/deploy-web/src/components/layout/Sidebar.tsx
+++ b/apps/deploy-web/src/components/layout/Sidebar.tsx
@@ -39,6 +39,7 @@ import Link from "next/link";
 
 import { useWallet } from "@src/context/WalletProvider";
 import { useFlag } from "@src/hooks/useFlag";
+import { useUser } from "@src/hooks/useUser";
 import sdlStore from "@src/store/sdlStore";
 import type { ISidebarGroupMenu, ISidebarRoute } from "@src/types";
 import { UrlService } from "@src/utils/urlUtils";
@@ -66,6 +67,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
   const muiTheme = useMuiTheme();
   const smallScreen = useMediaQuery(muiTheme.breakpoints.down("md"));
   const wallet = useWallet();
+  const user = useUser();
   const isAlertsEnabled = useFlag("alerts");
 
   const mainRoutes = useMemo(() => {
@@ -103,7 +105,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
       }
     ];
 
-    if (isAlertsEnabled) {
+    if (isAlertsEnabled && user?.userId) {
       routes.push({
         title: "Alerts",
         icon: props => <MessageAlert {...props} />,
@@ -113,7 +115,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
     }
 
     return routes;
-  }, [isAlertsEnabled]);
+  }, [isAlertsEnabled, user?.userId]);
 
   const routeGroups: ISidebarGroupMenu[] = useMemo(
     () => [

--- a/apps/deploy-web/src/hoc/registered-users-only/registered-users-only.hoc.spec.tsx
+++ b/apps/deploy-web/src/hoc/registered-users-only/registered-users-only.hoc.spec.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { UserProvider } from "@auth0/nextjs-auth0/client";
+import { faker } from "@faker-js/faker";
+
+import { RegisteredUsersOnly } from "./registered-users-only.hoc";
+
+import { render, screen, waitFor } from "@testing-library/react";
+
+describe("RegisteredUsersOnly", () => {
+  it("renders the wrapped component when user is registered", async () => {
+    setup({ isRegistered: true });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("test-component")).toBeInTheDocument();
+      expect(screen.getByText("Test Component Content")).toBeInTheDocument();
+      expect(screen.queryByTestId("fallback")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders fallback component when user is not registered", () => {
+    setup({ isRegistered: false });
+
+    expect(screen.getByTestId("fallback")).toBeInTheDocument();
+    expect(screen.getByText("Default Fallback Content")).toBeInTheDocument();
+    expect(screen.queryByTestId("test-component")).not.toBeInTheDocument();
+  });
+
+  it("passes props to the wrapped component", async () => {
+    setup({
+      isRegistered: true,
+      props: { testProp: "test-value" }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("test-component")).toBeInTheDocument();
+      expect(screen.getByTestId("test-prop")).toBeInTheDocument();
+      expect(screen.getByText("test-value")).toBeInTheDocument();
+    });
+  });
+
+  it("sets the correct displayName", () => {
+    const { TestComponent, FallbackComponent } = setup({ isRegistered: true });
+    const WrappedComponent = RegisteredUsersOnly(TestComponent, FallbackComponent);
+    expect(WrappedComponent.displayName).toBe("RegisteredUsersOnly(TestComponent)");
+  });
+
+  it("handles components without a displayName or name", () => {
+    const { FallbackComponent } = setup({ isRegistered: true });
+    const AnonymousComponent = () => <div>Anonymous</div>;
+    Object.defineProperty(AnonymousComponent, "displayName", { value: undefined });
+    Object.defineProperty(AnonymousComponent, "name", { value: undefined });
+
+    const WrappedAnonymous = RegisteredUsersOnly(AnonymousComponent, FallbackComponent);
+
+    expect(WrappedAnonymous.displayName).toBe("RegisteredUsersOnly(Component)");
+  });
+
+  function setup({ isRegistered = true, props = {} }: { isRegistered?: boolean; props?: Record<string, any>; fallbackComponent?: React.ComponentType }) {
+    const FallbackComponent = () => <div data-testid="fallback">Default Fallback Content</div>;
+
+    const TestComponent = (props: { testProp?: string }) => (
+      <div data-testid="test-component">
+        Test Component Content
+        {props.testProp && <span data-testid="test-prop">{props.testProp}</span>}
+      </div>
+    );
+    TestComponent.displayName = "TestComponent";
+
+    const getProfile = jest.fn().mockResolvedValue(
+      isRegistered
+        ? {
+            userId: faker.string.uuid(),
+            email: faker.internet.email()
+          }
+        : {}
+    );
+
+    const WrappedComponent = RegisteredUsersOnly(TestComponent, FallbackComponent);
+
+    render(
+      <UserProvider fetcher={getProfile}>
+        <WrappedComponent {...props} />
+      </UserProvider>
+    );
+
+    return {
+      FallbackComponent,
+      TestComponent
+    };
+  }
+});

--- a/apps/deploy-web/src/hoc/registered-users-only/registered-users-only.hoc.tsx
+++ b/apps/deploy-web/src/hoc/registered-users-only/registered-users-only.hoc.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+
+import { useUser } from "@src/hooks/useUser";
+import FourOhFour from "@src/pages/404";
+
+export const RegisteredUsersOnly = <P extends object>(Component: React.ComponentType<P>, FallbackComponent = FourOhFour) => {
+  const WithRegisteredUsersOnly = (props: P) => {
+    const user = useUser();
+
+    const isRegistered = !!user?.userId;
+    if (isRegistered) {
+      return <Component {...props} />;
+    }
+
+    return <FallbackComponent />;
+  };
+
+  const displayName = Component.displayName || Component.name || "Component";
+  WithRegisteredUsersOnly.displayName = `RegisteredUsersOnly(${displayName})`;
+
+  return WithRegisteredUsersOnly;
+};

--- a/apps/deploy-web/src/pages/alerts/contact-points/index.tsx
+++ b/apps/deploy-web/src/pages/alerts/contact-points/index.tsx
@@ -1,6 +1,7 @@
 import { ContactPointsPage } from "@src/components/alerts/ContactPointsPage";
-import { featureFlagService } from "@src/services/feature-flag";
+import { RegisteredUsersOnly } from "@src/hoc/registered-users-only/registered-users-only.hoc";
+import { routeProtector } from "@src/services/route-protector";
 
-export default ContactPointsPage;
+export default RegisteredUsersOnly(ContactPointsPage);
 
-export const getServerSideProps = featureFlagService.showIfEnabled("alerts");
+export const getServerSideProps = routeProtector.showToRegisteredUserIfEnabled("alerts");

--- a/apps/deploy-web/src/pages/alerts/contact-points/new.tsx
+++ b/apps/deploy-web/src/pages/alerts/contact-points/new.tsx
@@ -1,6 +1,7 @@
 import { CreateContactPointPage } from "@src/components/alerts/CreateContactPointPage";
-import { featureFlagService } from "@src/services/feature-flag";
+import { RegisteredUsersOnly } from "@src/hoc/registered-users-only/registered-users-only.hoc";
+import { routeProtector } from "@src/services/route-protector";
 
-export default CreateContactPointPage;
+export default RegisteredUsersOnly(CreateContactPointPage);
 
-export const getServerSideProps = featureFlagService.showIfEnabled("alerts");
+export const getServerSideProps = routeProtector.showToRegisteredUserIfEnabled("alerts");

--- a/apps/deploy-web/src/pages/alerts/index.tsx
+++ b/apps/deploy-web/src/pages/alerts/index.tsx
@@ -1,6 +1,7 @@
 import { AlertsPage } from "@src/components/alerts/AlertsPage";
-import { featureFlagService } from "@src/services/feature-flag";
+import { RegisteredUsersOnly } from "@src/hoc/registered-users-only/registered-users-only.hoc";
+import { routeProtector } from "@src/services/route-protector";
 
-export default AlertsPage;
+export default RegisteredUsersOnly(AlertsPage);
 
-export const getServerSideProps = featureFlagService.showIfEnabled("alerts");
+export const getServerSideProps = routeProtector.showToRegisteredUserIfEnabled("alerts");

--- a/apps/deploy-web/src/services/feature-flag/feature-flag.service.ts
+++ b/apps/deploy-web/src/services/feature-flag/feature-flag.service.ts
@@ -30,16 +30,18 @@ export class FeatureFlagService {
     return unleashCookie?.replace(this.UNLEASH_COOKIE_KEY, "");
   }
 
+  async isEnabledForCtx(name: string, ctx: GetServerSidePropsContext) {
+    if (this.config.NEXT_PUBLIC_UNLEASH_ENABLE_ALL) return true;
+
+    const sessionId = this.extractSessionId(ctx);
+
+    return await this.getFlag(name, sessionId);
+  }
+
   showIfEnabled(name: string): GetServerSideProps {
     return async ctx => {
-      if (this.config.NEXT_PUBLIC_UNLEASH_ENABLE_ALL) return { props: {} };
-
-      const sessionId = this.extractSessionId(ctx);
-      const isEnabled = await this.getFlag(name, sessionId);
-
-      if (!isEnabled) return { notFound: true };
-
-      return { props: {} };
+      const isEnabled = await this.isEnabledForCtx(name, ctx);
+      return isEnabled ? { props: {} } : { notFound: true };
     };
   }
 }

--- a/apps/deploy-web/src/services/route-protector/index.ts
+++ b/apps/deploy-web/src/services/route-protector/index.ts
@@ -1,0 +1,6 @@
+import { getSession } from "@auth0/nextjs-auth0";
+
+import { featureFlagService } from "@src/services/feature-flag";
+import { RouteProtectorService } from "@src/services/route-protector/route-protector.service";
+
+export const routeProtector = new RouteProtectorService(featureFlagService, getSession);

--- a/apps/deploy-web/src/services/route-protector/route-protector.service.spec.ts
+++ b/apps/deploy-web/src/services/route-protector/route-protector.service.spec.ts
@@ -1,0 +1,118 @@
+import { faker } from "@faker-js/faker";
+import { mock } from "jest-mock-extended";
+import type { GetServerSidePropsContext } from "next";
+
+import type { FeatureFlagService } from "../feature-flag/feature-flag.service";
+import { RouteProtectorService } from "./route-protector.service";
+
+describe(RouteProtectorService.name, () => {
+  describe("showToRegisteredUserIfEnabled", () => {
+    it("returns props when feature is enabled and user is logged in", async () => {
+      const { service, context } = setup({
+        isFeatureEnabled: true,
+        hasUserSession: true
+      });
+
+      const featureName = faker.word.sample();
+      const result = await service.showToRegisteredUserIfEnabled(featureName)(context);
+
+      expect(result).toEqual({ props: {} });
+    });
+
+    it("returns notFound when feature is enabled but user is not logged in", async () => {
+      const { service, context } = setup({
+        isFeatureEnabled: true,
+        hasUserSession: false
+      });
+
+      const featureName = faker.word.sample();
+      const result = await service.showToRegisteredUserIfEnabled(featureName)(context);
+
+      expect(result).toEqual({ notFound: true });
+    });
+
+    it("returns notFound when feature is disabled but user is logged in", async () => {
+      const { service, context } = setup({
+        isFeatureEnabled: false,
+        hasUserSession: true
+      });
+
+      const featureName = faker.word.sample();
+      const result = await service.showToRegisteredUserIfEnabled(featureName)(context);
+
+      expect(result).toEqual({ notFound: true });
+    });
+
+    it("returns notFound when both feature is disabled and user is not logged in", async () => {
+      const { service, context } = setup({
+        isFeatureEnabled: false,
+        hasUserSession: false
+      });
+
+      const featureName = faker.word.sample();
+      const result = await service.showToRegisteredUserIfEnabled(featureName)(context);
+
+      expect(result).toEqual({ notFound: true });
+    });
+
+    it("calls feature flag service with correct parameters", async () => {
+      const { service, context, featureFlagService } = setup({
+        isFeatureEnabled: true,
+        hasUserSession: true
+      });
+
+      const featureName = faker.word.sample();
+      await service.showToRegisteredUserIfEnabled(featureName)(context);
+
+      expect(featureFlagService.isEnabledForCtx).toHaveBeenCalledWith(featureName, context);
+    });
+
+    it("calls getSession with request and response objects", async () => {
+      const { service, context, getSession } = setup({
+        isFeatureEnabled: true,
+        hasUserSession: true
+      });
+
+      const featureName = faker.word.sample();
+      await service.showToRegisteredUserIfEnabled(featureName)(context);
+
+      expect(getSession).toHaveBeenCalledWith(context.req, context.res);
+    });
+  });
+
+  function setup(options: { isFeatureEnabled: boolean; hasUserSession: boolean }) {
+    const featureFlagService = mock<FeatureFlagService>();
+    featureFlagService.isEnabledForCtx.mockResolvedValue(options.isFeatureEnabled);
+
+    const getSession = jest.fn().mockResolvedValue(
+      options.hasUserSession
+        ? {
+            user: {
+              sub: faker.string.uuid(),
+              email: faker.internet.email(),
+              name: faker.person.fullName(),
+              picture: faker.image.avatar()
+            }
+          }
+        : null
+    );
+
+    const service = new RouteProtectorService(featureFlagService, getSession);
+
+    const context = {
+      req: {
+        headers: {
+          cookie: faker.string.sample(),
+          host: faker.internet.domainName()
+        },
+        url: faker.internet.url()
+      },
+      res: {
+        setHeader: jest.fn(),
+        getHeader: jest.fn()
+      }
+    } as unknown as GetServerSidePropsContext;
+
+    return { service, featureFlagService, getSession, context };
+  }
+});

--- a/apps/deploy-web/src/services/route-protector/route-protector.service.ts
+++ b/apps/deploy-web/src/services/route-protector/route-protector.service.ts
@@ -1,0 +1,26 @@
+import type { GetSession } from "@auth0/nextjs-auth0";
+import type { GetServerSideProps } from "next";
+
+import type { FeatureFlagService } from "../feature-flag/feature-flag.service";
+
+export class RouteProtectorService {
+  constructor(
+    private readonly featureFlagService: FeatureFlagService,
+    private readonly getSession: GetSession
+  ) {}
+
+  showToRegisteredUserIfEnabled(name: string): GetServerSideProps {
+    return async context => {
+      const session = await this.getSession(context.req, context.res);
+      const isEnabled = await this.featureFlagService.isEnabledForCtx(name, context);
+
+      if (isEnabled && session?.user) {
+        return {
+          props: {}
+        };
+      }
+
+      return { notFound: true };
+    };
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added route protection to certain pages, allowing access only for registered users when the relevant feature flag is enabled.
  - Introduced a higher-order component to restrict page access to registered users.
  - Sidebar navigation now conditionally displays the "Alerts" route based on user registration and feature flag status.

- **Bug Fixes**
  - Improved accuracy of sidebar route updates when user information changes.

- **Tests**
  - Added comprehensive tests for user-based route protection and feature flag logic.
  - Expanded and reorganized test coverage for feature flag and route protection services.

- **Refactor**
  - Centralized and streamlined route protection and feature flag evaluation logic for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->