### PR TITLE
refactor: api types

### DIFF
--- a/apps/api/src/auth/repositories/api-key/api-key.repository.ts
+++ b/apps/api/src/auth/repositories/api-key/api-key.repository.ts
@@ -2,8 +2,8 @@ import { eq, lt, sql } from "drizzle-orm";
 import { and } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
-import { ApiPgDatabase, ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
-import { AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
+import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
+import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
 
 type Table = ApiPgTables["ApiKeys"];

--- a/apps/api/src/billing/controllers/checkout/checkout.controller.ts
+++ b/apps/api/src/billing/controllers/checkout/checkout.controller.ts
@@ -3,7 +3,7 @@ import type { Context } from "hono";
 import { singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
-import { BillingConfig, InjectBillingConfig } from "@src/billing/providers";
+import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { CheckoutService } from "@src/billing/services/checkout/checkout.service";
 import { StripeWebhookService } from "@src/billing/services/stripe-webhook/stripe-webhook.service";
 

--- a/apps/api/src/billing/repositories/checkout-session/checkout-session.repository.ts
+++ b/apps/api/src/billing/repositories/checkout-session/checkout-session.repository.ts
@@ -2,8 +2,8 @@ import { LoggerService } from "@akashnetwork/logging";
 import { backOff } from "exponential-backoff";
 import { singleton } from "tsyringe";
 
-import { ApiPgDatabase, ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
-import { AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
+import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
+import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
 
 type Table = ApiPgTables["CheckoutSessions"];

--- a/apps/api/src/billing/repositories/payment-method/payment-method.repository.ts
+++ b/apps/api/src/billing/repositories/payment-method/payment-method.repository.ts
@@ -1,8 +1,8 @@
 import { and, eq, inArray, ne } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
-import { ApiPgDatabase, ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
-import { AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
+import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
+import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
 
 type Table = ApiPgTables["PaymentMethods"];

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -1,8 +1,8 @@
 import { and, count, eq, inArray, lte } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
-import { ApiPgDatabase, ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
-import { AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
+import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
+import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
 
 export type DbUserWalletInput = Partial<ApiPgTables["UserWallets"]["$inferInsert"]>;

--- a/apps/api/src/billing/services/balances/balances.service.ts
+++ b/apps/api/src/billing/services/balances/balances.service.ts
@@ -2,9 +2,9 @@ import { AuthzHttpService, DeploymentHttpService, DeploymentInfo } from "@akashn
 import { singleton } from "tsyringe";
 
 import { Wallet } from "@src/billing/lib/wallet/wallet";
-import { BillingConfig, InjectBillingConfig } from "@src/billing/providers";
+import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { InjectWallet } from "@src/billing/providers/wallet.provider";
-import { UserWalletInput, UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
+import { type UserWalletInput, type UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
 
 @singleton()
 export class BalancesService {

--- a/apps/api/src/billing/services/financial-stats/financial-stats.service.ts
+++ b/apps/api/src/billing/services/financial-stats/financial-stats.service.ts
@@ -6,7 +6,7 @@ import { Op, QueryTypes } from "sequelize";
 import { singleton } from "tsyringe";
 
 import { USDC_IBC_DENOMS } from "@src/billing/config/network.config";
-import { BillingConfig, InjectBillingConfig } from "@src/billing/providers";
+import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { UserWalletRepository } from "@src/billing/repositories";
 import { chainDb } from "@src/db/dbConnection";
 import { apiNodeUrl } from "@src/utils/constants";

--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
@@ -6,7 +6,7 @@ import add from "date-fns/add";
 import { singleton } from "tsyringe";
 
 import { Wallet } from "@src/billing/lib/wallet/wallet";
-import { BillingConfig, InjectBillingConfig } from "@src/billing/providers";
+import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { InjectWallet } from "@src/billing/providers/wallet.provider";
 import type { DryRunOptions } from "@src/core/types/console";
 import { ManagedSignerService } from "../managed-signer/managed-signer.service";

--- a/apps/api/src/billing/services/provider-cleanup/provider-cleanup.service.ts
+++ b/apps/api/src/billing/services/provider-cleanup/provider-cleanup.service.ts
@@ -1,11 +1,11 @@
 import { LoggerService } from "@akashnetwork/logging";
 import { singleton } from "tsyringe";
 
-import { BillingConfig, InjectBillingConfig } from "@src/billing/providers";
-import { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
+import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
+import { type UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
 import { ManagedUserWalletService, RpcMessageService } from "@src/billing/services";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
-import { ProviderCleanupParams } from "@src/billing/types/provider-cleanup";
+import { type ProviderCleanupParams } from "@src/billing/types/provider-cleanup";
 import { ErrorService } from "@src/core/services/error/error.service";
 import { ProviderCleanupSummarizer } from "@src/deployment/lib/provider-cleanup-summarizer/provider-cleanup-summarizer";
 import { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -2,8 +2,8 @@ import { LoggerService } from "@akashnetwork/logging";
 import { PromisePool } from "@supercharge/promise-pool";
 import { singleton } from "tsyringe";
 
-import { BillingConfig, InjectBillingConfig } from "@src/billing/providers";
-import { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
+import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
+import { type UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
 import { ManagedUserWalletService, WalletInitializerService } from "@src/billing/services";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { Semaphore } from "@src/core/lib/semaphore.decorator";

--- a/apps/api/src/core/services/analytics/analytics.service.ts
+++ b/apps/api/src/core/services/analytics/analytics.service.ts
@@ -1,7 +1,7 @@
 import { inject, singleton } from "tsyringe";
 
-import { AMPLITUDE, Amplitude } from "@src/core/providers/amplitude.provider";
-import { HASHER, Hasher } from "@src/core/providers/hash.provider";
+import { AMPLITUDE, type Amplitude } from "@src/core/providers/amplitude.provider";
+import { HASHER, type Hasher } from "@src/core/providers/hash.provider";
 import { LoggerService } from "@src/core/providers/logging.provider";
 import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
 

--- a/apps/api/src/core/services/tx/tx.service.ts
+++ b/apps/api/src/core/services/tx/tx.service.ts
@@ -4,7 +4,7 @@ import { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js/session";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { container, singleton } from "tsyringe";
 
-import { ApiPgDatabase, ApiPgTables, InjectPg } from "@src/core/providers/postgres.provider";
+import { type ApiPgDatabase, type ApiPgTables, InjectPg } from "@src/core/providers/postgres.provider";
 
 type TxType = "PG_TX";
 

--- a/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.ts
+++ b/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.ts
@@ -3,10 +3,10 @@ import { singleton } from "tsyringe";
 
 import { Protected } from "@src/auth/services/auth.service";
 import {
-  CreateDeploymentSettingRequest,
-  DeploymentSettingResponse,
-  FindDeploymentSettingParams,
-  UpdateDeploymentSettingRequest
+  type CreateDeploymentSettingRequest,
+  type DeploymentSettingResponse,
+  type FindDeploymentSettingParams,
+  type UpdateDeploymentSettingRequest
 } from "@src/deployment/http-schemas/deployment-setting.schema";
 import { DeploymentSettingService } from "@src/deployment/services/deployment-setting/deployment-setting.service";
 

--- a/apps/api/src/deployment/controllers/lease/lease.controller.ts
+++ b/apps/api/src/deployment/controllers/lease/lease.controller.ts
@@ -3,8 +3,8 @@ import { singleton } from "tsyringe";
 
 import { AuthService, Protected } from "@src/auth/services/auth.service";
 import { UserWalletRepository } from "@src/billing/repositories";
-import { GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
-import { CreateLeaseRequest } from "@src/deployment/http-schemas/lease.schema";
+import { type GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
+import { type CreateLeaseRequest } from "@src/deployment/http-schemas/lease.schema";
 import { LeaseService } from "@src/deployment/services/lease/lease.service";
 
 @singleton()

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -3,8 +3,8 @@ import { last } from "lodash";
 import { singleton } from "tsyringe";
 
 import { UserWallets } from "@src/billing/model-schemas";
-import { ApiPgDatabase, ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
-import { AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
+import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
+import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
 import { Users } from "@src/user/model-schemas";
 

--- a/apps/api/src/deployment/services/sdl/sdl.service.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.ts
@@ -3,7 +3,7 @@ import { v2Manifest, v2Sdl, v3Manifest } from "@akashnetwork/akashjs/build/sdl/t
 import { NetworkId } from "@akashnetwork/akashjs/build/types/network";
 import { singleton } from "tsyringe";
 
-import { BillingConfig, InjectBillingConfig } from "@src/billing/providers";
+import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 
 type NetworkType = "beta2" | "beta3";
 

--- a/apps/api/src/gpu/services/gpu.service.ts
+++ b/apps/api/src/gpu/services/gpu.service.ts
@@ -3,8 +3,8 @@ import { minutesToSeconds } from "date-fns";
 import { injectable } from "tsyringe";
 
 import { Memoize } from "@src/caching/helpers";
-import { GpuVendor, ProviderConfigGpusType } from "@src/types/gpu";
-import { GpuBreakdownQuery } from "../http-schemas/gpu.schema";
+import { type GpuVendor, ProviderConfigGpusType } from "@src/types/gpu";
+import { type GpuBreakdownQuery } from "../http-schemas/gpu.schema";
 import { GpuRepository } from "../repositories/gpu.repository";
 
 @injectable()

--- a/apps/api/src/healthz/services/healthz/healthz.service.ts
+++ b/apps/api/src/healthz/services/healthz/healthz.service.ts
@@ -4,7 +4,7 @@ import { injectable } from "tsyringe";
 
 import { LoggerService } from "@src/core/providers/logging.provider";
 import { InjectPg } from "@src/core/providers/postgres.provider";
-import { ApiPgDatabase } from "@src/core/providers/postgres.provider";
+import { type ApiPgDatabase } from "@src/core/providers/postgres.provider";
 import type { HealthzResponse } from "@src/healthz/routes/healthz.router";
 
 @injectable()

--- a/apps/api/src/provider/services/provider-graph-data/provider-graph-data.service.ts
+++ b/apps/api/src/provider/services/provider-graph-data/provider-graph-data.service.ts
@@ -5,7 +5,7 @@ import { singleton } from "tsyringe";
 
 import { Memoize } from "@src/caching/helpers";
 import { chainDb } from "@src/db/dbConnection";
-import { ProviderStats, ProviderStatsKey } from "@src/types";
+import { type ProviderStats, type ProviderStatsKey } from "@src/types";
 import { env } from "@src/utils/env";
 
 export const emptyProviderGraphData = {

--- a/apps/api/src/provider/services/provider/provider.service.ts
+++ b/apps/api/src/provider/services/provider/provider.service.ts
@@ -7,7 +7,7 @@ import { Op } from "sequelize";
 import { setTimeout as delay } from "timers/promises";
 import { singleton } from "tsyringe";
 
-import { BillingConfig, InjectBillingConfig } from "@src/billing/providers";
+import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import { AUDITOR, TRIAL_ATTRIBUTE } from "@src/deployment/config/provider.config";
 import { LeaseStatusResponse } from "@src/deployment/http-schemas/lease.schema";
 import { ProviderProxyService } from "@src/provider/services/provider/provider-proxy.service";

--- a/apps/api/src/user/repositories/user/user.repository.ts
+++ b/apps/api/src/user/repositories/user/user.repository.ts
@@ -3,8 +3,8 @@ import { and, desc, eq, isNull, lt, lte, SQL, sql } from "drizzle-orm";
 import { PgUpdateSetSource } from "drizzle-orm/pg-core";
 import { singleton } from "tsyringe";
 
-import { ApiPgDatabase, ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
-import { AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
+import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
+import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
 import { userAgentMaxLength } from "@src/user/model-schemas/user/user.schema";
 


### PR DESCRIPTION
## Why

This is needed for tsup to compile our app. Basically every type should be imported as type


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Consolidated and reduced runtime dependencies by converting several compile-time-only imports to type-only usage across backend services, repositories, and controllers.
- Chores
  - Code hygiene and import consistency improvements to reduce bundle/runtime surface without altering behavior or APIs.

No user-facing changes in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->