### PR TITLE
feat(log-collector): improve stream resilience with Promise.allSettled

### DIFF
--- a/apps/log-collector/src/services/k8s-log-collector/k8s-log-collector.service.spec.ts
+++ b/apps/log-collector/src/services/k8s-log-collector/k8s-log-collector.service.spec.ts
@@ -124,7 +124,7 @@ describe(K8sLogCollectorService.name, () => {
 
     jest.spyOn(k8sLogCollectorService as any, "createLogStream").mockReturnValue(mockStream);
 
-    await expect(k8sLogCollectorService.collectLogs(logDestination)).rejects.toThrow("Stream error");
+    await expect(k8sLogCollectorService.collectLogs(logDestination)).rejects.toThrow("Log streams failed for pods:");
 
     expect(loggerService.error).toHaveBeenCalledWith({
       error: expect.any(Error),


### PR DESCRIPTION
- Use Promise.allSettled() instead of Promise.all() for individual pod failure handling
- Improve error messages with specific failed pod names
- Add stream result logging for better debugging

Individual pod failures no longer kill other streams, but process still restarts on errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during log collection to provide clearer messages when log streams from pods fail.

* **Tests**
  * Updated test cases to reflect the new error messaging for failed log stream scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->