### PR TITLE
fix: log when calculated top-up-amount is not a positive value

### DIFF
--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -88,6 +88,15 @@ export class TopUpManagedDeploymentsService implements DeploymentsRefiller {
             this.cachedBalanceService.get(address),
             this.drainingDeploymentService.calculateTopUpAmount(deployment)
           ]);
+          if (desiredAmount <= 0) {
+            this.logger.warn({
+              event: "TOP_UP_AMOUNT_NON_POSITIVE",
+              desiredAmount,
+              dseq: deployment.dseq,
+              address: deployment.address,
+              blockRate: deployment.blockRate
+            });
+          }
           const sufficientAmount = balance.reserveSufficientAmount(desiredAmount);
 
           const messageInput: DepositDeploymentMsgOptions = {


### PR DESCRIPTION
refs #1841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added non-fatal warning logs when computed top-up amounts are non-positive, including contextual details to aid troubleshooting.
  * Improved observability for deployment settings and managed top-up flows without changing behavior or interfaces.
  * No user-facing changes; existing functionality and outcomes remain the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->