### PR TITLE
fix: adds blockchain node API proxy to the list of mainnet nework urls

### DIFF
--- a/packages/net/scripts/generate.ts
+++ b/packages/net/scripts/generate.ts
@@ -20,11 +20,17 @@ async function main() {
       fetchText(`${baseConfigUrl}/version.txt`)
     ]);
 
-    config[network] = {
+    const networkConfig = {
       version: version.trim(),
       apiUrls: apiUrls.trim().split("\n"),
       rpcUrls: rpcUrls.trim().split("\n")
     };
+
+    if (network === "mainnet") {
+      networkConfig.apiUrls.unshift("https://public-proxy.akt.dev/rest");
+    }
+
+    config[network] = networkConfig;
   }
 
   await fsp.mkdir(OUT_DIR, { recursive: true });

--- a/packages/net/src/NetConfig/NetConfig.ts
+++ b/packages/net/src/NetConfig/NetConfig.ts
@@ -5,7 +5,7 @@ export type SupportedChainNetworks = keyof typeof netConfigData;
 export class NetConfig {
   getBaseAPIUrl(network: SupportedChainNetworks): string {
     const apiUrls = netConfigData[network].apiUrls;
-    return apiUrls.length > 1 ? apiUrls[1] : apiUrls[0];
+    return apiUrls[0];
   }
 
   getSupportedNetworks(): SupportedChainNetworks[] {

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -2,6 +2,7 @@ export const netConfigData = {
   mainnet: {
     version: "0.38.0",
     apiUrls: [
+      "https://public-proxy.akt.dev/rest",
       "https://api.akashnet.net:443",
       "https://akash-api.polkachu.com:443",
       "https://akash.c29r3.xyz:443/api",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the logic for selecting the base API URL, ensuring the first URL is always used.
  - Updated network configuration to include a specific API URL for mainnet, improving network-specific customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->