### PR TITLE
fix: set a better date to work with

### DIFF
--- a/apps/api/test/functional/gpu.spec.ts
+++ b/apps/api/test/functional/gpu.spec.ts
@@ -6,6 +6,7 @@ import type { ProviderSnapshotNode } from "@akashnetwork/database/dbSchemas/akas
 import type { Day } from "@akashnetwork/database/dbSchemas/base/day";
 import type { Transaction } from "@akashnetwork/database/dbSchemas/base/transaction";
 import { faker } from "@faker-js/faker";
+import { format, setHours, setMinutes, setSeconds } from "date-fns";
 import Long from "long";
 import nock from "nock";
 
@@ -28,8 +29,8 @@ import {
 } from "@test/seeders";
 
 describe("GPU API", () => {
-  const now = new Date("2025-06-21T12:00:00.000Z");
-  const date = "2025-06-21";
+  const now = setSeconds(setMinutes(setHours(new Date(), 12), 0), 0);
+  const date = format(now, "yyyy-MM-dd");
 
   afterAll(async () => {
     await closeConnections();


### PR DESCRIPTION
Test started to break after we ran out of the 31-day window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated GPU API tests to use the current date dynamically instead of a fixed date, improving test flexibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->