### PR TITLE
refactor: changes LeaseHttpService to accept http client

### DIFF
--- a/apps/api/src/core/providers/http-sdk.provider.ts
+++ b/apps/api/src/core/providers/http-sdk.provider.ts
@@ -24,17 +24,13 @@ container.register(CHAIN_API_HTTP_CLIENT, {
   useFactory: () => createHttpClient({ baseURL: apiNodeUrl })
 });
 
-const SERVICES = [BalanceHttpService, AuthzHttpService, BlockHttpService, BidHttpService, LeaseHttpService, ProviderHttpService];
-
+const SERVICES = [BalanceHttpService, AuthzHttpService, BlockHttpService, BidHttpService, ProviderHttpService];
 SERVICES.forEach(Service => container.register(Service, { useValue: new Service({ baseURL: apiNodeUrl }) }));
 
+const NON_AXIOS_SERVICES: Array<new (httpClient: HttpClient) => unknown> = [DeploymentHttpService, LeaseHttpService, CosmosHttpService];
+NON_AXIOS_SERVICES.forEach(Service => container.register(Service, { useFactory: c => new Service(c.resolve(CHAIN_API_HTTP_CLIENT)) }));
+
 container.register(GitHubHttpService, { useValue: new GitHubHttpService({ baseURL: "https://raw.githubusercontent.com" }) });
-container.register(DeploymentHttpService, {
-  useFactory: c => new DeploymentHttpService(c.resolve(CHAIN_API_HTTP_CLIENT))
-});
-container.register(CosmosHttpService, {
-  useFactory: c => new CosmosHttpService(c.resolve(CHAIN_API_HTTP_CLIENT))
-});
 container.register(CoinGeckoHttpService, {
   useFactory: () => new CoinGeckoHttpService(createHttpClient({ baseURL: "https://api.coingecko.com" }))
 });

--- a/packages/http-sdk/src/lease/lease-http.service.ts
+++ b/packages/http-sdk/src/lease/lease-http.service.ts
@@ -1,6 +1,5 @@
-import type { AxiosRequestConfig } from "axios";
-
-import { HttpService } from "../http/http.service";
+import { extractData } from "../http/http.service";
+import type { HttpClient } from "../utils/httpClient";
 
 export type RestAkashLeaseListResponse = {
   leases: {
@@ -54,14 +53,12 @@ type LeaseListParams = {
   state?: "active" | "insufficient_funds" | "closed";
 };
 
-export class LeaseHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
-    super(config);
-  }
+export class LeaseHttpService {
+  constructor(private readonly httpClient: HttpClient) {}
 
   public async list({ owner, dseq, state }: LeaseListParams): Promise<RestAkashLeaseListResponse> {
-    return this.extractData(
-      await this.get<RestAkashLeaseListResponse>("/akash/market/v1beta4/leases/list", {
+    return extractData(
+      await this.httpClient.get<RestAkashLeaseListResponse>("/akash/market/v1beta4/leases/list", {
         params: {
           "filters.owner": owner,
           "filters.dseq": dseq,


### PR DESCRIPTION
## Why

Default http client is retriable. It makes it easier to make this service a retry on network or server error. ref #1424 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized HTTP client usage across multiple backend services for improved consistency and maintainability.
  * Consolidated service registration to reduce duplication and simplify configuration.
  * Updated lease and related services to accept a shared HTTP client instance rather than creating their own.

* **Impact**
  * No UI or functional changes for end-users.
  * Developers integrating the SDK may need minor adjustments to service instantiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->