### PR TITLE
chore: adds permissions to package-lock diff workflow

### DIFF
--- a/.github/workflows/diff-package-lock.yml
+++ b/.github/workflows/diff-package-lock.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   diff:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Why

To allow external contributor's workflow create PR comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions for improved security and access control during automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->