### PR TITLE
feat: adds notification on start trial

### DIFF
--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
@@ -2,11 +2,16 @@ import { mock } from "jest-mock-extended";
 import { container } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
+import type { FeatureFlagValue } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { UserWalletRepository } from "../../repositories/user-wallet/user-wallet.repository";
 import { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wallet.service";
 import { WalletInitializerService } from "./wallet-initializer.service";
 
 import { createChainWallet } from "@test/seeders/chain-wallet.seeder";
+import { UserSeeder } from "@test/seeders/user.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
 describe(WalletInitializerService.name, () => {
@@ -24,7 +29,8 @@ describe(WalletInitializerService.name, () => {
         findWalletByUserId,
         createWallet,
         createAndAuthorizeTrialSpending,
-        updateWalletById
+        updateWalletById,
+        enabledFeatures: [FeatureFlags.ANONYMOUS_FREE_TRIAL]
       });
 
       await di.resolve(WalletInitializerService).initializeAndGrantTrialLimits(userId);
@@ -53,7 +59,8 @@ describe(WalletInitializerService.name, () => {
       const di = setup({
         findWalletByUserId,
         createAndAuthorizeTrialSpending,
-        createWallet
+        createWallet,
+        enabledFeatures: [FeatureFlags.ANONYMOUS_FREE_TRIAL]
       });
 
       await di.resolve(WalletInitializerService).initializeAndGrantTrialLimits(userId);
@@ -75,16 +82,57 @@ describe(WalletInitializerService.name, () => {
         findWalletByUserId,
         createWallet,
         deleteWalletById,
-        createAndAuthorizeTrialSpending
+        createAndAuthorizeTrialSpending,
+        enabledFeatures: [FeatureFlags.ANONYMOUS_FREE_TRIAL]
       });
 
       await expect(di.resolve(WalletInitializerService).initializeAndGrantTrialLimits(userId)).rejects.toThrow("Failed to authorize trial");
       expect(createAndAuthorizeTrialSpending).toHaveBeenCalledWith({ addressIndex: newWallet.id });
       expect(deleteWalletById).toHaveBeenCalledWith(newWallet.id);
     });
+
+    it(`sends "Start trial" notification when ANONYMOUS_FREE_TRIAL is disabled`, async () => {
+      const userId = "test-user-id";
+      const newWallet = UserWalletSeeder.create({ userId });
+      const findWalletByUserId = jest.fn().mockImplementation(async () => null);
+      const createWallet = jest.fn().mockImplementation(async () => newWallet);
+      const createAndAuthorizeTrialSpending = jest.fn().mockImplementation(async () => createChainWallet());
+      const updateWalletById = jest.fn().mockImplementation(async () => newWallet);
+
+      const di = setup({
+        userId,
+        findWalletByUserId,
+        createWallet,
+        createAndAuthorizeTrialSpending,
+        updateWalletById,
+        enabledFeatures: []
+      });
+
+      await di.resolve(WalletInitializerService).initializeAndGrantTrialLimits(userId);
+
+      expect(di.resolve(NotificationService).createNotification).toHaveBeenCalledWith({
+        notificationId: `startTrial.${userId}`,
+        payload: {
+          summary: "Start Trial",
+          description: "You have started a trial of Akash Network"
+        },
+        user: {
+          id: userId,
+          email: di.resolve(AuthService).currentUser.email
+        }
+      });
+    });
   });
 
-  function setup(input?: SetupInput) {
+  function setup(input?: {
+    findWalletByUserId?: UserWalletRepository["findOneByUserId"];
+    updateWalletById?: UserWalletRepository["updateById"];
+    createWallet?: UserWalletRepository["create"];
+    deleteWalletById?: UserWalletRepository["deleteById"];
+    createAndAuthorizeTrialSpending?: ManagedUserWalletService["createAndAuthorizeTrialSpending"];
+    userId?: string;
+    enabledFeatures?: FeatureFlagValue[];
+  }) {
     const di = container.createChildContainer();
     di.registerInstance(
       ManagedUserWalletService,
@@ -111,20 +159,20 @@ describe(WalletInitializerService.name, () => {
     di.registerInstance(
       AuthService,
       mock<AuthService>({
-        ability: {}
+        ability: {},
+        currentUser: UserSeeder.create({ id: input?.userId })
+      })
+    );
+    di.registerInstance(NotificationService, mock<NotificationService>());
+    di.registerInstance(
+      FeatureFlagsService,
+      mock<FeatureFlagsService>({
+        isEnabled: jest.fn(flag => !!input?.enabledFeatures?.includes(flag))
       })
     );
 
     container.clearInstances();
 
     return di;
-  }
-
-  interface SetupInput {
-    findWalletByUserId?: UserWalletRepository["findOneByUserId"];
-    updateWalletById?: UserWalletRepository["updateById"];
-    createWallet?: UserWalletRepository["create"];
-    deleteWalletById?: UserWalletRepository["deleteById"];
-    createAndAuthorizeTrialSpending?: ManagedUserWalletService["createAndAuthorizeTrialSpending"];
   }
 });

--- a/apps/api/src/notifications/providers/notifications-api.provider.ts
+++ b/apps/api/src/notifications/providers/notifications-api.provider.ts
@@ -19,3 +19,5 @@ function createNotificationsApiClient(config: NotificationsConfig) {
     baseUrl: config.NOTIFICATIONS_API_BASE_URL
   });
 }
+
+export { operations } from "@akashnetwork/react-query-sdk/notifications";

--- a/apps/api/src/notifications/services/notification-templates/start-trial-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/start-trial-notification.ts
@@ -1,0 +1,16 @@
+import type { UserOutput } from "@src/user/repositories";
+import type { CreateNotificationInput } from "../notification/notification.service";
+
+export function startTrialNotification(user: UserOutput): CreateNotificationInput {
+  return {
+    notificationId: `startTrial.${user.id}`,
+    payload: {
+      summary: "Start Trial",
+      description: "You have started a trial of Akash Network"
+    },
+    user: {
+      id: user.id,
+      email: user.email
+    }
+  };
+}

--- a/apps/api/src/notifications/services/notification/notification.service.spec.ts
+++ b/apps/api/src/notifications/services/notification/notification.service.spec.ts
@@ -1,0 +1,183 @@
+import { mock, mockDeep } from "jest-mock-extended";
+
+import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { NotificationsApiClient } from "../../providers/notifications-api.provider";
+import { type CreateNotificationInput, NotificationService } from "./notification.service";
+
+describe(NotificationService.name, () => {
+  describe("createDefaultChannel", () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("calls API to create default email channel with user's email", async () => {
+      jest.useFakeTimers();
+      const { service, api } = setup();
+
+      const user = { id: "user-1", email: "user@example.com" };
+      api.v1.createDefaultChannel.mockResolvedValue({} as never);
+
+      await Promise.all([service.createDefaultChannel(user), jest.runAllTimersAsync()]);
+
+      expect(api.v1.createDefaultChannel).toHaveBeenCalledWith({
+        parameters: {
+          header: {
+            "x-user-id": user.id
+          }
+        },
+        body: {
+          data: {
+            name: "Default",
+            type: "email",
+            config: {
+              addresses: [user.email!]
+            }
+          }
+        }
+      });
+    });
+
+    it("retries if notification service returns an error", async () => {
+      jest.useFakeTimers();
+      const { service, api } = setup();
+
+      jest.useFakeTimers();
+      const user = { id: "user-1", email: "user@example.com" };
+      api.v1.createDefaultChannel.mockRejectedValueOnce({ error: { statusCode: 400 } });
+      api.v1.createDefaultChannel.mockResolvedValueOnce({} as never);
+
+      await Promise.all([service.createDefaultChannel(user), jest.runAllTimersAsync()]);
+
+      expect(api.v1.createDefaultChannel).toHaveBeenCalledTimes(2);
+      expect(api.v1.createDefaultChannel).toHaveBeenCalledWith({
+        parameters: {
+          header: {
+            "x-user-id": user.id
+          }
+        },
+        body: {
+          data: {
+            name: "Default",
+            type: "email",
+            config: {
+              addresses: [user.email!]
+            }
+          }
+        }
+      });
+    });
+  });
+
+  describe("createNotification", () => {
+    it("sends notification", async () => {
+      jest.useFakeTimers();
+      const { service, api } = setup();
+
+      const input: CreateNotificationInput = {
+        user: { id: "user-1", email: "user@example.com" },
+        notificationId: "notif-1",
+        payload: { summary: "s", description: "d" }
+      };
+
+      api.v1.createNotification.mockResolvedValueOnce({} as never);
+
+      await Promise.all([service.createNotification(input), jest.runAllTimersAsync()]);
+
+      expect(api.v1.createNotification).toHaveBeenCalledTimes(1);
+      const call = api.v1.createNotification.mock.calls[0]![0] as {
+        parameters?: { header?: Record<string, unknown> };
+        body: unknown;
+      };
+      expect(call.parameters?.header?.["x-user-id"]).toBe(input.user.id);
+      expect(call.body).toEqual({
+        notificationId: input.notificationId,
+        payload: input.payload
+      });
+
+      expect(api.v1.createDefaultChannel).not.toHaveBeenCalled();
+    });
+
+    it("creates default channel and retries when channel not found and user has email", async () => {
+      jest.useFakeTimers();
+      const { service, api } = setup();
+
+      const input: CreateNotificationInput = {
+        user: { id: "user-1", email: "user@example.com" },
+        notificationId: "notif-1",
+        payload: { summary: "s", description: "d" }
+      };
+
+      api.v1.createNotification
+        .mockResolvedValueOnce({ error: { code: "NOTIFICATION_CHANNEL_NOT_FOUND" }, response: new Response() })
+        .mockResolvedValueOnce({} as never);
+
+      api.v1.createDefaultChannel.mockResolvedValueOnce({} as never);
+
+      await Promise.all([service.createNotification(input), jest.runAllTimersAsync()]);
+
+      expect(api.v1.createDefaultChannel).toHaveBeenCalledTimes(1);
+      expect(api.v1.createNotification).toHaveBeenCalledTimes(2);
+
+      const defaultChannelCall = api.v1.createDefaultChannel.mock.calls[0]![0] as {
+        parameters?: { header?: Record<string, unknown> };
+        body: { data: { config: { addresses: string[] } } };
+      };
+      expect(defaultChannelCall.parameters?.header?.["x-user-id"]).toBe(input.user.id);
+      expect(defaultChannelCall.body.data.config.addresses).toEqual([input.user.email!]);
+    });
+
+    it("does not create default channel when user has no email and logs an error", async () => {
+      jest.useFakeTimers();
+      const logger = mock<LoggerService>();
+      const { service, api } = setup({ logger });
+
+      const input: CreateNotificationInput = {
+        user: { id: "user-1", email: null },
+        notificationId: "notif-1",
+        payload: { summary: "s", description: "d" }
+      };
+
+      api.v1.createNotification.mockResolvedValue({ error: { code: "NOTIFICATION_CHANNEL_NOT_FOUND" }, response: new Response() });
+
+      await Promise.all([service.createNotification(input), jest.runAllTimersAsync()]);
+
+      expect(logger.error).toHaveBeenCalledWith({
+        event: "FAILED_TO_CREATE_NOTIFICATION",
+        error: expect.any(Error),
+        userId: input.user.id
+      });
+      expect(api.v1.createDefaultChannel).not.toHaveBeenCalled();
+      expect(api.v1.createNotification).toHaveBeenCalledTimes(10);
+    });
+
+    it("fails after 10 attempts if notification service is not available and logs an error", async () => {
+      jest.useFakeTimers();
+      const logger = mock<LoggerService>();
+      const { service, api } = setup({ logger });
+
+      const input: CreateNotificationInput = {
+        user: { id: "user-1", email: null },
+        notificationId: "notif-1",
+        payload: { summary: "s", description: "d" }
+      };
+
+      api.v1.createNotification.mockRejectedValue(new Error("fetch failed"));
+
+      await Promise.all([service.createNotification(input), jest.runAllTimersAsync()]);
+
+      expect(logger.error).toHaveBeenCalledWith({
+        event: "FAILED_TO_CREATE_NOTIFICATION",
+        error: expect.any(Error),
+        userId: input.user.id
+      });
+      expect(api.v1.createNotification).toHaveBeenCalledTimes(10);
+    });
+  });
+
+  function setup(input?: { logger?: LoggerService }) {
+    const api = mockDeep<NotificationsApiClient>();
+    const service = new NotificationService(api, input?.logger ?? mock<LoggerService>());
+
+    return { service, api };
+  }
+});

