### PR TITLE
fix: properly propagate cpu value from slider

### DIFF
--- a/apps/deploy-web/src/components/sdl/CpuFormControl.tsx
+++ b/apps/deploy-web/src/components/sdl/CpuFormControl.tsx
@@ -46,7 +46,6 @@ export const CpuFormControl: React.FunctionComponent<Props> = ({ control, servic
                   <InfoCircle className="ml-2 text-xs text-muted-foreground" />
                 </CustomTooltip>
               </div>
-
               <Input
                 type="number"
                 color="secondary"
@@ -68,7 +67,7 @@ export const CpuFormControl: React.FunctionComponent<Props> = ({ control, servic
                 step={1}
                 color="secondary"
                 aria-label="CPU"
-                onValueChange={newValue => field.onChange(newValue)}
+                onValueChange={newValue => field.onChange(newValue[0])}
               />
             </div>
 


### PR DESCRIPTION
## Why

Changes to cpu in SDL builder via slider update cpu to be an array. This is the result of weird radix Slider API -> https://github.com/huntabyte/shadcn-svelte/discussions/217



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the value handling for the CPU slider to ensure only the selected numeric value is used when updating the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->