### PR TITLE
fix: ensure getAllItems cyclic loop check happens after the 1st iteration

### DIFF
--- a/packages/http-sdk/src/utils/pagination.utils.spec.ts
+++ b/packages/http-sdk/src/utils/pagination.utils.spec.ts
@@ -27,7 +27,20 @@ describe("Pagination utils", () => {
 
       expect(allItems).toEqual(items.slice(0, 20));
       expect(getItems).toHaveBeenCalledTimes(2);
-      expect(logger.error).toHaveBeenCalledWith({ event: "HTTP_SDK_CIRCULAR_LOOP" });
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "HTTP_SDK_CIRCULAR_LOOP" }));
+    });
+
+    it("does not report cyclic loop if the next key is null", async () => {
+      const items = Array.from({ length: 100 }, (_, i) => i);
+      const getItems = jest.fn(async () => {
+        return { items, pagination: { next_key: null } };
+      });
+      const logger = { error: jest.fn() };
+      const allItems = await getAllItems(getItems, logger);
+
+      expect(allItems).toEqual(items);
+      expect(getItems).toHaveBeenCalledTimes(1);
+      expect(logger.error).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/http-sdk/src/utils/pagination.utils.ts
+++ b/packages/http-sdk/src/utils/pagination.utils.ts
@@ -55,8 +55,9 @@ export async function getAllItems<T>(
 
     const itemsOnPage = await getItems(params);
 
-    if (nextKey === itemsOnPage.pagination.next_key) {
-      logger.error({ event: "HTTP_SDK_CIRCULAR_LOOP" });
+    // nextKey is null when the first page is returned
+    if (nextKey !== null && nextKey === itemsOnPage.pagination.next_key) {
+      logger.error({ event: "HTTP_SDK_CIRCULAR_LOOP", message: "Did you forget to pass pagination.key to request?" });
       break;
     }
     items = items.concat(itemsOnPage.items);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of circular pagination loops to prevent false positive error logs when starting pagination.
  * Enhanced error messages for circular pagination detection with additional hints.

* **Tests**
  * Updated and expanded test coverage to ensure correct behavior when pagination keys are null and to verify improved error logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->