### PR TITLE
refactor: gets rid of next.js publicRuntimeConfig

### DIFF
--- a/apps/deploy-web/__mocks__/next/config.ts
+++ b/apps/deploy-web/__mocks__/next/config.ts
@@ -1,9 +1,0 @@
-import packageJSON from "../../package.json";
-
-export default function getConfig() {
-  return {
-    publicRuntimeConfig: {
-      version: packageJSON.version
-    }
-  };
-}

--- a/apps/deploy-web/next.config.js
+++ b/apps/deploy-web/next.config.js
@@ -32,6 +32,9 @@ if (process.env.NODE_ENV === "test") {
 const moduleExports = {
   reactStrictMode: false,
   productionBrowserSourceMaps: true,
+  env: {
+    NEXT_PUBLIC_APP_VERSION: version
+  },
   compiler: {
     // Enables the styled-components SWC transform
     styledComponents: true
@@ -49,9 +52,6 @@ const moduleExports = {
   transpilePackages,
   experimental: {
     instrumentationHook: true
-  },
-  publicRuntimeConfig: {
-    version
   },
   i18n: {
     locales: ["en-US"],

--- a/apps/deploy-web/src/components/layout/Sidebar.tsx
+++ b/apps/deploy-web/src/components/layout/Sidebar.tsx
@@ -33,7 +33,6 @@ import {
   Youtube
 } from "iconoir-react";
 import { useAtom } from "jotai";
-import getConfig from "next/config";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -47,8 +46,6 @@ import { MobileSidebarUser } from "./MobileSidebarUser";
 import { ModeToggle } from "./ModeToggle";
 import { NodeStatusBar } from "./NodeStatusBar";
 import { SidebarGroupMenu } from "./SidebarGroupMenu";
-
-const { publicRuntimeConfig } = getConfig();
 
 type Props = {
   children?: ReactNode;
@@ -273,7 +270,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
                     customComponent: (
                       <div className="text-muted-foreground">
                         <Separator className="my-1" />
-                        <div className="px-4 py-2 text-sm">Version {publicRuntimeConfig?.version}</div>
+                        <div className="px-4 py-2 text-sm">Version {process.env.NEXT_PUBLIC_APP_VERSION}</div>
 
                         <div className="px-4 py-2">
                           <ModeToggle />

--- a/apps/deploy-web/src/utils/localStorage.ts
+++ b/apps/deploy-web/src/utils/localStorage.ts
@@ -1,9 +1,8 @@
 "use client";
 
-import getConfig from "next/config";
 import { gt, neq } from "semver";
 
-const { publicRuntimeConfig } = getConfig();
+const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || "0.0.0";
 
 const migrations: Record<string, () => void> = {
   "0.14.0": () => {}
@@ -13,7 +12,7 @@ const migrations: Record<string, () => void> = {
 // Check if latestUpdatedVersion is < currentVersion
 // If so run all the version > until current is reached.
 export const migrateLocalStorage = () => {
-  const currentVersion: string = publicRuntimeConfig.version;
+  const currentVersion = APP_VERSION;
   const version = getVersion();
   const hasPreviousVersion = version && neq(currentVersion, version);
 
@@ -46,5 +45,5 @@ function getVersion(): string {
     return "1.0.0";
   }
 
-  return publicRuntimeConfig.version;
+  return APP_VERSION;
 }


### PR DESCRIPTION
## Why

publicRuntimeConfig is deprecated and not available in next@15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the method for accessing the app version throughout the application, switching from runtime configuration to environment variables.
  * The app version is now displayed and used via the environment variable `NEXT_PUBLIC_APP_VERSION`.
* **Chores**
  * Removed obsolete configuration files and code related to the previous version retrieval method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->