### PR TITLE
fix: makes axios not to throw on 400 error for getting deployment

### DIFF
--- a/packages/http-sdk/src/deployment/deployment-http.service.ts
+++ b/packages/http-sdk/src/deployment/deployment-http.service.ts
@@ -142,7 +142,8 @@ export class DeploymentHttpService extends HttpService {
         params: {
           "id.owner": owner,
           "id.dseq": dseq
-        }
+        },
+        validateStatus: status => (status >= 200 && status < 300) || (status >= 400 && status < 500)
       })
     );
   }

--- a/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.spec.ts
+++ b/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.spec.ts
@@ -79,4 +79,39 @@ describe(collectFullErrorStack.name, () => {
     expect(result).toContain("error 1");
     expect(result).toContain("error 2");
   });
+
+  it("collects response/request full info", () => {
+    const error = new Error("test error");
+    Object.assign(error, {
+      response: {
+        status: 400,
+        data: { message: "Fatal error" },
+        config: {
+          url: "https://api.example.com/resource",
+          method: "GET"
+        }
+      }
+    });
+
+    const result = collectFullErrorStack(error);
+    expect(result).toContain("test error");
+    expect(result).toContain("Status: 400");
+    expect(result).toContain("Request: GET https://api.example.com/resource");
+    expect(result).toContain("Error: Fatal error");
+  });
+
+  it("collects response/request partial info", () => {
+    const error = new Error("test error");
+    Object.assign(error, {
+      response: {
+        status: 400
+      }
+    });
+
+    const result = collectFullErrorStack(error);
+    expect(result).toContain("test error");
+    expect(result).toContain("Status: 400");
+    expect(result).toContain("Request: Unknown request");
+    expect(result).toContain("Error: Not specified");
+  });
 });

--- a/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.ts
+++ b/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.ts
@@ -1,4 +1,4 @@
-export function collectFullErrorStack(error: Error | (Error & { errors?: Error[] }) | undefined | null, indent = 0): string {
+export function collectFullErrorStack(error: Error | AggregateError | ErrorWithResponse | undefined | null, indent = 0): string {
   const currentError = error;
   if (!currentError) return "";
 
@@ -13,5 +13,32 @@ export function collectFullErrorStack(error: Error | (Error & { errors?: Error[]
     stack.push("\nErrors:", ...errorStacks);
   }
 
+  if ("response" in currentError && currentError.response) {
+    const requestedPath = currentError.response.config?.url
+      ? `${currentError.response.config.method?.toUpperCase() || "(HTTP method not specified)"} ${currentError.response.config?.url}`
+      : "Unknown request";
+    stack.push(
+      "\nResponse:",
+      `\n\nRequest: ${requestedPath}`,
+      `\n\nStatus: ${currentError.response.status}`,
+      `\n\nError: ${currentError.response.data?.message || "Not specified"} (code: ${currentError.response.data?.code || "Not specified"})`
+    );
+  }
+
   return stack.join("\n").replace(/^/gm, " ".repeat(indent));
 }
+
+type ErrorWithResponse = Error & {
+  response?: {
+    status: number;
+    config?: {
+      url: string;
+      method: string;
+    };
+    data?: {
+      message?: string;
+      code?: unknown;
+    };
+  };
+};
+type AggregateError = Error & { errors?: Error[] };


### PR DESCRIPTION
## Why

Currently if deployment is not found console-api fails with internal server error, ref: https://github.com/akash-network/console/issues/1490

## What

Perceive 400 http status as expected error for finding deployment and improved error details gathering in logging package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
  - Enhanced error reporting to include detailed HTTP response and request information when available, improving clarity for errors involving network requests.

- **Tests**
  - Added new test cases to verify the improved error stack output for errors containing HTTP response details.

- **Bug Fixes**
  - Improved handling of errors with client error status codes (400–499) in deployment-related requests, allowing for better error processing and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->