### PR TITLE
feat(alert): only sends diff for deployment alerts upsert

### DIFF
--- a/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.tsx
@@ -17,18 +17,20 @@ import { ceilDecimal, denomToUdenom, udenomToDenom } from "@src/utils/mathHelper
 type DeploymentAlertsInput = components["schemas"]["DeploymentAlertCreateInput"]["data"];
 type DeploymentAlertsOutput = components["schemas"]["DeploymentAlertsResponse"]["data"];
 
+export type FullAlertsInput = {
+  deploymentClosed: NonNullable<DeploymentAlertsInput["alerts"]["deploymentClosed"]>;
+  deploymentBalance: NonNullable<DeploymentAlertsInput["alerts"]["deploymentBalance"]>;
+};
+
 export type ContainerInput = Omit<DeploymentAlertsInput, "owner" | "alerts"> & {
   alerts:
     | {
-        deploymentClosed: NonNullable<DeploymentAlertsInput["alerts"]["deploymentClosed"]>;
+        deploymentClosed: FullAlertsInput["deploymentClosed"];
       }
     | {
-        deploymentBalance: NonNullable<DeploymentAlertsInput["alerts"]["deploymentBalance"]>;
+        deploymentBalance: FullAlertsInput["deploymentBalance"];
       }
-    | {
-        deploymentClosed: NonNullable<DeploymentAlertsInput["alerts"]["deploymentClosed"]>;
-        deploymentBalance: NonNullable<DeploymentAlertsInput["alerts"]["deploymentBalance"]>;
-      };
+    | FullAlertsInput;
 };
 
 export type ChildrenProps = {

--- a/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentAlerts/DeploymentAlerts.spec.tsx
@@ -50,7 +50,8 @@ describe("DeploymentAlerts", () => {
     const channel1Id = faker.string.uuid();
     const channel2Id = faker.string.uuid();
 
-    const COMPONENTS = {
+    const DEPENDENCIES = {
+      useFlag: () => true,
       DeploymentCloseAlert: ({ disabled }: { disabled?: boolean }) => {
         const { register } = useFormContext();
         return (
@@ -105,7 +106,7 @@ describe("DeploymentAlerts", () => {
       isError: false
     };
 
-    render(<DeploymentAlertsView {...componentProps} components={COMPONENTS} />);
+    render(<DeploymentAlertsView {...componentProps} dependencies={DEPENDENCIES} />);
 
     return { componentProps };
   }


### PR DESCRIPTION
also adds a ff for the closed deployment alert

closes #1548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added feature flag support to control the visibility of the "deployment closed" alert.

* **Improvements**
  * Optimized alert updates to only submit changed alert data, reducing unnecessary updates.

* **Refactor**
  * Renamed internal properties for better clarity and maintainability; no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->