### PR TITLE
fix: keep order of services when switching from yaml to editor

### DIFF
--- a/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
@@ -1,4 +1,7 @@
-import { parseSvcCommand } from "./sdlImport";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { importSimpleSdl, parseSvcCommand } from "./sdlImport";
 
 describe("sdlImport", () => {
   describe("parseSvcCommand", () => {
@@ -36,6 +39,16 @@ describe("sdlImport", () => {
 
     it("returns rest of command as string if command is array of strings with sh -c, drops empty lines", () => {
       expect(parseSvcCommand(["sh", "-c", "echo 'foo'", "", "echo 'bar'"])).toEqual("echo 'foo'\necho 'bar'");
+    });
+  });
+
+  describe("importSimpleSdl", () => {
+    it("returns services in the same order as in the SDL YAML", () => {
+      const yml = fs.readFileSync(path.resolve(__dirname, "../../../tests/mocks/two-services-sdl.yml"), "utf8");
+
+      const services = importSimpleSdl(yml);
+
+      expect(services.map(service => service.title)).toEqual(["web", "service-2"]);
     });
   });
 });

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -28,8 +28,7 @@ export const importSimpleSdl = (yamlStr: string) => {
     const services: ServiceType[] = [];
     if (!yamlJson.services) return services;
 
-    const sortedServicesNames = Object.keys(yamlJson.services).sort();
-    sortedServicesNames.forEach(svcName => {
+    Object.keys(yamlJson.services).forEach(svcName => {
       const svc = yamlJson.services[svcName];
 
       const service: Partial<ServiceType> = {

--- a/apps/deploy-web/tests/mocks/two-services-sdl.yml
+++ b/apps/deploy-web/tests/mocks/two-services-sdl.yml
@@ -1,0 +1,57 @@
+---
+version: "2.0"
+services:
+  web:
+    image: baktun/hello-akash-world:1.0.0
+    expose:
+      - port: 3000
+        as: 80
+        to:
+          - global: true
+    env:
+      - NEW_FEATURE=enabled
+  service-2:
+    image: ""
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          - size: 512Mi
+    service-2:
+      resources:
+        cpu:
+          units: 0.1
+        memory:
+          size: 512Mi
+        storage:
+          - size: 1Gi
+  placement:
+    dcloud:
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+        service-2:
+          denom: uakt
+          amount: 100000
+      attributes:
+        console/trials: "true"
+deployment:
+  web:
+    dcloud:
+      profile: web
+      count: 1
+  service-2:
+    dcloud:
+      profile: service-2
+      count: 1


### PR DESCRIPTION
fixes #1862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Service lists now preserve the original YAML order during import, rather than sorting alphabetically. This ensures the display and processing order matches user-defined intent across the app.
- Tests
  - Added automated tests and a multi-service YAML fixture to verify and safeguard order preservation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->