### PR TITLE
feat(deployment): hide custodial auto top up with feature flag

### DIFF
--- a/apps/deploy-web/src/components/settings/SettingsContainer.tsx
+++ b/apps/deploy-web/src/components/settings/SettingsContainer.tsx
@@ -10,6 +10,7 @@ import { LocalDataManager } from "@src/components/settings/LocalDataManager";
 import { Fieldset } from "@src/components/shared/Fieldset";
 import { LabelValue } from "@src/components/shared/LabelValue";
 import { useWallet } from "@src/context/WalletProvider";
+import { useFlag } from "@src/hooks/useFlag";
 import { useWhen } from "@src/hooks/useWhen";
 import networkStore from "@src/store/networkStore";
 import Layout from "../layout/Layout";
@@ -24,6 +25,7 @@ export const SettingsContainer: React.FunctionComponent = () => {
   const selectedNetwork = networkStore.useSelectedNetwork();
   const wallet = useWallet();
   const router = useRouter();
+  const isCustodialAutoTopupEnabled = useFlag("custodial_auto_topup");
 
   useWhen(!wallet.isWalletConnected || wallet.isManaged, () => router.push("/"));
 
@@ -59,9 +61,11 @@ export const SettingsContainer: React.FunctionComponent = () => {
             <LocalDataManager />
           </Fieldset>
 
-          <Fieldset label="Auto Top Up">
-            <AutoTopUpSettingContainer />
-          </Fieldset>
+          {isCustodialAutoTopupEnabled && (
+            <Fieldset label="Auto Top Up">
+              <AutoTopUpSettingContainer />
+            </Fieldset>
+          )}
         </div>
 
         <Fieldset label="Certificates" className="mb-4">

--- a/apps/deploy-web/src/hooks/useFlag.tsx
+++ b/apps/deploy-web/src/hooks/useFlag.tsx
@@ -9,6 +9,7 @@ export type FeatureFlag =
   | "anonymous_free_trial"
   | "notifications_general_alerts_update"
   | "ui_deployment_closed_alert"
-  | "billing_usage";
+  | "billing_usage"
+  | "custodial_auto_topup";
 export const useFlag: FeatureFlagHook = browserEnvConfig.NEXT_PUBLIC_UNLEASH_ENABLE_ALL ? useDummyFlag : useFlagOriginal;
 type FeatureFlagHook = (flag: FeatureFlag) => boolean;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a feature flag to control visibility of the Auto Top Up setting in Settings.
  * Auto Top Up now appears only when the corresponding feature flag is enabled.

* **Chores**
  * Expanded the available feature flags to include “custodial_auto_topup,” enabling controlled rollout of the Auto Top Up setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->