### PR TITLE
fix: disable automatic SNI on provider proxy

### DIFF
--- a/apps/provider-proxy/src/services/ProviderProxy.ts
+++ b/apps/provider-proxy/src/services/ProviderProxy.ts
@@ -25,7 +25,8 @@ export class ProviderProxy {
       cert: options.cert,
       key: options.key,
       chainNetwork: options.network,
-      providerAddress: options.providerAddress
+      providerAddress: options.providerAddress,
+      servername: ""
     };
     const agent = this.getHttpsAgent(agentOptions);
     return new Promise<ProxyConnectionResult>((resolve, reject) => {

--- a/apps/provider-proxy/src/services/WebsocketServer.ts
+++ b/apps/provider-proxy/src/services/WebsocketServer.ts
@@ -273,7 +273,8 @@ export class WebsocketServer {
       agent: new https.Agent({
         // do not use TLS session resumption for websocket
         sessionTimeout: 0,
-        rejectUnauthorized: false
+        rejectUnauthorized: false,
+        servername: ""
       })
     });
 


### PR DESCRIPTION
## Why

New provider API expects clients not to send SNI request. When there is no SNI in TLS handshake, it fallbacks to mTLS, otherwise it will send let's encrypt certificate 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal network connection settings to improve compatibility with certain secure connections. No visible changes to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->