--- a/apps/api/src/notifications/services/notification/notification.service.ts
+++ b/apps/api/src/notifications/services/notification/notification.service.ts
@@ -1,0 +1,86 @@
+import { backOff, type BackoffOptions } from "exponential-backoff";
+import { inject, singleton } from "tsyringe";
+
+import { LoggerService } from "@src/core/providers/logging.provider";
+import { NOTIFICATIONS_API_CLIENT, NotificationsApiClient, operations } from "../../providers/notifications-api.provider";
+
+const DEFAULT_BACKOFF_OPTIONS: BackoffOptions = {
+  maxDelay: 5_000,
+  startingDelay: 500,
+  timeMultiple: 2,
+  numOfAttempts: 10
+};
+
+@singleton()
+export class NotificationService {
+  constructor(
+    @inject(NOTIFICATIONS_API_CLIENT) private readonly notificationsApi: NotificationsApiClient,
+    private readonly logger: LoggerService
+  ) {}
+
+  async createNotification(input: CreateNotificationInput): Promise<void> {
+    const { user, ...notification } = input;
+    await backOff(async () => {
+      const result = await this.notificationsApi.v1
+        .createNotification({
+          parameters: {
+            header: {
+              "x-user-id": user.id
+            }
+          } as any,
+          body: notification
+        })
+        .catch(error => ({ error, response: null }));
+
+      if (!result.error) return;
+
+      if (result.error.code === "NOTIFICATION_CHANNEL_NOT_FOUND" && user.email) {
+        await this.createDefaultChannel(user);
+      }
+
+      throw new Error("Failed to create notification", { cause: result.error });
+    }, DEFAULT_BACKOFF_OPTIONS).catch(error => {
+      this.logger.error({
+        event: "FAILED_TO_CREATE_NOTIFICATION",
+        error,
+        userId: user.id
+      });
+    });
+  }
+
+  async createDefaultChannel(user: UserInput): Promise<void> {
+    await backOff(async () => {
+      const result = await this.notificationsApi.v1
+        .createDefaultChannel({
+          parameters: {
+            header: {
+              "x-user-id": user.id
+            } as any
+          },
+          body: {
+            data: {
+              name: "Default",
+              type: "email",
+              config: {
+                addresses: [user.email!]
+              }
+            }
+          }
+        })
+        .catch(error => ({ error, response: null }));
+
+      if (!result.error) return;
+
+      throw new Error("Failed to create default notification channel", { cause: result.error });
+    }, DEFAULT_BACKOFF_OPTIONS);
+  }
+}
+
+interface UserInput {
+  id: string;
+  email?: string | null;
+}
+
+export type CreateNotificationInput = operations["createNotification"]["requestBody"]["content"]["application/json"] & {
+  user: UserInput;
+};

