### PR TITLE
refactor: properly close servers in functional tests

### DIFF
--- a/apps/provider-proxy/src/app.ts
+++ b/apps/provider-proxy/src/app.ts
@@ -12,6 +12,7 @@ import { proxyProviderRequest, proxyRoute } from "./routes/proxyProviderRequest"
 import { HonoErrorHandlerService } from "./services/HonoErrorHandlerService/HonoErrorHandlerService";
 import { WebsocketServer } from "./services/WebsocketServer";
 import type { AppEnv } from "./types/AppContext";
+import { shutdownServer } from "./utils/shutdownServer";
 import type { Container } from "./container";
 import { createContainer } from "./container";
 
@@ -61,9 +62,8 @@ export async function startAppServer(port: number): Promise<AppServer> {
   return {
     host: `http://localhost:${(httpAppServer.address() as AddressInfo).port}`,
     container,
-    close() {
-      wss.close();
-      httpAppServer.close();
+    async close() {
+      await Promise.all([shutdownServer(wss), shutdownServer(httpAppServer)]);
     }
   };
 }
@@ -71,5 +71,5 @@ export async function startAppServer(port: number): Promise<AppServer> {
 export interface AppServer {
   host: string;
   container: Container;
-  close(): void;
+  close(): Promise<void>;
 }

--- a/apps/provider-proxy/src/services/WebsocketServer.ts
+++ b/apps/provider-proxy/src/services/WebsocketServer.ts
@@ -56,8 +56,13 @@ export class WebsocketServer {
     private readonly logger?: LoggerService
   ) {}
 
-  close(): void {
-    this.wss?.close();
+  get listening(): boolean {
+    return !!this.wss;
+  }
+
+  close(cb?: (error?: Error) => void): void {
+    if (!this.wss) return cb?.();
+    this.wss.close(cb);
   }
 
   listen(): this {

--- a/apps/provider-proxy/src/utils/shutdownServer.ts
+++ b/apps/provider-proxy/src/utils/shutdownServer.ts
@@ -1,0 +1,17 @@
+export async function shutdownServer(server: ClosableServer | undefined): Promise<void> {
+  if (!server || !server.listening) return;
+  return new Promise<void>((resolve, reject) => {
+    server.close(error => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+export interface ClosableServer {
+  close: (cb?: (error?: Error) => void) => void;
+  listening: boolean;
+}

--- a/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
@@ -15,13 +15,12 @@ describe("Provider HTTP proxy", () => {
     await startServer();
   });
 
-  afterAll(() => {
-    stopServer();
+  afterAll(async () => {
+    await stopServer();
   });
 
-  afterEach(() => {
-    stopProviderServer();
-    stopChainAPIServer();
+  afterEach(async () => {
+    await Promise.all([stopProviderServer(), stopChainAPIServer()]);
   });
 
   it("proxies request if provider uses self-signed certificate which is available on chain", async () => {

--- a/apps/provider-proxy/test/setup/chainApiServer.ts
+++ b/apps/provider-proxy/test/setup/chainApiServer.ts
@@ -3,6 +3,8 @@ import type { X509Certificate } from "crypto";
 import http from "http";
 import type { AddressInfo } from "net";
 
+import { shutdownServer } from "../../src/utils/shutdownServer";
+
 let chainServer: http.Server | undefined;
 /**
  * Cannot mock blockchain API using nock and msw that's why have a separate server
@@ -47,8 +49,8 @@ export function startChainApiServer(certificates: X509Certificate[], options?: C
   });
 }
 
-export function stopChainAPIServer(): void {
-  chainServer?.close();
+export function stopChainAPIServer(): Promise<void> {
+  return shutdownServer(chainServer);
 }
 
 export interface ChainApiOptions {

--- a/apps/provider-proxy/test/setup/providerServer.ts
+++ b/apps/provider-proxy/test/setup/providerServer.ts
@@ -4,6 +4,7 @@ import https from "https";
 import type { AddressInfo } from "net";
 import WebSocket from "ws";
 
+import { shutdownServer } from "../../src/utils/shutdownServer";
 import type { CertPair } from "../seeders/createX509CertPair";
 import { createX509CertPair } from "../seeders/createX509CertPair";
 import { generateBech32 } from "./chainApiServer";
@@ -64,8 +65,8 @@ export function startProviderServer(options: ProviderServerOptions): Promise<str
   });
 }
 
-export function stopProviderServer() {
-  runningServer?.close();
+export function stopProviderServer(): Promise<void> {
+  return shutdownServer(runningServer);
 }
 
 type RequestHandlers = Record<string, (req: IncomingMessage, res: ServerResponse) => (() => void) | undefined | void>;

--- a/apps/provider-proxy/test/setup/proxyServer.ts
+++ b/apps/provider-proxy/test/setup/proxyServer.ts
@@ -8,8 +8,8 @@ export async function startServer(): Promise<string> {
   return server.host;
 }
 
-export function stopServer(): void {
-  server?.close();
+export async function stopServer(): Promise<void> {
+  await server?.close();
 }
 
 export async function request(url: string, init?: RequestInit): Promise<Response> {


### PR DESCRIPTION
## Why 

because that tests are flaky and sometimes fail https://github.com/akash-network/console/actions/runs/16149741030/job/45577813967?pr=1644 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to check if the WebSocket server is currently active.
  * Introduced a utility for graceful, promise-based server shutdowns.

* **Refactor**
  * Updated server shutdown processes throughout the app and tests to use asynchronous, promise-based methods for improved reliability and consistency.

* **Tests**
  * Enhanced test cleanup routines to ensure all servers are properly and asynchronously shut down after tests complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->