### PR TITLE
fix: set allowUrls for sentry on deploy-web

### DIFF
--- a/apps/deploy-web/sentry.client.config.ts
+++ b/apps/deploy-web/sentry.client.config.ts
@@ -2,7 +2,7 @@
 // The config you add here will be used whenever a page is visited.
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
-import { init as initSentry, thirdPartyErrorFilterIntegration } from "@sentry/nextjs";
+import { eventFiltersIntegration, init as initSentry, thirdPartyErrorFilterIntegration } from "@sentry/nextjs";
 
 initSentry({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
@@ -16,6 +16,9 @@ initSentry({
     thirdPartyErrorFilterIntegration({
       filterKeys: [process.env.NEXT_PUBLIC_SENTRY_APPLICATION_KEY!],
       behaviour: "drop-error-if-exclusively-contains-third-party-frames"
+    }),
+    eventFiltersIntegration({
+      allowUrls: [/https?:\/\/[^.]+\.akash\.network/]
     })
   ]
   // ...


### PR DESCRIPTION
## Why

because we receive errors from chrome extensions/etc but we don't care about them
<img width="946" height="300" alt="Screenshot 2025-09-10 at 14 20 51" src="https://github.com/user-attachments/assets/358fbd4a-78d6-43b7-93ca-fc92f3e9f0fe" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noise in error reporting by refining event filtering, resulting in clearer diagnostics and fewer irrelevant alerts for users.

* **Chores**
  * Updated monitoring configuration to include a URL allow-list for Akash network domains, improving the accuracy of captured events without affecting app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->