### PR TITLE
fix: ensure user can be signed in with a different anonymous user id but still be resolved to proper user

### DIFF
--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -237,7 +237,7 @@ describe(UserService.name, () => {
       expect(walletAfter?.userId).toBe(existingUser.id);
     });
 
-    it("does not throw error when user was already created under different anonymous user", async () => {
+    it("returns existing user (unique by userId) when user is registered under different anonymous user", async () => {
       const { service } = setup();
 
       const anonymousUserSeed = {
@@ -245,6 +245,7 @@ describe(UserService.name, () => {
         subscribedToNewsletter: false
       };
       const anonymousUser = await container.resolve(UserRepository).create(anonymousUserSeed);
+      const userWallet = await container.resolve(UserWalletRepository).create({ userId: anonymousUser.id });
 
       const input: RegisterUserInput = {
         userId: faker.string.uuid(),
@@ -257,10 +258,15 @@ describe(UserService.name, () => {
         userAgent: faker.string.alphanumeric(32),
         fingerprint: faker.string.alphanumeric(16)
       };
-      await service.registerUser(input);
+      const user = await service.registerUser(input);
 
-      const otherAnonymousUser = await container.resolve(UserRepository).create(anonymousUserSeed);
-      await service.registerUser({ ...input, anonymousUserId: otherAnonymousUser.id });
+      const anotherAnonymousUser = await container.resolve(UserRepository).create(anonymousUserSeed);
+      await container.resolve(UserWalletRepository).create({ userId: anotherAnonymousUser.id });
+
+      const existingUser = await service.registerUser({ ...input, anonymousUserId: anotherAnonymousUser.id });
+
+      expect(existingUser.id).toBe(user.id);
+      expect(await container.resolve(UserWalletRepository).findOneByUserId(existingUser.id)).toHaveProperty("id", userWallet.id);
     });
 
     it("updates user if registering existing user", async () => {

--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -237,6 +237,32 @@ describe(UserService.name, () => {
       expect(walletAfter?.userId).toBe(existingUser.id);
     });
 
+    it("does not throw error when user was already created under different anonymous user", async () => {
+      const { service } = setup();
+
+      const anonymousUserSeed = {
+        emailVerified: false,
+        subscribedToNewsletter: false
+      };
+      const anonymousUser = await container.resolve(UserRepository).create(anonymousUserSeed);
+
+      const input: RegisterUserInput = {
+        userId: faker.string.uuid(),
+        anonymousUserId: anonymousUser.id,
+        wantedUsername: `test-user-${Date.now()}`,
+        email: faker.internet.email(),
+        emailVerified: faker.datatype.boolean(),
+        subscribedToNewsletter: faker.datatype.boolean(),
+        ip: faker.internet.ipv4(),
+        userAgent: faker.string.alphanumeric(32),
+        fingerprint: faker.string.alphanumeric(16)
+      };
+      await service.registerUser(input);
+
+      const otherAnonymousUser = await container.resolve(UserRepository).create(anonymousUserSeed);
+      await service.registerUser({ ...input, anonymousUserId: otherAnonymousUser.id });
+    });
+
     it("updates user if registering existing user", async () => {
       const { service } = setup();
 

--- a/apps/api/src/user/services/user/user.service.ts
+++ b/apps/api/src/user/services/user/user.service.ts
@@ -46,16 +46,21 @@ export class UserService {
     };
 
     if (data.anonymousUserId) {
-      const user = await this.userRepository.updateBy(
-        {
-          id: data.anonymousUserId,
-          userId: null
-        },
-        userDetails,
-        { returning: true }
-      );
-
-      isAnonymous = !!user;
+      try {
+        const user = await this.userRepository.updateBy(
+          {
+            id: data.anonymousUserId,
+            userId: null
+          },
+          userDetails,
+          { returning: true }
+        );
+        isAnonymous = !!user;
+      } catch (error) {
+        if (!isUniqueViolation(error) || !error.constraint_name?.includes("userSetting_userId_unique")) {
+          throw error;
+        }
+      }
     }
 
     const user = await this.upsertUser({


### PR DESCRIPTION
refs #1934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer anonymous-session linking: when a conflict with an existing account occurs during anonymous linking, the linking step is now safely aborted for that conflict type and does not raise an error, preventing unintended account linking or profile changes.

* **Tests**
  * Added a test to validate behavior when registering with different anonymous sessions ensures existing user and wallet linkage remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->