### PR TITLE
Update trial-ended-notification.ts

### DIFF
--- a/apps/api/src/app/services/trial-started/trial-started.handler.spec.ts
+++ b/apps/api/src/app/services/trial-started/trial-started.handler.spec.ts
@@ -135,6 +135,9 @@ describe(TrialStartedHandler.name, () => {
         new NotificationJob({
           template: "trialEnded",
           userId: user.id,
+          vars: {
+            paymentLink
+          },
           conditions: { trial: true }
         }),
         {

--- a/apps/api/src/app/services/trial-started/trial-started.handler.ts
+++ b/apps/api/src/app/services/trial-started/trial-started.handler.ts
@@ -78,6 +78,9 @@ export class TrialStartedHandler implements JobHandler<TrialStarted> {
         new NotificationJob({
           template: "trialEnded",
           userId: user.id,
+          vars: {
+            paymentLink: this.billingConfig.get("CONSOLE_WEB_PAYMENT_LINK")
+          },
           conditions: notificationConditions
         }),
         {

--- a/apps/api/src/notifications/services/notification-handler/notification.handler.spec.ts
+++ b/apps/api/src/notifications/services/notification-handler/notification.handler.spec.ts
@@ -1,3 +1,4 @@
+import { faker } from "@faker-js/faker";
 import { mock } from "jest-mock-extended";
 
 import type { LoggerService } from "@src/core/providers/logging.provider";
@@ -38,6 +39,9 @@ describe(NotificationHandler.name, () => {
     await handler.handle({
       template: "trialEnded",
       userId: "non-existent-user",
+      vars: {
+        paymentLink: faker.internet.url()
+      },
       version: 1
     });
 
@@ -63,6 +67,9 @@ describe(NotificationHandler.name, () => {
     await handler.handle({
       template: "trialEnded",
       userId: user.id,
+      vars: {
+        paymentLink: faker.internet.url()
+      },
       version: 1
     });
 
@@ -89,6 +96,9 @@ describe(NotificationHandler.name, () => {
     await handler.handle({
       template: "trialEnded",
       userId: user.id,
+      vars: {
+        paymentLink: faker.internet.url()
+      },
       conditions: { trial: true }, // User doesn't have trial: true
       version: 1
     });
@@ -107,16 +117,20 @@ describe(NotificationHandler.name, () => {
     const { handler, userRepository, notificationService } = setup({
       findUserById: jest.fn().mockResolvedValue(user)
     });
+    const vars = {
+      paymentLink: faker.internet.url()
+    };
 
     await handler.handle({
       template: "trialEnded",
       userId: user.id,
+      vars,
       conditions: { trial: true },
       version: 1
     });
 
     expect(userRepository.findById).toHaveBeenCalledWith(user.id);
-    expect(notificationService.createNotification).toHaveBeenCalledWith(trialEndedNotification(user));
+    expect(notificationService.createNotification).toHaveBeenCalledWith(trialEndedNotification(user, vars));
   });
 
   it("creates notification when no conditions are provided", async () => {
@@ -218,9 +232,14 @@ describe(NotificationHandler.name, () => {
       findUserById: jest.fn().mockResolvedValue(user)
     });
 
+    const vars = {
+      paymentLink: faker.internet.url()
+    };
+
     await handler.handle({
       template: "trialEnded",
       userId: user.id,
+      vars,
       conditions: {
         trial: true,
         emailVerified: true
@@ -229,7 +248,7 @@ describe(NotificationHandler.name, () => {
     });
 
     expect(userRepository.findById).toHaveBeenCalledWith(user.id);
-    expect(notificationService.createNotification).toHaveBeenCalledWith(trialEndedNotification(user));
+    expect(notificationService.createNotification).toHaveBeenCalledWith(trialEndedNotification(user, vars));
   });
 
   it("returns early when complex conditions are not met", async () => {
@@ -247,6 +266,9 @@ describe(NotificationHandler.name, () => {
     await handler.handle({
       template: "trialEnded",
       userId: user.id,
+      vars: {
+        paymentLink: faker.internet.url()
+      },
       conditions: {
         trial: true,
         emailVerified: true

--- a/apps/api/src/notifications/services/notification-templates/trial-ended-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/trial-ended-notification.ts
@@ -1,13 +1,12 @@
 import type { UserOutput } from "@src/user/repositories";
 import type { CreateNotificationInput } from "../notification/notification.service";
 
-export function trialEndedNotification(user: UserOutput): CreateNotificationInput {
+export function trialEndedNotification(user: UserOutput, vars: { paymentLink: string }): CreateNotificationInput {
   return {
     notificationId: `trialEnded.${user.id}`,
     payload: {
       summary: "Your Free Trial Has Ended",
-      description:
-        "Your free trial with Akash Network has ended. To continue using the platform and accessing all features, please add a payment method and purchase some credits by visiting <insert link to payment page>."
+      description: `Your free trial with Akash Network has ended. To continue using the platform and accessing all features, please add a payment method and purchase some credits by visiting <a href="${vars.paymentLink}">Akash Console Payment Setup</a>.`
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/trial-ended-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/trial-ended-notification.ts
@@ -7,7 +7,7 @@ export function trialEndedNotification(user: UserOutput): CreateNotificationInpu
     payload: {
       summary: "Your Free Trial Has Ended",
       description:
-        "Your free trial with Akash Network has ended. To continue using the platform and accessing all features, please add a payment method and upgrade your account."
+        "Your free trial with Akash Network has ended. To continue using the platform and accessing all features, please add a payment method and purchase some credits by visiting <insert link to payment page>."
     },
     user: {
       id: user.id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Trial-ended notifications now include a personalized link to set up payment in the Console, enabling quick purchase of credits to continue service without interruption.
  - Updated messaging provides clearer guidance on next steps at the end of a trial, directing users to the payment setup page.
  - Improved notification consistency across flows to ensure the payment link is correctly included wherever trial-end notices are delivered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->