### PR TITLE
fix: changes notifications to use pg pool

### DIFF
--- a/apps/notifications/src/infrastructure/db/db.module.ts
+++ b/apps/notifications/src/infrastructure/db/db.module.ts
@@ -16,7 +16,7 @@ export const register = <TSchema extends Record<string, unknown> = Record<string
     useFactory(configService: ConfigService<DbConfig>) {
       return {
         pg: {
-          connection: "client",
+          connection: "pool",
           config: {
             connectionString: configService.getOrThrow("db.NOTIFICATIONS_POSTGRES_URL")
           }


### PR DESCRIPTION
## Why

`client` option creates a single connection to pg and runs all queries sequentially. So, if 2 queries are sent in parallel - the 2nd will wait while the 1st is processed by pg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Switched the notifications service to use pooled database connections.
  * No changes to user-facing behavior, APIs, or settings.
  * Existing connection strings remain valid; deployment and runtime compatibility maintained.
  * No updates required for clients or integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->