### PR TITLE
fix: enable sourcemaps for deploy-web

### DIFF
--- a/apps/deploy-web/next.config.js
+++ b/apps/deploy-web/next.config.js
@@ -31,6 +31,7 @@ if (process.env.NODE_ENV === "test") {
  */
 const moduleExports = {
   reactStrictMode: false,
+  productionBrowserSourceMaps: true,
   compiler: {
     // Enables the styled-components SWC transform
     styledComponents: true


### PR DESCRIPTION
## Why

to use them in sentry and for debugging

## What

Enable sourcemaps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enabled generation of source maps for improved debugging and error tracking in production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->