### PR TITLE
fix: fix wallet creation error on stripe webhook

### DIFF
--- a/apps/api/src/billing/services/refill/refill.service.spec.ts
+++ b/apps/api/src/billing/services/refill/refill.service.spec.ts
@@ -1,0 +1,120 @@
+import { mock } from "jest-mock-extended";
+
+import type { BillingConfig } from "@src/billing/providers";
+import type { UserWalletRepository } from "@src/billing/repositories";
+import type { ManagedUserWalletService } from "@src/billing/services";
+import type { BalancesService } from "@src/billing/services/balances/balances.service";
+import { RefillService } from "@src/billing/services/refill/refill.service";
+import type { WalletInitializerService } from "@src/billing/services/wallet-initializer/wallet-initializer.service";
+import type { AnalyticsService } from "@src/core/services/analytics/analytics.service";
+
+import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+
+describe(RefillService.name, () => {
+  describe("topUpWallet", () => {
+    const userId = "test-user-id";
+    const amountUsd = 100;
+
+    it("should top up existing wallet", async () => {
+      const { service, userWalletRepository, managedUserWalletService, balancesService, walletInitializerService, analyticsService } = setup();
+      const existingWallet = UserWalletSeeder.create({ userId });
+      userWalletRepository.findOneBy.mockResolvedValue(existingWallet);
+      managedUserWalletService.authorizeSpending.mockResolvedValue();
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(5000);
+      balancesService.refreshUserWalletLimits.mockResolvedValue();
+
+      await service.topUpWallet(amountUsd, userId);
+
+      expect(userWalletRepository.findOneBy).toHaveBeenCalledWith({ userId });
+      expect(managedUserWalletService.authorizeSpending).toHaveBeenCalledWith({
+        address: existingWallet.address,
+        limits: { deployment: 1005000, fees: 1000 }
+      });
+      expect(balancesService.retrieveDeploymentLimit).toHaveBeenCalledWith(existingWallet);
+      expect(balancesService.refreshUserWalletLimits).toHaveBeenCalledWith(existingWallet, { endTrial: true });
+      expect(walletInitializerService.initialize).not.toHaveBeenCalled();
+      expect(analyticsService.track).toHaveBeenCalledWith(userId, "balance_top_up");
+    });
+
+    it("should create new wallet when none exists", async () => {
+      const { service, userWalletRepository, walletInitializerService, balancesService, managedUserWalletService, analyticsService } = setup();
+      const newWallet = UserWalletSeeder.create({ userId });
+      userWalletRepository.findOneBy.mockResolvedValue(undefined);
+      walletInitializerService.initialize.mockResolvedValue(newWallet);
+      managedUserWalletService.authorizeSpending.mockResolvedValue();
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(0);
+      balancesService.refreshUserWalletLimits.mockResolvedValue();
+
+      await service.topUpWallet(amountUsd, userId);
+
+      expect(userWalletRepository.findOneBy).toHaveBeenCalledWith({ userId });
+      expect(managedUserWalletService.authorizeSpending).toHaveBeenCalledWith({
+        address: newWallet.address,
+        limits: { deployment: 1000000, fees: 1000 }
+      });
+      expect(balancesService.refreshUserWalletLimits).toHaveBeenCalledWith(newWallet, { endTrial: true });
+      expect(walletInitializerService.initialize).toHaveBeenCalledWith(userId);
+      expect(analyticsService.track).toHaveBeenCalledWith(userId, "balance_top_up");
+    });
+
+    it("should handle race condition when creating wallet", async () => {
+      const { service, userWalletRepository, managedUserWalletService, balancesService, walletInitializerService, analyticsService } = setup();
+      const existingWallet = UserWalletSeeder.create({ userId });
+      userWalletRepository.findOneBy.mockResolvedValue(undefined);
+      managedUserWalletService.authorizeSpending.mockResolvedValue();
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(0);
+      balancesService.refreshUserWalletLimits.mockResolvedValue();
+      walletInitializerService.initialize.mockImplementation(async () => {
+        userWalletRepository.findOneBy.mockResolvedValue(existingWallet);
+        return existingWallet;
+      });
+
+      await Promise.all([service.topUpWallet(amountUsd, userId), service.topUpWallet(2 * amountUsd, userId)]);
+
+      expect(userWalletRepository.findOneBy).toHaveBeenCalledWith({ userId });
+      expect(userWalletRepository.findOneBy).toHaveBeenCalledTimes(2);
+      expect(managedUserWalletService.authorizeSpending).toHaveBeenCalledWith({
+        address: existingWallet.address,
+        limits: { deployment: 1000000, fees: 1000 }
+      });
+      expect(managedUserWalletService.authorizeSpending).toHaveBeenCalledWith({
+        address: existingWallet.address,
+        limits: { deployment: 2 * 1000000, fees: 1000 }
+      });
+      expect(balancesService.refreshUserWalletLimits).toHaveBeenCalledWith(existingWallet, { endTrial: true });
+      expect(walletInitializerService.initialize).toHaveBeenCalledWith(userId);
+      expect(walletInitializerService.initialize).toHaveBeenCalledTimes(1);
+      expect(analyticsService.track).toHaveBeenCalledWith(userId, "balance_top_up");
+    });
+
+    function setup() {
+      const billingConfig = mock<BillingConfig>();
+      const userWalletRepository = mock<UserWalletRepository>();
+      const managedUserWalletService = mock<ManagedUserWalletService>();
+      const balancesService = mock<BalancesService>();
+      const walletInitializerService = mock<WalletInitializerService>();
+      const analyticsService = mock<AnalyticsService>();
+
+      billingConfig.FEE_ALLOWANCE_REFILL_AMOUNT = 1000;
+
+      const service = new RefillService(
+        billingConfig,
+        userWalletRepository,
+        managedUserWalletService,
+        balancesService,
+        walletInitializerService,
+        analyticsService
+      );
+
+      return {
+        service,
+        billingConfig,
+        userWalletRepository,
+        managedUserWalletService,
+        balancesService,
+        walletInitializerService,
+        analyticsService
+      };
+    }
+  });
+});

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -6,6 +6,7 @@ import { BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
 import { ManagedUserWalletService, WalletInitializerService } from "@src/billing/services";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { Semaphore } from "@src/core/lib/semaphore.decorator";
 import { AnalyticsService } from "@src/core/services/analytics/analytics.service";
 
 @singleton()
@@ -53,14 +54,8 @@ export class RefillService {
    * @param userId - The ID of the user to top up the wallet for
    */
   async topUpWallet(amountUsd: number, userId: UserWalletOutput["userId"]) {
-    let userWallet = await this.userWalletRepository.findOneBy({ userId });
-    let currentLimit: number = 0;
-
-    if (userWallet) {
-      currentLimit = await this.balancesService.retrieveDeploymentLimit(userWallet);
-    } else {
-      userWallet = await this.walletInitializerService.initialize(userId);
-    }
+    const userWallet = await this.getOrCreateUserWallet(userId);
+    const currentLimit = await this.balancesService.retrieveDeploymentLimit(userWallet);
 
     const nextLimit = currentLimit + amountUsd * 10000;
     const limits = { deployment: nextLimit, fees: this.config.FEE_ALLOWANCE_REFILL_AMOUNT };
@@ -72,5 +67,15 @@ export class RefillService {
     await this.balancesService.refreshUserWalletLimits(userWallet, { endTrial: true });
     this.analyticsService.track(userId!, "balance_top_up");
     this.logger.debug({ event: "WALLET_TOP_UP", userWallet, limits });
+  }
+
+  @Semaphore()
+  private async getOrCreateUserWallet(userId: UserWalletOutput["userId"]) {
+    const userWallet = await this.userWalletRepository.findOneBy({ userId });
+    if (userWallet) {
+      return userWallet;
+    }
+
+    return await this.walletInitializerService.initialize(userId);
   }
 }


### PR DESCRIPTION
I think multiple webhook calls incoming at the same time can cause a race condition:
- first one is not finding the wallet, creating it
- second one is not finding it either, trying to create it, but it's been already created by the first one in the meantime => unique index error

closes #1662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for wallet top-up scenarios, including handling of existing wallets, creation of new wallets, and concurrent top-up requests.
* **Refactor**
  * Improved wallet top-up process to ensure reliable wallet creation and management during concurrent requests, enhancing overall service stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->