### PR TITLE
feat: make Unleash session id visible for backend

### DIFF
--- a/apps/api/src/core/services/feature-flags/feature-flags.service.spec.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.service.spec.ts
@@ -78,11 +78,6 @@ describe(FeatureFlagsService.name, () => {
       });
       const createClient = jest.fn(() => client);
       const currentUser = { id: "123" };
-      const httpClientInfo: ClientInfoContextVariables["clientInfo"] = {
-        ip: "127.0.0.1",
-        userAgent: "test",
-        fingerprint: "test"
-      };
       const config = {
         DEPLOYMENT_ENV: "development",
         NODE_ENV: "development",
@@ -91,22 +86,17 @@ describe(FeatureFlagsService.name, () => {
       const service = await setup({
         config,
         createClient,
-        currentUser,
-        httpClientInfo
+        currentUser
       });
 
       service.isEnabled(FeatureFlags.NOTIFICATIONS_ALERT_CREATE);
 
       expect(client.isEnabled).toHaveBeenCalledWith(FeatureFlags.NOTIFICATIONS_ALERT_CREATE, {
         currentTime: expect.any(Date),
-        remoteAddress: httpClientInfo.ip,
         userId: currentUser.id,
         sessionId: undefined,
         environment: config.DEPLOYMENT_ENV,
         properties: {
-          userAgent: httpClientInfo.userAgent,
-          fingerprint: httpClientInfo.fingerprint,
-          nodeEnv: config.NODE_ENV,
           chainNetwork: config.NETWORK
         }
       });
@@ -118,11 +108,6 @@ describe(FeatureFlagsService.name, () => {
       });
       const createClient = jest.fn(() => client);
       const currentUser = { id: "123" };
-      const httpClientInfo: ClientInfoContextVariables["clientInfo"] = {
-        ip: "127.0.0.1",
-        userAgent: "test",
-        fingerprint: "test"
-      };
       const config = {
         DEPLOYMENT_ENV: "development",
         NODE_ENV: "development",
@@ -132,7 +117,6 @@ describe(FeatureFlagsService.name, () => {
         config,
         createClient,
         currentUser,
-        httpClientInfo,
         unleashSessionId: "test-session-123"
       });
 
@@ -140,14 +124,10 @@ describe(FeatureFlagsService.name, () => {
 
       expect(client.isEnabled).toHaveBeenCalledWith(FeatureFlags.NOTIFICATIONS_ALERT_CREATE, {
         currentTime: expect.any(Date),
-        remoteAddress: httpClientInfo.ip,
         userId: currentUser.id,
         sessionId: "test-session-123",
         environment: config.DEPLOYMENT_ENV,
         properties: {
-          userAgent: httpClientInfo.userAgent,
-          fingerprint: httpClientInfo.fingerprint,
-          nodeEnv: config.NODE_ENV,
           chainNetwork: config.NETWORK
         }
       });

--- a/apps/api/src/core/services/feature-flags/feature-flags.service.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.service.ts
@@ -32,20 +32,15 @@ export class FeatureFlagsService implements Disposable, AppInitializer {
 
     assert(this.client, "Feature flags service was not initialized. Call initialize() method first.");
 
-    const clientInfo = this.executionContext.get("HTTP_CONTEXT")?.get("clientInfo");
     const currentUser = this.executionContext.get("CURRENT_USER");
     const sessionId = this.extractSessionId();
 
     return this.client.isEnabled(featureFlag, {
       currentTime: new Date(),
-      remoteAddress: clientInfo?.ip,
       userId: currentUser?.id,
       sessionId,
       environment: this.configService.get("DEPLOYMENT_ENV"),
       properties: {
-        userAgent: clientInfo?.userAgent,
-        fingerprint: clientInfo?.fingerprint,
-        nodeEnv: this.configService.get("NODE_ENV"),
         chainNetwork: this.configService.get("NETWORK")
       }
     });

--- a/apps/api/src/core/services/feature-flags/feature-flags.service.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.service.ts
@@ -3,6 +3,7 @@ import { Disposable, inject, registry, singleton } from "tsyringe";
 import { Unleash, UnleashConfig } from "unleash-client";
 
 import { APP_INITIALIZER, AppInitializer, ON_APP_START } from "@src/core/providers/app-initializer";
+import type { AppContext } from "@src/core/types/app-context";
 import { CoreConfigService } from "../core-config/core-config.service";
 import { ExecutionContextService } from "../execution-context/execution-context.service";
 import { FeatureFlagValue } from "./feature-flags";
@@ -14,6 +15,7 @@ export class FeatureFlagsService implements Disposable, AppInitializer {
   private readonly executionContext: ExecutionContextService;
   private client?: Unleash;
   private readonly createClient: typeof createUnleashClient;
+  private readonly UNLEASH_COOKIE_KEY = "unleash-session-id=";
 
   constructor(
     configService: CoreConfigService,
@@ -32,11 +34,13 @@ export class FeatureFlagsService implements Disposable, AppInitializer {
 
     const clientInfo = this.executionContext.get("HTTP_CONTEXT")?.get("clientInfo");
     const currentUser = this.executionContext.get("CURRENT_USER");
+    const sessionId = this.extractSessionId();
 
     return this.client.isEnabled(featureFlag, {
       currentTime: new Date(),
       remoteAddress: clientInfo?.ip,
       userId: currentUser?.id,
+      sessionId,
       environment: this.configService.get("DEPLOYMENT_ENV"),
       properties: {
         userAgent: clientInfo?.userAgent,
@@ -45,6 +49,18 @@ export class FeatureFlagsService implements Disposable, AppInitializer {
         chainNetwork: this.configService.get("NETWORK")
       }
     });
+  }
+
+  private extractSessionId(): string | undefined {
+    const httpContext = this.executionContext.get("HTTP_CONTEXT") as AppContext | undefined;
+    if (!httpContext) return undefined;
+
+    const cookieHeader = httpContext.req.header("cookie");
+    if (!cookieHeader) return undefined;
+
+    const cookies = cookieHeader.split(";").map(c => c.trim());
+    const unleashCookie = cookies.find(c => c.startsWith(this.UNLEASH_COOKIE_KEY));
+    return unleashCookie?.replace(this.UNLEASH_COOKIE_KEY, "");
   }
 
   onChanged(callback: () => void) {

--- a/apps/deploy-web/src/lib/nextjs/pages/api/proxy/path.spec.ts
+++ b/apps/deploy-web/src/lib/nextjs/pages/api/proxy/path.spec.ts
@@ -1,0 +1,87 @@
+import { mock } from "jest-mock-extended";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+import type { NextApiRequestWithServices } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
+import { REQ_SERVICES_KEY } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
+import proxyHandler from "@src/pages/api/proxy/[...path]";
+import { services } from "@src/services/app-di-container/server-di-container.service";
+
+describe("proxy API handler", () => {
+  it("forwards cf_clearance and unleash-session-id cookies to backend", async () => {
+    const { req, handlerPromise } = setup({
+      url: "/api/proxy/v1/wallets?userId=2d888ad9-9359-4699-938f-3d66a8a8881a",
+      headers: {
+        cookie: "cf_clearance=test123; other-cookie=ignored; unleash-session-id=session456; another-cookie=also-ignored"
+      }
+    });
+
+    await handlerPromise;
+
+    expect(req.headers.cookie).toBe("cf_clearance=test123; unleash-session-id=session456");
+  });
+
+  function setup(input: {
+    url: string;
+    headers?: Record<string, string>;
+    socket?: { remoteAddress: string };
+    session?: { accessToken?: string; user: object };
+  }) {
+    const mockLogger = mock<typeof services.logger>();
+    const mockGetSession = jest.fn();
+    const mockUserTracker = mock<typeof services.userTracker>();
+    const mockApiUrlService = mock<typeof services.apiUrlService>();
+    const mockConfig = mock<typeof services.config>();
+
+    const mockProxy = {
+      once: jest.fn().mockReturnThis(),
+      web: jest.fn()
+    };
+
+    const mockHttpProxy = {
+      createProxyServer: jest.fn().mockReturnValue(mockProxy)
+    };
+
+    mockProxy.once.mockImplementation((event, callback) => {
+      if (event === "proxyRes") {
+        setTimeout(() => callback(), 0);
+      }
+      return mockProxy;
+    });
+
+    mockGetSession.mockResolvedValue(input.session || null);
+    mockApiUrlService.getBaseApiUrlFor.mockReturnValue("http://api.example.com");
+    mockConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID = "mainnet";
+
+    const req = mock<NextApiRequest>({
+      method: "GET",
+      url: input.url,
+      headers: input.headers,
+      socket: {
+        remoteAddress: "127.0.0.1",
+        ...input.socket
+      } as NextApiRequest["socket"]
+    });
+
+    const res = mock<NextApiResponse>();
+
+    (req as unknown as NextApiRequestWithServices)[REQ_SERVICES_KEY] = {
+      ...services,
+      logger: mockLogger,
+      getSession: mockGetSession,
+      httpProxy: mockHttpProxy,
+      apiUrlService: mockApiUrlService,
+      config: mockConfig,
+      userTracker: mockUserTracker
+    } as unknown as typeof services;
+
+    const handlerPromise = proxyHandler(req, res);
+
+    return {
+      req,
+      res,
+      mockLogger,
+      mockProxy,
+      handlerPromise
+    };
+  }
+});

--- a/apps/deploy-web/src/pages/api/proxy/[...path].ts
+++ b/apps/deploy-web/src/pages/api/proxy/[...path].ts
@@ -1,6 +1,3 @@
-import { getSession } from "@auth0/nextjs-auth0";
-import httpProxy from "http-proxy";
-
 import { defineApiHandler } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
 
 export default defineApiHandler({
@@ -10,7 +7,7 @@ export default defineApiHandler({
     req.url = req.url?.replace(/^\/api\/proxy/, "");
 
     services.logger.info({ event: "PROXY_API_REQUEST", url: req.url });
-    const session = await getSession(req, res);
+    const session = await services.getSession(req, res);
 
     // Extract and forward cf_clearance and unleash-session-id cookies
     const cookies = req.headers.cookie?.split(";").map(c => c.trim());
@@ -24,7 +21,7 @@ export default defineApiHandler({
       req.headers.authorization = `Bearer ${session.accessToken}`;
     }
 
-    const proxy = httpProxy.createProxyServer({
+    const proxy = services.httpProxy.createProxyServer({
       changeOrigin: true,
       target: services.apiUrlService.getBaseApiUrlFor(services.config.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID),
       secure: false,

--- a/apps/deploy-web/src/pages/api/proxy/[...path].ts
+++ b/apps/deploy-web/src/pages/api/proxy/[...path].ts
@@ -12,10 +12,13 @@ export default defineApiHandler({
     services.logger.info({ event: "PROXY_API_REQUEST", url: req.url });
     const session = await getSession(req, res);
 
-    // Extract and forward only cf_clearance cookie if present
+    // Extract and forward cf_clearance and unleash-session-id cookies
     const cookies = req.headers.cookie?.split(";").map(c => c.trim());
     const cfClearance = cookies?.find(c => c.startsWith("cf_clearance="));
-    req.headers.cookie = cfClearance || "";
+    const unleashSessionId = cookies?.find(c => c.startsWith("unleash-session-id="));
+
+    const cookiesToForward = [cfClearance, unleashSessionId].filter(Boolean);
+    req.headers.cookie = cookiesToForward.join("; ");
 
     if (session?.accessToken) {
       req.headers.authorization = `Bearer ${session.accessToken}`;

--- a/apps/deploy-web/src/services/app-di-container/server-di-container.service.ts
+++ b/apps/deploy-web/src/services/app-di-container/server-di-container.service.ts
@@ -2,6 +2,7 @@ import { createAPIClient } from "@akashnetwork/react-query-sdk/notifications";
 import { getSession } from "@auth0/nextjs-auth0";
 import { requestFn } from "@openapi-qraft/react";
 import * as unleashModule from "@unleash/nextjs";
+import httpProxy from "http-proxy";
 
 import { serverEnvConfig } from "@src/config/server-env.config";
 import { ApiUrlService } from "../api-url/api-url.service";
@@ -21,6 +22,7 @@ const rootContainer = createAppRootContainer({
 
 export const services = createChildContainer(rootContainer, {
   getSession: () => getSession,
+  httpProxy: () => ({ createProxyServer: httpProxy.createProxyServer }),
   featureFlagService: () => new FeatureFlagService(unleashModule, serverEnvConfig),
   notificationsApi: () =>
     createAPIClient({


### PR DESCRIPTION
closes #1867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Feature flags now consider session-specific context via the unleash-session-id cookie, enabling more precise and consistent rollouts.
  - The web proxy now forwards unleash-session-id alongside cf_clearance, preserving session-aware behavior across proxied requests.
  - No UI or public API changes; no user action required.

- Tests
  - Added tests verifying sessionId propagation and cookie-based parsing in feature flag evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->