### PR TITLE
fix: invalidate deployment when toggling alert status

### DIFF
--- a/apps/deploy-web/src/components/alerts/AlertsListContainer/AlertsListContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/AlertsListContainer/AlertsListContainer.tsx
@@ -5,6 +5,7 @@ import { useMemo } from "react";
 import React from "react";
 import { useCallback, useState } from "react";
 import type { components } from "@akashnetwork/react-query-sdk/notifications";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { useLocalNotes } from "@src/context/LocalNoteProvider";
 import { useServices } from "@src/context/ServicesProvider";
@@ -34,6 +35,7 @@ export const AlertsListContainer: FC<AlertsListContainerProps> = ({ children }) 
   const [limit, setLimit] = useState(10);
   const [loadingIds, setLoadingIds] = useState<Set<string>>(new Set());
   const { notificationsApi } = useServices();
+  const queryClient = useQueryClient();
   const { data, isError, isLoading, refetch } = notificationsApi.v1.getAlerts.useQuery({
     query: {
       page,
@@ -92,6 +94,10 @@ export const AlertsListContainer: FC<AlertsListContainerProps> = ({ children }) 
         });
         notificator.success(`Alert ${enabled ? "enabled" : "disabled"}`);
         refetch();
+
+        await queryClient.invalidateQueries({
+          queryKey: ["DEPLOYMENT_DETAIL"]
+        });
       } catch (error) {
         notificator.error("Failed to update alert");
       } finally {
@@ -102,7 +108,7 @@ export const AlertsListContainer: FC<AlertsListContainerProps> = ({ children }) 
         });
       }
     },
-    [patchMutation, notificator, refetch]
+    [patchMutation, notificator, refetch, queryClient]
   );
 
   const changePage = useCallback(({ page, limit }: { page: number; limit: number }) => {

--- a/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.tsx
+++ b/apps/deploy-web/src/components/alerts/AlertsListView/AlertsListView.tsx
@@ -21,7 +21,7 @@ export interface Props {
   data: Alert[];
   pagination: Pick<AlertsPagination, "page" | "limit" | "total" | "totalPages">;
   onPaginationChange: (params: { page: number; limit: number }) => void;
-  onToggle: (id: string, enabled: boolean) => void;
+  onToggle: (id: string, enabled: boolean, dseq?: string) => void;
   loadingIds: Set<string>;
   isLoading?: boolean;
   isError?: boolean;
@@ -52,7 +52,7 @@ export const AlertsListView: FC<Props> = ({
               checked={info.getValue()}
               disabled={isToggling}
               onCheckedChange={checked => {
-                onToggle(info.row.original.id, !!checked);
+                onToggle(info.row.original.id, !!checked, info.row.original.params?.dseq);
               }}
               aria-label={"Toggle alert"}
             />

--- a/apps/deploy-web/src/queries/queryKeys.ts
+++ b/apps/deploy-web/src/queries/queryKeys.ts
@@ -26,7 +26,7 @@ export class QueryKeys {
 
   // Deploy
   static getDeploymentListKey = (address: string) => ["DEPLOYMENT_LIST", address];
-  static getDeploymentDetailKey = (address: string, dseq: string) => ["DEPLOYMENT_DETAIL", address, dseq];
+  static getDeploymentDetailKey = (address: string, dseq?: string) => ["DEPLOYMENT_DETAIL", address, dseq].filter(Boolean);
   static getAllLeasesKey = (address: string) => ["ALL_LEASES", address];
   static getLeasesKey = (address: string, dseq: string) => ["LEASE_LIST", address, dseq];
   static getLeaseStatusKey = (dseq: string, gseq: number, oseq: number) => ["LEASE_STATUS", dseq, gseq, oseq];


### PR DESCRIPTION
closes #1768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Deployment details now refresh immediately after enabling or disabling an alert, preventing stale information.
  - Alert toggles reliably update related deployment data without requiring manual refresh or navigation.

- **New Features**
  - Alert toggles can optionally be tied to a specific deployment sequence so related deployment info updates correctly and stays in sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->