### PR TITLE
fix: do not retry loading API keys on a 403

### DIFF
--- a/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
@@ -78,7 +78,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const { analyticsService, tx: txHttpService } = useServices();
 
   const [, setSettingsId] = useAtom(settingsIdAtom);
-  const [isWalletLoaded, setIsWalletLoaded] = useState<boolean>(true);
+  const [isWalletLoaded, setIsWalletLoaded] = useState<boolean>(false);
   const [loadingState, setLoadingState] = useState<LoadingState | undefined>(undefined);
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
   const router = useRouter();

--- a/apps/deploy-web/src/hooks/usePayingCustomerRequiredEventHandler.tsx
+++ b/apps/deploy-web/src/hooks/usePayingCustomerRequiredEventHandler.tsx
@@ -24,13 +24,14 @@ export const usePayingCustomerRequiredEventHandler = (): ((messageOtherwise: str
               {messageOtherwise}
             </Alert>
           ),
-          actions: [
+          actions: ({ close }) => [
             {
               label: "Add Funds",
               side: "right",
               size: "lg",
               onClick: () => {
                 router.push(UrlService.payment());
+                close();
               }
             }
           ]


### PR DESCRIPTION
refs #1798

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Wallet state now initializes as not loaded, preventing premature wallet-dependent UI on first render.
  - “Add Funds” action closes the popup after redirecting to the payment page for a smoother flow.
  - API keys fetch stops retrying on unauthorized responses, showing errors immediately instead of repeated retries.
- Chores
  - Internal adjustments to action handling and retry logic to improve reliability without changing public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->