### PR TITLE
fix: ensure managed wallet deployment close doesnot depend on authService

### DIFF
--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -68,7 +68,7 @@ export class DeploymentWriterService {
   public async close(wallet: UserWalletOutput, dseq: string): Promise<{ success: boolean }> {
     const deployment = await this.deploymentReaderService.findByOwnerAndDseq(wallet.address!, dseq);
     const message = this.rpcMessageService.getCloseDeploymentMsg(wallet.address!, deployment.deployment.deployment_id.dseq);
-    await this.signerService.executeDecodedTxByUserId(wallet.userId, [message]);
+    await this.signerService.executeDecodedTxByUserWallet(wallet, [message]);
 
     return { success: true };
   }

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -517,7 +517,7 @@ describe("Deployments API", () => {
         rawLog: "success"
       };
 
-      jest.spyOn(signerService, "executeDecodedTxByUserId").mockResolvedValueOnce(mockTxResult);
+      jest.spyOn(signerService, "executeDecodedTxByUserWallet").mockResolvedValueOnce(mockTxResult);
 
       const response = await app.request(`/v1/deployments/${dseq}`, {
         method: "DELETE",


### PR DESCRIPTION
## Why

Otherwise we can't use it in background jobs because it requires authenticated user. CloseDeploymentJob failed with:

```
{
  "name": "Error",
  "stack": "Error: No context available\n    at ExecutionContextService.get context (webpack://akashnetwork/console-api/src/core/services/execution-context/execution-context.service.ts:22:13)\n    at ExecutionContextService.get (webpack://akashnetwork/console-api/src/core/services/execution-context/execution-context.service.ts:33:17)\n    at AuthService.get ability (webpack://akashnetwork/console-api/src/auth/services/auth.service.ts:26:41)\n    at ManagedSignerService.executeDecodedTxByUserId (webpack://akashnetwork/console-api/src/billing/services/managed-signer/managed-signer.service.ts:74:86)\n    at DeploymentWriterService.close (webpack://akashnetwork/console-api/src/deployment/services/deployment-writer/deployment-writer.service.ts:71:30)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async CloseTrialDeploymentHandler.handle (webpack://akashnetwork/console-api/src/app/services/close-trial-deployment/close-trial-deployment.handler.ts:61:5)\n    at async <anonymous> (webpack://akashnetwork/console-api/src/core/services/job-queue/job-queue.service.ts:106:13)\n    at async resolveWithinSeconds (webpack://akashnetwork/node_modules/pg-boss/src/manager.js:27:1)\n    at async Worker.onFetch (webpack://akashnetwork/node_modules/pg-boss/src/manager.js:216:1)",
  "message": "No context available"
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Corrected anonymous free trial validation to use the proper user context during transaction execution.
  - Aligned lease-created events with intended gating to prevent incorrect event emissions.
  - Reduced signing errors by using a wallet-aware execution path for decoded transactions.

- Refactor
  - Switched deployment close flow to use wallet-based transaction signing for consistency.
  - Introduced a wallet-aware transaction execution path to standardize behavior without changing end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->