### PR TITLE
fix: uses a separate consoleApiHttpClient for public access

### DIFF
--- a/apps/deploy-web/src/components/providers/ProviderRawData/ProviderRawData.spec.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderRawData/ProviderRawData.spec.tsx
@@ -20,7 +20,7 @@ describe(ProviderRawData.name, () => {
   });
 
   async function setup(props?: Props) {
-    const consoleApiHttpClient = () =>
+    const publicConsoleApiHttpClient = () =>
       ({
         get: jest.fn(async url => {
           if (url.includes("/providers/"))
@@ -30,7 +30,7 @@ describe(ProviderRawData.name, () => {
 
           throw new Error(`unexpected request: ${url}`);
         })
-      }) as unknown as AppDIContainer["consoleApiHttpClient"];
+      }) as unknown as AppDIContainer["publicConsoleApiHttpClient"];
     const chainApiHttpClient = () =>
       ({
         get: jest.fn(async url => {
@@ -46,7 +46,7 @@ describe(ProviderRawData.name, () => {
       }) as unknown as AppDIContainer["providerProxy"];
 
     const result = render(
-      <TestContainerProvider services={{ chainApiHttpClient, consoleApiHttpClient, providerProxy }}>
+      <TestContainerProvider services={{ chainApiHttpClient, publicConsoleApiHttpClient, providerProxy }}>
         <ProviderRawData owner={props?.provider?.owner || "test"} components={MockComponents(COMPONENTS, props?.components)} />
       </TestContainerProvider>
     );

--- a/apps/deploy-web/src/pages/api/auth/[...auth0].ts
+++ b/apps/deploy-web/src/pages/api/auth/[...auth0].ts
@@ -64,7 +64,7 @@ const authHandler = once((services: AppServices) =>
               }
 
               const userSettings = await services.consoleApiHttpClient.post(
-                `${services.config.BASE_API_MAINNET_URL}/user/tokenInfo`,
+                `${services.apiUrlService.getBaseApiUrlFor("mainnet")}/user/tokenInfo`,
                 {
                   wantedUsername: session.user.nickname,
                   email: session.user.email,

--- a/apps/deploy-web/src/queries/featureFlags.ts
+++ b/apps/deploy-web/src/queries/featureFlags.ts
@@ -11,12 +11,12 @@ import { QueryKeys } from "./queryKeys";
 const REFETCH_INTERVAL = 1000 * 60 * 5;
 /** @deprecated use useFlag instead */
 export function useFeatureFlags(options?: Omit<UseQueryOptions<Features>, "queryKey" | "queryFn">): UseQueryResult<Features> {
-  const { consoleApiHttpClient, apiUrlService } = useServices();
+  const { publicConsoleApiHttpClient, apiUrlService } = useServices();
   const networkId = networkStore.useSelectedNetworkId();
   return useQuery({
     ...options,
     queryKey: QueryKeys.getFeatureFlagsKey(networkId),
-    queryFn: () => getFeatureFlags(networkId, consoleApiHttpClient, apiUrlService),
+    queryFn: () => getFeatureFlags(networkId, publicConsoleApiHttpClient, apiUrlService),
     refetchInterval: REFETCH_INTERVAL
   });
 }
@@ -26,7 +26,8 @@ export interface Features {
 }
 
 export async function getFeatureFlags(networkId: NetworkId, consoleApiHttpClient: AxiosInstance, apiUrlService: ApiUrlService) {
-  const baseApiUrl = apiUrlService.getBaseApiUrlFor(networkId);
-  const response = await consoleApiHttpClient.get<{ data: Features }>(`${baseApiUrl}/v1/features`);
+  const response = await consoleApiHttpClient.get<{ data: Features }>("/v1/features", {
+    baseURL: apiUrlService.getBaseApiUrlFor(networkId)
+  });
   return response.data.data;
 }

--- a/apps/deploy-web/src/queries/useBlocksQuery.ts
+++ b/apps/deploy-web/src/queries/useBlocksQuery.ts
@@ -20,10 +20,10 @@ export function useBlock(id: string, options = {}) {
 }
 
 export function useBlocks(limit: number, options?: Omit<UseQueryOptions<Block[], Error, any, QueryKey>, "queryKey" | "queryFn">) {
-  const { consoleApiHttpClient } = useServices();
+  const { publicConsoleApiHttpClient } = useServices();
   return useQuery<Block[], Error>({
     queryKey: QueryKeys.getBlocksKey(limit),
-    queryFn: () => consoleApiHttpClient.get(ApiUrlService.blocks(limit)).then(response => response.data),
+    queryFn: () => publicConsoleApiHttpClient.get(ApiUrlService.blocks(limit)).then(response => response.data),
     ...options
   });
 }

--- a/apps/deploy-web/src/queries/useGpuQuery.ts
+++ b/apps/deploy-web/src/queries/useGpuQuery.ts
@@ -6,10 +6,10 @@ import { ApiUrlService } from "@src/utils/apiUtils";
 import { QueryKeys } from "./queryKeys";
 
 export function useGpuModels(options = {}) {
-  const { consoleApiHttpClient } = useServices();
+  const { publicConsoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getGpuModelsKey(),
-    queryFn: () => consoleApiHttpClient.get<GpuVendor[]>(ApiUrlService.gpuModels()).then(response => response.data),
+    queryFn: () => publicConsoleApiHttpClient.get<GpuVendor[]>(ApiUrlService.gpuModels()).then(response => response.data),
     ...options,
     refetchInterval: false,
     refetchIntervalInBackground: false,

--- a/apps/deploy-web/src/queries/useMarketData.spec.tsx
+++ b/apps/deploy-web/src/queries/useMarketData.spec.tsx
@@ -23,7 +23,7 @@ describe("useMarketData", () => {
 
     const { result } = setup({
       services: {
-        consoleApiHttpClient: () => consoleApiHttpClient
+        publicConsoleApiHttpClient: () => consoleApiHttpClient
       }
     });
 

--- a/apps/deploy-web/src/queries/useMarketData.ts
+++ b/apps/deploy-web/src/queries/useMarketData.ts
@@ -7,10 +7,10 @@ import { ApiUrlService } from "@src/utils/apiUtils";
 import { QueryKeys } from "./queryKeys";
 
 export function useMarketData(options?: Omit<UseQueryOptions<MarketData, Error, any, QueryKey>, "queryKey" | "queryFn">) {
-  const { consoleApiHttpClient } = useServices();
+  const { publicConsoleApiHttpClient } = useServices();
   return useQuery<MarketData, Error>({
     queryKey: QueryKeys.getFinancialDataKey(),
-    queryFn: () => consoleApiHttpClient.get<MarketData>(ApiUrlService.marketData()).then(response => response.data),
+    queryFn: () => publicConsoleApiHttpClient.get<MarketData>(ApiUrlService.marketData()).then(response => response.data),
     ...options
   });
 }

--- a/apps/deploy-web/src/queries/useProvidersQuery.ts
+++ b/apps/deploy-web/src/queries/useProvidersQuery.ts
@@ -13,12 +13,12 @@ export function useProviderDetail(
   owner: string,
   options: Omit<UseQueryOptions<ApiProviderDetail | null>, "queryKey" | "queryFn">
 ): UseQueryResult<ApiProviderDetail | null> {
-  const { consoleApiHttpClient } = useServices();
+  const { publicConsoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getProviderDetailKey(owner) as QueryKey,
     queryFn: async () => {
       if (!owner) return null;
-      const response = await consoleApiHttpClient.get(ApiUrlService.providerDetail(owner));
+      const response = await publicConsoleApiHttpClient.get(ApiUrlService.providerDetail(owner));
       return response.data;
     },
     ...options
@@ -49,19 +49,19 @@ export function useProviderStatus(
 }
 
 export function useNetworkCapacity(options = {}) {
-  const { consoleApiHttpClient } = useServices();
+  const { publicConsoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getNetworkCapacity(),
-    queryFn: () => consoleApiHttpClient.get(ApiUrlService.networkCapacity()).then(response => getNetworkCapacityDto(response.data)),
+    queryFn: () => publicConsoleApiHttpClient.get(ApiUrlService.networkCapacity()).then(response => getNetworkCapacityDto(response.data)),
     ...options
   });
 }
 
 export function useAuditors(options = {}) {
-  const { consoleApiHttpClient } = useServices();
+  const { publicConsoleApiHttpClient } = useServices();
   return useQuery<Array<Auditor>>({
     queryKey: QueryKeys.getAuditorsKey(),
-    queryFn: () => consoleApiHttpClient.get(ApiUrlService.auditors()).then(response => response.data),
+    queryFn: () => publicConsoleApiHttpClient.get(ApiUrlService.auditors()).then(response => response.data),
     ...options,
     refetchInterval: false,
     refetchIntervalInBackground: false,
@@ -71,19 +71,19 @@ export function useAuditors(options = {}) {
 }
 
 export function useProviderActiveLeasesGraph(providerAddress: string, options = {}) {
-  const { consoleApiHttpClient } = useServices();
+  const { publicConsoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getProviderActiveLeasesGraph(providerAddress),
-    queryFn: () => consoleApiHttpClient.get(ApiUrlService.providerActiveLeasesGraph(providerAddress)).then(response => response.data),
+    queryFn: () => publicConsoleApiHttpClient.get(ApiUrlService.providerActiveLeasesGraph(providerAddress)).then(response => response.data),
     ...options
   });
 }
 
 export function useProviderAttributesSchema(options = {}) {
-  const { consoleApiHttpClient } = useServices();
+  const { publicConsoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getProviderAttributesSchema(),
-    queryFn: () => consoleApiHttpClient.get<ProviderAttributesSchema>(ApiUrlService.providerAttributesSchema()).then(response => response.data),
+    queryFn: () => publicConsoleApiHttpClient.get<ProviderAttributesSchema>(ApiUrlService.providerAttributesSchema()).then(response => response.data),
     ...options,
     refetchInterval: false,
     refetchIntervalInBackground: false,
@@ -93,19 +93,19 @@ export function useProviderAttributesSchema(options = {}) {
 }
 
 export function useProviderList(options = {}) {
-  const { consoleApiHttpClient } = useServices();
+  const { publicConsoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getProviderListKey(),
-    queryFn: () => consoleApiHttpClient.get<ApiProviderList[]>(ApiUrlService.providerList()).then(response => response.data),
+    queryFn: () => publicConsoleApiHttpClient.get<ApiProviderList[]>(ApiUrlService.providerList()).then(response => response.data),
     ...options
   });
 }
 
 export function useProviderRegions(options = {}) {
-  const { consoleApiHttpClient } = useServices();
+  const { publicConsoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getProviderRegionsKey(),
-    queryFn: () => consoleApiHttpClient.get<ApiProviderRegion[]>(ApiUrlService.providerRegions()).then(response => response.data),
+    queryFn: () => publicConsoleApiHttpClient.get<ApiProviderRegion[]>(ApiUrlService.providerRegions()).then(response => response.data),
     ...options
   });
 }

--- a/apps/deploy-web/src/services/http/http-browser.service.ts
+++ b/apps/deploy-web/src/services/http/http-browser.service.ts
@@ -33,5 +33,7 @@ export const services = createChildContainer(rootContainer, {
   consoleApiHttpClient: () =>
     services.applyAxiosInterceptors(services.createAxios({ baseURL: browserEnvConfig.NEXT_PUBLIC_BASE_API_MAINNET_URL }), {
       request: [services.authService.withAnonymousUserHeader]
-    })
+    }),
+  /** TODO: https://github.com/akash-network/console/issues/1720 */
+  publicConsoleApiHttpClient: () => services.applyAxiosInterceptors(services.createAxios())
 });


### PR DESCRIPTION
## Why

we have public available API on console-api and user specific one. Eventually it should be a single API instance but at the moment it's not possible to get all public endpoints. There is a separate task for this https://github.com/akash-network/console/issues/1701 . Related https://github.com/akash-network/console/issues/1720

## What

Adds `publicConsoleApiHttpClient` service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a new public API client for accessing certain data endpoints.

* **Refactor**
  * Updated various data fetching hooks and related logic to use the new public API client instead of the previous internal client.
  * Adjusted test setups to accommodate the new API client.
  * Improved dynamic construction of API URLs for user authentication requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->