### PR TITLE
refactor: moves user registraction logic under user controller

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -73,7 +73,7 @@ import {
 import { Scheduler } from "./scheduler";
 import { templatesRouter } from "./template";
 import { transactionsRouter } from "./transaction";
-import { createAnonymousUserRouter, getAnonymousUserRouter } from "./user";
+import { createAnonymousUserRouter, getAnonymousUserRouter, getCurrentUserRouter, registerUserRouter } from "./user";
 import { validatorsRouter } from "./validator";
 
 const appHono = new Hono<AppEnv>();
@@ -123,6 +123,8 @@ const openApiHonoHandlers: OpenApiHonoHandler[] = [
   usageRouter,
   createAnonymousUserRouter,
   getAnonymousUserRouter,
+  registerUserRouter,
+  getCurrentUserRouter,
   sendVerificationEmailRouter,
   deploymentSettingRouter,
   deploymentsRouter,

--- a/apps/api/src/auth/services/auth.interceptor.spec.ts
+++ b/apps/api/src/auth/services/auth.interceptor.spec.ts
@@ -5,6 +5,7 @@ import { container as globalContainer } from "tsyringe";
 import { ApiKeyRepository } from "@src/auth/repositories/api-key/api-key.repository";
 import { ApiKeyAuthService } from "@src/auth/services/api-key/api-key-auth.service";
 import { AuthTokenService } from "@src/auth/services/auth-token/auth-token.service";
+import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
 import type { UserOutput } from "@src/user/repositories/user/user.repository";
 import { UserRepository } from "@src/user/repositories/user/user.repository";
 import { AbilityService } from "./ability/ability.service";
@@ -130,6 +131,23 @@ describe(AuthInterceptor.name, () => {
       })
     );
     di.register(AuthInterceptor, { useClass: AuthInterceptor });
+    di.register(ExecutionContextService, {
+      useValue: mock<ExecutionContextService>({
+        get: key =>
+          (
+            ({
+              HTTP_CONTEXT: {
+                var: {
+                  clientInfo: {
+                    ip: "127.0.0.1",
+                    fingerprint: "123"
+                  }
+                }
+              }
+            }) as any
+          )[key]
+      })
+    });
 
     const app = new Hono().use(di.resolve(AuthInterceptor).intercept()).get("/", c => c.text("Ok"));
     const headers: Record<string, string> = {};

--- a/apps/api/src/core/repositories/base.repository.ts
+++ b/apps/api/src/core/repositories/base.repository.ts
@@ -3,6 +3,7 @@ import type { DBQueryConfig } from "drizzle-orm";
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
 import type { PgTableWithColumns } from "drizzle-orm/pg-core";
 import type { SQL } from "drizzle-orm/sql/sql";
+import { PostgresError } from "postgres";
 
 import type { ApiPgDatabase, ApiPgTables, TxService } from "@src/core";
 import { DrizzleAbility } from "@src/lib/drizzle-ability/drizzle-ability";
@@ -221,3 +222,8 @@ type TableName<T extends PgTableWithColumns<any>> = T extends PgTableWithColumns
 type TableNameInSchema<T extends PgTableWithColumns<any>> = {
   [K in keyof TablesOnly<ApiPgTables> as TableName<ApiPgTables[K]>]: K;
 }[TableName<T>];
+
+const UNIQUE_VIOLATION_CODE = "23505";
+export function isUniqueViolation(error: unknown): error is PostgresError {
+  return error instanceof PostgresError && error.code === UNIQUE_VIOLATION_CODE;
+}

--- a/apps/api/src/routers/userRouter.ts
+++ b/apps/api/src/routers/userRouter.ts
@@ -39,6 +39,9 @@ userOptionalRouter.get("/byUsername/:username", async c => {
   return c.json(user);
 });
 
+/**
+ * @deprecated Use /v1/register-user instead
+ */
 userRequiredRouter.post("/tokenInfo", async c => {
   const userId = getCurrentUserId(c);
   const { wantedUsername, email, emailVerified, subscribedToNewsletter } = await c.req.json();

--- a/apps/api/src/user/routes/get-current-user/get-current-user.router.ts
+++ b/apps/api/src/user/routes/get-current-user/get-current-user.router.ts
@@ -1,0 +1,28 @@
+import { createRoute } from "@hono/zod-openapi";
+import { container } from "tsyringe";
+
+import { OpenApiHonoHandler } from "@src/core/services/open-api-hono-handler/open-api-hono-handler";
+import { UserController } from "@src/user/controllers/user/user.controller";
+import { GetUserResponseOutputSchema } from "@src/user/schemas/user.schema";
+
+const route = createRoute({
+  method: "get",
+  path: "/v1/user/me",
+  summary: "Retrieves the logged in user",
+  tags: ["Users"],
+  responses: {
+    200: {
+      description: "Returns the logged in user",
+      body: {
+        content: {
+          "application/json": {
+            schema: GetUserResponseOutputSchema
+          }
+        }
+      }
+    }
+  }
+});
+export const getCurrentUserRouter = new OpenApiHonoHandler().openapi(route, async function getCurrentUser(c) {
+  return c.json(await container.resolve(UserController).getCurrentUser(), 200);
+});

--- a/apps/api/src/user/routes/index.ts
+++ b/apps/api/src/user/routes/index.ts
@@ -1,2 +1,4 @@
 export * from "@src/user/routes/create-anonymous-user/create-anonymous-user.router";
 export * from "@src/user/routes/get-anonymous-user/get-anonymous-user.router";
+export * from "@src/user/routes/register-user/register-user.router";
+export * from "@src/user/routes/get-current-user/get-current-user.router";

--- a/apps/api/src/user/routes/register-user/register-user.router.ts
+++ b/apps/api/src/user/routes/register-user/register-user.router.ts
@@ -1,0 +1,52 @@
+import { createRoute } from "@hono/zod-openapi";
+import { container } from "tsyringe";
+import { z } from "zod";
+
+import { OpenApiHonoHandler } from "@src/core/services/open-api-hono-handler/open-api-hono-handler";
+import { UserController } from "@src/user/controllers/user/user.controller";
+import { UserSchema } from "@src/user/schemas/user.schema";
+
+const registerUserInputSchema = z.object({
+  wantedUsername: z.string(),
+  email: z.string(),
+  emailVerified: z.boolean(),
+  subscribedToNewsletter: z.boolean().optional()
+});
+export type RegisterUserInput = z.infer<typeof registerUserInputSchema>;
+
+const registerUserResponseSchema = z.object({
+  data: UserSchema
+});
+export type RegisterUserResponse = z.infer<typeof registerUserResponseSchema>;
+
+const route = createRoute({
+  method: "post",
+  path: "/v1/register-user",
+  summary: "Registers a new user",
+  tags: ["Users"],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: registerUserInputSchema
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: "Returns the registered user",
+      body: {
+        content: {
+          "application/json": {
+            schema: registerUserResponseSchema
+          }
+        }
+      }
+    }
+  }
+});
+export const registerUserRouter = new OpenApiHonoHandler().openapi(route, async function registerUser(c) {
+  const data = await container.resolve(UserController).registerUser(c.req.valid("json"));
+  return c.json(data, 200);
+});

--- a/apps/api/src/user/schemas/user.schema.ts
+++ b/apps/api/src/user/schemas/user.schema.ts
@@ -20,3 +20,19 @@ export const GetUserResponseOutputSchema = z.object({
 });
 
 export type GetUserResponseOutput = z.infer<typeof GetUserResponseOutputSchema>;
+
+export const UserSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  username: z.string(),
+  email: z.string(),
+  emailVerified: z.boolean(),
+  stripeCustomerId: z.string().optional().nullable(),
+  bio: z.string().optional().nullable(),
+  subscribedToNewsletter: z.boolean(),
+  youtubeUsername: z.string().optional().nullable(),
+  twitterUsername: z.string().optional().nullable(),
+  githubUsername: z.string().optional().nullable()
+});
+
+export type UserSchema = z.infer<typeof UserSchema>;

