### PR TITLE
revert: reverts changes to nginx configuration

### DIFF
--- a/apps/provider-proxy/nginx.conf
+++ b/apps/provider-proxy/nginx.conf
@@ -40,7 +40,4 @@ http {
             proxy_cookie_path / "/; HTTPOnly; Secure";
         }
     }
-
-    large_client_header_buffers 4 32k;
-    proxy_buffer_size 32k;
 }


### PR DESCRIPTION
## Why

because they cause error on nginx: 
> nginx: [emerg] "proxy_busy_buffers_size" must be less than the size of all "proxy_buffers" minus one buffer in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nginx configuration by removing certain buffer size directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->