### PR TITLE
feat(alert): disables form if deployment is closed

### DIFF
--- a/apps/deploy-web/src/components/alerts/NotificationChannelSelectForm/NotificationChannelSelect.spec.tsx
+++ b/apps/deploy-web/src/components/alerts/NotificationChannelSelectForm/NotificationChannelSelect.spec.tsx
@@ -32,8 +32,11 @@ describe(NotificationChannelSelectView.name, () => {
     setup({ fieldError: "Notification Channel is required" });
 
     const selectTrigger = screen.getByLabelText("Notification Channel");
+    const label = screen.getByText("Notification Channel");
+
     expect(selectTrigger).toHaveClass("border-red-500");
     expect(screen.queryByText("Notification Channel is required")).toBeInTheDocument();
+    expect(label).toHaveClass("cursor-not-allowed");
   });
 
   it("renders add notification channel link", () => {
@@ -49,14 +52,6 @@ describe(NotificationChannelSelectView.name, () => {
     const addLink = screen.getByRole("link", { name: "Add notification channel" });
     expect(addLink).toHaveClass("opacity-10");
     expect(addLink).toHaveClass("cursor-not-allowed");
-  });
-
-  it("applies error styling to label when disabled", () => {
-    setup({ disabled: true });
-
-    const label = screen.getByText("Notification Channel");
-    expect(label).toHaveClass("cursor-not-allowed");
-    expect(label).toHaveClass("text-red-500");
   });
 
   function setup(input: { data?: NotificationChannelsOutput; disabled?: boolean; fieldError?: string } = {}) {

--- a/apps/deploy-web/src/components/alerts/NotificationChannelSelectForm/NotificationChannelSelect.tsx
+++ b/apps/deploy-web/src/components/alerts/NotificationChannelSelectForm/NotificationChannelSelect.tsx
@@ -18,11 +18,12 @@ type ExternalProps = {
 type Props = Pick<ChildrenProps, "isFetched" | "data"> & ExternalProps;
 
 export const NotificationChannelSelectView: FC<Props> = ({ name, isFetched, data, disabled }) => {
-  const { control } = useFormContext();
+  const { control, getFieldState } = useFormContext();
+  const state = getFieldState(name);
 
   return (
     <LoadingBlocker isLoading={!isFetched}>
-      <FormLabel htmlFor="notification-channel-id" className={cn({ "cursor-not-allowed text-red-500": disabled })}>
+      <FormLabel htmlFor="notification-channel-id" className={cn({ "cursor-not-allowed text-red-500": state.error })}>
         Notification Channel
       </FormLabel>
       <div className="flex">

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.tsx
@@ -29,6 +29,7 @@ export type Props = {
   maxBalanceThreshold: number;
   onStateChange: (params: { hasChanges: boolean }) => void;
   notificationChannels: NotificationChannelsOutput;
+  disabled?: boolean;
 };
 
 const schema = z.object({
@@ -72,6 +73,7 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
   maxBalanceThreshold,
   onStateChange,
   notificationChannels,
+  disabled,
   components: c = COMPONENTS
 }) => {
   const strictSchema = useMemo(() => {
@@ -125,13 +127,15 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
       <form onSubmit={form.handleSubmit(submit)}>
         <div className="my-4 flex items-center text-xl font-bold">
           <h3 className="mr-4">Configure Alerts</h3>
-          <LoadingButton type="submit" loading={isLoading} disabled={!hasChanges}>
-            Save Changes
-          </LoadingButton>
+          {!disabled && (
+            <LoadingButton type="submit" loading={isLoading} disabled={!hasChanges}>
+              Save Changes
+            </LoadingButton>
+          )}
         </div>
         <div className="grid-col-1 mb-4 grid gap-4 md:grid-cols-2">
-          <c.DeploymentBalanceAlert disabled={isLoading} />
-          <c.DeploymentCloseAlert disabled={isLoading} />
+          <c.DeploymentBalanceAlert disabled={isLoading || disabled} />
+          <c.DeploymentCloseAlert disabled={isLoading || disabled} />
         </div>
       </form>
     </FormProvider>
@@ -139,7 +143,7 @@ export const DeploymentAlertsView: FC<ChildrenProps & Props> = ({
 };
 
 export type ExternalProps = {
-  deployment: Pick<DeploymentDto, "escrowBalance" | "dseq" | "denom">;
+  deployment: Pick<DeploymentDto, "escrowBalance" | "dseq" | "denom" | "state">;
 } & Pick<Props, "onStateChange">;
 
 export const DeploymentAlerts: FC<ExternalProps> = ({ deployment, onStateChange }) => {
@@ -149,7 +153,12 @@ export const DeploymentAlerts: FC<ExternalProps> = ({ deployment, onStateChange 
         <DeploymentAlertsContainer deployment={deployment}>
           {props => (
             <LoadingBlocker isLoading={!props.isFetched}>
-              <DeploymentAlertsView {...props} onStateChange={onStateChange} notificationChannels={notificationChannels} />
+              <DeploymentAlertsView
+                {...props}
+                onStateChange={onStateChange}
+                notificationChannels={notificationChannels}
+                disabled={deployment.state === "closed"}
+              />
             </LoadingBlocker>
           )}
         </DeploymentAlertsContainer>


### PR DESCRIPTION
<img width="1157" alt="image" src="https://github.com/user-attachments/assets/d290bca7-dfa7-4db8-be82-8320b4966437" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The alert configuration UI is now automatically disabled when a deployment is closed, preventing further changes.
- **Improvements**
	- Error styling for notification channel selection labels is now consistently applied based on field error state rather than the disabled state, improving visual feedback.
- **Bug Fixes**
	- Enhanced test coverage to ensure label styling accurately reflects error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->