--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -1,0 +1,272 @@
+import "@test/setup-functional-tests"; // eslint-disable-line simple-import-sort/imports
+
+import { faker } from "@faker-js/faker";
+import { mock } from "jest-mock-extended";
+import { container } from "tsyringe";
+
+import { UserWalletRepository } from "@src/billing/repositories/user-wallet/user-wallet.repository";
+import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { AnalyticsService } from "@src/core/services/analytics/analytics.service";
+import { UserRepository } from "@src/user/repositories/user/user.repository";
+import type { RegisterUserInput } from "./user.service";
+import { UserService } from "./user.service";
+
+describe(UserService.name, () => {
+  describe("registerUser", () => {
+    it("registers a new user if no anonymousUserId and no userId is provided", async () => {
+      const { service, analyticsService, logger } = setup();
+
+      const input: RegisterUserInput = {
+        userId: faker.string.uuid(),
+        wantedUsername: `test-user-${Date.now()}`,
+        email: faker.internet.email(),
+        emailVerified: faker.datatype.boolean(),
+        subscribedToNewsletter: faker.datatype.boolean(),
+        ip: faker.internet.ipv4(),
+        userAgent: faker.string.alphanumeric(32),
+        fingerprint: faker.string.alphanumeric(16)
+      };
+      const user = await service.registerUser(input);
+
+      expect(user).toMatchObject({
+        id: expect.any(String),
+        userId: input.userId,
+        email: input.email,
+        emailVerified: input.emailVerified,
+        subscribedToNewsletter: input.subscribedToNewsletter,
+        username: input.wantedUsername
+      });
+
+      expect(analyticsService.track).toHaveBeenCalledWith(user.id, "user_registered");
+      expect(logger.info).toHaveBeenCalledWith({ event: "USER_REGISTERED", id: user.id, userId: user.userId });
+    });
+
+    it("updates anonymous user if anonymousUserId is provided", async () => {
+      const { service, analyticsService, logger } = setup();
+
+      const anonymousUser = await container.resolve(UserRepository).create({
+        userId: null,
+        emailVerified: false,
+        subscribedToNewsletter: false
+      });
+
+      const input: RegisterUserInput = {
+        userId: faker.string.uuid(),
+        anonymousUserId: anonymousUser.id,
+        wantedUsername: `test-user-${Date.now()}`,
+        email: faker.internet.email(),
+        emailVerified: faker.datatype.boolean(),
+        subscribedToNewsletter: faker.datatype.boolean(),
+        ip: faker.internet.ipv4(),
+        userAgent: faker.string.alphanumeric(32),
+        fingerprint: faker.string.alphanumeric(16)
+      };
+      const user = await service.registerUser(input);
+      const reloadedUser = await container.resolve(UserRepository).findById(anonymousUser.id);
+
+      expect(reloadedUser).toMatchObject(user);
+      expect(analyticsService.track).toHaveBeenCalledWith(user.id, "user_registered");
+      expect(logger.info).toHaveBeenCalledWith({ event: "ANONYMOUS_USER_REGISTERED", id: user.id, userId: user.userId });
+    });
+
+    it("creates a new user if anonymousUserId is provided but no anonymous user exists", async () => {
+      const { service, analyticsService, logger } = setup();
+
+      const input: RegisterUserInput = {
+        userId: faker.string.uuid(),
+        anonymousUserId: faker.string.uuid(),
+        wantedUsername: `test-user-${Date.now()}`,
+        email: faker.internet.email(),
+        emailVerified: faker.datatype.boolean(),
+        subscribedToNewsletter: faker.datatype.boolean(),
+        ip: faker.internet.ipv4(),
+        userAgent: faker.string.alphanumeric(32),
+        fingerprint: faker.string.alphanumeric(16)
+      };
+      const user = await service.registerUser(input);
+
+      expect(user).toMatchObject({
+        id: expect.any(String),
+        userId: input.userId,
+        username: input.wantedUsername,
+        email: input.email,
+        emailVerified: input.emailVerified
+      });
+      expect(analyticsService.track).toHaveBeenCalledWith(user.id, "user_registered");
+      expect(logger.info).toHaveBeenCalledWith({ event: "USER_REGISTERED", id: user.id, userId: user.userId });
+    });
+
+    it("creates a new user if anonymousUserId is provided, anonymous user exists but has non-nullable userId", async () => {
+      const { service, analyticsService, logger } = setup();
+
+      const anonymousUser = await container.resolve(UserRepository).create({
+        userId: faker.string.uuid(),
+        emailVerified: false,
+        subscribedToNewsletter: false
+      });
+
+      const input: RegisterUserInput = {
+        userId: faker.string.uuid(),
+        anonymousUserId: anonymousUser.id,
+        wantedUsername: `test-user-${Date.now()}`,
+        email: faker.internet.email(),
+        emailVerified: faker.datatype.boolean(),
+        subscribedToNewsletter: faker.datatype.boolean(),
+        ip: faker.internet.ipv4(),
+        userAgent: faker.string.alphanumeric(32),
+        fingerprint: faker.string.alphanumeric(16)
+      };
+      const user = await service.registerUser(input);
+      const reloadedUser = await container.resolve(UserRepository).findById(anonymousUser.id);
+
+      expect(reloadedUser!.id).not.toBe(user.id);
+      expect(reloadedUser!.userId).not.toBe(user.userId);
+      expect(analyticsService.track).toHaveBeenCalledWith(user.id, "user_registered");
+      expect(logger.info).toHaveBeenCalledWith({ event: "USER_REGISTERED", id: user.id, userId: user.userId });
+    });
+
+    it("resolves username collision by adjusting username", async () => {
+      const { service } = setup();
+
+      const conflictingUsername = "conflictuser";
+
+      const existingUser = await container.resolve(UserRepository).create({
+        userId: faker.string.uuid(),
+        username: conflictingUsername,
+        emailVerified: false,
+        subscribedToNewsletter: false
+      });
+      const input: RegisterUserInput = {
+        userId: faker.string.uuid(),
+        wantedUsername: conflictingUsername,
+        email: faker.internet.email(),
+        emailVerified: faker.datatype.boolean(),
+        subscribedToNewsletter: faker.datatype.boolean(),
+        ip: faker.internet.ipv4(),
+        userAgent: faker.string.alphanumeric(32),
+        fingerprint: faker.string.alphanumeric(16)
+      };
+      const newUsers = await Promise.all([
+        service.registerUser({ ...input, email: faker.internet.email(), userId: faker.string.uuid() }),
+        service.registerUser({ ...input, email: faker.internet.email(), userId: faker.string.uuid() })
+      ]);
+
+      expect(newUsers.map(u => u.id)).not.toContain(existingUser.id);
+      expect(newUsers[0].username).not.toBe(existingUser.username);
+      expect(newUsers[0].username).toMatch(new RegExp(`^${conflictingUsername}`));
+      expect(newUsers[1].username).not.toBe(existingUser.username);
+      expect(newUsers[1].username).toMatch(new RegExp(`^${conflictingUsername}`));
+    });
+
+    it("transfers wallet from previous non-anonymous user to the newly registered user", async () => {
+      const { service } = setup();
+
+      const existingUser = await container.resolve(UserRepository).create({
+        userId: faker.string.uuid(),
+        emailVerified: false,
+        subscribedToNewsletter: false,
+        username: faker.internet.userName()
+      });
+
+      const wallet = await container.resolve(UserWalletRepository).create({
+        userId: existingUser.id,
+        address: faker.string.alphanumeric(40)
+      });
+
+      const input: RegisterUserInput = {
+        userId: faker.string.uuid(),
+        wantedUsername: faker.internet.userName(),
+        email: faker.internet.email(),
+        emailVerified: faker.datatype.boolean(),
+        subscribedToNewsletter: faker.datatype.boolean(),
+        ip: faker.internet.ipv4(),
+        userAgent: faker.string.alphanumeric(32),
+        fingerprint: faker.string.alphanumeric(16)
+      };
+      const newUser = await service.registerUser({ ...input, anonymousUserId: existingUser.id });
+
+      const updatedWallet = await container.resolve(UserWalletRepository).findById(wallet.id);
+      expect(updatedWallet?.userId).toBe(newUser.id);
+    });
+
+    it("ignores wallet transfer conflicts (destination already has wallet)", async () => {
+      const { service } = setup();
+
+      const existingUser = await container.resolve(UserRepository).create({
+        userId: faker.string.uuid(),
+        emailVerified: false,
+        subscribedToNewsletter: false,
+        username: faker.internet.userName()
+      });
+      const wallet = await container.resolve(UserWalletRepository).create({
+        userId: existingUser.id,
+        address: faker.string.alphanumeric(40)
+      });
+
+      const destinationUser = await container.resolve(UserRepository).create({
+        userId: faker.string.uuid(),
+        emailVerified: false,
+        subscribedToNewsletter: false,
+        username: faker.internet.userName()
+      });
+      await container.resolve(UserWalletRepository).create({ userId: destinationUser.id, address: faker.string.alphanumeric(40) });
+
+      const input: RegisterUserInput = {
+        userId: destinationUser.userId!,
+        wantedUsername: faker.internet.userName(),
+        email: faker.internet.email(),
+        emailVerified: faker.datatype.boolean(),
+        subscribedToNewsletter: faker.datatype.boolean(),
+        ip: faker.internet.ipv4(),
+        userAgent: faker.string.alphanumeric(32),
+        fingerprint: faker.string.alphanumeric(16)
+      };
+
+      await expect(service.registerUser({ ...input, anonymousUserId: existingUser.id })).resolves.toBeDefined();
+
+      const walletAfter = await container.resolve(UserWalletRepository).findById(wallet.id);
+      expect(walletAfter?.userId).toBe(existingUser.id);
+    });
+
+    it("updates user if registering existing user", async () => {
+      const { service } = setup();
+
+      const existingUser = await container.resolve(UserRepository).create({
+        userId: faker.string.uuid(),
+        email: faker.internet.email(),
+        emailVerified: false,
+        subscribedToNewsletter: false
+      });
+
+      const input: RegisterUserInput = {
+        userId: existingUser.userId!,
+        wantedUsername: faker.internet.userName(),
+        email: `new_email_${existingUser.email}`,
+        emailVerified: true,
+        subscribedToNewsletter: true,
+        ip: faker.internet.ipv4(),
+        userAgent: faker.string.alphanumeric(32),
+        fingerprint: faker.string.alphanumeric(16)
+      };
+
+      const newUser = await service.registerUser(input);
+
+      expect(newUser).toMatchObject({
+        id: existingUser.id,
+        userId: existingUser.userId!,
+        username: input.wantedUsername,
+        email: input.email,
+        emailVerified: input.emailVerified,
+        subscribedToNewsletter: input.subscribedToNewsletter
+      });
+    });
+  });
+
+  function setup() {
+    const analyticsService = mock<AnalyticsService>();
+    const logger = mock<LoggerService>();
+    const service = new UserService(container.resolve(UserRepository), analyticsService, container.resolve(UserWalletRepository), logger);
+
+    return { service, analyticsService, logger };
+  }
+});

