### PR TITLE
feat(deployment): close trial deployments after 24h

### DIFF
--- a/.helm/console-api-staging-mainnet-values.yaml
+++ b/.helm/console-api-staging-mainnet-values.yaml
@@ -26,3 +26,9 @@ jobs:
       - node
       - dist/console.js
       - cleanup-stale-anonymous-users
+  - name: cleanup-trial-deployments
+    schedule: "*/30 * * * *" # Every 30 minutes
+    command:
+      - node
+      - dist/console.js
+      - cleanup-trial-deployments

--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -9,6 +9,7 @@ export const envSchema = z.object({
   TRIAL_ALLOWANCE_EXPIRATION_DAYS: z.number({ coerce: true }).default(30),
   TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT: z.number({ coerce: true }),
   TRIAL_FEES_ALLOWANCE_AMOUNT: z.number({ coerce: true }),
+  TRIAL_DEPLOYMENT_CLEANUP_HOURS: z.number({ coerce: true }).default(24),
   DEPLOYMENT_GRANT_DENOM: z.string(),
   GAS_SAFETY_MULTIPLIER: z.number({ coerce: true }).default(1.6),
   AVERAGE_GAS_PRICE: z.number({ coerce: true }).default(0.0025),

--- a/apps/api/src/chain/repositories/block.repository.ts
+++ b/apps/api/src/chain/repositories/block.repository.ts
@@ -8,4 +8,10 @@ export class BlockRepository {
 
     return (height as number) ?? 0;
   }
+
+  async getLatestHeight(): Promise<number> {
+    const height = await Block.max("height");
+
+    return (height as number) ?? 0;
+  }
 }

--- a/apps/api/src/console.ts
+++ b/apps/api/src/console.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import { WalletController } from "@src/billing/controllers/wallet/wallet.controller";
 import { chainDb } from "@src/db/dbConnection";
 import { TopUpDeploymentsController } from "@src/deployment/controllers/deployment/top-up-deployments.controller";
+import { TrialController } from "@src/deployment/controllers/deployment/trial.controller";
 import { GpuBotController } from "@src/deployment/controllers/gpu-bot/gpu-bot.controller";
 import { ProviderController } from "@src/provider/controllers/provider/provider.controller";
 import { UserController } from "@src/user/controllers/user/user.controller";
@@ -50,6 +51,16 @@ program
   .action(async (options, command) => {
     await executeCliHandler(command.name(), async () => {
       await container.resolve(TopUpDeploymentsController).cleanUpStaleDeployment(options);
+    });
+  });
+
+program
+  .command("cleanup-trial-deployments")
+  .description("Close trial deployments that have been active for more than the configured time (default: 24h)")
+  .option("-c, --concurrency <number>", "How many wallets are processed concurrently", value => z.number({ coerce: true }).optional().default(10).parse(value))
+  .action(async (options, command) => {
+    await executeCliHandler(command.name(), async () => {
+      await container.resolve(TrialController).cleanUpTrialDeployments(options);
     });
   });
 

--- a/apps/api/src/deployment/controllers/deployment/trial.controller.spec.ts
+++ b/apps/api/src/deployment/controllers/deployment/trial.controller.spec.ts
@@ -1,33 +1,31 @@
+import type { MockProxy } from "jest-mock-extended";
 import { mock } from "jest-mock-extended";
 
 import type { TrialDeploymentsCleanerService } from "@src/deployment/services/trial-deployments-cleaner/trial-deployments-cleaner.service";
 import { TrialController } from "./trial.controller";
 
-describe("TrialController", () => {
-  it("should call the trial deployments cleaner service with the provided options", async () => {
-    const options = { concurrency: 5 };
-    const { trialController, mockTrialDeploymentsCleanerService } = setup({ options });
+describe(TrialController.name, () => {
+  describe("cleanUpTrialDeployments", () => {
+    it("should call the trial deployments cleaner service with the provided options", async () => {
+      const { controller, trialDeploymentsCleanerService } = setup();
+      const options = { concurrency: 5 };
 
-    await trialController.cleanUpTrialDeployments(options);
+      await controller.cleanUpTrialDeployments(options);
 
-    expect(mockTrialDeploymentsCleanerService.cleanup).toHaveBeenCalledWith(options);
+      expect(trialDeploymentsCleanerService.cleanup).toHaveBeenCalledWith(options);
+    });
   });
 
-  it("should call the trial deployments cleaner service with default options when none provided", async () => {
-    const { trialController, mockTrialDeploymentsCleanerService } = setup({ options: {} });
-
-    await trialController.cleanUpTrialDeployments({});
-
-    expect(mockTrialDeploymentsCleanerService.cleanup).toHaveBeenCalledWith({});
-  });
-
-  function setup(_input: { options: { concurrency?: number } }) {
-    const mockTrialDeploymentsCleanerService = mock<TrialDeploymentsCleanerService>();
-    const trialController = new TrialController(mockTrialDeploymentsCleanerService);
+  function setup(): {
+    controller: TrialController;
+    trialDeploymentsCleanerService: MockProxy<TrialDeploymentsCleanerService>;
+  } {
+    const trialDeploymentsCleanerService = mock<TrialDeploymentsCleanerService>();
+    const controller = new TrialController(trialDeploymentsCleanerService);
 
     return {
-      trialController,
-      mockTrialDeploymentsCleanerService
+      controller,
+      trialDeploymentsCleanerService
     };
   }
 });

--- a/apps/api/src/deployment/controllers/deployment/trial.controller.spec.ts
+++ b/apps/api/src/deployment/controllers/deployment/trial.controller.spec.ts
@@ -1,0 +1,33 @@
+import { mock } from "jest-mock-extended";
+
+import type { TrialDeploymentsCleanerService } from "@src/deployment/services/trial-deployments-cleaner/trial-deployments-cleaner.service";
+import { TrialController } from "./trial.controller";
+
+describe("TrialController", () => {
+  it("should call the trial deployments cleaner service with the provided options", async () => {
+    const options = { concurrency: 5 };
+    const { trialController, mockTrialDeploymentsCleanerService } = setup({ options });
+
+    await trialController.cleanUpTrialDeployments(options);
+
+    expect(mockTrialDeploymentsCleanerService.cleanup).toHaveBeenCalledWith(options);
+  });
+
+  it("should call the trial deployments cleaner service with default options when none provided", async () => {
+    const { trialController, mockTrialDeploymentsCleanerService } = setup({ options: {} });
+
+    await trialController.cleanUpTrialDeployments({});
+
+    expect(mockTrialDeploymentsCleanerService.cleanup).toHaveBeenCalledWith({});
+  });
+
+  function setup(_input: { options: { concurrency?: number } }) {
+    const mockTrialDeploymentsCleanerService = mock<TrialDeploymentsCleanerService>();
+    const trialController = new TrialController(mockTrialDeploymentsCleanerService);
+
+    return {
+      trialController,
+      mockTrialDeploymentsCleanerService
+    };
+  }
+});

--- a/apps/api/src/deployment/controllers/deployment/trial.controller.ts
+++ b/apps/api/src/deployment/controllers/deployment/trial.controller.ts
@@ -1,0 +1,13 @@
+import { singleton } from "tsyringe";
+
+import { TrialDeploymentsCleanerService } from "@src/deployment/services/trial-deployments-cleaner/trial-deployments-cleaner.service";
+import { CleanUpTrialDeploymentsParams } from "@src/deployment/types/trial-deployments";
+
+@singleton()
+export class TrialController {
+  constructor(private readonly trialDeploymentsCleanerService: TrialDeploymentsCleanerService) {}
+
+  async cleanUpTrialDeployments(options: CleanUpTrialDeploymentsParams) {
+    await this.trialDeploymentsCleanerService.cleanup(options);
+  }
+}

--- a/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
@@ -14,6 +14,11 @@ export interface ProviderCleanupOptions {
   provider: string;
 }
 
+export interface TrialDeploymentsOptions {
+  owner: string;
+  cutoffHeight: number;
+}
+
 export interface StaleDeploymentsOutput {
   dseq: number;
 }
@@ -51,6 +56,22 @@ export class DeploymentRepository {
       },
       group: ["deployment.dseq"],
       having: literal(`COUNT("leases"."deploymentId") = 0`),
+      raw: true
+    });
+
+    return deployments ? (deployments as unknown as StaleDeploymentsOutput[]) : [];
+  }
+
+  async findTrialDeployments(options: TrialDeploymentsOptions): Promise<StaleDeploymentsOutput[]> {
+    const deployments = await Deployment.findAll({
+      attributes: ["dseq"],
+      where: {
+        owner: options.owner,
+        createdHeight: {
+          [Op.lt]: options.cutoffHeight
+        },
+        closedHeight: null
+      },
       raw: true
     });
 

--- a/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
@@ -14,7 +14,7 @@ export interface ProviderCleanupOptions {
   provider: string;
 }
 
-export interface TrialDeploymentsOptions {
+export interface DeploymentsBeforeCutoffOptions {
   owner: string;
   cutoffHeight: number;
 }
@@ -62,7 +62,7 @@ export class DeploymentRepository {
     return deployments ? (deployments as unknown as StaleDeploymentsOutput[]) : [];
   }
 
-  async findTrialDeployments(options: TrialDeploymentsOptions): Promise<StaleDeploymentsOutput[]> {
+  async findDeploymentsBeforeCutoff(options: DeploymentsBeforeCutoffOptions): Promise<StaleDeploymentsOutput[]> {
     const deployments = await Deployment.findAll({
       attributes: ["dseq"],
       where: {

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -166,12 +166,12 @@ describe(DrainingDeploymentService.name, () => {
       {
         name: "should calculate amount for integer block rate",
         input: { blockRate: 50 },
-        expected: 87463
+        expected: 90000
       },
       {
         name: "should floor decimal block rate",
         input: { blockRate: 10.7 },
-        expected: 18717
+        expected: 19260
       }
     ];
 

--- a/apps/api/src/deployment/services/trial-deployments-cleaner/trial-deployments-cleaner.service.spec.ts
+++ b/apps/api/src/deployment/services/trial-deployments-cleaner/trial-deployments-cleaner.service.spec.ts
@@ -1,0 +1,313 @@
+import "@test/mocks/logger-service.mock";
+
+import type { BillingConfig } from "@src/billing/providers";
+import type { UserWalletRepository } from "@src/billing/repositories";
+import type { RpcMessageService } from "@src/billing/services";
+import type { ManagedUserWalletService } from "@src/billing/services";
+import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import type { BlockRepository } from "@src/chain/repositories/block.repository";
+import type { ErrorService } from "@src/core/services/error/error.service";
+import type { DeploymentRepository, StaleDeploymentsOutput } from "@src/deployment/repositories/deployment/deployment.repository";
+import { averageBlockCountInAnHour } from "@src/utils/constants";
+import { TrialDeploymentsCleanerService } from "./trial-deployments-cleaner.service";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { StaleDeploymentSeeder } from "@test/seeders/stale-deployment.seeder";
+import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+
+jest.mock("@akashnetwork/logging");
+
+describe(TrialDeploymentsCleanerService.name, () => {
+  const CURRENT_BLOCK_HEIGHT = 7481457;
+  const TRIAL_DEPLOYMENT_CLEANUP_HOURS = 24;
+
+  describe("cleanup", () => {
+    const CONCURRENCY = 10;
+    const CUTOFF_HEIGHT = CURRENT_BLOCK_HEIGHT - Math.floor(TRIAL_DEPLOYMENT_CLEANUP_HOURS * averageBlockCountInAnHour);
+
+    it("should cleanup trial deployments for trial users", async () => {
+      const trialWallets = [
+        UserWalletSeeder.create({
+          address: createAkashAddress(),
+          isTrialing: true
+        }),
+        UserWalletSeeder.create({
+          address: createAkashAddress(),
+          isTrialing: true
+        })
+      ];
+
+      const staleDeployments1 = [StaleDeploymentSeeder.create({ dseq: 123456 }), StaleDeploymentSeeder.create({ dseq: 123457 })];
+
+      const staleDeployments2 = [StaleDeploymentSeeder.create({ dseq: 123458 })];
+
+      const closeMessages1 = [
+        { type: "close", dseq: "123456" },
+        { type: "close", dseq: "123457" }
+      ];
+
+      const closeMessages2 = [{ type: "close", dseq: "123458" }];
+
+      const { service, userWalletRepository, deploymentRepository, blockRepository, rpcMessageService, managedSignerService } = setup({
+        trialWallets,
+        staleDeployments1,
+        staleDeployments2,
+        closeMessages1,
+        closeMessages2,
+        concurrency: CONCURRENCY
+      });
+
+      await service.cleanup({ concurrency: CONCURRENCY });
+
+      expect(blockRepository.getLatestHeight).toHaveBeenCalled();
+      expect(userWalletRepository.paginate).toHaveBeenCalledWith(
+        {
+          query: { isTrialing: true },
+          limit: CONCURRENCY
+        },
+        expect.any(Function)
+      );
+
+      expect(deploymentRepository.findTrialDeployments).toHaveBeenCalledWith({
+        owner: trialWallets[0].address,
+        cutoffHeight: CUTOFF_HEIGHT
+      });
+      expect(deploymentRepository.findTrialDeployments).toHaveBeenCalledWith({
+        owner: trialWallets[1].address,
+        cutoffHeight: CUTOFF_HEIGHT
+      });
+
+      expect(rpcMessageService.getCloseDeploymentMsg).toHaveBeenCalledWith(trialWallets[0].address, staleDeployments1[0].dseq);
+      expect(rpcMessageService.getCloseDeploymentMsg).toHaveBeenCalledWith(trialWallets[0].address, staleDeployments1[1].dseq);
+      expect(rpcMessageService.getCloseDeploymentMsg).toHaveBeenCalledWith(trialWallets[1].address, staleDeployments2[0].dseq);
+
+      expect(managedSignerService.executeManagedTx).toHaveBeenCalledWith(trialWallets[0].id, closeMessages1);
+      expect(managedSignerService.executeManagedTx).toHaveBeenCalledWith(trialWallets[1].id, closeMessages2);
+    });
+
+    it("should not process wallets with no stale deployments", async () => {
+      const trialWallets = [
+        UserWalletSeeder.create({
+          address: createAkashAddress(),
+          isTrialing: true
+        })
+      ];
+
+      const { service, deploymentRepository, rpcMessageService, managedSignerService } = setup({
+        trialWallets,
+        staleDeployments: [],
+        concurrency: CONCURRENCY
+      });
+
+      await service.cleanup({ concurrency: CONCURRENCY });
+
+      expect(deploymentRepository.findTrialDeployments).toHaveBeenCalledWith({
+        owner: trialWallets[0].address,
+        cutoffHeight: CUTOFF_HEIGHT
+      });
+
+      // Should not call RPC message service or managed signer service
+      expect(rpcMessageService.getCloseDeploymentMsg).not.toHaveBeenCalled();
+      expect(managedSignerService.executeManagedTx).not.toHaveBeenCalled();
+    });
+
+    it("should handle fee authorization errors and retry", async () => {
+      const trialWallet = UserWalletSeeder.create({
+        address: createAkashAddress(),
+        isTrialing: true
+      });
+
+      const staleDeployments = [StaleDeploymentSeeder.create({ dseq: 123456 })];
+
+      const closeMessage = { type: "close", dseq: "123456" };
+
+      const { service, managedSignerService, managedUserWalletService, config } = setup({
+        trialWallets: [trialWallet],
+        staleDeployments,
+        closeMessages: [closeMessage],
+        concurrency: CONCURRENCY,
+        feeError: true
+      });
+
+      await service.cleanup({ concurrency: CONCURRENCY });
+
+      expect(managedSignerService.executeManagedTx).toHaveBeenCalledTimes(2);
+      expect(managedUserWalletService.authorizeSpending).toHaveBeenCalledWith({
+        address: trialWallet.address,
+        limits: {
+          fees: config.FEE_ALLOWANCE_REFILL_AMOUNT
+        }
+      });
+    });
+
+    it("should use default concurrency when none provided", async () => {
+      const trialWallets = [
+        UserWalletSeeder.create({
+          address: createAkashAddress(),
+          isTrialing: true
+        })
+      ];
+
+      const { service, userWalletRepository } = setup({
+        trialWallets,
+        staleDeployments: [],
+        concurrency: 10
+      });
+
+      await service.cleanup({});
+
+      expect(userWalletRepository.paginate).toHaveBeenCalledWith(
+        {
+          query: { isTrialing: true },
+          limit: 10
+        },
+        expect.any(Function)
+      );
+    });
+
+    it("should handle non-fee errors and throw them", async () => {
+      const trialWallet = UserWalletSeeder.create({
+        address: createAkashAddress(),
+        isTrialing: true
+      });
+
+      const staleDeployments = [StaleDeploymentSeeder.create({ dseq: 123456 })];
+
+      const closeMessage = { type: "close", dseq: "123456" };
+
+      const { service, managedSignerService, managedUserWalletService } = setup({
+        trialWallets: [trialWallet],
+        staleDeployments,
+        closeMessages: [closeMessage],
+        concurrency: CONCURRENCY,
+        networkError: true
+      });
+
+      await service.cleanup({ concurrency: CONCURRENCY });
+
+      expect(managedSignerService.executeManagedTx).toHaveBeenCalledTimes(1);
+      expect(managedUserWalletService.authorizeSpending).not.toHaveBeenCalled();
+    });
+
+    function setup(input: {
+      trialWallets: any[];
+      staleDeployments?: StaleDeploymentsOutput[];
+      staleDeployments1?: StaleDeploymentsOutput[];
+      staleDeployments2?: StaleDeploymentsOutput[];
+      closeMessages?: any[];
+      closeMessages1?: any[];
+      closeMessages2?: any[];
+      concurrency?: number;
+      feeError?: boolean;
+      networkError?: boolean;
+    }) {
+      const userWalletRepository = {
+        paginate: jest.fn()
+      } as Partial<jest.Mocked<UserWalletRepository>> as jest.Mocked<UserWalletRepository>;
+
+      const deploymentRepository = {
+        findTrialDeployments: jest.fn()
+      } as Partial<jest.Mocked<DeploymentRepository>> as jest.Mocked<DeploymentRepository>;
+
+      const blockRepository = {
+        getLatestHeight: jest.fn().mockResolvedValue(CURRENT_BLOCK_HEIGHT)
+      } as Partial<jest.Mocked<BlockRepository>> as jest.Mocked<BlockRepository>;
+
+      const rpcMessageService = {
+        getCloseDeploymentMsg: jest.fn()
+      } as Partial<jest.Mocked<RpcMessageService>> as jest.Mocked<RpcMessageService>;
+
+      const managedSignerService = {
+        executeManagedTx: jest.fn()
+      } as Partial<jest.Mocked<ManagedSignerService>> as jest.Mocked<ManagedSignerService>;
+
+      const managedUserWalletService = {
+        authorizeSpending: jest.fn()
+      } as Partial<jest.Mocked<ManagedUserWalletService>> as jest.Mocked<ManagedUserWalletService>;
+
+      const errorService = {
+        execWithErrorHandler: jest.fn()
+      } as Partial<jest.Mocked<ErrorService>> as jest.Mocked<ErrorService>;
+
+      const config = {
+        TRIAL_DEPLOYMENT_CLEANUP_HOURS,
+        FEE_ALLOWANCE_REFILL_AMOUNT: 1000000
+      } as Partial<jest.Mocked<BillingConfig>> as jest.Mocked<BillingConfig>;
+
+      const service = new TrialDeploymentsCleanerService(
+        userWalletRepository,
+        deploymentRepository,
+        blockRepository,
+        rpcMessageService,
+        managedSignerService,
+        config,
+        managedUserWalletService,
+        errorService
+      );
+
+      // Mock user wallet pagination
+      (userWalletRepository.paginate as jest.Mock).mockImplementation(async (params, callback) => {
+        expect(params.query.isTrialing).toBe(true);
+        expect(params.limit).toBe(input.concurrency || 10);
+        await callback(input.trialWallets);
+      });
+
+      // Mock deployment repository
+      if (input.staleDeployments1 && input.staleDeployments2) {
+        (deploymentRepository.findTrialDeployments as jest.Mock).mockResolvedValueOnce(input.staleDeployments1).mockResolvedValueOnce(input.staleDeployments2);
+      } else if (input.staleDeployments) {
+        (deploymentRepository.findTrialDeployments as jest.Mock).mockResolvedValue(input.staleDeployments);
+      }
+
+      // Mock RPC message service
+      if (input.closeMessages1 && input.closeMessages2) {
+        (rpcMessageService.getCloseDeploymentMsg as jest.Mock)
+          .mockReturnValueOnce(input.closeMessages1[0])
+          .mockReturnValueOnce(input.closeMessages1[1])
+          .mockReturnValueOnce(input.closeMessages2[0]);
+      } else if (input.closeMessages) {
+        input.closeMessages.forEach(message => {
+          (rpcMessageService.getCloseDeploymentMsg as jest.Mock).mockReturnValueOnce(message);
+        });
+      }
+
+      // Mock managed signer service
+      if (input.feeError) {
+        (managedSignerService.executeManagedTx as jest.Mock).mockRejectedValueOnce(new Error("not allowed to pay fees")).mockResolvedValueOnce(undefined);
+      } else if (input.networkError) {
+        const networkError = new Error("Network timeout");
+        (managedSignerService.executeManagedTx as jest.Mock).mockRejectedValue(networkError);
+      } else {
+        (managedSignerService.executeManagedTx as jest.Mock).mockResolvedValue(undefined);
+      }
+
+      // Mock managed user wallet service
+      (managedUserWalletService.authorizeSpending as jest.Mock).mockResolvedValue(undefined);
+
+      // Mock error service to execute the cleanup function
+      (errorService.execWithErrorHandler as jest.Mock).mockImplementation(async (params, cleanupFn) => {
+        expect(params.wallet).toBeDefined();
+        expect(params.event).toBe("TRIAL_DEPLOYMENT_CLEANUP_ERROR");
+        expect(params.context).toBe(TrialDeploymentsCleanerService.name);
+
+        if (input.networkError) {
+          await expect(cleanupFn()).rejects.toThrow("Network timeout");
+        } else {
+          await cleanupFn();
+        }
+      });
+
+      return {
+        service,
+        userWalletRepository,
+        deploymentRepository,
+        blockRepository,
+        rpcMessageService,
+        managedSignerService,
+        managedUserWalletService,
+        errorService,
+        config
+      };
+    }
+  });
+});

--- a/apps/api/src/deployment/services/trial-deployments-cleaner/trial-deployments-cleaner.service.ts
+++ b/apps/api/src/deployment/services/trial-deployments-cleaner/trial-deployments-cleaner.service.ts
@@ -14,6 +14,7 @@ import { averageBlockCountInAnHour } from "@src/utils/constants";
 @singleton()
 export class TrialDeploymentsCleanerService {
   private readonly logger = LoggerService.forContext(TrialDeploymentsCleanerService.name);
+  private readonly MAX_LIVE_BLOCKS = Math.floor(this.config.TRIAL_DEPLOYMENT_CLEANUP_HOURS * averageBlockCountInAnHour);
 
   constructor(
     private readonly userWalletRepository: UserWalletRepository,
@@ -28,15 +29,13 @@ export class TrialDeploymentsCleanerService {
 
   async cleanup(options: CleanUpTrialDeploymentsParams) {
     const currentHeight = await this.blockRepository.getLatestHeight();
-    const blocksToSubtract = Math.floor(this.config.TRIAL_DEPLOYMENT_CLEANUP_HOURS * averageBlockCountInAnHour);
-    const cutoffHeight = currentHeight - blocksToSubtract;
+    const cutoffHeight = currentHeight - this.MAX_LIVE_BLOCKS;
 
     this.logger.info({
       event: "TRIAL_DEPLOYMENT_CLEANUP_START",
       currentHeight,
       cutoffHeight,
-      cleanupHours: this.config.TRIAL_DEPLOYMENT_CLEANUP_HOURS,
-      blocksToSubtract
+      cleanupHours: this.config.TRIAL_DEPLOYMENT_CLEANUP_HOURS
     });
 
     await this.userWalletRepository.paginate(

--- a/apps/api/src/deployment/services/trial-deployments-cleaner/trial-deployments-cleaner.service.ts
+++ b/apps/api/src/deployment/services/trial-deployments-cleaner/trial-deployments-cleaner.service.ts
@@ -1,0 +1,112 @@
+import { LoggerService } from "@akashnetwork/logging";
+import { singleton } from "tsyringe";
+
+import { BillingConfig, InjectBillingConfig } from "@src/billing/providers";
+import { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
+import { ManagedUserWalletService, RpcMessageService } from "@src/billing/services";
+import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import { BlockRepository } from "@src/chain/repositories/block.repository";
+import { ErrorService } from "@src/core/services/error/error.service";
+import { DeploymentRepository, StaleDeploymentsOutput } from "@src/deployment/repositories/deployment/deployment.repository";
+import { CleanUpTrialDeploymentsParams } from "@src/deployment/types/trial-deployments";
+import { averageBlockCountInAnHour } from "@src/utils/constants";
+
+@singleton()
+export class TrialDeploymentsCleanerService {
+  private readonly logger = LoggerService.forContext(TrialDeploymentsCleanerService.name);
+
+  constructor(
+    private readonly userWalletRepository: UserWalletRepository,
+    private readonly deploymentRepository: DeploymentRepository,
+    private readonly blockRepository: BlockRepository,
+    private readonly rpcMessageService: RpcMessageService,
+    private readonly managedSignerService: ManagedSignerService,
+    @InjectBillingConfig() private readonly config: BillingConfig,
+    private readonly managedUserWalletService: ManagedUserWalletService,
+    private readonly errorService: ErrorService
+  ) {}
+
+  async cleanup(options: CleanUpTrialDeploymentsParams) {
+    const currentHeight = await this.blockRepository.getLatestHeight();
+    const blocksToSubtract = Math.floor(this.config.TRIAL_DEPLOYMENT_CLEANUP_HOURS * averageBlockCountInAnHour);
+    const cutoffHeight = currentHeight - blocksToSubtract;
+
+    this.logger.info({
+      event: "TRIAL_DEPLOYMENT_CLEANUP_START",
+      currentHeight,
+      cutoffHeight,
+      cleanupHours: this.config.TRIAL_DEPLOYMENT_CLEANUP_HOURS,
+      blocksToSubtract
+    });
+
+    await this.userWalletRepository.paginate(
+      {
+        query: { isTrialing: true },
+        limit: options.concurrency || 10
+      },
+      async wallets => {
+        const cleanUpAllWallets = wallets.map(async wallet => {
+          await this.errorService.execWithErrorHandler(
+            {
+              wallet,
+              event: "TRIAL_DEPLOYMENT_CLEANUP_ERROR",
+              context: TrialDeploymentsCleanerService.name
+            },
+            () => this.cleanUpForWallet(wallet, cutoffHeight)
+          );
+        });
+
+        await Promise.all(cleanUpAllWallets);
+      }
+    );
+
+    this.logger.info({ event: "TRIAL_DEPLOYMENT_CLEANUP_COMPLETE" });
+  }
+
+  private async cleanUpForWallet(wallet: UserWalletOutput, cutoffHeight: number) {
+    const deployments = await this.deploymentRepository.findTrialDeployments({
+      owner: wallet.address!,
+      cutoffHeight
+    });
+
+    if (!deployments.length) {
+      return;
+    }
+
+    const messages = deployments.map((deployment: StaleDeploymentsOutput) => this.rpcMessageService.getCloseDeploymentMsg(wallet.address!, deployment.dseq));
+
+    this.logger.info({
+      event: "TRIAL_DEPLOYMENT_CLEANUP",
+      owner: wallet.address,
+      deploymentCount: deployments.length,
+      dseqs: deployments.map((d: StaleDeploymentsOutput) => d.dseq)
+    });
+
+    try {
+      await this.managedSignerService.executeManagedTx(wallet.id, messages);
+      this.logger.info({
+        event: "TRIAL_DEPLOYMENT_CLEANUP_SUCCESS",
+        owner: wallet.address,
+        deploymentCount: deployments.length
+      });
+    } catch (error: any) {
+      if (error.message.includes("not allowed to pay fees")) {
+        await this.managedUserWalletService.authorizeSpending({
+          address: wallet.address!,
+          limits: {
+            fees: this.config.FEE_ALLOWANCE_REFILL_AMOUNT
+          }
+        });
+
+        await this.managedSignerService.executeManagedTx(wallet.id, messages);
+        this.logger.info({
+          event: "TRIAL_DEPLOYMENT_CLEANUP_SUCCESS",
+          owner: wallet.address,
+          deploymentCount: deployments.length
+        });
+      } else {
+        throw error;
+      }
+    }
+  }
+}

--- a/apps/api/src/deployment/types/trial-deployments.ts
+++ b/apps/api/src/deployment/types/trial-deployments.ts
@@ -1,0 +1,3 @@
+import type { ConcurrencyOptions } from "@src/core/types/console";
+
+export interface CleanUpTrialDeploymentsParams extends ConcurrencyOptions {}

--- a/apps/api/src/utils/constants.ts
+++ b/apps/api/src/utils/constants.ts
@@ -2,7 +2,7 @@ import { netConfig, type SupportedChainNetworks } from "@akashnetwork/net";
 
 import { env } from "./env";
 
-export const averageBlockTime = 6.174;
+export const averageBlockTime = 6;
 export const averageDaysInMonth = 30.437;
 export const averageHoursInAMonth = averageDaysInMonth * 24;
 export const averageBlockCountInAMonth = (averageDaysInMonth * 24 * 60 * 60) / averageBlockTime;

--- a/apps/api/test/functional/gpu.spec.ts
+++ b/apps/api/test/functional/gpu.spec.ts
@@ -265,6 +265,8 @@ describe("GPU API", () => {
 
   describe("GET /v1/gpu-prices", () => {
     it("returns GPU pricing information", async () => {
+      await setup();
+
       const response = await app.request(`/v1/gpu-prices`);
 
       expect(response.status).toBe(200);
@@ -306,11 +308,11 @@ describe("GPU API", () => {
             },
             price: {
               currency: "USD",
-              min: 1.17,
-              max: 1.17,
-              avg: 1.17,
-              weightedAverage: 1.17,
-              med: 1.17
+              min: 1.2,
+              max: 1.2,
+              avg: 1.2,
+              weightedAverage: 1.2,
+              med: 1.2
             }
           },
           {
@@ -328,11 +330,11 @@ describe("GPU API", () => {
             },
             price: {
               currency: "USD",
-              min: 0.58,
-              max: 0.58,
-              avg: 0.58,
-              weightedAverage: 0.58,
-              med: 0.58
+              min: 0.6,
+              max: 0.6,
+              avg: 0.6,
+              weightedAverage: 0.6,
+              med: 0.6
             }
           },
           {

--- a/apps/api/test/seeders/index.ts
+++ b/apps/api/test/seeders/index.ts
@@ -10,5 +10,6 @@ export * from "./deployment-group-resource.seeder";
 export * from "./akash-message.seeder";
 export * from "./akash-address.seeder";
 export * from "./lease.seeder";
+export * from "./stale-deployment.seeder";
 export * from "./transaction.seeder";
 export * from "./validator.seeder";

--- a/apps/api/test/seeders/stale-deployment.seeder.ts
+++ b/apps/api/test/seeders/stale-deployment.seeder.ts
@@ -1,0 +1,11 @@
+import { faker } from "@faker-js/faker";
+
+import type { StaleDeploymentsOutput } from "@src/deployment/repositories/deployment/deployment.repository";
+
+export class StaleDeploymentSeeder {
+  static create({ dseq = faker.number.int({ min: 1, max: 99999999 }) }: Partial<StaleDeploymentsOutput> = {}): StaleDeploymentsOutput {
+    return {
+      dseq
+    };
+  }
+}


### PR DESCRIPTION
https://github.com/akash-network/console/issues/1700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced automated cleanup for trial deployments active beyond a configurable duration, accessible via a new CLI command.
  * Added services and controllers to support the cleanup process for stale trial deployments.
  * Added new environment variable to configure trial deployment cleanup timing.

* **Bug Fixes**
  * Adjusted GPU price statistics in tests for more accurate values.

* **Tests**
  * Added comprehensive tests for trial deployment cleanup logic and related services.
  * Updated tests to use dynamic dates and revised expected calculation outputs.
  * Introduced new test seeders for stale deployments.

* **Chores**
  * Exported new seeders for easier test data management.

* **Refactor**
  * Updated calculation constants for average block time and related values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->