--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -10,12 +10,12 @@ import type { AnalyticsService } from "@src/core/services/analytics/analytics.se
 import { UserRepository } from "@src/user/repositories/user/user.repository";
 import type { RegisterUserInput } from "./user.service";
 import { UserService } from "./user.service";
-import type { NotificationsApiClient } from "@src/notifications/providers/notifications-api.provider";
+import type { NotificationService } from "@src/notifications/services/notification/notification.service";
 
 describe(UserService.name, () => {
   describe("registerUser", () => {
     it("registers a new user if no anonymousUserId and no userId is provided", async () => {
-      const createDefaultNotificationChannel = jest.fn(async () => ({}));
+      const createDefaultNotificationChannel = jest.fn(() => Promise.resolve());
       const { service, analyticsService, logger } = setup({ createDefaultNotificationChannel });
 
       const input: RegisterUserInput = {
@@ -41,21 +41,12 @@ describe(UserService.name, () => {
 
       expect(analyticsService.track).toHaveBeenCalledWith(user.id, "user_registered");
       expect(logger.info).toHaveBeenCalledWith({ event: "USER_REGISTERED", id: user.id, userId: user.userId });
-      expect(createDefaultNotificationChannel).toHaveBeenCalledWith({
-        parameters: {
-          header: {
-            "x-user-id": user.id
-          }
-        },
-        body: {
-          data: expect.objectContaining({
-            type: "email",
-            config: {
-              addresses: [input.email]
-            }
-          })
-        }
-      });
+      expect(createDefaultNotificationChannel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: user.id,
+          email: user.email
+        })
+      );
     });
 
     it("updates anonymous user if anonymousUserId is provided", async () => {
@@ -292,33 +283,6 @@ describe(UserService.name, () => {
 
       const error = new Error("test");
       const { service, logger } = setup({
-        createDefaultNotificationChannel: () => Promise.resolve({ error })
-      });
-
-      const user = await service.registerUser(input);
-
-      expect(user.id).toBeDefined();
-      expect(logger.error).toHaveBeenCalledWith({
-        event: "FAILED_TO_CREATE_DEFAULT_NOTIFICATION_CHANNEL",
-        id: user.id,
-        error
-      });
-    });
-
-    it("logs an error if createDefaultNotificationChannel fails", async () => {
-      const input: RegisterUserInput = {
-        userId: faker.string.uuid(),
-        wantedUsername: `test-user-${Date.now()}`,
-        email: faker.internet.email(),
-        emailVerified: faker.datatype.boolean(),
-        subscribedToNewsletter: faker.datatype.boolean(),
-        ip: faker.internet.ipv4(),
-        userAgent: faker.string.alphanumeric(32),
-        fingerprint: faker.string.alphanumeric(16)
-      };
-
-      const error = new Error("test");
-      const { service, logger } = setup({
         createDefaultNotificationChannel: () => Promise.reject(error)
       });
 
@@ -333,7 +297,7 @@ describe(UserService.name, () => {
     });
   });
 
-  function setup(input?: { createDefaultNotificationChannel?: () => Promise<{ error?: unknown }> }) {
+  function setup(input?: { createDefaultNotificationChannel?: NotificationService["createDefaultChannel"] }) {
     const analyticsService = mock<AnalyticsService>();
     const logger = mock<LoggerService>();
     const service = new UserService(
@@ -341,10 +305,8 @@ describe(UserService.name, () => {
       analyticsService,
       container.resolve(UserWalletRepository),
       logger,
-      mock<NotificationsApiClient>({
-        v1: {
-          createDefaultChannel: input?.createDefaultNotificationChannel ?? (async () => ({}))
-        } as unknown as NotificationsApiClient["v1"]
+      mock<NotificationService>({
+        createDefaultChannel: input?.createDefaultNotificationChannel ?? (() => Promise.resolve())
       })
     );
 

--- a/apps/api/test/services/stub.ts
+++ b/apps/api/test/services/stub.ts
@@ -1,1 +1,2 @@
+/** @deprecated use `mock` from jest-mock-extended instead */
 export const stub = <T>(obj: Record<string, any> = {}) => obj as jest.Mocked<T>;

--- a/apps/api/test/services/wallet-testing.service.ts
+++ b/apps/api/test/services/wallet-testing.service.ts
@@ -8,6 +8,7 @@ import { AuthService } from "@src/auth/services/auth.service";
 import type { UserWalletOutput } from "@src/billing/repositories/user-wallet/user-wallet.repository";
 import { WalletInitializerService } from "@src/billing/services";
 import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
+import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import type { UserOutput } from "@src/user/repositories";
 
 export class WalletTestingService<T extends Hono<any>> {
@@ -29,6 +30,8 @@ export class WalletTestingService<T extends Hono<any>> {
   }
 
   private async createWallet(user: UserOutput) {
+    jest.spyOn(container.resolve(NotificationService), "createNotification").mockResolvedValue(undefined);
+
     return container.resolve(ExecutionContextService).runWithContext(async () => {
       container.resolve(AuthService).currentUser = user;
       container.resolve(AuthService).ability = container.resolve(AbilityService).getAbilityFor("REGULAR_ANONYMOUS_USER", user);
@@ -122,6 +125,7 @@ export class WalletTestingService<T extends Hono<any>> {
 
     const decoded = decode(access_token) as { sub: string; email: string; nickname: string; email_verified: boolean };
 
+    jest.spyOn(container.resolve(NotificationService), "createDefaultChannel").mockResolvedValue(undefined);
     const userResponse = await this.app.request(`/v1/register-user`, {
       method: "POST",
       headers: new Headers({

--- a/apps/notifications/src/interfaces/rest/controllers/jobs/jobs.controller.spec.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/jobs/jobs.controller.spec.ts
@@ -1,0 +1,179 @@
+import { generateMock } from "@anatine/zod-mock";
+import { Test } from "@nestjs/testing";
+import { hoursToMilliseconds } from "date-fns";
+
+import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
+import { BrokerService } from "@src/infrastructure/broker/services/broker/broker.service";
+import { NotificationChannelRepository } from "@src/modules/notifications/repositories/notification-channel/notification-channel.repository";
+import { AuthService } from "../../services/auth/auth.service";
+import { notificationChannelOutputSchema } from "../notification-channel/notification-channel.controller";
+import { DEFAULT_NOTIFICATION_EXPIRATION_IN_SECONDS, JobsController } from "./jobs.controller";
+
+import { MockProvider } from "@test/mocks/provider.mock";
+
+describe(JobsController.name, () => {
+  describe("createNotification", () => {
+    it("returns 400 if notificationChannelId is not specified and no default notification channel exists", async () => {
+      const findDefaultByUserId = jest.fn(async () => undefined);
+      const module = await setup({
+        findDefaultByUserId
+      });
+
+      const result = await module.get(JobsController).createNotification({
+        notificationId: "notifyAboutStartTrial",
+        payload: {
+          description: "test",
+          summary: "test"
+        }
+      });
+
+      expect(findDefaultByUserId).toHaveBeenCalledWith(module.get(AuthService).userId);
+      expect(result.mapErr(err => err.getStatus()).val).toEqual(400);
+    });
+
+    it("returns 400 if notificationChannelId is specified and no notification channel exists", async () => {
+      const findById = jest.fn(async () => undefined);
+      const module = await setup({
+        findById
+      });
+
+      const result = await module.get(JobsController).createNotification({
+        notificationChannelId: "notificationChannelId",
+        notificationId: "notifyAboutStartTrial",
+        payload: {
+          description: "test",
+          summary: "test"
+        }
+      });
+
+      expect(findById).toHaveBeenCalledWith("notificationChannelId");
+      expect(result.mapErr(err => err.getStatus()).val).toEqual(400);
+    });
+
+    it("creates a notification job if notificationChannelId is specified and notification channel exists", async () => {
+      const channel = generateMock(notificationChannelOutputSchema);
+      const findDefaultByUserId = jest.fn(async () => channel);
+      const module = await setup({
+        findDefaultByUserId
+      });
+
+      const result = await module.get(JobsController).createNotification({
+        notificationId: "notifyAboutStartTrial",
+        payload: {
+          description: "test",
+          summary: "test"
+        }
+      });
+
+      expect(findDefaultByUserId).toHaveBeenCalledWith(module.get(AuthService).userId);
+      expect(result.ok).toBe(true);
+      expect(module.get(BrokerService).publish).toHaveBeenCalledWith(
+        eventKeyRegistry.createNotification,
+        {
+          notificationChannelId: channel.id,
+          payload: {
+            description: "test",
+            summary: "test"
+          }
+        },
+        {
+          id: "notifyAboutStartTrial",
+          expireInSeconds: DEFAULT_NOTIFICATION_EXPIRATION_IN_SECONDS
+        }
+      );
+    });
+
+    it("creates a notification job if notificationChannelId is not specified and default notification channel exists", async () => {
+      const channel = generateMock(notificationChannelOutputSchema);
+      const findById = jest.fn(async () => channel);
+      const module = await setup({
+        findById
+      });
+
+      const result = await module.get(JobsController).createNotification({
+        notificationChannelId: channel.id,
+        notificationId: "notifyAboutStartTrial",
+        payload: {
+          description: "test",
+          summary: "test"
+        }
+      });
+
+      expect(findById).toHaveBeenCalledWith(channel.id);
+      expect(result.ok).toBe(true);
+      expect(module.get(BrokerService).publish).toHaveBeenCalledWith(
+        eventKeyRegistry.createNotification,
+        {
+          notificationChannelId: channel.id,
+          payload: {
+            description: "test",
+            summary: "test"
+          }
+        },
+        {
+          id: "notifyAboutStartTrial",
+          expireInSeconds: DEFAULT_NOTIFICATION_EXPIRATION_IN_SECONDS
+        }
+      );
+    });
+
+    it("publishes a notification job which startsAfter specified time and expires in 24 hours", async () => {
+      const channel = generateMock(notificationChannelOutputSchema);
+      const findDefaultByUserId = jest.fn(async () => channel);
+      const module = await setup({
+        findDefaultByUserId
+      });
+
+      const startAfter = new Date(Date.now() + hoursToMilliseconds(1));
+      await module.get(JobsController).createNotification({
+        notificationId: "notifyAbout1WeekTrial",
+        startAfter: startAfter.toISOString(),
+        payload: {
+          description: "test",
+          summary: "test"
+        }
+      });
+
+      expect(module.get(BrokerService).publish).toHaveBeenCalledWith(
+        eventKeyRegistry.createNotification,
+        {
+          notificationChannelId: channel.id,
+          payload: {
+            description: "test",
+            summary: "test"
+          }
+        },
+        {
+          id: "notifyAbout1WeekTrial",
+          startAfter,
+          expireInSeconds: Math.ceil((startAfter.getTime() - Date.now()) / 1000) + DEFAULT_NOTIFICATION_EXPIRATION_IN_SECONDS
+        }
+      );
+    });
+  });
+
+  async function setup(input?: {
+    findDefaultByUserId?: NotificationChannelRepository["findDefaultByUserId"];
+    findById?: NotificationChannelRepository["findById"];
+  }) {
+    const module = await Test.createTestingModule({
+      controllers: [JobsController],
+      providers: [
+        // keep new lines
+        MockProvider(BrokerService),
+        MockProvider(AuthService, {
+          userId: "defaultUserId"
+        }),
+        MockProvider(NotificationChannelRepository, {
+          accessibleBy() {
+            return this;
+          },
+          findDefaultByUserId: input?.findDefaultByUserId,
+          findById: input?.findById
+        })
+      ]
+    }).compile();
+
+    return module;
+  }
+});

--- a/apps/notifications/src/interfaces/rest/controllers/jobs/jobs.controller.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/jobs/jobs.controller.ts
@@ -1,0 +1,77 @@
+import { BadRequestException, Body, Controller, HttpCode, Post } from "@nestjs/common";
+import { ApiNoContentResponse } from "@nestjs/swagger";
+import { hoursToSeconds } from "date-fns";
+import { createZodDto } from "nestjs-zod";
+import { Err, Ok, Result } from "ts-results";
+import { z } from "zod";
+
+import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
+import { BrokerService, PublishOptions } from "@src/infrastructure/broker/services/broker/broker.service";
+import { NotificationChannelRepository } from "@src/modules/notifications/repositories/notification-channel/notification-channel.repository";
+import { AuthService } from "../../services/auth/auth.service";
+
+class NotificationJobDto extends createZodDto(
+  z.object({
+    notificationId: z.string(),
+    notificationChannelId: z.string().optional(),
+    startAfter: z.string().datetime().optional(),
+    payload: z.object({
+      summary: z.string(),
+      description: z.string()
+    })
+  })
+) {}
+
+export const DEFAULT_NOTIFICATION_EXPIRATION_IN_SECONDS = hoursToSeconds(24);
+
+@Controller({
+  version: "1",
+  path: "jobs"
+})
+export class JobsController {
+  constructor(
+    private readonly brokerService: BrokerService,
+    private readonly authService: AuthService,
+    private readonly notificationChannelRepository: NotificationChannelRepository
+  ) {}
+
+  @Post("notification")
+  @HttpCode(204)
+  @ApiNoContentResponse({ description: "Creates a notification job" })
+  async createNotification(@Body() job: NotificationJobDto): Promise<Result<void, BadRequestException>> {
+    const notificationChannelRepository = this.notificationChannelRepository.accessibleBy(this.authService.ability, "read");
+    const notificationChannel = job.notificationChannelId
+      ? await notificationChannelRepository.findById(job.notificationChannelId)
+      : await notificationChannelRepository.findDefaultByUserId(this.authService.userId);
+
+    if (!notificationChannel) {
+      return Err(
+        new BadRequestException({
+          message: "Notification channel not found",
+          code: "NOTIFICATION_CHANNEL_NOT_FOUND"
+        })
+      );
+    }
+
+    const startAfter = job.startAfter ? new Date(job.startAfter) : undefined;
+    const publishOptions: PublishOptions = {
+      id: job.notificationId,
+      startAfter,
+      expireInSeconds: DEFAULT_NOTIFICATION_EXPIRATION_IN_SECONDS
+    };
+
+    if (startAfter) {
+      publishOptions.expireInSeconds = Math.ceil((startAfter.getTime() - Date.now()) / 1000) + DEFAULT_NOTIFICATION_EXPIRATION_IN_SECONDS;
+    }
+
+    await this.brokerService.publish(
+      eventKeyRegistry.createNotification,
+      {
+        payload: job.payload,
+        notificationChannelId: notificationChannel.id
+      },
+      publishOptions
+    );
+    return Ok(undefined);
+  }
+}

--- a/apps/notifications/src/interfaces/rest/controllers/notification-channel/notification-channel.controller.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/notification-channel/notification-channel.controller.ts
@@ -18,7 +18,7 @@ export const notificationChannelCreateInputSchema = z.object({
   name: z.string(),
   type: z.literal("email"),
   config: notificationChannelConfigSchema,
-  isDefault: z.boolean().default(false)
+  isDefault: z.boolean().optional()
 });
 
 export const notificationChannelCreateDefaultInputSchema = notificationChannelCreateInputSchema.omit({ isDefault: true });
@@ -71,6 +71,7 @@ export class NotificationChannelController {
     return Ok({
       data: await this.notificationChannelRepository.accessibleBy(this.authService.ability, "create").create({
         ...data,
+        isDefault: data.isDefault ?? false,
         userId: this.authService.userId
       })
     });

--- a/apps/notifications/src/interfaces/rest/filters/http-exception/http-exception.filter.ts
+++ b/apps/notifications/src/interfaces/rest/filters/http-exception/http-exception.filter.ts
@@ -25,10 +25,13 @@ export class HttpExceptionFilter implements ExceptionFilter {
       });
     } else if (exception instanceof HttpException && !isSerializationException) {
       const statusCode = exception.getStatus();
+      const errorResponse = exception.getResponse();
+      const details = typeof errorResponse === "string" ? { message: response } : errorResponse;
       response.status(statusCode).json({
         statusCode,
         message: exception.message,
-        errors: exception.cause
+        errors: exception.cause,
+        ...details
       });
     } else if (exception instanceof ForbiddenError) {
       response.status(403).json({

--- a/apps/notifications/src/interfaces/rest/rest.module.ts
+++ b/apps/notifications/src/interfaces/rest/rest.module.ts
@@ -4,11 +4,13 @@ import { APP_INTERCEPTOR } from "@nestjs/core";
 import { ZodSerializerInterceptor } from "nestjs-zod";
 
 import { CommonModule } from "@src/common/common.module";
+import { BrokerModule } from "@src/infrastructure/broker";
 import { DeploymentAlertController } from "@src/interfaces/rest/controllers/deployment-alert/deployment-alert.controller";
 import { HealthzController } from "@src/interfaces/rest/controllers/healthz/healthz.controller";
 import { AlertModule } from "@src/modules/alert/alert.module";
 import { NotificationsModule } from "@src/modules/notifications/notifications.module";
 import { AlertController } from "./controllers/alert/alert.controller";
+import { JobsController } from "./controllers/jobs/jobs.controller";
 import { NotificationChannelController } from "./controllers/notification-channel/notification-channel.controller";
 import { AuthInterceptor } from "./interceptors/auth/auth.interceptor";
 import { LocalHttpLoggerMiddleware } from "./interceptors/http-logger/http-logger.middleware";
@@ -16,14 +18,14 @@ import { HttpResultInterceptor } from "./interceptors/http-result/http-result.in
 import { AuthService } from "./services/auth/auth.service";
 
 @Module({
-  imports: [CommonModule, AlertModule, NotificationsModule, ConfigModule.forRoot({ isGlobal: true })],
+  imports: [CommonModule, AlertModule, NotificationsModule, BrokerModule, ConfigModule.forRoot({ isGlobal: true })],
   providers: [
     { provide: APP_INTERCEPTOR, useClass: ZodSerializerInterceptor },
     { provide: APP_INTERCEPTOR, useClass: HttpResultInterceptor },
     { provide: APP_INTERCEPTOR, useClass: AuthInterceptor },
     AuthService
   ],
-  controllers: [AlertController, NotificationChannelController, DeploymentAlertController, HealthzController]
+  controllers: [AlertController, NotificationChannelController, DeploymentAlertController, HealthzController, JobsController]
 })
 export default class RestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/apps/notifications/swagger/swagger.json
+++ b/apps/notifications/swagger/swagger.json
@@ -594,76 +594,20 @@
     "/v1/notification-channels/default": {
       "post": {
         "operationId": "createDefaultChannel",
-        "parameters": [
-          {
-            "name": "Authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "parameters": [],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/NotificationChannelCreateInput"
+                "$ref": "#/components/schemas/NotificationChannelCreateDefaultInput"
               }
             }
           }
         },
         "responses": {
           "204": {
-            "description": "Creates the default notification channel only if it doesn't exist. If it does exist, it returns the existing channel.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AugmentedZodDto"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Validation error responded when some request parameters are invalid",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ValidationErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized error responded when the user is not authenticated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/UnauthorizedErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden error responded when the user is not authorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ForbiddenErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error, should probably be reported",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/InternalServerErrorResponse"
-                }
-              }
-            }
+            "description": "Creates the default notification channel only if it doesn't exist."
           }
         },
         "tags": [
@@ -1111,6 +1055,30 @@
         },
         "tags": [
           "DeploymentAlert"
+        ]
+      }
+    },
+    "/v1/jobs/notification": {
+      "post": {
+        "operationId": "createNotification",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationJobDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Creates a notification job"
+          }
+        },
+        "tags": [
+          "Jobs"
         ]
       }
     }
@@ -4390,6 +4358,9 @@
                 "required": [
                   "addresses"
                 ]
+              },
+              "isDefault": {
+                "type": "boolean"
               }
             },
             "required": [
@@ -4433,6 +4404,9 @@
                   "addresses"
                 ]
               },
+              "isDefault": {
+                "type": "boolean"
+              },
               "id": {
                 "type": "string",
                 "format": "uuid"
@@ -4441,9 +4415,6 @@
                 "type": "string",
                 "format": "uuid"
               },
-              "isDefault": {
-                "type": "boolean"
-              },
               "createdAt": {},
               "updatedAt": {}
             },
@@ -4451,9 +4422,9 @@
               "name",
               "type",
               "config",
+              "isDefault",
               "id",
               "userId",
-              "isDefault",
               "createdAt",
               "updatedAt"
             ]
@@ -4463,7 +4434,48 @@
           "data"
         ]
       },
-      "AugmentedZodDto": {},
+      "NotificationChannelCreateDefaultInput": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "email"
+                ]
+              },
+              "config": {
+                "type": "object",
+                "properties": {
+                  "addresses": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "format": "email"
+                    }
+                  }
+                },
+                "required": [
+                  "addresses"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "type",
+              "config"
+            ]
+          }
+        },
+        "required": [
+          "data"
+        ]
+      },
       "NotFoundErrorResponse": {
         "type": "object",
         "properties": {
@@ -4513,6 +4525,9 @@
                     "addresses"
                   ]
                 },
+                "isDefault": {
+                  "type": "boolean"
+                },
                 "id": {
                   "type": "string",
                   "format": "uuid"
@@ -4521,9 +4536,6 @@
                   "type": "string",
                   "format": "uuid"
                 },
-                "isDefault": {
-                  "type": "boolean"
-                },
                 "createdAt": {},
                 "updatedAt": {}
               },
@@ -4531,9 +4543,9 @@
                 "name",
                 "type",
                 "config",
+                "isDefault",
                 "id",
                 "userId",
-                "isDefault",
                 "createdAt",
                 "updatedAt"
               ]
@@ -4770,6 +4782,40 @@
         },
         "required": [
           "data"
+        ]
+      },
+      "NotificationJobDto": {
+        "type": "object",
+        "properties": {
+          "notificationId": {
+            "type": "string"
+          },
+          "notificationChannelId": {
+            "type": "string"
+          },
+          "startAfter": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "payload": {
+            "type": "object",
+            "properties": {
+              "summary": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "summary",
+              "description"
+            ]
+          }
+        },
+        "required": [
+          "notificationId",
+          "payload"
         ]
       }
     }

