### PR TITLE
feat(log-collector): integrate LogCollectorControl with SimpleSdlBuiderForm

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/SdlBuilder.tsx
+++ b/apps/deploy-web/src/components/new-deployment/SdlBuilder.tsx
@@ -1,17 +1,15 @@
 "use client";
 import type { Dispatch } from "react";
-import { useCallback } from "react";
 import React, { useEffect, useRef, useState } from "react";
-import { useFieldArray, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { Alert, Button, Form, Spinner } from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
 import cloneDeep from "lodash/cloneDeep";
-import { nanoid } from "nanoid";
 
-import { findOwnLogCollectorServiceIndex, isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
 import { useSdlBuilder } from "@src/context/SdlBuilderProvider/SdlBuilderProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useManagedWalletDenom } from "@src/hooks/useManagedWalletDenom";
+import { useSdlServiceManager } from "@src/hooks/useSdlServiceManager/useSdlServiceManager";
 import { useWhen } from "@src/hooks/useWhen";
 import { useGpuModels } from "@src/queries/useGpuQuery";
 import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
@@ -52,15 +50,7 @@ export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
       resolver: zodResolver(SdlBuilderFormValuesSchema)
     });
     const { control, trigger, watch, setValue } = form;
-    const {
-      fields: services,
-      remove: removeService,
-      append: appendService
-    } = useFieldArray({
-      control,
-      name: "services",
-      keyName: "id"
-    });
+    const serviceManager = useSdlServiceManager({ control });
 
     const { services: formServices = [] } = watch();
     const { data: gpuModels } = useGpuModels();
@@ -142,38 +132,6 @@ export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
       }
     };
 
