### PR TITLE
refactor: adds unit tests for start-trial

### DIFF
--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -5,7 +5,7 @@ import { singleton } from "tsyringe";
 import { AuthService, Protected } from "@src/auth/services/auth.service";
 import type { StripePricesOutputResponse } from "@src/billing";
 import { ApplyCouponRequest, ConfirmPaymentRequest, Discount, Transaction } from "@src/billing/http-schemas/stripe.schema";
-import { StripeService } from "@src/billing/services/stripe/stripe.service";
+import { PaymentMethod, StripeService } from "@src/billing/services/stripe/stripe.service";
 import { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
 import { Semaphore } from "@src/core/lib/semaphore.decorator";
 
@@ -33,7 +33,7 @@ export class StripeController {
   }
 
   @Protected([{ action: "read", subject: "StripePayment" }])
-  async getPaymentMethods(): Promise<{ data: Stripe.PaymentMethod[] }> {
+  async getPaymentMethods(): Promise<{ data: PaymentMethod[] }> {
     const { currentUser } = this.authService;
 
     if (!currentUser.stripeCustomerId) {

--- a/apps/api/src/billing/controllers/wallet/wallet.controller.spec.ts
+++ b/apps/api/src/billing/controllers/wallet/wallet.controller.spec.ts
@@ -1,0 +1,169 @@
+import type { MongoAbility } from "@casl/ability";
+import { createMongoAbility } from "@casl/ability";
+import { faker } from "@faker-js/faker";
+import { mock } from "jest-mock-extended";
+import { container as rootContainer } from "tsyringe";
+
+import { AuthService } from "@src/auth/services/auth.service";
+import { WalletInitializerService } from "@src/billing/services";
+import { StripeService } from "@src/billing/services/stripe/stripe.service";
+import type { FeatureFlagValue } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import type { UserOutput } from "@src/user/repositories";
+import { WalletController } from "./wallet.controller";
+
+import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
+import { UserSeeder } from "@test/seeders/user.seeder";
+
+describe("WalletController", () => {
+  describe("when ANONYMOUS_FREE_TRIAL is enabled", () => {
+    it("creates a wallet for user with not verified email", async () => {
+      const user = UserSeeder.create({
+        emailVerified: false
+      });
+      const container = setup({
+        enabledFeatures: [FeatureFlags.ANONYMOUS_FREE_TRIAL],
+        user
+      });
+      const walletController = container.resolve(WalletController);
+      await walletController.create({
+        data: {
+          userId: user.id
+        }
+      });
+      expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).toHaveBeenCalledWith(user.id);
+    });
+
+    it("creates a wallet for a user without configured payments methods", async () => {
+      const user = UserSeeder.create({
+        emailVerified: true,
+        stripeCustomerId: null
+      });
+      const container = setup({
+        enabledFeatures: [FeatureFlags.ANONYMOUS_FREE_TRIAL],
+        user
+      });
+      const walletController = container.resolve(WalletController);
+      await walletController.create({
+        data: {
+          userId: user.id
+        }
+      });
+      expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).toHaveBeenCalledWith(user.id);
+    });
+  });
+
+  describe("when ANONYMOUS_FREE_TRIAL is disabled", () => {
+    it("forbids starting a trial for a user with not verified email", async () => {
+      const user = UserSeeder.create({
+        emailVerified: false
+      });
+      const container = setup({
+        user
+      });
+      const walletController = container.resolve(WalletController);
+      await expect(() =>
+        walletController.create({
+          data: {
+            userId: user.id
+          }
+        })
+      ).rejects.toThrow(/email not verified/i);
+      expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).not.toHaveBeenCalled();
+    });
+
+    it("forbids starting a trial for a user without configured payments methods", async () => {
+      const user = UserSeeder.create({
+        emailVerified: true,
+        stripeCustomerId: faker.string.uuid()
+      });
+      const container = setup({
+        user,
+        hasPaymentMethods: false
+      });
+      const walletController = container.resolve(WalletController);
+      await expect(() =>
+        walletController.create({
+          data: {
+            userId: user.id
+          }
+        })
+      ).rejects.toThrow(/payment method required/i);
+      expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).not.toHaveBeenCalled();
+    });
+
+    it("forbids starting a trial for a user with duplicate trial account", async () => {
+      const user = UserSeeder.create({
+        emailVerified: true,
+        stripeCustomerId: faker.string.uuid()
+      });
+      const container = setup({
+        user,
+        hasDuplicateTrialAccount: true,
+        hasPaymentMethods: true
+      });
+      const walletController = container.resolve(WalletController);
+      await expect(() =>
+        walletController.create({
+          data: {
+            userId: user.id
+          }
+        })
+      ).rejects.toThrow(/associated with another trial account/i);
+      expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).not.toHaveBeenCalled();
+    });
+
+    it("creates a wallet for a user with all valid requirements", async () => {
+      const user = UserSeeder.create({
+        emailVerified: true,
+        stripeCustomerId: faker.string.uuid()
+      });
+      const container = setup({
+        user,
+        hasPaymentMethods: true,
+        hasDuplicateTrialAccount: false
+      });
+      const walletController = container.resolve(WalletController);
+      await walletController.create({
+        data: {
+          userId: user.id
+        }
+      });
+      expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).toHaveBeenCalledWith(user.id);
+    });
+  });
+
+  function setup(input?: { user?: UserOutput; enabledFeatures?: FeatureFlagValue[]; hasPaymentMethods?: boolean; hasDuplicateTrialAccount?: boolean }) {
+    rootContainer.register(AuthService, {
+      useValue: mock<AuthService>({
+        ability: createMongoAbility<MongoAbility>([
+          {
+            action: "create",
+            subject: "UserWallet"
+          }
+        ]),
+        currentUser: input?.user || UserSeeder.create()
+      })
+    });
+    rootContainer.register(FeatureFlagsService, {
+      useValue: mock<FeatureFlagsService>({
+        isEnabled: jest.fn().mockImplementation(flag => !!input?.enabledFeatures?.includes(flag))
+      })
+    });
+    rootContainer.register(WalletInitializerService, {
+      useValue: mock<WalletInitializerService>()
+    });
+    rootContainer.register(StripeService, {
+      useValue: mock<StripeService>({
+        getPaymentMethods: jest.fn(async () => {
+          if (!input?.hasPaymentMethods) return [];
+          return [generatePaymentMethod()];
+        }),
+        hasDuplicateTrialAccount: jest.fn().mockResolvedValue(input?.hasDuplicateTrialAccount ?? false)
+      })
+    });
+
+    return rootContainer;
+  }
+});

