### PR TITLE
fix: serve Swagger docs from app.ts

### DIFF
--- a/apps/api/src/auth/routes/send-verification-email/send-verification-email.router.ts
+++ b/apps/api/src/auth/routes/send-verification-email/send-verification-email.router.ts
@@ -17,6 +17,7 @@ const route = createRoute({
   method: "post",
   path: "/v1/send-verification-email",
   summary: "Resends a verification email",
+  tags: ["Users"],
   request: {
     body: {
       required: true,

--- a/apps/api/src/billing/routes/stripe-prices/stripe-prices.router.ts
+++ b/apps/api/src/billing/routes/stripe-prices/stripe-prices.router.ts
@@ -21,6 +21,7 @@ const route = createRoute({
   method: "get",
   path: "/v1/stripe/prices",
   summary: "",
+  tags: ["Payment"],
   request: {},
   responses: {
     200: {

--- a/apps/api/src/billing/routes/stripe-webhook/stripe-webhook.router.ts
+++ b/apps/api/src/billing/routes/stripe-webhook/stripe-webhook.router.ts
@@ -9,6 +9,7 @@ const route = createRoute({
   method: "post",
   path: "/v1/stripe-webhook",
   summary: "Stripe Webhook Handler",
+  tags: ["Payment"],
   request: {
     body: {
       content: {
@@ -21,11 +22,7 @@ const route = createRoute({
   responses: {
     200: {
       description: "Webhook processed successfully",
-      content: {
-        "application/json": {
-          schema: z.void()
-        }
-      }
+      content: {}
     },
     400: {
       description: "Stripe signature is required",
@@ -49,5 +46,5 @@ stripeWebhook.openapi(route, async function routeStripeWebhook(c) {
   }
 
   await container.resolve(CheckoutController).webhook(sig, await c.req.text());
-  return c.json(null, 200) as never;
+  return c.text("", 200) as never;
 });

--- a/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
+++ b/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
@@ -12,8 +12,8 @@ export class OpenApiDocsService {
       openapi: "3.0.0",
       servers: [{ url: `${env.SERVER_ORIGIN}/${version}` }],
       info: {
-        title: "Console API",
-        description: "Access Akash data from our indexer",
+        title: "Akash Network Console API",
+        description: "API providing data to the Akash Network Console",
         version: version
       },
       paths: {},

--- a/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
+++ b/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
@@ -1,0 +1,44 @@
+import { LoggerService } from "@akashnetwork/logging";
+
+import { env } from "@src/utils/env";
+import type { OpenApiHonoHandler } from "../open-api-hono-handler/open-api-hono-handler";
+
+const logger = LoggerService.forContext("OpenApiDocsService");
+
+export class OpenApiDocsService {
+  generateDocs(handlers: OpenApiHonoHandler[]) {
+    const version = "v1";
+    const docs = {
+      openapi: "3.0.0",
+      servers: [{ url: `${env.SERVER_ORIGIN}/${version}` }],
+      info: {
+        title: "Console API",
+        description: "Access Akash data from our indexer",
+        version: version
+      },
+      paths: {},
+      components: {}
+    };
+
+    for (const handler of handlers) {
+      try {
+        const handlerDocs = handler.getOpenAPIDocument({
+          openapi: "3.0.0",
+          info: {
+            title: "Unified API",
+            version: "1.0.0"
+          }
+        });
+
+        Object.assign(docs.paths, handlerDocs.paths);
+      } catch (error) {
+        logger.error({
+          name: `Error generating OpenAPI docs for handler, example path: ${handler.routes[0]?.path || "unknown"}`,
+          error
+        });
+      }
+    }
+
+    return docs;
+  }
+}

--- a/apps/api/src/routers/apiRouter.ts
+++ b/apps/api/src/routers/apiRouter.ts
@@ -1,27 +1,11 @@
-import { swaggerUI } from "@hono/swagger-ui";
 import { OpenAPIHono } from "@hono/zod-openapi";
 
-import { env } from "@src/utils/env";
 import routesV1 from "../routes/v1";
 
 export const apiRouter = new OpenAPIHono();
 
 function registerApiVersion(version: string, baseRouter: OpenAPIHono, versionRoutes: OpenAPIHono[]) {
   const versionRouter = new OpenAPIHono();
-
-  versionRouter.doc(`/doc`, {
-    openapi: "3.0.0",
-    servers: [{ url: `${env.SERVER_ORIGIN}/${version}` }],
-    info: {
-      title: "Console API",
-      description: "Access Akash data from our indexer",
-      version: version
-    }
-  });
-  const swaggerInstance = swaggerUI({ url: `/${version}/doc` });
-
-  versionRouter.get(`/swagger`, swaggerInstance);
-  versionRouter.get(`/swagger/`, c => c.redirect(`/${version}/swagger`));
 
   versionRoutes.forEach(route => versionRouter.route(`/`, route));
   baseRouter.route(`/${version}`, versionRouter);

--- a/apps/api/src/user/routes/get-anonymous-user/get-anonymous-user.router.ts
+++ b/apps/api/src/user/routes/get-anonymous-user/get-anonymous-user.router.ts
@@ -1,7 +1,8 @@
-import { createRoute, OpenAPIHono } from "@hono/zod-openapi";
+import { createRoute } from "@hono/zod-openapi";
 import { container } from "tsyringe";
 import { z } from "zod";
 
+import { OpenApiHonoHandler } from "@src/core/services/open-api-hono-handler/open-api-hono-handler";
 import { UserController } from "@src/user/controllers/user/user.controller";
 import { GetUserResponseOutputSchema } from "@src/user/schemas/user.schema";
 
@@ -30,7 +31,7 @@ const route = createRoute({
     }
   }
 });
-export const getAnonymousUserRouter = new OpenAPIHono();
+export const getAnonymousUserRouter = new OpenApiHonoHandler();
 
 getAnonymousUserRouter.openapi(route, async function routeWallet(c) {
   return c.json(await container.resolve(UserController).getById(c.req.valid("param")), 200);

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -1,0 +1,11641 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
+{
+  "components": {},
+  "info": {
+    "description": "Access Akash data from our indexer",
+    "title": "Console API",
+    "version": "v1",
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/v1/addresses/{address}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "description": "Account Address",
+              "example": "akash13265twfqejnma6cc93rw5dxk4cldyz2zyy8cdm",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "assets": {
+                      "items": {
+                        "properties": {
+                          "amount": {
+                            "type": "number",
+                          },
+                          "description": {
+                            "type": "string",
+                          },
+                          "ibcToken": {
+                            "type": "string",
+                          },
+                          "logoUrl": {
+                            "type": "string",
+                          },
+                          "symbol": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "amount",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "available": {
+                      "type": "number",
+                    },
+                    "commission": {
+                      "type": "number",
+                    },
+                    "delegated": {
+                      "type": "number",
+                    },
+                    "delegations": {
+                      "items": {
+                        "properties": {
+                          "amount": {
+                            "type": "number",
+                          },
+                          "reward": {
+                            "nullable": true,
+                            "type": "number",
+                          },
+                          "validator": {
+                            "properties": {
+                              "address": {
+                                "type": "string",
+                              },
+                              "avatarUrl": {
+                                "type": "string",
+                              },
+                              "moniker": {
+                                "type": "string",
+                              },
+                              "operatorAddress": {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                          },
+                        },
+                        "required": [
+                          "validator",
+                          "amount",
+                          "reward",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "latestTransactions": {
+                      "items": {
+                        "properties": {
+                          "datetime": {
+                            "type": "string",
+                          },
+                          "error": {
+                            "nullable": true,
+                            "type": "string",
+                          },
+                          "fee": {
+                            "type": "number",
+                          },
+                          "gasUsed": {
+                            "type": "number",
+                          },
+                          "gasWanted": {
+                            "type": "number",
+                          },
+                          "hash": {
+                            "type": "string",
+                          },
+                          "height": {
+                            "type": "number",
+                          },
+                          "isSigner": {
+                            "type": "boolean",
+                          },
+                          "isSuccess": {
+                            "type": "boolean",
+                          },
+                          "memo": {
+                            "nullable": true,
+                            "type": "string",
+                          },
+                          "messages": {
+                            "items": {
+                              "properties": {
+                                "amount": {
+                                  "type": "number",
+                                },
+                                "id": {
+                                  "type": "string",
+                                },
+                                "isReceiver": {
+                                  "type": "boolean",
+                                },
+                                "type": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "id",
+                                "type",
+                                "amount",
+                                "isReceiver",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                        },
+                        "required": [
+                          "height",
+                          "datetime",
+                          "hash",
+                          "isSuccess",
+                          "error",
+                          "gasUsed",
+                          "gasWanted",
+                          "fee",
+                          "memo",
+                          "isSigner",
+                          "messages",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "redelegations": {
+                      "items": {
+                        "properties": {
+                          "amount": {
+                            "type": "number",
+                          },
+                          "completionTime": {
+                            "type": "string",
+                          },
+                          "creationHeight": {
+                            "type": "number",
+                          },
+                          "dstAddress": {
+                            "properties": {
+                              "address": {
+                                "type": "string",
+                              },
+                              "avatarUrl": {
+                                "type": "string",
+                              },
+                              "moniker": {
+                                "type": "string",
+                              },
+                              "operatorAddress": {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "srcAddress": {
+                            "properties": {
+                              "address": {
+                                "type": "string",
+                              },
+                              "avatarUrl": {
+                                "type": "string",
+                              },
+                              "moniker": {
+                                "type": "string",
+                              },
+                              "operatorAddress": {
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                          },
+                        },
+                        "required": [
+                          "srcAddress",
+                          "dstAddress",
+                          "creationHeight",
+                          "completionTime",
+                          "amount",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "rewards": {
+                      "type": "number",
+                    },
+                    "total": {
+                      "type": "number",
+                    },
+                  },
+                  "required": [
+                    "total",
+                    "delegations",
+                    "available",
+                    "delegated",
+                    "rewards",
+                    "assets",
+                    "redelegations",
+                    "commission",
+                    "latestTransactions",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns address details",
+          },
+          "400": {
+            "description": "Invalid address",
+          },
+        },
+        "summary": "Get address details",
+        "tags": [
+          "Addresses",
+        ],
+      },
+    },
+    "/v1/addresses/{address}/deployments/{skip}/{limit}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "description": "Wallet Address",
+              "example": "akash13265twfqejnma6cc93rw5dxk4cldyz2zyy8cdm",
+              "type": "string",
+            },
+          },
+          {
+            "in": "path",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "description": "Deployments to skip",
+              "example": 10,
+              "minimum": 0,
+              "nullable": true,
+              "type": "number",
+            },
+          },
+          {
+            "in": "path",
+            "name": "limit",
+            "required": true,
+            "schema": {
+              "description": "Deployments to return",
+              "example": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "description": "Filter by status",
+              "enum": [
+                "active",
+                "closed",
+              ],
+              "example": "closed",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "reverseSorting",
+            "required": false,
+            "schema": {
+              "description": "Reverse sorting",
+              "example": "true",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "count": {
+                      "type": "number",
+                    },
+                    "results": {
+                      "items": {
+                        "properties": {
+                          "cpuUnits": {
+                            "type": "number",
+                          },
+                          "createdHeight": {
+                            "type": "number",
+                          },
+                          "dseq": {
+                            "type": "string",
+                          },
+                          "gpuUnits": {
+                            "type": "number",
+                          },
+                          "leases": {
+                            "items": {
+                              "properties": {
+                                "dseq": {
+                                  "type": "string",
+                                },
+                                "gseq": {
+                                  "type": "number",
+                                },
+                                "id": {
+                                  "type": "string",
+                                },
+                                "oseq": {
+                                  "type": "number",
+                                },
+                                "owner": {
+                                  "type": "string",
+                                },
+                                "price": {
+                                  "properties": {
+                                    "amount": {
+                                      "type": "string",
+                                    },
+                                    "denom": {
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "denom",
+                                    "amount",
+                                  ],
+                                  "type": "object",
+                                },
+                                "provider": {
+                                  "properties": {
+                                    "address": {
+                                      "type": "string",
+                                    },
+                                    "hostUri": {
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "address",
+                                    "hostUri",
+                                  ],
+                                  "type": "object",
+                                },
+                                "state": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "id",
+                                "owner",
+                                "dseq",
+                                "gseq",
+                                "oseq",
+                                "state",
+                                "price",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                          "memoryQuantity": {
+                            "type": "number",
+                          },
+                          "owner": {
+                            "type": "string",
+                          },
+                          "status": {
+                            "type": "string",
+                          },
+                          "storageQuantity": {
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "owner",
+                          "dseq",
+                          "status",
+                          "createdHeight",
+                          "cpuUnits",
+                          "gpuUnits",
+                          "memoryQuantity",
+                          "storageQuantity",
+                          "leases",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "count",
+                    "results",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns deployment list",
+          },
+          "400": {
+            "description": "Invalid address",
+          },
+        },
+        "summary": "Get a list of deployments by owner address.",
+        "tags": [
+          "Addresses",
+          "Deployments",
+        ],
+      },
+    },
+    "/v1/addresses/{address}/transactions/{skip}/{limit}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "description": "Wallet Address",
+              "example": "akash13265twfqejnma6cc93rw5dxk4cldyz2zyy8cdm",
+              "type": "string",
+            },
+          },
+          {
+            "in": "path",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "description": "Transactions to skip",
+              "example": 10,
+              "minimum": 0,
+              "nullable": true,
+              "type": "number",
+            },
+          },
+          {
+            "in": "path",
+            "name": "limit",
+            "required": true,
+            "schema": {
+              "description": "Transactions to return",
+              "example": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "number",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "count": {
+                      "type": "number",
+                    },
+                    "results": {
+                      "items": {
+                        "properties": {
+                          "datetime": {
+                            "type": "string",
+                          },
+                          "error": {
+                            "nullable": true,
+                            "type": "string",
+                          },
+                          "fee": {
+                            "type": "number",
+                          },
+                          "gasUsed": {
+                            "type": "number",
+                          },
+                          "gasWanted": {
+                            "type": "number",
+                          },
+                          "hash": {
+                            "type": "string",
+                          },
+                          "height": {
+                            "type": "number",
+                          },
+                          "isSigner": {
+                            "type": "boolean",
+                          },
+                          "isSuccess": {
+                            "type": "boolean",
+                          },
+                          "memo": {
+                            "nullable": true,
+                            "type": "string",
+                          },
+                          "messages": {
+                            "items": {
+                              "properties": {
+                                "amount": {
+                                  "type": "number",
+                                },
+                                "id": {
+                                  "type": "string",
+                                },
+                                "isReceiver": {
+                                  "type": "boolean",
+                                },
+                                "type": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "id",
+                                "type",
+                                "amount",
+                                "isReceiver",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                        },
+                        "required": [
+                          "height",
+                          "datetime",
+                          "hash",
+                          "isSuccess",
+                          "error",
+                          "gasUsed",
+                          "gasWanted",
+                          "fee",
+                          "memo",
+                          "isSigner",
+                          "messages",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "count",
+                    "results",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns transaction list",
+          },
+          "400": {
+            "description": "Invalid address or parameters",
+          },
+        },
+        "summary": "Get a list of transactions for a given address.",
+        "tags": [
+          "Addresses",
+          "Transactions",
+        ],
+      },
+    },
+    "/v1/anonymous-users": {
+      "post": {
+        "responses": {
+          "200": {
+            "body": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "_cached": null,
+                    "_def": {
+                      "catchall": {
+                        "_def": {
+                          "typeName": "ZodNever",
+                        },
+                        "~standard": {
+                          "vendor": "zod",
+                          "version": 1,
+                        },
+                      },
+                      "typeName": "ZodObject",
+                      "unknownKeys": "strip",
+                    },
+                    "~standard": {
+                      "vendor": "zod",
+                      "version": 1,
+                    },
+                  },
+                },
+              },
+            },
+            "description": "Returns a created anonymous user",
+          },
+        },
+        "summary": "Creates an anonymous user",
+        "tags": [
+          "Users",
+        ],
+      },
+    },
+    "/v1/anonymous-users/:id": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "body": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "_cached": null,
+                    "_def": {
+                      "catchall": {
+                        "_def": {
+                          "typeName": "ZodNever",
+                        },
+                        "~standard": {
+                          "vendor": "zod",
+                          "version": 1,
+                        },
+                      },
+                      "typeName": "ZodObject",
+                      "unknownKeys": "strip",
+                    },
+                    "~standard": {
+                      "vendor": "zod",
+                      "version": 1,
+                    },
+                  },
+                },
+              },
+            },
+            "description": "Returns an anonymous user",
+          },
+        },
+        "summary": "Retrieves an anonymous user by id",
+        "tags": [
+          "Users",
+        ],
+      },
+    },
+    "/v1/api-keys": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "properties": {
+                          "apiKey": {
+                            "type": "string",
+                          },
+                          "createdAt": {
+                            "format": "date-time",
+                            "type": "string",
+                          },
+                          "expiresAt": {
+                            "format": "date-time",
+                            "nullable": true,
+                            "type": "string",
+                          },
+                          "id": {
+                            "format": "uuid",
+                            "type": "string",
+                          },
+                          "keyFormat": {
+                            "type": "string",
+                          },
+                          "lastUsedAt": {
+                            "format": "date-time",
+                            "nullable": true,
+                            "type": "string",
+                          },
+                          "name": {
+                            "type": "string",
+                          },
+                          "updatedAt": {
+                            "format": "date-time",
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "id",
+                          "name",
+                          "expiresAt",
+                          "createdAt",
+                          "updatedAt",
+                          "lastUsedAt",
+                          "keyFormat",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns list of API keys",
+          },
+        },
+        "summary": "List all API keys",
+        "tags": [
+          "API Keys",
+        ],
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "expiresAt": {
+                        "format": "date-time",
+                        "type": "string",
+                      },
+                      "name": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "name",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "apiKey": {
+                          "type": "string",
+                        },
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "expiresAt": {
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "id": {
+                          "format": "uuid",
+                          "type": "string",
+                        },
+                        "keyFormat": {
+                          "type": "string",
+                        },
+                        "lastUsedAt": {
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "expiresAt",
+                        "createdAt",
+                        "updatedAt",
+                        "lastUsedAt",
+                        "keyFormat",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "API key created successfully",
+          },
+        },
+        "summary": "Create new API key",
+        "tags": [
+          "API Keys",
+        ],
+      },
+    },
+    "/v1/api-keys/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "204": {
+            "description": "API key deleted successfully",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "API key not found",
+          },
+        },
+        "summary": "Delete API key",
+        "tags": [
+          "API Keys",
+        ],
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "apiKey": {
+                          "type": "string",
+                        },
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "expiresAt": {
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "id": {
+                          "format": "uuid",
+                          "type": "string",
+                        },
+                        "keyFormat": {
+                          "type": "string",
+                        },
+                        "lastUsedAt": {
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "expiresAt",
+                        "createdAt",
+                        "updatedAt",
+                        "lastUsedAt",
+                        "keyFormat",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns API key details",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "API key not found",
+          },
+        },
+        "summary": "Get API key by ID",
+        "tags": [
+          "API Keys",
+        ],
+      },
+      "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                      },
+                    },
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "apiKey": {
+                          "type": "string",
+                        },
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "expiresAt": {
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "id": {
+                          "format": "uuid",
+                          "type": "string",
+                        },
+                        "keyFormat": {
+                          "type": "string",
+                        },
+                        "lastUsedAt": {
+                          "format": "date-time",
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "expiresAt",
+                        "createdAt",
+                        "updatedAt",
+                        "lastUsedAt",
+                        "keyFormat",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "API key updated successfully",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "API key not found",
+          },
+        },
+        "summary": "Update API key",
+        "tags": [
+          "API Keys",
+        ],
+      },
+    },
+    "/v1/auditors": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "address": {
+                        "type": "string",
+                      },
+                      "id": {
+                        "type": "string",
+                      },
+                      "name": {
+                        "type": "string",
+                      },
+                      "website": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "id",
+                      "name",
+                      "address",
+                      "website",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "List of auditors",
+          },
+        },
+        "summary": "Get a list of auditors.",
+        "tags": [
+          "Providers",
+        ],
+      },
+    },
+    "/v1/balances": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Optional wallet address to fetch balances for instead of the current user",
+            "in": "query",
+            "name": "address",
+            "required": false,
+            "schema": {
+              "description": "Optional wallet address to fetch balances for instead of the current user",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "balance": {
+                          "type": "number",
+                        },
+                        "deployments": {
+                          "type": "number",
+                        },
+                        "total": {
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "balance",
+                        "deployments",
+                        "total",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns user balances",
+          },
+        },
+        "summary": "Get user balances",
+        "tags": [
+          "Wallet",
+        ],
+      },
+    },
+    "/v1/bids": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "dseq",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "userId",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "properties": {
+                          "bid": {
+                            "properties": {
+                              "bid_id": {
+                                "properties": {
+                                  "dseq": {
+                                    "type": "string",
+                                  },
+                                  "gseq": {
+                                    "type": "number",
+                                  },
+                                  "oseq": {
+                                    "type": "number",
+                                  },
+                                  "owner": {
+                                    "type": "string",
+                                  },
+                                  "provider": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                ],
+                                "type": "object",
+                              },
+                              "created_at": {
+                                "type": "string",
+                              },
+                              "price": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                              "resources_offer": {
+                                "items": {
+                                  "properties": {
+                                    "count": {
+                                      "type": "number",
+                                    },
+                                    "resources": {
+                                      "properties": {
+                                        "cpu": {
+                                          "properties": {
+                                            "attributes": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string",
+                                                  },
+                                                  "value": {
+                                                    "type": "string",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "key",
+                                                  "value",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              "type": "array",
+                                            },
+                                            "units": {
+                                              "properties": {
+                                                "val": {
+                                                  "type": "string",
+                                                },
+                                              },
+                                              "required": [
+                                                "val",
+                                              ],
+                                              "type": "object",
+                                            },
+                                          },
+                                          "required": [
+                                            "units",
+                                            "attributes",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        "endpoints": {
+                                          "items": {
+                                            "properties": {
+                                              "kind": {
+                                                "type": "string",
+                                              },
+                                              "sequence_number": {
+                                                "type": "number",
+                                              },
+                                            },
+                                            "required": [
+                                              "kind",
+                                              "sequence_number",
+                                            ],
+                                            "type": "object",
+                                          },
+                                          "type": "array",
+                                        },
+                                        "gpu": {
+                                          "properties": {
+                                            "attributes": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string",
+                                                  },
+                                                  "value": {
+                                                    "type": "string",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "key",
+                                                  "value",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              "type": "array",
+                                            },
+                                            "units": {
+                                              "properties": {
+                                                "val": {
+                                                  "type": "string",
+                                                },
+                                              },
+                                              "required": [
+                                                "val",
+                                              ],
+                                              "type": "object",
+                                            },
+                                          },
+                                          "required": [
+                                            "units",
+                                            "attributes",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        "memory": {
+                                          "properties": {
+                                            "attributes": {
+                                              "items": {
+                                                "properties": {
+                                                  "key": {
+                                                    "type": "string",
+                                                  },
+                                                  "value": {
+                                                    "type": "string",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "key",
+                                                  "value",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              "type": "array",
+                                            },
+                                            "quantity": {
+                                              "properties": {
+                                                "val": {
+                                                  "type": "string",
+                                                },
+                                              },
+                                              "required": [
+                                                "val",
+                                              ],
+                                              "type": "object",
+                                            },
+                                          },
+                                          "required": [
+                                            "quantity",
+                                            "attributes",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        "storage": {
+                                          "items": {
+                                            "properties": {
+                                              "attributes": {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string",
+                                                    },
+                                                    "value": {
+                                                      "type": "string",
+                                                    },
+                                                  },
+                                                  "required": [
+                                                    "key",
+                                                    "value",
+                                                  ],
+                                                  "type": "object",
+                                                },
+                                                "type": "array",
+                                              },
+                                              "name": {
+                                                "type": "string",
+                                              },
+                                              "quantity": {
+                                                "properties": {
+                                                  "val": {
+                                                    "type": "string",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "val",
+                                                ],
+                                                "type": "object",
+                                              },
+                                            },
+                                            "required": [
+                                              "name",
+                                              "quantity",
+                                              "attributes",
+                                            ],
+                                            "type": "object",
+                                          },
+                                          "type": "array",
+                                        },
+                                      },
+                                      "required": [
+                                        "cpu",
+                                        "gpu",
+                                        "memory",
+                                        "storage",
+                                        "endpoints",
+                                      ],
+                                      "type": "object",
+                                    },
+                                  },
+                                  "required": [
+                                    "resources",
+                                    "count",
+                                  ],
+                                  "type": "object",
+                                },
+                                "type": "array",
+                              },
+                              "state": {
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "bid_id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "resources_offer",
+                            ],
+                            "type": "object",
+                          },
+                          "escrow_account": {
+                            "properties": {
+                              "balance": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                              "depositor": {
+                                "type": "string",
+                              },
+                              "funds": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                              "id": {
+                                "properties": {
+                                  "scope": {
+                                    "type": "string",
+                                  },
+                                  "xid": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "scope",
+                                  "xid",
+                                ],
+                                "type": "object",
+                              },
+                              "owner": {
+                                "type": "string",
+                              },
+                              "settled_at": {
+                                "type": "string",
+                              },
+                              "state": {
+                                "type": "string",
+                              },
+                              "transferred": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                            },
+                            "required": [
+                              "id",
+                              "owner",
+                              "state",
+                              "balance",
+                              "transferred",
+                              "settled_at",
+                              "depositor",
+                              "funds",
+                            ],
+                            "type": "object",
+                          },
+                        },
+                        "required": [
+                          "bid",
+                          "escrow_account",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "List of bids",
+          },
+        },
+        "summary": "List bids",
+        "tags": [
+          "Bids",
+        ],
+      },
+    },
+    "/v1/blocks": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Number of blocks to return",
+              "example": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "number",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "datetime": {
+                        "type": "string",
+                      },
+                      "height": {
+                        "type": "number",
+                      },
+                      "proposer": {
+                        "properties": {
+                          "address": {
+                            "type": "string",
+                          },
+                          "avatarUrl": {
+                            "nullable": true,
+                            "type": "string",
+                          },
+                          "moniker": {
+                            "type": "string",
+                          },
+                          "operatorAddress": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "address",
+                          "operatorAddress",
+                          "moniker",
+                          "avatarUrl",
+                        ],
+                        "type": "object",
+                      },
+                      "totalTransactionCount": {
+                        "type": "number",
+                      },
+                      "transactionCount": {
+                        "type": "number",
+                      },
+                    },
+                    "required": [
+                      "height",
+                      "proposer",
+                      "transactionCount",
+                      "totalTransactionCount",
+                      "datetime",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "Returns block list",
+          },
+        },
+        "summary": "Get a list of recent blocks.",
+        "tags": [
+          "Blocks",
+        ],
+      },
+    },
+    "/v1/blocks/{height}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "height",
+            "required": false,
+            "schema": {
+              "description": "Block Height",
+              "example": 12121212,
+              "nullable": true,
+              "type": "number",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "datetime": {
+                      "type": "string",
+                    },
+                    "gasUsed": {
+                      "type": "number",
+                    },
+                    "gasWanted": {
+                      "type": "number",
+                    },
+                    "hash": {
+                      "type": "string",
+                    },
+                    "height": {
+                      "type": "number",
+                    },
+                    "proposer": {
+                      "properties": {
+                        "address": {
+                          "type": "string",
+                        },
+                        "avatarUrl": {
+                          "type": "string",
+                        },
+                        "moniker": {
+                          "type": "string",
+                        },
+                        "operatorAddress": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "operatorAddress",
+                        "moniker",
+                        "address",
+                      ],
+                      "type": "object",
+                    },
+                    "transactions": {
+                      "items": {
+                        "properties": {
+                          "datetime": {
+                            "type": "string",
+                          },
+                          "error": {
+                            "nullable": true,
+                            "type": "string",
+                          },
+                          "fee": {
+                            "type": "number",
+                          },
+                          "hash": {
+                            "type": "string",
+                          },
+                          "isSuccess": {
+                            "type": "boolean",
+                          },
+                          "messages": {
+                            "items": {
+                              "properties": {
+                                "amount": {
+                                  "type": "number",
+                                },
+                                "id": {
+                                  "type": "string",
+                                },
+                                "type": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "id",
+                                "type",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                        },
+                        "required": [
+                          "hash",
+                          "isSuccess",
+                          "fee",
+                          "datetime",
+                          "messages",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "height",
+                    "datetime",
+                    "proposer",
+                    "hash",
+                    "gasUsed",
+                    "gasWanted",
+                    "transactions",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns predicted block date",
+          },
+          "400": {
+            "description": "Invalid height",
+          },
+          "404": {
+            "description": "Block not found",
+          },
+        },
+        "summary": "Get a block by height.",
+        "tags": [
+          "Blocks",
+        ],
+      },
+    },
+    "/v1/certificates": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "certPem": {
+                          "minLength": 1,
+                          "type": "string",
+                        },
+                        "encryptedKey": {
+                          "minLength": 1,
+                          "type": "string",
+                        },
+                        "pubkeyPem": {
+                          "minLength": 1,
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "certPem",
+                        "pubkeyPem",
+                        "encryptedKey",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Certificate created",
+          },
+        },
+        "summary": "Create certificate",
+        "tags": [
+          "Certificate",
+        ],
+      },
+    },
+    "/v1/checkout": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "amount",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "301": {
+            "description": "Redirects to the checkout page",
+          },
+        },
+        "summary": "Creates a stripe checkout session and redirects to checkout",
+        "tags": [
+          "Wallet",
+        ],
+      },
+    },
+    "/v1/dashboard-data": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "chainStats": {
+                      "properties": {
+                        "bondedTokens": {
+                          "type": "number",
+                        },
+                        "communityPool": {
+                          "type": "number",
+                        },
+                        "height": {
+                          "type": "number",
+                        },
+                        "inflation": {
+                          "type": "number",
+                        },
+                        "stakingAPR": {
+                          "type": "number",
+                        },
+                        "totalSupply": {
+                          "type": "number",
+                        },
+                        "transactionCount": {
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "height",
+                        "transactionCount",
+                        "bondedTokens",
+                        "totalSupply",
+                        "communityPool",
+                        "inflation",
+                      ],
+                      "type": "object",
+                    },
+                    "compare": {
+                      "properties": {
+                        "activeCPU": {
+                          "type": "number",
+                        },
+                        "activeGPU": {
+                          "type": "number",
+                        },
+                        "activeLeaseCount": {
+                          "type": "number",
+                        },
+                        "activeMemory": {
+                          "type": "number",
+                        },
+                        "activeStorage": {
+                          "type": "number",
+                        },
+                        "dailyLeaseCount": {
+                          "type": "number",
+                        },
+                        "dailyUAktSpent": {
+                          "type": "number",
+                        },
+                        "dailyUUsdSpent": {
+                          "type": "number",
+                        },
+                        "dailyUUsdcSpent": {
+                          "type": "number",
+                        },
+                        "date": {
+                          "type": "string",
+                        },
+                        "height": {
+                          "type": "number",
+                        },
+                        "totalLeaseCount": {
+                          "type": "number",
+                        },
+                        "totalUAktSpent": {
+                          "type": "number",
+                        },
+                        "totalUUsdSpent": {
+                          "type": "number",
+                        },
+                        "totalUUsdcSpent": {
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "date",
+                        "height",
+                        "activeLeaseCount",
+                        "totalLeaseCount",
+                        "dailyLeaseCount",
+                        "totalUAktSpent",
+                        "dailyUAktSpent",
+                        "totalUUsdcSpent",
+                        "dailyUUsdcSpent",
+                        "totalUUsdSpent",
+                        "dailyUUsdSpent",
+                        "activeCPU",
+                        "activeGPU",
+                        "activeMemory",
+                        "activeStorage",
+                      ],
+                      "type": "object",
+                    },
+                    "latestBlocks": {
+                      "items": {
+                        "properties": {
+                          "datetime": {
+                            "type": "string",
+                          },
+                          "height": {
+                            "type": "number",
+                          },
+                          "proposer": {
+                            "properties": {
+                              "address": {
+                                "type": "string",
+                              },
+                              "avatarUrl": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              "moniker": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              "operatorAddress": {
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "address",
+                              "operatorAddress",
+                              "moniker",
+                              "avatarUrl",
+                            ],
+                            "type": "object",
+                          },
+                          "totalTransactionCount": {
+                            "type": "number",
+                          },
+                          "transactionCount": {
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "height",
+                          "proposer",
+                          "transactionCount",
+                          "totalTransactionCount",
+                          "datetime",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "latestTransactions": {
+                      "items": {
+                        "properties": {
+                          "datetime": {
+                            "type": "string",
+                          },
+                          "error": {
+                            "nullable": true,
+                            "type": "string",
+                          },
+                          "fee": {
+                            "type": "number",
+                          },
+                          "gasUsed": {
+                            "type": "number",
+                          },
+                          "gasWanted": {
+                            "type": "number",
+                          },
+                          "hash": {
+                            "type": "string",
+                          },
+                          "height": {
+                            "type": "number",
+                          },
+                          "isSuccess": {
+                            "type": "boolean",
+                          },
+                          "memo": {
+                            "type": "string",
+                          },
+                          "messages": {
+                            "items": {
+                              "properties": {
+                                "amount": {
+                                  "type": "number",
+                                },
+                                "id": {
+                                  "type": "string",
+                                },
+                                "type": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "id",
+                                "type",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                        },
+                        "required": [
+                          "height",
+                          "datetime",
+                          "hash",
+                          "isSuccess",
+                          "error",
+                          "gasUsed",
+                          "gasWanted",
+                          "fee",
+                          "memo",
+                          "messages",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "networkCapacity": {
+                      "properties": {
+                        "activeCPU": {
+                          "type": "number",
+                        },
+                        "activeEphemeralStorage": {
+                          "type": "number",
+                        },
+                        "activeGPU": {
+                          "type": "number",
+                        },
+                        "activeMemory": {
+                          "type": "number",
+                        },
+                        "activePersistentStorage": {
+                          "type": "number",
+                        },
+                        "activeProviderCount": {
+                          "type": "number",
+                        },
+                        "activeStorage": {
+                          "type": "number",
+                        },
+                        "availableCPU": {
+                          "type": "number",
+                        },
+                        "availableEphemeralStorage": {
+                          "type": "number",
+                        },
+                        "availableGPU": {
+                          "type": "number",
+                        },
+                        "availableMemory": {
+                          "type": "number",
+                        },
+                        "availablePersistentStorage": {
+                          "type": "number",
+                        },
+                        "availableStorage": {
+                          "type": "number",
+                        },
+                        "pendingCPU": {
+                          "type": "number",
+                        },
+                        "pendingEphemeralStorage": {
+                          "type": "number",
+                        },
+                        "pendingGPU": {
+                          "type": "number",
+                        },
+                        "pendingMemory": {
+                          "type": "number",
+                        },
+                        "pendingPersistentStorage": {
+                          "type": "number",
+                        },
+                        "pendingStorage": {
+                          "type": "number",
+                        },
+                        "totalCPU": {
+                          "type": "number",
+                        },
+                        "totalGPU": {
+                          "type": "number",
+                        },
+                        "totalMemory": {
+                          "type": "number",
+                        },
+                        "totalStorage": {
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "activeProviderCount",
+                        "activeCPU",
+                        "activeGPU",
+                        "activeMemory",
+                        "activeStorage",
+                        "pendingCPU",
+                        "pendingGPU",
+                        "pendingMemory",
+                        "pendingStorage",
+                        "availableCPU",
+                        "availableGPU",
+                        "availableMemory",
+                        "availableStorage",
+                        "totalCPU",
+                        "totalGPU",
+                        "totalMemory",
+                        "totalStorage",
+                        "activeEphemeralStorage",
+                        "pendingEphemeralStorage",
+                        "availableEphemeralStorage",
+                        "activePersistentStorage",
+                        "pendingPersistentStorage",
+                        "availablePersistentStorage",
+                      ],
+                      "type": "object",
+                    },
+                    "networkCapacityStats": {
+                      "properties": {
+                        "compare": {
+                          "properties": {
+                            "count": {
+                              "type": "number",
+                            },
+                            "cpu": {
+                              "type": "number",
+                            },
+                            "gpu": {
+                              "type": "number",
+                            },
+                            "memory": {
+                              "type": "number",
+                            },
+                            "storage": {
+                              "type": "number",
+                            },
+                          },
+                          "required": [
+                            "count",
+                            "cpu",
+                            "gpu",
+                            "memory",
+                            "storage",
+                          ],
+                          "type": "object",
+                        },
+                        "compareValue": {
+                          "type": "number",
+                        },
+                        "currentValue": {
+                          "type": "number",
+                        },
+                        "now": {
+                          "properties": {
+                            "count": {
+                              "type": "number",
+                            },
+                            "cpu": {
+                              "type": "number",
+                            },
+                            "gpu": {
+                              "type": "number",
+                            },
+                            "memory": {
+                              "type": "number",
+                            },
+                            "storage": {
+                              "type": "number",
+                            },
+                          },
+                          "required": [
+                            "count",
+                            "cpu",
+                            "gpu",
+                            "memory",
+                            "storage",
+                          ],
+                          "type": "object",
+                        },
+                        "snapshots": {
+                          "items": {
+                            "properties": {
+                              "date": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "type": "number",
+                              },
+                            },
+                            "required": [
+                              "date",
+                              "value",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "currentValue",
+                        "compareValue",
+                        "snapshots",
+                        "now",
+                        "compare",
+                      ],
+                      "type": "object",
+                    },
+                    "now": {
+                      "properties": {
+                        "activeCPU": {
+                          "type": "number",
+                        },
+                        "activeGPU": {
+                          "type": "number",
+                        },
+                        "activeLeaseCount": {
+                          "type": "number",
+                        },
+                        "activeMemory": {
+                          "type": "number",
+                        },
+                        "activeStorage": {
+                          "type": "number",
+                        },
+                        "dailyLeaseCount": {
+                          "type": "number",
+                        },
+                        "dailyUAktSpent": {
+                          "type": "number",
+                        },
+                        "dailyUUsdSpent": {
+                          "type": "number",
+                        },
+                        "dailyUUsdcSpent": {
+                          "type": "number",
+                        },
+                        "date": {
+                          "type": "string",
+                        },
+                        "height": {
+                          "type": "number",
+                        },
+                        "totalLeaseCount": {
+                          "type": "number",
+                        },
+                        "totalUAktSpent": {
+                          "type": "number",
+                        },
+                        "totalUUsdSpent": {
+                          "type": "number",
+                        },
+                        "totalUUsdcSpent": {
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "date",
+                        "height",
+                        "activeLeaseCount",
+                        "totalLeaseCount",
+                        "dailyLeaseCount",
+                        "totalUAktSpent",
+                        "dailyUAktSpent",
+                        "totalUUsdcSpent",
+                        "dailyUUsdcSpent",
+                        "totalUUsdSpent",
+                        "dailyUUsdSpent",
+                        "activeCPU",
+                        "activeGPU",
+                        "activeMemory",
+                        "activeStorage",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "chainStats",
+                    "now",
+                    "compare",
+                    "networkCapacity",
+                    "networkCapacityStats",
+                    "latestBlocks",
+                    "latestTransactions",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns dashboard data",
+          },
+        },
+        "tags": [
+          "Analytics",
+        ],
+      },
+    },
+    "/v1/deployment-settings": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "autoTopUpEnabled": {
+                        "default": false,
+                        "description": "Whether auto top-up is enabled for this deployment",
+                        "type": "boolean",
+                      },
+                      "dseq": {
+                        "description": "Deployment sequence number",
+                        "type": "string",
+                      },
+                      "userId": {
+                        "description": "User ID",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "userId",
+                      "dseq",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "autoTopUpEnabled": {
+                          "type": "boolean",
+                        },
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "dseq": {
+                          "type": "string",
+                        },
+                        "estimatedTopUpAmount": {
+                          "type": "number",
+                        },
+                        "id": {
+                          "format": "uuid",
+                          "type": "string",
+                        },
+                        "topUpFrequencyMs": {
+                          "type": "number",
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "userId": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "userId",
+                        "dseq",
+                        "autoTopUpEnabled",
+                        "estimatedTopUpAmount",
+                        "topUpFrequencyMs",
+                        "createdAt",
+                        "updatedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Deployment settings created successfully",
+          },
+        },
+        "summary": "Create deployment settings",
+        "tags": [
+          "Deployment Settings",
+        ],
+      },
+    },
+    "/v1/deployment-settings/{userId}/{dseq}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "description": "User ID",
+              "type": "string",
+            },
+          },
+          {
+            "in": "path",
+            "name": "dseq",
+            "required": true,
+            "schema": {
+              "description": "Deployment sequence number",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "autoTopUpEnabled": {
+                          "type": "boolean",
+                        },
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "dseq": {
+                          "type": "string",
+                        },
+                        "estimatedTopUpAmount": {
+                          "type": "number",
+                        },
+                        "id": {
+                          "format": "uuid",
+                          "type": "string",
+                        },
+                        "topUpFrequencyMs": {
+                          "type": "number",
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "userId": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "userId",
+                        "dseq",
+                        "autoTopUpEnabled",
+                        "estimatedTopUpAmount",
+                        "topUpFrequencyMs",
+                        "createdAt",
+                        "updatedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns deployment settings",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Deployment settings not found",
+          },
+        },
+        "summary": "Get deployment settings by user ID and dseq",
+        "tags": [
+          "Deployment Settings",
+        ],
+      },
+      "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "description": "User ID",
+              "type": "string",
+            },
+          },
+          {
+            "in": "path",
+            "name": "dseq",
+            "required": true,
+            "schema": {
+              "description": "Deployment sequence number",
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "autoTopUpEnabled": {
+                        "description": "Whether auto top-up is enabled for this deployment",
+                        "type": "boolean",
+                      },
+                    },
+                    "required": [
+                      "autoTopUpEnabled",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "autoTopUpEnabled": {
+                          "type": "boolean",
+                        },
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "dseq": {
+                          "type": "string",
+                        },
+                        "estimatedTopUpAmount": {
+                          "type": "number",
+                        },
+                        "id": {
+                          "format": "uuid",
+                          "type": "string",
+                        },
+                        "topUpFrequencyMs": {
+                          "type": "number",
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "userId": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "userId",
+                        "dseq",
+                        "autoTopUpEnabled",
+                        "estimatedTopUpAmount",
+                        "topUpFrequencyMs",
+                        "createdAt",
+                        "updatedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Deployment settings updated successfully",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Deployment settings not found",
+          },
+        },
+        "summary": "Update deployment settings",
+        "tags": [
+          "Deployment Settings",
+        ],
+      },
+    },
+    "/v1/deployment/{owner}/{dseq}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "description": "Owner's Address",
+              "example": "akash13265twfqejnma6cc93rw5dxk4cldyz2zyy8cdm",
+              "type": "string",
+            },
+          },
+          {
+            "in": "path",
+            "name": "dseq",
+            "required": true,
+            "schema": {
+              "description": "Deployment DSEQ",
+              "example": "1000000",
+              "type": "integer",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "balance": {
+                      "type": "number",
+                    },
+                    "denom": {
+                      "type": "string",
+                    },
+                    "dseq": {
+                      "type": "string",
+                    },
+                    "events": {
+                      "items": {
+                        "properties": {
+                          "date": {
+                            "type": "string",
+                          },
+                          "txHash": {
+                            "type": "string",
+                          },
+                          "type": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "txHash",
+                          "date",
+                          "type",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "leases": {
+                      "items": {
+                        "properties": {
+                          "cpuUnits": {
+                            "type": "number",
+                          },
+                          "gpuUnits": {
+                            "type": "number",
+                          },
+                          "gseq": {
+                            "type": "number",
+                          },
+                          "memoryQuantity": {
+                            "type": "number",
+                          },
+                          "monthlyCostUDenom": {
+                            "type": "number",
+                          },
+                          "oseq": {
+                            "type": "number",
+                          },
+                          "provider": {
+                            "nullable": true,
+                            "properties": {
+                              "address": {
+                                "type": "string",
+                              },
+                              "attributes": {
+                                "items": {
+                                  "properties": {
+                                    "key": {
+                                      "type": "string",
+                                    },
+                                    "value": {
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "key",
+                                    "value",
+                                  ],
+                                  "type": "object",
+                                },
+                                "type": "array",
+                              },
+                              "hostUri": {
+                                "type": "string",
+                              },
+                              "isDeleted": {
+                                "type": "boolean",
+                              },
+                            },
+                            "required": [
+                              "address",
+                              "hostUri",
+                              "isDeleted",
+                              "attributes",
+                            ],
+                            "type": "object",
+                          },
+                          "status": {
+                            "type": "string",
+                          },
+                          "storageQuantity": {
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "gseq",
+                          "oseq",
+                          "provider",
+                          "status",
+                          "monthlyCostUDenom",
+                          "cpuUnits",
+                          "gpuUnits",
+                          "memoryQuantity",
+                          "storageQuantity",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "other": {
+                      "properties": {
+                        "deployment": {
+                          "properties": {
+                            "created_at": {
+                              "type": "string",
+                            },
+                            "deployment_id": {
+                              "properties": {
+                                "dseq": {
+                                  "type": "string",
+                                },
+                                "owner": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "owner",
+                                "dseq",
+                              ],
+                              "type": "object",
+                            },
+                            "state": {
+                              "type": "string",
+                            },
+                            "version": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "deployment_id",
+                            "state",
+                            "version",
+                            "created_at",
+                          ],
+                          "type": "object",
+                        },
+                        "escrow_account": {
+                          "properties": {
+                            "balance": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                            "depositor": {
+                              "type": "string",
+                            },
+                            "funds": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                            "id": {
+                              "properties": {
+                                "scope": {
+                                  "type": "string",
+                                },
+                                "xid": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "scope",
+                                "xid",
+                              ],
+                              "type": "object",
+                            },
+                            "owner": {
+                              "type": "string",
+                            },
+                            "settled_at": {
+                              "type": "string",
+                            },
+                            "state": {
+                              "type": "string",
+                            },
+                            "transferred": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "owner",
+                            "state",
+                            "balance",
+                            "transferred",
+                            "settled_at",
+                            "depositor",
+                            "funds",
+                          ],
+                          "type": "object",
+                        },
+                        "groups": {
+                          "items": {
+                            "properties": {
+                              "created_at": {
+                                "type": "string",
+                              },
+                              "group_id": {
+                                "properties": {
+                                  "dseq": {
+                                    "type": "string",
+                                  },
+                                  "gseq": {
+                                    "type": "number",
+                                  },
+                                  "owner": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                ],
+                                "type": "object",
+                              },
+                              "group_spec": {
+                                "properties": {
+                                  "name": {
+                                    "type": "string",
+                                  },
+                                  "requirements": {
+                                    "properties": {
+                                      "attributes": {
+                                        "items": {
+                                          "properties": {
+                                            "key": {
+                                              "type": "string",
+                                            },
+                                            "value": {
+                                              "type": "string",
+                                            },
+                                          },
+                                          "required": [
+                                            "key",
+                                            "value",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        "type": "array",
+                                      },
+                                      "signed_by": {
+                                        "properties": {
+                                          "all_of": {
+                                            "items": {
+                                              "type": "string",
+                                            },
+                                            "type": "array",
+                                          },
+                                          "any_of": {
+                                            "items": {
+                                              "type": "string",
+                                            },
+                                            "type": "array",
+                                          },
+                                        },
+                                        "required": [
+                                          "all_of",
+                                          "any_of",
+                                        ],
+                                        "type": "object",
+                                      },
+                                    },
+                                    "required": [
+                                      "signed_by",
+                                      "attributes",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "resources": {
+                                    "items": {
+                                      "properties": {
+                                        "count": {
+                                          "type": "number",
+                                        },
+                                        "price": {
+                                          "properties": {
+                                            "amount": {
+                                              "type": "string",
+                                            },
+                                            "denom": {
+                                              "type": "string",
+                                            },
+                                          },
+                                          "required": [
+                                            "denom",
+                                            "amount",
+                                          ],
+                                          "type": "object",
+                                        },
+                                        "resource": {
+                                          "properties": {
+                                            "cpu": {
+                                              "properties": {
+                                                "attributes": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string",
+                                                      },
+                                                      "value": {
+                                                        "type": "string",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "value",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                  "type": "array",
+                                                },
+                                                "units": {
+                                                  "properties": {
+                                                    "val": {
+                                                      "type": "string",
+                                                    },
+                                                  },
+                                                  "required": [
+                                                    "val",
+                                                  ],
+                                                  "type": "object",
+                                                },
+                                              },
+                                              "required": [
+                                                "units",
+                                                "attributes",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            "endpoints": {
+                                              "items": {
+                                                "properties": {
+                                                  "kind": {
+                                                    "type": "string",
+                                                  },
+                                                  "sequence_number": {
+                                                    "type": "number",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "kind",
+                                                  "sequence_number",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              "type": "array",
+                                            },
+                                            "gpu": {
+                                              "properties": {
+                                                "attributes": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string",
+                                                      },
+                                                      "value": {
+                                                        "type": "string",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "value",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                  "type": "array",
+                                                },
+                                                "units": {
+                                                  "properties": {
+                                                    "val": {
+                                                      "type": "string",
+                                                    },
+                                                  },
+                                                  "required": [
+                                                    "val",
+                                                  ],
+                                                  "type": "object",
+                                                },
+                                              },
+                                              "required": [
+                                                "units",
+                                                "attributes",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            "id": {
+                                              "type": "number",
+                                            },
+                                            "memory": {
+                                              "properties": {
+                                                "attributes": {
+                                                  "items": {
+                                                    "properties": {
+                                                      "key": {
+                                                        "type": "string",
+                                                      },
+                                                      "value": {
+                                                        "type": "string",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "key",
+                                                      "value",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                  "type": "array",
+                                                },
+                                                "quantity": {
+                                                  "properties": {
+                                                    "val": {
+                                                      "type": "string",
+                                                    },
+                                                  },
+                                                  "required": [
+                                                    "val",
+                                                  ],
+                                                  "type": "object",
+                                                },
+                                              },
+                                              "required": [
+                                                "quantity",
+                                                "attributes",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            "storage": {
+                                              "items": {
+                                                "properties": {
+                                                  "attributes": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string",
+                                                        },
+                                                        "value": {
+                                                          "type": "string",
+                                                        },
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "value",
+                                                      ],
+                                                      "type": "object",
+                                                    },
+                                                    "type": "array",
+                                                  },
+                                                  "name": {
+                                                    "type": "string",
+                                                  },
+                                                  "quantity": {
+                                                    "properties": {
+                                                      "val": {
+                                                        "type": "string",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "val",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "name",
+                                                  "quantity",
+                                                  "attributes",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              "type": "array",
+                                            },
+                                          },
+                                          "required": [
+                                            "id",
+                                            "cpu",
+                                            "memory",
+                                            "storage",
+                                            "gpu",
+                                            "endpoints",
+                                          ],
+                                          "type": "object",
+                                        },
+                                      },
+                                      "required": [
+                                        "resource",
+                                        "count",
+                                        "price",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    "type": "array",
+                                  },
+                                },
+                                "required": [
+                                  "name",
+                                  "requirements",
+                                  "resources",
+                                ],
+                                "type": "object",
+                              },
+                              "state": {
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "group_id",
+                              "state",
+                              "group_spec",
+                              "created_at",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "deployment",
+                        "groups",
+                        "escrow_account",
+                      ],
+                      "type": "object",
+                    },
+                    "owner": {
+                      "type": "string",
+                    },
+                    "status": {
+                      "type": "string",
+                    },
+                    "totalMonthlyCostUDenom": {
+                      "type": "number",
+                    },
+                  },
+                  "required": [
+                    "owner",
+                    "dseq",
+                    "balance",
+                    "denom",
+                    "status",
+                    "totalMonthlyCostUDenom",
+                    "leases",
+                    "events",
+                    "other",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns deployment details",
+          },
+          "400": {
+            "description": "Invalid address or dseq",
+          },
+          "404": {
+            "description": "Deployment not found",
+          },
+        },
+        "summary": "Get deployment details",
+        "tags": [
+          "Deployments",
+        ],
+      },
+    },
+    "/v1/deployments": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "nullable": true,
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 1000,
+              "minimum": 1,
+              "type": "number",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "deployments": {
+                          "items": {
+                            "properties": {
+                              "deployment": {
+                                "properties": {
+                                  "created_at": {
+                                    "type": "string",
+                                  },
+                                  "deployment_id": {
+                                    "properties": {
+                                      "dseq": {
+                                        "type": "string",
+                                      },
+                                      "owner": {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "owner",
+                                      "dseq",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "state": {
+                                    "type": "string",
+                                  },
+                                  "version": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "deployment_id",
+                                  "state",
+                                  "version",
+                                  "created_at",
+                                ],
+                                "type": "object",
+                              },
+                              "escrow_account": {
+                                "properties": {
+                                  "balance": {
+                                    "properties": {
+                                      "amount": {
+                                        "type": "string",
+                                      },
+                                      "denom": {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "denom",
+                                      "amount",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "depositor": {
+                                    "type": "string",
+                                  },
+                                  "funds": {
+                                    "properties": {
+                                      "amount": {
+                                        "type": "string",
+                                      },
+                                      "denom": {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "denom",
+                                      "amount",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "id": {
+                                    "properties": {
+                                      "scope": {
+                                        "type": "string",
+                                      },
+                                      "xid": {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "scope",
+                                      "xid",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "owner": {
+                                    "type": "string",
+                                  },
+                                  "settled_at": {
+                                    "type": "string",
+                                  },
+                                  "state": {
+                                    "type": "string",
+                                  },
+                                  "transferred": {
+                                    "properties": {
+                                      "amount": {
+                                        "type": "string",
+                                      },
+                                      "denom": {
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "denom",
+                                      "amount",
+                                    ],
+                                    "type": "object",
+                                  },
+                                },
+                                "required": [
+                                  "id",
+                                  "owner",
+                                  "state",
+                                  "balance",
+                                  "transferred",
+                                  "settled_at",
+                                  "depositor",
+                                  "funds",
+                                ],
+                                "type": "object",
+                              },
+                              "leases": {
+                                "items": {
+                                  "properties": {
+                                    "closed_on": {
+                                      "type": "string",
+                                    },
+                                    "created_at": {
+                                      "type": "string",
+                                    },
+                                    "lease_id": {
+                                      "properties": {
+                                        "dseq": {
+                                          "type": "string",
+                                        },
+                                        "gseq": {
+                                          "type": "number",
+                                        },
+                                        "oseq": {
+                                          "type": "number",
+                                        },
+                                        "owner": {
+                                          "type": "string",
+                                        },
+                                        "provider": {
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "owner",
+                                        "dseq",
+                                        "gseq",
+                                        "oseq",
+                                        "provider",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    "price": {
+                                      "properties": {
+                                        "amount": {
+                                          "type": "string",
+                                        },
+                                        "denom": {
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "denom",
+                                        "amount",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    "state": {
+                                      "type": "string",
+                                    },
+                                    "status": {
+                                      "nullable": true,
+                                      "properties": {
+                                        "forwarded_ports": {
+                                          "additionalProperties": {
+                                            "items": {
+                                              "properties": {
+                                                "available": {
+                                                  "type": "number",
+                                                },
+                                                "externalPort": {
+                                                  "type": "number",
+                                                },
+                                                "host": {
+                                                  "type": "string",
+                                                },
+                                                "port": {
+                                                  "type": "number",
+                                                },
+                                              },
+                                              "required": [
+                                                "port",
+                                                "externalPort",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            "type": "array",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "ips": {
+                                          "additionalProperties": {
+                                            "items": {
+                                              "properties": {
+                                                "ExternalPort": {
+                                                  "type": "number",
+                                                },
+                                                "IP": {
+                                                  "type": "string",
+                                                },
+                                                "Port": {
+                                                  "type": "number",
+                                                },
+                                                "Protocol": {
+                                                  "type": "string",
+                                                },
+                                              },
+                                              "required": [
+                                                "IP",
+                                                "Port",
+                                                "ExternalPort",
+                                                "Protocol",
+                                              ],
+                                              "type": "object",
+                                            },
+                                            "type": "array",
+                                          },
+                                          "type": "object",
+                                        },
+                                        "services": {
+                                          "additionalProperties": {
+                                            "properties": {
+                                              "available": {
+                                                "type": "number",
+                                              },
+                                              "available_replicas": {
+                                                "type": "number",
+                                              },
+                                              "name": {
+                                                "type": "string",
+                                              },
+                                              "observed_generation": {
+                                                "type": "number",
+                                              },
+                                              "ready_replicas": {
+                                                "type": "number",
+                                              },
+                                              "replicas": {
+                                                "type": "number",
+                                              },
+                                              "total": {
+                                                "type": "number",
+                                              },
+                                              "updated_replicas": {
+                                                "type": "number",
+                                              },
+                                              "uris": {
+                                                "items": {
+                                                  "type": "string",
+                                                },
+                                                "type": "array",
+                                              },
+                                            },
+                                            "required": [
+                                              "name",
+                                              "available",
+                                              "total",
+                                              "uris",
+                                              "observed_generation",
+                                              "replicas",
+                                              "updated_replicas",
+                                              "ready_replicas",
+                                              "available_replicas",
+                                            ],
+                                            "type": "object",
+                                          },
+                                          "type": "object",
+                                        },
+                                      },
+                                      "required": [
+                                        "forwarded_ports",
+                                        "ips",
+                                        "services",
+                                      ],
+                                      "type": "object",
+                                    },
+                                  },
+                                  "required": [
+                                    "lease_id",
+                                    "state",
+                                    "price",
+                                    "created_at",
+                                    "closed_on",
+                                    "status",
+                                  ],
+                                  "type": "object",
+                                },
+                                "type": "array",
+                              },
+                            },
+                            "required": [
+                              "deployment",
+                              "leases",
+                              "escrow_account",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                        "pagination": {
+                          "properties": {
+                            "hasMore": {
+                              "type": "boolean",
+                            },
+                            "limit": {
+                              "type": "number",
+                            },
+                            "skip": {
+                              "type": "number",
+                            },
+                            "total": {
+                              "type": "number",
+                            },
+                          },
+                          "required": [
+                            "total",
+                            "skip",
+                            "limit",
+                            "hasMore",
+                          ],
+                          "type": "object",
+                        },
+                      },
+                      "required": [
+                        "deployments",
+                        "pagination",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns paginated list of deployments",
+          },
+        },
+        "summary": "List deployments with pagination and filtering",
+        "tags": [
+          "Deployments",
+        ],
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "deposit": {
+                        "description": "Amount to deposit in dollars (e.g. 5.5)",
+                        "type": "number",
+                      },
+                      "sdl": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "sdl",
+                      "deposit",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "dseq": {
+                          "type": "string",
+                        },
+                        "manifest": {
+                          "type": "string",
+                        },
+                        "signTx": {
+                          "properties": {
+                            "code": {
+                              "type": "number",
+                            },
+                            "rawLog": {
+                              "type": "string",
+                            },
+                            "transactionHash": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "code",
+                            "transactionHash",
+                            "rawLog",
+                          ],
+                          "type": "object",
+                        },
+                      },
+                      "required": [
+                        "dseq",
+                        "manifest",
+                        "signTx",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Create deployment successfully",
+          },
+        },
+        "summary": "Create new deployment",
+        "tags": [
+          "Deployments",
+        ],
+      },
+    },
+    "/v1/deployments/{dseq}": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Deployment sequence number",
+            "in": "path",
+            "name": "dseq",
+            "required": true,
+            "schema": {
+              "description": "Deployment sequence number",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                        },
+                      },
+                      "required": [
+                        "success",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Deployment closed successfully",
+          },
+        },
+        "summary": "Close a deployment",
+        "tags": [
+          "Deployments",
+        ],
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dseq",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "deployment": {
+                          "properties": {
+                            "created_at": {
+                              "type": "string",
+                            },
+                            "deployment_id": {
+                              "properties": {
+                                "dseq": {
+                                  "type": "string",
+                                },
+                                "owner": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "owner",
+                                "dseq",
+                              ],
+                              "type": "object",
+                            },
+                            "state": {
+                              "type": "string",
+                            },
+                            "version": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "deployment_id",
+                            "state",
+                            "version",
+                            "created_at",
+                          ],
+                          "type": "object",
+                        },
+                        "escrow_account": {
+                          "properties": {
+                            "balance": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                            "depositor": {
+                              "type": "string",
+                            },
+                            "funds": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                            "id": {
+                              "properties": {
+                                "scope": {
+                                  "type": "string",
+                                },
+                                "xid": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "scope",
+                                "xid",
+                              ],
+                              "type": "object",
+                            },
+                            "owner": {
+                              "type": "string",
+                            },
+                            "settled_at": {
+                              "type": "string",
+                            },
+                            "state": {
+                              "type": "string",
+                            },
+                            "transferred": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "owner",
+                            "state",
+                            "balance",
+                            "transferred",
+                            "settled_at",
+                            "depositor",
+                            "funds",
+                          ],
+                          "type": "object",
+                        },
+                        "leases": {
+                          "items": {
+                            "properties": {
+                              "closed_on": {
+                                "type": "string",
+                              },
+                              "created_at": {
+                                "type": "string",
+                              },
+                              "lease_id": {
+                                "properties": {
+                                  "dseq": {
+                                    "type": "string",
+                                  },
+                                  "gseq": {
+                                    "type": "number",
+                                  },
+                                  "oseq": {
+                                    "type": "number",
+                                  },
+                                  "owner": {
+                                    "type": "string",
+                                  },
+                                  "provider": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                ],
+                                "type": "object",
+                              },
+                              "price": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                              "state": {
+                                "type": "string",
+                              },
+                              "status": {
+                                "nullable": true,
+                                "properties": {
+                                  "forwarded_ports": {
+                                    "additionalProperties": {
+                                      "items": {
+                                        "properties": {
+                                          "available": {
+                                            "type": "number",
+                                          },
+                                          "externalPort": {
+                                            "type": "number",
+                                          },
+                                          "host": {
+                                            "type": "string",
+                                          },
+                                          "port": {
+                                            "type": "number",
+                                          },
+                                        },
+                                        "required": [
+                                          "port",
+                                          "externalPort",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "type": "array",
+                                    },
+                                    "type": "object",
+                                  },
+                                  "ips": {
+                                    "additionalProperties": {
+                                      "items": {
+                                        "properties": {
+                                          "ExternalPort": {
+                                            "type": "number",
+                                          },
+                                          "IP": {
+                                            "type": "string",
+                                          },
+                                          "Port": {
+                                            "type": "number",
+                                          },
+                                          "Protocol": {
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "IP",
+                                          "Port",
+                                          "ExternalPort",
+                                          "Protocol",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "type": "array",
+                                    },
+                                    "type": "object",
+                                  },
+                                  "services": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "available": {
+                                          "type": "number",
+                                        },
+                                        "available_replicas": {
+                                          "type": "number",
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                        },
+                                        "observed_generation": {
+                                          "type": "number",
+                                        },
+                                        "ready_replicas": {
+                                          "type": "number",
+                                        },
+                                        "replicas": {
+                                          "type": "number",
+                                        },
+                                        "total": {
+                                          "type": "number",
+                                        },
+                                        "updated_replicas": {
+                                          "type": "number",
+                                        },
+                                        "uris": {
+                                          "items": {
+                                            "type": "string",
+                                          },
+                                          "type": "array",
+                                        },
+                                      },
+                                      "required": [
+                                        "name",
+                                        "available",
+                                        "total",
+                                        "uris",
+                                        "observed_generation",
+                                        "replicas",
+                                        "updated_replicas",
+                                        "ready_replicas",
+                                        "available_replicas",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    "type": "object",
+                                  },
+                                },
+                                "required": [
+                                  "forwarded_ports",
+                                  "ips",
+                                  "services",
+                                ],
+                                "type": "object",
+                              },
+                            },
+                            "required": [
+                              "lease_id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "closed_on",
+                              "status",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "deployment",
+                        "leases",
+                        "escrow_account",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns deployment info",
+          },
+        },
+        "summary": "Get a deployment",
+        "tags": [
+          "Deployments",
+        ],
+      },
+      "put": {
+        "parameters": [
+          {
+            "description": "Deployment sequence number",
+            "in": "path",
+            "name": "dseq",
+            "required": true,
+            "schema": {
+              "description": "Deployment sequence number",
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "certificate": {
+                        "properties": {
+                          "certPem": {
+                            "type": "string",
+                          },
+                          "keyPem": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "certPem",
+                          "keyPem",
+                        ],
+                        "type": "object",
+                      },
+                      "sdl": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "sdl",
+                      "certificate",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "deployment": {
+                          "properties": {
+                            "created_at": {
+                              "type": "string",
+                            },
+                            "deployment_id": {
+                              "properties": {
+                                "dseq": {
+                                  "type": "string",
+                                },
+                                "owner": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "owner",
+                                "dseq",
+                              ],
+                              "type": "object",
+                            },
+                            "state": {
+                              "type": "string",
+                            },
+                            "version": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "deployment_id",
+                            "state",
+                            "version",
+                            "created_at",
+                          ],
+                          "type": "object",
+                        },
+                        "escrow_account": {
+                          "properties": {
+                            "balance": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                            "depositor": {
+                              "type": "string",
+                            },
+                            "funds": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                            "id": {
+                              "properties": {
+                                "scope": {
+                                  "type": "string",
+                                },
+                                "xid": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "scope",
+                                "xid",
+                              ],
+                              "type": "object",
+                            },
+                            "owner": {
+                              "type": "string",
+                            },
+                            "settled_at": {
+                              "type": "string",
+                            },
+                            "state": {
+                              "type": "string",
+                            },
+                            "transferred": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "owner",
+                            "state",
+                            "balance",
+                            "transferred",
+                            "settled_at",
+                            "depositor",
+                            "funds",
+                          ],
+                          "type": "object",
+                        },
+                        "leases": {
+                          "items": {
+                            "properties": {
+                              "closed_on": {
+                                "type": "string",
+                              },
+                              "created_at": {
+                                "type": "string",
+                              },
+                              "lease_id": {
+                                "properties": {
+                                  "dseq": {
+                                    "type": "string",
+                                  },
+                                  "gseq": {
+                                    "type": "number",
+                                  },
+                                  "oseq": {
+                                    "type": "number",
+                                  },
+                                  "owner": {
+                                    "type": "string",
+                                  },
+                                  "provider": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                ],
+                                "type": "object",
+                              },
+                              "price": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                              "state": {
+                                "type": "string",
+                              },
+                              "status": {
+                                "nullable": true,
+                                "properties": {
+                                  "forwarded_ports": {
+                                    "additionalProperties": {
+                                      "items": {
+                                        "properties": {
+                                          "available": {
+                                            "type": "number",
+                                          },
+                                          "externalPort": {
+                                            "type": "number",
+                                          },
+                                          "host": {
+                                            "type": "string",
+                                          },
+                                          "port": {
+                                            "type": "number",
+                                          },
+                                        },
+                                        "required": [
+                                          "port",
+                                          "externalPort",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "type": "array",
+                                    },
+                                    "type": "object",
+                                  },
+                                  "ips": {
+                                    "additionalProperties": {
+                                      "items": {
+                                        "properties": {
+                                          "ExternalPort": {
+                                            "type": "number",
+                                          },
+                                          "IP": {
+                                            "type": "string",
+                                          },
+                                          "Port": {
+                                            "type": "number",
+                                          },
+                                          "Protocol": {
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "IP",
+                                          "Port",
+                                          "ExternalPort",
+                                          "Protocol",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "type": "array",
+                                    },
+                                    "type": "object",
+                                  },
+                                  "services": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "available": {
+                                          "type": "number",
+                                        },
+                                        "available_replicas": {
+                                          "type": "number",
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                        },
+                                        "observed_generation": {
+                                          "type": "number",
+                                        },
+                                        "ready_replicas": {
+                                          "type": "number",
+                                        },
+                                        "replicas": {
+                                          "type": "number",
+                                        },
+                                        "total": {
+                                          "type": "number",
+                                        },
+                                        "updated_replicas": {
+                                          "type": "number",
+                                        },
+                                        "uris": {
+                                          "items": {
+                                            "type": "string",
+                                          },
+                                          "type": "array",
+                                        },
+                                      },
+                                      "required": [
+                                        "name",
+                                        "available",
+                                        "total",
+                                        "uris",
+                                        "observed_generation",
+                                        "replicas",
+                                        "updated_replicas",
+                                        "ready_replicas",
+                                        "available_replicas",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    "type": "object",
+                                  },
+                                },
+                                "required": [
+                                  "forwarded_ports",
+                                  "ips",
+                                  "services",
+                                ],
+                                "type": "object",
+                              },
+                            },
+                            "required": [
+                              "lease_id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "closed_on",
+                              "status",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "deployment",
+                        "leases",
+                        "escrow_account",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Deployment updated successfully",
+          },
+        },
+        "summary": "Update a deployment",
+        "tags": [
+          "Deployments",
+        ],
+      },
+    },
+    "/v1/deposit-deployment": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "deposit": {
+                        "description": "Amount to deposit in dollars (e.g. 5.5)",
+                        "type": "number",
+                      },
+                      "dseq": {
+                        "description": "Deployment sequence number",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "dseq",
+                      "deposit",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "deployment": {
+                          "properties": {
+                            "created_at": {
+                              "type": "string",
+                            },
+                            "deployment_id": {
+                              "properties": {
+                                "dseq": {
+                                  "type": "string",
+                                },
+                                "owner": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "owner",
+                                "dseq",
+                              ],
+                              "type": "object",
+                            },
+                            "state": {
+                              "type": "string",
+                            },
+                            "version": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "deployment_id",
+                            "state",
+                            "version",
+                            "created_at",
+                          ],
+                          "type": "object",
+                        },
+                        "escrow_account": {
+                          "properties": {
+                            "balance": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                            "depositor": {
+                              "type": "string",
+                            },
+                            "funds": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                            "id": {
+                              "properties": {
+                                "scope": {
+                                  "type": "string",
+                                },
+                                "xid": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "scope",
+                                "xid",
+                              ],
+                              "type": "object",
+                            },
+                            "owner": {
+                              "type": "string",
+                            },
+                            "settled_at": {
+                              "type": "string",
+                            },
+                            "state": {
+                              "type": "string",
+                            },
+                            "transferred": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "owner",
+                            "state",
+                            "balance",
+                            "transferred",
+                            "settled_at",
+                            "depositor",
+                            "funds",
+                          ],
+                          "type": "object",
+                        },
+                        "leases": {
+                          "items": {
+                            "properties": {
+                              "closed_on": {
+                                "type": "string",
+                              },
+                              "created_at": {
+                                "type": "string",
+                              },
+                              "lease_id": {
+                                "properties": {
+                                  "dseq": {
+                                    "type": "string",
+                                  },
+                                  "gseq": {
+                                    "type": "number",
+                                  },
+                                  "oseq": {
+                                    "type": "number",
+                                  },
+                                  "owner": {
+                                    "type": "string",
+                                  },
+                                  "provider": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                ],
+                                "type": "object",
+                              },
+                              "price": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                              "state": {
+                                "type": "string",
+                              },
+                              "status": {
+                                "nullable": true,
+                                "properties": {
+                                  "forwarded_ports": {
+                                    "additionalProperties": {
+                                      "items": {
+                                        "properties": {
+                                          "available": {
+                                            "type": "number",
+                                          },
+                                          "externalPort": {
+                                            "type": "number",
+                                          },
+                                          "host": {
+                                            "type": "string",
+                                          },
+                                          "port": {
+                                            "type": "number",
+                                          },
+                                        },
+                                        "required": [
+                                          "port",
+                                          "externalPort",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "type": "array",
+                                    },
+                                    "type": "object",
+                                  },
+                                  "ips": {
+                                    "additionalProperties": {
+                                      "items": {
+                                        "properties": {
+                                          "ExternalPort": {
+                                            "type": "number",
+                                          },
+                                          "IP": {
+                                            "type": "string",
+                                          },
+                                          "Port": {
+                                            "type": "number",
+                                          },
+                                          "Protocol": {
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "IP",
+                                          "Port",
+                                          "ExternalPort",
+                                          "Protocol",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "type": "array",
+                                    },
+                                    "type": "object",
+                                  },
+                                  "services": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "available": {
+                                          "type": "number",
+                                        },
+                                        "available_replicas": {
+                                          "type": "number",
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                        },
+                                        "observed_generation": {
+                                          "type": "number",
+                                        },
+                                        "ready_replicas": {
+                                          "type": "number",
+                                        },
+                                        "replicas": {
+                                          "type": "number",
+                                        },
+                                        "total": {
+                                          "type": "number",
+                                        },
+                                        "updated_replicas": {
+                                          "type": "number",
+                                        },
+                                        "uris": {
+                                          "items": {
+                                            "type": "string",
+                                          },
+                                          "type": "array",
+                                        },
+                                      },
+                                      "required": [
+                                        "name",
+                                        "available",
+                                        "total",
+                                        "uris",
+                                        "observed_generation",
+                                        "replicas",
+                                        "updated_replicas",
+                                        "ready_replicas",
+                                        "available_replicas",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    "type": "object",
+                                  },
+                                },
+                                "required": [
+                                  "forwarded_ports",
+                                  "ips",
+                                  "services",
+                                ],
+                                "type": "object",
+                              },
+                            },
+                            "required": [
+                              "lease_id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "closed_on",
+                              "status",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "deployment",
+                        "leases",
+                        "escrow_account",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Deposit successful",
+          },
+        },
+        "summary": "Deposit into a deployment",
+        "tags": [
+          "Deployments",
+        ],
+      },
+    },
+    "/v1/features": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "additionalProperties": {
+                        "type": "boolean",
+                      },
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "List of enabled feature flags",
+          },
+        },
+        "summary": "Returns enabled feature flags",
+        "tags": [
+          "Feature flags",
+        ],
+      },
+    },
+    "/v1/gpu": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "vendor",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "model",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "memory_size",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "gpus": {
+                      "properties": {
+                        "details": {
+                          "additionalProperties": {
+                            "items": {
+                              "properties": {
+                                "allocatable": {
+                                  "type": "number",
+                                },
+                                "allocated": {
+                                  "type": "number",
+                                },
+                                "interface": {
+                                  "type": "string",
+                                },
+                                "model": {
+                                  "type": "string",
+                                },
+                                "ram": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "model",
+                                "ram",
+                                "interface",
+                                "allocatable",
+                                "allocated",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                          "type": "object",
+                        },
+                        "total": {
+                          "properties": {
+                            "allocatable": {
+                              "type": "number",
+                            },
+                            "allocated": {
+                              "type": "number",
+                            },
+                          },
+                          "required": [
+                            "allocatable",
+                            "allocated",
+                          ],
+                          "type": "object",
+                        },
+                      },
+                      "required": [
+                        "total",
+                        "details",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "gpus",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "List of gpu models and their availability.",
+          },
+          "400": {
+            "description": "Invalid provider parameter, should be a valid akash address or host uri",
+          },
+        },
+        "summary": "Get a list of gpu models and their availability.",
+        "tags": [
+          "Gpu",
+        ],
+      },
+    },
+    "/v1/gpu-breakdown": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "vendor",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "model",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "date": {
+                        "type": "string",
+                      },
+                      "gpuUtilization": {
+                        "type": "number",
+                      },
+                      "leasedGpus": {
+                        "type": "number",
+                      },
+                      "model": {
+                        "type": "string",
+                      },
+                      "nodeCount": {
+                        "type": "number",
+                      },
+                      "providerCount": {
+                        "type": "number",
+                      },
+                      "totalGpus": {
+                        "type": "number",
+                      },
+                      "vendor": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "date",
+                      "vendor",
+                      "model",
+                      "providerCount",
+                      "nodeCount",
+                      "totalGpus",
+                      "leasedGpus",
+                      "gpuUtilization",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "Gets gpu analytics breakdown by vendor and model. If no vendor or model is provided, all GPUs are returned.",
+          },
+        },
+        "summary": "Gets gpu analytics breakdown by vendor and model. If no vendor or model is provided, all GPUs are returned.",
+        "tags": [
+          "Gpu",
+        ],
+      },
+    },
+    "/v1/gpu-models": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "models": {
+                        "items": {
+                          "properties": {
+                            "interface": {
+                              "items": {
+                                "type": "string",
+                              },
+                              "type": "array",
+                            },
+                            "memory": {
+                              "items": {
+                                "type": "string",
+                              },
+                              "type": "array",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "name",
+                            "memory",
+                            "interface",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "name": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "name",
+                      "models",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "List of gpu models per.",
+          },
+        },
+        "summary": "Get a list of gpu models per vendor. Based on the content from https://raw.githubusercontent.com/akash-network/provider-configs/main/devices/pcie/gpus.json.",
+        "tags": [
+          "Gpu",
+        ],
+      },
+    },
+    "/v1/gpu-prices": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "availability": {
+                      "properties": {
+                        "available": {
+                          "type": "number",
+                        },
+                        "total": {
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "total",
+                        "available",
+                      ],
+                      "type": "object",
+                    },
+                    "models": {
+                      "items": {
+                        "properties": {
+                          "availability": {
+                            "properties": {
+                              "available": {
+                                "type": "number",
+                              },
+                              "total": {
+                                "type": "number",
+                              },
+                            },
+                            "required": [
+                              "total",
+                              "available",
+                            ],
+                            "type": "object",
+                          },
+                          "interface": {
+                            "type": "string",
+                          },
+                          "model": {
+                            "type": "string",
+                          },
+                          "price": {
+                            "nullable": true,
+                            "properties": {
+                              "avg": {
+                                "type": "number",
+                              },
+                              "currency": {
+                                "example": "USD",
+                                "type": "string",
+                              },
+                              "max": {
+                                "type": "number",
+                              },
+                              "med": {
+                                "type": "number",
+                              },
+                              "min": {
+                                "type": "number",
+                              },
+                              "weightedAverage": {
+                                "type": "number",
+                              },
+                            },
+                            "required": [
+                              "currency",
+                              "min",
+                              "max",
+                              "avg",
+                              "weightedAverage",
+                              "med",
+                            ],
+                            "type": "object",
+                          },
+                          "providerAvailability": {
+                            "properties": {
+                              "available": {
+                                "type": "number",
+                              },
+                              "total": {
+                                "type": "number",
+                              },
+                            },
+                            "required": [
+                              "total",
+                              "available",
+                            ],
+                            "type": "object",
+                          },
+                          "ram": {
+                            "type": "string",
+                          },
+                          "vendor": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "vendor",
+                          "model",
+                          "ram",
+                          "interface",
+                          "availability",
+                          "providerAvailability",
+                          "price",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "availability",
+                    "models",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "List of gpu models with their availability and pricing.",
+          },
+        },
+        "summary": "Get a list of gpu models with their availability and pricing.",
+        "tags": [
+          "Gpu",
+        ],
+      },
+    },
+    "/v1/graph-data/{dataName}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dataName",
+            "required": true,
+            "schema": {
+              "enum": [
+                "dailyUAktSpent",
+                "dailyUUsdcSpent",
+                "dailyUUsdSpent",
+                "dailyLeaseCount",
+                "totalUAktSpent",
+                "totalUUsdcSpent",
+                "totalUUsdSpent",
+                "activeLeaseCount",
+                "totalLeaseCount",
+                "activeCPU",
+                "activeGPU",
+                "activeMemory",
+                "activeStorage",
+                "gpuUtilization",
+              ],
+              "example": "dailyUAktSpent",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "compareValue": {
+                      "type": "number",
+                    },
+                    "currentValue": {
+                      "type": "number",
+                    },
+                    "snapshots": {
+                      "items": {
+                        "properties": {
+                          "date": {
+                            "example": "2021-07-01T00:00:00.000Z",
+                            "type": "string",
+                          },
+                          "value": {
+                            "example": 100,
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "date",
+                          "value",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "currentValue",
+                    "compareValue",
+                    "snapshots",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns graph data",
+          },
+          "404": {
+            "description": "Graph data not found",
+          },
+        },
+        "tags": [
+          "Analytics",
+        ],
+      },
+    },
+    "/v1/leases": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "certificate": {
+                    "properties": {
+                      "certPem": {
+                        "type": "string",
+                      },
+                      "keyPem": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "certPem",
+                      "keyPem",
+                    ],
+                    "type": "object",
+                  },
+                  "leases": {
+                    "items": {
+                      "properties": {
+                        "dseq": {
+                          "type": "string",
+                        },
+                        "gseq": {
+                          "type": "number",
+                        },
+                        "oseq": {
+                          "type": "number",
+                        },
+                        "provider": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "dseq",
+                        "gseq",
+                        "oseq",
+                        "provider",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                  "manifest": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "manifest",
+                  "certificate",
+                  "leases",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "deployment": {
+                          "properties": {
+                            "created_at": {
+                              "type": "string",
+                            },
+                            "deployment_id": {
+                              "properties": {
+                                "dseq": {
+                                  "type": "string",
+                                },
+                                "owner": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "owner",
+                                "dseq",
+                              ],
+                              "type": "object",
+                            },
+                            "state": {
+                              "type": "string",
+                            },
+                            "version": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "deployment_id",
+                            "state",
+                            "version",
+                            "created_at",
+                          ],
+                          "type": "object",
+                        },
+                        "escrow_account": {
+                          "properties": {
+                            "balance": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                            "depositor": {
+                              "type": "string",
+                            },
+                            "funds": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                            "id": {
+                              "properties": {
+                                "scope": {
+                                  "type": "string",
+                                },
+                                "xid": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "scope",
+                                "xid",
+                              ],
+                              "type": "object",
+                            },
+                            "owner": {
+                              "type": "string",
+                            },
+                            "settled_at": {
+                              "type": "string",
+                            },
+                            "state": {
+                              "type": "string",
+                            },
+                            "transferred": {
+                              "properties": {
+                                "amount": {
+                                  "type": "string",
+                                },
+                                "denom": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "denom",
+                                "amount",
+                              ],
+                              "type": "object",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "owner",
+                            "state",
+                            "balance",
+                            "transferred",
+                            "settled_at",
+                            "depositor",
+                            "funds",
+                          ],
+                          "type": "object",
+                        },
+                        "leases": {
+                          "items": {
+                            "properties": {
+                              "closed_on": {
+                                "type": "string",
+                              },
+                              "created_at": {
+                                "type": "string",
+                              },
+                              "lease_id": {
+                                "properties": {
+                                  "dseq": {
+                                    "type": "string",
+                                  },
+                                  "gseq": {
+                                    "type": "number",
+                                  },
+                                  "oseq": {
+                                    "type": "number",
+                                  },
+                                  "owner": {
+                                    "type": "string",
+                                  },
+                                  "provider": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                ],
+                                "type": "object",
+                              },
+                              "price": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                              "state": {
+                                "type": "string",
+                              },
+                              "status": {
+                                "nullable": true,
+                                "properties": {
+                                  "forwarded_ports": {
+                                    "additionalProperties": {
+                                      "items": {
+                                        "properties": {
+                                          "available": {
+                                            "type": "number",
+                                          },
+                                          "externalPort": {
+                                            "type": "number",
+                                          },
+                                          "host": {
+                                            "type": "string",
+                                          },
+                                          "port": {
+                                            "type": "number",
+                                          },
+                                        },
+                                        "required": [
+                                          "port",
+                                          "externalPort",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "type": "array",
+                                    },
+                                    "type": "object",
+                                  },
+                                  "ips": {
+                                    "additionalProperties": {
+                                      "items": {
+                                        "properties": {
+                                          "ExternalPort": {
+                                            "type": "number",
+                                          },
+                                          "IP": {
+                                            "type": "string",
+                                          },
+                                          "Port": {
+                                            "type": "number",
+                                          },
+                                          "Protocol": {
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "IP",
+                                          "Port",
+                                          "ExternalPort",
+                                          "Protocol",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "type": "array",
+                                    },
+                                    "type": "object",
+                                  },
+                                  "services": {
+                                    "additionalProperties": {
+                                      "properties": {
+                                        "available": {
+                                          "type": "number",
+                                        },
+                                        "available_replicas": {
+                                          "type": "number",
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                        },
+                                        "observed_generation": {
+                                          "type": "number",
+                                        },
+                                        "ready_replicas": {
+                                          "type": "number",
+                                        },
+                                        "replicas": {
+                                          "type": "number",
+                                        },
+                                        "total": {
+                                          "type": "number",
+                                        },
+                                        "updated_replicas": {
+                                          "type": "number",
+                                        },
+                                        "uris": {
+                                          "items": {
+                                            "type": "string",
+                                          },
+                                          "type": "array",
+                                        },
+                                      },
+                                      "required": [
+                                        "name",
+                                        "available",
+                                        "total",
+                                        "uris",
+                                        "observed_generation",
+                                        "replicas",
+                                        "updated_replicas",
+                                        "ready_replicas",
+                                        "available_replicas",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    "type": "object",
+                                  },
+                                },
+                                "required": [
+                                  "forwarded_ports",
+                                  "ips",
+                                  "services",
+                                ],
+                                "type": "object",
+                              },
+                            },
+                            "required": [
+                              "lease_id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "closed_on",
+                              "status",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "deployment",
+                        "leases",
+                        "escrow_account",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Leases created and manifest sent",
+          },
+        },
+        "summary": "Create leases and send manifest",
+        "tags": [
+          "Leases",
+        ],
+      },
+    },
+    "/v1/leases-duration/{owner}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "example": "akash13265twfqejnma6cc93rw5dxk4cldyz2zyy8cdm",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "dseq",
+            "required": false,
+            "schema": {
+              "type": "integer",
+            },
+          },
+          {
+            "in": "query",
+            "name": "startDate",
+            "required": false,
+            "schema": {
+              "default": "2000-01-01",
+              "format": "YYYY-MM-DD",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "endDate",
+            "required": false,
+            "schema": {
+              "default": "2100-01-01",
+              "format": "YYYY-MM-DD",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "leaseCount": {
+                      "type": "number",
+                    },
+                    "leases": {
+                      "items": {
+                        "properties": {
+                          "closedDate": {
+                            "type": "string",
+                          },
+                          "closedHeight": {
+                            "type": "number",
+                          },
+                          "dseq": {
+                            "type": "string",
+                          },
+                          "durationInBlocks": {
+                            "type": "number",
+                          },
+                          "durationInHours": {
+                            "type": "number",
+                          },
+                          "durationInSeconds": {
+                            "type": "number",
+                          },
+                          "gseq": {
+                            "type": "number",
+                          },
+                          "oseq": {
+                            "type": "number",
+                          },
+                          "provider": {
+                            "type": "string",
+                          },
+                          "startDate": {
+                            "type": "string",
+                          },
+                          "startHeight": {
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "dseq",
+                          "oseq",
+                          "gseq",
+                          "provider",
+                          "startHeight",
+                          "startDate",
+                          "closedHeight",
+                          "closedDate",
+                          "durationInBlocks",
+                          "durationInSeconds",
+                          "durationInHours",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "totalDurationInHours": {
+                      "type": "number",
+                    },
+                    "totalDurationInSeconds": {
+                      "type": "number",
+                    },
+                  },
+                  "required": [
+                    "leaseCount",
+                    "totalDurationInSeconds",
+                    "totalDurationInHours",
+                    "leases",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "List of leases durations and total duration.",
+          },
+          "400": {
+            "description": "Invalid start date, must be in the following format: YYYY-MM-DD",
+          },
+        },
+        "summary": "Get leases durations.",
+        "tags": [
+          "Analytics",
+        ],
+      },
+    },
+    "/v1/market-data/{coin?}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "coin",
+            "required": false,
+            "schema": {
+              "default": "akash-network",
+              "enum": [
+                "akash-network",
+                "usd-coin",
+              ],
+              "example": "akash-network",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "marketCap": {
+                      "type": "number",
+                    },
+                    "marketCapRank": {
+                      "type": "number",
+                    },
+                    "price": {
+                      "type": "number",
+                    },
+                    "priceChange24h": {
+                      "type": "number",
+                    },
+                    "priceChangePercentage24": {
+                      "type": "number",
+                    },
+                    "volume": {
+                      "type": "number",
+                    },
+                  },
+                  "required": [
+                    "price",
+                    "volume",
+                    "marketCap",
+                    "marketCapRank",
+                    "priceChange24h",
+                    "priceChangePercentage24",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns market stats",
+          },
+        },
+        "tags": [
+          "Analytics",
+        ],
+      },
+    },
+    "/v1/network-capacity": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "activeCPU": {
+                      "type": "number",
+                    },
+                    "activeEphemeralStorage": {
+                      "type": "number",
+                    },
+                    "activeGPU": {
+                      "type": "number",
+                    },
+                    "activeMemory": {
+                      "type": "number",
+                    },
+                    "activePersistentStorage": {
+                      "type": "number",
+                    },
+                    "activeProviderCount": {
+                      "type": "number",
+                    },
+                    "activeStorage": {
+                      "type": "number",
+                    },
+                    "availableCPU": {
+                      "type": "number",
+                    },
+                    "availableEphemeralStorage": {
+                      "type": "number",
+                    },
+                    "availableGPU": {
+                      "type": "number",
+                    },
+                    "availableMemory": {
+                      "type": "number",
+                    },
+                    "availablePersistentStorage": {
+                      "type": "number",
+                    },
+                    "availableStorage": {
+                      "type": "number",
+                    },
+                    "pendingCPU": {
+                      "type": "number",
+                    },
+                    "pendingEphemeralStorage": {
+                      "type": "number",
+                    },
+                    "pendingGPU": {
+                      "type": "number",
+                    },
+                    "pendingMemory": {
+                      "type": "number",
+                    },
+                    "pendingPersistentStorage": {
+                      "type": "number",
+                    },
+                    "pendingStorage": {
+                      "type": "number",
+                    },
+                    "totalCPU": {
+                      "type": "number",
+                    },
+                    "totalGPU": {
+                      "type": "number",
+                    },
+                    "totalMemory": {
+                      "type": "number",
+                    },
+                    "totalStorage": {
+                      "type": "number",
+                    },
+                  },
+                  "required": [
+                    "activeProviderCount",
+                    "activeCPU",
+                    "activeGPU",
+                    "activeMemory",
+                    "activeStorage",
+                    "pendingCPU",
+                    "pendingGPU",
+                    "pendingMemory",
+                    "pendingStorage",
+                    "availableCPU",
+                    "availableGPU",
+                    "availableMemory",
+                    "availableStorage",
+                    "totalCPU",
+                    "totalGPU",
+                    "totalMemory",
+                    "totalStorage",
+                    "activeEphemeralStorage",
+                    "pendingEphemeralStorage",
+                    "availableEphemeralStorage",
+                    "activePersistentStorage",
+                    "pendingPersistentStorage",
+                    "availablePersistentStorage",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns network capacity stats",
+          },
+        },
+        "tags": [
+          "Analytics",
+        ],
+      },
+    },
+    "/v1/nodes/{network}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "network",
+            "required": true,
+            "schema": {
+              "enum": [
+                "mainnet",
+                "testnet",
+                "sandbox",
+              ],
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "api": {
+                        "type": "string",
+                      },
+                      "id": {
+                        "type": "string",
+                      },
+                      "rpc": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "id",
+                      "api",
+                      "rpc",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "List of nodes",
+          },
+        },
+        "summary": "Get a list of nodes (api/rpc) for a specific network.",
+        "tags": [
+          "Chain",
+        ],
+      },
+    },
+    "/v1/predicted-block-date/{height}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "height",
+            "required": false,
+            "schema": {
+              "description": "Block height",
+              "example": 20000000,
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "blockWindow",
+            "required": false,
+            "schema": {
+              "default": 10000,
+              "description": "Block window",
+              "example": 10000,
+              "type": "number",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "blockWindow": {
+                      "example": 10000,
+                      "type": "number",
+                    },
+                    "height": {
+                      "example": 10000000,
+                      "type": "number",
+                    },
+                    "predictedDate": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "predictedDate",
+                    "height",
+                    "blockWindow",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns predicted block date",
+          },
+          "400": {
+            "description": "Invalid height or block window",
+          },
+        },
+        "summary": "Get the estimated date of a future block.",
+        "tags": [
+          "Blocks",
+        ],
+      },
+    },
+    "/v1/predicted-date-height/{timestamp}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "timestamp",
+            "required": false,
+            "schema": {
+              "description": "Unix Timestamp",
+              "example": 1704392968,
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "blockWindow",
+            "required": false,
+            "schema": {
+              "default": 10000,
+              "description": "Block window",
+              "example": 10000,
+              "type": "number",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "blockWindow": {
+                      "example": 10000,
+                      "type": "number",
+                    },
+                    "date": {
+                      "example": "2024-01-04T18:29:28.000Z",
+                      "type": "string",
+                    },
+                    "predictedHeight": {
+                      "example": 10000000,
+                      "type": "number",
+                    },
+                  },
+                  "required": [
+                    "predictedHeight",
+                    "date",
+                    "blockWindow",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns predicted block height",
+          },
+          "400": {
+            "description": "Invalid timestamp or block window",
+          },
+        },
+        "summary": "Get the estimated height of a future date and time.",
+        "tags": [
+          "Blocks",
+        ],
+      },
+    },
+    "/v1/pricing": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "properties": {
+                      "cpu": {
+                        "description": "CPU in thousandths of a core. 1000 = 1 core",
+                        "example": 1000,
+                        "minimum": 0,
+                        "type": "number",
+                      },
+                      "memory": {
+                        "description": "Memory in bytes",
+                        "example": 1000000000,
+                        "type": "number",
+                      },
+                      "storage": {
+                        "description": "Storage in bytes",
+                        "example": 1000000000,
+                        "type": "number",
+                      },
+                    },
+                    "required": [
+                      "cpu",
+                      "memory",
+                      "storage",
+                    ],
+                    "type": "object",
+                  },
+                  {
+                    "items": {
+                      "properties": {
+                        "cpu": {
+                          "description": "CPU in thousandths of a core. 1000 = 1 core",
+                          "example": 1000,
+                          "minimum": 0,
+                          "type": "number",
+                        },
+                        "memory": {
+                          "description": "Memory in bytes",
+                          "example": 1000000000,
+                          "type": "number",
+                        },
+                        "storage": {
+                          "description": "Storage in bytes",
+                          "example": 1000000000,
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "cpu",
+                        "memory",
+                        "storage",
+                      ],
+                      "type": "object",
+                    },
+                    "type": "array",
+                  },
+                ],
+              },
+            },
+          },
+          "description": "Deployment specs to use for the price estimation. **An array of specs can also be sent, in that case an array of estimations will be returned in the same order.**",
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "properties": {
+                        "akash": {
+                          "description": "Akash price estimation (USD/month)",
+                          "type": "number",
+                        },
+                        "aws": {
+                          "description": "AWS price estimation (USD/month)",
+                          "type": "number",
+                        },
+                        "azure": {
+                          "description": "Azure price estimation (USD/month)",
+                          "type": "number",
+                        },
+                        "gcp": {
+                          "description": "GCP price estimation (USD/month)",
+                          "type": "number",
+                        },
+                        "spec": {
+                          "properties": {
+                            "cpu": {
+                              "description": "CPU in thousandths of a core. 1000 = 1 core",
+                              "example": 1000,
+                              "minimum": 0,
+                              "type": "number",
+                            },
+                            "memory": {
+                              "description": "Memory in bytes",
+                              "example": 1000000000,
+                              "type": "number",
+                            },
+                            "storage": {
+                              "description": "Storage in bytes",
+                              "example": 1000000000,
+                              "type": "number",
+                            },
+                          },
+                          "required": [
+                            "cpu",
+                            "memory",
+                            "storage",
+                          ],
+                          "type": "object",
+                        },
+                      },
+                      "required": [
+                        "spec",
+                        "akash",
+                        "aws",
+                        "gcp",
+                        "azure",
+                      ],
+                      "type": "object",
+                    },
+                    {
+                      "items": {
+                        "properties": {
+                          "akash": {
+                            "description": "Akash price estimation (USD/month)",
+                            "type": "number",
+                          },
+                          "aws": {
+                            "description": "AWS price estimation (USD/month)",
+                            "type": "number",
+                          },
+                          "azure": {
+                            "description": "Azure price estimation (USD/month)",
+                            "type": "number",
+                          },
+                          "gcp": {
+                            "description": "GCP price estimation (USD/month)",
+                            "type": "number",
+                          },
+                          "spec": {
+                            "properties": {
+                              "cpu": {
+                                "description": "CPU in thousandths of a core. 1000 = 1 core",
+                                "example": 1000,
+                                "minimum": 0,
+                                "type": "number",
+                              },
+                              "memory": {
+                                "description": "Memory in bytes",
+                                "example": 1000000000,
+                                "type": "number",
+                              },
+                              "storage": {
+                                "description": "Storage in bytes",
+                                "example": 1000000000,
+                                "type": "number",
+                              },
+                            },
+                            "required": [
+                              "cpu",
+                              "memory",
+                              "storage",
+                            ],
+                            "type": "object",
+                          },
+                        },
+                        "required": [
+                          "spec",
+                          "akash",
+                          "aws",
+                          "gcp",
+                          "azure",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  ],
+                },
+              },
+            },
+            "description": "Returns a list of deployment templates grouped by cateogories",
+          },
+          "400": {
+            "description": "Invalid parameters",
+          },
+        },
+        "summary": "Estimate the price of a deployment on akash and other cloud providers.",
+        "tags": [
+          "Other",
+        ],
+      },
+    },
+    "/v1/proposals": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "id": {
+                        "type": "number",
+                      },
+                      "status": {
+                        "type": "string",
+                      },
+                      "submitTime": {
+                        "type": "string",
+                      },
+                      "title": {
+                        "type": "string",
+                      },
+                      "totalDeposit": {
+                        "type": "number",
+                      },
+                      "votingEndTime": {
+                        "type": "string",
+                      },
+                      "votingStartTime": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "id",
+                      "title",
+                      "status",
+                      "submitTime",
+                      "votingStartTime",
+                      "votingEndTime",
+                      "totalDeposit",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "Returns a list of proposals",
+          },
+        },
+        "tags": [
+          "Proposals",
+        ],
+      },
+    },
+    "/v1/proposals/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "description": "Proposal ID",
+              "example": 1,
+              "nullable": true,
+              "type": "number",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "description": {
+                      "type": "string",
+                    },
+                    "id": {
+                      "type": "number",
+                    },
+                    "paramChanges": {
+                      "items": {
+                        "properties": {
+                          "key": {
+                            "type": "string",
+                          },
+                          "subspace": {
+                            "type": "string",
+                          },
+                          "value": {
+                            "nullable": true,
+                          },
+                        },
+                        "required": [
+                          "subspace",
+                          "key",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "status": {
+                      "type": "string",
+                    },
+                    "submitTime": {
+                      "type": "string",
+                    },
+                    "tally": {
+                      "properties": {
+                        "abstain": {
+                          "type": "number",
+                        },
+                        "no": {
+                          "type": "number",
+                        },
+                        "noWithVeto": {
+                          "type": "number",
+                        },
+                        "total": {
+                          "type": "number",
+                        },
+                        "yes": {
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "yes",
+                        "abstain",
+                        "no",
+                        "noWithVeto",
+                        "total",
+                      ],
+                      "type": "object",
+                    },
+                    "title": {
+                      "type": "string",
+                    },
+                    "totalDeposit": {
+                      "type": "number",
+                    },
+                    "votingEndTime": {
+                      "type": "string",
+                    },
+                    "votingStartTime": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "id",
+                    "title",
+                    "description",
+                    "status",
+                    "submitTime",
+                    "votingStartTime",
+                    "votingEndTime",
+                    "totalDeposit",
+                    "tally",
+                    "paramChanges",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Return a proposal by id",
+          },
+          "400": {
+            "description": "Invalid proposal id",
+          },
+          "404": {
+            "description": "Proposal not found",
+          },
+        },
+        "tags": [
+          "Proposals",
+        ],
+      },
+    },
+    "/v1/provider-attributes-schema": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "city": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "country": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "email": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "feat-endpoint-custom-domain": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "feat-endpoint-ip": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "feat-persistent-storage": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "feat-persistent-storage-type": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "hardware-cpu": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "hardware-cpu-arch": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "hardware-disk": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "hardware-gpu": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "hardware-gpu-model": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "hardware-memory": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "host": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "hosting-provider": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "location-region": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "location-type": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "network-provider": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "network-speed-down": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "network-speed-up": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "organization": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "status-page": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "tier": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "timezone": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "website": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "workload-support-chia": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                    "workload-support-chia-capabilities": {
+                      "properties": {
+                        "description": {
+                          "type": "string",
+                        },
+                        "key": {
+                          "type": "string",
+                        },
+                        "required": {
+                          "type": "boolean",
+                        },
+                        "type": {
+                          "enum": [
+                            "string",
+                            "number",
+                            "boolean",
+                            "option",
+                            "multiple-option",
+                          ],
+                          "type": "string",
+                        },
+                        "values": {
+                          "items": {
+                            "properties": {
+                              "description": {
+                                "type": "string",
+                              },
+                              "key": {
+                                "type": "string",
+                              },
+                              "value": {
+                                "nullable": true,
+                              },
+                            },
+                            "required": [
+                              "key",
+                              "description",
+                            ],
+                            "type": "object",
+                          },
+                          "nullable": true,
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "key",
+                        "type",
+                        "required",
+                        "description",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "host",
+                    "email",
+                    "organization",
+                    "website",
+                    "tier",
+                    "status-page",
+                    "location-region",
+                    "country",
+                    "city",
+                    "timezone",
+                    "location-type",
+                    "hosting-provider",
+                    "hardware-cpu",
+                    "hardware-cpu-arch",
+                    "hardware-gpu",
+                    "hardware-gpu-model",
+                    "hardware-disk",
+                    "hardware-memory",
+                    "network-provider",
+                    "network-speed-up",
+                    "network-speed-down",
+                    "feat-persistent-storage",
+                    "feat-persistent-storage-type",
+                    "workload-support-chia",
+                    "workload-support-chia-capabilities",
+                    "feat-endpoint-ip",
+                    "feat-endpoint-custom-domain",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Return the provider attributes schema",
+          },
+        },
+        "summary": "Get the provider attributes schema",
+        "tags": [
+          "Providers",
+        ],
+      },
+    },
+    "/v1/provider-dashboard/{owner}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "owner",
+            "required": true,
+            "schema": {
+              "example": "akash18ga02jzaq8cw52anyhzkwta5wygufgu6zsz6xc",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "current": {
+                      "properties": {
+                        "activeCPU": {
+                          "type": "number",
+                        },
+                        "activeEphemeralStorage": {
+                          "type": "number",
+                        },
+                        "activeGPU": {
+                          "type": "number",
+                        },
+                        "activeLeaseCount": {
+                          "type": "number",
+                        },
+                        "activeMemory": {
+                          "type": "number",
+                        },
+                        "activePersistentStorage": {
+                          "type": "number",
+                        },
+                        "activeStorage": {
+                          "type": "number",
+                        },
+                        "dailyLeaseCount": {
+                          "type": "number",
+                        },
+                        "dailyUAktEarned": {
+                          "type": "number",
+                        },
+                        "dailyUUsdEarned": {
+                          "type": "number",
+                        },
+                        "dailyUUsdcEarned": {
+                          "type": "number",
+                        },
+                        "date": {
+                          "type": "string",
+                        },
+                        "height": {
+                          "type": "number",
+                        },
+                        "totalLeaseCount": {
+                          "type": "number",
+                        },
+                        "totalUAktEarned": {
+                          "type": "number",
+                        },
+                        "totalUUsdEarned": {
+                          "type": "number",
+                        },
+                        "totalUUsdcEarned": {
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "date",
+                        "height",
+                        "activeLeaseCount",
+                        "totalLeaseCount",
+                        "dailyLeaseCount",
+                        "totalUAktEarned",
+                        "dailyUAktEarned",
+                        "totalUUsdcEarned",
+                        "dailyUUsdcEarned",
+                        "totalUUsdEarned",
+                        "dailyUUsdEarned",
+                        "activeCPU",
+                        "activeGPU",
+                        "activeMemory",
+                        "activeEphemeralStorage",
+                        "activePersistentStorage",
+                        "activeStorage",
+                      ],
+                      "type": "object",
+                    },
+                    "previous": {
+                      "properties": {
+                        "activeCPU": {
+                          "type": "number",
+                        },
+                        "activeEphemeralStorage": {
+                          "type": "number",
+                        },
+                        "activeGPU": {
+                          "type": "number",
+                        },
+                        "activeLeaseCount": {
+                          "type": "number",
+                        },
+                        "activeMemory": {
+                          "type": "number",
+                        },
+                        "activePersistentStorage": {
+                          "type": "number",
+                        },
+                        "activeStorage": {
+                          "type": "number",
+                        },
+                        "dailyLeaseCount": {
+                          "type": "number",
+                        },
+                        "dailyUAktEarned": {
+                          "type": "number",
+                        },
+                        "dailyUUsdEarned": {
+                          "type": "number",
+                        },
+                        "dailyUUsdcEarned": {
+                          "type": "number",
+                        },
+                        "date": {
+                          "type": "string",
+                        },
+                        "height": {
+                          "type": "number",
+                        },
+                        "totalLeaseCount": {
+                          "type": "number",
+                        },
+                        "totalUAktEarned": {
+                          "type": "number",
+                        },
+                        "totalUUsdEarned": {
+                          "type": "number",
+                        },
+                        "totalUUsdcEarned": {
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "date",
+                        "height",
+                        "activeLeaseCount",
+                        "totalLeaseCount",
+                        "dailyLeaseCount",
+                        "totalUAktEarned",
+                        "dailyUAktEarned",
+                        "totalUUsdcEarned",
+                        "dailyUUsdcEarned",
+                        "totalUUsdEarned",
+                        "dailyUUsdEarned",
+                        "activeCPU",
+                        "activeGPU",
+                        "activeMemory",
+                        "activeEphemeralStorage",
+                        "activePersistentStorage",
+                        "activeStorage",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "current",
+                    "previous",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Dashboard data",
+          },
+          "404": {
+            "description": "Provider not found",
+          },
+        },
+        "summary": "Get dashboard data for provider console.",
+        "tags": [
+          "Providers",
+        ],
+      },
+    },
+    "/v1/provider-graph-data/{dataName}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dataName",
+            "required": true,
+            "schema": {
+              "enum": [
+                "count",
+                "cpu",
+                "gpu",
+                "memory",
+                "storage",
+              ],
+              "example": "cpu",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "compare": {
+                      "properties": {
+                        "count": {
+                          "example": 100,
+                          "type": "number",
+                        },
+                        "cpu": {
+                          "example": 100,
+                          "type": "number",
+                        },
+                        "gpu": {
+                          "example": 100,
+                          "type": "number",
+                        },
+                        "memory": {
+                          "example": 100,
+                          "type": "number",
+                        },
+                        "storage": {
+                          "example": 100,
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "count",
+                        "cpu",
+                        "gpu",
+                        "memory",
+                        "storage",
+                      ],
+                      "type": "object",
+                    },
+                    "compareValue": {
+                      "type": "number",
+                    },
+                    "currentValue": {
+                      "type": "number",
+                    },
+                    "now": {
+                      "properties": {
+                        "count": {
+                          "example": 100,
+                          "type": "number",
+                        },
+                        "cpu": {
+                          "example": 100,
+                          "type": "number",
+                        },
+                        "gpu": {
+                          "example": 100,
+                          "type": "number",
+                        },
+                        "memory": {
+                          "example": 100,
+                          "type": "number",
+                        },
+                        "storage": {
+                          "example": 100,
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "count",
+                        "cpu",
+                        "gpu",
+                        "memory",
+                        "storage",
+                      ],
+                      "type": "object",
+                    },
+                    "snapshots": {
+                      "items": {
+                        "properties": {
+                          "date": {
+                            "example": "2021-07-01T00:00:00.000Z",
+                            "type": "string",
+                          },
+                          "value": {
+                            "example": 100,
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "date",
+                          "value",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "currentValue",
+                    "compareValue",
+                    "snapshots",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns provider graph data",
+          },
+          "404": {
+            "description": "Graph data not found",
+          },
+        },
+        "tags": [
+          "Analytics",
+        ],
+      },
+    },
+    "/v1/provider-regions": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "description": {
+                        "type": "string",
+                      },
+                      "key": {
+                        "type": "string",
+                      },
+                      "providers": {
+                        "items": {
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "value": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "providers",
+                      "key",
+                      "description",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "Return a list of provider regions",
+          },
+        },
+        "summary": "Get a list of provider regions",
+        "tags": [
+          "Providers",
+        ],
+      },
+    },
+    "/v1/provider-versions": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "properties": {
+                      "count": {
+                        "type": "number",
+                      },
+                      "providers": {
+                        "items": {
+                          "type": "string",
+                        },
+                        "type": "array",
+                      },
+                      "ratio": {
+                        "type": "number",
+                      },
+                      "version": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "version",
+                      "count",
+                      "ratio",
+                      "providers",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "object",
+                },
+              },
+            },
+            "description": "List of providers grouped by version.",
+          },
+        },
+        "summary": "Get providers grouped by version.",
+        "tags": [
+          "Providers",
+        ],
+      },
+    },
+    "/v1/providers": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "scope",
+            "required": false,
+            "schema": {
+              "default": "all",
+              "enum": [
+                "all",
+                "trial",
+              ],
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "activeStats": {
+                        "properties": {
+                          "cpu": {
+                            "type": "number",
+                          },
+                          "gpu": {
+                            "type": "number",
+                          },
+                          "memory": {
+                            "type": "number",
+                          },
+                          "storage": {
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "cpu",
+                          "gpu",
+                          "memory",
+                          "storage",
+                        ],
+                        "type": "object",
+                      },
+                      "akashVersion": {
+                        "type": "string",
+                      },
+                      "attributes": {
+                        "items": {
+                          "properties": {
+                            "auditedBy": {
+                              "items": {
+                                "type": "string",
+                              },
+                              "type": "array",
+                            },
+                            "key": {
+                              "type": "string",
+                            },
+                            "value": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "key",
+                            "value",
+                            "auditedBy",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "availableStats": {
+                        "properties": {
+                          "cpu": {
+                            "type": "number",
+                          },
+                          "gpu": {
+                            "type": "number",
+                          },
+                          "memory": {
+                            "type": "number",
+                          },
+                          "storage": {
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "cpu",
+                          "gpu",
+                          "memory",
+                          "storage",
+                        ],
+                        "type": "object",
+                      },
+                      "city": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "cosmosSdkVersion": {
+                        "type": "string",
+                      },
+                      "country": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "createdHeight": {
+                        "type": "number",
+                      },
+                      "deploymentCount": {
+                        "nullable": true,
+                        "type": "number",
+                      },
+                      "email": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "featEndpointCustomDomain": {
+                        "type": "boolean",
+                      },
+                      "featEndpointIp": {
+                        "type": "boolean",
+                      },
+                      "featPersistentStorage": {
+                        "type": "boolean",
+                      },
+                      "featPersistentStorageType": {
+                        "items": {
+                          "type": "string",
+                        },
+                        "nullable": true,
+                        "type": "array",
+                      },
+                      "gpuModels": {
+                        "items": {
+                          "properties": {
+                            "interface": {
+                              "type": "string",
+                            },
+                            "model": {
+                              "type": "string",
+                            },
+                            "ram": {
+                              "type": "string",
+                            },
+                            "vendor": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "vendor",
+                            "model",
+                            "ram",
+                            "interface",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "hardwareCpu": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "hardwareCpuArch": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "hardwareDisk": {
+                        "items": {
+                          "type": "string",
+                        },
+                        "nullable": true,
+                        "type": "array",
+                      },
+                      "hardwareGpuModels": {
+                        "items": {
+                          "type": "string",
+                        },
+                        "nullable": true,
+                        "type": "array",
+                      },
+                      "hardwareGpuVendor": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "hardwareMemory": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "host": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "hostUri": {
+                        "type": "string",
+                      },
+                      "hostingProvider": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "ipCountry": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "ipCountryCode": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "ipLat": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "ipLon": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "ipRegion": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "ipRegionCode": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "isAudited": {
+                        "type": "boolean",
+                      },
+                      "isOnline": {
+                        "type": "boolean",
+                      },
+                      "isValidVersion": {
+                        "type": "boolean",
+                      },
+                      "lastCheckDate": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "lastOnlineDate": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "leaseCount": {
+                        "nullable": true,
+                        "type": "number",
+                      },
+                      "locationRegion": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "locationType": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "name": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "networkProvider": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "networkSpeedDown": {
+                        "type": "number",
+                      },
+                      "networkSpeedUp": {
+                        "type": "number",
+                      },
+                      "organization": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "owner": {
+                        "type": "string",
+                      },
+                      "pendingStats": {
+                        "properties": {
+                          "cpu": {
+                            "type": "number",
+                          },
+                          "gpu": {
+                            "type": "number",
+                          },
+                          "memory": {
+                            "type": "number",
+                          },
+                          "storage": {
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "cpu",
+                          "gpu",
+                          "memory",
+                          "storage",
+                        ],
+                        "type": "object",
+                      },
+                      "statusPage": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "tier": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "timezone": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "uptime1d": {
+                        "nullable": true,
+                        "type": "number",
+                      },
+                      "uptime30d": {
+                        "nullable": true,
+                        "type": "number",
+                      },
+                      "uptime7d": {
+                        "nullable": true,
+                        "type": "number",
+                      },
+                      "website": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "workloadSupportChia": {
+                        "type": "boolean",
+                      },
+                      "workloadSupportChiaCapabilities": {
+                        "items": {
+                          "type": "string",
+                        },
+                        "nullable": true,
+                        "type": "array",
+                      },
+                    },
+                    "required": [
+                      "owner",
+                      "name",
+                      "hostUri",
+                      "createdHeight",
+                      "cosmosSdkVersion",
+                      "akashVersion",
+                      "ipRegion",
+                      "ipRegionCode",
+                      "ipCountry",
+                      "ipCountryCode",
+                      "ipLat",
+                      "ipLon",
+                      "uptime1d",
+                      "uptime7d",
+                      "uptime30d",
+                      "isValidVersion",
+                      "isOnline",
+                      "lastOnlineDate",
+                      "isAudited",
+                      "activeStats",
+                      "pendingStats",
+                      "availableStats",
+                      "gpuModels",
+                      "attributes",
+                      "host",
+                      "organization",
+                      "statusPage",
+                      "locationRegion",
+                      "country",
+                      "city",
+                      "timezone",
+                      "locationType",
+                      "hostingProvider",
+                      "hardwareCpu",
+                      "hardwareCpuArch",
+                      "hardwareGpuVendor",
+                      "hardwareGpuModels",
+                      "hardwareDisk",
+                      "featPersistentStorage",
+                      "featPersistentStorageType",
+                      "hardwareMemory",
+                      "networkProvider",
+                      "networkSpeedDown",
+                      "networkSpeedUp",
+                      "tier",
+                      "featEndpointCustomDomain",
+                      "workloadSupportChia",
+                      "workloadSupportChiaCapabilities",
+                      "featEndpointIp",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "Returns a list of providers",
+          },
+        },
+        "summary": "Get a list of providers.",
+        "tags": [
+          "Providers",
+        ],
+      },
+    },
+    "/v1/providers/{address}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "description": "Provider Address",
+              "example": "akash18ga02jzaq8cw52anyhzkwta5wygufgu6zsz6xc",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "activeStats": {
+                      "properties": {
+                        "cpu": {
+                          "type": "number",
+                        },
+                        "gpu": {
+                          "type": "number",
+                        },
+                        "memory": {
+                          "type": "number",
+                        },
+                        "storage": {
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "cpu",
+                        "gpu",
+                        "memory",
+                        "storage",
+                      ],
+                      "type": "object",
+                    },
+                    "akashVersion": {
+                      "type": "string",
+                    },
+                    "attributes": {
+                      "items": {
+                        "properties": {
+                          "auditedBy": {
+                            "items": {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                          "key": {
+                            "type": "string",
+                          },
+                          "value": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "key",
+                          "value",
+                          "auditedBy",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "availableStats": {
+                      "properties": {
+                        "cpu": {
+                          "type": "number",
+                        },
+                        "gpu": {
+                          "type": "number",
+                        },
+                        "memory": {
+                          "type": "number",
+                        },
+                        "storage": {
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "cpu",
+                        "gpu",
+                        "memory",
+                        "storage",
+                      ],
+                      "type": "object",
+                    },
+                    "city": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "cosmosSdkVersion": {
+                      "type": "string",
+                    },
+                    "country": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "createdHeight": {
+                      "type": "number",
+                    },
+                    "deploymentCount": {
+                      "type": "number",
+                    },
+                    "email": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "featEndpointCustomDomain": {
+                      "type": "boolean",
+                    },
+                    "featEndpointIp": {
+                      "type": "boolean",
+                    },
+                    "featPersistentStorage": {
+                      "type": "boolean",
+                    },
+                    "featPersistentStorageType": {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "gpuModels": {
+                      "items": {
+                        "properties": {
+                          "interface": {
+                            "type": "string",
+                          },
+                          "model": {
+                            "type": "string",
+                          },
+                          "ram": {
+                            "type": "string",
+                          },
+                          "vendor": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "vendor",
+                          "model",
+                          "ram",
+                          "interface",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "hardwareCpu": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "hardwareCpuArch": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "hardwareDisk": {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "hardwareGpuModels": {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                    "hardwareGpuVendor": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "hardwareMemory": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "host": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "hostUri": {
+                      "type": "string",
+                    },
+                    "hostingProvider": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "ipCountry": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "ipCountryCode": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "ipLat": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "ipLon": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "ipRegion": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "ipRegionCode": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "isAudited": {
+                      "type": "boolean",
+                    },
+                    "isOnline": {
+                      "type": "boolean",
+                    },
+                    "isValidVersion": {
+                      "type": "boolean",
+                    },
+                    "lastCheckDate": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "lastOnlineDate": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "leaseCount": {
+                      "type": "number",
+                    },
+                    "locationRegion": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "locationType": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "name": {
+                      "type": "string",
+                    },
+                    "networkProvider": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "networkSpeedDown": {
+                      "type": "number",
+                    },
+                    "networkSpeedUp": {
+                      "type": "number",
+                    },
+                    "organization": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "owner": {
+                      "type": "string",
+                    },
+                    "pendingStats": {
+                      "properties": {
+                        "cpu": {
+                          "type": "number",
+                        },
+                        "gpu": {
+                          "type": "number",
+                        },
+                        "memory": {
+                          "type": "number",
+                        },
+                        "storage": {
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "cpu",
+                        "gpu",
+                        "memory",
+                        "storage",
+                      ],
+                      "type": "object",
+                    },
+                    "stats": {
+                      "properties": {
+                        "cpu": {
+                          "properties": {
+                            "active": {
+                              "type": "number",
+                            },
+                            "available": {
+                              "type": "number",
+                            },
+                            "pending": {
+                              "type": "number",
+                            },
+                          },
+                          "required": [
+                            "active",
+                            "available",
+                            "pending",
+                          ],
+                          "type": "object",
+                        },
+                        "gpu": {
+                          "properties": {
+                            "active": {
+                              "type": "number",
+                            },
+                            "available": {
+                              "type": "number",
+                            },
+                            "pending": {
+                              "type": "number",
+                            },
+                          },
+                          "required": [
+                            "active",
+                            "available",
+                            "pending",
+                          ],
+                          "type": "object",
+                        },
+                        "memory": {
+                          "properties": {
+                            "active": {
+                              "type": "number",
+                            },
+                            "available": {
+                              "type": "number",
+                            },
+                            "pending": {
+                              "type": "number",
+                            },
+                          },
+                          "required": [
+                            "active",
+                            "available",
+                            "pending",
+                          ],
+                          "type": "object",
+                        },
+                        "storage": {
+                          "properties": {
+                            "ephemeral": {
+                              "properties": {
+                                "active": {
+                                  "type": "number",
+                                },
+                                "available": {
+                                  "type": "number",
+                                },
+                                "pending": {
+                                  "type": "number",
+                                },
+                              },
+                              "required": [
+                                "active",
+                                "available",
+                                "pending",
+                              ],
+                              "type": "object",
+                            },
+                            "persistent": {
+                              "properties": {
+                                "active": {
+                                  "type": "number",
+                                },
+                                "available": {
+                                  "type": "number",
+                                },
+                                "pending": {
+                                  "type": "number",
+                                },
+                              },
+                              "required": [
+                                "active",
+                                "available",
+                                "pending",
+                              ],
+                              "type": "object",
+                            },
+                          },
+                          "required": [
+                            "ephemeral",
+                            "persistent",
+                          ],
+                          "type": "object",
+                        },
+                      },
+                      "required": [
+                        "cpu",
+                        "gpu",
+                        "memory",
+                        "storage",
+                      ],
+                      "type": "object",
+                    },
+                    "statusPage": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "tier": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "timezone": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "uptime": {
+                      "items": {
+                        "properties": {
+                          "checkDate": {
+                            "type": "string",
+                          },
+                          "id": {
+                            "type": "string",
+                          },
+                          "isOnline": {
+                            "type": "boolean",
+                          },
+                        },
+                        "required": [
+                          "id",
+                          "isOnline",
+                          "checkDate",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "uptime1d": {
+                      "type": "number",
+                    },
+                    "uptime30d": {
+                      "type": "number",
+                    },
+                    "uptime7d": {
+                      "type": "number",
+                    },
+                    "website": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "workloadSupportChia": {
+                      "type": "boolean",
+                    },
+                    "workloadSupportChiaCapabilities": {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "owner",
+                    "name",
+                    "hostUri",
+                    "createdHeight",
+                    "email",
+                    "website",
+                    "lastCheckDate",
+                    "deploymentCount",
+                    "leaseCount",
+                    "cosmosSdkVersion",
+                    "akashVersion",
+                    "ipRegion",
+                    "ipRegionCode",
+                    "ipCountry",
+                    "ipCountryCode",
+                    "ipLat",
+                    "ipLon",
+                    "uptime1d",
+                    "uptime7d",
+                    "uptime30d",
+                    "isValidVersion",
+                    "isOnline",
+                    "lastOnlineDate",
+                    "isAudited",
+                    "stats",
+                    "activeStats",
+                    "pendingStats",
+                    "availableStats",
+                    "gpuModels",
+                    "attributes",
+                    "host",
+                    "organization",
+                    "statusPage",
+                    "locationRegion",
+                    "country",
+                    "city",
+                    "timezone",
+                    "locationType",
+                    "hostingProvider",
+                    "hardwareCpu",
+                    "hardwareCpuArch",
+                    "hardwareGpuVendor",
+                    "hardwareGpuModels",
+                    "hardwareDisk",
+                    "featPersistentStorage",
+                    "featPersistentStorageType",
+                    "hardwareMemory",
+                    "networkProvider",
+                    "networkSpeedDown",
+                    "networkSpeedUp",
+                    "tier",
+                    "featEndpointCustomDomain",
+                    "workloadSupportChia",
+                    "workloadSupportChiaCapabilities",
+                    "featEndpointIp",
+                    "uptime",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Return a provider details",
+          },
+          "400": {
+            "description": "Invalid address",
+          },
+          "404": {
+            "description": "Provider not found",
+          },
+        },
+        "summary": "Get a provider details.",
+        "tags": [
+          "Providers",
+        ],
+      },
+    },
+    "/v1/providers/{providerAddress}/active-leases-graph-data": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "providerAddress",
+            "required": true,
+            "schema": {
+              "example": "akash18ga02jzaq8cw52anyhzkwta5wygufgu6zsz6xc",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "compare": {
+                      "properties": {
+                        "count": {
+                          "example": 100,
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "count",
+                      ],
+                      "type": "object",
+                    },
+                    "compareValue": {
+                      "type": "number",
+                    },
+                    "currentValue": {
+                      "type": "number",
+                    },
+                    "now": {
+                      "properties": {
+                        "count": {
+                          "example": 100,
+                          "type": "number",
+                        },
+                      },
+                      "required": [
+                        "count",
+                      ],
+                      "type": "object",
+                    },
+                    "snapshots": {
+                      "items": {
+                        "properties": {
+                          "date": {
+                            "example": "2021-07-01T00:00:00.000Z",
+                            "type": "string",
+                          },
+                          "value": {
+                            "example": 100,
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "date",
+                          "value",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "currentValue",
+                    "compareValue",
+                    "snapshots",
+                    "now",
+                    "compare",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns a provider's active leases graph data",
+          },
+          "400": {
+            "description": "Invalid address",
+          },
+        },
+        "tags": [
+          "Analytics",
+          "Providers",
+        ],
+      },
+    },
+    "/v1/providers/{provider}/deployments/{skip}/{limit}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider",
+            "required": true,
+            "schema": {
+              "description": "Provider Address",
+              "example": "akash18ga02jzaq8cw52anyhzkwta5wygufgu6zsz6xc",
+              "type": "string",
+            },
+          },
+          {
+            "in": "path",
+            "name": "skip",
+            "required": false,
+            "schema": {
+              "description": "Deployments to skip",
+              "example": 10,
+              "minimum": 0,
+              "nullable": true,
+              "type": "number",
+            },
+          },
+          {
+            "in": "path",
+            "name": "limit",
+            "required": true,
+            "schema": {
+              "description": "Deployments to return",
+              "example": 10,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "description": "Filter by status",
+              "enum": [
+                "active",
+                "closed",
+              ],
+              "example": "closed",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "deployments": {
+                      "items": {
+                        "properties": {
+                          "balance": {
+                            "type": "number",
+                          },
+                          "createdDate": {
+                            "nullable": true,
+                            "type": "string",
+                          },
+                          "createdHeight": {
+                            "type": "number",
+                          },
+                          "denom": {
+                            "type": "string",
+                          },
+                          "dseq": {
+                            "type": "string",
+                          },
+                          "leases": {
+                            "items": {
+                              "properties": {
+                                "closedDate": {
+                                  "nullable": true,
+                                  "type": "string",
+                                },
+                                "closedHeight": {
+                                  "nullable": true,
+                                  "type": "number",
+                                },
+                                "createdDate": {
+                                  "nullable": true,
+                                  "type": "string",
+                                },
+                                "createdHeight": {
+                                  "type": "number",
+                                },
+                                "gseq": {
+                                  "type": "number",
+                                },
+                                "oseq": {
+                                  "type": "number",
+                                },
+                                "price": {
+                                  "type": "number",
+                                },
+                                "provider": {
+                                  "type": "string",
+                                },
+                                "resources": {
+                                  "properties": {
+                                    "cpu": {
+                                      "type": "number",
+                                    },
+                                    "ephemeralStorage": {
+                                      "type": "number",
+                                    },
+                                    "gpu": {
+                                      "type": "number",
+                                    },
+                                    "memory": {
+                                      "type": "number",
+                                    },
+                                    "persistentStorage": {
+                                      "type": "number",
+                                    },
+                                  },
+                                  "required": [
+                                    "cpu",
+                                    "memory",
+                                    "gpu",
+                                    "ephemeralStorage",
+                                    "persistentStorage",
+                                  ],
+                                  "type": "object",
+                                },
+                                "status": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "provider",
+                                "gseq",
+                                "oseq",
+                                "price",
+                                "createdHeight",
+                                "createdDate",
+                                "closedHeight",
+                                "closedDate",
+                                "status",
+                                "resources",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                          "owner": {
+                            "type": "string",
+                          },
+                          "resources": {
+                            "properties": {
+                              "cpu": {
+                                "type": "number",
+                              },
+                              "ephemeralStorage": {
+                                "type": "number",
+                              },
+                              "gpu": {
+                                "type": "number",
+                              },
+                              "memory": {
+                                "type": "number",
+                              },
+                              "persistentStorage": {
+                                "type": "number",
+                              },
+                            },
+                            "required": [
+                              "cpu",
+                              "memory",
+                              "gpu",
+                              "ephemeralStorage",
+                              "persistentStorage",
+                            ],
+                            "type": "object",
+                          },
+                          "settledAt": {
+                            "nullable": true,
+                            "type": "number",
+                          },
+                          "status": {
+                            "type": "string",
+                          },
+                          "transferred": {
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "owner",
+                          "dseq",
+                          "denom",
+                          "createdHeight",
+                          "createdDate",
+                          "status",
+                          "balance",
+                          "transferred",
+                          "settledAt",
+                          "resources",
+                          "leases",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "total": {
+                      "type": "number",
+                    },
+                  },
+                  "required": [
+                    "total",
+                    "deployments",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns deployment list",
+          },
+          "400": {
+            "description": "Invalid status filter",
+          },
+        },
+        "summary": "Get a list of deployments for a provider.",
+        "tags": [
+          "Providers",
+          "Deployments",
+        ],
+      },
+    },
+    "/v1/send-verification-email": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "userId": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "userId",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "required": true,
+        },
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "Returns a created wallet",
+          },
+        },
+        "summary": "Resends a verification email",
+        "tags": [
+          "Users",
+        ],
+      },
+    },
+    "/v1/start-trial": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "userId": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "userId",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "address": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "creditAmount": {
+                          "type": "number",
+                        },
+                        "id": {
+                          "type": "number",
+                        },
+                        "isTrialing": {
+                          "type": "boolean",
+                        },
+                        "userId": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "userId",
+                        "creditAmount",
+                        "address",
+                        "isTrialing",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns a created wallet",
+          },
+        },
+        "summary": "Creates a managed wallet for a user",
+        "tags": [
+          "Wallet",
+        ],
+      },
+    },
+    "/v1/stripe-webhook": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "text/plain": {
+              "schema": {
+                "type": "string",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {},
+            "description": "Webhook processed successfully",
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "error",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Stripe signature is required",
+          },
+        },
+        "summary": "Stripe Webhook Handler",
+        "tags": [
+          "Payment",
+        ],
+      },
+    },
+    "/v1/stripe/coupons/apply": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "couponId": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "couponId",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "coupon": {
+                          "nullable": true,
+                          "properties": {
+                            "amount_off": {
+                              "nullable": true,
+                              "type": "number",
+                            },
+                            "description": {
+                              "nullable": true,
+                              "type": "string",
+                            },
+                            "id": {
+                              "type": "string",
+                            },
+                            "name": {
+                              "nullable": true,
+                              "type": "string",
+                            },
+                            "percent_off": {
+                              "nullable": true,
+                              "type": "number",
+                            },
+                            "valid": {
+                              "nullable": true,
+                              "type": "boolean",
+                            },
+                          },
+                          "required": [
+                            "id",
+                          ],
+                          "type": "object",
+                        },
+                        "error": {
+                          "properties": {
+                            "code": {
+                              "type": "string",
+                            },
+                            "message": {
+                              "type": "string",
+                            },
+                            "type": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "message",
+                          ],
+                          "type": "object",
+                        },
+                      },
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Coupon applied successfully",
+          },
+        },
+        "summary": "Apply a coupon to the current user",
+        "tags": [
+          "Payment",
+        ],
+      },
+    },
+    "/v1/stripe/coupons/customer-discounts": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "discounts": {
+                          "items": {
+                            "properties": {
+                              "amount_off": {
+                                "nullable": true,
+                                "type": "number",
+                              },
+                              "code": {
+                                "type": "string",
+                              },
+                              "coupon_id": {
+                                "type": "string",
+                              },
+                              "currency": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              "id": {
+                                "type": "string",
+                              },
+                              "name": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              "percent_off": {
+                                "nullable": true,
+                                "type": "number",
+                              },
+                              "type": {
+                                "enum": [
+                                  "coupon",
+                                  "promotion_code",
+                                ],
+                                "type": "string",
+                              },
+                              "valid": {
+                                "type": "boolean",
+                              },
+                            },
+                            "required": [
+                              "type",
+                              "id",
+                              "valid",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "discounts",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Customer discounts retrieved successfully",
+          },
+        },
+        "summary": "Get current discounts applied to the customer",
+        "tags": [
+          "Payment",
+        ],
+      },
+    },
+    "/v1/stripe/payment-methods": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "properties": {
+                          "billing_details": {
+                            "properties": {
+                              "address": {
+                                "nullable": true,
+                                "properties": {
+                                  "city": {
+                                    "nullable": true,
+                                    "type": "string",
+                                  },
+                                  "country": {
+                                    "nullable": true,
+                                    "type": "string",
+                                  },
+                                  "line1": {
+                                    "nullable": true,
+                                    "type": "string",
+                                  },
+                                  "line2": {
+                                    "nullable": true,
+                                    "type": "string",
+                                  },
+                                  "postal_code": {
+                                    "nullable": true,
+                                    "type": "string",
+                                  },
+                                  "state": {
+                                    "nullable": true,
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "city",
+                                  "country",
+                                  "line1",
+                                  "line2",
+                                  "postal_code",
+                                  "state",
+                                ],
+                                "type": "object",
+                              },
+                              "email": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              "name": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              "phone": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                          },
+                          "card": {
+                            "nullable": true,
+                            "properties": {
+                              "brand": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              "country": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              "exp_month": {
+                                "type": "number",
+                              },
+                              "exp_year": {
+                                "type": "number",
+                              },
+                              "funding": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              "last4": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              "network": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              "three_d_secure_usage": {
+                                "nullable": true,
+                                "properties": {
+                                  "supported": {
+                                    "nullable": true,
+                                    "type": "boolean",
+                                  },
+                                },
+                                "type": "object",
+                              },
+                            },
+                            "required": [
+                              "brand",
+                              "last4",
+                              "exp_month",
+                              "exp_year",
+                            ],
+                            "type": "object",
+                          },
+                          "type": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "type",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Payment methods retrieved successfully",
+          },
+        },
+        "summary": "Get all payment methods for the current user",
+        "tags": [
+          "Payment",
+        ],
+      },
+    },
+    "/v1/stripe/payment-methods/:paymentMethodId": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "paymentMethodId",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "description": "Payment method removed successfully",
+          },
+        },
+        "summary": "Remove a payment method",
+        "tags": [
+          "Payment",
+        ],
+      },
+    },
+    "/v1/stripe/payment-methods/setup": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "clientSecret": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "clientSecret",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "SetupIntent created successfully",
+          },
+        },
+        "summary": "Create a Stripe SetupIntent for adding a payment method",
+        "tags": [
+          "Payment",
+        ],
+      },
+    },
+    "/v1/stripe/prices": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "properties": {
+                          "currency": {
+                            "type": "string",
+                          },
+                          "isCustom": {
+                            "type": "boolean",
+                          },
+                          "unitAmount": {
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "currency",
+                          "unitAmount",
+                          "isCustom",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "",
+          },
+        },
+        "summary": "",
+        "tags": [
+          "Payment",
+        ],
+      },
+    },
+    "/v1/stripe/transactions": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 100,
+              "description": "Number of transactions to return",
+              "example": 100,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "startingAfter",
+            "required": false,
+            "schema": {
+              "description": "ID of the last transaction from the previous page",
+              "example": "ch_1234567890",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "hasMore": {
+                          "type": "boolean",
+                        },
+                        "nextPage": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "transactions": {
+                          "items": {
+                            "properties": {
+                              "amount": {
+                                "type": "number",
+                              },
+                              "created": {
+                                "type": "number",
+                              },
+                              "currency": {
+                                "type": "string",
+                              },
+                              "description": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              "id": {
+                                "type": "string",
+                              },
+                              "metadata": {
+                                "additionalProperties": {
+                                  "type": "string",
+                                },
+                                "nullable": true,
+                                "type": "object",
+                              },
+                              "paymentMethod": {
+                                "nullable": true,
+                                "properties": {
+                                  "billing_details": {
+                                    "properties": {
+                                      "address": {
+                                        "nullable": true,
+                                        "properties": {
+                                          "city": {
+                                            "nullable": true,
+                                            "type": "string",
+                                          },
+                                          "country": {
+                                            "nullable": true,
+                                            "type": "string",
+                                          },
+                                          "line1": {
+                                            "nullable": true,
+                                            "type": "string",
+                                          },
+                                          "line2": {
+                                            "nullable": true,
+                                            "type": "string",
+                                          },
+                                          "postal_code": {
+                                            "nullable": true,
+                                            "type": "string",
+                                          },
+                                          "state": {
+                                            "nullable": true,
+                                            "type": "string",
+                                          },
+                                        },
+                                        "required": [
+                                          "city",
+                                          "country",
+                                          "line1",
+                                          "line2",
+                                          "postal_code",
+                                          "state",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "email": {
+                                        "nullable": true,
+                                        "type": "string",
+                                      },
+                                      "name": {
+                                        "nullable": true,
+                                        "type": "string",
+                                      },
+                                      "phone": {
+                                        "nullable": true,
+                                        "type": "string",
+                                      },
+                                    },
+                                    "type": "object",
+                                  },
+                                  "card": {
+                                    "nullable": true,
+                                    "properties": {
+                                      "brand": {
+                                        "nullable": true,
+                                        "type": "string",
+                                      },
+                                      "country": {
+                                        "nullable": true,
+                                        "type": "string",
+                                      },
+                                      "exp_month": {
+                                        "type": "number",
+                                      },
+                                      "exp_year": {
+                                        "type": "number",
+                                      },
+                                      "funding": {
+                                        "nullable": true,
+                                        "type": "string",
+                                      },
+                                      "last4": {
+                                        "nullable": true,
+                                        "type": "string",
+                                      },
+                                      "network": {
+                                        "nullable": true,
+                                        "type": "string",
+                                      },
+                                      "three_d_secure_usage": {
+                                        "nullable": true,
+                                        "properties": {
+                                          "supported": {
+                                            "nullable": true,
+                                            "type": "boolean",
+                                          },
+                                        },
+                                        "type": "object",
+                                      },
+                                    },
+                                    "required": [
+                                      "brand",
+                                      "last4",
+                                      "exp_month",
+                                      "exp_year",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "type": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "type",
+                                ],
+                                "type": "object",
+                              },
+                              "receiptUrl": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                              "status": {
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "id",
+                              "amount",
+                              "currency",
+                              "status",
+                              "created",
+                              "paymentMethod",
+                            ],
+                            "type": "object",
+                          },
+                          "type": "array",
+                        },
+                      },
+                      "required": [
+                        "transactions",
+                        "hasMore",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Customer transactions retrieved successfully",
+          },
+        },
+        "summary": "Get transaction history for the current customer",
+        "tags": [
+          "Payment",
+        ],
+      },
+    },
+    "/v1/stripe/transactions/confirm": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "amount": {
+                        "type": "number",
+                      },
+                      "currency": {
+                        "type": "string",
+                      },
+                      "paymentMethodId": {
+                        "type": "string",
+                      },
+                      "userId": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "userId",
+                      "paymentMethodId",
+                      "amount",
+                      "currency",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "description": "Payment processed",
+          },
+        },
+        "summary": "Confirm a payment using a saved payment method",
+        "tags": [
+          "Payment",
+        ],
+      },
+    },
+    "/v1/transactions": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "description": "Number of transactions to return",
+              "example": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "type": "number",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "datetime": {
+                        "type": "string",
+                      },
+                      "error": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "fee": {
+                        "type": "number",
+                      },
+                      "gasUsed": {
+                        "type": "number",
+                      },
+                      "gasWanted": {
+                        "type": "number",
+                      },
+                      "hash": {
+                        "type": "string",
+                      },
+                      "height": {
+                        "type": "number",
+                      },
+                      "isSuccess": {
+                        "type": "boolean",
+                      },
+                      "memo": {
+                        "type": "string",
+                      },
+                      "messages": {
+                        "items": {
+                          "properties": {
+                            "amount": {
+                              "type": "number",
+                            },
+                            "id": {
+                              "type": "string",
+                            },
+                            "type": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "type",
+                            "amount",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                    },
+                    "required": [
+                      "height",
+                      "datetime",
+                      "hash",
+                      "isSuccess",
+                      "error",
+                      "gasUsed",
+                      "gasWanted",
+                      "fee",
+                      "memo",
+                      "messages",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "Returns transaction list",
+          },
+        },
+        "summary": "Get a list of transactions.",
+        "tags": [
+          "Transactions",
+        ],
+      },
+    },
+    "/v1/transactions/{hash}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "hash",
+            "required": true,
+            "schema": {
+              "description": "Transaction hash",
+              "example": "A19F1950D97E576F0D7B591D71A8D0366AA8BA0A7F3DA76F44769188644BE9EB",
+              "minLength": 1,
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "datetime": {
+                      "type": "string",
+                    },
+                    "error": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "fee": {
+                      "type": "number",
+                    },
+                    "gasUsed": {
+                      "type": "number",
+                    },
+                    "gasWanted": {
+                      "type": "number",
+                    },
+                    "hash": {
+                      "type": "string",
+                    },
+                    "height": {
+                      "type": "number",
+                    },
+                    "isSuccess": {
+                      "type": "boolean",
+                    },
+                    "memo": {
+                      "type": "string",
+                    },
+                    "messages": {
+                      "items": {
+                        "properties": {
+                          "data": {
+                            "additionalProperties": {
+                              "type": "string",
+                            },
+                            "type": "object",
+                          },
+                          "id": {
+                            "type": "string",
+                          },
+                          "relatedDeploymentId": {
+                            "nullable": true,
+                            "type": "string",
+                          },
+                          "type": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "data",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "multisigThreshold": {
+                      "type": "number",
+                    },
+                    "signers": {
+                      "items": {
+                        "type": "string",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "height",
+                    "datetime",
+                    "hash",
+                    "isSuccess",
+                    "signers",
+                    "error",
+                    "gasUsed",
+                    "gasWanted",
+                    "fee",
+                    "memo",
+                    "messages",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns predicted block date",
+          },
+          "404": {
+            "description": "Transaction not found",
+          },
+        },
+        "summary": "Get a transaction by hash.",
+        "tags": [
+          "Transactions",
+        ],
+      },
+    },
+    "/v1/tx": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "messages": {
+                        "items": {
+                          "properties": {
+                            "typeUrl": {
+                              "enum": [
+                                "/akash.deployment.v1beta3.MsgCreateDeployment",
+                                "/akash.cert.v1beta3.MsgCreateCertificate",
+                                "/akash.market.v1beta4.MsgCreateLease",
+                                "/akash.deployment.v1beta3.MsgUpdateDeployment",
+                                "/akash.deployment.v1beta3.MsgCloseDeployment",
+                                "/akash.deployment.v1beta3.MsgDepositDeployment",
+                              ],
+                              "type": "string",
+                            },
+                            "value": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "typeUrl",
+                            "value",
+                          ],
+                          "type": "object",
+                        },
+                        "minItems": 1,
+                        "type": "array",
+                      },
+                      "userId": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "userId",
+                      "messages",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "code": {
+                          "type": "number",
+                        },
+                        "rawLog": {
+                          "type": "string",
+                        },
+                        "transactionHash": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "code",
+                        "transactionHash",
+                        "rawLog",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns a signed transaction",
+          },
+        },
+        "summary": "Signs a transaction via a user managed wallet",
+        "tags": [
+          "Wallet",
+        ],
+      },
+    },
+    "/v1/usage/history": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "description": "The wallet address to get billing and usage data for",
+              "example": "akash18andxgtd6r08zzfpcdqg9pdr6smks7gv76tyt6",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "startDate",
+            "required": false,
+            "schema": {
+              "description": "Start date (YYYY-MM-DD). Defaults to 30 days before endDate",
+              "example": "2024-01-01",
+              "format": "date",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "endDate",
+            "required": false,
+            "schema": {
+              "default": "2025-07-03",
+              "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
+              "example": "2024-01-31",
+              "format": "date",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "activeLeases": {
+                        "description": "Number of active leases on this date",
+                        "example": 3,
+                        "type": "number",
+                      },
+                      "dailyAktSpent": {
+                        "description": "AKT tokens spent on this date",
+                        "example": 12.5,
+                        "type": "number",
+                      },
+                      "dailyUsdSpent": {
+                        "description": "Total USD value spent on this date (AKT + USDC)",
+                        "example": 17.75,
+                        "type": "number",
+                      },
+                      "dailyUsdcSpent": {
+                        "description": "USDC spent on this date",
+                        "example": 5.25,
+                        "type": "number",
+                      },
+                      "date": {
+                        "description": "Date in YYYY-MM-DD format",
+                        "example": "2024-01-15",
+                        "type": "string",
+                      },
+                      "totalAktSpent": {
+                        "description": "Cumulative AKT tokens spent up to this date",
+                        "example": 125.75,
+                        "type": "number",
+                      },
+                      "totalUsdSpent": {
+                        "description": "Cumulative USD value spent up to this date",
+                        "example": 178.25,
+                        "type": "number",
+                      },
+                      "totalUsdcSpent": {
+                        "description": "Cumulative USDC spent up to this date",
+                        "example": 52.5,
+                        "type": "number",
+                      },
+                    },
+                    "required": [
+                      "date",
+                      "activeLeases",
+                      "dailyAktSpent",
+                      "totalAktSpent",
+                      "dailyUsdcSpent",
+                      "totalUsdcSpent",
+                      "dailyUsdSpent",
+                      "totalUsdSpent",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "Returns billing and usage data",
+          },
+          "400": {
+            "description": "Invalid address format",
+          },
+        },
+        "summary": "Get historical data of billing and usage for a wallet address.",
+        "tags": [
+          "Billing",
+        ],
+      },
+    },
+    "/v1/usage/history/stats": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "description": "The wallet address to get billing and usage data for",
+              "example": "akash18andxgtd6r08zzfpcdqg9pdr6smks7gv76tyt6",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "startDate",
+            "required": false,
+            "schema": {
+              "description": "Start date (YYYY-MM-DD). Defaults to 30 days before endDate",
+              "example": "2024-01-01",
+              "format": "date",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "endDate",
+            "required": false,
+            "schema": {
+              "default": "2025-07-03",
+              "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
+              "example": "2024-01-31",
+              "format": "date",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "averageLeasesPerDay": {
+                      "description": "Average number of leases deployed per day",
+                      "example": 1.5,
+                      "type": "number",
+                    },
+                    "averagePerDay": {
+                      "description": "Average spending per day in USD",
+                      "example": 12.34,
+                      "type": "number",
+                    },
+                    "totalLeases": {
+                      "description": "Total number of leases deployed",
+                      "example": 15,
+                      "type": "number",
+                    },
+                    "totalSpent": {
+                      "description": "Total amount spent in USD",
+                      "example": 1234.56,
+                      "type": "number",
+                    },
+                  },
+                  "required": [
+                    "totalSpent",
+                    "averagePerDay",
+                    "totalLeases",
+                    "averageLeasesPerDay",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns usage stats data",
+          },
+          "400": {
+            "description": "Invalid address format",
+          },
+        },
+        "summary": "Get historical usage stats for a wallet address.",
+        "tags": [
+          "Billing",
+        ],
+      },
+    },
+    "/v1/validators": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "commission": {
+                        "type": "number",
+                      },
+                      "identity": {
+                        "type": "string",
+                      },
+                      "keybaseAvatarUrl": {
+                        "nullable": true,
+                        "type": "string",
+                      },
+                      "moniker": {
+                        "type": "string",
+                      },
+                      "operatorAddress": {
+                        "type": "string",
+                      },
+                      "rank": {
+                        "type": "number",
+                      },
+                      "votingPower": {
+                        "type": "number",
+                      },
+                      "votingPowerRatio": {
+                        "type": "number",
+                      },
+                    },
+                    "required": [
+                      "operatorAddress",
+                      "moniker",
+                      "votingPower",
+                      "commission",
+                      "identity",
+                      "votingPowerRatio",
+                      "rank",
+                      "keybaseAvatarUrl",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "Returns validators",
+          },
+        },
+        "tags": [
+          "Validators",
+        ],
+      },
+    },
+    "/v1/validators/{address}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "address",
+            "required": true,
+            "schema": {
+              "description": "Validator Address",
+              "example": "akashvaloper14mt78hz73d9tdwpdvkd59ne9509kxw8yj7qy8f",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "address": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "commission": {
+                      "type": "number",
+                    },
+                    "description": {
+                      "type": "string",
+                    },
+                    "identity": {
+                      "type": "string",
+                    },
+                    "keybaseAvatarUrl": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "keybaseUsername": {
+                      "nullable": true,
+                      "type": "string",
+                    },
+                    "maxCommission": {
+                      "type": "number",
+                    },
+                    "maxCommissionChange": {
+                      "type": "number",
+                    },
+                    "moniker": {
+                      "type": "string",
+                    },
+                    "operatorAddress": {
+                      "type": "string",
+                    },
+                    "rank": {
+                      "type": "number",
+                    },
+                    "votingPower": {
+                      "type": "number",
+                    },
+                    "website": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "operatorAddress",
+                    "address",
+                    "moniker",
+                    "keybaseUsername",
+                    "keybaseAvatarUrl",
+                    "votingPower",
+                    "commission",
+                    "maxCommission",
+                    "maxCommissionChange",
+                    "identity",
+                    "description",
+                    "website",
+                    "rank",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Return a validator information",
+          },
+          "400": {
+            "description": "Invalid address",
+          },
+          "404": {
+            "description": "Validator not found",
+          },
+        },
+        "tags": [
+          "Validators",
+        ],
+      },
+    },
+    "/v1/version/{network}": {
+      "get": {
+        "description": "Provide a cached version of one of these files: [https://raw.githubusercontent.com/akash-network/net/master/mainnet/version.txt](https://raw.githubusercontent.com/akash-network/net/master/mainnet/version.txt), [https://raw.githubusercontent.com/akash-network/net/master/sandbox/version.txt](https://raw.githubusercontent.com/akash-network/net/master/sandbox/version.txt), [https://raw.githubusercontent.com/akash-network/net/master/testnet-02/version.txt](https://raw.githubusercontent.com/akash-network/net/master/testnet-02/version.txt)",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "network",
+            "required": true,
+            "schema": {
+              "enum": [
+                "mainnet",
+                "testnet",
+                "sandbox",
+              ],
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "description": "Network version",
+          },
+        },
+        "summary": "Get network version.",
+        "tags": [
+          "Chain",
+        ],
+      },
+    },
+    "/v1/wallets": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "awaitSessionId",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "properties": {
+                          "address": {
+                            "nullable": true,
+                            "type": "string",
+                          },
+                          "creditAmount": {
+                            "type": "number",
+                          },
+                          "id": {
+                            "type": "number",
+                          },
+                          "isTrialing": {
+                            "type": "boolean",
+                          },
+                          "userId": {
+                            "nullable": true,
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "id",
+                          "userId",
+                          "creditAmount",
+                          "address",
+                          "isTrialing",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns a created wallet",
+          },
+        },
+        "summary": "Get a list of wallets",
+        "tags": [
+          "Wallet",
+        ],
+      },
+    },
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3080/v1",
+    },
+  ],
+}
+`;

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -4,8 +4,8 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
 {
   "components": {},
   "info": {
-    "description": "Access Akash data from our indexer",
-    "title": "Console API",
+    "description": "API providing data to the Akash Network Console",
+    "title": "Akash Network Console API",
     "version": "v1",
   },
   "openapi": "3.0.0",
@@ -10854,6 +10854,289 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
         "summary": "Confirm a payment using a saved payment method",
         "tags": [
           "Payment",
+        ],
+      },
+    },
+    "/v1/templates": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "properties": {
+                      "templates": {
+                        "items": {
+                          "properties": {
+                            "config": {
+                              "properties": {
+                                "ssh": {
+                                  "type": "boolean",
+                                },
+                              },
+                              "type": "object",
+                            },
+                            "deploy": {
+                              "type": "string",
+                            },
+                            "githubUrl": {
+                              "type": "string",
+                            },
+                            "guide": {
+                              "type": "string",
+                            },
+                            "id": {
+                              "type": "string",
+                            },
+                            "logoUrl": {
+                              "nullable": true,
+                              "type": "string",
+                            },
+                            "name": {
+                              "type": "string",
+                            },
+                            "path": {
+                              "type": "string",
+                            },
+                            "persistentStorageEnabled": {
+                              "type": "boolean",
+                            },
+                            "readme": {
+                              "type": "string",
+                            },
+                            "summary": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "name",
+                            "path",
+                            "logoUrl",
+                            "summary",
+                            "readme",
+                            "deploy",
+                            "persistentStorageEnabled",
+                            "githubUrl",
+                            "config",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "title": {
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "title",
+                      "templates",
+                    ],
+                    "type": "object",
+                  },
+                  "type": "array",
+                },
+              },
+            },
+            "description": "Returns a list of deployment templates grouped by categories",
+          },
+        },
+        "tags": [
+          "Other",
+        ],
+      },
+    },
+    "/v1/templates-list": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "items": {
+                        "properties": {
+                          "templates": {
+                            "items": {
+                              "properties": {
+                                "config": {
+                                  "properties": {
+                                    "ssh": {
+                                      "type": "boolean",
+                                    },
+                                  },
+                                  "type": "object",
+                                },
+                                "deploy": {
+                                  "type": "string",
+                                },
+                                "githubUrl": {
+                                  "type": "string",
+                                },
+                                "guide": {
+                                  "type": "string",
+                                },
+                                "id": {
+                                  "type": "string",
+                                },
+                                "logoUrl": {
+                                  "nullable": true,
+                                  "type": "string",
+                                },
+                                "name": {
+                                  "type": "string",
+                                },
+                                "path": {
+                                  "type": "string",
+                                },
+                                "persistentStorageEnabled": {
+                                  "type": "boolean",
+                                },
+                                "readme": {
+                                  "type": "string",
+                                },
+                                "summary": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "id",
+                                "name",
+                                "path",
+                                "logoUrl",
+                                "summary",
+                                "readme",
+                                "deploy",
+                                "persistentStorageEnabled",
+                                "githubUrl",
+                                "config",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                          "title": {
+                            "type": "string",
+                          },
+                        },
+                        "required": [
+                          "title",
+                          "templates",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns a list of deployment templates grouped by categories",
+          },
+        },
+        "tags": [
+          "Other",
+        ],
+      },
+    },
+    "/v1/templates/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Template ID",
+              "example": "akash-network-cosmos-omnibus-agoric",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "config": {
+                          "properties": {
+                            "ssh": {
+                              "type": "boolean",
+                            },
+                          },
+                          "type": "object",
+                        },
+                        "deploy": {
+                          "type": "string",
+                        },
+                        "githubUrl": {
+                          "type": "string",
+                        },
+                        "guide": {
+                          "type": "string",
+                        },
+                        "id": {
+                          "type": "string",
+                        },
+                        "logoUrl": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "name": {
+                          "type": "string",
+                        },
+                        "path": {
+                          "type": "string",
+                        },
+                        "persistentStorageEnabled": {
+                          "type": "boolean",
+                        },
+                        "readme": {
+                          "type": "string",
+                        },
+                        "summary": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "name",
+                        "path",
+                        "logoUrl",
+                        "summary",
+                        "readme",
+                        "deploy",
+                        "persistentStorageEnabled",
+                        "githubUrl",
+                        "config",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Return a template by id",
+          },
+          "404": {
+            "description": "Template not found",
+          },
+        },
+        "tags": [
+          "Other",
         ],
       },
     },

--- a/apps/api/test/functional/blocks.spec.ts
+++ b/apps/api/test/functional/blocks.spec.ts
@@ -137,7 +137,8 @@ describe("Blocks", () => {
 
         expect(response.status).toBe(200);
         const data = (await response.json()) as { predictedHeight: number };
-        expect(data.predictedHeight).toBe(expectedHeight);
+        expect(data.predictedHeight).toBeGreaterThanOrEqual(expectedHeight - 1);
+        expect(data.predictedHeight).toBeLessThanOrEqual(expectedHeight + 1);
       });
     });
 

--- a/apps/api/test/functional/docs.spec.ts
+++ b/apps/api/test/functional/docs.spec.ts
@@ -1,0 +1,18 @@
+import { app } from "@src/app";
+
+describe("API Docs", () => {
+  describe("GET /v1/doc", () => {
+    it(`returns docs with all routes expected`, async () => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date("2025-07-03T12:00:00.000Z"));
+
+      const response = await app.request(`/v1/doc`);
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data).toMatchSnapshot();
+
+      jest.useRealTimers();
+    });
+  });
+});


### PR DESCRIPTION
Moved it to app.ts, as majority of the endpoints are already there - and the rest should follow soon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an endpoint to serve OpenAPI JSON documentation.
  * Added a Swagger UI interface for interactive API exploration.

* **Improvements**
  * Enhanced API documentation by categorizing endpoints with relevant tags (e.g., "Users", "Payment").
  * Unified route handler registration for better maintainability.
  * Added a service to aggregate and generate comprehensive OpenAPI documentation.

* **Bug Fixes**
  * Adjusted response format for the Stripe webhook endpoint to ensure proper status handling.

* **Tests**
  * Added tests to verify the API documentation endpoint returns the correct structure.
  * Updated block height prediction tests to allow a range for predicted values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->