### PR TITLE
fix: returns 400 if provider API returns "validation failed" in response

### DIFF
--- a/apps/provider-proxy/src/services/ProviderService/ProviderService.spec.ts
+++ b/apps/provider-proxy/src/services/ProviderService/ProviderService.spec.ts
@@ -75,6 +75,11 @@ describe(ProviderService.name, () => {
         expected: true
       },
       {
+        name: 'includes "validation failed"',
+        body: "manifest version validation failed",
+        expected: true
+      },
+      {
         name: "is empty",
         body: "",
         expected: false

--- a/apps/provider-proxy/src/services/ProviderService/ProviderService.ts
+++ b/apps/provider-proxy/src/services/ProviderService/ProviderService.ts
@@ -40,7 +40,7 @@ export class ProviderService {
   isValidationServerError(rawBody: unknown): boolean {
     if (typeof rawBody !== "string") return false;
     const body = rawBody.trim();
-    return body.startsWith("manifest cross-validation error: ") || body.startsWith("hostname not allowed:");
+    return body.startsWith("manifest cross-validation error:") || body.startsWith("hostname not allowed:") || body.includes("validation failed");
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection for validation server errors, ensuring more error messages are correctly identified and handled.

* **Tests**
  * Added a new test case to verify the updated error detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->