### PR TITLE
refactor: stop extending Axios in HttpService, expect an instance instead

### DIFF
--- a/apps/api/src/chain/services/block-http/block-http.service.spec.ts
+++ b/apps/api/src/chain/services/block-http/block-http.service.spec.ts
@@ -2,23 +2,26 @@ import "@test/mocks/logger-service.mock";
 
 import { BlockHttpService as BlockHttpServiceCommon } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
+import axios from "axios";
 
 import { BlockHttpService } from "./block-http.service";
 
 describe(BlockHttpService.name, () => {
-  let service: BlockHttpService;
-  let blockHttpService: BlockHttpServiceCommon;
-
-  beforeEach(() => {
-    blockHttpService = new BlockHttpServiceCommon();
-    service = new BlockHttpService(blockHttpService);
-  });
-
   it("should get current height", async () => {
-    const height = faker.number.int({ min: 1000000, max: 10000000 });
-    jest.spyOn(blockHttpService, "getCurrentHeight").mockResolvedValue(height);
-    const result = await service.getCurrentHeight();
+    const { height, blockHttpService } = setup();
+
+    const result = await blockHttpService.getCurrentHeight();
 
     expect(result).toBe(height);
   });
+
+  const setup = () => {
+    const blockHttpServiceCommon = new BlockHttpServiceCommon(axios.create());
+    const blockHttpService = new BlockHttpService(blockHttpServiceCommon);
+
+    const height = faker.number.int({ min: 1000000, max: 10000000 });
+    jest.spyOn(blockHttpServiceCommon, "getCurrentHeight").mockResolvedValue(height);
+
+    return { height, blockHttpServiceCommon, blockHttpService };
+  };
 });

--- a/apps/api/src/core/providers/http-sdk.provider.ts
+++ b/apps/api/src/core/providers/http-sdk.provider.ts
@@ -11,6 +11,7 @@ import {
   NodeHttpService,
   ProviderHttpService
 } from "@akashnetwork/http-sdk";
+import axios from "axios";
 import { container } from "tsyringe";
 
 import { apiNodeUrl, nodeApiBasePath } from "@src/utils/constants";
@@ -26,8 +27,8 @@ const SERVICES = [
   CosmosHttpService
 ];
 
-SERVICES.forEach(Service => container.register(Service, { useValue: new Service({ baseURL: apiNodeUrl }) }));
+SERVICES.forEach(Service => container.register(Service, { useValue: new Service(axios.create({ baseURL: apiNodeUrl })) }));
 
-container.register(GitHubHttpService, { useValue: new GitHubHttpService({ baseURL: "https://raw.githubusercontent.com" }) });
-container.register(CoinGeckoHttpService, { useValue: new CoinGeckoHttpService({ baseURL: "https://api.coingecko.com" }) });
-container.register(NodeHttpService, { useValue: new NodeHttpService({ baseURL: nodeApiBasePath }) });
+container.register(GitHubHttpService, { useValue: new GitHubHttpService(axios.create({ baseURL: "https://raw.githubusercontent.com" })) });
+container.register(CoinGeckoHttpService, { useValue: new CoinGeckoHttpService(axios.create({ baseURL: "https://api.coingecko.com" })) });
+container.register(NodeHttpService, { useValue: new NodeHttpService(axios.create({ baseURL: nodeApiBasePath })) });

--- a/apps/api/test/services/test-wallet.service.ts
+++ b/apps/api/test/services/test-wallet.service.ts
@@ -2,6 +2,7 @@ import { BalanceHttpService } from "@akashnetwork/http-sdk";
 import type { EncodeObject } from "@cosmjs/proto-signing";
 import { coins } from "@cosmjs/proto-signing";
 import { calculateFee, GasPrice, SigningStargateClient } from "@cosmjs/stargate";
+import axios from "axios";
 import dotenv from "dotenv";
 import dotenvExpand from "dotenv-expand";
 import * as fs from "fs";