--- a/apps/notifications/test/mocks/provider.mock.ts
+++ b/apps/notifications/test/mocks/provider.mock.ts
@@ -1,6 +1,10 @@
-import type { Provider } from "@nestjs/common";
+import type { InjectionToken, Provider } from "@nestjs/common";
 import { mock } from "jest-mock-extended";
 
-export const MockProvider = <T>(Constructor: (new (...args: any[]) => T) | string): Provider => {
-  return { provide: Constructor, useValue: mock<T>() };
+export const MockProvider = <T>(token: InjectionToken<T>, override?: DeepPartial<T>): Provider => {
+  return { provide: token, useValue: mock<T>(override as Parameters<typeof mock<T>>[0]) };
+};
+
+type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
 };

--- a/packages/react-query-sdk/src/notifications/schema.ts
+++ b/packages/react-query-sdk/src/notifications/schema.ts
@@ -100,6 +100,22 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/v1/jobs/notification": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post: operations["createNotification"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -625,6 +641,7 @@ export interface components {
         config: {
           addresses: string[];
         };
+        isDefault?: boolean;
       };
     };
     NotificationChannelOutput: {
@@ -635,16 +652,25 @@ export interface components {
         config: {
           addresses: string[];
         };
+        isDefault: boolean;
         /** Format: uuid */
         id: string;
         /** Format: uuid */
         userId: string;
-        isDefault: boolean;
         createdAt: unknown;
         updatedAt: unknown;
       };
     };
