### PR TITLE
chore: adds cursor rules related to using setup function instead of beforeEach

### DIFF
--- a/.cursor/rules/query-by-in-tests.mdc
+++ b/.cursor/rules/query-by-in-tests.mdc
@@ -1,0 +1,37 @@
+---
+description:
+globs: apps/deploy-web/**/*.spec.tsx,apps/provider-console/**/*.spec.tsx
+alwaysApply: false
+---
+# Use queryBy instead of getBy in test expectations
+
+## Description
+- Use `queryBy` methods instead of `getBy` methods in test expectations
+- `queryBy` methods return `null` if element is not found, making it safer for testing both presence and absence of elements
+- `getBy` methods throw an error if element is not found, which can make tests harder to debug
+
+## File Pattern
+`*.spec.tsx`
+
+## Examples
+
+### Good
+```typescript
+// Testing presence of element
+expect(screen.queryByText("John Doe")).toBeInTheDocument();
+
+// Testing absence of element
+expect(screen.queryByText("John Doe")).not.toBeInTheDocument();
+```
+
+### Bad
+```typescript
+// Using getBy for presence check
+expect(screen.getByText("John Doe")).toBeInTheDocument();
+
+// Using getBy for absence check (will throw error)
+expect(screen.getByText("John Doe")).not.toBeInTheDocument();
+```
+
+## References
+- [DeploymentName.spec.tsx](mdc:apps/deploy-web/src/components/deployments/DeploymentName/DeploymentName.spec.tsx)

--- a/.cursor/rules/setup-instead-of-before-each.mdc
+++ b/.cursor/rules/setup-instead-of-before-each.mdc
@@ -1,0 +1,51 @@
+---
+description:
+globs: **/*.spec.tsx,**/*.spec.ts
+alwaysApply: false
+---
+# Use setup function instead of beforeEach
+
+## Description
+- Use `setup` function instead of `beforeEach`
+- `setup` function must be at the bottom of the root `describe` block
+- `setup` function creates an object under test and returns it
+- `setup` function should accept a single parameter with inline type definition
+- Don't use shared state in `setup` function
+- Don't specify return type of `setup` function
+
+## Examples
+
+### Good
+```typescript
+describe("UserProfile", () => {
+  it("renders user name when provided", () => {
+    setup({ name: "John Doe" });
+    expect(screen.queryByText("John Doe")).toBeInTheDocument();
+  });
+
+  function setup(input: { name?: string; email?: string; isLoading?: boolean; error?: string }) {
+    render(<UserProfile {...input} />);
+    return input;
+  }
+});
+```
+
+### Bad
+```typescript
+describe("UserProfile", () => {
+  let props: UserProfileProps;
+
+  beforeEach(() => {
+    props = { name: "John Doe" };
+    render(<UserProfile {...props} />);
+  });
+
+  it("renders user name when provided", () => {
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+  });
+});
+```
+
+## References
+- [DeploymentName.spec.tsx](mdc:apps/deploy-web/src/components/deployments/DeploymentName/DeploymentName.spec.tsx)
+- https://github.com/akash-network/console/discussions/910


### PR DESCRIPTION
## Why

ref https://github.com/akash-network/console/discussions/910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added new guidelines for writing tests, recommending the use of `queryBy` methods over `getBy` methods for safer assertions.
	- Introduced a rule advising the use of a `setup` function instead of `beforeEach` in test suites, with examples and best practices provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->