### PR TITLE
fix: fixes e2e tests and adds closeDeployments script

### DIFF
--- a/.github/actions/console-web-ui-testing/action.yml
+++ b/.github/actions/console-web-ui-testing/action.yml
@@ -43,6 +43,12 @@ runs:
       shell: bash
       continue-on-error: true
       run: npm run test:e2e --workspace=apps/deploy-web
+    - name: Tests cleanup
+      shell: bash
+      env:
+        TEST_WALLET_MNEMONIC: ${{ inputs.test-wallet-mnemonic }}
+      run: |
+        npx ts-node -P packages/dev-config/tsconfig.base-node.json apps/deploy-web/script/closeDeployments.ts
     - uses: actions/upload-artifact@v4
       id: playwright-report
       if: ${{ !cancelled() }}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -141,7 +141,7 @@
     "prettier-plugin-tailwindcss": "^0.6.1",
     "supertest": "^6.1.5",
     "ts-jest": "^29.1.4",
-    "ts-loader": "^9.2.5",
+    "ts-loader": "^9.5.2",
     "type-fest": "^4.26.1",
     "typescript": "~5.8.2",
     "webpack": "^5.91.0",

--- a/apps/api/tsconfig.build.json
+++ b/apps/api/tsconfig.build.json
@@ -5,7 +5,7 @@
     "paths": {
       "@src/*": ["./src/*"],
       "@test/*": ["./test/*"]
-    },
+    }
   },
   "extends": "@akashnetwork/dev-config/tsconfig.base-node.json"
 }

--- a/apps/api/webpack.dev.js
+++ b/apps/api/webpack.dev.js
@@ -6,6 +6,7 @@ const webpack = require("webpack");
 
 const { NODE_ENV = "development" } = process.env;
 
+/** @type {import('webpack').Configuration} */
 module.exports = {
   entry: "./src/index.ts",
   mode: NODE_ENV,

--- a/apps/api/webpack.prod.js
+++ b/apps/api/webpack.prod.js
@@ -6,6 +6,7 @@ const hq = require("alias-hq");
 
 const { NODE_ENV = "production" } = process.env;
 
+/** @type {import('webpack').Configuration} */
 module.exports = {
   entry: "./src/index.ts",
   mode: NODE_ENV,

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -173,6 +173,7 @@
     "prettier": "^3.3.0",
     "prettier-plugin-tailwindcss": "^0.6.1",
     "tailwindcss": "^3.4.3",
+    "ts-node": "^10.9.2",
     "typescript": "~5.8.2",
     "whatwg-fetch": "^3.6.20"
   },

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
@@ -220,7 +220,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq }) => {
           <Tabs value={activeTab} onValueChange={onChangeTab}>
             <TabsList className={cn("grid w-full", `grid-cols-${tabs.length}`)}>
               {tabs.map(tab => (
-                <TabsTrigger key={tab.value} value={tab.value} data-testid={tab.value.toLowerCase()}>
+                <TabsTrigger key={tab.value} value={tab.value}>
                   {tab.label}
                 </TabsTrigger>
               ))}

--- a/apps/deploy-web/src/components/deployments/LeaseRow.tsx
+++ b/apps/deploy-web/src/components/deployments/LeaseRow.tsx
@@ -378,7 +378,7 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(
                     <>
                       <div className="mt-2">
                         <LabelValueOld label="URI(s):" />
-                        <ul className="mt-2 space-y-2">
+                        <ul className="mt-2 space-y-2" aria-label="URIs">
                           {service.uris.map(uri => {
                             return (
                               <li className="flex items-center" key={uri}>

--- a/apps/deploy-web/tests/pages/DeployBasePage.tsx
+++ b/apps/deploy-web/tests/pages/DeployBasePage.tsx
@@ -68,8 +68,8 @@ export class DeployBasePage {
   async validateLease() {
     await this.page.waitForURL(new RegExp(`${testEnvConfig.BASE_URL}/deployments/\\d+`));
     await expect(this.page.getByText("SuccessfulCreate", { exact: true })).toBeVisible({ timeout: 10000 });
-    await this.page.getByTestId("deployment-tab-leases").click();
-    await this.page.getByTestId("lease-list-row-0").isVisible();
+    await this.page.getByRole("tab", { name: /Leases/i }).click();
+    await this.page.getByLabel(/URIs/i).getByRole("link").first().isVisible();
     await expect(this.page.getByTestId("lease-row-0-state")).toHaveText("active");
   }
 

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -86,7 +86,7 @@
     "prettier-plugin-tailwindcss": "^0.6.1",
     "supertest": "^6.1.5",
     "ts-jest": "^29.1.4",
-    "ts-loader": "^9.5.1",
+    "ts-loader": "^9.5.2",
     "typescript": "~5.8.2",
     "webpack": "^5.91.0",
     "webpack-cli": "4.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
       },
       "engines": {
         "node": "22.14.0",
-        "npm": "11.2.0"
+        "npm": "^11.2.0"
       }
     },
     "apps/api": {
@@ -143,7 +143,7 @@
         "prettier-plugin-tailwindcss": "^0.6.1",
         "supertest": "^6.1.5",
         "ts-jest": "^29.1.4",
-        "ts-loader": "^9.2.5",
+        "ts-loader": "^9.5.2",
         "type-fest": "^4.26.1",
         "typescript": "~5.8.2",
         "webpack": "^5.91.0",
@@ -1123,20 +1123,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "apps/api/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "apps/api/node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -1304,6 +1290,7 @@
         "prettier": "^3.3.0",
         "prettier-plugin-tailwindcss": "^0.6.1",
         "tailwindcss": "^3.4.3",
+        "ts-node": "^10.9.2",
         "typescript": "~5.8.2",
         "whatwg-fetch": "^3.6.20"
       }
@@ -1382,6 +1369,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "apps/deploy-web/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "apps/deploy-web/node_modules/dotenv": {
       "version": "16.4.5",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
@@ -1421,18 +1415,48 @@
         "node": "^8.1 || >=10.*"
       }
     },
-    "apps/deploy-web/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+    "apps/deploy-web/node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
       },
-      "engines": {
-        "node": ">=14.17"
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "apps/indexer": {
@@ -1499,7 +1523,7 @@
         "prettier-plugin-tailwindcss": "^0.6.1",
         "supertest": "^6.1.5",
         "ts-jest": "^29.1.4",
-        "ts-loader": "^9.5.1",
+        "ts-loader": "^9.5.2",
         "typescript": "~5.8.2",
         "webpack": "^5.91.0",
         "webpack-cli": "4.10.0",
@@ -2164,20 +2188,6 @@
       "version": "0.1.14",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.14.tgz",
       "integrity": "sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A=="
-    },
-    "apps/indexer/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
     },
     "apps/notifications": {
       "name": "@akashnetwork/notifications",
@@ -3116,19 +3126,6 @@
         "node": ">=6"
       }
     },
-    "apps/notifications/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "apps/notifications/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -3230,20 +3227,6 @@
       "integrity": "sha512-6hzdNH5723A4FLaYZWpK50iyZH8iS2Jq5zuPRRotOFkhu6kxxJiebVdJ72tCR5XkiIeYFOU5NUawFZOac+VeYw==",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "apps/provider-console/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "apps/provider-proxy": {
@@ -4007,20 +3990,6 @@
         "node": ">=10"
       }
     },
