### PR TITLE
fix: prevent request to provider-proxy when deployment is closed

### DIFF
--- a/apps/deploy-web/jest.config.ts
+++ b/apps/deploy-web/jest.config.ts
@@ -33,14 +33,17 @@ const getConfig = createJestConfig({
 
 export default async (): Promise<Config.InitialOptions> => {
   return {
-    collectCoverageFrom: ["<rootDir>/src/**/*.{js,ts,tsx}"],
     rootDir: ".",
     projects: [
       {
+        collectCoverageFrom: ["<rootDir>/src/**/*.{js,ts,tsx}"],
+        coveragePathIgnorePatterns: ["/lib/nextjs/", "/tests/"],
         displayName: "unit",
         ...(await getConfig())
       },
       {
+        collectCoverageFrom: ["<rootDir>/src/lib/nextjs/**/*.{js,ts,tsx}"],
+        coveragePathIgnorePatterns: ["/lib/nextjs/setup-node-tests.ts", "/tests/"],
         displayName: "unit-node",
         testEnvironment: "node",
         testMatch: ["<rootDir>/src/lib/nextjs/**/*.spec.{tsx,ts}"],

--- a/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.spec.tsx
+++ b/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.spec.tsx
@@ -16,7 +16,7 @@ import { ServicesProvider } from "@src/context/ServicesProvider";
 import { queryClient } from "@src/queries";
 import { deploymentToDto } from "@src/utils/deploymentDetailUtils";
 
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { buildRpcDeployment } from "@tests/seeders/deployment";
 import { buildNotificationChannel } from "@tests/seeders/notificationChannel";
 import { createContainerTestingChildCapturer } from "@tests/unit/container-testing-child-capturer";
@@ -51,7 +51,9 @@ describe(DeploymentAlertsContainer.name, () => {
           }
         })
       );
-      expect(screen.queryByTestId("alert-config-success-notification")).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByTestId("alert-config-success-notification")).toBeInTheDocument();
+      });
     });
   });
 

