### PR TITLE
fix: refactor http-sdk services to accept httpClient

### DIFF
--- a/apps/api/src/core/providers/http-sdk.provider.ts
+++ b/apps/api/src/core/providers/http-sdk.provider.ts
@@ -1,3 +1,4 @@
+import type { HttpClient } from "@akashnetwork/http-sdk";
 import {
   AuthzHttpService,
   BalanceHttpService,
@@ -5,29 +6,38 @@ import {
   BlockHttpService,
   CoinGeckoHttpService,
   CosmosHttpService,
+  createHttpClient,
   DeploymentHttpService,
   GitHubHttpService,
   LeaseHttpService,
   NodeHttpService,
   ProviderHttpService
 } from "@akashnetwork/http-sdk";
+import type { InjectionToken } from "tsyringe";
 import { container } from "tsyringe";
 
 import { apiNodeUrl, nodeApiBasePath } from "@src/utils/constants";
 
-const SERVICES = [
-  BalanceHttpService,
-  AuthzHttpService,
-  BlockHttpService,
-  BidHttpService,
-  DeploymentHttpService,
-  LeaseHttpService,
-  ProviderHttpService,
-  CosmosHttpService
-];
+export const CHAIN_API_HTTP_CLIENT: InjectionToken<HttpClient> = Symbol("CHAIN_API_HTTP_CLIENT");
+
+container.register(CHAIN_API_HTTP_CLIENT, {
+  useFactory: () => createHttpClient({ baseURL: apiNodeUrl })
+});
+
+const SERVICES = [BalanceHttpService, AuthzHttpService, BlockHttpService, BidHttpService, LeaseHttpService, ProviderHttpService];
 
 SERVICES.forEach(Service => container.register(Service, { useValue: new Service({ baseURL: apiNodeUrl }) }));
 
 container.register(GitHubHttpService, { useValue: new GitHubHttpService({ baseURL: "https://raw.githubusercontent.com" }) });
-container.register(CoinGeckoHttpService, { useValue: new CoinGeckoHttpService({ baseURL: "https://api.coingecko.com" }) });
-container.register(NodeHttpService, { useValue: new NodeHttpService({ baseURL: nodeApiBasePath }) });
+container.register(DeploymentHttpService, {
+  useFactory: c => new DeploymentHttpService(c.resolve(CHAIN_API_HTTP_CLIENT))
+});
+container.register(CosmosHttpService, {
+  useFactory: c => new CosmosHttpService(c.resolve(CHAIN_API_HTTP_CLIENT))
+});
+container.register(CoinGeckoHttpService, {
+  useFactory: () => new CoinGeckoHttpService(createHttpClient({ baseURL: "https://api.coingecko.com" }))
+});
+container.register(NodeHttpService, {
+  useFactory: () => new NodeHttpService(createHttpClient({ baseURL: nodeApiBasePath }))
+});

--- a/apps/notifications/src/modules/alert/providers/http-sdk.provider.ts
+++ b/apps/notifications/src/modules/alert/providers/http-sdk.provider.ts
@@ -1,4 +1,4 @@
-import { DeploymentHttpService, LeaseHttpService } from "@akashnetwork/http-sdk";
+import { createHttpClient, DeploymentHttpService, LeaseHttpService } from "@akashnetwork/http-sdk";
 import type { Provider } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 
@@ -9,9 +9,11 @@ export const HTTP_SDK_PROVIDERS: Provider[] = [
     provide: DeploymentHttpService,
     inject: [ConfigService],
     useFactory: (configService: ConfigService<AlertConfig>) =>
-      new DeploymentHttpService({
-        baseURL: configService.getOrThrow("alert.API_NODE_ENDPOINT")
-      })
+      new DeploymentHttpService(
+        createHttpClient({
+          baseURL: configService.getOrThrow("alert.API_NODE_ENDPOINT")
+        })
+      )
   },
   {
     provide: LeaseHttpService,

--- a/apps/notifications/src/modules/alert/services/deployment/deployment.service.ts
+++ b/apps/notifications/src/modules/alert/services/deployment/deployment.service.ts
@@ -1,6 +1,5 @@
 import { DeploymentHttpService, LeaseHttpService } from "@akashnetwork/http-sdk";
 import { Injectable } from "@nestjs/common";
-import { backOff } from "exponential-backoff";
 import { Err, Ok, Result } from "ts-results";
 
 import { LoggerService } from "@src/common/services/logger/logger.service";
@@ -72,13 +71,7 @@ export class DeploymentService {
 
   async getDeploymentInfo(owner: string, dseq: string): Promise<Result<DeploymentInfo, RichError>> {
     try {
-      const result = await backOff(() => this.deploymentHttpService.findByOwnerAndDseq(owner, dseq), {
-        maxDelay: 5_000,
-        startingDelay: 500,
-        timeMultiple: 2,
-        numOfAttempts: 3,
-        jitter: "full"
-      });
+      const result = await this.deploymentHttpService.findByOwnerAndDseq(owner, dseq);
 
       if ("code" in result) {
         return Err(new RichError(result.message, result.code, { owner, dseq, details: result.details }, result));

--- a/packages/http-sdk/src/coin-gecko/coin-gecko-http.service.ts
+++ b/packages/http-sdk/src/coin-gecko/coin-gecko-http.service.ts
@@ -1,24 +1,11 @@
-import type { AxiosError, AxiosInstance, AxiosRequestConfig } from "axios";
-import axiosRetry from "axios-retry";
-
-import { HttpService } from "../http/http.service";
+import type { HttpClient } from "../utils/httpClient";
 import type { CoinGeckoCoinsResponse } from "./types";
 
-const RETRY_COUNT = 3;
-const RETRY_DELAY_MILLISECONDS = 100;
+export class CoinGeckoHttpService {
+  constructor(private readonly httpClient: HttpClient) {}
 
-export class CoinGeckoHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-
-    axiosRetry(this as unknown as AxiosInstance, {
-      retries: RETRY_COUNT,
-      retryDelay: retryCount => Math.pow(2, retryCount) * RETRY_DELAY_MILLISECONDS,
-      retryCondition: (error: AxiosError) => axiosRetry.isNetworkError(error) || (error.response?.status !== undefined && error.response.status >= 500)
-    });
-  }
-
-  async getMarketData(coin: string) {
-    return this.extractData(await this.get<CoinGeckoCoinsResponse>(`/api/v3/coins/${coin}`));
+  async getMarketData(coin: string): Promise<CoinGeckoCoinsResponse> {
+    const response = await this.httpClient.get<CoinGeckoCoinsResponse>(`/api/v3/coins/${coin}`);
+    return response.data;
   }
 }

--- a/packages/http-sdk/src/http/http.service.ts
+++ b/packages/http-sdk/src/http/http.service.ts
@@ -10,6 +10,10 @@ export class HttpService extends Axios {
   }
 
   protected extractData<T = unknown>(response: AxiosResponse<T>): AxiosResponse<T>["data"] {
-    return response.data;
+    return extractData(response);
   }
+}
+
+export function extractData<T = unknown>(response: AxiosResponse<T>): T {
+  return response.data;
 }

--- a/packages/http-sdk/src/index.ts
+++ b/packages/http-sdk/src/index.ts
@@ -23,3 +23,4 @@ export * from "./coin-gecko";
 export * from "./node";
 export * from "./certificates/certificates.service";
 export { getAllItems } from "./utils/pagination.utils";
+export { createHttpClient, type HttpClient, type HttpClientOptions } from "./utils/httpClient";

--- a/packages/http-sdk/src/node/node-http.service.ts
+++ b/packages/http-sdk/src/node/node-http.service.ts
@@ -1,29 +1,16 @@
-import type { AxiosError, AxiosInstance, AxiosRequestConfig } from "axios";
-import axiosRetry from "axios-retry";
-
-import { HttpService } from "../http/http.service";
+import { extractData } from "../http/http.service";
+import type { HttpClient } from "../utils/httpClient";
 import type { NetworkNode } from "./types";
 
-const RETRY_COUNT = 3;
-const RETRY_DELAY_MILLISECONDS = 100;
+export class NodeHttpService {
+  constructor(private readonly httpClient: HttpClient) {}
 
-export class NodeHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-
-    axiosRetry(this as unknown as AxiosInstance, {
-      retries: RETRY_COUNT,
-      retryDelay: retryCount => Math.pow(2, retryCount) * RETRY_DELAY_MILLISECONDS,
-      retryCondition: (error: AxiosError) => axiosRetry.isNetworkError(error) || (error.response?.status !== undefined && error.response.status >= 500)
-    });
+  async getNodes(network: "mainnet" | "testnet" | "sandbox"): Promise<NetworkNode[]> {
+    return extractData(await this.httpClient.get<NetworkNode[]>(`console/main/config/${network}-nodes.json`));
   }
 
-  async getNodes(network: "mainnet" | "testnet" | "sandbox") {
-    return this.extractData(await this.get<NetworkNode[]>(`console/main/config/${network}-nodes.json`));
-  }
-
-  async getVersion(network: "mainnet" | "testnet" | "sandbox") {
+  async getVersion(network: "mainnet" | "testnet" | "sandbox"): Promise<string> {
     const networkPath = network === "testnet" ? "testnet-02" : network;
-    return this.extractData(await this.get<string>(`net/master/${networkPath}/version.txt`));
+    return extractData(await this.httpClient.get<string>(`net/master/${networkPath}/version.txt`));
   }
 }

--- a/packages/http-sdk/src/utils/httpClient.ts
+++ b/packages/http-sdk/src/utils/httpClient.ts
@@ -1,0 +1,24 @@
+import type { AxiosInstance, CreateAxiosDefaults } from "axios";
+import axios from "axios";
+import axiosRetry from "axios-retry";
+
+export function createHttpClient(config: HttpClientOptions = {}): HttpClient {
+  const instance = axios.create({
+    ...config,
+    headers: {
+      "Content-Type": "application/json",
+      ...config?.headers
+    }
+  });
+
+  axiosRetry(instance, {
+    retries: 3,
+    retryDelay: axiosRetry.exponentialDelay,
+    retryCondition: axiosRetry.isNetworkOrIdempotentRequestError
+  });
+
+  return instance;
+}
+
+export type HttpClient = AxiosInstance;
+export type HttpClientOptions = CreateAxiosDefaults;


### PR DESCRIPTION
## Why 

ref #1424 , fixes axios-retry part

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a shared HTTP client and factory for consistent, resilient network requests across the platform.

- Refactor
  - Migrated many network services to use the shared HTTP client, standardizing request/response handling and retry behavior.
  - Reworked several service implementations to use the client abstraction instead of internal HTTP helpers.

- Chores
  - Simplified provider/service registration to reduce duplication.

- Bug Fixes
  - Removed an internal exponential-backoff wrapper from a notifications deployment fetch to rely on the unified client’s retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->