### PR TITLE
fix: don't throw an error when reserving zero

### DIFF
--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
@@ -64,11 +64,17 @@ describe(CachedBalanceService.name, () => {
       expect(amount).toBe(1000);
     });
 
-    it("should throw error when trying to reserve zero or negative amount", async () => {
+    it("should not throw error when reserving zero", async () => {
       const balance = await service.get(address);
 
-      expect(() => balance.reserveSufficientAmount(0)).toThrow("Insufficient balance");
-      expect(() => balance.reserveSufficientAmount(-100)).toThrow("Insufficient balance");
+      const amount = balance.reserveSufficientAmount(0);
+      expect(amount).toBe(0);
+    });
+
+    it("should throw error when trying to reserve negative amount", async () => {
+      const balance = await service.get(address);
+
+      expect(() => balance.reserveSufficientAmount(-100)).toThrow("Invalid amount");
     });
   });
 });

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
@@ -6,15 +6,18 @@ class CachedBalance {
   constructor(private value: number) {}
 
   public reserveSufficientAmount(desiredAmount: number) {
-    const value = Math.min(desiredAmount, this.value);
+    if (desiredAmount < 0) {
+      throw new Error(`Invalid amount: ${desiredAmount}`);
+    }
 
-    if (value <= 0) {
+    if (desiredAmount > 0 && this.value === 0) {
       throw new Error(`Insufficient balance: ${this.value} < ${desiredAmount}`);
     }
 
-    this.value -= value;
+    const reservedAmount = Math.min(desiredAmount, this.value);
+    this.value -= reservedAmount;
 
-    return value;
+    return reservedAmount;
   }
 }
 


### PR DESCRIPTION
closes #1841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Zero-amount balance reservations are allowed and now return 0.

- Bug Fixes
  - Negative reservation requests now produce a clear "Invalid amount" error instead of "Insufficient balance".
  - Reservations for positive amounts now reserve up to the available balance and return the reserved amount.

- Tests
  - Added tests covering zero and negative reservation cases and updated coverage for clarified behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->