### PR TITLE
fix: upgrade hono/node-server in provider-proxy to fix crash

### DIFF
--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -25,7 +25,7 @@
     "@akashnetwork/logging": "*",
     "@akashnetwork/net": "*",
     "@cosmjs/encoding": "^0.32.4",
-    "@hono/node-server": "^1.13.8",
+    "@hono/node-server": "^1.19.0",
     "@hono/otel": "~0.4.0",
     "@hono/zod-openapi": "^0.18.4",
     "@opentelemetry/api": "^1.9.0",

--- a/apps/provider-proxy/tsconfig.build.json
+++ b/apps/provider-proxy/tsconfig.build.json
@@ -3,7 +3,7 @@
     "strict": true,
     "isolatedModules": true,
     "target": "es2022",
-    "lib": ["ESNext"]
+    "lib": ["ESNext", "ES2024"]
   },
   "extends": "@akashnetwork/dev-config/tsconfig.base-node.json"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4549,7 +4549,7 @@
         "@akashnetwork/logging": "*",
         "@akashnetwork/net": "*",
         "@cosmjs/encoding": "^0.32.4",
-        "@hono/node-server": "^1.13.8",
+        "@hono/node-server": "^1.19.0",
         "@hono/otel": "~0.4.0",
         "@hono/zod-openapi": "^0.18.4",
         "@opentelemetry/api": "^1.9.0",
@@ -4988,9 +4988,9 @@
       }
     },
     "apps/provider-proxy/node_modules/@hono/node-server": {
-      "version": "1.13.8",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.13.8.tgz",
-      "integrity": "sha512-fsn8ucecsAXUoVxrUil0m13kOEq4mkX4/4QozCqmY+HpGfKl74OYSn8JcMA8GnG0ClfdRI4/ZSeG7zhFaVg+wg==",
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.0.tgz",
+      "integrity": "sha512-1k8/8OHf5VIymJEcJyVksFpT+AQ5euY0VA5hUkCnlKpD4mr8FSbvXaHblxeTTEr90OaqWzAkQaqD80qHZQKxBA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"


### PR DESCRIPTION
## Why

#1852 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Client-initiated cancellation with abort propagation through proxy requests; returns 499 when clients abort.
- Bug Fixes
  - Stops retries after client cancellation.
  - Prevents crashes when connections close after partial response.
  - Uses 502 as a reliable fallback status when none is provided.
- Tests
  - Added functional tests for cancel-before-response and cancel-after-first-chunk scenarios.
- Chores
  - Updated server dependency and expanded TypeScript libs to include ES2024.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->