### PR TITLE
chore: runs security checks only on PR

### DIFF
--- a/.github/workflows/console-api-validate-n-build.yml
+++ b/.github/workflows/console-api-validate-n-build.yml
@@ -67,7 +67,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     needs: should-validate
-    if: needs.should-validate.outputs.has_changes == 'true'
+    if: needs.should-validate.outputs.has_changes == 'true' && github.event_name == 'pull_request'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/console-web-docker-build.yml
+++ b/.github/workflows/console-web-docker-build.yml
@@ -54,7 +54,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     needs: should-validate
-    if: needs.should-validate.outputs.has_changes == 'true'
+    if: needs.should-validate.outputs.has_changes == 'true' && github.event_name == 'pull_request'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/indexer-docker-build.yml
+++ b/.github/workflows/indexer-docker-build.yml
@@ -26,7 +26,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     needs: should-validate
-    if: needs.should-validate.outputs.has_changes == 'true'
+    if: needs.should-validate.outputs.has_changes == 'true' && github.event_name == 'pull_request'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/notifications-validate-n-build.yml
+++ b/.github/workflows/notifications-validate-n-build.yml
@@ -52,7 +52,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     needs: should-validate
-    if: needs.should-validate.outputs.has_changes == 'true'
+    if: needs.should-validate.outputs.has_changes == 'true' && github.event_name == 'pull_request'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/provider-console-docker-build.yml
+++ b/.github/workflows/provider-console-docker-build.yml
@@ -25,7 +25,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     needs: should-validate
-    if: needs.should-validate.outputs.has_changes == 'true'
+    if: needs.should-validate.outputs.has_changes == 'true' && github.event_name == 'pull_request'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/provider-proxy-docker-build.yml
+++ b/.github/workflows/provider-proxy-docker-build.yml
@@ -57,7 +57,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     needs: should-validate
-    if: needs.should-validate.outputs.has_changes == 'true'
+    if: needs.should-validate.outputs.has_changes == 'true' && github.event_name == 'pull_request'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/reusable-deploy-k8s.yml
+++ b/.github/workflows/reusable-deploy-k8s.yml
@@ -164,9 +164,6 @@ jobs:
           TS_OAUTH_CLIENT_ID: ${{ vars.OP_TS_OAUTH_CLIENT_ID_URI }}
           TS_OAUTH_SECRET: ${{ vars.OP_TS_OAUTH_CLIENT_SECRET_URI }}
 
-      - name: Install jq
-        uses: dcarbone/install-jq-action@v3.0.1
-
       - name: Tailscale
         uses: tailscale/github-action@v3
         with:

--- a/.github/workflows/stats-web-docker-build.yml
+++ b/.github/workflows/stats-web-docker-build.yml
@@ -32,7 +32,7 @@ jobs:
   test-stats-web-build:
     runs-on: ubuntu-latest
     needs: should-validate
-    if: needs.should-validate.outputs.has_changes == 'true'
+    if: needs.should-validate.outputs.has_changes == 'true' && github.event_name == 'pull_request'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow jobs to run certain security and build checks only on pull request events with relevant changes, reducing unnecessary runs on other event types.
	- Removed the installation step for the jq tool in the deployment workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->