-    AugmentedZodDto: unknown;
+    NotificationChannelCreateDefaultInput: {
+      data: {
+        name: string;
+        /** @enum {string} */
+        type: "email";
+        config: {
+          addresses: string[];
+        };
+      };
+    };
     NotFoundErrorResponse: {
       statusCode: number;
       message: string;
@@ -657,11 +683,11 @@ export interface components {
         config: {
           addresses: string[];
         };
+        isDefault: boolean;
         /** Format: uuid */
         id: string;
         /** Format: uuid */
         userId: string;
-        isDefault: boolean;
         createdAt: unknown;
         updatedAt: unknown;
       }[];
@@ -730,6 +756,16 @@ export interface components {
             suppressedBySystem?: boolean;
           };
         };
+      };
+    };
+    NotificationJobDto: {
+      notificationId: string;
+      notificationChannelId?: string;
+      /** Format: date-time */
+      startAfter?: string;
+      payload: {
+        summary: string;
+        description: string;
       };
     };
   };
@@ -1182,62 +1218,22 @@ export interface operations {
   createDefaultChannel: {
     parameters: {
       query?: never;
-      header?: {
-        Authorization?: string;
-      };
+      header?: never;
       path?: never;
       cookie?: never;
     };
     requestBody: {
       content: {
-        "application/json": components["schemas"]["NotificationChannelCreateInput"];
+        "application/json": components["schemas"]["NotificationChannelCreateDefaultInput"];
       };
     };
     responses: {
-      /** @description Creates the default notification channel only if it doesn't exist. If it does exist, it returns the existing channel. */
+      /** @description Creates the default notification channel only if it doesn't exist. */
       204: {
         headers: {
           [name: string]: unknown;
         };
-        content: {
-          "application/json": components["schemas"]["AugmentedZodDto"];
-        };
-      };
-      /** @description Validation error responded when some request parameters are invalid */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ValidationErrorResponse"];
-        };
-      };
-      /** @description Unauthorized error responded when the user is not authenticated */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["UnauthorizedErrorResponse"];
-        };
-      };
-      /** @description Forbidden error responded when the user is not authorized */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ForbiddenErrorResponse"];
-        };
-      };
-      /** @description Internal server error, should probably be reported */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["InternalServerErrorResponse"];
-        };
+        content?: never;
       };
     };
   };
