### PR TITLE
refactor: archive completed jobs in 24h

### DIFF
--- a/apps/notifications/src/common/config/event-key-registry.config.ts
+++ b/apps/notifications/src/common/config/event-key-registry.config.ts
@@ -1,5 +1,5 @@
-export const eventKeyRegistry = Object.freeze({
+export const eventKeyRegistry = {
   blockCreated: "blockchain.v1.block.created",
   eventCloseDeployment: "akash.v1.deployment.deployment-closed",
   createNotification: "notifications.v1.notification.create"
-});
+} as const;

--- a/apps/notifications/src/infrastructure/broker/config/env.config.ts
+++ b/apps/notifications/src/infrastructure/broker/config/env.config.ts
@@ -1,7 +1,9 @@
+import { hoursToSeconds } from "date-fns";
 import { z } from "zod";
 
 export const schema = z.object({
   EVENT_BROKER_POSTGRES_URI: z.string(),
+  EVENT_BROKER_ARCHIVE_COMPLETED_AFTER_SECONDS: z.number().default(hoursToSeconds(24)),
   APP_NAME: z.string()
 });
 

--- a/apps/notifications/src/infrastructure/broker/providers/pg-boss/pg-boss.provider.spec.ts
+++ b/apps/notifications/src/infrastructure/broker/providers/pg-boss/pg-boss.provider.spec.ts
@@ -26,6 +26,7 @@ describe("createPgBoss", () => {
     expect(MockPgBoss).toHaveBeenCalledTimes(2);
     expect(MockPgBoss.mock.calls[0][0]).toEqual(config["broker.EVENT_BROKER_POSTGRES_URI"]);
     expect(MockPgBoss.mock.calls[1][0]).toEqual({
+      archiveCompletedAfterSeconds: config["broker.EVENT_BROKER_ARCHIVE_COMPLETED_AFTER_SECONDS"],
       db: {
         executeSql: expect.any(Function)
       }

--- a/apps/notifications/src/infrastructure/broker/providers/pg-boss/pg-boss.provider.ts
+++ b/apps/notifications/src/infrastructure/broker/providers/pg-boss/pg-boss.provider.ts
@@ -18,7 +18,8 @@ export const createPgBossFactory =
         executeSql(text: string, values: any[]): Promise<{ rows: any[] }> {
           return client.query(text, values);
         }
-      }
+      },
+      archiveCompletedAfterSeconds: config.getOrThrow("broker.EVENT_BROKER_ARCHIVE_COMPLETED_AFTER_SECONDS")
     }).start();
   };
 

--- a/apps/notifications/src/infrastructure/broker/services/broker/broker.service.spec.ts
+++ b/apps/notifications/src/infrastructure/broker/services/broker/broker.service.spec.ts
@@ -6,6 +6,7 @@ import type { MockProxy } from "jest-mock-extended";
 import { Client } from "pg";
 import PgBoss from "pg-boss";
 
+import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import { LoggerService } from "@src/common/services/logger/logger.service";
 import type { BrokerConfig } from "@src/infrastructure/broker/config";
 import { NAMESPACE } from "@src/infrastructure/broker/config";
@@ -25,8 +26,8 @@ describe(BrokerService.name, () => {
     it("should publish an event to PgBoss", async () => {
       const { service, pgBoss } = await setup();
 
-      const eventName = faker.string.alphanumeric(10);
-      const eventPayload = { data: faker.lorem.sentence() };
+      const eventName = eventKeyRegistry.blockCreated;
+      const eventPayload = { height: faker.number.int() };
 
       await service.publish(eventName, eventPayload);
 

--- a/apps/notifications/src/infrastructure/broker/services/broker/event-map.ts
+++ b/apps/notifications/src/infrastructure/broker/services/broker/event-map.ts
@@ -1,0 +1,10 @@
+import type { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
+import type { ChainBlockCreatedDto } from "@src/modules/alert/dto/chain-block-created.dto";
+import type { EventClosedDeploymentDto } from "@src/modules/alert/dto/event-closed-deployment.dto";
+import type { AlertMessage } from "@src/modules/alert/types/message-callback.type";
+
+export type EventToPayload = {
+  [eventKeyRegistry.createNotification]: AlertMessage;
+  [eventKeyRegistry.blockCreated]: ChainBlockCreatedDto;
+  [eventKeyRegistry.eventCloseDeployment]: EventClosedDeploymentDto;
+};

--- a/apps/notifications/src/lib/rich-error/rich-error.ts
+++ b/apps/notifications/src/lib/rich-error/rich-error.ts
@@ -30,8 +30,9 @@ export class RichError extends Error {
     public message: string,
     public code: string | number = "UNDEFINED",
     public data: Record<string, unknown> = {},
-    public cause?: unknown
+    cause?: unknown
   ) {
-    super(message);
+    super(message, { cause });
+    this.name = "RichError";
   }
 }

--- a/apps/notifications/src/modules/alert/services/alert-message/alert-message.service.ts
+++ b/apps/notifications/src/modules/alert/services/alert-message/alert-message.service.ts
@@ -5,7 +5,7 @@ import { TemplateService } from "@src/modules/alert/services/template/template.s
 export interface SendOptions {
   summary: string;
   description: string;
-  vars: Record<string, any>;
+  vars?: Record<string, any>;
 }
 
 export interface AlertMessagePayload {
@@ -17,7 +17,7 @@ export interface AlertMessagePayload {
 export class AlertMessageService {
   constructor(private readonly templateService: TemplateService) {}
 
-  getMessage({ vars, ...templates }: SendOptions): AlertMessagePayload {
+  getMessage({ vars = {}, ...templates }: SendOptions): AlertMessagePayload {
     return {
       summary: this.templateService.interpolate(templates.summary, vars),
       description: this.templateService.interpolate(templates.description, vars)

--- a/apps/notifications/test/seeders/broker-config.seeder.ts
+++ b/apps/notifications/test/seeders/broker-config.seeder.ts
@@ -7,7 +7,8 @@ import { namespaced } from "@src/lib/namespaced/namespaced";
 
 export const generateEnvBrokerConfig = (): BrokerEnvConfig => ({
   APP_NAME: faker.lorem.word(),
-  EVENT_BROKER_POSTGRES_URI: `postgres://user:password@localhost:5432/${faker.lorem.word()}`
+  EVENT_BROKER_POSTGRES_URI: `postgres://user:password@localhost:5432/${faker.lorem.word()}`,
+  EVENT_BROKER_ARCHIVE_COMPLETED_AFTER_SECONDS: 1000
 });
 
 export const generateBrokerConfig = (): BrokerConfig => namespaced(NAMESPACE, generateEnvBrokerConfig());


### PR DESCRIPTION
## Why

Currently successful jobs are removed right after execution but we need to keep them for some time to deduplicate jobs enqueueing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the archive duration for completed events in the event broker via a new environment variable.

* **Improvements**
  * Enhanced type safety and payload validation for event publishing and handling.
  * Refined shutdown and polling logic for chain event processing to improve reliability and control.
  * The alert message service now allows sending messages without requiring template variables.
  * Improved error handling by enhancing error cause propagation.

* **Bug Fixes**
  * Improved test synchronization to ensure block processing completes before shutdown.

* **Chores**
  * Updated tests and configuration seeders to reflect new environment variables and improved type mappings.
  * Simplified immutability enforcement for event key registry from runtime to compile-time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->