### PR TITLE
fix(alert): clear up unsaved changes for a closed deployment

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
@@ -18,6 +18,7 @@ import { useWallet } from "@src/context/WalletProvider";
 import { useFlag } from "@src/hooks/useFlag";
 import { useNavigationGuard } from "@src/hooks/useNavigationGuard/useNavigationGuard";
 import { useUser } from "@src/hooks/useUser";
+import { useWhen } from "@src/hooks/useWhen";
 import { useDeploymentDetail } from "@src/queries/useDeploymentQuery";
 import { useDeploymentLeaseList } from "@src/queries/useLeaseQuery";
 import { useProviderList } from "@src/queries/useProvidersQuery";
@@ -204,6 +205,10 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq }) => {
     enabled: !!badgedTabs.ALERTS,
     message: "You have unsaved alert configuration changes that will be lost. Would you like to continue?",
     skipWhen: params => params.to.startsWith(`/deployments/${dseq}`)
+  });
+
+  useWhen(deployment?.state !== "active", () => {
+    setBadgedTabs({});
   });
 
   return (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Tab badges are now reset automatically when a deployment is not active, ensuring badge indicators remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->