### PR TITLE
fix: ensure getAllItems doesn't stuck inside infinite loop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23036,6 +23036,7 @@
       "version": "29.5.14",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
       "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -26514,6 +26515,7 @@
     },
     "node_modules/bs-logger": {
       "version": "0.2.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-json-stable-stringify": "2.x"
@@ -37027,6 +37029,7 @@
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -37446,6 +37449,7 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/make-fetch-happen": {
@@ -47130,29 +47134,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stream": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.3.tgz",
-      "integrity": "sha512-aMsbn7VKrl4A2T7QAQQbzgN7NVc70vgF5INQrBXqn4dCXN1zy3L9HGgLO5s7PExmdrzTJ8uR/27aviW8or8/+A==",
-      "dependencies": {
-        "component-emitter": "^2.0.0"
-      }
-    },
     "node_modules/stream-shift": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="
-    },
-    "node_modules/stream/node_modules/component-emitter": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-2.0.0.tgz",
-      "integrity": "sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw==",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -48628,18 +48613,20 @@
       "license": "Apache-2.0"
     },
     "node_modules/ts-jest": {
-      "version": "29.2.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.5.tgz",
-      "integrity": "sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==",
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.0.tgz",
+      "integrity": "sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "ejs": "^3.1.10",
         "fast-json-stable-stringify": "^2.1.0",
-        "jest-util": "^29.0.0",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.6.3",
+        "semver": "^7.7.2",
+        "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -48650,10 +48637,11 @@
       },
       "peerDependencies": {
         "@babel/core": ">=7.0.0-beta.0 <8",
-        "@jest/transform": "^29.0.0",
-        "@jest/types": "^29.0.0",
-        "babel-jest": "^29.0.0",
-        "jest": "^29.0.0",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
         "typescript": ">=4.3 <6"
       },
       "peerDependenciesMeta": {
@@ -48671,7 +48659,36 @@
         },
         "esbuild": {
           "optional": true
+        },
+        "jest-util": {
+          "optional": true
         }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ts-loader": {
