### PR TITLE
fix(billing): add date filtering to deployment count by owner

### DIFF
--- a/apps/api/src/billing/services/usage/usage.service.spec.ts
+++ b/apps/api/src/billing/services/usage/usage.service.spec.ts
@@ -41,7 +41,7 @@ describe(UsageService.name, () => {
         const result = await service.getHistoryStats(address, startDate, endDate);
 
         expect(usageRepository.getHistory).toHaveBeenCalledWith(address, startDate, endDate);
-        expect(deploymentRepository.countByOwner).toHaveBeenCalledWith(address);
+        expect(deploymentRepository.countByOwner).toHaveBeenCalledWith(address, startDate, endDate);
 
         expect(result).toEqual({
           totalSpent: 15.55,
@@ -92,7 +92,7 @@ describe(UsageService.name, () => {
         const result = await service.getHistoryStats(address, startDate, endDate);
 
         expect(usageRepository.getHistory).toHaveBeenCalledWith(address, startDate, endDate);
-        expect(deploymentRepository.countByOwner).toHaveBeenCalledWith(address);
+        expect(deploymentRepository.countByOwner).toHaveBeenCalledWith(address, startDate, endDate);
 
         expect(result).toEqual({
           totalSpent: 0,

--- a/apps/api/src/billing/services/usage/usage.service.ts
+++ b/apps/api/src/billing/services/usage/usage.service.ts
@@ -16,7 +16,10 @@ export class UsageService {
   }
 
   async getHistoryStats(address: string, startDate: string, endDate: string): Promise<UsageHistoryStats> {
-    const [historyData, totalDeployments] = await Promise.all([this.getHistory(address, startDate, endDate), this.deploymentRepository.countByOwner(address)]);
+    const [historyData, totalDeployments] = await Promise.all([
+      this.getHistory(address, startDate, endDate),
+      this.deploymentRepository.countByOwner(address, startDate, endDate)
+    ]);
 
     if (historyData.length === 0) {
       return {

--- a/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
@@ -31,9 +31,18 @@ export class DeploymentRepository {
     });
   }
 
-  async countByOwner(owner: string): Promise<number> {
+  async countByOwner(owner: string, startDate: string, endDate: string): Promise<number> {
     return await Deployment.count({
-      where: { owner }
+      where: {
+        owner,
+        closedHeight: { [Op.not]: null },
+        "$createdBlock.datetime$": { [Op.gte]: startDate },
+        "$closedBlock.datetime$": { [Op.lte]: endDate }
+      },
+      include: [
+        { model: Block, as: "createdBlock" },
+        { model: Block, as: "closedBlock" }
+      ]
     });
   }
 


### PR DESCRIPTION
Fixes #1787

Add date range parameters to countByOwner method of DeploymentRepository, which is currently only used by usage.service. This ensures that only deployments within the specified date range are counted in the usage dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Usage history statistics now correctly respect the selected date range.
  - Total deployments and average deployments per day are calculated only for the specified period.
  - Consistent behavior when no history data exists for the chosen range.

- Chores
  - Internal updates to align data retrieval with date-filtered reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->