### PR TITLE
fix: make date range picker scrollable if it overflows container

### DIFF
--- a/packages/ui/components/custom/date-range-picker.tsx
+++ b/packages/ui/components/custom/date-range-picker.tsx
@@ -256,7 +256,7 @@ export function DateRangePicker({
               )}
             </Button>
           </PopoverTrigger>
-          <PopoverContent className="mx-4 w-screen max-w-sm p-0" align="center">
+          <PopoverContent className="mx-4 max-h-[calc(var(--radix-popover-content-available-height))] w-screen max-w-sm overflow-auto p-0" align="center">
             <div className="space-y-4 p-4">
               {showPresets && (
                 <Collapsible open={presetsOpen} onOpenChange={togglePresetsVisibility}>
@@ -401,7 +401,7 @@ export function DateRangePicker({
             )}
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-auto p-0" align="start">
+        <PopoverContent className="max-h-[calc(var(--radix-popover-content-available-height))] w-auto overflow-auto p-0" align="start">
           <div className="flex">
             <div className="min-w-[200px] border-r p-3">
               {showPresets && (


### PR DESCRIPTION
Fixes #1789

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Constrained the date range picker popover to the available viewport height and enabled vertical scrolling when content exceeds the space. Prevents the popover from extending off-screen or being clipped on both desktop and mobile.
  - Improves usability on smaller screens by keeping the popover fully accessible without altering alignment or date selection behavior. Ensures a smoother, more consistent interaction when navigating longer content within the popover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->