### PR TITLE
fix: ensure tracing context is propagated during proxing

### DIFF
--- a/apps/provider-proxy/src/services/ProviderProxy.ts
+++ b/apps/provider-proxy/src/services/ProviderProxy.ts
@@ -5,6 +5,7 @@ import https from "https";
 import { LRUCache } from "lru-cache";
 import { TLSSocket } from "tls";
 
+import { propagateTracingContext } from "../utils/telemetry";
 import type { CertificateValidator, CertValidationResultError } from "./CertificateValidator";
 
 export class ProviderProxy {
@@ -38,7 +39,7 @@ export class ProviderProxy {
           },
           agent
         },
-        async res => {
+        propagateTracingContext(async res => {
           try {
             const socket = res.socket;
             if (!socket || !(socket instanceof TLSSocket)) {
@@ -75,19 +76,25 @@ export class ProviderProxy {
             res.destroy();
             resolve({ ok: false, code: "connectionError", error });
           }
-        }
+        })
       );
 
       if (!req.reusedSocket) {
-        req.on("error", error => {
-          resolve({ ok: false, code: "connectionError", error });
-        });
-        req.on("timeout", () => {
-          // here we are just notified that response take more than specified in request options timeout
-          // then we manually destroy request and it drops connection and
-          // on('error') handler is called with Error code = ECONNRESET
-          req.destroy();
-        });
+        req.on(
+          "error",
+          propagateTracingContext(error => {
+            resolve({ ok: false, code: "connectionError", error });
+          })
+        );
+        req.on(
+          "timeout",
+          propagateTracingContext(() => {
+            // here we are just notified that response take more than specified in request options timeout
+            // then we manually destroy request and it drops connection and
+            // on('error') handler is called with Error code = ECONNRESET
+            req.destroy();
+          })
+        );
       }
 
       if (options.body && options.method !== "GET") req.write(options.body);


### PR DESCRIPTION
## Why

I assume that provider proxy may loose tracing context in callbacks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal tracing context propagation for more consistent monitoring and diagnostics during HTTPS requests. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->