### PR TITLE
fix(notifications): properly names send queue

### DIFF
--- a/apps/notifications/src/common/config/event-key-registry.config.ts
+++ b/apps/notifications/src/common/config/event-key-registry.config.ts
@@ -1,0 +1,7 @@
+import { MsgCloseDeployment } from "@akashnetwork/akash-api/v1beta3";
+
+export const eventKeyRegistry = Object.freeze({
+  blockCreated: "blockchain.v1.block.created",
+  msgCloseDeployment: MsgCloseDeployment["$type"],
+  createNotification: "notifications.v1.notification.create"
+});

--- a/apps/notifications/src/interfaces/alert-events/handlers/chain-events/chain-events.handler.spec.ts
+++ b/apps/notifications/src/interfaces/alert-events/handlers/chain-events/chain-events.handler.spec.ts
@@ -3,6 +3,7 @@ import type { TestingModule } from "@nestjs/testing";
 import { Test } from "@nestjs/testing";
 import type { MockProxy } from "jest-mock-extended";
 
+import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import { BrokerService } from "@src/infrastructure/broker";
 import { ChainBlockCreatedDto } from "@src/modules/alert/dto/chain-block-created.dto";
 import { MsgCloseDeploymentDto } from "@src/modules/alert/dto/msg-close-deployment.dto";
@@ -25,7 +26,7 @@ describe(ChainEventsHandler.name, () => {
       await controller.processDeploymentClosed(mockEvent);
 
       expect(chainMessageAlertService.alertFor).toHaveBeenCalledWith(mockEvent, expect.any(Function));
-      expect(brokerService.publish).toHaveBeenCalledWith("notifications.v1.notification.send", alertMessage);
+      expect(brokerService.publish).toHaveBeenCalledWith(eventKeyRegistry.createNotification, alertMessage);
     });
   });
 
@@ -40,7 +41,7 @@ describe(ChainEventsHandler.name, () => {
       await controller.processBlock(mockBlock);
 
       expect(deploymentBalanceAlertsService.alertFor).toHaveBeenCalledWith(mockBlock, expect.any(Function));
-      expect(brokerService.publish).toHaveBeenCalledWith("notifications.v1.notification.send", alertMessage);
+      expect(brokerService.publish).toHaveBeenCalledWith(eventKeyRegistry.createNotification, alertMessage);
     });
   });
 

--- a/apps/notifications/src/interfaces/alert-events/handlers/chain-events/chain-events.handler.ts
+++ b/apps/notifications/src/interfaces/alert-events/handlers/chain-events/chain-events.handler.ts
@@ -1,6 +1,6 @@
-import { MsgCloseDeployment } from "@akashnetwork/akash-api/v1beta3";
 import { Injectable } from "@nestjs/common";
 
+import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import { BrokerService, Handler } from "@src/infrastructure/broker";
 import { ChainBlockCreatedDto } from "@src/modules/alert/dto/chain-block-created.dto";
 import { MsgCloseDeploymentDto } from "@src/modules/alert/dto/msg-close-deployment.dto";
@@ -16,18 +16,18 @@ export class ChainEventsHandler {
   ) {}
 
   @Handler({
-    key: "blockchain.v1.block.created",
+    key: eventKeyRegistry.blockCreated,
     dto: ChainBlockCreatedDto
   })
   async processBlock(block: ChainBlockCreatedDto) {
-    await this.deploymentBalanceAlertsService.alertFor(block, message => this.brokerService.publish("notifications.v1.notification.send", message));
+    await this.deploymentBalanceAlertsService.alertFor(block, message => this.brokerService.publish(eventKeyRegistry.createNotification, message));
   }
 
   @Handler({
-    key: MsgCloseDeployment["$type"],
+    key: eventKeyRegistry.msgCloseDeployment,
     dto: MsgCloseDeploymentDto
   })
   async processDeploymentClosed(event: MsgCloseDeploymentDto) {
-    await this.chainMessageAlertService.alertFor(event, message => this.brokerService.publish("notifications.v1.notification.send", message));
+    await this.chainMessageAlertService.alertFor(event, message => this.brokerService.publish(eventKeyRegistry.createNotification, message));
   }
 }

--- a/apps/notifications/src/interfaces/notifications-events/handlers/notification/notification.handler.ts
+++ b/apps/notifications/src/interfaces/notifications-events/handlers/notification/notification.handler.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@nestjs/common";
 
+import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import { Handler } from "@src/infrastructure/broker";
 import { NotificationCommandDto } from "@src/modules/notifications/dto/NotificationCommand.dto";
 import { NotificationRouterService } from "@src/modules/notifications/services/notification-router/notification-router.service";
