### PR TITLE
feat(alert): implements notification channel safe delete

### DIFF
--- a/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.spec.tsx
+++ b/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.spec.tsx
@@ -38,7 +38,7 @@ describe(AlertsListView.name, () => {
     setup({ data: [mockAlert] });
 
     expect(screen.getByText(mockAlert.deploymentName)).toBeInTheDocument();
-    expect(screen.getByText("Threshold")).toBeInTheDocument();
+    expect(screen.getByText("Escrow Threshold")).toBeInTheDocument();
     expect(screen.getByText(capitalize(mockAlert.status))).toBeInTheDocument();
 
     const checkbox = screen.getByRole("checkbox");

--- a/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.tsx
+++ b/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.tsx
@@ -64,7 +64,7 @@ export const AlertsListView: FC<Props> = ({
       header: "Deployment Name",
       cell: info =>
         info.row.original.params?.dseq ? (
-          <Link href={UrlService.deploymentDetails(info.row.original.params.dseq)} className="font-bold">
+          <Link href={UrlService.deploymentDetails(info.row.original.params.dseq, "ALERTS")} className="font-bold">
             {info.getValue()}
           </Link>
         ) : (
@@ -85,7 +85,7 @@ export const AlertsListView: FC<Props> = ({
         const params = info.row.original.params;
 
         if (type === "DEPLOYMENT_BALANCE") {
-          return "Threshold";
+          return "Escrow Threshold";
         } else if (type === "CHAIN_MESSAGE" && params && "type" in params && params.type === "DEPLOYMENT_CLOSED") {
           return "Deployment Close";
         }

--- a/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.spec.tsx
+++ b/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.spec.tsx
@@ -94,7 +94,7 @@ describe(DeploymentAlertsContainer.name, () => {
     );
   });
 
-  it("handles deployment balance alert configuration", async () => {
+  it("handles escrow balance alert configuration", async () => {
     const { requestFn, child, dseq } = await setup();
     const input: ContainerInput = {
       alerts: {

--- a/apps/deploy-web/src/components/alerts/NotificationChannelsListContainer/NotificationChannelsListContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/NotificationChannelsListContainer/NotificationChannelsListContainer.tsx
@@ -30,6 +30,10 @@ type NotificationChannelsListContainerProps = {
   children: (props: ChildrenProps) => ReactNode;
 };
 
+const ERROR_MESSAGES: Record<string, string> = {
+  "Cannot delete notification channel with alerts": "Cannot delete notification channel with alerts"
+};
+
 export const NotificationChannelsListContainer: FC<NotificationChannelsListContainerProps> = ({ onFetched, children }) => {
   const [page, setPage] = useState(1);
   const [limit, setLimit] = useState(10);
@@ -63,7 +67,11 @@ export const NotificationChannelsListContainer: FC<NotificationChannelsListConta
           refetch();
         }
       } catch (error) {
-        notificator.error("Failed to remove notification channel", {
+        const message =
+          error && typeof error === "object" && "message" in error && typeof error?.message === "string" && ERROR_MESSAGES[error.message]
+            ? ERROR_MESSAGES[error.message]
+            : "Failed to remove notification channel";
+        notificator.error(message, {
           dataTestId: "notification-channel-remove-error-notification"
         });
       } finally {

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
@@ -16,7 +16,7 @@ describe("DeploymentAlerts", () => {
     fireEvent.click(screen.getByLabelText("Enabled", { selector: '[name="deploymentBalance.enabled"]' }));
     fireEvent.click(screen.getByLabelText("Enabled", { selector: '[name="deploymentClosed.enabled"]' }));
 
-    fireEvent.change(screen.getByRole("combobox", { name: /deployment balance notification channel/i }), {
+    fireEvent.change(screen.getByRole("combobox", { name: /escrow balance notification channel/i }), {
       target: { value: componentProps.notificationChannels[0].id }
     });
     fireEvent.change(screen.getByRole("combobox", { name: /deployment close notification channel/i }), {
@@ -68,7 +68,7 @@ describe("DeploymentAlerts", () => {
         return (
           <div>
             <input type="checkbox" {...register("deploymentBalance.enabled")} aria-label="Enabled" disabled={disabled} />
-            <select {...register("deploymentBalance.notificationChannelId")} aria-label="Deployment Balance Notification Channel" disabled={disabled}>
+            <select {...register("deploymentBalance.notificationChannelId")} aria-label="Escrow Balance Notification Channel" disabled={disabled}>
               <option value={channel1Id}>Channel 1</option>
               <option value={channel2Id}>Channel 2</option>
             </select>

--- a/apps/deploy-web/src/components/deployments/DeploymentBalanceAlert/DeploymentBalanceAlert.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentBalanceAlert/DeploymentBalanceAlert.tsx
@@ -20,7 +20,7 @@ export const DeploymentBalanceAlert: FC<Props> = ({ disabled }) => {
     <Fieldset
       label={
         <div className="flex items-center justify-between">
-          <p className="mr-3 text-xl font-bold">Deployment Deposit</p>
+          <p className="mr-3 text-xl font-bold">Escrow Balance</p>
           <FormField
             control={control}
             name="deploymentBalance.enabled"
@@ -54,7 +54,7 @@ export const DeploymentBalanceAlert: FC<Props> = ({ disabled }) => {
                 label={
                   <div className="inline-flex items-center">
                     Threshold, USD
-                    <CustomTooltip title="Alert if the deployment deposit is less than this amount.">
+                    <CustomTooltip title="Alert if the deployment escrow balance is less than this amount.">
                       <InfoCircle className="ml-2 text-xs text-muted-foreground" />
                     </CustomTooltip>
                   </div>

--- a/apps/deploy-web/src/components/layout/Sidebar.tsx
+++ b/apps/deploy-web/src/components/layout/Sidebar.tsx
@@ -105,7 +105,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
       }
     ];
 
-    if (isAlertsEnabled && user?.userId) {
+    if (isAlertsEnabled && user?.userId && wallet.isManaged) {
       routes.push({
         title: "Alerts",
         icon: props => <MessageAlert {...props} />,
@@ -115,7 +115,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
     }
 
     return routes;
-  }, [isAlertsEnabled, user?.userId]);
+  }, [isAlertsEnabled, user?.userId, wallet.isManaged]);
 
   const routeGroups: ISidebarGroupMenu[] = useMemo(
     () => [

--- a/apps/notifications/drizzle/0002_bumpy_cargill.sql
+++ b/apps/notifications/drizzle/0002_bumpy_cargill.sql
@@ -1,0 +1,2 @@
+DROP INDEX "idx_alerts_type_enabled";--> statement-breakpoint
+ALTER TABLE "notification_channels" ADD COLUMN "deleted_at" timestamp;

--- a/apps/notifications/drizzle/meta/0002_snapshot.json
+++ b/apps/notifications/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,428 @@
+{
+  "id": "740fabd7-a27d-414a-9e85-6131833408b2",
+  "prevId": "8cfb9adf-d5f5-4dd6-94d0-9a32a7c68397",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_channel_id": {
+          "name": "notification_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "type": {
+          "name": "type",
+          "type": "alert_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "alert_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OK'"
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_block_height": {
+          "name": "min_block_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_alerts_user_id": {
+          "name": "idx_alerts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_alerts_notification_channel_id": {
+          "name": "idx_alerts_notification_channel_id",
+          "columns": [
+            {
+              "expression": "notification_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_alerts_status": {
+          "name": "idx_alerts_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_alerts_min_block_height_id": {
+          "name": "idx_alerts_min_block_height_id",
+          "columns": [
+            {
+              "expression": "min_block_height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_alerts_created_at_id": {
+          "name": "idx_alerts_created_at_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_alerts_params": {
+          "name": "idx_alerts_params",
+          "columns": [
+            {
+              "expression": "\"params\" jsonb_path_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_alerts_enabled_type_status": {
+          "name": "idx_alerts_enabled_type_status",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alerts_notification_channel_id_notification_channels_id_fk": {
+          "name": "alerts_notification_channel_id_notification_channels_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "notification_channels",
+          "columnsFrom": [
+            "notification_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_cursor": {
+      "name": "block_cursor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'latest'"
+        },
+        "last_processed_block": {
+          "name": "last_processed_block",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_channels": {
+      "name": "notification_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_channel_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_channels_user_id": {
+          "name": "idx_notification_channels_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_channels_created_at": {
+          "name": "idx_notification_channels_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.alert_status": {
+      "name": "alert_status",
+      "schema": "public",
+      "values": [
+        "OK",
+        "TRIGGERED"
+      ]
+    },
+    "public.alert_type": {
+      "name": "alert_type",
+      "schema": "public",
+      "values": [
+        "CHAIN_MESSAGE",
+        "DEPLOYMENT_BALANCE"
+      ]
+    },
+    "public.notification_channel_type": {
+      "name": "notification_channel_type",
+      "schema": "public",
+      "values": [
+        "email"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/notifications/drizzle/meta/_journal.json
+++ b/apps/notifications/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1749739128369,
       "tag": "0001_foamy_spitfire",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1750681348747,
+      "tag": "0002_bumpy_cargill",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/notifications/src/modules/alert/repositories/alert/alert.repository.ts
+++ b/apps/notifications/src/modules/alert/repositories/alert/alert.repository.ts
@@ -171,6 +171,18 @@ export class AlertRepository {
     });
   }
 
+  async countActiveByNotificationChannelId(notificationChannelId: string): Promise<number> {
+    const result = await this.db
+      .select({ count: count(schema.Alert.id) })
+      .from(schema.Alert)
+      .where(
+        this.whereAccessibleBy(
+          and(eq(schema.Alert.notificationChannelId, notificationChannelId), sql`NOT(${schema.Alert.params} @> '{"suppressedBySystem": true}')`)
+        )
+      );
+    return Number(result[0].count);
+  }
+
   async paginate(options: ListLookupOptions): Promise<PaginatedResult<AlertOutputWithNotificationName>> {
     const page = options.page || 1;
     const limit = options.limit || 10;

--- a/apps/notifications/src/modules/alert/services/deployment-alert/deployment-alert.service.ts
+++ b/apps/notifications/src/modules/alert/services/deployment-alert/deployment-alert.service.ts
@@ -205,11 +205,13 @@ export class DeploymentAlertService {
 
   private getConsoleLink(dseq: string): string {
     const baseUrl = this.configService.getOrThrow("alert.CONSOLE_WEB_URL");
-    return `<a href="https://${baseUrl}/deployments/${dseq}">${baseUrl}</a>`;
+    return `<a href="https://${baseUrl}/deployments/${dseq}?tab=ALERTS">${baseUrl}</a>`;
   }
 
   async get(dseq: string, ability: MongoAbility): Promise<DeploymentAlertOutput> {
-    const alerts = (await this.alertRepository.accessibleBy(ability, "read", "DeploymentAlert").findAllDeploymentAlerts({ dseq, includeSuppressed: true })) as RepositoryAlert[];
+    const alerts = (await this.alertRepository
+      .accessibleBy(ability, "read", "DeploymentAlert")
+      .findAllDeploymentAlerts({ dseq, includeSuppressed: true })) as RepositoryAlert[];
 
     const result: DeploymentAlertOutput = {
       dseq,

--- a/apps/notifications/src/modules/notifications/model-schemas/notification-channel.schema.ts
+++ b/apps/notifications/src/modules/notifications/model-schemas/notification-channel.schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { index, jsonb, pgEnum, pgTable, uuid, varchar } from "drizzle-orm/pg-core";
+import { index, jsonb, pgEnum, pgTable, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
 
 import { timestamps } from "@src/lib/db/timestamps";
 
@@ -16,6 +16,7 @@ export const NotificationChannel = pgTable(
     userId: uuid("user_id").notNull(),
     type: NotificationChannelType("type").notNull(),
     config: jsonb("config").notNull(),
+    deletedAt: timestamp("deleted_at"),
 
     ...timestamps
   },


### PR DESCRIPTION
also applies a couple of minor copy/ui fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for soft deletion of notification channels, preventing deletion if the channel is still linked to existing alerts.
  - Introduced a new database schema with tables for alerts, notification channels (with soft delete support), and block cursors.

- **Improvements**
  - Updated user interface text to use "Escrow Balance" instead of "Deployment Deposit" for alerts and notifications.
  - Enhanced error messages when removing notification channels for clearer user feedback.
  - Sidebar now only displays the "Alerts" menu for managed wallets.

- **Bug Fixes**
  - Improved error handling during test database setup to prevent unhandled exceptions.

- **Tests**
  - Updated and expanded tests to cover new alert and notification channel deletion logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->