### PR TITLE
fix: generation of dashboard data result

### DIFF
--- a/apps/api/src/dashboard/controllers/dashboard-data/dashboard-data.controller.ts
+++ b/apps/api/src/dashboard/controllers/dashboard-data/dashboard-data.controller.ts
@@ -46,15 +46,15 @@ export class DashboardDataController {
 
   async getDashboardData(): Promise<DashboardDataResponse> {
     const [{ now, compare }, chainStatsQuery, networkCapacity, networkCapacityStats, latestBlocks, latestTransactions] = await Promise.all([
-      runOrLog(this.statsService.getDashboardData, cloneDeep(emptyDashboardData)),
-      runOrLog(this.statsService.getChainStats, {
+      runOrLog(() => this.statsService.getDashboardData(), cloneDeep(emptyDashboardData)),
+      runOrLog(() => this.statsService.getChainStats(), {
         bondedTokens: 0,
         totalSupply: 0,
         communityPool: 0,
         inflation: 0,
         stakingAPR: undefined
       }),
-      runOrLog(this.statsService.getNetworkCapacity, cloneDeep(emptyNetworkCapacity)),
+      runOrLog(() => this.statsService.getNetworkCapacity(), cloneDeep(emptyNetworkCapacity)),
       runOrLog(() => this.providerGraphDataService.getProviderGraphData("count"), cloneDeep(emptyProviderGraphData)),
       runOrLog(() => this.akashBlockService.getBlocks(5), []),
       runOrLog(() => this.transactionService.getTransactions(5), [])


### PR DESCRIPTION
## Why

Issue found in logs

## What

```
TypeError: Cannot read properties of undefined (reading 'cosmosHttpService')
    at /app/apps/api/dist/server.js:122384:39
    at /app/apps/api/dist/server.js:134823:22
    at getChainStats (/app/apps/api/dist/server.js:122383:46)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async cacheResponse (/app/apps/api/dist/server.js:3181:17)
    at async memoizedFunction (/app/apps/api/dist/server.js:3145:16)
    at async /app/apps/api/dist/server.js:134823:16
    at async Promise.all (index 1)
    at async DashboardDataController.getDashboardData (/app/apps/api/dist/server.js:241057:126)
    at async routeDashboardData (/app/apps/api/dist/server.js:609131:22)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of dashboard data loading by updating how data is fetched in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->