### PR TITLE
fix(log-collector): properly extracts image version for ci build

### DIFF
--- a/.github/workflows/log-collector-release.yml
+++ b/.github/workflows/log-collector-release.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Build Docker image
         shell: bash
         run: |
-          image="${{ vars.LOG_COLLECTOR_REGISTRY }}:${{ needs.release.outputs.git_tag }}"
-          docker build -f apps/log-collector/Dockerfile -t $image .
-          docker push $image
+          full_tag="${{ needs.release.outputs.git_tag }}"
+          version="${full_tag#*/}"
+          version="${version#v}"
+          image="${{ vars.LOG_COLLECTOR_REGISTRY }}:$version"
+
+          docker build -f apps/log-collector/Dockerfile -t "$image" .
+          docker push "$image"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker image tagging in the release workflow for more consistent versioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->