-    "apps/provider-proxy/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "apps/provider-proxy/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -4128,20 +4097,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "apps/stats-web/node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -14617,20 +14572,6 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/@openapi-qraft/cli/node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@openapi-qraft/plugin": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@openapi-qraft/plugin/-/plugin-2.6.0.tgz",
@@ -24355,12 +24296,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.13.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.11.tgz",
-      "integrity": "sha512-iEUCUJoU0i3VnrCmgoWCXttklWcvoCIx4jzcP22fioIVSdTmjgoEvmAO/QPw6TcS9k5FrNgn4w7q5lGOd1CT5g==",
+      "version": "22.15.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -48530,20 +48471,6 @@
         "node": "^18 || >=20"
       }
     },
-    "node_modules/swagger-typescript-api/node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/swagger-ui-dist": {
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
@@ -50012,7 +49939,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.1.3",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -50157,9 +50086,9 @@
       "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -52533,7 +52462,8 @@
         "@cosmjs/proto-signing": "^0.32.4",
         "@faker-js/faker": "^9.7.0",
         "@types/elliptic": "^6.4.18",
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "typescript": "~5.8.2"
       }
     },
     "packages/jwt/node_modules/@cosmjs/crypto": {
@@ -52753,7 +52683,8 @@
       "version": "0.0.2",
       "license": "Apache-2.0",
       "devDependencies": {
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "typescript": "~5.8.2"
       }
     },
     "packages/network-store": {
@@ -52854,7 +52785,7 @@
         "tailwind-scrollbar": "^3.1.0",
         "tailwindcss": "^3.4.3",
         "tailwindcss-animate": "^1.0.7",
-        "typescript": "5.1.3"
+        "typescript": "~5.8.2"
       }
     },
     "packages/ui/node_modules/lucide-react": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "packageManager": "npm@11.2.0",
   "engines": {
     "node": "22.14.0",
-    "npm": "11.2.0"
+    "npm": "^11.2.0"
   },
   "volta": {
     "node": "22.14.0",

--- a/packages/jwt/package.json
+++ b/packages/jwt/package.json
@@ -11,7 +11,7 @@
   "main": "src/index.ts",
   "scripts": {
     "format": "prettier --write ./*.{ts,json} 'src/**/*.{ts,json}'",
-    "generate": "ts-node scripts/generate.ts && npm run format",
+    "generate": "node --experimental-strip-types scripts/generate.ts && npm run format",
     "lint": "eslint .",
     "test": "npm run generate && jest",
     "test:cov": "npm run test -- --coverage",
@@ -33,6 +33,7 @@
     "@cosmjs/proto-signing": "^0.32.4",
     "@faker-js/faker": "^9.7.0",
     "@types/elliptic": "^6.4.18",
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "typescript": "~5.8.2"
   }
 }

