### PR TITLE
fix(alert): properly displays deployment closed alert type in a list

### DIFF
--- a/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.tsx
+++ b/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.tsx
@@ -86,7 +86,7 @@ export const AlertsListView: FC<Props> = ({
 
         if (type === "DEPLOYMENT_BALANCE") {
           return "Escrow Threshold";
-        } else if (type === "CHAIN_MESSAGE" && params && "type" in params && params.type === "DEPLOYMENT_CLOSED") {
+        } else if (params && "type" in params && params.type === "DEPLOYMENT_CLOSED") {
           return "Deployment Close";
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened the condition for displaying "Deployment Close" in the alerts list, ensuring more relevant alerts are correctly labeled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->