@@ -9,7 +10,7 @@ export class NotificationHandler {
   constructor(private readonly notificationRouter: NotificationRouterService) {}
 
   @Handler({
-    key: "notifications.v1.notification.create",
+    key: eventKeyRegistry.createNotification,
     dto: NotificationCommandDto
   })
   async send(event: NotificationCommandDto) {

--- a/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.spec.ts
+++ b/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.spec.ts
@@ -6,6 +6,7 @@ import { Test } from "@nestjs/testing";
 import type { MockProxy } from "jest-mock-extended";
 import { setTimeout as delay } from "timers/promises";
 
+import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import { LoggerService } from "@src/common/services/logger/logger.service";
 import { ShutdownService } from "@src/common/services/shutdown/shutdown.service";
 import { BrokerService } from "@src/infrastructure/broker";
@@ -43,7 +44,7 @@ describe(ChainEventsPollerService.name, () => {
 
     expect(module.get(BrokerService).publishAll).toHaveBeenCalledWith([
       {
-        eventName: "blockchain.v1.block.created",
+        eventName: eventKeyRegistry.blockCreated,
         event: { height: mockBlock.height }
       },
       {

--- a/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.ts
+++ b/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.ts
@@ -6,6 +6,7 @@ import { backOff } from "exponential-backoff";
 import { BehaviorSubject, filter, firstValueFrom } from "rxjs";
 import { setTimeout as delay } from "timers/promises";
 
+import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import { LoggerService } from "@src/common/services/logger/logger.service";
 import { ShutdownService } from "@src/common/services/shutdown/shutdown.service";
 import { BrokerService } from "@src/infrastructure/broker";
@@ -91,7 +92,7 @@ export class ChainEventsPollerService implements OnModuleInit, OnModuleDestroy {
 
       await this.brokerService.publishAll([
         {
-          eventName: "blockchain.v1.block.created",
+          eventName: eventKeyRegistry.blockCreated,
           event: {
             height: block.height
           }

--- a/apps/notifications/test/functional/balance-alert.spec.ts
+++ b/apps/notifications/test/functional/balance-alert.spec.ts
@@ -6,6 +6,7 @@ import { Test } from "@nestjs/testing";
 import type { NodePgDatabase } from "drizzle-orm/node-postgres";
 import nock from "nock";
 
+import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import { BrokerService } from "@src/infrastructure/broker";
 import { DRIZZLE_PROVIDER_TOKEN } from "@src/infrastructure/db/config/db.config";
 import AlertEventsModule from "@src/interfaces/alert-events/alert-events.module";
@@ -97,7 +98,7 @@ describe("balance alerts", () => {
 
     expect(alertsProcessed).toBe(1);
     expect(brokerService.publish).toHaveBeenCalledTimes(1);
-    expect(brokerService.publish).toHaveBeenCalledWith("notifications.v1.notification.send", {
+    expect(brokerService.publish).toHaveBeenCalledWith(eventKeyRegistry.createNotification, {
       contactPointId: contactPoint.id,
       payload: {
         summary: `[FIRING] deployment low: ${matchingDseq}`,

--- a/apps/notifications/test/functional/chain-message-alert.spec.ts
+++ b/apps/notifications/test/functional/chain-message-alert.spec.ts
@@ -2,6 +2,7 @@ import { generateMock } from "@anatine/zod-mock";
 import { faker } from "@faker-js/faker";
 import { Test } from "@nestjs/testing";
 
+import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import { BrokerService } from "@src/infrastructure/broker";
 import { DRIZZLE_PROVIDER_TOKEN } from "@src/infrastructure/db/config/db.config";
 import AlertEventsModule from "@src/interfaces/alert-events/alert-events.module";
@@ -81,7 +82,7 @@ describe("chain message alerts", () => {
     await controller.processDeploymentClosed(message);
 
     expect(brokerService.publish).toHaveBeenCalledTimes(1);
-    expect(brokerService.publish).toHaveBeenCalledWith("notifications.v1.notification.send", {
+    expect(brokerService.publish).toHaveBeenCalledWith(eventKeyRegistry.createNotification, {
       contactPointId: contactPoint.id,
       payload: {
         summary: `deployment ${dseq} closed`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Centralized event key strings into a shared registry for improved consistency and maintainability across notification and blockchain event handling.
- **Bug Fixes**
  - Updated notification events to use the topic "notifications.v1.notification.create" instead of "notifications.v1.notification.send" for improved consistency in published notifications.
- **Tests**
  - Adjusted test cases to verify the new notification topic and event keys, ensuring accurate validation of event publishing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->