--- a/packages/jwt/scripts/generate.ts
+++ b/packages/jwt/scripts/generate.ts
@@ -1,8 +1,10 @@
 import * as fsp from "fs/promises";
-import { join as joinPath, normalize } from "path";
+import { dirname, join as joinPath, normalize } from "path";
+import { fileURLToPath } from "url";
 
-const PROJECT_DIR = normalize(joinPath(__dirname, "..", "..", ".."));
-const PACKAGE_DIR = normalize(joinPath(__dirname, ".."));
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const PROJECT_DIR = normalize(joinPath(scriptDir, "..", "..", ".."));
+const PACKAGE_DIR = normalize(joinPath(scriptDir, ".."));
 const OUT_DIR = joinPath(PACKAGE_DIR, "src", "generated");
 const BRANCH = process.env.AKASH_API_BRANCH || "refs/heads/main";
 const JWT_SCHEMA_URL = `https://raw.githubusercontent.com/akash-network/akash-api/${BRANCH}/specs/jwt-schema.json`;

--- a/packages/net/package.json
+++ b/packages/net/package.json
@@ -11,13 +11,14 @@
   "main": "src/index.ts",
   "scripts": {
     "format": "prettier --write ./*.{ts,json} './src/**/*.{ts,json}'",
-    "generate": "ts-node scripts/generate.ts && npm run format",
+    "generate": "node --experimental-strip-types scripts/generate.ts && npm run format",
     "lint": "eslint .",
     "test": "npm run generate && jest",
     "test:cov": "npm run test -- --coverage",
     "validate:types": "tsc --noEmit && echo"
   },
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "typescript": "~5.8.2"
   }
 }

--- a/packages/net/scripts/generate.ts
+++ b/packages/net/scripts/generate.ts
@@ -1,8 +1,10 @@
 import fsp from "fs/promises";
-import { join as joinPath, normalize } from "path";
+import { dirname, join as joinPath, normalize } from "path";
+import { fileURLToPath } from "url";
 
-const PROJECT_DIR = normalize(joinPath(__dirname, "..", "..", ".."));
-const PACKAGE_DIR = normalize(joinPath(__dirname, ".."));
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const PROJECT_DIR = normalize(joinPath(scriptDir, "..", "..", ".."));
+const PACKAGE_DIR = normalize(joinPath(scriptDir, ".."));
 const OUT_DIR = joinPath(PACKAGE_DIR, "src", "generated");
 const AKASH_NET_BASE = "https://raw.githubusercontent.com/akash-network/net/main";
 const networks = ["mainnet", "sandbox", "testnet-02"];

--- a/packages/net/src/NetConfig/NetConfig.ts
+++ b/packages/net/src/NetConfig/NetConfig.ts
@@ -20,4 +20,9 @@ export class NetConfig {
         return null;
     }
   }
+
+  getBaseRpcUrl(network: SupportedChainNetworks): string {
+    const rpcUrls = netConfigData[network].rpcUrls;
+    return rpcUrls[0];
+  }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -74,6 +74,6 @@
     "tailwind-scrollbar": "^3.1.0",
     "tailwindcss": "^3.4.3",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "5.1.3"
+    "typescript": "~5.8.2"
   }
 }


### PR DESCRIPTION
## Why

Currently e2e tests are broken by recent changes in the deploy-web. ref #1354

## What

1. Fixes e2e tests
2. adds closeDeployments script which is executed after e2e tests to ensure that e2e tests do not occupy all resources on sandbox providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved accessibility by adding an accessible label to the list of service URIs in deployments.
- **Testing**
  - Updated test logic to use role-based selectors and accessible labels for lease validation.
  - Added a cleanup step to automated end-to-end test workflows.
- **Dependencies**
  - Updated and added various development dependencies, including TypeScript, ts-node, and ts-loader, across multiple packages.
- **Documentation**
  - Added type annotations to Webpack configuration files for improved editor support.
- **Other Improvements**
  - Enhanced compatibility with ES modules in internal scripts.
  - Corrected JSON formatting in configuration files.
  - Relaxed version constraints for npm and TypeScript dependencies.
  - Removed test identifiers from deployment detail tabs for a cleaner UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->