### PR TITLE
refactor: reduces usage of services variable

### DIFF
--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationContainer/EmailVerificationContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationContainer/EmailVerificationContainer.spec.tsx
@@ -157,14 +157,11 @@ describe("EmailVerificationContainer", () => {
     });
 
     const mockUseServices = jest.fn().mockReturnValue({
-      analyticsService: mockAnalyticsService
-    });
-
-    const mockServices = {
+      analyticsService: mockAnalyticsService,
       auth: {
         sendVerificationEmail: mockSendVerificationEmail
       }
-    } as any;
+    });
 
     const mockSnackbar = ({ title, subTitle, iconVariant }: any) => (
       <div data-testid="snackbar" data-title={title} data-subtitle={subTitle} data-icon-variant={iconVariant} />
@@ -174,7 +171,6 @@ describe("EmailVerificationContainer", () => {
       useCustomUser: mockUseCustomUser,
       useSnackbar: mockUseSnackbar,
       useServices: mockUseServices,
-      services: mockServices,
       Snackbar: mockSnackbar
     };
 

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationContainer/EmailVerificationContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationContainer/EmailVerificationContainer.tsx
@@ -6,13 +6,11 @@ import { useSnackbar } from "notistack";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
-import { services } from "@src/services/app-di-container/browser-di-container";
 
 const DEPENDENCIES = {
   useCustomUser,
   useSnackbar,
   useServices,
-  services,
   Snackbar
 };
 
@@ -34,7 +32,7 @@ export const EmailVerificationContainer: FC<EmailVerificationContainerProps> = (
   const { enqueueSnackbar } = d.useSnackbar();
   const [isResending, setIsResending] = useState(false);
   const [isChecking, setIsChecking] = useState(false);
-  const { analyticsService } = d.useServices();
+  const { analyticsService, auth } = d.useServices();
 
   const isEmailVerified = !!user?.emailVerified;
 
@@ -43,7 +41,7 @@ export const EmailVerificationContainer: FC<EmailVerificationContainerProps> = (
 
     setIsResending(true);
     try {
-      await d.services.auth.sendVerificationEmail(user.id);
+      await auth.sendVerificationEmail(user.id);
       enqueueSnackbar(<d.Snackbar title="Verification email sent" subTitle="Please check your email and click the verification link" iconVariant="success" />, {
         variant: "success"
       });
@@ -54,7 +52,7 @@ export const EmailVerificationContainer: FC<EmailVerificationContainerProps> = (
     } finally {
       setIsResending(false);
     }
-  }, [user?.id, d.services.auth, enqueueSnackbar, d.Snackbar]);
+  }, [user?.id, auth, enqueueSnackbar, d.Snackbar]);
 
   const handleCheckVerification = useCallback(async () => {
     setIsChecking(true);

--- a/apps/deploy-web/src/hooks/useEmailVerificationRequiredEventHandler.tsx
+++ b/apps/deploy-web/src/hooks/useEmailVerificationRequiredEventHandler.tsx
@@ -4,14 +4,14 @@ import { Snackbar } from "@akashnetwork/ui/components";
 import { usePopup } from "@akashnetwork/ui/context";
 import { useSnackbar } from "notistack";
 
+import { useServices } from "@src/context/ServicesProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
-import { analyticsService } from "@src/services/analytics/analytics.service";
-import { services } from "@src/services/app-di-container/browser-di-container";
 
 export const useEmailVerificationRequiredEventHandler = (): ((messageOtherwise: string) => (callback: MouseEventHandler) => MouseEventHandler) => {
   const { requireAction } = usePopup();
   const { user } = useCustomUser();
   const { enqueueSnackbar } = useSnackbar();
+  const { auth, analyticsService } = useServices();
 
   return useCallback(
     (messageOtherwise: string) => (handler: MouseEventHandler) => {
@@ -30,7 +30,7 @@ export const useEmailVerificationRequiredEventHandler = (): ((messageOtherwise: 
                   return;
                 }
 
-                services.auth
+                auth
                   .sendVerificationEmail(user.id)
                   .then(() => {
                     enqueueSnackbar(


### PR DESCRIPTION
## Why

We need to inject services via `useServices` not by directly importing it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in how authentication and analytics services are accessed within onboarding and email verification flows.
  * Centralized service access through the use of a context provider, streamlining internal dependencies.

* **Tests**
  * Simplified test setup for email verification by consolidating service mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->