--- a/apps/api/src/user/services/user/user.service.ts
+++ b/apps/api/src/user/services/user/user.service.ts
@@ -1,0 +1,149 @@
+import randomInt from "lodash/random";
+import { singleton } from "tsyringe";
+
+import { UserWalletRepository } from "@src/billing/repositories/user-wallet/user-wallet.repository";
+import { LoggerService } from "@src/core/providers/logging.provider";
+import { isUniqueViolation } from "@src/core/repositories/base.repository";
+import { AnalyticsService } from "@src/core/services/analytics/analytics.service";
+import { UserOutput, UserRepository } from "../../repositories/user/user.repository";
+
+@singleton()
+export class UserService {
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly analyticsService: AnalyticsService,
+    private readonly userWalletRepository: UserWalletRepository,
+    private readonly logger: LoggerService
+  ) {}
+
+  async registerUser(data: RegisterUserInput): Promise<{
+    id: string;
+    userId: string;
+    username: string;
+    email: string;
+    emailVerified: boolean;
+    stripeCustomerId: string | null;
+    bio: string | null;
+    subscribedToNewsletter: boolean;
+    youtubeUsername: string | null;
+    twitterUsername: string | null;
+    githubUsername: string | null;
+  }> {
+    let isAnonymous = false;
+    const userDetails = {
+      userId: data.userId,
+      email: data.email,
+      emailVerified: data.emailVerified,
+      subscribedToNewsletter: data.subscribedToNewsletter,
+      lastIp: data.ip,
+      lastUserAgent: data.userAgent,
+      lastFingerprint: data.fingerprint
+    };
+
+    if (data.anonymousUserId) {
+      const user = await this.userRepository.updateBy(
+        {
+          id: data.anonymousUserId,
+          userId: null
+        },
+        userDetails,
+        { returning: true }
+      );
+
+      isAnonymous = !!user;
+    }
+
+    const user = await this.upsertUser({
+      ...userDetails,
+      username: data.wantedUsername
+    });
+
+    if (!isAnonymous && data.anonymousUserId && user.id !== data.anonymousUserId) {
+      await this.tryToTransferWallet(data.anonymousUserId, user.id);
+    }
+
+    const event = isAnonymous ? "ANONYMOUS_USER_REGISTERED" : "USER_REGISTERED";
+    this.logger.info({ event, id: user.id, userId: user.userId });
+    this.analyticsService.track(user.id, "user_registered");
+
+    const { id, userId, username, email, emailVerified, stripeCustomerId, bio, subscribedToNewsletter, youtubeUsername, twitterUsername, githubUsername } =
+      user;
+
+    return {
+      id,
+      userId,
+      username,
+      email,
+      emailVerified,
+      stripeCustomerId,
+      bio,
+      subscribedToNewsletter,
+      youtubeUsername,
+      twitterUsername,
+      githubUsername
+    } as Awaited<ReturnType<this["registerUser"]>>;
+  }
+
+  private async upsertUser(userDetails: UpdateUserInput, attempt = 0): Promise<UserOutput> {
+    try {
+      return await this.userRepository.upsert(userDetails);
+    } catch (error) {
+      if (userDetails.username && isUniqueViolation(error) && error.constraint_name?.includes("username") && attempt < 10) {
+        return this.upsertUser(
+          {
+            ...userDetails,
+            username: adjustUsername(userDetails.username)
+          },
+          attempt + 1
+        );
+      }
+
+      throw error;
+    }
+  }
+
+  private async tryToTransferWallet(prevUserId: string, nextUserId: string) {
+    try {
+      await this.userWalletRepository.updateBy({ userId: prevUserId }, { userId: nextUserId });
+    } catch (error) {
+      if (!isUniqueViolation(error) || error.constraint_name !== "user_wallets_user_id_unique") {
+        throw error;
+      }
+    }
+  }
+}
+
+function adjustUsername(wantedUsername: string) {
+  let baseUsername = wantedUsername.replace(/[^\w-]+/g, "");
+
+  if (baseUsername.length < 3) {
+    baseUsername = baseUsername.padEnd(10, "anonymous");
+  } else if (baseUsername.length > 40) {
+    baseUsername = baseUsername.slice(0, 40);
+  }
+
+  return baseUsername + randomInt(1000, 9999).toString();
+}
+
+type UpdateUserInput = Partial<{
+  userId: string;
+  username: string;
+  email: string;
+  emailVerified: boolean;
+  subscribedToNewsletter: boolean;
+  lastIp: string;
+  lastUserAgent: string;
+  lastFingerprint: string;
+}>;
+
+export interface RegisterUserInput {
+  anonymousUserId?: string;
+  userId: string;
+  wantedUsername: string;
+  email: string;
+  emailVerified: boolean;
+  subscribedToNewsletter: boolean;
+  ip: string;
+  userAgent: string;
+  fingerprint: string;
+}

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -10036,6 +10036,73 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
         ],
       },
     },
