### PR TITLE
fix: handle "tx already in cache" gracefully

### DIFF
--- a/apps/api/src/billing/lib/batch-signing-client/batch-signing-client.service.spec.ts
+++ b/apps/api/src/billing/lib/batch-signing-client/batch-signing-client.service.spec.ts
@@ -1,0 +1,87 @@
+import { sha256 } from "@cosmjs/crypto";
+import { toHex } from "@cosmjs/encoding";
+import { Registry } from "@cosmjs/proto-signing";
+import { TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx";
+import { mock } from "jest-mock-extended";
+
+import type { BillingConfigService } from "../../services/billing-config/billing-config.service";
+import { SyncSigningStargateClient } from "../sync-signing-stargate-client/sync-signing-stargate-client";
+import type { Wallet } from "../wallet/wallet";
+import { BatchSigningClientService } from "./batch-signing-client.service";
+
+describe("BatchSigningClientService", () => {
+  it("should handle duplicate tx error gracefully and proceed with hash", async () => {
+    const { service, expectedHash } = setup();
+    const messages = [{ typeUrl: "/akash.test.MsgTest", value: {} }];
+
+    const result = await service["executeTxBatch"]([{ messages }]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.hash).toBe(expectedHash);
+  });
+
+  function setup() {
+    const dummyTxRaw = TxRaw.fromPartial({
+      bodyBytes: new Uint8Array([1, 2, 3]),
+      authInfoBytes: new Uint8Array([4, 5, 6]),
+      signatures: [new Uint8Array([7, 8, 9])]
+    });
+    const dummyTxBytes = TxRaw.encode(dummyTxRaw).finish();
+    const expectedHash = toHex(sha256(dummyTxBytes));
+
+    const mockWallet = mock<Wallet>();
+    mockWallet.getFirstAddress.mockResolvedValue("akash1testaddress");
+
+    const mockConfig = mock<BillingConfigService>();
+    (mockConfig.get as jest.Mock).mockImplementation((key: string) => {
+      if (key === "MASTER_WALLET_MNEMONIC") return "test mnemonic";
+      if (key === "RPC_NODE_ENDPOINT") return "http://localhost:26657";
+      if (key === "WALLET_BATCHING_INTERVAL_MS") return "0";
+      if (key === "GAS_SAFETY_MULTIPLIER") return "1.2";
+      if (key === "AVERAGE_GAS_PRICE") return 0.025;
+      return undefined;
+    });
+
+    const mockRegistry = new Registry();
+
+    const mockClient = mock<SyncSigningStargateClient>();
+    mockClient.getChainId.mockResolvedValue("test-chain");
+    mockClient.getAccount.mockResolvedValue({
+      address: "akash1testaddress",
+      pubkey: null,
+      accountNumber: 1,
+      sequence: 1
+    });
+    mockClient.sign.mockResolvedValue(dummyTxRaw);
+    mockClient.simulate.mockResolvedValue(100000);
+    mockClient.getTx.mockResolvedValue({
+      height: 1,
+      txIndex: 0,
+      hash: expectedHash,
+      code: 0,
+      events: [],
+      rawLog: "",
+      tx: new Uint8Array(),
+      msgResponses: [],
+      gasUsed: BigInt(100000),
+      gasWanted: BigInt(100000)
+    });
+
+    mockClient.tmBroadcastTxSync.mockImplementation(async () => {
+      const error = new Error("tx already exists in cache");
+      throw error;
+    });
+    mockClient.broadcastTx.mockImplementation(async () => {
+      const error = new Error("tx already exists in cache");
+      throw error;
+    });
+
+    Object.defineProperty(SyncSigningStargateClient, "connectWithSigner", {
+      value: jest.fn().mockResolvedValue(mockClient)
+    });
+
+    const service = new BatchSigningClientService(mockConfig, mockWallet, mockRegistry);
+
+    return { service, expectedHash, mockWallet, mockConfig, mockRegistry, mockClient };
+  }
+});

--- a/apps/api/src/billing/providers/signing-client.provider.ts
+++ b/apps/api/src/billing/providers/signing-client.provider.ts
@@ -1,6 +1,7 @@
 import { container, inject } from "tsyringe";
 
 import { BatchSigningClientService } from "@src/billing/lib/batch-signing-client/batch-signing-client.service";
+import { SyncSigningStargateClient } from "@src/billing/lib/sync-signing-stargate-client/sync-signing-stargate-client";
 import { TYPE_REGISTRY } from "@src/billing/providers/type-registry.provider";
 import { MANAGED_MASTER_WALLET, UAKT_TOP_UP_MASTER_WALLET, USDC_TOP_UP_MASTER_WALLET } from "@src/billing/providers/wallet.provider";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
@@ -9,7 +10,13 @@ import type { MasterWalletType } from "@src/billing/types/wallet.type";
 export const MANAGED_MASTER_SIGNING_CLIENT = "MANAGED_MASTER_SIGNING_CLIENT";
 container.register(MANAGED_MASTER_SIGNING_CLIENT, {
   useFactory: c =>
-    new BatchSigningClientService(c.resolve(BillingConfigService), c.resolve(MANAGED_MASTER_WALLET), c.resolve(TYPE_REGISTRY), MANAGED_MASTER_SIGNING_CLIENT)
+    new BatchSigningClientService(
+      c.resolve(BillingConfigService),
+      c.resolve(MANAGED_MASTER_WALLET),
+      c.resolve(TYPE_REGISTRY),
+      SyncSigningStargateClient.connectWithSigner.bind(SyncSigningStargateClient),
+      MANAGED_MASTER_SIGNING_CLIENT
+    )
 });
 
 export const UAKT_TOP_UP_MASTER_SIGNING_CLIENT = "UAKT_TOP_UP_MASTER_SIGNING_CLIENT";
@@ -19,6 +26,7 @@ container.register(UAKT_TOP_UP_MASTER_SIGNING_CLIENT, {
       c.resolve(BillingConfigService),
       c.resolve(UAKT_TOP_UP_MASTER_WALLET),
       c.resolve(TYPE_REGISTRY),
+      SyncSigningStargateClient.connectWithSigner.bind(SyncSigningStargateClient),
       UAKT_TOP_UP_MASTER_SIGNING_CLIENT
     )
 });
