### PR TITLE
chore: fixes coverage calculation for deploy-web

### DIFF
--- a/apps/deploy-web/jest.config.ts
+++ b/apps/deploy-web/jest.config.ts
@@ -12,7 +12,7 @@ const common: Config.InitialOptions = {
     "^@tests(.*)$": "<rootDir>/tests/$1"
   },
   transform: {
-    "\\.tsx?$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.json" }]
+    "\\.tsx?$": ["ts-jest", { tsconfig: "<rootDir>/tsconfig.spec.json" }]
   }
 };
 
@@ -34,16 +34,15 @@ const getConfig = createJestConfig({
 export default async (): Promise<Config.InitialOptions> => {
   return {
     rootDir: ".",
+    collectCoverageFrom: ["<rootDir>/src/**/*.{js,ts,tsx}"],
     projects: [
       {
-        collectCoverageFrom: ["<rootDir>/src/**/*.{js,ts,tsx}"],
         coveragePathIgnorePatterns: ["/lib/nextjs/", "/tests/"],
         displayName: "unit",
         ...(await getConfig())
       },
       {
-        collectCoverageFrom: ["<rootDir>/src/lib/nextjs/**/*.{js,ts,tsx}"],
-        coveragePathIgnorePatterns: ["/lib/nextjs/setup-node-tests.ts", "/tests/"],
+        coveragePathIgnorePatterns: ["/lib/nextjs/setup-node-tests\\.ts$", "/tests/", "\\.spec\\.tsx?$"],
         displayName: "unit-node",
         testEnvironment: "node",
         testMatch: ["<rootDir>/src/lib/nextjs/**/*.spec.{tsx,ts}"],

--- a/apps/deploy-web/tsconfig.spec.json
+++ b/apps/deploy-web/tsconfig.spec.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
## Why

Because of 2 separate jest projects in deploy-web, its coverage was calculated incorrectly. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test coverage settings to apply consistently across all projects.
  * Refined coverage exclusion patterns for improved accuracy in coverage reports.
  * Added a dedicated TypeScript configuration for test environments with JSX support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->