### PR TITLE
chore: refactor api functional tests to get rid of anonymous user

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,7 +25,7 @@
     "release": "release-it",
     "start": "webpack --config webpack.dev.js --watch",
     "test": "jest --selectProjects unit functional",
-    "test:ci-setup": "dc up:dev db mock-oauth2-server",
+    "test:ci-setup": "dc up:dev -d db mock-oauth2-server",
     "test:ci-teardown": "dc down",
     "test:cov": "jest --selectProjects unit functional --coverage --reporters=default --reporters=jest-junit",
     "test:functional": "jest --selectProjects functional",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,7 +25,7 @@
     "release": "release-it",
     "start": "webpack --config webpack.dev.js --watch",
     "test": "jest --selectProjects unit functional",
-    "test:ci-setup": "dc up:db",
+    "test:ci-setup": "dc up:dev db mock-oauth2-server",
     "test:ci-teardown": "dc down",
     "test:cov": "jest --selectProjects unit functional --coverage --reporters=default --reporters=jest-junit",
     "test:functional": "jest --selectProjects functional",

--- a/apps/api/test/functional/api-key.spec.ts
+++ b/apps/api/test/functional/api-key.spec.ts
@@ -31,7 +31,7 @@ describe("API Keys", () => {
   // Refactor once the proper auth0 mocking is implemented
   // https://github.com/akash-network/console/issues/552
   async function createTestUser(trial = false) {
-    const { user, token } = await walletService.createAnonymousUserAndWallet();
+    const { user, token } = await walletService.createUserAndWallet();
     const userWithId = { ...user, userId: faker.string.uuid() };
 
     jest.spyOn(userRepository, "findByUserId").mockImplementation(async id => {

--- a/apps/api/test/functional/balances.spec.ts
+++ b/apps/api/test/functional/balances.spec.ts
@@ -114,7 +114,7 @@ describe("Balances", () => {
     let config: jest.Mocked<CoreConfigService>;
 
     async function createTestUser() {
-      const { user, wallet } = await walletService.createAnonymousUserAndWallet();
+      const { user, wallet } = await walletService.createUserAndWallet();
       const userWithId = { ...user, userId: faker.string.uuid() };
       config = stub<CoreConfigService>({ get: jest.fn() });
       config.get.mockReturnValue("test");

--- a/apps/api/test/functional/certificate.spec.ts
+++ b/apps/api/test/functional/certificate.spec.ts
@@ -24,7 +24,7 @@ describe("Certificate API", () => {
   let config: jest.Mocked<CoreConfigService>;
 
   async function createTestUser() {
-    const { user, token, wallet } = await walletService.createAnonymousUserAndWallet();
+    const { user, token, wallet } = await walletService.createUserAndWallet();
     const userWithId = { ...user, userId: faker.string.uuid() };
     config = stub<CoreConfigService>({ get: jest.fn() });
     config.get.mockReturnValue("test");

--- a/apps/api/test/functional/deployment-setting.spec.ts
+++ b/apps/api/test/functional/deployment-setting.spec.ts
@@ -30,7 +30,7 @@ describe("Deployment Settings", () => {
     });
 
     it("should return a new deployment setting if not found", async () => {
-      const { token, user } = await walletService.createAnonymousUserAndWallet();
+      const { token, user } = await walletService.createUserAndWallet();
       const dseq = faker.string.numeric();
 
       const response = await app.request(`/v1/deployment-settings/${user.id}/${dseq}`, {
@@ -56,10 +56,7 @@ describe("Deployment Settings", () => {
     });
 
     it("should return 404 when accessing other user's deployment settings", async () => {
-      const [{ user: user1 }, { token: token2 }] = await Promise.all([
-        walletService.createAnonymousUserAndWallet(),
-        walletService.createAnonymousUserAndWallet()
-      ]);
+      const [{ user: user1 }, { token: token2 }] = await Promise.all([walletService.createUserAndWallet(), walletService.createUserAndWallet()]);
 
       const dseq = faker.string.numeric();
       await deploymentSettingRepository.create({
@@ -84,7 +81,7 @@ describe("Deployment Settings", () => {
     });
 
     it("should return deployment settings if found", async () => {
-      const { token, user, wallet } = await walletService.createAnonymousUserAndWallet();
+      const { token, user, wallet } = await walletService.createUserAndWallet();
       const dseq = faker.string.numeric();
 
       const settings = await deploymentSettingRepository.create({
@@ -137,10 +134,7 @@ describe("Deployment Settings", () => {
     });
 
     it("should return 403 when creating deployment settings for another user", async () => {
-      const [{ user: user1 }, { token: token2 }] = await Promise.all([
-        walletService.createAnonymousUserAndWallet(),
-        walletService.createAnonymousUserAndWallet()
-      ]);
+      const [{ user: user1 }, { token: token2 }] = await Promise.all([walletService.createUserAndWallet(), walletService.createUserAndWallet()]);
 
       const dseq = faker.string.numeric();
 
@@ -169,7 +163,7 @@ describe("Deployment Settings", () => {
     });
 
     it("should create deployment settings", async () => {
-      const { token, user, wallet } = await walletService.createAnonymousUserAndWallet();
+      const { token, user, wallet } = await walletService.createUserAndWallet();
       const dseq = faker.string.numeric();
 
       const response = await app.request("/v1/deployment-settings", {
@@ -224,7 +218,7 @@ describe("Deployment Settings", () => {
     });
 
     it("should create and return new setting if not found", async () => {
-      const { token, user, wallet } = await walletService.createAnonymousUserAndWallet();
+      const { token, user, wallet } = await walletService.createUserAndWallet();
       const dseq = faker.string.numeric();
 
       const response = await app.request(`/v1/deployment-settings/${user.id}/${dseq}`, {
@@ -259,10 +253,7 @@ describe("Deployment Settings", () => {
     });
 
     it("should return 404 when updating other user's deployment settings", async () => {
-      const [{ user: user1 }, { token: token2 }] = await Promise.all([
-        walletService.createAnonymousUserAndWallet(),
-        walletService.createAnonymousUserAndWallet()
-      ]);
+      const [{ user: user1 }, { token: token2 }] = await Promise.all([walletService.createUserAndWallet(), walletService.createUserAndWallet()]);
 
       const dseq = faker.string.numeric();
       await deploymentSettingRepository.create({
@@ -294,7 +285,7 @@ describe("Deployment Settings", () => {
     });
 
     it("should update deployment settings", async () => {
-      const { token, user, wallet } = await walletService.createAnonymousUserAndWallet();
+      const { token, user, wallet } = await walletService.createUserAndWallet();
       const dseq = faker.string.numeric();
 
       const settings = await deploymentSettingRepository.create({

--- a/apps/api/test/functional/lease-flow.spec.ts
+++ b/apps/api/test/functional/lease-flow.spec.ts
@@ -32,7 +32,7 @@ describe("Lease Flow", () => {
   const yml = createSdlYml();
 
   async function createTestUser() {
-    const { user, wallet } = await walletService.createAnonymousUserAndWallet();
+    const { user, wallet } = await walletService.createUserAndWallet();
     const userWithId = { ...user, userId: faker.string.uuid() };
     config = stub<CoreConfigService>({ get: jest.fn() });
     config.get.mockReturnValue("test");

--- a/apps/api/test/functional/sign-and-broadcast-tx.spec.ts
+++ b/apps/api/test/functional/sign-and-broadcast-tx.spec.ts
@@ -15,7 +15,7 @@ describe("Tx Sign", () => {
 
   describe("POST /v1/tx", () => {
     it("should create a wallet for a user", async () => {
-      const { user, token, wallet } = await walletService.createAnonymousUserAndWallet();
+      const { user, token, wallet } = await walletService.createUserAndWallet();
       const res = await app.request("/v1/tx", {
         method: "POST",
         body: await createMessagePayload(user.id, wallet.address),
@@ -27,7 +27,7 @@ describe("Tx Sign", () => {
     });
 
     it("should throw 401 provided no auth header", async () => {
-      const { user, wallet } = await walletService.createAnonymousUserAndWallet();
+      const { user, wallet } = await walletService.createUserAndWallet();
       const res = await app.request("/v1/tx", {
         method: "POST",
         body: await createMessagePayload(user.id, wallet.address),
@@ -39,7 +39,7 @@ describe("Tx Sign", () => {
     });
 
     it("should throw 404 provided a different user auth header", async () => {
-      const { user, wallet } = await walletService.createAnonymousUserAndWallet();
+      const { user, wallet } = await walletService.createUserAndWallet();
       const differentUserResponse = await app.request("/v1/anonymous-users", {
         method: "POST",
         headers: new Headers({ "Content-Type": "application/json" })

--- a/apps/api/test/functional/wallets-refill.spec.ts
+++ b/apps/api/test/functional/wallets-refill.spec.ts
@@ -23,7 +23,7 @@ describe("Wallets Refill", () => {
       config.FEE_ALLOWANCE_REFILL_THRESHOLD = 2;
       const NUMBER_OF_WALLETS = 5;
       const prepareRecords = Array.from({ length: NUMBER_OF_WALLETS }).map(async (_, index) => {
-        const records = await walletService.createAnonymousUserAndWallet();
+        const records = await walletService.createUserAndWallet();
         const { user, token } = records;
         const { wallet } = records;
         let walletRecord = await userWalletRepository.findById(wallet.id);

--- a/apps/api/test/services/wallet-testing.service.ts
+++ b/apps/api/test/services/wallet-testing.service.ts
@@ -74,6 +74,7 @@ export class WalletTestingService<T extends Hono<any>> {
     updated_at: string;
     sub: string;
   }) {
+    const oauth2ServerUrl = "http://localhost:8080";
     const redirectUri = "http://localhost:8080/api";
     const requestParams = new URLSearchParams({
       client_id: "debug-client",
@@ -84,7 +85,7 @@ export class WalletTestingService<T extends Hono<any>> {
       action: "signup",
       nonce: "9iicXKCPLq68WIm8DPexHa4j7-qLqRpWXkxbOBjgrQI"
     });
-    const tokenResponse = await fetch(`http://mock-oauth2-server:8080/default/authorize?${requestParams}`, {
+    const tokenResponse = await fetch(`${oauth2ServerUrl}/default/authorize?${requestParams}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded"
@@ -107,7 +108,7 @@ export class WalletTestingService<T extends Hono<any>> {
     const redirectLocation = new URL(tokenResponse.headers.get("Location") ?? "");
     const code = redirectLocation.searchParams.get("code") || "";
 
-    const result = await fetch(`http://mock-oauth2-server:8080/default/token`, {
+    const result = await fetch(`${oauth2ServerUrl}/default/token`, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded"

--- a/apps/api/test/services/wallet-testing.service.ts
+++ b/apps/api/test/services/wallet-testing.service.ts
@@ -1,11 +1,28 @@
+import { faker } from "@faker-js/faker";
 import type { Hono } from "hono";
 import { decode } from "jsonwebtoken";
+import { container } from "tsyringe";
+
+import { AbilityService } from "@src/auth/services/ability/ability.service";
+import { AuthService } from "@src/auth/services/auth.service";
+import type { UserWalletOutput } from "@src/billing/repositories/user-wallet/user-wallet.repository";
+import { WalletInitializerService } from "@src/billing/services";
+import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
 
 export class WalletTestingService<T extends Hono<any>> {
   constructor(private readonly app: T) {}
 
   async createUserAndWallet() {
-    const { user, token } = await this.createRegisteredUser();
+    const { user, token } = await this.createRegisteredUser({
+      username: faker.internet.displayName(),
+      email: faker.internet.email(),
+      email_verified: true,
+      name: faker.person.fullName(),
+      nickname: faker.person.firstName(),
+      picture: faker.image.url(),
+      updated_at: faker.date.recent().toISOString(),
+      sub: faker.string.uuid()
+    });
     const walletResponse = await this.app.request("/v1/start-trial", {
       method: "POST",
       body: JSON.stringify({
@@ -18,18 +35,18 @@ export class WalletTestingService<T extends Hono<any>> {
     return { user, token, wallet };
   }
 
+  /** @deprecated anonymous users will not be supported in the nearest future */
   async createAnonymousUserAndWallet() {
     const { user, token } = await this.createUser();
-    const walletResponse = await this.app.request("/v1/start-trial", {
-      method: "POST",
-      body: JSON.stringify({
-        data: { userId: user.id }
-      }),
-      headers: new Headers({ "Content-Type": "application/json", authorization: `Bearer ${token}` })
-    });
-    const { data: wallet } = (await walletResponse.json()) as any;
+    return container.resolve(ExecutionContextService).runWithContext(async () => {
+      container.resolve(AuthService).currentUser = user;
+      container.resolve(AuthService).ability = container.resolve(AbilityService).getAbilityFor("REGULAR_ANONYMOUS_USER", user);
+      const wallet = (await container.resolve(WalletInitializerService).initializeAndGrantTrialLimits(user.id)) as {
+        [K in keyof UserWalletOutput]: NonNullable<UserWalletOutput[K]>;
+      };
 
-    return { user, token, wallet };
+      return { user, token, wallet };
+    });
   }
 
   async createUser() {
@@ -45,24 +62,72 @@ export class WalletTestingService<T extends Hono<any>> {
   /**
    * Creates a registered user and returns the user and token.
    * Specify the user code to use for the user.
-   * "debug" will create a user with the email "dev@example.com" and the nickname "dev".
-   * "debug1" will create a user with the email "dev1@example.com" and the nickname "dev1".
-   * "debug2" through "debug20" will create users with corresponding emails and nicknames.
-   * This is setup in the docker-compose.dev.yml file.
-   * @param userCode - The user code to use for the user.
    * @returns The user and token.
    */
-  async createRegisteredUser(userCode: string = "debug") {
-    const tokenResponse = await fetch("http://localhost:8080/default/token", {
+  async createRegisteredUser(claims: {
+    username: string;
+    email: string;
+    email_verified: boolean;
+    name: string;
+    nickname: string;
+    picture: string;
+    updated_at: string;
+    sub: string;
+  }) {
+    const redirectUri = "http://localhost:8080/api";
+    const requestParams = new URLSearchParams({
+      client_id: "debug-client",
+      scope: "openid profile email",
+      response_type: "code",
+      redirect_uri: redirectUri,
+      audience: "my-audience",
+      action: "signup",
+      nonce: "9iicXKCPLq68WIm8DPexHa4j7-qLqRpWXkxbOBjgrQI"
+    });
+    const tokenResponse = await fetch(`http://mock-oauth2-server:8080/default/authorize?${requestParams}`, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded"
       },
-      body: `grant_type=authorization_code&code=${userCode}&client_id=debug-client&code_verifier=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN123456`
+      redirect: "manual",
+      body: new URLSearchParams({
+        username: claims.username,
+        claims: JSON.stringify({
+          sub: claims.sub,
+          email: claims.email,
+          email_verified: claims.email_verified,
+          name: claims.name,
+          nickname: claims.nickname,
+          picture: claims.picture,
+          updated_at: claims.updated_at
+        })
+      })
     });
 
-    const tokenData = (await tokenResponse.json()) as { access_token: string };
-    const { access_token } = tokenData;
+    const redirectLocation = new URL(tokenResponse.headers.get("Location") ?? "");
+    const code = redirectLocation.searchParams.get("code") || "";
+
+    const result = await fetch(`http://mock-oauth2-server:8080/default/token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: redirectUri,
+        client_id: "debug-client",
+        client_secret: "debug-client-secret"
+      }).toString()
+    });
+    const { access_token } = (await result.json()) as {
+      token_type: string;
+      access_token: string;
+      refresh_token: string;
+      id_token: string;
+      expires_in: number;
+    };
+
     const decoded = decode(access_token) as { sub: string; email: string; nickname: string; email_verified: boolean };
 
     const userResponse = await this.app.request(`/user/tokenInfo`, {

--- a/packages/docker/docker-compose.prod-with-db.yml
+++ b/packages/docker/docker-compose.prod-with-db.yml
@@ -30,46 +30,6 @@ services:
       timeout: 5s
       retries: 20
 
-  mock-oauth2-server:
-    image: ghcr.io/navikt/mock-oauth2-server:2.1.10
-    ports:
-      - "8080:8080"
-    volumes:
-      - ./oauth/login.html:/app/config/login.html:ro
-    environment:
-      JSON_CONFIG: |
-        {
-          "interactiveLogin": true,
-          "loginPagePath": "/app/config/login.html",
-          "tokenCallbacks": [
-            {
-              "issuerId": "default",
-              "tokenExpiry": 3600,
-              "requestMappings": [
-                {
-                  "requestParam": "code",
-                  "match": "debug",
-                  "claims": {
-                    "sub": "user123",
-                    "aud": ["my-audience"],
-                    "email": "dev@example.com",
-                    "nickname": "dev"
-                  }
-                },
-                {
-                  "requestParam": "client_id",
-                  "match": "m2m-client",
-                  "claims": {
-                    "sub": "m2m-client",
-                    "aud": ["my-audience"],
-                    "scope": "read write"
-                  }
-                }
-              ]
-            }
-          ]
-        }
-
 volumes:
   postgres_data:
     driver: local


### PR DESCRIPTION
## Why

#1721 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated test scripts to start additional services required for testing.
  * Removed the mock OAuth2 server from the production Docker Compose configuration.
* **Tests**
  * Changed test user creation in multiple functional tests to use registered users instead of anonymous users.
  * Refactored the user creation utility to simulate a full OAuth2 flow with customizable user claims for improved test accuracy.
  * Improved test isolation and readability in the user initialization tests by encapsulating setup logic.
  * Added deprecation notice for anonymous user creation in test utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->