### PR TITLE
refactor: creates separate axios instance per intent

### DIFF
--- a/apps/deploy-web/src/components/sdl/EditDescriptionForm.tsx
+++ b/apps/deploy-web/src/components/sdl/EditDescriptionForm.tsx
@@ -27,7 +27,7 @@ export const EditDescriptionForm: React.FunctionComponent<Props> = ({ id, descri
   const formRef = useRef<HTMLFormElement>(null);
   const [isSaving, setIsSaving] = useState(false);
   const { enqueueSnackbar } = useSnackbar();
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
   const form = useForm<FormValues>({
     defaultValues: {
       description: description || ""
@@ -38,7 +38,7 @@ export const EditDescriptionForm: React.FunctionComponent<Props> = ({ id, descri
 
   const onSubmit = async (data: FormValues) => {
     setIsSaving(true);
-    await axios.post("/api/proxy/user/saveTemplateDesc", {
+    await consoleApiHttpClient.post("/user/saveTemplateDesc", {
       id: id,
       description: data.description
     });

--- a/apps/deploy-web/src/components/sdl/SimpleSdlBuilderForm.tsx
+++ b/apps/deploy-web/src/components/sdl/SimpleSdlBuilderForm.tsx
@@ -15,7 +15,6 @@ import { USER_TEMPLATE_CODE } from "@src/config/deploy.config";
 import { useServices } from "@src/context/ServicesProvider";
 import useFormPersist from "@src/hooks/useFormPersist";
 import { useGpuModels } from "@src/queries/useGpuQuery";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 import sdlStore from "@src/store/sdlStore";
 import type { ITemplate, SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { SdlBuilderFormValuesSchema } from "@src/types";
@@ -34,7 +33,7 @@ const DEFAULT_SERVICES = {
 };
 
 export const SimpleSDLBuilderForm: React.FunctionComponent = () => {
-  const { axios } = useServices();
+  const { consoleApiHttpClient, analyticsService } = useServices();
   const [error, setError] = useState(null);
   const [templateMetadata, setTemplateMetadata] = useState<ITemplate | null>(null);
   const [serviceCollapsed, setServiceCollapsed] = useState<number[]>([]);
@@ -98,7 +97,7 @@ export const SimpleSDLBuilderForm: React.FunctionComponent = () => {
   const loadTemplate = async (id: string) => {
     try {
       setIsLoadingTemplate(true);
-      const response = await axios.get(`/api/proxy/user/template/${id}`);
+      const response = await consoleApiHttpClient.get(`/user/template/${id}`);
       const template: ITemplate = response.data;
 
       const services = importSimpleSdl(template.sdl);

--- a/apps/deploy-web/src/components/user/UserSettingsForm.tsx
+++ b/apps/deploy-web/src/components/user/UserSettingsForm.tsx
@@ -12,7 +12,6 @@ import type { RequiredUserConsumer } from "@src/components/user/RequiredUserCont
 import { UserProfileLayout } from "@src/components/user/UserProfileLayout";
 import { useServices } from "@src/context/ServicesProvider";
 import { useSaveSettings } from "@src/queries/useSaveSettings";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 import type { UserSettings } from "@src/types/user";
 import Layout from "../layout/Layout";
 
@@ -30,7 +29,7 @@ const formSchema = z.object({
 });
 
 export const UserSettingsForm: RequiredUserConsumer = ({ user }) => {
-  const { axios } = useServices();
+  const { consoleApiHttpClient, analyticsService } = useServices();
   const [isCheckingAvailability, setIsCheckingAvailability] = useState<boolean>(false);
   const [isAvailable, setIsAvailable] = useState<boolean | null>(null);
   const form = useForm<z.infer<typeof formSchema>>({
@@ -73,7 +72,7 @@ export const UserSettingsForm: RequiredUserConsumer = ({ user }) => {
     if (user && username && username.length >= 3 && username.length <= 40 && username !== user.username) {
       const timeoutId = setTimeout(async () => {
         setIsCheckingAvailability(true);
-        const response = await axios.get("/api/proxy/user/checkUsernameAvailability/" + username);
+        const response = await consoleApiHttpClient.get(`/user/checkUsernameAvailability/${username}`);
 
         setIsCheckingAvailability(false);
         setIsAvailable(response.data.isAvailable);

--- a/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
+++ b/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
@@ -32,8 +32,7 @@ export function useServices() {
 function createAppContainer<T extends Factories>(settings: Settings, services: T) {
   const di = createChildContainer(rootContainer, {
     authzHttpService: () => new AuthzHttpService({ baseURL: settings?.apiEndpoint }),
-    walletBalancesService: () =>
-      new WalletBalancesService(di.authzHttpService, di.axios, browserEnvConfig.NEXT_PUBLIC_MASTER_WALLET_ADDRESS, settings.apiEndpoint),
+    walletBalancesService: () => new WalletBalancesService(di.authzHttpService, di.chainApiHttpClient, browserEnvConfig.NEXT_PUBLIC_MASTER_WALLET_ADDRESS),
     certificatesService: () => new CertificatesService(di.chainApiHttpClient),
     chainApiHttpClient: () => rootContainer.createAxios({ baseURL: settings?.apiEndpoint }),
     ...services

--- a/apps/deploy-web/src/context/SettingsProvider/SettingsProviderContext.tsx
+++ b/apps/deploy-web/src/context/SettingsProvider/SettingsProviderContext.tsx
@@ -49,7 +49,7 @@ const defaultSettings: Settings = {
 };
 
 export const SettingsProvider: FCWithChildren = ({ children }) => {
-  const { axios, queryClient } = useRootContainer();
+  const { externalApiHttpClient, queryClient } = useRootContainer();
   const [settings, setSettings] = useState<Settings>(defaultSettings);
   const [isLoadingSettings, setIsLoadingSettings] = useState(true);
   const [isSettingsInit, setIsSettingsInit] = useState(false);
@@ -79,7 +79,7 @@ export const SettingsProvider: FCWithChildren = ({ children }) => {
       const settingsStr = getLocalStorageItem("settings");
       const settings = { ...defaultSettings, ...JSON.parse(settingsStr || "{}") } as Settings;
 
-      const { data: nodes } = await axios.get<Array<{ id: string; api: string; rpc: string }>>(selectedNetwork.nodesUrl);
+      const { data: nodes } = await externalApiHttpClient.get<Array<{ id: string; api: string; rpc: string }>>(selectedNetwork.nodesUrl);
       const nodesWithStatuses: Array<BlockchainNode> = await Promise.all(
         nodes.map(async node => {
           const nodeStatus = await loadNodeStatus(node.rpc);
@@ -155,7 +155,7 @@ export const SettingsProvider: FCWithChildren = ({ children }) => {
     let nodeStatus: NodeStatus | null = null;
 
     try {
-      const response = await axios.get(`${rpcUrl}/status`, { timeout: 10000 });
+      const response = await externalApiHttpClient.get(`${rpcUrl}/status`, { timeout: 10000 });
       nodeStatus = response.data.result as NodeStatus;
       status = "active";
     } catch (error) {

--- a/apps/deploy-web/src/pages/api/auth/[...auth0].ts
+++ b/apps/deploy-web/src/pages/api/auth/[...auth0].ts
@@ -63,7 +63,7 @@ const authHandler = once((services: AppServices) =>
                 headers.set("x-anonymous-authorization", anonymousAuthorization);
               }
 
-              const userSettings = await services.axios.post(
+              const userSettings = await services.consoleApiHttpClient.post(
                 `${services.config.BASE_API_MAINNET_URL}/user/tokenInfo`,
                 {
                   wantedUsername: session.user.nickname,

--- a/apps/deploy-web/src/pages/api/bitbucket/authenticate.ts
+++ b/apps/deploy-web/src/pages/api/bitbucket/authenticate.ts
@@ -12,7 +12,7 @@ export default defineApiHandler({
   }),
   async handler({ body, res, services }) {
     const { NEXT_PUBLIC_BITBUCKET_CLIENT_ID, BITBUCKET_CLIENT_SECRET } = services.config;
-    const bitbucketAuth = new BitbucketAuth(NEXT_PUBLIC_BITBUCKET_CLIENT_ID!, BITBUCKET_CLIENT_SECRET);
+    const bitbucketAuth = new BitbucketAuth(NEXT_PUBLIC_BITBUCKET_CLIENT_ID!, BITBUCKET_CLIENT_SECRET, services.externalApiHttpClient);
 
     const tokens = await bitbucketAuth.exchangeAuthorizationCodeForTokens(body.code);
     res.status(200).json(tokens);

--- a/apps/deploy-web/src/pages/api/bitbucket/refresh.ts
+++ b/apps/deploy-web/src/pages/api/bitbucket/refresh.ts
@@ -12,7 +12,7 @@ export default defineApiHandler({
   }),
   async handler({ body, res, services }) {
     const { NEXT_PUBLIC_BITBUCKET_CLIENT_ID, BITBUCKET_CLIENT_SECRET } = services.config;
-    const bitbucketAuth = new BitbucketAuth(NEXT_PUBLIC_BITBUCKET_CLIENT_ID!, BITBUCKET_CLIENT_SECRET);
+    const bitbucketAuth = new BitbucketAuth(NEXT_PUBLIC_BITBUCKET_CLIENT_ID!, BITBUCKET_CLIENT_SECRET, services.externalApiHttpClient);
 
     const tokens = await bitbucketAuth.refreshTokensUsingRefreshToken(body.refreshToken);
     res.status(200).json(tokens);

--- a/apps/deploy-web/src/pages/api/github/authenticate.ts
+++ b/apps/deploy-web/src/pages/api/github/authenticate.ts
@@ -12,7 +12,12 @@ export default defineApiHandler({
   }),
   async handler({ body, res, services }) {
     const { NEXT_PUBLIC_GITHUB_CLIENT_ID, GITHUB_CLIENT_SECRET, NEXT_PUBLIC_REDIRECT_URI } = services.config;
-    const gitHubAuth = new GitHubAuth(NEXT_PUBLIC_GITHUB_CLIENT_ID as string, GITHUB_CLIENT_SECRET as string, NEXT_PUBLIC_REDIRECT_URI as string);
+    const gitHubAuth = new GitHubAuth(
+      NEXT_PUBLIC_GITHUB_CLIENT_ID as string,
+      GITHUB_CLIENT_SECRET as string,
+      NEXT_PUBLIC_REDIRECT_URI,
+      services.externalApiHttpClient
+    );
 
     const accessToken = await gitHubAuth.exchangeAuthorizationCodeForToken(body.code);
     res.status(200).json({ accessToken });

--- a/apps/deploy-web/src/pages/api/gitlab/authenticate.ts
+++ b/apps/deploy-web/src/pages/api/gitlab/authenticate.ts
@@ -12,7 +12,12 @@ export default defineApiHandler({
   }),
   async handler({ body, res, services }) {
     const { NEXT_PUBLIC_GITLAB_CLIENT_ID, GITLAB_CLIENT_SECRET, NEXT_PUBLIC_REDIRECT_URI } = services.config;
-    const gitlabAuth = new GitlabAuth(NEXT_PUBLIC_GITLAB_CLIENT_ID as string, GITLAB_CLIENT_SECRET as string, NEXT_PUBLIC_REDIRECT_URI as string);
+    const gitlabAuth = new GitlabAuth(
+      NEXT_PUBLIC_GITLAB_CLIENT_ID as string,
+      GITLAB_CLIENT_SECRET as string,
+      NEXT_PUBLIC_REDIRECT_URI,
+      services.externalApiHttpClient
+    );
 
     const tokens = await gitlabAuth.exchangeAuthorizationCodeForTokens(body.code);
     res.status(200).json(tokens);

--- a/apps/deploy-web/src/pages/api/gitlab/refresh.ts
+++ b/apps/deploy-web/src/pages/api/gitlab/refresh.ts
@@ -12,7 +12,7 @@ export default defineApiHandler({
   }),
   async handler({ body, res, services }) {
     const { NEXT_PUBLIC_GITLAB_CLIENT_ID, GITLAB_CLIENT_SECRET } = services.config;
-    const gitlabAuth = new GitlabAuth(NEXT_PUBLIC_GITLAB_CLIENT_ID as string, GITLAB_CLIENT_SECRET as string);
+    const gitlabAuth = new GitlabAuth(NEXT_PUBLIC_GITLAB_CLIENT_ID as string, GITLAB_CLIENT_SECRET as string, undefined, services.externalApiHttpClient);
 
     const tokens = await gitlabAuth.refreshTokensUsingRefreshToken(body.refreshToken);
     res.status(200).json(tokens);

--- a/apps/deploy-web/src/pages/profile/[username]/index.tsx
+++ b/apps/deploy-web/src/pages/profile/[username]/index.tsx
@@ -24,7 +24,7 @@ export const getServerSideProps = defineServerSideProps({
     })
   }),
   async handler({ params, services }): Promise<GetServerSidePropsResult<Props>> {
-    const { data: user } = await services.axios.get(`${services.apiUrlService.getBaseApiUrlFor("mainnet")}/user/byUsername/${params.username}`);
+    const { data: user } = await services.consoleApiHttpClient.get(`${services.apiUrlService.getBaseApiUrlFor("mainnet")}/user/byUsername/${params.username}`);
 
     return {
       props: {

--- a/apps/deploy-web/src/pages/providers/[owner]/index.tsx
+++ b/apps/deploy-web/src/pages/providers/[owner]/index.tsx
@@ -30,7 +30,7 @@ export const getServerSideProps = defineServerSideProps({
   }),
   async handler({ params, query, services }): Promise<GetServerSidePropsResult<Props>> {
     const apiUrl = services.apiUrlService.getBaseApiUrlFor(query.network);
-    const response = await services.axios.get(`${apiUrl}/v1/providers/${params.owner}`);
+    const response = await services.consoleApiHttpClient.get(`${apiUrl}/v1/providers/${params.owner}`);
 
     return {
       props: {

--- a/apps/deploy-web/src/pages/template/[id]/index.tsx
+++ b/apps/deploy-web/src/pages/template/[id]/index.tsx
@@ -34,7 +34,7 @@ export const getServerSideProps = defineServerSideProps({
         }
       };
     }
-    const response = await services.axios.get(`${services.apiUrlService.getBaseApiUrlFor("mainnet")}/user/template/${params.id}`, config);
+    const response = await services.consoleApiHttpClient.get(`${services.apiUrlService.getBaseApiUrlFor("mainnet")}/user/template/${params.id}`, config);
 
     return {
       props: {

--- a/apps/deploy-web/src/queries/featureFlags.ts
+++ b/apps/deploy-web/src/queries/featureFlags.ts
@@ -9,13 +9,14 @@ import networkStore from "@src/store/networkStore";
 import { QueryKeys } from "./queryKeys";
 
 const REFETCH_INTERVAL = 1000 * 60 * 5;
+/** @deprecated use useFlag instead */
 export function useFeatureFlags(options?: Omit<UseQueryOptions<Features>, "queryKey" | "queryFn">): UseQueryResult<Features> {
-  const { axios, apiUrlService } = useServices();
+  const { consoleApiHttpClient, apiUrlService } = useServices();
   const networkId = networkStore.useSelectedNetworkId();
   return useQuery({
     ...options,
     queryKey: QueryKeys.getFeatureFlagsKey(networkId),
-    queryFn: () => getFeatureFlags(networkId, axios, apiUrlService),
+    queryFn: () => getFeatureFlags(networkId, consoleApiHttpClient, apiUrlService),
     refetchInterval: REFETCH_INTERVAL
   });
 }
@@ -24,8 +25,8 @@ export interface Features {
   allowAnonymousUserTrial?: boolean;
 }
 
-export async function getFeatureFlags(networkId: NetworkId, axios: AxiosInstance, apiUrlService: ApiUrlService) {
+export async function getFeatureFlags(networkId: NetworkId, consoleApiHttpClient: AxiosInstance, apiUrlService: ApiUrlService) {
   const baseApiUrl = apiUrlService.getBaseApiUrlFor(networkId);
-  const response = await axios.get<{ data: Features }>(`${baseApiUrl}/v1/features`);
+  const response = await consoleApiHttpClient.get<{ data: Features }>(`${baseApiUrl}/v1/features`);
   return response.data.data;
 }

--- a/apps/deploy-web/src/queries/useBlocksQuery.ts
+++ b/apps/deploy-web/src/queries/useBlocksQuery.ts
@@ -20,10 +20,10 @@ export function useBlock(id: string, options = {}) {
 }
 
 export function useBlocks(limit: number, options?: Omit<UseQueryOptions<Block[], Error, any, QueryKey>, "queryKey" | "queryFn">) {
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
   return useQuery<Block[], Error>({
     queryKey: QueryKeys.getBlocksKey(limit),
-    queryFn: () => axios.get(ApiUrlService.blocks(limit)).then(response => response.data),
+    queryFn: () => consoleApiHttpClient.get(ApiUrlService.blocks(limit)).then(response => response.data),
     ...options
   });
 }

--- a/apps/deploy-web/src/queries/useGpuQuery.ts
+++ b/apps/deploy-web/src/queries/useGpuQuery.ts
@@ -6,10 +6,10 @@ import { ApiUrlService } from "@src/utils/apiUtils";
 import { QueryKeys } from "./queryKeys";
 
 export function useGpuModels(options = {}) {
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getGpuModelsKey(),
-    queryFn: () => axios.get<GpuVendor[]>(ApiUrlService.gpuModels()).then(response => response.data),
+    queryFn: () => consoleApiHttpClient.get<GpuVendor[]>(ApiUrlService.gpuModels()).then(response => response.data),
     ...options,
     refetchInterval: false,
     refetchIntervalInBackground: false,

--- a/apps/deploy-web/src/queries/useMarketData.spec.tsx
+++ b/apps/deploy-web/src/queries/useMarketData.spec.tsx
@@ -18,52 +18,19 @@ describe("useMarketData", () => {
       priceChange24h: 0.05,
       priceChangePercentage24: 5.0
     };
-    const axios = mock<AxiosInstance>();
-    axios.get.mockResolvedValue({ data: mockData });
+    const consoleApiHttpClient = mock<AxiosInstance>();
+    consoleApiHttpClient.get.mockResolvedValue({ data: mockData });
 
     const { result } = setup({
       services: {
-        axios: () => axios
+        consoleApiHttpClient: () => consoleApiHttpClient
       }
     });
 
     await waitFor(() => {
-      expect(axios.get).toHaveBeenCalledWith(ApiUrlService.marketData());
+      expect(consoleApiHttpClient.get).toHaveBeenCalledWith(ApiUrlService.marketData());
       expect(result.current.isSuccess).toBe(true);
       expect(result.current.data).toEqual(mockData);
-    });
-  });
-
-  it("handles empty response data", async () => {
-    const axios = mock<AxiosInstance>();
-    axios.get.mockResolvedValue({ data: null });
-
-    const { result } = setup({
-      services: {
-        axios: () => axios
-      }
-    });
-
-    await waitFor(() => {
-      expect(axios.get).toHaveBeenCalledWith(ApiUrlService.marketData());
-      expect(result.current.isSuccess).toBe(true);
-      expect(result.current.data).toBeNull();
-    });
-  });
-
-  it("should handle error when fetching market data", async () => {
-    const axios = mock<AxiosInstance>();
-    axios.get.mockRejectedValue(new Error("Failed to fetch market data"));
-
-    const { result } = setup({
-      services: {
-        axios: () => axios
-      }
-    });
-
-    await waitFor(() => {
-      expect(axios.get).toHaveBeenCalledWith(ApiUrlService.marketData());
-      expect(result.current.isError).toBe(true);
     });
   });
 

--- a/apps/deploy-web/src/queries/useMarketData.ts
+++ b/apps/deploy-web/src/queries/useMarketData.ts
@@ -7,10 +7,10 @@ import { ApiUrlService } from "@src/utils/apiUtils";
 import { QueryKeys } from "./queryKeys";
 
 export function useMarketData(options?: Omit<UseQueryOptions<MarketData, Error, any, QueryKey>, "queryKey" | "queryFn">) {
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
   return useQuery<MarketData, Error>({
     queryKey: QueryKeys.getFinancialDataKey(),
-    queryFn: () => axios.get<MarketData>(ApiUrlService.marketData()).then(response => response.data),
+    queryFn: () => consoleApiHttpClient.get<MarketData>(ApiUrlService.marketData()).then(response => response.data),
     ...options
   });
 }

--- a/apps/deploy-web/src/queries/useProvidersQuery.ts
+++ b/apps/deploy-web/src/queries/useProvidersQuery.ts
@@ -13,12 +13,12 @@ export function useProviderDetail(
   owner: string,
   options: Omit<UseQueryOptions<ApiProviderDetail | null>, "queryKey" | "queryFn">
 ): UseQueryResult<ApiProviderDetail | null> {
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getProviderDetailKey(owner) as QueryKey,
     queryFn: async () => {
       if (!owner) return null;
-      const response = await axios.get(ApiUrlService.providerDetail(owner));
+      const response = await consoleApiHttpClient.get(ApiUrlService.providerDetail(owner));
       return response.data;
     },
     ...options
@@ -49,19 +49,19 @@ export function useProviderStatus(
 }
 
 export function useNetworkCapacity(options = {}) {
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getNetworkCapacity(),
-    queryFn: () => axios.get(ApiUrlService.networkCapacity()).then(response => getNetworkCapacityDto(response.data)),
+    queryFn: () => consoleApiHttpClient.get(ApiUrlService.networkCapacity()).then(response => getNetworkCapacityDto(response.data)),
     ...options
   });
 }
 
 export function useAuditors(options = {}) {
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
   return useQuery<Array<Auditor>>({
     queryKey: QueryKeys.getAuditorsKey(),
-    queryFn: () => axios.get(ApiUrlService.auditors()).then(response => response.data),
+    queryFn: () => consoleApiHttpClient.get(ApiUrlService.auditors()).then(response => response.data),
     ...options,
     refetchInterval: false,
     refetchIntervalInBackground: false,
@@ -71,19 +71,19 @@ export function useAuditors(options = {}) {
 }
 
 export function useProviderActiveLeasesGraph(providerAddress: string, options = {}) {
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getProviderActiveLeasesGraph(providerAddress),
-    queryFn: () => axios.get(ApiUrlService.providerActiveLeasesGraph(providerAddress)).then(response => response.data),
+    queryFn: () => consoleApiHttpClient.get(ApiUrlService.providerActiveLeasesGraph(providerAddress)).then(response => response.data),
     ...options
   });
 }
 
 export function useProviderAttributesSchema(options = {}) {
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getProviderAttributesSchema(),
-    queryFn: () => axios.get<ProviderAttributesSchema>(ApiUrlService.providerAttributesSchema()).then(response => response.data),
+    queryFn: () => consoleApiHttpClient.get<ProviderAttributesSchema>(ApiUrlService.providerAttributesSchema()).then(response => response.data),
     ...options,
     refetchInterval: false,
     refetchIntervalInBackground: false,
@@ -93,19 +93,19 @@ export function useProviderAttributesSchema(options = {}) {
 }
 
 export function useProviderList(options = {}) {
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getProviderListKey(),
-    queryFn: () => axios.get<ApiProviderList[]>(ApiUrlService.providerList()).then(response => response.data),
+    queryFn: () => consoleApiHttpClient.get<ApiProviderList[]>(ApiUrlService.providerList()).then(response => response.data),
     ...options
   });
 }
 
 export function useProviderRegions(options = {}) {
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getProviderRegionsKey(),
-    queryFn: () => axios.get<ApiProviderRegion[]>(ApiUrlService.providerRegions()).then(response => response.data),
+    queryFn: () => consoleApiHttpClient.get<ApiProviderRegion[]>(ApiUrlService.providerRegions()).then(response => response.data),
     ...options
   });
 }

--- a/apps/deploy-web/src/queries/useSaveSettings.spec.tsx
+++ b/apps/deploy-web/src/queries/useSaveSettings.spec.tsx
@@ -17,11 +17,11 @@ describe("Settings management", () => {
         username: "testuser",
         subscribedToNewsletter: true
       };
-      const axios = mock<AxiosInstance>();
+      const consoleApiHttpClient = mock<AxiosInstance>();
       const fetchUser = jest.fn(async () => ({ email: "test@akash.network" }));
       const { result } = setup({
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         },
         fetchUser
       });
@@ -29,7 +29,7 @@ describe("Settings management", () => {
       act(() => result.current.mutate(newSettings));
       await waitFor(async () => !result.current.isPending);
 
-      expect(axios.put).toHaveBeenCalledWith(expect.stringContaining("user/updateSettings"), newSettings);
+      expect(consoleApiHttpClient.put).toHaveBeenCalledWith(expect.stringContaining("user/updateSettings"), newSettings);
       expect(fetchUser).toHaveBeenCalledTimes(2);
       expect(result.current.isSuccess).toBe(true);
       expect(await screen.findByText(/Settings saved/i)).toBeInTheDocument();
@@ -41,12 +41,12 @@ describe("Settings management", () => {
         subscribedToNewsletter: true
       };
 
-      const axios = mock<AxiosInstance>();
-      axios.put.mockRejectedValue(new Error("Network error"));
+      const consoleApiHttpClient = mock<AxiosInstance>();
+      consoleApiHttpClient.put.mockRejectedValue(new Error("Network error"));
       const fetchUser = jest.fn(async () => ({ email: "test@akash.network" }));
       const { result } = setup({
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         },
         fetchUser
       });

--- a/apps/deploy-web/src/queries/useSaveSettings.ts
+++ b/apps/deploy-web/src/queries/useSaveSettings.ts
@@ -10,13 +10,13 @@ import { ApiUrlService } from "@src/utils/apiUtils";
 import { QueryKeys } from "./queryKeys";
 
 export function useSaveSettings() {
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
 
   const { enqueueSnackbar } = useSnackbar();
   const { checkSession } = useCustomUser();
 
   return useMutation<AxiosResponse<any, any>, unknown, UserSettings>({
-    mutationFn: newSettings => axios.put("/api/proxy/user/updateSettings", newSettings),
+    mutationFn: newSettings => consoleApiHttpClient.put("/user/updateSettings", newSettings),
     onSuccess: () => {
       enqueueSnackbar("Settings saved", { variant: "success" });
       checkSession();

--- a/apps/deploy-web/src/queries/useTemplateQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useTemplateQuery.spec.tsx
@@ -1,7 +1,7 @@
 import type { TemplateHttpService } from "@akashnetwork/http-sdk";
 import type { UserProfile } from "@auth0/nextjs-auth0/client";
 import { UserProvider } from "@auth0/nextjs-auth0/client";
-import type { AxiosInstance } from "axios";
+import type { AxiosInstance } from "consoleApiHttpClient";
 import { mock } from "jest-mock-extended";
 
 import type { Props as ServicesProviderProps } from "@src/context/ServicesProvider";
@@ -57,29 +57,29 @@ const mockTemplateCategory = {
 describe("useTemplateQuery", () => {
   describe(useUserTemplates.name, () => {
     it("fetches user templates successfully", async () => {
-      const axios = mock<AxiosInstance>();
-      axios.get.mockResolvedValue({ data: [mockTemplate] });
+      const consoleApiHttpClient = mock<AxiosInstance>();
+      consoleApiHttpClient.get.mockResolvedValue({ data: [mockTemplate] });
 
       const { result } = setupQuery(() => useUserTemplates("test-user"), {
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         }
       });
 
       await waitFor(() => {
-        expect(axios.get).toHaveBeenCalledWith("/api/proxy/user/templates/test-user");
+        expect(consoleApiHttpClient.get).toHaveBeenCalledWith("/user/templates/test-user");
         expect(result.current.isSuccess).toBe(true);
         expect(result.current.data).toEqual([mockTemplate]);
       });
     });
 
     it("handles error when fetching user templates", async () => {
-      const axios = mock<AxiosInstance>();
-      axios.get.mockRejectedValue(new Error("Failed to fetch templates"));
+      const consoleApiHttpClient = mock<AxiosInstance>();
+      consoleApiHttpClient.get.mockRejectedValue(new Error("Failed to fetch templates"));
 
       const { result } = setupQuery(() => useUserTemplates("test-user"), {
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         }
       });
 
@@ -89,30 +89,30 @@ describe("useTemplateQuery", () => {
 
   describe("useUserFavoriteTemplates", () => {
     it("fetches user favorite templates successfully", async () => {
-      const axios = mock<AxiosInstance>();
+      const consoleApiHttpClient = mock<AxiosInstance>();
       const favoriteTemplates = [{ id: "template-1", title: "Favorite Template" }];
-      axios.get.mockResolvedValue({ data: favoriteTemplates });
+      consoleApiHttpClient.get.mockResolvedValue({ data: favoriteTemplates });
 
       const { result } = setup({
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         }
       });
 
       await waitFor(() => {
-        expect(axios.get).toHaveBeenCalledWith("/api/proxy/user/favoriteTemplates");
+        expect(consoleApiHttpClient.get).toHaveBeenCalledWith("/user/favoriteTemplates");
         expect(result.current.isSuccess).toBe(true);
         expect(result.current.data).toEqual(favoriteTemplates);
       });
     });
 
     it("handles error when fetching user favorite templates", async () => {
-      const axios = mock<AxiosInstance>();
-      axios.get.mockRejectedValue(new Error("Failed to fetch favorite templates"));
+      const consoleApiHttpClient = mock<AxiosInstance>();
+      consoleApiHttpClient.get.mockRejectedValue(new Error("Failed to fetch favorite templates"));
 
       const { result } = setup({
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         }
       });
 
@@ -131,29 +131,29 @@ describe("useTemplateQuery", () => {
 
   describe(useTemplate.name, () => {
     it("fetches single template successfully", async () => {
-      const axios = mock<AxiosInstance>();
-      axios.get.mockResolvedValue({ data: mockTemplate });
+      const consoleApiHttpClient = mock<AxiosInstance>();
+      consoleApiHttpClient.get.mockResolvedValue({ data: mockTemplate });
 
       const { result } = setup({
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         }
       });
 
       await waitFor(() => {
-        expect(axios.get).toHaveBeenCalledWith("/api/proxy/user/template/template-1");
+        expect(consoleApiHttpClient.get).toHaveBeenCalledWith("/user/template/template-1");
         expect(result.current.isSuccess).toBe(true);
         expect(result.current.data).toEqual(mockTemplate);
       });
     });
 
     it("handles error when fetching single template", async () => {
-      const axios = mock<AxiosInstance>();
-      axios.get.mockRejectedValue(new Error("Template not found"));
+      const consoleApiHttpClient = mock<AxiosInstance>();
+      consoleApiHttpClient.get.mockRejectedValue(new Error("Template not found"));
 
       const { result } = setup({
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         }
       });
 
@@ -171,12 +171,12 @@ describe("useTemplateQuery", () => {
 
   describe(useSaveUserTemplate.name, () => {
     it("saves template successfully", async () => {
-      const axios = mock<AxiosInstance>();
-      axios.post.mockResolvedValue({ data: "saved-template-id" });
+      const consoleApiHttpClient = mock<AxiosInstance>();
+      consoleApiHttpClient.post.mockResolvedValue({ data: "saved-template-id" });
 
       const { result } = setup({
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         }
       });
 
@@ -188,7 +188,7 @@ describe("useTemplateQuery", () => {
 
       act(() => result.current.mutate(templateData));
       await waitFor(() => {
-        expect(axios.post).toHaveBeenCalledWith("/api/proxy/user/saveTemplate", {
+        expect(consoleApiHttpClient.post).toHaveBeenCalledWith("/user/saveTemplate", {
           id: undefined,
           sdl: "version: '2.0'",
           isPublic: true,
@@ -203,12 +203,12 @@ describe("useTemplateQuery", () => {
     });
 
     it("handles error when saving template", async () => {
-      const axios = mock<AxiosInstance>();
-      axios.post.mockRejectedValue(new Error("Failed to save template"));
+      const consoleApiHttpClient = mock<AxiosInstance>();
+      consoleApiHttpClient.post.mockRejectedValue(new Error("Failed to save template"));
 
       const { result } = setup({
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         }
       });
 
@@ -229,29 +229,29 @@ describe("useTemplateQuery", () => {
 
   describe(useDeleteTemplate.name, () => {
     it("deletes template successfully", async () => {
-      const axios = mock<AxiosInstance>();
-      axios.delete.mockResolvedValue({});
+      const consoleApiHttpClient = mock<AxiosInstance>();
+      consoleApiHttpClient.delete.mockResolvedValue({});
 
       const { result } = setup({
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         }
       });
 
       act(() => result.current.mutate());
       await waitFor(() => {
-        expect(axios.delete).toHaveBeenCalledWith("/api/proxy/user/deleteTemplate/template-1");
+        expect(consoleApiHttpClient.delete).toHaveBeenCalledWith("/user/deleteTemplate/template-1");
         expect(result.current.isSuccess).toBe(true);
       });
     });
 
     it("handles error when deleting template", async () => {
-      const axios = mock<AxiosInstance>();
-      axios.delete.mockRejectedValue(new Error("Failed to delete template"));
+      const consoleApiHttpClient = mock<AxiosInstance>();
+      consoleApiHttpClient.delete.mockRejectedValue(new Error("Failed to delete template"));
 
       const { result } = setup({
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         }
       });
 
@@ -271,30 +271,30 @@ describe("useTemplateQuery", () => {
 
   describe("useAddFavoriteTemplate", () => {
     it("adds favorite template successfully and shows snackbar", async () => {
-      const axios = mock<AxiosInstance>();
-      axios.post.mockResolvedValue({});
+      const consoleApiHttpClient = mock<AxiosInstance>();
+      consoleApiHttpClient.post.mockResolvedValue({});
 
       const { result } = setup({
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         }
       });
 
       act(() => result.current.mutate());
       await waitFor(async () => {
-        expect(axios.post).toHaveBeenCalledWith("/api/proxy/user/addFavoriteTemplate/template-1");
+        expect(consoleApiHttpClient.post).toHaveBeenCalledWith("/user/addFavoriteTemplate/template-1");
         expect(result.current.isSuccess).toBe(true);
         expect(await screen.findByText(/Favorite added!/i)).toBeInTheDocument();
       });
     });
 
     it("handles error when adding favorite template", async () => {
-      const axios = mock<AxiosInstance>();
-      axios.post.mockRejectedValue(new Error("Failed to add favorite"));
+      const consoleApiHttpClient = mock<AxiosInstance>();
+      consoleApiHttpClient.post.mockRejectedValue(new Error("Failed to add favorite"));
 
       const { result } = setup({
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         }
       });
 
@@ -314,30 +314,30 @@ describe("useTemplateQuery", () => {
 
   describe("useRemoveFavoriteTemplate", () => {
     it("removes favorite template successfully and shows snackbar", async () => {
-      const axios = mock<AxiosInstance>();
-      axios.delete.mockResolvedValue({});
+      const consoleApiHttpClient = mock<AxiosInstance>();
+      consoleApiHttpClient.delete.mockResolvedValue({});
 
       const { result } = setup({
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         }
       });
 
       act(() => result.current.mutate());
       await waitFor(async () => {
-        expect(axios.delete).toHaveBeenCalledWith("/api/proxy/user/removeFavoriteTemplate/template-1");
+        expect(consoleApiHttpClient.delete).toHaveBeenCalledWith("/user/removeFavoriteTemplate/template-1");
         expect(result.current.isSuccess).toBe(true);
         expect(await screen.findByText(/Favorite removed/i)).toBeInTheDocument();
       });
     });
 
     it("handles error when removing favorite template", async () => {
-      const axios = mock<AxiosInstance>();
-      axios.delete.mockRejectedValue(new Error("Failed to remove favorite"));
+      const consoleApiHttpClient = mock<AxiosInstance>();
+      consoleApiHttpClient.delete.mockRejectedValue(new Error("Failed to remove favorite"));
 
       const { result } = setup({
         services: {
-          axios: () => axios
+          consoleApiHttpClient: () => consoleApiHttpClient
         }
       });
 

--- a/apps/deploy-web/src/queries/useTemplateQuery.tsx
+++ b/apps/deploy-web/src/queries/useTemplateQuery.tsx
@@ -11,30 +11,30 @@ import type { ITemplate } from "@src/types";
 import { QueryKeys } from "./queryKeys";
 
 export function useUserTemplates(username: string, options?: Omit<UseQueryOptions<ITemplate[], Error, any, QueryKey>, "queryKey" | "queryFn">) {
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
   return useQuery<ITemplate[], Error>({
     queryKey: QueryKeys.getUserTemplatesKey(username),
-    queryFn: () => axios.get<ITemplate[]>(`/api/proxy/user/templates/${username}`).then(response => response.data),
+    queryFn: () => consoleApiHttpClient.get<ITemplate[]>(`/user/templates/${username}`).then(response => response.data),
     ...options
   });
 }
 
 export function useUserFavoriteTemplates(options?: Omit<UseQueryOptions<Partial<ITemplate>[], Error, any, QueryKey>, "queryKey" | "queryFn">) {
   const { user } = useCustomUser();
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
   return useQuery<Partial<ITemplate>[], Error>({
     queryKey: QueryKeys.getUserFavoriteTemplatesKey(user?.sub || ""),
-    queryFn: () => axios.get<Partial<ITemplate>[]>(`/api/proxy/user/favoriteTemplates`).then(response => response.data),
+    queryFn: () => consoleApiHttpClient.get<Partial<ITemplate>[]>(`/user/favoriteTemplates`).then(response => response.data),
     ...options
   });
 }
 
 export function useTemplate(id: string, options?: Omit<UseQueryOptions<ITemplate, Error, any, QueryKey>, "queryKey" | "queryFn">) {
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
 
   return useQuery<ITemplate, Error>({
     queryKey: QueryKeys.getTemplateKey(id),
-    queryFn: () => axios.get<ITemplate>(`/api/proxy/user/template/${id}`).then(response => response.data),
+    queryFn: () => consoleApiHttpClient.get<ITemplate>(`/user/template/${id}`).then(response => response.data),
     ...options
   });
 }
@@ -45,11 +45,11 @@ export function useSaveUserTemplate(
   } = {}
 ) {
   const queryClient = useQueryClient();
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
 
   return useMutation({
     mutationFn: (template: Partial<ITemplate>) =>
-      axios.post("/api/proxy/user/saveTemplate", {
+      consoleApiHttpClient.post("/user/saveTemplate", {
         id: template.id,
         sdl: template.sdl,
         isPublic: template.isPublic,
@@ -71,10 +71,10 @@ export function useSaveUserTemplate(
 export function useDeleteTemplate(id: string) {
   const { user } = useCustomUser();
   const queryClient = useQueryClient();
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
 
   return useMutation({
-    mutationFn: () => axios.delete(`/api/proxy/user/deleteTemplate/${id}`),
+    mutationFn: () => consoleApiHttpClient.delete(`/user/deleteTemplate/${id}`),
     onSuccess: () => {
       if (user.username) {
         queryClient.setQueryData(QueryKeys.getUserTemplatesKey(user?.username), (oldData: ITemplate[] = []) => {
@@ -87,10 +87,10 @@ export function useDeleteTemplate(id: string) {
 
 export function useAddFavoriteTemplate(id: string) {
   const { enqueueSnackbar } = useSnackbar();
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
 
   return useMutation({
-    mutationFn: () => axios.post(`/api/proxy/user/addFavoriteTemplate/${id}`),
+    mutationFn: () => consoleApiHttpClient.post(`/user/addFavoriteTemplate/${id}`),
     onSuccess: () => {
       enqueueSnackbar(<Snackbar title="Favorite added!" iconVariant="success" />, { variant: "success" });
     }
@@ -99,10 +99,10 @@ export function useAddFavoriteTemplate(id: string) {
 
 export function useRemoveFavoriteTemplate(id: string) {
   const { enqueueSnackbar } = useSnackbar();
-  const { axios } = useServices();
+  const { consoleApiHttpClient } = useServices();
 
   return useMutation({
-    mutationFn: () => axios.delete(`/api/proxy/user/removeFavoriteTemplate/${id}`),
+    mutationFn: () => consoleApiHttpClient.delete(`/user/removeFavoriteTemplate/${id}`),
     onSuccess: () => {
       enqueueSnackbar(<Snackbar title="Favorite removed" iconVariant="success" />, { variant: "success" });
     }

--- a/apps/deploy-web/src/services/app-di-container/app-di-container.ts
+++ b/apps/deploy-web/src/services/app-di-container/app-di-container.ts
@@ -63,9 +63,9 @@ export const createAppRootContainer = (config: ServicesConfig) => {
       container.applyAxiosInterceptors(new TxHttpService(customRegistry, apiConfig), {
         request: [container.authService.withAnonymousUserHeader]
       }),
-    template: () => container.applyAxiosInterceptors(new TemplateHttpService(apiConfig), {}),
+    template: () => container.applyAxiosInterceptors(new TemplateHttpService(apiConfig)),
     usage: () =>
-      withInterceptors(new UsageHttpService(apiConfig), {
+      container.applyAxiosInterceptors(new UsageHttpService(apiConfig), {
         request: [container.authService.withAnonymousUserHeader]
       }),
     auth: () =>
@@ -81,7 +81,13 @@ export const createAppRootContainer = (config: ServicesConfig) => {
       container.applyAxiosInterceptors(new ApiKeyHttpService(), {
         request: [container.authService.withAnonymousUserHeader]
       }),
-    axios: () => container.createAxios(),
+    externalApiHttpClient: () =>
+      container.createAxios({
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json"
+        }
+      }),
     createAxios:
       () =>
       (options?: CreateAxiosDefaults): AxiosInstance =>
@@ -136,9 +142,9 @@ export interface ServicesConfig {
   apiUrlService: () => ApiUrlService;
 }
 
-function withInterceptors<T extends Axios | AxiosInstance = AxiosInstance>(axios: T, interceptors: Interceptors) {
-  interceptors.request?.forEach(interceptor => axios.interceptors.request.use(interceptor));
-  interceptors.response?.forEach(interceptor => axios.interceptors.response.use(interceptor));
+function withInterceptors<T extends Axios | AxiosInstance = AxiosInstance>(axios: T, interceptors?: Interceptors) {
+  interceptors?.request?.forEach(interceptor => axios.interceptors.request.use(interceptor));
+  interceptors?.response?.forEach(interceptor => axios.interceptors.response.use(interceptor));
   return axios;
 }
 

--- a/apps/deploy-web/src/services/auth/auth.service.ts
+++ b/apps/deploy-web/src/services/auth/auth.service.ts
@@ -8,7 +8,7 @@ export class AuthService {
   }
 
   withAnonymousUserHeader(config: InternalAxiosRequestConfig) {
-    const token = localStorage.getItem(ANONYMOUS_USER_TOKEN_KEY);
+    const token = typeof localStorage !== "undefined" ? localStorage.getItem(ANONYMOUS_USER_TOKEN_KEY) : null;
 
     if (token) {
       config.headers.set("authorization", `Bearer ${token}`);

--- a/apps/deploy-web/src/services/auth/bitbucket.service.ts
+++ b/apps/deploy-web/src/services/auth/bitbucket.service.ts
@@ -1,5 +1,4 @@
-import type { AxiosResponse } from "axios";
-import axios from "axios";
+import type { AxiosInstance, AxiosResponse } from "axios";
 import { URLSearchParams } from "url";
 
 import type { GitProviderTokens } from "@src/types/remotedeploy";
@@ -13,8 +12,10 @@ class BitbucketAuth {
   private tokenUrl: string;
   private clientId: string;
   private clientSecret: string;
+  private readonly httpClient: AxiosInstance;
 
-  constructor(clientId: string, clientSecret: string) {
+  constructor(clientId: string, clientSecret: string, httpClient: AxiosInstance) {
+    this.httpClient = httpClient;
     this.tokenUrl = "https://bitbucket.org/site/oauth2/access_token";
     this.clientId = clientId;
     this.clientSecret = clientSecret;
@@ -31,14 +32,14 @@ class BitbucketAuth {
     };
 
     try {
-      const response: AxiosResponse = await axios.post(this.tokenUrl, params.toString(), { headers });
+      const response: AxiosResponse = await this.httpClient.post(this.tokenUrl, params.toString(), { headers });
       const { access_token, refresh_token }: Tokens = response.data;
       return {
         accessToken: access_token,
         refreshToken: refresh_token
       };
-    } catch (error: any) {
-      throw new Error(error);
+    } catch (error) {
+      throw new Error("Failed to exchange authorization code for tokens", { cause: error });
     }
   }
 
@@ -53,14 +54,14 @@ class BitbucketAuth {
     };
 
     try {
-      const response: AxiosResponse = await axios.post(this.tokenUrl, params.toString(), { headers });
+      const response: AxiosResponse = await this.httpClient.post(this.tokenUrl, params.toString(), { headers });
       const { access_token, refresh_token }: Tokens = response.data;
       return {
         accessToken: access_token,
         refreshToken: refresh_token
       };
-    } catch (error: any) {
-      throw new Error(error);
+    } catch (error) {
+      throw new Error("Failed to refresh tokens using refresh token", { cause: error });
     }
   }
 }

--- a/apps/deploy-web/src/services/auth/github.service.ts
+++ b/apps/deploy-web/src/services/auth/github.service.ts
@@ -1,22 +1,23 @@
-import type { AxiosResponse } from "axios";
-import axios from "axios";
+import type { AxiosInstance, AxiosResponse } from "axios";
 
 class GitHubAuth {
   private tokenUrl: string;
   private clientId: string;
   private clientSecret: string;
   private redirectUri: string | undefined;
+  private readonly httpClient: AxiosInstance;
 
-  constructor(clientId: string, clientSecret: string, redirectUri?: string) {
+  constructor(clientId: string, clientSecret: string, redirectUri: string | undefined, httpClient: AxiosInstance) {
     this.tokenUrl = "https://github.com/login/oauth/access_token";
     this.clientId = clientId;
     this.clientSecret = clientSecret;
     this.redirectUri = redirectUri;
+    this.httpClient = httpClient;
   }
 
   async exchangeAuthorizationCodeForToken(authorizationCode: string): Promise<string> {
     try {
-      const response: AxiosResponse = await axios.post(this.tokenUrl, {
+      const response: AxiosResponse = await this.httpClient.post(this.tokenUrl, {
         client_id: this.clientId,
         client_secret: this.clientSecret,
         code: authorizationCode,
@@ -26,8 +27,8 @@ class GitHubAuth {
       const params = new URLSearchParams(response.data);
       const accessToken = params.get("access_token");
       return accessToken as string;
-    } catch (error: any) {
-      throw new Error(error);
+    } catch (error) {
+      throw new Error("Failed to exchange authorization code for token", { cause: error });
     }
   }
 }

--- a/apps/deploy-web/src/services/http/http-browser.service.ts
+++ b/apps/deploy-web/src/services/http/http-browser.service.ts
@@ -26,7 +26,12 @@ export const services = createChildContainer(rootContainer, {
       baseUrl: "/api/proxy",
       queryClient: services.queryClient
     }),
-  githubService: () => new GitHubService(),
-  bitbucketService: () => new BitbucketService(),
-  gitlabService: () => new GitLabService()
+  githubService: () => new GitHubService(services.internalApiHttpClient, services.createAxios),
+  bitbucketService: () => new BitbucketService(services.internalApiHttpClient, services.createAxios),
+  gitlabService: () => new GitLabService(services.internalApiHttpClient, services.createAxios),
+  internalApiHttpClient: () => services.createAxios(),
+  consoleApiHttpClient: () =>
+    services.applyAxiosInterceptors(services.createAxios({ baseURL: browserEnvConfig.NEXT_PUBLIC_BASE_API_MAINNET_URL }), {
+      request: [services.authService.withAnonymousUserHeader]
+    })
 });

--- a/apps/deploy-web/src/services/http/http-server.service.ts
+++ b/apps/deploy-web/src/services/http/http-server.service.ts
@@ -27,7 +27,8 @@ export const services = createChildContainer(rootContainer, {
       requestFn,
       baseUrl: serverEnvConfig.BASE_API_MAINNET_URL
     }),
-  config: () => serverEnvConfig
+  config: () => serverEnvConfig,
+  consoleApiHttpClient: () => services.applyAxiosInterceptors(services.createAxios())
 });
 
 export type AppServices = typeof services;

--- a/apps/deploy-web/src/services/wallet-balances/wallet-balances.service.spec.ts
+++ b/apps/deploy-web/src/services/wallet-balances/wallet-balances.service.spec.ts
@@ -1,6 +1,5 @@
 import type { AuthzHttpService } from "@akashnetwork/http-sdk";
-import type { AxiosInstance } from "axios";
-import { type AxiosResponse } from "axios";
+import type { AxiosInstance, AxiosResponse } from "axios";
 import { mock } from "jest-mock-extended";
 
 import { UAKT_DENOM, USDC_IBC_DENOMS } from "@src/config/denom.config";
@@ -55,7 +54,12 @@ describe(WalletBalancesService.name, () => {
     });
   });
 
-  function setup(input: TestInput) {
+  function setup(input: {
+    getValidDepositDeploymentGrantsForGranterAndGrantee?: AuthzHttpService["getValidDepositDeploymentGrantsForGranterAndGrantee"];
+    getBalances?: () => RestApiBalancesResponseType;
+    getDeploymentList?: () => RpcDeployment[];
+    masterWalletAddress?: string;
+  }) {
     return new WalletBalancesService(
       mock({
         getValidDepositDeploymentGrantsForGranterAndGrantee: input.getValidDepositDeploymentGrantsForGranterAndGrantee
@@ -107,16 +111,7 @@ describe(WalletBalancesService.name, () => {
           return Promise.reject(new Error("Not implemented"));
         }
       }) as unknown as AxiosInstance,
-      input.masterWalletAddress || "akash1234",
-      input.apiEndpoint || "http://test.com"
+      input.masterWalletAddress || "akash1234"
     );
-  }
-
-  interface TestInput {
-    getValidDepositDeploymentGrantsForGranterAndGrantee?: AuthzHttpService["getValidDepositDeploymentGrantsForGranterAndGrantee"];
-    getBalances?: () => RestApiBalancesResponseType;
-    getDeploymentList?: () => RpcDeployment[];
-    masterWalletAddress?: string;
-    apiEndpoint?: string;
   }
 });

--- a/apps/deploy-web/src/services/wallet-balances/wallet-balances.service.ts
+++ b/apps/deploy-web/src/services/wallet-balances/wallet-balances.service.ts
@@ -12,17 +12,16 @@ import { deploymentToDto } from "@src/utils/deploymentDetailUtils";
 export class WalletBalancesService {
   constructor(
     private readonly authzHttpService: AuthzHttpService,
-    private readonly axios: AxiosInstance,
-    private readonly masterWalletAddress: string,
-    private readonly apiEndpoint: string
+    private readonly chainApiHttpClient: AxiosInstance,
+    private readonly masterWalletAddress: string
   ) {}
 
   async getBalances(address: string): Promise<Balances> {
     const usdcIbcDenom = getUsdcDenom();
     const [balanceResponse, deploymentGrant, activeDeploymentsResponse] = await Promise.all([
-      this.axios.get<RestApiBalancesResponseType>(ApiUrlService.balance(this.apiEndpoint, address)),
+      this.chainApiHttpClient.get<RestApiBalancesResponseType>(ApiUrlService.balance("", address)),
       this.authzHttpService.getValidDepositDeploymentGrantsForGranterAndGrantee(this.masterWalletAddress, address),
-      loadWithPagination<RpcDeployment[]>(ApiUrlService.deploymentList(this.apiEndpoint, address, true), "deployments", 1000, this.axios)
+      loadWithPagination<RpcDeployment[]>(ApiUrlService.deploymentList("", address, true), "deployments", 1000, this.chainApiHttpClient)
     ]);
 
     const deploymentGrantsUAKT = parseFloat(

--- a/apps/deploy-web/src/utils/apiUtils.ts
+++ b/apps/deploy-web/src/utils/apiUtils.ts
@@ -131,8 +131,11 @@ export class ApiUrlService {
   }
 }
 
-// TODO: implement proper pagination on clients
-//   Issue: https://github.com/akash-network/console/milestone/7
+/**
+ * @deprecated use getAllItems utility from @akashnetwork/http-sdk
+ * TODO: implement proper pagination on clients
+ * Issue: https://github.com/akash-network/console/milestone/7
+ */
 export async function loadWithPagination<T>(baseUrl: string, dataKey: string, limit: number, httpClient: AxiosInstance) {
   let items: T[] = [];
   let nextKey: string | null = null;

--- a/apps/deploy-web/tests/unit/TestContainerProvider.tsx
+++ b/apps/deploy-web/tests/unit/TestContainerProvider.tsx
@@ -1,0 +1,23 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import type { Props as ServicesProviderProps } from "@src/context/ServicesProvider/ServicesProvider";
+import { ServicesProvider, useServices } from "@src/context/ServicesProvider/ServicesProvider";
+
+export const TestContainerProvider: React.FC<ServicesProviderProps> = ({ children, services }) => {
+  const queryClient = new QueryClient();
+  const testServices = {
+    queryClient: () => queryClient,
+    ...services
+  };
+
+  return (
+    <ServicesProvider services={testServices}>
+      <QueryProviderFromDI>{children}</QueryProviderFromDI>
+    </ServicesProvider>
+  );
+};
+
+function QueryProviderFromDI({ children }: { children: React.ReactNode }) {
+  const { queryClient } = useServices();
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/apps/deploy-web/tests/unit/query-client.tsx
+++ b/apps/deploy-web/tests/unit/query-client.tsx
@@ -1,8 +1,7 @@
-import { QueryClientProvider } from "@tanstack/react-query";
 import { QueryClient } from "@tanstack/react-query";
 
 import type { Props as ServicesProviderProps } from "@src/context/ServicesProvider";
-import { ServicesProvider } from "@src/context/ServicesProvider";
+import { TestContainerProvider } from "./TestContainerProvider";
 
 import type { RenderHookResult } from "@testing-library/react";
 import { renderHook } from "@testing-library/react";
@@ -17,7 +16,10 @@ export function setupQuery<T>(hook: () => T, options?: RenderAppHookOptions): Re
       }
     }
   });
-  let wrapper = createWrapper(queryClient, options?.services);
+  let wrapper = createWrapper({
+    queryClient: () => queryClient,
+    ...options?.services
+  });
   const customWrapper = options?.wrapper;
   if (customWrapper) {
     const originalWrapper = wrapper;
@@ -27,12 +29,8 @@ export function setupQuery<T>(hook: () => T, options?: RenderAppHookOptions): Re
   return renderHook(hook, { wrapper });
 }
 
-function createWrapper(queryClient: QueryClient, services?: ServicesProviderProps["services"]) {
-  return ({ children }: { children: React.ReactNode }) => (
-    <QueryClientProvider client={queryClient}>
-      <ServicesProvider services={services}>{children}</ServicesProvider>
-    </QueryClientProvider>
-  );
+function createWrapper(services?: ServicesProviderProps["services"]) {
+  return ({ children }: { children: React.ReactNode }) => <TestContainerProvider services={services}>{children}</TestContainerProvider>;
 }
 
 export interface RenderAppHookOptions {

--- a/packages/http-sdk/src/index.ts
+++ b/packages/http-sdk/src/index.ts
@@ -22,3 +22,4 @@ export * from "./cosmos";
 export * from "./coin-gecko";
 export * from "./node";
 export * from "./certificates/certificates.service";
+export { getAllItems } from "./utils/pagination.utils";


### PR DESCRIPTION
## Why

Closes #1668

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a unified HTTP client for API requests, improving consistency across user, provider, template, and settings features.
  * Added a new test utility component for streamlined service context and React Query client setup in tests.

* **Bug Fixes**
  * Improved error handling by reporting errors through a dedicated error handler instead of external services in anonymous user queries.
  * Added safeguards to prevent errors when accessing local storage in unsupported environments.

* **Refactor**
  * Standardized API endpoint URLs and replaced all direct axios usage with injected, context-aware HTTP clients.
  * Updated authentication and remote deploy services to use injected HTTP clients, enhancing modularity and testability.
  * Simplified and consolidated test setups for components and queries.
  * Refined dependency injection container by introducing a new preconfigured HTTP client and unifying interceptor application.

* **Documentation**
  * Marked certain hooks and utilities as deprecated and recommended alternatives in code comments.

* **Tests**
  * Updated and streamlined test utilities and mocks to support the new HTTP client structure.
  * Removed some redundant or outdated test cases for clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->