@@ -51585,6 +51602,7 @@
       "version": "1.1.5",
       "license": "Apache-2.0",
       "dependencies": {
+        "@akashnetwork/logging": "*",
         "axios": "^1.7.2",
         "axios-retry": "^4.5.0",
         "date-fns": "^4.1.0",
@@ -51594,7 +51612,10 @@
       "devDependencies": {
         "@cosmjs/proto-signing": "^0.32.4",
         "@cosmjs/stargate": "^0.32.4",
-        "@types/lodash": "^4.17.7"
+        "@types/jest": "^29.5.14",
+        "@types/lodash": "^4.17.7",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.4.0"
       }
     },
     "packages/http-sdk/node_modules/@cosmjs/encoding": {
@@ -51775,18 +51796,17 @@
       "version": "2.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/jest": "^29.5.14",
         "http-errors": "^2.0.0",
-        "jest": "^29.7.0",
         "pino": "^9.5.0",
-        "stream": "^0.0.3",
-        "ts-jest": "^29.1.4",
         "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/http-errors": "^2.0.4",
+        "@types/jest": "^29.5.14",
         "@types/node": "^22.8.6",
-        "pino-pretty": "^11.3.0"
+        "jest": "^29.7.0",
+        "pino-pretty": "^11.3.0",
+        "ts-jest": "^29.4.0"
       },
       "peerDependencies": {
         "hono": "4.6.12"

--- a/packages/http-sdk/jest.config.ts
+++ b/packages/http-sdk/jest.config.ts
@@ -1,0 +1,8 @@
+import type { Config } from "jest";
+
+export default {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/src/**/*.spec.ts"],
+  verbose: true
+} satisfies Config;

--- a/packages/http-sdk/package.json
+++ b/packages/http-sdk/package.json
@@ -9,9 +9,11 @@
   "scripts": {
     "format": "prettier --write ./*.{ts,json} **/*.{ts,json}",
     "lint": "eslint .",
+    "test": "jest",
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
+    "@akashnetwork/logging": "*",
     "axios": "^1.7.2",
     "axios-retry": "^4.5.0",
     "date-fns": "^4.1.0",
@@ -21,6 +23,9 @@
   "devDependencies": {
     "@cosmjs/proto-signing": "^0.32.4",
     "@cosmjs/stargate": "^0.32.4",
-    "@types/lodash": "^4.17.7"
+    "@types/jest": "^29.5.14",
+    "@types/lodash": "^4.17.7",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.0"
   }
 }

--- a/packages/http-sdk/src/certificates/certificates.service.ts
+++ b/packages/http-sdk/src/certificates/certificates.service.ts
@@ -29,6 +29,8 @@ export class CertificatesService {
     };
 
     if (params.state) queryParams["filter.state"] = params.state;
+    if (params["pagination.key"]) queryParams["pagination.key"] = params["pagination.key"];
+    if (params["pagination.count_total"]) queryParams["pagination.count_total"] = params["pagination.count_total"];
 
     const response = await this.axios.get<RestApiCertificatesResponseType>("/akash/cert/v1beta3/certificates/list", { params: queryParams });
     return response.data;
@@ -49,4 +51,6 @@ type GetCertificatesParams = {
   address: string;
   state?: string;
   limit?: number;
+  "pagination.key"?: string | null;
+  "pagination.count_total"?: string;
 };

--- a/packages/http-sdk/src/utils/logger.ts
+++ b/packages/http-sdk/src/utils/logger.ts
@@ -1,0 +1,5 @@
+import { LoggerService } from "@akashnetwork/logging";
+
+export const sdkLogger = new LoggerService({
+  name: "http-sdk"
+});

--- a/packages/http-sdk/src/utils/pagination.utils.spec.ts
+++ b/packages/http-sdk/src/utils/pagination.utils.spec.ts
@@ -1,0 +1,33 @@
+import { getAllItems } from "./pagination.utils";
+
+describe("Pagination utils", () => {
+  describe(getAllItems.name, () => {
+    it("returns all items", async () => {
+      const items = Array.from({ length: 100 }, (_, i) => i);
+      const getItems = jest.fn(async (params: Record<string, string | number>) => {
+        const startIndex = params["pagination.key"] ? Number(params["pagination.key"]) : 0;
+        const endIndex = startIndex + 20;
+        return {
+          items: items.slice(startIndex, endIndex),
+          pagination: { next_key: endIndex < items.length ? String(endIndex) : null }
+        };
+      });
+      const allItems = await getAllItems(getItems);
+
+      expect(allItems).toEqual(items);
+    });
+
+    it("detects cyclic loop and logs an error", async () => {
+      const items = Array.from({ length: 100 }, (_, i) => i);
+      const getItems = jest.fn(async () => {
+        return { items: items.slice(0, 20), pagination: { next_key: "0" } };
+      });
+      const logger = { error: jest.fn() };
+      const allItems = await getAllItems(getItems, logger);
+
+      expect(allItems).toEqual(items.slice(0, 20));
+      expect(getItems).toHaveBeenCalledTimes(2);
+      expect(logger.error).toHaveBeenCalledWith({ event: "HTTP_SDK_CIRCULAR_LOOP" });
+    });
+  });
+});

--- a/packages/http-sdk/src/utils/pagination.utils.ts
+++ b/packages/http-sdk/src/utils/pagination.utils.ts
@@ -1,3 +1,7 @@
+import type { LoggerService } from "@akashnetwork/logging";
+
+import { sdkLogger } from "./logger";
+
 /**
  * Helper function to load data with pagination
  * @param baseUrl Base URL for the API request
@@ -37,7 +41,8 @@ export function hasQueryParam(url: string): boolean {
 }
 
 export async function getAllItems<T>(
-  getItems: (params: Record<string, string | number>) => Promise<{ items: T[]; pagination: { next_key: string | null } }>
+  getItems: (params: Record<string, string | number>) => Promise<{ items: T[]; pagination: { next_key: string | null } }>,
+  logger: Pick<LoggerService, "error"> = sdkLogger
 ): Promise<T[]> {
   let items: T[] = [];
   let nextKey: string | null = null;
@@ -50,6 +55,10 @@ export async function getAllItems<T>(
 
     const itemsOnPage = await getItems(params);
 
+    if (nextKey === itemsOnPage.pagination.next_key) {
+      logger.error({ event: "HTTP_SDK_CIRCULAR_LOOP" });
+      break;
+    }
     items = items.concat(itemsOnPage.items);
     nextKey = itemsOnPage.pagination.next_key;
   } while (nextKey);

--- a/packages/http-sdk/tsconfig.build.json
+++ b/packages/http-sdk/tsconfig.build.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "baseUrl": ".",
     "noImplicitAny": true,
-    "strict": true
+    "strict": true,
+    "isolatedModules": true
   },
   "extends": "@akashnetwork/dev-config/tsconfig.base-node.json"
 }

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -20,18 +20,17 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@types/jest": "^29.5.14",
     "http-errors": "^2.0.0",
-    "jest": "^29.7.0",
     "pino": "^9.5.0",
-    "stream": "^0.0.3",
-    "ts-jest": "^29.1.4",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/http-errors": "^2.0.4",
+    "@types/jest": "^29.5.14",
     "@types/node": "^22.8.6",
-    "pino-pretty": "^11.3.0"
+    "jest": "^29.7.0",
+    "pino-pretty": "^11.3.0",
+    "ts-jest": "^29.4.0"
   },
   "peerDependencies": {
     "hono": "4.6.12"


### PR DESCRIPTION
## Why

bug

## What

ensure getAllItems doesn't stuck inside infinite loop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added logging support to the HTTP SDK for improved error tracking during pagination.
  * Enhanced certificate retrieval with additional pagination options.

* **Bug Fixes**
  * Introduced a safeguard to prevent infinite loops during paginated data retrieval.

* **Tests**
  * Added comprehensive tests for pagination utilities, including circular loop detection.

* **Chores**
  * Integrated Jest testing framework and scripts for the HTTP SDK.
  * Updated and reorganized dependencies for improved development workflow.
  * Enabled stricter TypeScript module isolation in the build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->