### PR TITLE
feat: adds safe node packages installation

### DIFF
--- a/.github/actions/setup-app-deps/action.yml
+++ b/.github/actions/setup-app-deps/action.yml
@@ -37,7 +37,7 @@ runs:
         APP_UNDER_TEST: ${{ inputs.app }}
       run: |
         if [[ "$APP_UNDER_TEST" == "all" ]]; then
-          npm ci
+          npm run safe-install
         else
-          npm ci -w "apps/$APP_UNDER_TEST"
+          npm run safe-install -- -w "apps/$APP_UNDER_TEST"
         fi

--- a/.github/workflows/create-pre-release-pr.yml
+++ b/.github/workflows/create-pre-release-pr.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.deps-cache.outputs.cache-hit != 'true'
-        run: npm ci -w packages/releaser
+        run: npm run safe-install -- -w packages/releaser
 
       - name: Generate Release Changes
         run: |

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lint:fix": "npm run lint -- --fix",
     "prepare": "husky || true",
     "pretty": "prettier --write \"./**/*.{js,jsx,mjs,cjs,ts,tsx,json}\"",
+    "safe-install": "script/safe-deps-install.sh",
     "stats:dev": "turbo dev --filter=\"./apps/stats-web/\" --filter=\"./apps/api\"",
     "stats:dev:no-db": "cross-env SKIP_DC_DB=true turbo dev --filter=\"./apps/stats-web/\" --filter=\"./apps/api\"",
     "update-apps-local-deps": "turbo update-apps-local-deps --filter=\"./packages/*\""
@@ -85,5 +86,11 @@
   "volta": {
     "node": "22.14.0",
     "npm": "11.2.0"
-  }
+  },
+  "trustedDependencies": [
+    "esbuild@0.24.2",
+    "@swc/core@1.11.10",
+    "@sentry/cli@2.39.1",
+    "unrs-resolver@1.3.3"
+  ]
 }

--- a/packages/docker/Dockerfile.nextjs
+++ b/packages/docker/Dockerfile.nextjs
@@ -27,6 +27,8 @@ COPY --parents /packages/*/package.json /app
 RUN npm version --allow-same-version 1.0.0 -w $WORKSPACE --no-workspaces-update && \
     npm install --package-lock-only
 
+COPY script/safe-deps-install.sh /app/script/safe-deps-install.sh
+
 FROM base AS development
 
 ENV NODE_ENV development
@@ -35,7 +37,7 @@ RUN apk add --no-cache libc6-compat
 
 COPY --from=prepare /app .
 
-RUN npm ci && npm cache clean --force
+RUN npm run safe-install && npm cache clean --force
 
 COPY $WORKSPACE ./$WORKSPACE
 COPY /packages /app/packages

--- a/packages/docker/Dockerfile.node
+++ b/packages/docker/Dockerfile.node
@@ -20,11 +20,13 @@ COPY --parents packages/*/package.json /app
 RUN npm version --allow-same-version 1.0.0 -w $WORKSPACE --no-workspaces-update && \
     npm install --package-lock-only
 
+COPY script/safe-deps-install.sh /app/script/safe-deps-install.sh
+
 FROM base AS development
 
 COPY --from=prepare /app .
 
-RUN npm ci --workspace $WORKSPACE && npm cache clean --force
+RUN npm run safe-install -- --workspace $WORKSPACE && npm cache clean --force
 COPY $WORKSPACE ./$WORKSPACE
 COPY packages ./packages
 
@@ -48,7 +50,7 @@ RUN addgroup --system --gid $APP_GROUP_ID $APP_GROUP \
 
 COPY --from=prepare /app .
 # webpack built apps are not fully bundled, so we need to install dependencies separately
-RUN npm ci --workspace $WORKSPACE --omit=dev && npm cache clean --force
+RUN npm run safe-install -- --workspace $WORKSPACE --omit=dev && npm cache clean --force
 
 COPY --from=builder /app/package*.json /app/
 COPY --from=builder /app/$WORKSPACE/package.json /app/$WORKSPACE/