+    "/v1/register-user": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "email": {
+                    "type": "string",
+                  },
+                  "emailVerified": {
+                    "type": "boolean",
+                  },
+                  "subscribedToNewsletter": {
+                    "type": "boolean",
+                  },
+                  "wantedUsername": {
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "wantedUsername",
+                  "email",
+                  "emailVerified",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "body": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "_cached": null,
+                    "_def": {
+                      "catchall": {
+                        "_def": {
+                          "typeName": "ZodNever",
+                        },
+                        "~standard": {
+                          "vendor": "zod",
+                          "version": 1,
+                        },
+                      },
+                      "typeName": "ZodObject",
+                      "unknownKeys": "strip",
+                    },
+                    "~standard": {
+                      "vendor": "zod",
+                      "version": 1,
+                    },
+                  },
+                },
+              },
+            },
+            "description": "Returns the registered user",
+          },
+        },
+        "summary": "Registers a new user",
+        "tags": [
+          "Users",
+        ],
+      },
+    },
     "/v1/send-verification-email": {
       "post": {
         "requestBody": {
@@ -11741,6 +11808,45 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
         "summary": "Get historical usage stats for a wallet address.",
         "tags": [
           "Billing",
+        ],
+      },
+    },
+    "/v1/user/me": {
+      "get": {
+        "responses": {
+          "200": {
+            "body": {
+              "content": {
+                "application/json": {
+                  "schema": {
+                    "_cached": null,
+                    "_def": {
+                      "catchall": {
+                        "_def": {
+                          "typeName": "ZodNever",
+                        },
+                        "~standard": {
+                          "vendor": "zod",
+                          "version": 1,
+                        },
+                      },
+                      "typeName": "ZodObject",
+                      "unknownKeys": "strip",
+                    },
+                    "~standard": {
+                      "vendor": "zod",
+                      "version": 1,
+                    },
+                  },
+                },
+              },
+            },
+            "description": "Returns the logged in user",
+          },
+        },
+        "summary": "Retrieves the logged in user",
+        "tags": [
+          "Users",
         ],
       },
     },

--- a/apps/api/test/services/wallet-testing.service.ts
+++ b/apps/api/test/services/wallet-testing.service.ts
@@ -122,7 +122,7 @@ export class WalletTestingService<T extends Hono<any>> {
 
     const decoded = decode(access_token) as { sub: string; email: string; nickname: string; email_verified: boolean };
 
-    const userResponse = await this.app.request(`/user/tokenInfo`, {
+    const userResponse = await this.app.request(`/v1/register-user`, {
       method: "POST",
       headers: new Headers({
         "Content-Type": "application/json",
@@ -135,8 +135,9 @@ export class WalletTestingService<T extends Hono<any>> {
         subscribedToNewsletter: false
       })
     });
+    const body = (await userResponse.json()) as { data: any };
 
-    return { user: (await userResponse.json()) as any, token: access_token };
+    return { user: body.data, token: access_token };
   }
 
   async getWalletByUserId(userId: string, token: string): Promise<{ id: number; address: string; creditAmount: number }> {

--- a/apps/deploy-web/src/components/layout/AccountMenu.tsx
+++ b/apps/deploy-web/src/components/layout/AccountMenu.tsx
@@ -14,6 +14,7 @@ import ClickAwayListener from "@mui/material/ClickAwayListener";
 import { GraphUp, Key, LogOut, MultiplePages, Settings, Star, User } from "iconoir-react";
 import { useRouter } from "next/navigation";
 
+import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
 import { useFlag } from "@src/hooks/useFlag";
@@ -27,6 +28,7 @@ export function AccountMenu() {
   const router = useRouter();
   const isBillingUsageEnabled = useFlag("billing_usage");
   const wallet = useWallet();
+  const { authService } = useServices();
 
   return (
     <React.Fragment>
@@ -98,7 +100,7 @@ export function AccountMenu() {
                           </CustomDropdownLinkItem>
                         )}
                         <DropdownMenuSeparator />
-                        <CustomDropdownLinkItem onClick={() => (window.location.href = UrlService.logout())} icon={<LogOut />}>
+                        <CustomDropdownLinkItem onClick={() => authService.logout()} icon={<LogOut />}>
                           Logout
                         </CustomDropdownLinkItem>
                       </div>

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
@@ -185,7 +185,10 @@ describe("OnboardingContainer", () => {
 
     const mockUseUser = jest.fn().mockReturnValue(input.user || { emailVerified: false });
     const mockUsePaymentMethodsQuery = jest.fn().mockReturnValue({ data: input.paymentMethods || [] });
-    const mockUseServices = jest.fn().mockReturnValue({ analyticsService: mockAnalyticsService });
+    const mockUseServices = jest.fn().mockReturnValue({
+      analyticsService: mockAnalyticsService,
+      urlService: mockUrlService
+    });
     const mockUseRouter = jest.fn().mockReturnValue(mockRouter);
 
     // Create dependencies object
@@ -193,8 +196,7 @@ describe("OnboardingContainer", () => {
       useUser: mockUseUser,
       usePaymentMethodsQuery: mockUsePaymentMethodsQuery,
       useServices: mockUseServices,
-      useRouter: mockUseRouter,
-      UrlService: mockUrlService
+      useRouter: mockUseRouter
     };
 
     const mockChildren = jest.fn().mockReturnValue(<div>Test</div>);

--- a/apps/deploy-web/src/services/app-di-container/app-di-container.ts
+++ b/apps/deploy-web/src/services/app-di-container/app-di-container.ts
@@ -45,7 +45,7 @@ export const createAppRootContainer = (config: ServicesConfig) => {
           response: [...(interceptors?.response || [])]
         });
     },
-    authService: () => new AuthService(),
+    authService: () => new AuthService(container.urlService),
     user: () =>
       container.applyAxiosInterceptors(new UserHttpService(apiConfig), {
         request: [container.authService.withAnonymousUserHeader],

--- a/apps/deploy-web/src/services/auth/auth.service.ts
+++ b/apps/deploy-web/src/services/auth/auth.service.ts
@@ -1,9 +1,10 @@
 import type { InternalAxiosRequestConfig } from "axios";
 
 import { ANONYMOUS_USER_TOKEN_KEY } from "@src/config/auth.config";
+import { ONBOARDING_STEP_KEY } from "../storage/keys";
 
 export class AuthService {
-  constructor() {
+  constructor(private readonly urlService: LogoutUrlService) {
     this.withAnonymousUserHeader = this.withAnonymousUserHeader.bind(this);
   }
 
@@ -18,4 +19,15 @@ export class AuthService {
 
     return config;
   }
+
+  logout() {
+    if (typeof window === "undefined") return;
+    window.localStorage.removeItem(ANONYMOUS_USER_TOKEN_KEY);
+    window.localStorage.removeItem(ONBOARDING_STEP_KEY);
+    window.location.href = this.urlService.logout();
+  }
+}
+
+interface LogoutUrlService {
+  logout(): string;
 }

--- a/apps/deploy-web/src/services/storage/keys.ts
+++ b/apps/deploy-web/src/services/storage/keys.ts
@@ -1,0 +1,1 @@
+export const ONBOARDING_STEP_KEY = "onboardingStep";


### PR DESCRIPTION
## Why

To make logic more transparent and add tests on db level to cover different edge cases. Ref: #1735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added POST /v1/register-user and GET /v1/user/me (included in OpenAPI) and a public User schema.

* **Refactor**
  * Auth callback now registers/refreshes users and merges profile data.
  * Frontend onboarding uses a centralized storage key and injected URL service; logout now uses in-app logout that clears tokens and redirects.

* **Tests**
  * New comprehensive tests for user registration, wallet/anonymous flows, and auth interceptor behavior.

* **Documentation**
  * Deprecated old token info route in favor of new endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->