@@ -30,6 +38,7 @@ container.register(USDC_TOP_UP_MASTER_SIGNING_CLIENT, {
       c.resolve(BillingConfigService),
       c.resolve(USDC_TOP_UP_MASTER_WALLET),
       c.resolve(TYPE_REGISTRY),
+      SyncSigningStargateClient.connectWithSigner.bind(SyncSigningStargateClient),
       USDC_TOP_UP_MASTER_SIGNING_CLIENT
     )
 });

--- a/apps/api/src/billing/services/dedupe-signing-client/dedupe-signing-client.service.ts
+++ b/apps/api/src/billing/services/dedupe-signing-client/dedupe-signing-client.service.ts
@@ -4,6 +4,7 @@ import * as crypto from "crypto";
 import { singleton } from "tsyringe";
 
 import { BatchSigningClientService, ExecuteTxOptions } from "@src/billing/lib/batch-signing-client/batch-signing-client.service";
+import { SyncSigningStargateClient } from "@src/billing/lib/sync-signing-stargate-client/sync-signing-stargate-client";
 import { Wallet } from "@src/billing/lib/wallet/wallet";
 import { InjectTypeRegistry } from "@src/billing/providers/type-registry.provider";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
@@ -44,7 +45,12 @@ export class DedupeSigningClientService {
       this.logger.debug({ event: "DEDUPE_SIGNING_CLIENT_CREATE", key });
       this.clientsByAddress.set(key, {
         key: key,
-        client: new BatchSigningClientService(this.config, new Wallet(mnemonic, addressIndex), this.registry)
+        client: new BatchSigningClientService(
+          this.config,
+          new Wallet(mnemonic, addressIndex),
+          this.registry,
+          SyncSigningStargateClient.connectWithSigner.bind(SyncSigningStargateClient)
+        )
       });
     }
 


### PR DESCRIPTION
closes #1692

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction batch processing to handle duplicate transaction errors gracefully, ensuring all transactions are processed and their hashes returned even if duplicates occur.

* **Tests**
  * Added tests verifying proper handling of duplicate transaction errors during batch processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->