@@ -19,9 +20,11 @@ const MIN_AMOUNTS: Record<string, number> = {
 };
 
 export class TestWalletService {
-  private readonly balanceHttpService = new BalanceHttpService({
-    baseURL: config!.API_NODE_ENDPOINT
-  });
+  private readonly balanceHttpService = new BalanceHttpService(
+    axios.create({
+      baseURL: config!.API_NODE_ENDPOINT
+    })
+  );
 
   private mnemonics: Record<string, string> = {};
 

--- a/apps/deploy-web/src/components/turnstile/Turnstile.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.tsx
@@ -27,10 +27,10 @@ let originalFetch: typeof fetch | undefined;
 
 const addResponseInterceptor = (intercept: (service: Axios, value: AxiosError) => AxiosResponse | Promise<AxiosResponse>) => {
   const removes = HTTP_SERVICES.map(service => {
-    const interceptorId = service.interceptors.response.use(null, error => intercept(service, error));
+    const interceptorId = service.axios.interceptors.response.use(null, error => intercept(service.axios, error));
 
     return () => {
-      service.interceptors.response.eject(interceptorId);
+      service.axios.interceptors.response.eject(interceptorId);
     };
   });
 

--- a/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
+++ b/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
@@ -31,7 +31,7 @@ export function useServices() {
 
 function createAppContainer<T extends Factories>(settings: Settings, services: T) {
   const di = createChildContainer(rootContainer, {
-    authzHttpService: () => new AuthzHttpService({ baseURL: settings?.apiEndpoint }),
+    authzHttpService: () => new AuthzHttpService(rootContainer.createAxios({ baseURL: settings?.apiEndpoint })),
     walletBalancesService: () => new WalletBalancesService(di.authzHttpService, di.chainApiHttpClient, browserEnvConfig.NEXT_PUBLIC_MASTER_WALLET_ADDRESS),
     certificatesService: () => new CertificatesService(di.chainApiHttpClient),
     chainApiHttpClient: () => rootContainer.createAxios({ baseURL: settings?.apiEndpoint }),

--- a/apps/deploy-web/src/queries/useBalancesQuery.ts
+++ b/apps/deploy-web/src/queries/useBalancesQuery.ts
@@ -10,7 +10,7 @@ export function useBalances(address?: string, options?: Omit<UseQueryOptions<Bal
   return useQuery({
     queryKey: QueryKeys.getBalancesKey(address) as QueryKey,
     queryFn: () => (address ? di.walletBalancesService.getBalances(address) : null),
-    enabled: !!address && !!di.authzHttpService.getUri(),
+    enabled: !!address && !!di.authzHttpService.axios.getUri(),
     ...options
   });
 }

--- a/apps/deploy-web/src/queries/useGrantsQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useGrantsQuery.spec.tsx
@@ -28,7 +28,9 @@ describe("useGrantsQuery", () => {
       };
 
       const authzHttpService = mock<AuthzHttpService>({
-        defaults: { baseURL: "https://api.akash.network" },
+        axios: {
+          defaults: { baseURL: "https://api.akash.network" }
+        } as AxiosInstance,
         getPaginatedDepositDeploymentGrants: jest.fn().mockResolvedValue(mockData)
       });
       const { result } = setupQuery(() => useGranterGrants("test-address", 0, 1000), {
@@ -46,7 +48,9 @@ describe("useGrantsQuery", () => {
 
     it("does not fetch when address is not provided", () => {
       const authzHttpService = mock<AuthzHttpService>({
-        defaults: { baseURL: "https://api.akash.network" },
+        axios: {
+          defaults: { baseURL: "https://api.akash.network" }
+        } as AxiosInstance,
         getPaginatedDepositDeploymentGrants: jest.fn().mockResolvedValue([])
       });
       setupQuery(() => useGranterGrants("", 0, 1000), {
@@ -69,7 +73,9 @@ describe("useGrantsQuery", () => {
         }
       ];
       const authzHttpService = mock<AuthzHttpService>({
-        defaults: { baseURL: "https://api.akash.network" },
+        axios: {
+          defaults: { baseURL: "https://api.akash.network" }
+        } as AxiosInstance,
         getAllDepositDeploymentGrants: jest.fn().mockResolvedValue(mockData)
       });
 
@@ -88,7 +94,9 @@ describe("useGrantsQuery", () => {
 
     it("does not fetch when address is not provided", () => {
       const authzHttpService = mock<AuthzHttpService>({
-        defaults: { baseURL: "https://api.akash.network" },
+        axios: {
+          defaults: { baseURL: "https://api.akash.network" }
+        } as AxiosInstance,
         getAllDepositDeploymentGrants: jest.fn().mockResolvedValue([])
       });
       setupQuery(() => useGranteeGrants(""), {
@@ -108,7 +116,9 @@ describe("useGrantsQuery", () => {
         pagination: { total: 1 }
       };
       const authzHttpService = mock<AuthzHttpService>({
-        defaults: { baseURL: "https://api.akash.network" },
+        axios: {
+          defaults: { baseURL: "https://api.akash.network" }
+        } as AxiosInstance,
         getPaginatedFeeAllowancesForGranter: jest.fn().mockResolvedValue(mockData)
       });
 
@@ -127,7 +137,9 @@ describe("useGrantsQuery", () => {
 
     it("does not fetch when address is not provided", () => {
       const authzHttpService = mock<AuthzHttpService>({
-        defaults: { baseURL: "https://api.akash.network" },
+        axios: {
+          defaults: { baseURL: "https://api.akash.network" }
+        } as AxiosInstance,
         getPaginatedFeeAllowancesForGranter: jest.fn().mockResolvedValue([])
       });
       setupQuery(() => useAllowancesIssued("", 0, 1000), {

--- a/apps/deploy-web/src/queries/useGrantsQuery.ts
+++ b/apps/deploy-web/src/queries/useGrantsQuery.ts
@@ -17,7 +17,7 @@ export function useGranterGrants(
   const { authzHttpService } = useServices();
   const offset = page * limit;
 
-  options.enabled = options.enabled !== false && !!address && !!authzHttpService.defaults.baseURL;
+  options.enabled = options.enabled !== false && !!address && !!authzHttpService.axios.defaults.baseURL;
 
   return useQuery({
     queryKey: QueryKeys.getGranterGrants(address, page, offset),
@@ -29,7 +29,7 @@ export function useGranterGrants(
 export function useGranteeGrants(address: string, options: Omit<UseQueryOptions<DepositDeploymentGrant[]>, "queryKey" | "queryFn"> = {}) {
   const { authzHttpService } = useServices();
 
-  options.enabled = options.enabled !== false && !!address && !!authzHttpService.defaults.baseURL;
+  options.enabled = options.enabled !== false && !!address && !!authzHttpService.axios.defaults.baseURL;
 
   return useQuery({
     queryKey: QueryKeys.getGranteeGrants(address || "UNDEFINED"),
@@ -47,7 +47,7 @@ export function useAllowancesIssued(
   const { authzHttpService } = useServices();
   const offset = page * limit;
 
-  options.enabled = options.enabled !== false && !!address && !!authzHttpService.defaults.baseURL;
+  options.enabled = options.enabled !== false && !!address && !!authzHttpService.axios.defaults.baseURL;
 
   return useQuery({
     queryKey: QueryKeys.getAllowancesIssued(address, page, offset),

--- a/apps/deploy-web/src/services/http/http-browser.service.ts
+++ b/apps/deploy-web/src/services/http/http-browser.service.ts
@@ -19,7 +19,7 @@ const rootContainer = createAppRootContainer({
 });
 
 export const services = createChildContainer(rootContainer, {
-  userProviderService: () => new UserProviderService(),
+  userProviderService: () => new UserProviderService(services.defaultAxios),
   notificationsApi: () =>
     createAPIClient({
       requestFn,

--- a/apps/deploy-web/src/services/managed-wallet-http/managed-wallet-http.service.ts
+++ b/apps/deploy-web/src/services/managed-wallet-http/managed-wallet-http.service.ts
@@ -1,6 +1,6 @@
 import type { ApiManagedWalletOutput, ApiWalletOutput } from "@akashnetwork/http-sdk";
 import { ManagedWalletHttpService as ManagedWalletHttpServiceOriginal } from "@akashnetwork/http-sdk";
-import type { AxiosRequestConfig } from "axios";
+import type { AxiosInstance } from "axios";
 
 import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 
@@ -8,10 +8,10 @@ export class ManagedWalletHttpService extends ManagedWalletHttpServiceOriginal {
   private checkoutSessionId: string | null = null;
 
   constructor(
-    config: AxiosRequestConfig,
+    axios: AxiosInstance,
     private readonly analyticsService: AnalyticsService
   ) {
-    super(config);
+    super(axios);
 
     this.extractSessionResults();
   }

--- a/apps/deploy-web/src/services/user-provider/user-provider.service.ts
+++ b/apps/deploy-web/src/services/user-provider/user-provider.service.ts
@@ -1,14 +1,15 @@
 import { HttpService } from "@akashnetwork/http-sdk";
 import type { UserProfile } from "@auth0/nextjs-auth0/client";
-import type { InternalAxiosRequestConfig } from "axios";
+import type { AxiosInstance, InternalAxiosRequestConfig } from "axios";
 
 import { ANONYMOUS_USER_TOKEN_KEY } from "@src/config/auth.config";
 
 export class UserProviderService extends HttpService {
-  constructor() {
-    super();
+  constructor(axios: AxiosInstance) {
+    super(axios);
+
     this.getProfile = this.getProfile.bind(this);
-    this.interceptors.request.use((config: InternalAxiosRequestConfig) => {
+    this.axios.interceptors.request.use((config: InternalAxiosRequestConfig) => {
       const token = localStorage.getItem(ANONYMOUS_USER_TOKEN_KEY);
 
       if (token) {

--- a/apps/notifications/src/modules/alert/providers/http-sdk.provider.ts
+++ b/apps/notifications/src/modules/alert/providers/http-sdk.provider.ts
@@ -1,6 +1,7 @@
 import { DeploymentHttpService, LeaseHttpService } from "@akashnetwork/http-sdk";
 import type { Provider } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import axios from "axios";
 
 import type { AlertConfig } from "@src/modules/alert/config";
 
@@ -9,16 +10,20 @@ export const HTTP_SDK_PROVIDERS: Provider[] = [
     provide: DeploymentHttpService,
     inject: [ConfigService],
     useFactory: (configService: ConfigService<AlertConfig>) =>
-      new DeploymentHttpService({
-        baseURL: configService.getOrThrow("alert.API_NODE_ENDPOINT")
-      })
+      new DeploymentHttpService(
+        axios.create({
+          baseURL: configService.getOrThrow("alert.API_NODE_ENDPOINT")
+        })
+      )
   },
   {
     provide: LeaseHttpService,
     inject: [ConfigService],
     useFactory: (configService: ConfigService<AlertConfig>) =>
-      new LeaseHttpService({
-        baseURL: configService.getOrThrow("alert.API_NODE_ENDPOINT")
-      })
+      new LeaseHttpService(
+        axios.create({
+          baseURL: configService.getOrThrow("alert.API_NODE_ENDPOINT")
+        })
+      )
   }
 ];

--- a/packages/http-sdk/src/api-http/api-http.service.ts
+++ b/packages/http-sdk/src/api-http/api-http.service.ts
@@ -7,10 +7,6 @@ export interface ApiOutput<T> {
 }
 
 export class ApiHttpService extends HttpService {
-  constructor(config?: AxiosRequestConfig) {
-    super(config);
-  }
-
   post<T = any, R = AxiosResponse<ApiOutput<T>>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R> {
     return super.post(url, data, config);
   }

--- a/packages/http-sdk/src/auth/auth-http.service.ts
+++ b/packages/http-sdk/src/auth/auth-http.service.ts
@@ -1,12 +1,6 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { HttpService } from "../http/http.service";
 
 export class AuthHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-  }
-
   async sendVerificationEmail(userId: string) {
     return this.post("/v1/send-verification-email", { data: { userId } });
   }

--- a/packages/http-sdk/src/authz/authz-http.service.ts
+++ b/packages/http-sdk/src/authz/authz-http.service.ts
@@ -1,4 +1,3 @@
-import type { AxiosRequestConfig } from "axios";
 import { isFuture } from "date-fns";
 
 import { HttpService } from "../http/http.service";
@@ -58,10 +57,6 @@ export class AuthzHttpService extends HttpService {
     "/akash.deployment.v1beta3.DepositDeploymentAuthorization";
 
   private readonly FEE_ALLOWANCE_TYPE: FeeAllowance["allowance"]["@type"] = "/cosmos.feegrant.v1beta1.BasicAllowance";
-
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-  }
 
   async getFeeAllowancesForGrantee(address: string) {
     const allowances = this.extractData(await this.get<FeeAllowanceListResponse>(`cosmos/feegrant/v1beta1/allowances/${address}`));

--- a/packages/http-sdk/src/balance/balance-http.service.ts
+++ b/packages/http-sdk/src/balance/balance-http.service.ts
@@ -1,5 +1,3 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { HttpService } from "../http/http.service";
 import type { Denom } from "../types/denom.type";
 
@@ -18,10 +16,6 @@ interface BalanceResponse {
 }
 
 export class BalanceHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-  }
-
   async getBalance(address: string, denom: string): Promise<Balance | undefined> {
     const response = this.extractData(await this.get<BalanceResponse>(`cosmos/bank/v1beta1/balances/${address}/by_denom?denom=${denom}`));
     return response.balance ? { amount: parseFloat(response.balance.amount), denom: response.balance.denom } : undefined;

--- a/packages/http-sdk/src/bid/bid-http.service.ts
+++ b/packages/http-sdk/src/bid/bid-http.service.ts
@@ -1,5 +1,3 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { HttpService } from "../http/http.service";
 
 type Bid = {
@@ -51,10 +49,6 @@ type RestAkashBidListResponse = {
 };
 
 export class BidHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-  }
-
   public async list(owner: string, dseq: string): Promise<Bid[]> {
     const response = this.extractData(await this.get<RestAkashBidListResponse>(`/akash/market/v1beta4/bids/list?filters.owner=${owner}&filters.dseq=${dseq}`));
 

--- a/packages/http-sdk/src/block/block-http.service.ts
+++ b/packages/http-sdk/src/block/block-http.service.ts
@@ -1,5 +1,3 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { HttpService } from "../http/http.service";
 
 interface BlockResponse {
@@ -11,10 +9,6 @@ interface BlockResponse {
 }
 
 export class BlockHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-  }
-
   async getCurrentHeight() {
     const response = this.extractData(await this.get<BlockResponse>("blocks/latest"));
 

--- a/packages/http-sdk/src/coin-gecko/coin-gecko-http.service.ts
+++ b/packages/http-sdk/src/coin-gecko/coin-gecko-http.service.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, AxiosInstance, AxiosRequestConfig } from "axios";
+import type { AxiosError, AxiosInstance } from "axios";
 import axiosRetry from "axios-retry";
 
 import { HttpService } from "../http/http.service";
@@ -8,10 +8,10 @@ const RETRY_COUNT = 3;
 const RETRY_DELAY_MILLISECONDS = 100;
 
 export class CoinGeckoHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
+  constructor(axios: AxiosInstance) {
+    super(axios);
 
-    axiosRetry(this as unknown as AxiosInstance, {
+    axiosRetry(axios, {
       retries: RETRY_COUNT,
       retryDelay: retryCount => Math.pow(2, retryCount) * RETRY_DELAY_MILLISECONDS,
       retryCondition: (error: AxiosError) => axiosRetry.isNetworkError(error) || (error.response?.status !== undefined && error.response.status >= 500)

--- a/packages/http-sdk/src/cosmos/cosmos-http.service.ts
+++ b/packages/http-sdk/src/cosmos/cosmos-http.service.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, AxiosInstance, AxiosRequestConfig } from "axios";
+import type { AxiosError, AxiosInstance } from "axios";
 import axiosRetry from "axios-retry";
 
 import { HttpService } from "../http/http.service";
@@ -24,10 +24,10 @@ const RETRY_COUNT = 3;
 const RETRY_DELAY_MILLISECONDS = 100;
 
 export class CosmosHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
+  constructor(axios: AxiosInstance) {
+    super(axios);
 
-    axiosRetry(this as unknown as AxiosInstance, {
+    axiosRetry(axios, {
       retries: RETRY_COUNT,
       retryDelay: retryCount => Math.pow(2, retryCount) * RETRY_DELAY_MILLISECONDS,
       retryCondition: (error: AxiosError) => axiosRetry.isNetworkError(error) || (error.response?.status !== undefined && error.response.status >= 500)

--- a/packages/http-sdk/src/deployment-setting/deployment-setting-http.service.ts
+++ b/packages/http-sdk/src/deployment-setting/deployment-setting-http.service.ts
@@ -1,5 +1,3 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { ApiHttpService } from "../api-http/api-http.service";
 
 export interface DeploymentSettingOutput {
@@ -29,10 +27,6 @@ export interface FindDeploymentSettingParams {
 }
 
 export class DeploymentSettingHttpService extends ApiHttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-  }
-
   async findByUserIdAndDseq(params: FindDeploymentSettingParams): Promise<DeploymentSettingOutput> {
     return this.extractApiData(await this.get<DeploymentSettingOutput>(`/v1/deployment-settings/${params.userId}/${params.dseq}`));
   }

--- a/packages/http-sdk/src/deployment/deployment-http.service.ts
+++ b/packages/http-sdk/src/deployment/deployment-http.service.ts
@@ -1,4 +1,3 @@
-import type { AxiosRequestConfig } from "axios";
 import z from "zod";
 
 import { HttpService } from "../http/http.service";
@@ -132,10 +131,6 @@ interface PaginationParams {
 }
 
 export class DeploymentHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-  }
-
   public async findByOwnerAndDseq(owner: string, dseq: string): Promise<RestAkashDeploymentInfoResponse> {
     return this.extractData(
       await this.get<RestAkashDeploymentInfoResponse>("/akash/deployment/v1beta3/deployments/info", {
@@ -156,7 +151,7 @@ export class DeploymentHttpService extends HttpService {
    * @returns Paginated response with deployments
    */
   public async loadDeploymentList(owner: string, state?: "active" | "closed", pagination?: PaginationParams): Promise<DeploymentListResponse> {
-    const baseUrl = this.getUri({
+    const baseUrl = this.axios.getUri({
       url: `/akash/deployment/v1beta3/deployments/list?filters.owner=${owner}${state ? `&filters.state=${state}` : ""}`
     });
     const defaultLimit = 1000;

--- a/packages/http-sdk/src/git-hub/git-hub-http.service.ts
+++ b/packages/http-sdk/src/git-hub/git-hub-http.service.ts
@@ -1,5 +1,3 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { HttpService } from "../http/http.service";
 
 type ProviderAttributeSchemaDetailValue = { key: string; description: string; value?: string };
@@ -53,10 +51,6 @@ export class GitHubHttpService extends HttpService {
   private readonly organization = "akash-network";
   private readonly repository = "console";
   private readonly branch = "main";
-
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-  }
 
   async getProviderAttributesSchema() {
     return this.extractData(await this.get<ProviderAttributesSchema>(this.getFullPath("/config/provider-attributes.json")));

--- a/packages/http-sdk/src/http/http.service.ts
+++ b/packages/http-sdk/src/http/http.service.ts
@@ -1,15 +1,33 @@
-import axios, { Axios, type AxiosRequestConfig, type AxiosResponse } from "axios";
+import { type AxiosInstance, type AxiosResponse } from "axios";
 
-export class HttpService extends Axios {
-  constructor(config?: AxiosRequestConfig) {
-    const { headers, ...defaults } = axios.defaults;
-    super({
-      ...defaults,
-      ...config
-    });
-  }
+export class HttpService {
+  constructor(private readonly _axios: AxiosInstance) {}
 
   protected extractData<T = unknown>(response: AxiosResponse<T>): AxiosResponse<T>["data"] {
     return response.data;
+  }
+
+  get<T = unknown, R = AxiosResponse<T>>(...args: Parameters<AxiosInstance["get"]>): Promise<R> {
+    return this.axios.get(...args);
+  }
+
+  post<T = unknown, R = AxiosResponse<T>>(...args: Parameters<AxiosInstance["post"]>): Promise<R> {
+    return this.axios.post(...args);
+  }
+
+  patch<T = unknown, R = AxiosResponse<T>>(...args: Parameters<AxiosInstance["patch"]>): Promise<R> {
+    return this.axios.patch(...args);
+  }
+
+  put<T = unknown, R = AxiosResponse<T>>(...args: Parameters<AxiosInstance["put"]>): Promise<R> {
+    return this.axios.put(...args);
+  }
+
+  delete<T = unknown, R = AxiosResponse<T>>(...args: Parameters<AxiosInstance["delete"]>): Promise<R> {
+    return this.axios.delete(...args);
+  }
+
+  get axios() {
+    return this._axios;
   }
 }

--- a/packages/http-sdk/src/lease/lease-http.service.ts
+++ b/packages/http-sdk/src/lease/lease-http.service.ts
@@ -1,5 +1,3 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { HttpService } from "../http/http.service";
 
 export type RestAkashLeaseListResponse = {
@@ -55,10 +53,6 @@ type LeaseListParams = {
 };
 
 export class LeaseHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-  }
-
   public async list({ owner, dseq, state }: LeaseListParams): Promise<RestAkashLeaseListResponse> {
     return this.extractData(
       await this.get<RestAkashLeaseListResponse>("/akash/market/v1beta4/leases/list", {

--- a/packages/http-sdk/src/node/node-http.service.ts
+++ b/packages/http-sdk/src/node/node-http.service.ts
@@ -1,4 +1,4 @@
-import type { AxiosError, AxiosInstance, AxiosRequestConfig } from "axios";
+import type { AxiosError, AxiosInstance } from "axios";
 import axiosRetry from "axios-retry";
 
 import { HttpService } from "../http/http.service";
@@ -8,10 +8,10 @@ const RETRY_COUNT = 3;
 const RETRY_DELAY_MILLISECONDS = 100;
 
 export class NodeHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
+  constructor(axios: AxiosInstance) {
+    super(axios);
 
-    axiosRetry(this as unknown as AxiosInstance, {
+    axiosRetry(axios, {
       retries: RETRY_COUNT,
       retryDelay: retryCount => Math.pow(2, retryCount) * RETRY_DELAY_MILLISECONDS,
       retryCondition: (error: AxiosError) => axiosRetry.isNetworkError(error) || (error.response?.status !== undefined && error.response.status >= 500)

--- a/packages/http-sdk/src/provider/provider-http.service.ts
+++ b/packages/http-sdk/src/provider/provider-http.service.ts
@@ -1,13 +1,7 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { HttpService } from "../http/http.service";
 import type { GetProviderResponse } from "./types";
 
 export class ProviderHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-  }
-
   async getProvider(address: string): Promise<GetProviderResponse> {
     return this.extractData(await this.get<GetProviderResponse>(`/akash/provider/v1beta3/providers/${address}`));
   }

--- a/packages/http-sdk/src/stripe/stripe.service.ts
+++ b/packages/http-sdk/src/stripe/stripe.service.ts
@@ -13,10 +13,6 @@ import type {
 } from "./stripe.types";
 
 export class StripeService extends ApiHttpService {
-  constructor(config?: AxiosRequestConfig) {
-    super(config);
-  }
-
   // Payment Methods
   async createSetupIntent(config?: AxiosRequestConfig): Promise<SetupIntentResponse> {
     return this.extractApiData(await this.post("/v1/stripe/payment-methods/setup", {}, config));

--- a/packages/http-sdk/src/template/template-http.service.ts
+++ b/packages/http-sdk/src/template/template-http.service.ts
@@ -1,5 +1,3 @@
-import type { AxiosRequestConfig } from "axios";
-
 import type { ApiOutput } from "../api-http/api-http.service";
 import { ApiHttpService } from "../api-http/api-http.service";
 
@@ -33,10 +31,6 @@ export interface TemplateCategory {
 }
 
 export class TemplateHttpService extends ApiHttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-  }
-
   async findById(id: string): Promise<TemplateOutput> {
     return this.extractApiData(await this.get<TemplateOutput>(`/v1/templates/${id}`));
   }

--- a/packages/http-sdk/src/tx-http/tx-http.service.ts
+++ b/packages/http-sdk/src/tx-http/tx-http.service.ts
@@ -1,7 +1,7 @@
 import type { Registry } from "@cosmjs/proto-signing";
 import type { EncodeObject } from "@cosmjs/proto-signing/build/registry";
 import type { DeliverTxResponse } from "@cosmjs/stargate";
-import type { AxiosRequestConfig } from "axios";
+import type { AxiosInstance } from "axios";
 
 import { ApiHttpService } from "../api-http/api-http.service";
 
@@ -14,10 +14,10 @@ export type TxOutput = Pick<DeliverTxResponse, "code" | "transactionHash" | "raw
 
 export class TxHttpService extends ApiHttpService {
   constructor(
-    private readonly registry: Registry,
-    config?: AxiosRequestConfig
+    axios: AxiosInstance,
+    private readonly registry: Registry
   ) {
-    super(config);
+    super(axios);
   }
   async signAndBroadcastTx(input: TxInput) {
     const messages = input.messages.map(m => ({ ...m, value: Buffer.from(this.registry.encode(m)).toString("base64") }));

--- a/packages/http-sdk/src/usage/usage-http.service.ts
+++ b/packages/http-sdk/src/usage/usage-http.service.ts
@@ -1,4 +1,3 @@
-import type { AxiosRequestConfig } from "axios";
 import { format } from "date-fns";
 
 import { HttpService } from "../http/http.service";
@@ -11,10 +10,6 @@ type UsageParams = {
 };
 
 export class UsageHttpService extends HttpService {
-  constructor(config?: AxiosRequestConfig) {
-    super(config);
-  }
-
   async getUsage(params: UsageParams): Promise<UsageHistory> {
     return this.extractData(
       await this.get("/v1/usage/history", {

--- a/packages/http-sdk/src/user-http/user-http.service.ts
+++ b/packages/http-sdk/src/user-http/user-http.service.ts
@@ -1,4 +1,4 @@
-import type { AxiosRequestConfig } from "axios";
+import type { AxiosInstance } from "axios";
 import memoize from "lodash/memoize";
 
 import type { ApiOutput } from "../api-http/api-http.service";
@@ -25,8 +25,9 @@ export type UserCreateResponse = {
 };
 
 export class UserHttpService extends HttpService {
-  constructor(config?: AxiosRequestConfig) {
-    super(config);
+  constructor(axios: AxiosInstance) {
+    super(axios);
+
     this.getOrCreateAnonymousUser = memoize(this.getOrCreateAnonymousUser.bind(this));
   }
 


### PR DESCRIPTION
closes #1424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified all HTTP service classes to use pre-configured Axios instances instead of configuration objects.
  * Centralized Axios instance creation and interceptor management across backend and frontend services.
  * Updated service constructors and dependency injection to accept Axios instances, simplifying service instantiation and configuration.
  * Improved analytics tracking for specific API responses by consolidating response interceptors.
  * No changes to user-facing features or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->