### PR TITLE
fix: ignore errors in SQL formatting

### DIFF
--- a/apps/api/src/core/services/postgres-logger/postgres-logger.service.ts
+++ b/apps/api/src/core/services/postgres-logger/postgres-logger.service.ts
@@ -26,7 +26,11 @@ export class PostgresLoggerService implements LogWriter {
     let formatted = message.replace(this.isDrizzle ? /^Query: / : /^Executing \(default\):/, "");
 
     if (this.useFormat) {
-      formatted = format(formatted, { language: "postgresql" });
+      try {
+        formatted = format(formatted, { language: "postgresql" });
+      } catch {
+        // do nothing if formatting fails, we still have the raw SQL
+      }
     }
 
     this.logger.debug(formatted);

--- a/packages/docker/Dockerfile.node
+++ b/packages/docker/Dockerfile.node
@@ -3,7 +3,7 @@
 FROM node:22.15.1-alpine AS base
 
 # see https://r1ch.net/blog/node-v20-aggregateeerror-etimedout-happy-eyeballs and https://github.com/nodejs/node/issues/54359
-ARG NODE_OPTIONS="--no-network-family-autoselection"
+ARG NODE_OPTIONS="--no-network-family-autoselection --enable-source-maps"
 ARG GITHUB_PAT
 ARG WORKSPACE
 ENV WORKSPACE $WORKSPACE


### PR DESCRIPTION
## Why

SQL formatter cannot format SQL with complex parameters. Ideally, we need to feed those parameters via a separate option to sql formatter but it requires additional parsing (at least for sequelize).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in SQL logging to prevent interruptions if SQL formatting fails.

* **Chores**
  * Enabled source map support in the Node.js Docker environment for improved debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->