--- a/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
+++ b/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
@@ -147,6 +147,7 @@ export const TemplateList: React.FunctionComponent<Props> = ({ onChangeGitProvid
                 <Link
                   href={UrlService.newDeployment({ step: RouteStep.editDeployment, templateId: helloWorldTemplate.code })}
                   className="text-inherit underline"
+                  prefetch={false}
                   data-testid="hello-world-card"
                 >
                   Try hello world app!
@@ -155,7 +156,7 @@ export const TemplateList: React.FunctionComponent<Props> = ({ onChangeGitProvid
             </div>
 
             <div className="my-6">
-              <Link href={UrlService.templates()} className="inline-flex items-center space-x-2 text-xs font-bold text-muted-foreground">
+              <Link href={UrlService.templates()} prefetch={false} className="inline-flex items-center space-x-2 text-xs font-bold text-muted-foreground">
                 <span>View All Templates</span>
                 <ArrowRight className="text-xs" />
               </Link>

--- a/apps/deploy-web/src/components/templates/TemplateBox.tsx
+++ b/apps/deploy-web/src/components/templates/TemplateBox.tsx
@@ -19,6 +19,7 @@ export const TemplateBox: React.FunctionComponent<Props> = ({ template, linkHref
     <Link
       className={cn(cardClasses, "min-h-[100px] cursor-pointer !no-underline hover:bg-secondary/60 dark:hover:bg-secondary/30")}
       href={linkHref ? linkHref : UrlService.templateDetails(template.id as string)}
+      prefetch={false}
     >
       <CardHeader>
         <div className="flex items-center">

--- a/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
+++ b/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
@@ -1,7 +1,5 @@
 import React, { useContext } from "react";
 import { AuthzHttpService, CertificatesService } from "@akashnetwork/http-sdk";
-import { createAPIClient } from "@akashnetwork/react-query-sdk/notifications";
-import { requestFn } from "@openapi-qraft/react";
 
 import { browserEnvConfig } from "@src/config/browser-env.config";
 import type { DIContainer, Factories } from "@src/services/container/createContainer";
@@ -33,12 +31,6 @@ export function useServices() {
 
 function createAppContainer<T extends Factories>(settings: Settings, services: T) {
   const di = createChildContainer(rootContainer, {
-    notificationsApi: () =>
-      createAPIClient({
-        requestFn,
-        baseUrl: "/api/proxy",
-        queryClient: di.queryClient
-      }),
     authzHttpService: () => new AuthzHttpService({ baseURL: settings?.apiEndpoint }),
     walletBalancesService: () =>
       new WalletBalancesService(di.authzHttpService, di.axios, browserEnvConfig.NEXT_PUBLIC_MASTER_WALLET_ADDRESS, settings.apiEndpoint),

--- a/apps/deploy-web/src/lib/nextjs/defineApiHandler/defineApiHandler.spec.ts
+++ b/apps/deploy-web/src/lib/nextjs/defineApiHandler/defineApiHandler.spec.ts
@@ -142,7 +142,10 @@ describe("defineApiHandler", () => {
   function createRequest(input?: Partial<NextApiRequest>) {
     return mock<NextApiRequest>({
       headers: {
-        "content-type": "application/json"
+        "content-type": "application/json",
+        "x-forwarded-host": "localhost",
+        "x-forwarded-for": "127.0.0.1",
+        "x-forwarded-proto": "http"
       },
       ...input
     });

--- a/apps/deploy-web/src/lib/nextjs/defineServerSideProps/defineServerSideProps.spec.ts
+++ b/apps/deploy-web/src/lib/nextjs/defineServerSideProps/defineServerSideProps.spec.ts
@@ -174,12 +174,12 @@ describe(defineServerSideProps, () => {
     const result = (await setup({
       route: "/test",
       context: {
-        req: mock<Request>({ headers, originalUrl: "/test", url: "/test" })
+        req: createRequest({ headers })
       },
       handler: async (): Promise<Result> => ({ props: { headers: requestExecutionContext.getStore()?.headers } })
     })) as Result;
 
-    expect(Object.fromEntries((result.props as any).headers.entries())).toEqual(headers);
+    expect(Object.fromEntries((result.props as any).headers.entries())).toEqual(expect.objectContaining(headers));
   });
 
   it("executes async & sync handlers", async () => {
@@ -312,7 +312,7 @@ describe(defineServerSideProps, () => {
     context?: Partial<AppTypedContext>;
   }) {
     const context: GetServerSidePropsContext = {
-      req: mock<Request>({ url: "/test", originalUrl: "/test", headers: { host: "localhost" } }),
+      req: createRequest(),
       res: mock<GetServerSidePropsContext["res"]>(),
       query: {},
       params: {},
@@ -330,6 +330,19 @@ describe(defineServerSideProps, () => {
       handler: input.handler
     })(context);
   }
-});
 
-type Request = GetServerSidePropsContext["req"] & { originalUrl?: string };
+  function createRequest({ headers, ...input }: Partial<GetServerSidePropsContext["req"]> = {}) {
+    return mock<GetServerSidePropsContext["req"]>({
+      url: "/test",
+      headers: {
+        host: "localhost",
+        "content-type": "application/json",
+        "x-forwarded-host": "localhost",
+        "x-forwarded-for": "127.0.0.1",
+        "x-forwarded-proto": "http",
+        ...headers
+      },
+      ...input
+    });
+  }
+});

--- a/apps/deploy-web/src/services/http/http-browser.service.ts
+++ b/apps/deploy-web/src/services/http/http-browser.service.ts
@@ -1,3 +1,6 @@
+import { createAPIClient } from "@akashnetwork/react-query-sdk/notifications";
+import { requestFn } from "@openapi-qraft/react";
+
 import { browserEnvConfig } from "@src/config/browser-env.config";
 import { createAppRootContainer } from "@src/services/app-di-container/app-di-container";
 import { browserApiUrlService } from "../api-url/browser-api-url.service";
@@ -13,5 +16,11 @@ const rootContainer = createAppRootContainer({
 });
 
 export const services = createChildContainer(rootContainer, {
-  userProviderService: () => new UserProviderService()
+  userProviderService: () => new UserProviderService(),
+  notificationsApi: () =>
+    createAPIClient({
+      requestFn,
+      baseUrl: "/api/proxy",
+      queryClient: services.queryClient
+    })
 });


### PR DESCRIPTION
## Why

Bug, currently after deployment is closed, app sends request to check its lease which fails with 404 error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved deployment detail handling for more accurate lease status updates based on deployment state.
  * Added a notifications API service to support notification-related features.

* **Performance**
  * Disabled automatic prefetching on template and deployment-related links to optimize resource usage and navigation.

* **Chores**
  * Updated internal service management for cleaner and more maintainable code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->