### PR TITLE
fix: skips init phase for feature flags service if FEATURES_ENABlED_ALL=true

### DIFF
--- a/apps/api/src/core/services/feature-flags/feature-flags.service.spec.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.service.spec.ts
@@ -29,6 +29,20 @@ describe(FeatureFlagsService.name, () => {
     );
   });
 
+  it("skips initialization if FEATURE_FLAGS_ENABLE_ALL is true", async () => {
+    const createClient = jest.fn(() => createUnleashMockClient());
+    const service = await setup({
+      config: { FEATURE_FLAGS_ENABLE_ALL: true },
+      skipInitialization: true,
+      createClient
+    });
+
+    await service.initialize();
+
+    expect(createClient).not.toHaveBeenCalled();
+    expect(service.isEnabled(FeatureFlags.NOTIFICATIONS_ALERT_CREATE)).toBe(true);
+  });
+
   it("throws an error if service was not initialized but trying to check feature flag", async () => {
     const service = await setup({ skipInitialization: true });
     expect(() => service.isEnabled(FeatureFlags.NOTIFICATIONS_ALERT_CREATE)).toThrow(/was not initialized/);
@@ -119,6 +133,11 @@ describe(FeatureFlagsService.name, () => {
       const result = service.isEnabled(FeatureFlags.NOTIFICATIONS_ALERT_CREATE);
 
       expect(result).toBe(true);
+    });
+
+    it("returns true for all feature flags if FEATURE_FLAGS_ENABLE_ALL is true", async () => {
+      const service = await setup({ config: { FEATURE_FLAGS_ENABLE_ALL: true } });
+      expect(service.isEnabled(`unknown-flag-${Date.now()}` as FeatureFlagValue)).toBe(true);
     });
   });
 

--- a/apps/api/src/core/services/feature-flags/feature-flags.service.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.service.ts
@@ -50,6 +50,8 @@ export class FeatureFlagsService implements Disposable {
   }
 
   async initialize(): Promise<void> {
+    if (this.configService.get("FEATURE_FLAGS_ENABLE_ALL")) return;
+
     const url = this.configService.get("UNLEASH_SERVER_API_URL");
     const token = this.configService.get("UNLEASH_SERVER_API_TOKEN");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved feature flag handling to ensure that when all feature flags are globally enabled, unnecessary initialization steps are skipped and all feature checks return true as expected.

- **Tests**
  - Added new test cases to verify correct behavior when the global enable-all feature flag is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->