--- a/apps/api/src/billing/services/stripe/stripe.service.spec.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.spec.ts
@@ -1,7 +1,7 @@
 import { mock } from "jest-mock-extended";
 import type Stripe from "stripe";
 
-import type { PaymentMethodRepository, UserWalletRepository } from "@src/billing/repositories";
+import type { PaymentMethodRepository } from "@src/billing/repositories";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { RefillService } from "@src/billing/services/refill/refill.service";
 import type { UserRepository } from "@src/user/repositories";
@@ -799,9 +799,8 @@ function setup() {
   const userRepository = mock<UserRepository>();
   const refillService = mock<RefillService>();
   const paymentMethodRepository = mock<PaymentMethodRepository>();
-  const userWalletRepository = mock<UserWalletRepository>();
 
-  const service = new StripeService(billingConfig, userRepository, refillService, paymentMethodRepository, userWalletRepository);
+  const service = new StripeService(billingConfig, userRepository, refillService, paymentMethodRepository);
   const stripeData = StripeSeederCreate();
 
   // Store the last user for correct mocking

--- a/apps/api/test/functional/api-key.spec.ts
+++ b/apps/api/test/functional/api-key.spec.ts
@@ -16,7 +16,7 @@ import { WalletTestingService } from "@test/services/wallet-testing.service";
 const OBFUSCATED_API_KEY_PATTERN = /^ac\.sk\.test\.[A-Za-z0-9]{6}\*{3}[A-Za-z0-9]{6}$/;
 const FULL_API_KEY_PATTERN = /^ac\.sk\.test\.[A-Za-z0-9]{64}$/;
 
-jest.setTimeout(20000);
+jest.setTimeout(30000);
 
 describe("API Keys", () => {
   const walletService = new WalletTestingService(app);

--- a/apps/api/test/functional/start-trial.spec.ts
+++ b/apps/api/test/functional/start-trial.spec.ts
@@ -9,6 +9,8 @@ import { BILLING_CONFIG } from "@src/billing/providers";
 import { resolveWallet } from "@src/billing/providers/wallet.provider";
 import type { ApiPgDatabase } from "@src/core";
 import { POSTGRES_DB, resolveTable } from "@src/core";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 
 jest.setTimeout(20000);
 
@@ -19,93 +21,127 @@ describe("start trial", () => {
   const userWalletsQuery = db.query.UserWallets;
   const authzHttpService = container.resolve(AuthzHttpService);
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe("POST /v1/start-trial", () => {
-    it("should create a wallet for a user", async () => {
-      const userResponse = await app.request("/v1/anonymous-users", {
-        method: "POST",
-        headers: new Headers({ "Content-Type": "application/json" })
-      });
-      const {
-        data: { id: userId },
-        token
-      } = (await userResponse.json()) as any;
-      const headers = new Headers({ "Content-Type": "application/json", authorization: `Bearer ${token}` });
-      const createWalletResponse = await app.request("/v1/start-trial", {
-        method: "POST",
-        body: JSON.stringify({ data: { userId } }),
-        headers
-      });
-      const getWalletsResponse = await app.request(`/v1/wallets?userId=${userId}`, { headers });
-      const userWallet = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, userId) });
-      const masterWalletAddress = await resolveWallet("MANAGED").getFirstAddress();
-      if (!userWallet?.address) throw new Error("User wallet address is null-ish");
+    describe("when ANONYMOUS_FREE_TRIAL allowed", () => {
+      it("creates a wallet for a user", async () => {
+        const userResponse = await app.request("/v1/anonymous-users", {
+          method: "POST",
+          headers: new Headers({ "Content-Type": "application/json" })
+        });
+        const {
+          data: { id: userId },
+          token
+        } = (await userResponse.json()) as any;
+        const headers = new Headers({ "Content-Type": "application/json", authorization: `Bearer ${token}` });
 
-      const allowances = await Promise.all([
-        authzHttpService.getValidDepositDeploymentGrantsForGranterAndGrantee(masterWalletAddress, userWallet.address),
-        authzHttpService.getValidFeeAllowancesForGrantee(userWallet.address)
-      ]);
+        jest.spyOn(container.resolve(FeatureFlagsService), "isEnabled").mockImplementation(flag => flag === FeatureFlags.ANONYMOUS_FREE_TRIAL);
+        const createWalletResponse = await app.request("/v1/start-trial", {
+          method: "POST",
+          body: JSON.stringify({ data: { userId } }),
+          headers
+        });
+        const getWalletsResponse = await app.request(`/v1/wallets?userId=${userId}`, { headers });
+        const userWallet = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, userId) });
+        const masterWalletAddress = await resolveWallet("MANAGED").getFirstAddress();
+        if (!userWallet?.address) throw new Error("User wallet address is null-ish");
 
-      expect(createWalletResponse.status).toBe(200);
-      expect(getWalletsResponse.status).toBe(200);
-      expect(await createWalletResponse.json()).toMatchObject({
-        data: {
-          id: expect.any(Number),
-          userId,
-          creditAmount: expect.any(Number),
-          address: expect.any(String),
-          isTrialing: true
-        }
-      });
-      expect(await getWalletsResponse.json()).toMatchObject({
-        data: [
-          {
+        const allowances = await Promise.all([
+          authzHttpService.getValidDepositDeploymentGrantsForGranterAndGrantee(masterWalletAddress, userWallet.address),
+          authzHttpService.getValidFeeAllowancesForGrantee(userWallet.address)
+        ]);
+
+        expect(createWalletResponse.status).toBe(200);
+        expect(getWalletsResponse.status).toBe(200);
+        expect(await createWalletResponse.json()).toMatchObject({
+          data: {
             id: expect.any(Number),
             userId,
             creditAmount: expect.any(Number),
             address: expect.any(String),
             isTrialing: true
           }
-        ]
-      });
-      expect(userWallet).toMatchObject({
-        id: expect.any(Number),
-        userId,
-        address: expect.any(String),
-        deploymentAllowance: `${config.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT}.00`,
-        feeAllowance: `${config.TRIAL_FEES_ALLOWANCE_AMOUNT}.00`,
-        isTrialing: true
-      });
-      expect(allowances).toMatchObject([
-        {
-          authorization: {
-            "@type": "/akash.deployment.v1beta3.DepositDeploymentAuthorization",
-            spend_limit: { denom: config.DEPLOYMENT_GRANT_DENOM, amount: String(config.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT) }
-          },
-          expiration: expect.any(String)
-        },
-        [
-          {
-            granter: expect.any(String),
-            grantee: userWallet.address,
-            allowance: {
-              "@type": "/cosmos.feegrant.v1beta1.BasicAllowance",
-              spend_limit: [{ denom: "uakt", amount: String(config.TRIAL_FEES_ALLOWANCE_AMOUNT) }],
-              expiration: expect.any(String)
+        });
+        expect(await getWalletsResponse.json()).toMatchObject({
+          data: [
+            {
+              id: expect.any(Number),
+              userId,
+              creditAmount: expect.any(Number),
+              address: expect.any(String),
+              isTrialing: true
             }
-          }
-        ]
-      ]);
+          ]
+        });
+        expect(userWallet).toMatchObject({
+          id: expect.any(Number),
+          userId,
+          address: expect.any(String),
+          deploymentAllowance: `${config.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT}.00`,
+          feeAllowance: `${config.TRIAL_FEES_ALLOWANCE_AMOUNT}.00`,
+          isTrialing: true
+        });
+        expect(allowances).toMatchObject([
+          {
+            authorization: {
+              "@type": "/akash.deployment.v1beta3.DepositDeploymentAuthorization",
+              spend_limit: { denom: config.DEPLOYMENT_GRANT_DENOM, amount: String(config.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT) }
+            },
+            expiration: expect.any(String)
+          },
+          [
+            {
+              granter: expect.any(String),
+              grantee: userWallet.address,
+              allowance: {
+                "@type": "/cosmos.feegrant.v1beta1.BasicAllowance",
+                spend_limit: [{ denom: "uakt", amount: String(config.TRIAL_FEES_ALLOWANCE_AMOUNT) }],
+                expiration: expect.any(String)
+              }
+            }
+          ]
+        ]);
+      });
+
+      it("should throw 401 provided no auth header ", async () => {
+        jest.spyOn(container.resolve(FeatureFlagsService), "isEnabled").mockImplementation(flag => flag === FeatureFlags.ANONYMOUS_FREE_TRIAL);
+        const createWalletResponse = await app.request("/v1/start-trial", {
+          method: "POST",
+          body: JSON.stringify({ data: { userId: faker.string.uuid() } }),
+          headers: new Headers({ "Content-Type": "application/json" })
+        });
+
+        expect(createWalletResponse.status).toBe(401);
+        expect(await createWalletResponse.json()).toMatchObject({ error: "UnauthorizedError", message: "Unauthorized" });
+      });
     });
 
-    it("should throw 401 provided no auth header ", async () => {
-      const createWalletResponse = await app.request("/v1/start-trial", {
-        method: "POST",
-        body: JSON.stringify({ data: { userId: faker.string.uuid() } }),
-        headers: new Headers({ "Content-Type": "application/json" })
-      });
+    describe("when when ANONYMOUS_FREE_TRIAL disallowed", () => {
+      it("forbids anonymous users to start a trial", async () => {
+        const userResponse = await app.request("/v1/anonymous-users", {
+          method: "POST",
+          headers: new Headers({ "Content-Type": "application/json" })
+        });
+        const {
+          data: { id: userId },
+          token
+        } = (await userResponse.json()) as any;
+        const headers = new Headers({ "Content-Type": "application/json", authorization: `Bearer ${token}` });
 
-      expect(createWalletResponse.status).toBe(401);
-      expect(await createWalletResponse.json()).toMatchObject({ error: "UnauthorizedError", message: "Unauthorized" });
+        jest.spyOn(container.resolve(FeatureFlagsService), "isEnabled").mockImplementation(flag => flag !== FeatureFlags.ANONYMOUS_FREE_TRIAL);
+        const createWalletResponse = await app.request("/v1/start-trial", {
+          method: "POST",
+          body: JSON.stringify({ data: { userId } }),
+          headers
+        });
+        const body = await createWalletResponse.json();
+
+        expect(createWalletResponse.status).toBe(400);
+        expect(body).toMatchObject({ error: "BadRequestError", message: "Email not verified" });
+      });
     });
   });
 

--- a/apps/api/test/functional/wallets-refill.spec.ts
+++ b/apps/api/test/functional/wallets-refill.spec.ts
@@ -55,7 +55,7 @@ describe("Wallets Refill", () => {
 
       const records = await Promise.all(prepareRecords);
       await walletController.refillWallets();
-      const trialingWallet = records.pop();
+      const trialingWallet = records.pop()!;
 
       await Promise.all([
         ...records.map(async ({ wallet }) => {
@@ -63,7 +63,7 @@ describe("Wallets Refill", () => {
 
           expect(walletRecord?.feeAllowance).toBe(config.FEE_ALLOWANCE_REFILL_AMOUNT);
         }),
-        userWalletRepository.findById(trialingWallet?.wallet.id).then(walletRecord => {
+        userWalletRepository.findById(trialingWallet.wallet.id).then(walletRecord => {
           expect(walletRecord?.feeAllowance).toBe(config.FEE_ALLOWANCE_REFILL_THRESHOLD);
         })
       ]);

--- a/apps/api/test/seeders/payment-method.seeder.ts
+++ b/apps/api/test/seeders/payment-method.seeder.ts
@@ -1,0 +1,33 @@
+import { faker } from "@faker-js/faker";
+
+import type { PaymentMethod } from "@src/billing/services/stripe/stripe.service";
+
+export function generatePaymentMethod(): PaymentMethod {
+  return {
+    id: faker.string.uuid(),
+    type: faker.finance.transactionType(),
+    card: {
+      brand: faker.helpers.arrayElement(["Visa", "MasterCard", "American Express", null]),
+      last4: faker.finance.creditCardNumber().slice(-4),
+      exp_month: faker.number.int({ min: 1, max: 12 }),
+      exp_year: faker.number.int({ min: new Date().getFullYear(), max: new Date().getFullYear() + 5 }),
+      funding: faker.helpers.arrayElement(["credit", "debit", null]),
+      country: faker.location.countryCode(),
+      network: faker.helpers.arrayElement(["Visa", "MasterCard", "American Express", null]),
+      fingerprint: faker.string.uuid()
+    },
+    billing_details: {
+      address: {
+        city: faker.location.city(),
+        country: faker.location.countryCode(),
+        line1: faker.location.streetAddress(),
+        line2: faker.datatype.boolean() ? faker.location.secondaryAddress() : null,
+        postal_code: faker.location.zipCode(),
+        state: faker.location.state()
+      },
+      email: faker.internet.email(),
+      name: faker.person.fullName(),
+      phone: faker.phone.number()
+    }
+  };
+}


### PR DESCRIPTION
## Why

covering /start-trial with functional tests is challenging and as we plan to mock stripe calls, I think it's better to use unit tests for this and later add e2e tests for /start-trial, using either real bank card or do it on staging using AKT and stripe test env

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility to generate mock payment method data for testing.
  * Introduced comprehensive tests for wallet creation under different feature flag and user scenarios.

* **Bug Fixes**
  * Improved test coverage for trial wallet creation, ensuring correct behavior based on feature flags and user status.

* **Refactor**
  * Updated and simplified wallet and user creation logic in test utilities.
  * Standardized the structure and typing of payment methods across services and controllers.
  * Removed unnecessary dependencies from Stripe service and its tests.
  * Ensured explicit non-null assertions in wallet refill tests.

* **Tests**
  * Enhanced and expanded test cases for wallet and trial creation, including feature-flag-driven scenarios.
  * Added after-test cleanup to ensure isolation between test cases.
  * Increased timeout for API key functional tests to improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->