### PR TITLE
fix: adds suppressBySystem flag to alerts params

### DIFF
--- a/apps/notifications/src/interfaces/rest/controllers/deployment-alert/deployment-alert.controller.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/deployment-alert/deployment-alert.controller.ts
@@ -32,7 +32,8 @@ export class DeploymentAlertCreateInput extends createZodDto(deploymentAlertCrea
 
 const baseAlertOutputSchema = z.object({
   id: z.string().uuid(),
-  status: z.string()
+  status: z.string(),
+  suppressedBySystem: z.boolean().optional()
 });
 
 const deploymentBalanceAlertOutputSchema = deploymentBalanceAlertInput.merge(baseAlertOutputSchema);

--- a/apps/notifications/src/modules/alert/repositories/alert/alert-json-fields.schema.ts
+++ b/apps/notifications/src/modules/alert/repositories/alert/alert-json-fields.schema.ts
@@ -36,12 +36,14 @@ const dseqSchema = z.string().regex(/^\d+$/, {
 
 export const deploymentBalanceParamsSchema = z.object({
   dseq: dseqSchema,
-  owner: z.string()
+  owner: z.string(),
+  suppressedBySystem: z.boolean().optional()
 });
 
 export const chainMessageParamsSchema = z.object({
   dseq: dseqSchema,
-  type: z.string()
+  type: z.string(),
+  suppressedBySystem: z.boolean().optional()
 });
 
 export const chainMessageTypeSchema = z.literal("CHAIN_MESSAGE");

--- a/apps/notifications/src/modules/alert/repositories/alert/alert.repository.ts
+++ b/apps/notifications/src/modules/alert/repositories/alert/alert.repository.ts
@@ -149,7 +149,7 @@ export class AlertRepository {
         where: this.whereAccessibleBy(
           and(
             sql`${schema.Alert.params}->>'dseq' = ${conditions.dseq}`,
-            conditions.includeSuppressed ? undefined : sql`${schema.Alert.params}->>'suppressedBySystem' != 'true'`,
+            conditions.includeSuppressed ? undefined : sql`NOT(${schema.Alert.params} @> '{"suppressedBySystem": true}')`,
             or(
               sql`${schema.Alert.params}->>'type' IS NOT NULL`,
               and(eq(schema.Alert.type, "DEPLOYMENT_BALANCE"), sql`${schema.Alert.params}->>'owner' IS NOT NULL`)

--- a/apps/notifications/src/modules/alert/services/chain-message-alert/chain-message-alert.service.ts
+++ b/apps/notifications/src/modules/alert/services/chain-message-alert/chain-message-alert.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@nestjs/common";
 
 import { LoggerService } from "@src/common/services/logger/logger.service";
-import { AlertRepository, ChainMessageAlertOutput, DeploymentBalanceAlertOutput } from "@src/modules/alert/repositories/alert/alert.repository";
+import { AlertRepository, ChainMessageAlertOutput, UpdateInput } from "@src/modules/alert/repositories/alert/alert.repository";
 import { AlertMessageService } from "@src/modules/alert/services/alert-message/alert-message.service";
 import { ConditionsMatcherService } from "@src/modules/alert/services/conditions-matcher/conditions-matcher.service";
 import type { MessageCallback } from "@src/modules/alert/types/message-callback.type";
@@ -28,10 +28,12 @@ export class ChainMessageAlertService {
           return;
         }
 
-        const update: Partial<DeploymentBalanceAlertOutput> = { status: "TRIGGERED" };
+        const update: UpdateInput = { status: "TRIGGERED" };
 
         if ("type" in event && event.type === "akash.deployment.v1beta3.MsgCloseDeployment") {
           update.enabled = false;
+          update.params ??= {};
+          update.params.suppressedBySystem = true;
         }
 
         const updatedAlert = await this.alertRepository.updateById(alert.id, update);

--- a/apps/notifications/src/modules/alert/services/deployment-alert/deployment-alert.service.spec.ts
+++ b/apps/notifications/src/modules/alert/services/deployment-alert/deployment-alert.service.spec.ts
@@ -169,13 +169,15 @@ describe(DeploymentAlertService.name, () => {
             enabled: deploymentBalanceRawAlert.enabled,
             threshold: deploymentBalanceRawAlert.conditions.value,
             id: deploymentBalanceRawAlert.id,
-            status: deploymentBalanceRawAlert.status
+            status: deploymentBalanceRawAlert.status,
+            suppressedBySystem: false
           },
           deploymentClosed: {
             notificationChannelId: deploymentClosedRawAlert.notificationChannelId,
             enabled: deploymentClosedRawAlert.enabled,
             id: deploymentClosedRawAlert.id,
-            status: deploymentClosedRawAlert.status
+            status: deploymentClosedRawAlert.status,
+            suppressedBySystem: false
           }
         }
       });

--- a/apps/notifications/src/modules/alert/services/deployment-balance-alerts/deployment-balance-alerts.service.spec.ts
+++ b/apps/notifications/src/modules/alert/services/deployment-balance-alerts/deployment-balance-alerts.service.spec.ts
@@ -207,7 +207,10 @@ describe(DeploymentBalanceAlertsService.name, () => {
       });
       expect(onMessage).toHaveBeenCalledWith(alertMessage);
       expect(alertRepository.updateById).toHaveBeenCalledWith(alert.id, {
-        enabled: false
+        enabled: false,
+        params: {
+          suppressedBySystem: true
+        }
       });
     });
 

--- a/apps/notifications/src/modules/alert/services/deployment-balance-alerts/deployment-balance-alerts.service.ts
+++ b/apps/notifications/src/modules/alert/services/deployment-balance-alerts/deployment-balance-alerts.service.ts
@@ -101,7 +101,12 @@ export class DeploymentBalanceAlertsService {
   }
 
   private async suspendErroneousAlert(error: RichError, alert: DeploymentBalanceAlertOutput) {
-    const updatedAlert = await this.alertRepository.updateById(alert.id, { enabled: false });
+    const updatedAlert = await this.alertRepository.updateById(alert.id, {
+      enabled: false,
+      params: {
+        suppressedBySystem: true
+      }
+    });
 
     if (error.code === "DEPLOYMENT_CLOSED") {
       return this.alertMessageService.getMessage({

--- a/apps/notifications/test/functional/deployment-alert-crud.spec.ts
+++ b/apps/notifications/test/functional/deployment-alert-crud.spec.ts
@@ -57,13 +57,15 @@ describe("Deployment Alerts CRUD", () => {
             enabled: input.data.alerts.deploymentBalance!.enabled,
             threshold: input.data.alerts.deploymentBalance!.threshold,
             status: "OK",
-            id: expect.any(String)
+            id: expect.any(String),
+            suppressedBySystem: false
           },
           deploymentClosed: {
             notificationChannelId,
             enabled: input.data.alerts.deploymentClosed!.enabled,
             status: "OK",
-            id: expect.any(String)
+            id: expect.any(String),
+            suppressedBySystem: false
           }
         }
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Deployment alerts now include a suppression status indicating if an alert has been suppressed by the system.
  - Suppressed alerts cannot be modified through upsert operations.
- **Bug Fixes**
  - Suppressed alerts are excluded from alert listings unless explicitly requested.
- **Tests**
  - Updated tests to verify the presence and correct handling of the suppression status on deployment alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->