### PR TITLE
fix: fixes unathorized response from provider API

### DIFF
--- a/apps/deploy-web/src/pages/_app.tsx
+++ b/apps/deploy-web/src/pages/_app.tsx
@@ -75,7 +75,11 @@ const App: React.FunctionComponent<Props> = props => {
 
         <UserProviders>
           <WalletProvider>
-            <Component {...pageProps} />
+            <CertificateProvider>
+              <BackgroundTaskProvider>
+                <Component {...pageProps} />
+              </BackgroundTaskProvider>
+            </CertificateProvider>
           </WalletProvider>
         </UserProviders>
       </>
@@ -105,11 +109,7 @@ function AppRoot(props: Props & { children: React.ReactNode }) {
                               <ServicesProvider>
                                 <CustomChainProvider>
                                   <ChainParamProvider>
-                                    <CertificateProvider>
-                                      <BackgroundTaskProvider>
-                                        <LocalNoteProvider>{props.children}</LocalNoteProvider>
-                                      </BackgroundTaskProvider>
-                                    </CertificateProvider>
+                                    <LocalNoteProvider>{props.children}</LocalNoteProvider>
                                   </ChainParamProvider>
                                 </CustomChainProvider>
                               </ServicesProvider>


### PR DESCRIPTION
## Why

Provider API returns 401 for sendManifest command because certificate is not included in the request



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the placement of certain context providers to improve the structure of the application. This change does not affect user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->