--- a/script/safe-deps-install.sh
+++ b/script/safe-deps-install.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env sh
+
+##
+# This script is used to install the dependencies for the project.
+# It ignores the postinstall scripts for all packages except those listed in trusted_deps list.
+# This gives us additional security protection against malicious packages.
+##
+
+# Enable debugging in GHA
+if [ "$ACTIONS_RUNNER_DEBUG" = "true" ]; then
+  set -x
+fi
+
+print_message() {
+  color=$1
+  shift
+  message=$@
+
+  case $color in
+    "error")
+      echo "\033[0;31mERROR:\033[0m $message"
+      ;;
+    "warn")
+      echo "\033[0;33mWARNING:\033[0m $message"
+      ;;
+    "important")
+      echo "\033[1m$message\033[0m"
+      ;;
+    * )
+      echo "$message"
+      ;;
+  esac
+}
+
+npm ci --ignore-scripts "${@}"
+
+echo "\n"
+print_message "important" "Triggering install npm script for trusted packages"
+echo "\n"
+
+for package_and_version in $(node -p -e 'require("./package.json").trustedDependencies.join("\n")'); do
+  if [ "$(echo $package_and_version | cut -c1)" = "@" ]; then
+    package=@$(echo $package_and_version | cut -d'@' -f2)
+    trusted_version=$(echo $package_and_version | cut -d'@' -f3)
+  else
+    package=$(echo $package_and_version | cut -d'@' -f1)
+    trusted_version=$(echo $package_and_version | cut -d'@' -f2)
+  fi
+
+  print_message "info" "$package@$trusted_version: npm run install"
+
+  if [ -z "$trusted_version" ]; then
+    print_message "error" "Skipping $package_and_version because it does not have a version"
+    echo "\n"
+    continue
+  fi
+
+  for package_json_path in $(find . -name package.json ! -path \*/.next/\* -path \*/node_modules/$package/\* -print); do
+    dir_path=$(dirname $package_json_path)
+    pkg_version=$(grep -E '"version": *"[^"]*"' $package_json_path | head -n 1 | cut -d'"' -f4)
+
+    if [ "$pkg_version" != "$trusted_version" ]; then
+      print_message "error" "$package_json_path (version: $pkg_version) is not trusted (expected: $trusted_version)"
+      continue
+    fi
+
+    print_message "info" "... running npm run install in $dir_path (version: $pkg_version)"
+    (cd $dir_path && npm run --if-present install) || print_message "error" "  $package_json_path (version: $pkg_version) failed to run npm run install"
+  done
+  echo "\n"
+done


### PR DESCRIPTION
## Why

To prevent potential security attacks from a package by using pre/postinstall hooks. Additionally we will know for what packages (and which versions!) we need to run pre/postinstall script. Usually package authors use that hooks to compile a package written in another language or to download some binaries specific to the machine which uses this dependency

Closes #1549 

## What

Adds `safe-install` npm script which is a wrapper around `npm ci --ignore-scripts`. Additionally, it reads `trustedDependencies` array from package.json and runs for every package `npm run install` if its version matches trusted version. Otherwise package is ignored.

The script doesn't fail but prints a log of errors. It's done intentionally because sometimes we may want to just ignore it and not fail CI. Anyway, if that package does something important, then CI will fail on later stage

`trustedDependencies` is not an object as other `*Depndencies` because we may want to specify multiple packages with the same name but different versions. And **yes**, it's important to ensure that package specific version and what its pre/postinstall script does. We don't have those much and will not update them often.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency installation across workflows and Dockerfiles to use a new custom script that selectively runs trusted post-install scripts.
  * Added a new npm script for safe dependency installation to improve security and reliability.
  * Introduced a list of trusted dependency versions for better control and transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->