### PR TITLE
refactor: renames and moves di container files to different location

### DIFF
--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationContainer/EmailVerificationContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationContainer/EmailVerificationContainer.tsx
@@ -6,7 +6,7 @@ import { useSnackbar } from "notistack";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
-import { services } from "@src/services/http/http-browser.service";
+import { services } from "@src/services/app-di-container/browser-di-container";
 
 const DEPENDENCIES = {
   useCustomUser,

--- a/apps/deploy-web/src/components/turnstile/Turnstile.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.tsx
@@ -11,7 +11,7 @@ import { motion } from "framer-motion";
 import dynamic from "next/dynamic";
 
 import { useWhen } from "@src/hooks/useWhen";
-import { services } from "@src/services/http/http-browser.service";
+import { services } from "@src/services/app-di-container/browser-di-container";
 
 const HTTP_SERVICES = [
   services.managedWalletService,

--- a/apps/deploy-web/src/context/ServicesProvider/RootContainerProvider.tsx
+++ b/apps/deploy-web/src/context/ServicesProvider/RootContainerProvider.tsx
@@ -1,7 +1,7 @@
 import { useContext } from "react";
 
+import { services as rootContainer } from "@src/services/app-di-container/browser-di-container";
 import { createChildContainer, type DIContainer } from "@src/services/container/createContainer";
-import { services as rootContainer } from "@src/services/http/http-browser.service";
 import type { RootContainer } from "./ServicesContext";
 import { ServicesContext } from "./ServicesContext";
 

--- a/apps/deploy-web/src/context/ServicesProvider/ServicesContext.ts
+++ b/apps/deploy-web/src/context/ServicesProvider/ServicesContext.ts
@@ -1,6 +1,6 @@
 import { createContext } from "react";
 
-import { services as rootContainer } from "@src/services/http/http-browser.service";
+import { services as rootContainer } from "@src/services/app-di-container/browser-di-container";
 
 export type RootContainer = typeof rootContainer;
 

--- a/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
+++ b/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
@@ -2,9 +2,9 @@ import React, { useContext } from "react";
 import { AuthzHttpService, CertificatesService } from "@akashnetwork/http-sdk";
 
 import { browserEnvConfig } from "@src/config/browser-env.config";
+import { services as rootContainer } from "@src/services/app-di-container/browser-di-container";
 import type { DIContainer, Factories } from "@src/services/container/createContainer";
 import { createChildContainer } from "@src/services/container/createContainer";
-import { services as rootContainer } from "@src/services/http/http-browser.service";
 import { WalletBalancesService } from "@src/services/wallet-balances/wallet-balances.service";
 import type { Settings } from "../SettingsProvider/SettingsProviderContext";
 import { useSettings } from "../SettingsProvider/SettingsProviderContext";

--- a/apps/deploy-web/src/hooks/useEmailVerificationRequiredEventHandler.tsx
+++ b/apps/deploy-web/src/hooks/useEmailVerificationRequiredEventHandler.tsx
@@ -6,7 +6,7 @@ import { useSnackbar } from "notistack";
 
 import { useCustomUser } from "@src/hooks/useCustomUser";
 import { analyticsService } from "@src/services/analytics/analytics.service";
-import { services } from "@src/services/http/http-browser.service";
+import { services } from "@src/services/app-di-container/browser-di-container";
 
 export const useEmailVerificationRequiredEventHandler = (): ((messageOtherwise: string) => (callback: MouseEventHandler) => MouseEventHandler) => {
   const { requireAction } = usePopup();

--- a/apps/deploy-web/src/lib/nextjs/defineApiHandler/defineApiHandler.spec.ts
+++ b/apps/deploy-web/src/lib/nextjs/defineApiHandler/defineApiHandler.spec.ts
@@ -3,7 +3,7 @@ import { mock } from "jest-mock-extended";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { z } from "zod";
 
-import { services } from "@src/services/http/http-server.service";
+import { services } from "@src/services/app-di-container/server-di-container.service";
 import type { NextApiRequestWithServices } from "./defineApiHandler";
 import { defineApiHandler, REQ_SERVICES_KEY } from "./defineApiHandler";
 

--- a/apps/deploy-web/src/lib/nextjs/defineApiHandler/defineApiHandler.ts
+++ b/apps/deploy-web/src/lib/nextjs/defineApiHandler/defineApiHandler.ts
@@ -2,7 +2,7 @@ import { wrapApiHandlerWithSentry } from "@sentry/nextjs";
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
 import type { z } from "zod";
 
-import { services } from "@src/services/http/http-server.service";
+import { services } from "@src/services/app-di-container/server-di-container.service";
 import { createRequestExecutionContext, requestExecutionContext } from "../requestExecutionContext";
 
 /** @internal use for testing only */

--- a/apps/deploy-web/src/lib/nextjs/defineServerSideProps/defineServerSideProps.spec.ts
+++ b/apps/deploy-web/src/lib/nextjs/defineServerSideProps/defineServerSideProps.spec.ts
@@ -5,7 +5,7 @@ import type { GetServerSidePropsContext, GetServerSidePropsResult } from "next";
 import type { z } from "zod";
 import { z as zod, ZodError } from "zod";
 
-import { services } from "@src/services/http/http-server.service";
+import { services } from "@src/services/app-di-container/server-di-container.service";
 import { requestExecutionContext } from "../requestExecutionContext";
 import type { AppTypedContext } from "./defineServerSideProps";
 import { defineServerSideProps } from "./defineServerSideProps";

--- a/apps/deploy-web/src/lib/nextjs/defineServerSideProps/defineServerSideProps.ts
+++ b/apps/deploy-web/src/lib/nextjs/defineServerSideProps/defineServerSideProps.ts
@@ -4,7 +4,7 @@ import type { GetServerSideProps, GetServerSidePropsContext, GetServerSidePropsR
 import type { ParsedUrlQuery } from "querystring";
 import type { z } from "zod";
 
-import { services } from "@src/services/http/http-server.service";
+import { services } from "@src/services/app-di-container/server-di-container.service";
 import { createRequestExecutionContext, requestExecutionContext } from "../requestExecutionContext";
 
 export interface WrapServerSideOptions<TSchema extends z.ZodSchema<any> | undefined, TProps, TParams extends ParsedUrlQuery, TPreviewData extends PreviewData> {

--- a/apps/deploy-web/src/pages/api/auth/[...auth0].ts
+++ b/apps/deploy-web/src/pages/api/auth/[...auth0].ts
@@ -6,8 +6,8 @@ import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { ServerEnvConfig } from "@src/config/env-config.schema";
 import { defineApiHandler } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
+import type { AppServices } from "@src/services/app-di-container/server-di-container.service";
 import type { SeverityLevel } from "@src/services/error-handler/error-handler.service";
-import type { AppServices } from "@src/services/http/http-server.service";
 
 export default defineApiHandler({
   route: "/api/auth/[...auth0]",

--- a/apps/deploy-web/src/services/app-di-container/browser-di-container.ts
+++ b/apps/deploy-web/src/services/app-di-container/browser-di-container.ts
@@ -3,13 +3,13 @@ import { requestFn } from "@openapi-qraft/react";
 
 import { browserEnvConfig } from "@src/config/browser-env.config";
 import { ApiUrlService } from "@src/services/api-url/api-url.service";
-import { createAppRootContainer } from "@src/services/app-di-container/app-di-container";
 import networkStore from "@src/store/networkStore";
 import { createChildContainer } from "../container/createContainer";
 import { BitbucketService } from "../remote-deploy/bitbucket-http.service";
 import { GitHubService } from "../remote-deploy/github-http.service";
 import { GitLabService } from "../remote-deploy/gitlab-http.service";
 import { UserProviderService } from "../user-provider/user-provider.service";
+import { createAppRootContainer } from "./app-di-container";
 
 const rootContainer = createAppRootContainer({
   runtimeEnv: "browser",

--- a/apps/deploy-web/src/services/app-di-container/server-di-container.service.ts
+++ b/apps/deploy-web/src/services/app-di-container/server-di-container.service.ts
@@ -4,11 +4,11 @@ import { requestFn } from "@openapi-qraft/react";
 import * as unleashModule from "@unleash/nextjs";
 
 import { serverEnvConfig } from "@src/config/server-env.config";
-import { createAppRootContainer } from "@src/services/app-di-container/app-di-container";
 import { ApiUrlService } from "../api-url/api-url.service";
 import { clientIpForwardingInterceptor } from "../client-ip-forwarding/client-ip-forwarding.interceptor";
 import { createChildContainer } from "../container/createContainer";
 import { FeatureFlagService } from "../feature-flag/feature-flag.service";
+import { createAppRootContainer } from "./app-di-container";
 
 const rootContainer = createAppRootContainer({
   ...serverEnvConfig,

--- a/apps/deploy-web/src/utils/apiUtils.ts
+++ b/apps/deploy-web/src/utils/apiUtils.ts
@@ -1,6 +1,6 @@
 import type { AxiosInstance } from "axios";
 
-import { services } from "@src/services/http/http-browser.service";
+import { services } from "@src/services/app-di-container/browser-di-container";
 import networkStore from "@src/store/networkStore";
 import { appendSearchParams } from "./urlUtils";
 


### PR DESCRIPTION
## Why

because server and browser containers contain not only http services and I want to fix the naming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to use a new service import path across various components and utilities. No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->