### PR TITLE
feat: adds logging to retry logic in provider-proxy

### DIFF
--- a/apps/provider-proxy/src/routes/proxyProviderRequest.ts
+++ b/apps/provider-proxy/src/routes/proxyProviderRequest.ts
@@ -80,7 +80,8 @@ export async function proxyProviderRequest(ctx: AppContext): Promise<Response | 
         const isServerError = result.ok && (!result.response.statusCode || result.response.statusCode > 500);
         const isConnectionError = result.ok === false && result.code === "connectionError" && canRetryOnError(result.error);
         return isServerError || isConnectionError;
-      }
+      },
+      logger: ctx.get("container").appLogger
     }
   );
 

--- a/apps/provider-proxy/src/services/ProviderService/ProviderService.ts
+++ b/apps/provider-proxy/src/services/ProviderService/ProviderService.ts
@@ -1,3 +1,4 @@
+import type { LoggerService } from "@akashnetwork/logging";
 import type { SupportedChainNetworks } from "@akashnetwork/net";
 import { X509Certificate } from "crypto";
 
@@ -6,7 +7,8 @@ import { httpRetry } from "../../utils/retry";
 export class ProviderService {
   constructor(
     private readonly getChainBaseUrl: (network: SupportedChainNetworks) => string,
-    private readonly fetch: typeof global.fetch
+    private readonly fetch: typeof global.fetch,
+    private readonly logger?: LoggerService
   ) {}
 
   async getCertificate(network: SupportedChainNetworks, providerAddress: string, serialNumber: string): Promise<X509Certificate | null> {
@@ -23,7 +25,8 @@ export class ProviderService {
     }
 
     const response = await httpRetry(() => this.fetch(`${baseUrl}/akash/cert/v1beta3/certificates/list?${queryParams}`), {
-      retryIf: response => response.status > 500
+      retryIf: response => response.status > 500,
+      logger: this.logger
     });
 
     if (response.status >= 200 && response.status < 300) {


### PR DESCRIPTION
## Why

Probably this is a blind spot which is reported by OTEL but we don't have logs for. Eventually I will suppress metrics collection for this section but first need to prove that this is the blind spot we were looking for

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced retry operations with structured logging, providing more detailed information about retry attempts and failures.

* **Bug Fixes**
  * Improved reliability and traceability during network retries by integrating logging into relevant service and utility functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->