### PR TITLE
feat(log-collector): adds optional pod label filtering

### DIFF
--- a/apps/log-collector/README.md
+++ b/apps/log-collector/README.md
@@ -20,7 +20,7 @@ The Log Collector leverages internal Kubernetes access to discover and stream lo
 ## How It Works
 
 1. **Namespace Discovery**: The collector automatically detects the Kubernetes namespace it's deployed in
-2. **Pod Discovery**: Scans the namespace for all running pods (excluding pods from the same deployment)
+2. **Pod Discovery**: Scans the namespace for all running pods (excluding pods from the same deployment), with optional label-based filtering via `POD_LABEL_SELECTOR`
 3. **Log Streaming**: Establishes log streams for each pod
 4. **File Output**: Writes collected logs to files for external processing
 5. **Log Rotation**: Automatically rotates log files when they reach the configured size limit, maintaining up to `LOG_MAX_ROTATED_FILES` rotated files
@@ -32,11 +32,11 @@ The Log Collector leverages internal Kubernetes access to discover and stream lo
 
 These are the environment variables you need to configure for production deployment:
 
-| Variable                  | Description                   | Default             | Example             |
-| ------------------------- | ----------------------------- | ------------------- | ------------------- |
-| `LOG_MAX_FILE_SIZE_BYTES` | Max file size before rotation | `10_485_760` (10MB) | `20_971_520` (20MB) |
-| `LOG_MAX_ROTATED_FILES`   | Max number of rotated files   | `5`                 | `10`                |
-
+| Variable                  | Description                                 | Default             | Example                            |
+| ------------------------- | ------------------------------------------- | ------------------- | ---------------------------------- |
+| `LOG_MAX_FILE_SIZE_BYTES` | Max file size before rotation               | `10_485_760` (10MB) | `20_971_520` (20MB)                |
+| `LOG_MAX_ROTATED_FILES`   | Max number of rotated files                 | `5`                 | `10`                               |
+| `POD_LABEL_SELECTOR`      | Kubernetes label selector for pod discovery | unset (all pods)    | `"app=web,environment=production"` |
 ### Log Collection Configuration
 
 **Note**: Output destinations are automatically configured at startup based on environment variables. No manual configuration files needed.

--- a/apps/log-collector/src/services/config/config.service.ts
+++ b/apps/log-collector/src/services/config/config.service.ts
@@ -19,7 +19,8 @@ export class ConfigService {
       .number({ coerce: true })
       .optional()
       .default(10 * 1024 * 1024),
-    LOG_MAX_ROTATED_FILES: z.number({ coerce: true }).optional().default(5)
+    LOG_MAX_ROTATED_FILES: z.number({ coerce: true }).optional().default(5),
+    POD_LABEL_SELECTOR: z.string().optional()
   });
 
   /** Validated and transformed environment configuration */

--- a/apps/log-collector/src/services/pod-discovery/pod-discovery.service.ts
+++ b/apps/log-collector/src/services/pod-discovery/pod-discovery.service.ts
@@ -64,7 +64,7 @@ export class PodDiscoveryService {
    *
    * This method:
    * 1. Determines the current namespace from config or kubeconfig
-   * 2. Lists all pods in the namespace using the Kubernetes API
+   * 2. Lists all pods in the namespace using the Kubernetes API with optional label filtering
    * 3. Maps raw pod objects to simplified PodInfo structures
    * 4. Filters out the current pod to prevent self-collection
    * 5. Logs discovery statistics
@@ -77,7 +77,11 @@ export class PodDiscoveryService {
 
     this.loggerService.info({ message: "Discovering pods in namespace", namespace });
 
-    const { items: podsRaw } = await this.k8sClient.listNamespacedPod({ namespace });
+    const { items: podsRaw } = await this.k8sClient.listNamespacedPod({
+      namespace,
+      labelSelector: this.config.get("POD_LABEL_SELECTOR")
+    });
+
     const pods = podsRaw.map(pod => this.mapPodToInfo(pod, namespace));
 
     const currentPodName = this.config.get("HOSTNAME");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added optional POD_LABEL_SELECTOR env var to enable label-based pod discovery; when unset, discovery still returns all pods in the namespace.

- Documentation
  - README updated with POD_LABEL_SELECTOR entry (description, default, example) and clarified pod discovery behavior; environment variables table formatting improved.

- Tests
  - Tests updated to include labelSelector in pod listing calls and added coverage for when POD_LABEL_SELECTOR is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->