### PR TITLE
fix(billing): only check for deployment allowance tx when create

### DIFF
--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -70,7 +70,10 @@ export class ManagedSignerService {
     const user = this.authService.currentUser.userId === userId ? this.authService.currentUser : await this.userRepository.findById(userId);
     assert(user, 404, "User Not Found");
     assert(userWallet.feeAllowance > 0, 403, "UserWallet has no fee allowance");
-    assert(userWallet.deploymentAllowance > 0, 403, "UserWallet has no deployment allowance");
+
+    if (messages.some(message => message.typeUrl === "/akash.deployment.v1beta3.MsgCreateDeployment")) {
+      assert(userWallet.deploymentAllowance > 0, 403, "UserWallet has no deployment allowance");
+    }
 
     if (this.featureFlagsService.isEnabled(FeatureFlags.ANONYMOUS_FREE_TRIAL)) {
       await Promise.all(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted transaction validation to require a deployment allowance only for deployment actions. Non-deployment transactions are no longer blocked by missing deployment allowances, reducing erroneous rejections.
  * Preserves existing fee checks and behavior for deployment-related transactions, ensuring consistent validation where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->