### PR TITLE
refactor(contact-point): decouple list components, rename pagination methods

### DIFF
--- a/apps/deploy-web/src/components/alerts/ContactPointsListContainer/ContactPointsListContainer.spec.tsx
+++ b/apps/deploy-web/src/components/alerts/ContactPointsListContainer/ContactPointsListContainer.spec.tsx
@@ -116,7 +116,7 @@ describe("ContactPointsListContainer", () => {
         <ServicesProvider services={services}>
           <QueryClientProvider client={queryClient}>
             <ContactPointsListContainer>
-              {({ data, pagination, onPageChange, removingIds, isLoading, isError, onRemove }) => (
+              {({ data, pagination, onPaginationChange, removingIds, isLoading, isError, onRemove }) => (
                 <div>
                   {isLoading && <div>Loading...</div>}
                   {isError && <div>Error loading contact points</div>}
@@ -134,12 +134,16 @@ describe("ContactPointsListContainer", () => {
                     <span>
                       Page {pagination.page} of {pagination.totalPages}
                     </span>
-                    <button data-testid="prev-page-button" onClick={() => onPageChange(pagination.page - 1, pagination.limit)} disabled={pagination.page <= 1}>
+                    <button
+                      data-testid="prev-page-button"
+                      onClick={() => onPaginationChange(pagination.page - 1, pagination.limit)}
+                      disabled={pagination.page <= 1}
+                    >
                       Previous
                     </button>
                     <button
                       data-testid="next-page-button"
-                      onClick={() => onPageChange(pagination.page, pagination.limit)}
+                      onClick={() => onPaginationChange(pagination.page, pagination.limit)}
                       disabled={pagination.page >= pagination.totalPages}
                     >
                       Next

--- a/apps/deploy-web/src/components/alerts/ContactPointsListContainer/ContactPointsListContainer.spec.tsx
+++ b/apps/deploy-web/src/components/alerts/ContactPointsListContainer/ContactPointsListContainer.spec.tsx
@@ -136,14 +136,24 @@ describe("ContactPointsListContainer", () => {
                     </span>
                     <button
                       data-testid="prev-page-button"
-                      onClick={() => onPaginationChange(pagination.page - 1, pagination.limit)}
+                      onClick={() =>
+                        onPaginationChange({
+                          page: pagination.page - 1,
+                          limit: pagination.limit
+                        })
+                      }
                       disabled={pagination.page <= 1}
                     >
                       Previous
                     </button>
                     <button
                       data-testid="next-page-button"
-                      onClick={() => onPaginationChange(pagination.page, pagination.limit)}
+                      onClick={() =>
+                        onPaginationChange({
+                          page: pagination.page + 1,
+                          limit: pagination.limit
+                        })
+                      }
                       disabled={pagination.page >= pagination.totalPages}
                     >
                       Next

--- a/apps/deploy-web/src/components/alerts/ContactPointsListContainer/ContactPointsListContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/ContactPointsListContainer/ContactPointsListContainer.tsx
@@ -5,14 +5,25 @@ import React from "react";
 import { useCallback, useState } from "react";
 import type { components } from "@akashnetwork/react-query-sdk/notifications";
 
-import type { ContactPointsListViewProps } from "@src/components/alerts/ContactPointsListView/ContactPointsListView";
 import { useServices } from "@src/context/ServicesProvider";
 import { useNotificator } from "@src/hooks/useNotificator";
 
-export type ContactPoint = components["schemas"]["ContactPointOutput"]["data"];
+type ContactPoint = components["schemas"]["ContactPointOutput"]["data"];
+type ContactPointsInput = components["schemas"]["ContactPointListOutput"]["data"];
+type ContactPointsPagination = components["schemas"]["ContactPointListOutput"]["pagination"];
+
+type ChildrenProps = {
+  data: ContactPointsInput;
+  pagination: Pick<ContactPointsPagination, "page" | "limit" | "total" | "totalPages">;
+  isLoading: boolean;
+  removingIds: Set<ContactPoint["id"]>;
+  onRemove: (id: ContactPoint["id"]) => Promise<void>;
+  onPaginationChange: (state: { page: number; limit: number }) => void;
+  isError: boolean;
+};
 
 type ContactPointsListContainerProps = {
-  children: (props: ContactPointsListViewProps) => ReactNode;
+  children: (props: ChildrenProps) => ReactNode;
 };
 
 export const ContactPointsListContainer: FC<ContactPointsListContainerProps> = ({ children }) => {
@@ -62,9 +73,9 @@ export const ContactPointsListContainer: FC<ContactPointsListContainerProps> = (
     [mutation, data?.data.length, page, refetch, notificator]
   );
 
-  const changePage = useCallback((page: number, pageSize: number) => {
-    setPage(page + 1);
-    setLimit(pageSize);
+  const changePage = useCallback(({ page, limit }: { page: number; limit: number }) => {
+    setPage(page);
+    setLimit(limit);
   }, []);
 
   return (
@@ -77,7 +88,7 @@ export const ContactPointsListContainer: FC<ContactPointsListContainerProps> = (
           totalPages: data?.pagination.totalPages ?? 0
         },
         data: data?.data || [],
-        onPageChange: changePage,
+        onPaginationChange: changePage,
         onRemove: remove,
         removingIds,
         isLoading,

--- a/apps/deploy-web/src/components/alerts/ContactPointsListView/ContactPointsListView.spec.tsx
+++ b/apps/deploy-web/src/components/alerts/ContactPointsListView/ContactPointsListView.spec.tsx
@@ -109,7 +109,7 @@ describe("ContactPointsListView", () => {
       isLoading: false,
       onRemove: jest.fn(),
       removingIds: new Set(),
-      onPageChange: jest.fn(),
+      onPaginationChange: jest.fn(),
       isError: false,
       ...props
     };

--- a/apps/deploy-web/src/components/alerts/ContactPointsListView/ContactPointsListView.tsx
+++ b/apps/deploy-web/src/components/alerts/ContactPointsListView/ContactPointsListView.tsx
@@ -21,9 +21,9 @@ import { createColumnHelper, flexRender, getCoreRowModel, useReactTable } from "
 import { Bin, Edit } from "iconoir-react";
 import Link from "next/link";
 
-import type { ContactPoint } from "@src/components/alerts/ContactPointsListContainer/ContactPointsListContainer";
 import { UrlService } from "@src/utils/urlUtils";
 
+type ContactPoint = components["schemas"]["ContactPointOutput"]["data"];
 type ContactPointsInput = components["schemas"]["ContactPointListOutput"]["data"];
 type ContactPointsPagination = components["schemas"]["ContactPointListOutput"]["pagination"];
 
@@ -33,11 +33,11 @@ export type ContactPointsListViewProps = {
   isLoading: boolean;
   removingIds: Set<ContactPoint["id"]>;
   onRemove: (id: ContactPoint["id"]) => Promise<void>;
-  onPageChange: (page: number, limit: number) => void;
+  onPaginationChange: (state: { page: number; limit: number }) => void;
   isError: boolean;
 };
 
-export const ContactPointsListView: FC<ContactPointsListViewProps> = ({ data, pagination, onPageChange, isLoading, removingIds, onRemove, isError }) => {
+export const ContactPointsListView: FC<ContactPointsListViewProps> = ({ data, pagination, onPaginationChange, isLoading, removingIds, onRemove, isError }) => {
   const { confirm } = usePopup();
   const columnHelper = createColumnHelper<ContactPoint>();
 
@@ -118,8 +118,11 @@ export const ContactPointsListView: FC<ContactPointsListViewProps> = ({ data, pa
       }
     },
     onPaginationChange: updaterOrValue => {
-      const tablePagination = typeof updaterOrValue === "function" ? updaterOrValue(table.getState().pagination) : updaterOrValue;
-      onPageChange(tablePagination.pageIndex, tablePagination.pageSize);
+      const { pageIndex, pageSize } = typeof updaterOrValue === "function" ? updaterOrValue(table.getState().pagination) : updaterOrValue;
+      onPaginationChange({
+        page: pageIndex + 1,
+        limit: pageSize
+      });
     }
   });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Unified the pagination callback across relevant components and tests by renaming the prop to `onPaginationChange` and updating its usage to accept a single object with `page` and `limit`.
  - Improved type definitions for component props related to pagination and data handling.

- **Tests**
  - Updated test files to reflect the new pagination callback name and signature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->