### PR TITLE
fix(billing): return empty array for discounts when no stripe id

### DIFF
--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -124,7 +124,9 @@ export class StripeController {
   async getCustomerDiscounts(): Promise<{ data: { discounts: Discount[] } }> {
     const { currentUser } = this.authService;
 
-    assert(currentUser.stripeCustomerId, 500, "Payment account not properly configured. Please contact support.");
+    if (!currentUser.stripeCustomerId) {
+      return { data: { discounts: [] } };
+    }
 
     const discounts = await this.stripe.getCustomerDiscounts(currentUser.stripeCustomerId);
     return { data: { discounts } };


### PR DESCRIPTION
fixes: http://github.com/akash-network/console/issues/1676

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for retrieving customer discounts, ensuring users without a linked account receive an empty list instead of an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->