@@ -1575,6 +1571,28 @@ export interface operations {
         content: {
           "application/json": components["schemas"]["InternalServerErrorResponse"];
         };
+      };
+    };
+  };
+  createNotification: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["NotificationJobDto"];
+      };
+    };
+    responses: {
+      /** @description Creates a notification job */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/packages/react-query-sdk/src/notifications/services/V1Service.ts
+++ b/packages/react-query-sdk/src/notifications/services/V1Service.ts
@@ -2562,21 +2562,14 @@ export interface V1Service {
      * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useMutation|`useMutation(...)` documentation}
      * @example Mutation with predefined parameters, e.g., for updating
      * ```ts
-     * const { mutate, isPending } = qraft.v1Service.createDefaultChannel.useMutation({
-     *     header: {
-     *         Authorization: authorization
-     *     }
-     * })
+     * const { mutate, isPending } = qraft.v1Service.createDefaultChannel.useMutation({})
      * mutate(body);
      * ```
      * @example Mutation without predefined parameters, e.g., for creating
      * ```ts
      * const { mutate, isPending } = qraft.v1Service.createDefaultChannel.useMutation()
      * mutate({
-     *     body: bodyPayload,
-     *     header: {
-     *         Authorization: authorization
-     *     }
+     *     body: bodyPayload
      * });
      * ```
      */
@@ -2598,21 +2591,14 @@ export interface V1Service {
      * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useMutation|`useMutation(...)` documentation}
      * @example Mutation with predefined parameters, e.g., for updating
      * ```ts
-     * const { mutate, isPending } = qraft.v1Service.createDefaultChannel.useMutation({
-     *     header: {
-     *         Authorization: authorization
-     *     }
-     * })
+     * const { mutate, isPending } = qraft.v1Service.createDefaultChannel.useMutation({})
      * mutate(body);
      * ```
      * @example Mutation without predefined parameters, e.g., for creating
      * ```ts
      * const { mutate, isPending } = qraft.v1Service.createDefaultChannel.useMutation()
      * mutate({
-     *     body: bodyPayload,
-     *     header: {
-     *         Authorization: authorization
-     *     }
+     *     body: bodyPayload
      * });
      * ```
      */
@@ -2638,11 +2624,7 @@ export interface V1Service {
      * @example Check how many mutations are currently in progress with the specified parameters.
      * ```ts
      * const createDefaultChannelTotal = qraft.v1Service.createDefaultChannel.useIsMutating({
-     *     parameters: {
-     *         header: {
-     *             Authorization: authorization
-     *         }
-     *     }
+     *     parameters: {}
      * })
      * ```
      */
@@ -2708,11 +2690,7 @@ export interface V1Service {
      * ```ts
      * const createDefaultChannelMutationData = qraft.v1Service.createDefaultChannel.useMutationState({
      *     filters: {
-     *         parameters: {
-     *             header: {
-     *                 Authorization: authorization
-     *             }
-     *         }
+     *         parameters: {}
      *     },
      *     select: mutation => mutation.state.data
      * })
@@ -4757,6 +4735,176 @@ export interface V1Service {
       error: GetDeploymentAlertsError;
     };
   };
+  createNotification: {
+    /**/
+    getMutationKey(
+      parameters: DeepReadonly<CreateNotificationParameters> | void
+    ): ServiceOperationMutationKey<CreateNotificationSchema, CreateNotificationParameters>;
+    /**
+     * Enables performing asynchronous data mutation operations such as POST, PUT, PATCH, or DELETE requests.
+     * Handles loading state, optimistic updates, and error handling.
+     *
+     * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useMutation|`useMutation(...)` documentation}
+     * @example Mutation with predefined parameters, e.g., for updating
+     * ```ts
+     * const { mutate, isPending } = qraft.v1Service.createNotification.useMutation({})
+     * mutate(body);
+     * ```
+     * @example Mutation without predefined parameters, e.g., for creating
+     * ```ts
+     * const { mutate, isPending } = qraft.v1Service.createNotification.useMutation()
+     * mutate({
+     *     body: bodyPayload
+     * });
+     * ```
+     */
+    useMutation<TVariables extends CreateNotificationBody, TContext = unknown>(
+      parameters: DeepReadonly<CreateNotificationParameters>,
+      options?: ServiceOperationUseMutationOptions<
+        CreateNotificationSchema,
+        CreateNotificationData,
+        CreateNotificationParameters,
+        TVariables,
+        CreateNotificationError | Error,
+        TContext
+      >
+    ): UseMutationResult<CreateNotificationData, CreateNotificationError | Error, TVariables, TContext>;
+    /**
+     * Enables performing asynchronous data mutation operations such as POST, PUT, PATCH, or DELETE requests.
+     * Handles loading state, optimistic updates, and error handling.
+     *
+     * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useMutation|`useMutation(...)` documentation}
+     * @example Mutation with predefined parameters, e.g., for updating
+     * ```ts
+     * const { mutate, isPending } = qraft.v1Service.createNotification.useMutation({})
+     * mutate(body);
+     * ```
+     * @example Mutation without predefined parameters, e.g., for creating
+     * ```ts
+     * const { mutate, isPending } = qraft.v1Service.createNotification.useMutation()
+     * mutate({
+     *     body: bodyPayload
+     * });
+     * ```
+     */
+    useMutation<TVariables extends MutationVariables<CreateNotificationBody, CreateNotificationParameters>, TContext = unknown>(
+      parameters: void,
+      options?: ServiceOperationUseMutationOptions<
+        CreateNotificationSchema,
+        CreateNotificationData,
+        CreateNotificationParameters,
+        TVariables,
+        CreateNotificationError | Error,
+        TContext
+      >
+    ): UseMutationResult<CreateNotificationData, CreateNotificationError | Error, TVariables, TContext>;
+    /**
+     * Returns the count of currently in-progress mutations.
+     *
+     * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useIsMutating|`useIsMutating(...)` documentation}
+     * @example Check how many mutations are currently in progress for the specified service method.
+     * ```ts
+     * const createNotificationTotal = qraft.v1Service.createNotification.useIsMutating()
+     * ```
+     * @example Check how many mutations are currently in progress with the specified parameters.
+     * ```ts
+     * const createNotificationTotal = qraft.v1Service.createNotification.useIsMutating({
+     *     parameters: {}
+     * })
+     * ```
+     */
+    useIsMutating<TContext = unknown>(
+      filters?:
+        | MutationFiltersByParameters<CreateNotificationBody, CreateNotificationData, CreateNotificationParameters, CreateNotificationError | Error, TContext>
+        | MutationFiltersByMutationKey<
+            CreateNotificationSchema,
+            CreateNotificationBody,
+            CreateNotificationData,
+            CreateNotificationParameters,
+            CreateNotificationError | Error,
+            TContext
+          >
+    ): number;
+    /**/
+    isMutating<TContext>(
+      filters?:
+        | MutationFiltersByParameters<CreateNotificationBody, CreateNotificationData, CreateNotificationParameters, CreateNotificationError | Error, TContext>
+        | MutationFiltersByMutationKey<
+            CreateNotificationSchema,
+            CreateNotificationBody,
+            CreateNotificationData,
+            CreateNotificationParameters,
+            CreateNotificationError | Error,
+            TContext
+          >
+    ): number;
+    /**/
+    (
+      options: ServiceOperationMutationFnOptions<CreateNotificationBody, CreateNotificationParameters>,
+      client?: (
+        schema: CreateNotificationSchema,
+        options: ServiceOperationMutationFnOptions<CreateNotificationBody, CreateNotificationParameters>
+      ) => Promise<RequestFnResponse<CreateNotificationData, CreateNotificationError>>
+    ): Promise<RequestFnResponse<CreateNotificationData, CreateNotificationError>>;
+    /**
+     * Provides access to the current state of a mutation, including its status, any resulting data, and associated errors.
+     *
+     * @see {@link https://openapi-qraft.github.io/openapi-qraft/docs/hooks/useMutationState|`useMutationState(...)` documentation}
+     * @example Get all variables of all running mutations.
+     * ```ts
+     * const createNotificationPendingMutationVariables = qraft.v1Service.createNotification.useMutationState({
+     *     filters: {
+     *         status: "pending"
+     *     },
+     *     select: mutation => mutation.state.variables
+     * })
+     * ```
+     * @example Get all data for specific mutations via the `parameters`.
+     * ```ts
+     * const createNotificationMutationData = qraft.v1Service.createNotification.useMutationState({
+     *     filters: {
+     *         parameters: {}
+     *     },
+     *     select: mutation => mutation.state.data
+     * })
+     * ```
+     */
+    useMutationState<
+      TContext = unknown,
+      TResult = MutationState<
+        CreateNotificationData,
+        CreateNotificationError | Error,
+        MutationVariables<CreateNotificationBody, CreateNotificationParameters>,
+        TContext
+      >
+    >(options?: {
+      filters?:
+        | MutationFiltersByParameters<CreateNotificationBody, CreateNotificationData, CreateNotificationParameters, CreateNotificationError | Error, TContext>
+        | MutationFiltersByMutationKey<
+            CreateNotificationSchema,
+            CreateNotificationBody,
+            CreateNotificationData,
+            CreateNotificationParameters,
+            CreateNotificationError | Error,
+            TContext
+          >;
+      select?: (
+        mutation: Mutation<
+          CreateNotificationData,
+          CreateNotificationError | Error,
+          MutationVariables<CreateNotificationBody, CreateNotificationParameters>,
+          TContext
+        >
+      ) => TResult;
+    }): Array<TResult>;
+    schema: CreateNotificationSchema;
+    types: {
+      parameters: CreateNotificationParameters;
+      data: CreateNotificationData;
+      error: CreateNotificationError;
+      body: CreateNotificationBody;
+    };
+  };
 }
 export const createAlert = {
   schema: {
@@ -4881,6 +5029,16 @@ export const getDeploymentAlerts = {
   schema: GetDeploymentAlertsSchema;
   [QraftServiceOperationsToken]: V1Service["getDeploymentAlerts"];
 };
+export const createNotification = {
+  schema: {
+    method: "post",
+    url: "/v1/jobs/notification",
+    mediaType: ["application/json"]
+  }
+} as {
+  schema: CreateNotificationSchema;
+  [QraftServiceOperationsToken]: V1Service["createNotification"];
+};
 export const v1Service = {
   createAlert,
   getAlerts,
@@ -4894,7 +5052,8 @@ export const v1Service = {
   patchNotificationChannel,
   deleteNotificationChannel,
   upsertDeploymentAlert,
-  getDeploymentAlerts
+  getDeploymentAlerts,
+  createNotification
 } as const;
 type CreateAlertSchema = {
   method: "post";
@@ -4985,13 +5144,13 @@ type CreateDefaultChannelSchema = {
   url: "/v1/notification-channels/default";
   mediaType: ["application/json"];
 };
-type CreateDefaultChannelParameters = paths["/v1/notification-channels/default"]["post"]["parameters"];
-type CreateDefaultChannelData = paths["/v1/notification-channels/default"]["post"]["responses"]["204"]["content"]["application/json"];
-type CreateDefaultChannelError =
-  | paths["/v1/notification-channels/default"]["post"]["responses"]["400"]["content"]["application/json"]
-  | paths["/v1/notification-channels/default"]["post"]["responses"]["401"]["content"]["application/json"]
-  | paths["/v1/notification-channels/default"]["post"]["responses"]["403"]["content"]["application/json"]
-  | paths["/v1/notification-channels/default"]["post"]["responses"]["500"]["content"]["application/json"];
+type CreateDefaultChannelParameters = {
+  query?: never;
+  header?: never;
+  path?: never;
+};
+type CreateDefaultChannelData = null;
+type CreateDefaultChannelError = unknown;
 type CreateDefaultChannelBody = paths["/v1/notification-channels/default"]["post"]["requestBody"]["content"]["application/json"];
 type GetNotificationChannelSchema = {
   method: "get";
@@ -5056,3 +5215,16 @@ type GetDeploymentAlertsError =
   | paths["/v1/deployment-alerts/{dseq}"]["get"]["responses"]["401"]["content"]["application/json"]
   | paths["/v1/deployment-alerts/{dseq}"]["get"]["responses"]["403"]["content"]["application/json"]
   | paths["/v1/deployment-alerts/{dseq}"]["get"]["responses"]["500"]["content"]["application/json"];
+type CreateNotificationSchema = {
+  method: "post";
+  url: "/v1/jobs/notification";
+  mediaType: ["application/json"];
+};
+type CreateNotificationParameters = {
+  query?: never;
+  header?: never;
+  path?: never;
+};
+type CreateNotificationData = null;
+type CreateNotificationError = unknown;
+type CreateNotificationBody = paths["/v1/jobs/notification"]["post"]["requestBody"]["content"]["application/json"];


### PR DESCRIPTION
## Why

#1735 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sends "Start Trial" notification for relevant users when the anonymous-free-trial flag is disabled.
  * Adds a notifications job endpoint to create/schedule notification jobs and a resilient NotificationService with retries and default-channel fallback.
  * SDK/clients expose a createNotification operation.

* **Documentation**
  * API docs and SDK updated with POST /v1/jobs/notification, new schemas, and simplified default-channel contract.

* **Bug Fixes**
  * Error responses include extra exception fields for richer diagnostics.

* **Tests**
  * New and updated tests covering notification flows, jobs controller, feature-flag wallet behavior, and user-service integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->