### PR TITLE
fix: throws errors supported by global error handler for api keys auth

### DIFF
--- a/apps/api/src/auth/services/auth.interceptor.ts
+++ b/apps/api/src/auth/services/auth.interceptor.ts
@@ -1,7 +1,7 @@
 import { LoggerService } from "@akashnetwork/logging";
 import { secondsInMinute } from "date-fns";
 import { Context, Next } from "hono";
-import { HTTPException } from "hono/http-exception";
+import { Unauthorized } from "http-errors";
 import { LRUCache } from "lru-cache";
 import { singleton } from "tsyringe";
 
@@ -72,9 +72,7 @@ export class AuthInterceptor implements HonoInterceptor {
           return await next();
         } catch (error) {
           this.logger.error(error);
-          throw new HTTPException(401, {
-            message: "Invalid API key"
-          });
+          throw new Unauthorized("Invalid API key");
         }
       }
 


### PR DESCRIPTION
closes #1836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid API keys now correctly return a 401 Unauthorized error, aligning with authentication standards and making error handling more predictable for API consumers. The error message remains clear and explicit. No impact to logging or other behaviors. Clients that detect 401 responses for auth failures should see improved compatibility and consistency across endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->