### PR TITLE
fix(billing): prevent empty accounts to sign

### DIFF
--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -69,6 +69,8 @@ export class ManagedSignerService {
     assert(userWallet, 404, "UserWallet Not Found");
     const user = this.authService.currentUser.userId === userId ? this.authService.currentUser : await this.userRepository.findById(userId);
     assert(user, 404, "User Not Found");
+    assert(userWallet.feeAllowance > 0, 403, "UserWallet has no fee allowance");
+    assert(userWallet.deploymentAllowance > 0, 403, "UserWallet has no deployment allowance");
 
     if (this.featureFlagsService.isEnabled(FeatureFlags.ANONYMOUS_FREE_TRIAL)) {
       await Promise.all(

--- a/apps/api/test/functional/lease-flow.spec.ts
+++ b/apps/api/test/functional/lease-flow.spec.ts
@@ -70,7 +70,7 @@ describe("Lease Flow", () => {
 
     const findOneByUserIdMock = jest.fn().mockImplementation(async (id: string) => {
       if (id === userWithId.id) {
-        return { ...wallet, isTrialing: false };
+        return { ...wallet, isTrialing: false, feeAllowance: 1_000_000, deploymentAllowance: 1_000_000 };
       }
       return undefined;
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to prevent users from executing transactions if their wallet's fee or deployment allowances are zero or negative, providing clear error messages in such cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->