### PR TITLE
chore: adds cursor rule to not use jest.mock in tests generation

### DIFF
--- a/.cursor/rules/no-jest-mock.mdc
+++ b/.cursor/rules/no-jest-mock.mdc
@@ -1,0 +1,48 @@
+---
+description: "Disallow use of jest.mock() in test files"
+globs: **/*.spec.ts,**/*.spec.tsx
+alwaysApply: false
+---
+# Don't use jest.mock
+
+## Description
+
+Don't use `jest.mock()` to mock dependencies. Instead, use `jest-mock-extended` to create mocks and pass mocks as dependencies to the service under test.
+
+## Why
+
+- Avoid implicit dependencies: `jest.mock` mocks internal implementation details
+- Improve maintainability: explicit mocks make tests easier to understand and refactor
+- Better type safety: with jest-mock-extended, you get autocompletion and type checking for mocks.
+- No shared state state between tests: `jest.mock` introduce shared state which can lead to flaky and unreliable tests
+
+## Examples
+
+### Do this
+```ts
+import { mock } from "jest-mock-extended";
+
+describe("UserService", () => {
+  it("creates user", async () => {
+    const userRepository = mock<UserRepository>();
+    const userService = new UserService(userRepository);
+
+    userRepository.create.mockResolvedValue({ id: 1 });
+
+    await expect(userService.create()).resolves.toEqual({ id: 1 });
+  });
+});
+```
+
+### Don't do this
+
+```ts
+jest.mock("./user.repository");
+
+describe("UserService", () => {
+  it("creates user", async () => {
+    const userService = new UserService();
+    await expect(userService.create()).resolves.toEqual({ id: 1 });
+  });
+});
+```


### PR DESCRIPTION
## Why

To force cursor generate tests without `jest.mock()`. More details in the corresponding mdc document

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new guidelines for mocking dependencies in tests, recommending explicit mocks with `jest-mock-extended` instead of `jest.mock()`.
  * Explained benefits including improved maintainability, type safety, and test reliability, with example usage provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->