### PR TITLE
feat(notifications): adds a discord link to one of the onboarding messages

### DIFF
--- a/apps/api/src/notifications/services/notification-templates/trial-first-deployment-lease-created-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/trial-first-deployment-lease-created-notification.ts
@@ -6,7 +6,7 @@ export function trialFirstDeploymentLeaseCreatedNotification(user: UserOutput, v
     notificationId: `trialFirstDeploymentLeaseCreated.${vars.owner}`,
     payload: {
       summary: "You deployed your first application!",
-      description: `Congratulations on creating your first deployment (dseq: ${vars.dseq}) with Akash Console. If you have questions about anything you see, hit up our discord server <insert link to https://discord.com/invite/akash> `
+      description: `Congratulations on creating your first deployment (dseq: ${vars.dseq}) with Akash Console. If you have questions about anything you see, hit up our <a href="https://discord.com/invite/akash">Discord server</a>`
     },
     user: {
       id: user.id,
@@ -14,4 +14,3 @@ export function trialFirstDeploymentLeaseCreatedNotification(user: UserOutput, v
     }
   };
 }
-

--- a/apps/api/src/notifications/services/notification-templates/trial-first-deployment-lease-created-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/trial-first-deployment-lease-created-notification.ts
@@ -5,8 +5,8 @@ export function trialFirstDeploymentLeaseCreatedNotification(user: UserOutput, v
   return {
     notificationId: `trialFirstDeploymentLeaseCreated.${vars.owner}`,
     payload: {
-      summary: "Your First Deployment Has Been Created",
-      description: `Your first deployment (dseq: ${vars.dseq}) has been created.`
+      summary: "You deployed your first application!",
+      description: `Congratulations on creating your first deployment (dseq: ${vars.dseq}) with Akash Console. If you have questions about anything you see, hit up our discord server <insert link to https://discord.com/invite/akash> `
     },
     user: {
       id: user.id,
@@ -14,3 +14,4 @@ export function trialFirstDeploymentLeaseCreatedNotification(user: UserOutput, v
     }
   };
 }
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the first-deployment notification to be more celebratory and user-friendly.
  - Title changed to “You deployed your first application!”
  - Message now congratulates the user, references their deployment ID (dseq), and includes a direct link to our Discord for support.
  - Improves clarity, guidance, and next-step assistance for new users after their initial deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->