### PR TITLE
fix: add indexer to github release

### DIFF
--- a/.github/workflows/reusable-create-github-release.yml
+++ b/.github/workflows/reusable-create-github-release.yml
@@ -58,6 +58,8 @@ jobs:
             git_tag="stats-web/v$git_tag"
           elif [ "${{ inputs.app }}" = "notifications" ]; then
             git_tag="notifications/v$git_tag"
+          elif [ "${{ inputs.app }}" = "indexer" ]; then
+            git_tag="indexer/v$git_tag"
           else
             echo "Error: Unsupported app type '${{ inputs.app }}'."
             exit 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release workflow to support a new application type "indexer" with appropriately prefixed version tags during GitHub releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->