-    const calcNextServiceTitle = useCallback(() => {
-      const visibleServices = formServices.filter(service => !isLogCollectorService(service));
-      const lastService = visibleServices[visibleServices.length - 1];
-      const lastServiceIndex = lastService?.title?.match(/service-(\d+)/)?.[1];
-
-      let nextIndex = lastServiceIndex ? parseInt(lastServiceIndex) + 1 : visibleServices.length + 1;
-      let hasDuplicate = false;
-
-      do {
-        hasDuplicate = visibleServices.some(service => service.title === `service-${nextIndex}`);
-
-        if (hasDuplicate) {
-          nextIndex++;
-        }
-      } while (hasDuplicate);
-
-      return `service-${nextIndex}`;
-    }, [formServices]);
-
-    const add = useCallback(() => {
-      appendService({ ...defaultService, id: nanoid(), title: calcNextServiceTitle() });
-    }, [appendService, calcNextServiceTitle]);
-
-    const remove = useCallback(
-      (index: number) => {
-        const ownLogCollectorServiceIndex = findOwnLogCollectorServiceIndex(formServices[index], formServices);
-        const indexes = (ownLogCollectorServiceIndex === -1 ? [index] : [index, ownLogCollectorServiceIndex]).sort((a, b) => b - a);
-        removeService(indexes);
-      },
-      [formServices, removeService]
-    );
-
     return (
       <div className="pb-8">
         {!isInit ? (
@@ -195,7 +153,7 @@ export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
             <Form {...form}>
               <form ref={formRef} autoComplete="off">
                 {formServices &&
-                  services.map((service, serviceIndex) => (
+                  formServices.map((service, serviceIndex) => (
                     <SimpleServiceFormControl
                       key={service.id}
                       serviceIndex={serviceIndex}
@@ -204,7 +162,7 @@ export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
                       _services={formServices as ServiceType[]}
                       control={control}
                       trigger={trigger}
-                      onRemoveService={remove}
+                      onRemoveService={serviceManager.remove}
                       serviceCollapsed={serviceCollapsed}
                       setServiceCollapsed={setServiceCollapsed}
                       hasSecretOption={false}
@@ -221,7 +179,7 @@ export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
                 {!hasComponent("ssh") && !isGitProviderTemplate && (
                   <div className="flex items-center justify-end pt-4">
                     <div>
-                      <Button variant="default" size="sm" type="button" onClick={add}>
+                      <Button variant="default" size="sm" type="button" onClick={serviceManager.add}>
                         Add Service
                       </Button>
                     </div>

--- a/apps/deploy-web/src/components/sdl/DatadogEnvConfig/DatadogEnvConfig.tsx
+++ b/apps/deploy-web/src/components/sdl/DatadogEnvConfig/DatadogEnvConfig.tsx
@@ -24,7 +24,7 @@ export const DatadogEnvConfig: FC<Props> = ({ serviceIndex, dependencies: d = { 
     <>
       <div className="mt-4">
         <Input
-          value={env.getValue("DD_SITE")}
+          value={env.values.DD_SITE}
           onChange={e => env.setValue("DD_SITE", e.target.value)}
           type="text"
           label="Regional URL"
@@ -37,7 +37,7 @@ export const DatadogEnvConfig: FC<Props> = ({ serviceIndex, dependencies: d = { 
 
       <div className="mt-4">
         <Input
-          value={env.getValue("DD_API_KEY")}
+          value={env.values.DD_API_KEY}
           onChange={e => env.setValue("DD_API_KEY", e.target.value)}
           type="password"
           label="API Key"

--- a/apps/deploy-web/src/components/sdl/SimpleSdlBuilderForm.tsx
+++ b/apps/deploy-web/src/components/sdl/SimpleSdlBuilderForm.tsx
@@ -1,11 +1,10 @@
 "use client";
 import { useEffect, useRef, useState } from "react";
-import { useFieldArray, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import { Alert, Button, Form, Snackbar, Spinner } from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { NavArrowRight } from "iconoir-react";
 import { useAtom } from "jotai";
-import { nanoid } from "nanoid";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSnackbar } from "notistack";
@@ -14,6 +13,7 @@ import { SimpleServiceFormControl } from "@src/components/sdl/SimpleServiceFormC
 import { USER_TEMPLATE_CODE } from "@src/config/deploy.config";
 import { useServices } from "@src/context/ServicesProvider";
 import useFormPersist from "@src/hooks/useFormPersist";
+import { useSdlServiceManager } from "@src/hooks/useSdlServiceManager/useSdlServiceManager";
 import { useGpuModels } from "@src/queries/useGpuQuery";
 import sdlStore from "@src/store/sdlStore";
 import type { ITemplate, SdlBuilderFormValuesType, ServiceType } from "@src/types";
@@ -57,16 +57,8 @@ export const SimpleSDLBuilderForm: React.FunctionComponent = () => {
     defaultValues: DEFAULT_SERVICES,
     storage: typeof window === "undefined" ? undefined : window.localStorage
   });
-  const {
-    fields: services,
-    remove: removeService,
-    append: appendService
-  } = useFieldArray({
-    control,
-    name: "services",
-    keyName: "id"
-  });
   const { services: _services } = watch();
+  const serviceManager = useSdlServiceManager({ control });
   const router = useRouter();
   const searchParams = useSearchParams();
   const templateQueryId = searchParams?.get("id");
@@ -115,14 +107,6 @@ export const SimpleSDLBuilderForm: React.FunctionComponent = () => {
 
       setIsLoadingTemplate(false);
     }
-  };
-
-  const onAddService = () => {
-    appendService({ ...defaultService, id: nanoid(), title: `service-${services.length + 1}` });
-  };
-
-  const onRemoveService = (index: number) => {
-    removeService(index);
   };
 
   const onSubmit = async (data: SdlBuilderFormValuesType) => {
@@ -303,7 +287,7 @@ export const SimpleSDLBuilderForm: React.FunctionComponent = () => {
               setValue={setValue}
               control={control}
               trigger={trigger}
-              onRemoveService={onRemoveService}
+              onRemoveService={serviceManager.remove}
               serviceCollapsed={serviceCollapsed}
               setServiceCollapsed={setServiceCollapsed}
               gpuModels={gpuModels}
@@ -318,7 +302,7 @@ export const SimpleSDLBuilderForm: React.FunctionComponent = () => {
 
           <div className="flex items-center justify-end pt-4">
             <div>
-              <Button color="secondary" variant="default" onClick={onAddService} type="button">
+              <Button color="secondary" variant="default" onClick={serviceManager.add} type="button">
                 Add Service
               </Button>
             </div>

--- a/apps/deploy-web/src/hooks/useSdlEnv/useSdlEnv.spec.tsx
+++ b/apps/deploy-web/src/hooks/useSdlEnv/useSdlEnv.spec.tsx
@@ -11,8 +11,9 @@ import { buildSDLService } from "@tests/seeders/sdlService";
 describe("useSdlEnv", () => {
   it("initializes with empty environment variables", async () => {
     const { result } = await setup();
-    expect(result.current.getValue("API_KEY")).toBe("");
-    expect(result.current.getValue("DATABASE_URL")).toBe("");
+
+    expect(result.current.values.API_KEY).toBeUndefined();
+    expect(result.current.values.DATABASE_URL).toBeUndefined();
     expect(result.current.errors).toEqual({});
   });
 
@@ -23,8 +24,8 @@ describe("useSdlEnv", () => {
       result.current.setValue("DATABASE_URL", "postgresql://localhost:5432/mydb");
     });
 
-    expect(result.current.getValue("API_KEY")).toBe("secret-key-123");
-    expect(result.current.getValue("DATABASE_URL")).toBe("postgresql://localhost:5432/mydb");
+    expect(result.current.values.API_KEY).toBe("secret-key-123");
+    expect(result.current.values.DATABASE_URL).toBe("postgresql://localhost:5432/mydb");
   });
 
   it("removes environment variable when value is empty", async () => {
@@ -34,7 +35,7 @@ describe("useSdlEnv", () => {
       result.current.setValue("API_KEY", "");
     });
 
-    expect(result.current.getValue("API_KEY")).toBe("");
+    expect(result.current.values.API_KEY).toBe("");
   });
 
   it("updates existing environment variable", async () => {
@@ -44,7 +45,7 @@ describe("useSdlEnv", () => {
       result.current.setValue("API_KEY", "new-key");
     });
 
-    expect(result.current.getValue("API_KEY")).toBe("new-key");
+    expect(result.current.values.API_KEY).toBe("new-key");
   });
 
   it("handles validation errors from schema", async () => {
@@ -75,14 +76,14 @@ describe("useSdlEnv", () => {
       result.current.setValue("DEBUG", "true");
     });
 
-    expect(result.current.getValue("API_KEY")).toBe("key1");
-    expect(result.current.getValue("DATABASE_URL")).toBe("url1");
-    expect(result.current.getValue("DEBUG")).toBe("true");
+    expect(result.current.values.API_KEY).toBe("key1");
+    expect(result.current.values.DATABASE_URL).toBe("url1");
+    expect(result.current.values.DEBUG).toBe("true");
   });
 
-  it("returns empty string for keys without values", async () => {
+  it("returns undefined for keys without values", async () => {
     const { result } = await setup();
-    expect(result.current.getValue("DEBUG")).toBe("");
+    expect(result.current.values.DEBUG).toBeUndefined();
   });
 
   async function setup() {

--- a/apps/deploy-web/src/hooks/useSdlServiceManager/useSdlServiceManager.spec.tsx
+++ b/apps/deploy-web/src/hooks/useSdlServiceManager/useSdlServiceManager.spec.tsx
@@ -1,0 +1,190 @@
+import type { UseFormReturn } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { useSdlServiceManager } from "./useSdlServiceManager";
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { buildSDLService } from "@tests/seeders/sdlService";
+
+describe(useSdlServiceManager.name, () => {
+  it("adds a new service with correct title", async () => {
+    const { result, form } = await setup();
+
+    await act(async () => {
+      result.current.add();
+    });
+
+    const currentServices = form.getValues("services");
+    expect(currentServices).toHaveLength(1);
+    expect(currentServices[0].title).toBe("service-1");
+  });
+
+  it("adds multiple services with sequential titles", async () => {
+    const { result, form } = await setup();
+
+    await act(async () => {
+      result.current.add();
+    });
+
+    await act(async () => {
+      result.current.add();
+    });
+
+    await act(async () => {
+      result.current.add();
+    });
+
+    const currentServices = form.getValues("services");
+    expect(currentServices).toHaveLength(3);
+    expect(currentServices[0].title).toBe("service-1");
+    expect(currentServices[1].title).toBe("service-2");
+    expect(currentServices[2].title).toBe("service-3");
+  });
+
+  it("adds services with correct titles when existing services have gaps", async () => {
+    const { result, form } = await setup({
+      defaultServices: [buildSDLService({ title: "service-1" }), buildSDLService({ title: "service-3" }), buildSDLService({ title: "service-5" })]
+    });
+
+    await act(async () => {
+      result.current.add();
+    });
+
+    const currentServices = form.getValues("services");
+    expect(currentServices).toHaveLength(4);
+    expect(currentServices[3].title).toBe("service-6");
+  });
+
+  it("removes a service by index", async () => {
+    const { result, form } = await setup({
+      defaultServices: [buildSDLService({ title: "service-1" }), buildSDLService({ title: "service-2" }), buildSDLService({ title: "service-3" })]
+    });
+
+    await act(async () => {
+      result.current.remove(1);
+    });
+
+    const currentServices = form.getValues("services");
+    expect(currentServices).toHaveLength(2);
+    expect(currentServices[0].title).toBe("service-1");
+    expect(currentServices[1].title).toBe("service-3");
+  });
+
+  it("removes a service and its associated log collector service", async () => {
+    const { result, form } = await setup({
+      defaultServices: [
+        buildSDLService({ title: "service-1" }),
+        buildSDLService({
+          title: "service-1-log-collector",
+          image: "ghcr.io/akash-network/log-collector:1.7.0"
+        }),
+        buildSDLService({ title: "service-2" })
+      ]
+    });
+
+    await act(async () => {
+      result.current.remove(0);
+    });
+
+    const currentServices = form.getValues("services");
+    expect(currentServices).toHaveLength(1);
+    expect(currentServices[0].title).toBe("service-2");
+  });
+
+  it("handles removal when no log collector service exists", async () => {
+    const { result, form } = await setup({
+      defaultServices: [buildSDLService({ title: "service-1" }), buildSDLService({ title: "service-2" })]
+    });
+
+    await act(async () => {
+      result.current.remove(0);
+    });
+
+    const currentServices = form.getValues("services");
+    expect(currentServices).toHaveLength(1);
+    expect(currentServices[0].title).toBe("service-2");
+  });
+
+  it("ignores log collector services when calculating next service title", async () => {
+    const { result, form } = await setup({
+      defaultServices: [
+        buildSDLService({ title: "service-1" }),
+        buildSDLService({
+          title: "service-1-log-collector",
+          image: "ghcr.io/akash-network/log-collector:1.7.0"
+        }),
+        buildSDLService({ title: "service-3" })
+      ]
+    });
+
+    await act(async () => {
+      result.current.add();
+    });
+
+    const currentServices = form.getValues("services");
+    expect(currentServices).toHaveLength(4);
+    expect(currentServices[3].title).toBe("service-4");
+  });
+
+  it("handles services with non-standard titles", async () => {
+    const { result, form } = await setup({
+      defaultServices: [buildSDLService({ title: "custom-service" }), buildSDLService({ title: "another-service" })]
+    });
+
+    await act(async () => {
+      result.current.add();
+    });
+
+    const currentServices = form.getValues("services");
+    expect(currentServices).toHaveLength(3);
+    expect(currentServices[2].title).toBe("service-3");
+  });
+
+  it("handles empty services array", async () => {
+    const { result, form } = await setup({
+      defaultServices: []
+    });
+
+    await act(async () => {
+      result.current.add();
+    });
+
+    const currentServices = form.getValues("services");
+    expect(currentServices).toHaveLength(1);
+    expect(currentServices[0].title).toBe("service-1");
+  });
+
+  async function setup({ defaultServices = [] }: { defaultServices?: SdlBuilderFormValuesType["services"] } = {}) {
+    let methods: UseFormReturn<SdlBuilderFormValuesType>;
+
+    const TestWrapper = ({ children, defaultValues }: { children: React.ReactNode; defaultValues: SdlBuilderFormValuesType }) => {
+      methods = useForm<SdlBuilderFormValuesType>({
+        defaultValues
+      });
+
+      return <FormProvider {...methods}>{children}</FormProvider>;
+    };
+
+    const defaultFormValues: SdlBuilderFormValuesType = {
+      services: defaultServices,
+      imageList: [],
+      hasSSHKey: false
+    };
+
+    const { result } = renderHook(
+      () =>
+        useSdlServiceManager({
+          control: methods.control
+        }),
+      {
+        wrapper: ({ children }) => <TestWrapper defaultValues={defaultFormValues}>{children}</TestWrapper>
+      }
+    );
+
+    return {
+      result,
+      form: await waitFor(() => methods)
+    };
+  }
+});

--- a/apps/deploy-web/src/hooks/useSdlServiceManager/useSdlServiceManager.ts
+++ b/apps/deploy-web/src/hooks/useSdlServiceManager/useSdlServiceManager.ts
@@ -1,0 +1,63 @@
+import { useCallback, useMemo } from "react";
+import type { Control } from "react-hook-form";
+import { useFieldArray, useWatch } from "react-hook-form";
+import { nanoid } from "nanoid";
+
+import { findOwnLogCollectorServiceIndex, isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { defaultService } from "@src/utils/sdl/data";
+
+type Props = {
+  control: Control<SdlBuilderFormValuesType>;
+};
+
+export const useSdlServiceManager = ({ control }: Props) => {
+  const watchedServices = useWatch<SdlBuilderFormValuesType>({ control, name: "services", defaultValue: [] });
+  const services = useMemo(() => (Array.isArray(watchedServices) ? (watchedServices as SdlBuilderFormValuesType["services"]) : []), [watchedServices]);
+
+  const { remove: removeService, append: appendService } = useFieldArray({
+    control,
+    name: "services",
+    keyName: "id"
+  });
+
+  const calcNextServiceTitle = useCallback(() => {
+    const visibleServices = services.filter(service => !isLogCollectorService(service));
+    const lastService = visibleServices[visibleServices.length - 1];
+    const lastServiceIndex = lastService?.title?.match(/service-(\d+)/)?.[1];
+
+    let nextIndex = lastServiceIndex ? parseInt(lastServiceIndex) + 1 : visibleServices.length + 1;
+    let hasDuplicate = false;
+
+    do {
+      hasDuplicate = visibleServices.some(service => service.title === `service-${nextIndex}`);
+
+      if (hasDuplicate) {
+        nextIndex++;
+      }
+    } while (hasDuplicate);
+
+    return `service-${nextIndex}`;
+  }, [services]);
+
+  const add = useCallback(() => {
+    appendService({ ...defaultService, id: nanoid(), title: calcNextServiceTitle() });
+  }, [appendService, calcNextServiceTitle]);
+
+  const remove = useCallback(
+    (index: number) => {
+      const ownLogCollectorServiceIndex = findOwnLogCollectorServiceIndex(services[index], services);
+      const indexes = (ownLogCollectorServiceIndex === -1 ? [index] : [index, ownLogCollectorServiceIndex]).sort((a, b) => b - a);
+      removeService(indexes);
+    },
+    [services, removeService]
+  );
+
+  return useMemo(
+    () => ({
+      add,
+      remove
+    }),
+    [add, remove]
+  );
+};

--- a/apps/deploy-web/src/hooks/useThrottledEffect/useThrottledEffect.spec.tsx
+++ b/apps/deploy-web/src/hooks/useThrottledEffect/useThrottledEffect.spec.tsx
@@ -1,0 +1,202 @@
+import { useThrottledEffect } from "./useThrottledEffect";
+
+import { act, renderHook } from "@testing-library/react";
+
+describe(useThrottledEffect.name, () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  it("executes effect after delay", () => {
+    const effect = jest.fn();
+    renderHook(({ deps }) => useThrottledEffect(effect, deps, 100), { initialProps: { deps: [1] } });
+
+    expect(effect).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+
+  it("throttles rapid dependency changes", () => {
+    const effect = jest.fn();
+    const { rerender } = renderHook(({ deps }) => useThrottledEffect(effect, deps, 100), { initialProps: { deps: [1] } });
+
+    rerender({ deps: [2] });
+    rerender({ deps: [3] });
+    rerender({ deps: [4] });
+
+    expect(effect).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(effect).toHaveBeenCalledTimes(1);
+    expect(effect).toHaveBeenCalledWith();
+  });
+
+  it("cancels previous timeout when dependencies change", () => {
+    const effect = jest.fn();
+    const { rerender } = renderHook(({ deps }) => useThrottledEffect(effect, deps, 100), { initialProps: { deps: [1] } });
+
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+
+    rerender({ deps: [2] });
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls cleanup function when effect returns cleanup", () => {
+    const cleanup = jest.fn();
+    const effect = jest.fn(() => cleanup);
+
+    const { rerender } = renderHook(({ deps }) => useThrottledEffect(effect, deps, 100), { initialProps: { deps: [1] } });
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    rerender({ deps: [2] });
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(cleanup).toHaveBeenCalledTimes(2);
+  });
+
+  it("handles effect that returns void", () => {
+    const effect = jest.fn(() => {});
+
+    const { rerender } = renderHook(({ deps }) => useThrottledEffect(effect, deps, 100), { initialProps: { deps: [1] } });
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    rerender({ deps: [2] });
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(effect).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses default delay of 100ms", () => {
+    const effect = jest.fn();
+    renderHook(({ deps }) => useThrottledEffect(effect, deps), {
+      initialProps: { deps: [1] }
+    });
+
+    expect(effect).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects custom delay", () => {
+    const effect = jest.fn();
+    renderHook(({ deps }) => useThrottledEffect(effect, deps, 200), {
+      initialProps: { deps: [1] }
+    });
+
+    expect(effect).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(effect).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up on unmount", () => {
+    const cleanup = jest.fn();
+    const effect = jest.fn(() => cleanup);
+
+    const { unmount } = renderHook(({ deps }) => useThrottledEffect(effect, deps, 100), { initialProps: { deps: [1] } });
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles multiple rapid changes with cleanup", () => {
+    const cleanup = jest.fn();
+    const effect = jest.fn(() => cleanup);
+
+    const { rerender } = renderHook(({ deps }) => useThrottledEffect(effect, deps, 100), { initialProps: { deps: [1] } });
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    rerender({ deps: [2] });
+    rerender({ deps: [3] });
+    rerender({ deps: [4] });
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(effect).toHaveBeenCalledTimes(2);
+    expect(cleanup).toHaveBeenCalledTimes(4);
+  });
+
+  it("handles empty dependency array", () => {
+    const effect = jest.fn();
+    renderHook(() => useThrottledEffect(effect, [], 100));
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles undefined dependencies", () => {
+    const effect = jest.fn();
+    renderHook(() => useThrottledEffect(effect, [], 100));
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/deploy-web/src/hooks/useThrottledEffect/useThrottledEffect.ts
+++ b/apps/deploy-web/src/hooks/useThrottledEffect/useThrottledEffect.ts
@@ -1,0 +1,30 @@
+import { useEffect, useRef } from "react";
+
+export function useThrottledEffect(effect: () => void | (() => void), deps: React.DependencyList, delay = 100) {
+  const timeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cleanup = useRef<void | (() => void)>();
+
+  useEffect(() => {
+    if (timeout.current) {
+      clearTimeout(timeout.current);
+    }
+
+    timeout.current = setTimeout(() => {
+      if (typeof cleanup.current === "function") {
+        cleanup.current();
+      }
+      cleanup.current = effect();
+      timeout.current = null;
+    }, delay);
+
+    return () => {
+      if (timeout.current) {
+        clearTimeout(timeout.current);
+        timeout.current = null;
+      }
+      if (typeof cleanup.current === "function") {
+        cleanup.current();
+      }
+    };
+  }, deps);
+}

--- a/apps/deploy-web/src/utils/keyValue/keyValue.ts
+++ b/apps/deploy-web/src/utils/keyValue/keyValue.ts
@@ -9,3 +9,12 @@ export function kvArrayToObject<T extends string, V>(arr: { key: T; value?: V }[
     {} as Record<T, V | undefined>
   );
 }
+
+export function objectToKvArray<T extends string, V>(obj: Record<T, V>): { key: T; value: V }[];
+export function objectToKvArray<T extends string, V>(obj: Record<T, V | undefined>): { key: T; value?: V }[];
+export function objectToKvArray<T extends string, V>(obj: Record<T, V | undefined>): { key: T; value?: V }[] {
+  return Object.entries(obj).map(([key, value]) => ({
+    key: key as T,
+    value: value as V | undefined
+  }));
+}

--- a/apps/deploy-web/tests/seeders/sdlService.ts
+++ b/apps/deploy-web/tests/seeders/sdlService.ts
@@ -7,7 +7,7 @@ export const buildSDLService = (overrides: Partial<ServiceType> = {}): ServiceTy
   title: faker.lorem.word(),
   image: faker.helpers.arrayElement(["nginx:latest", "node:18-alpine", "postgres:15", "redis:7-alpine", "python:3.11-slim"]),
   placement: {
-    name: faker.helpers.arrayElement(["default", "dcloud", "mainnet"]),
+    name: faker.lorem.word(),
     pricing: {
       amount: faker.number.int({ min: 100, max: 10000 }),
       denom: faker.helpers.arrayElement(["uakt", "uakt"])


### PR DESCRIPTION
- Extract service management into useSdlServiceManager hook
- Update useSdlEnv to work with form values directly
- Add useThrottledEffect for pod selector updates
- Enable LogCollectorControl in SimpleSdlBuilderForm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Easier adding/removing services with automatic sequential naming.
  - Removing a service also removes its associated log collector when present.
  - Log collector settings auto-sync with the target service and update smoothly.

- Changes
  - Log collector storage size adjusted to 512.
  - Datadog config reads environment values directly (no UI change).

- Refactor
  - Streamlined service list and environment handling for more predictable, consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->