### PR TITLE
fix: throw 502 on PostgreSQL connection error

### DIFF
--- a/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts
+++ b/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts
@@ -1,7 +1,7 @@
 import { LoggerService } from "@akashnetwork/logging";
 import { ForbiddenError } from "@casl/ability";
 import { isHttpError } from "http-errors";
-import { DatabaseError } from "sequelize";
+import { ConnectionAcquireTimeoutError, ConnectionError, DatabaseError } from "sequelize";
 import { singleton } from "tsyringe";
 import { ZodError } from "zod";
 
@@ -57,6 +57,18 @@ export class HonoErrorHandlerService {
           type: "authorization_error"
         },
         { status: 403 }
+      );
+    }
+
+    if (error instanceof ConnectionAcquireTimeoutError || error instanceof ConnectionError) {
+      return c.json(
+        {
+          error: "BadGatewayError",
+          message: "Database connection timeout",
+          code: "database_timeout",
+          type: "service_unavailable"
+        },
+        { status: 502 }
       );
     }
 


### PR DESCRIPTION
fixes #1944

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - API now returns a clear 502 Bad Gateway for database connection/timeouts with a dedicated "database_timeout" code and "service_unavailable" type.
- Bug Fixes
  - More consistent, user-friendly responses during temporary database connectivity outages.
- Documentation
  - Clarified API behavior and expected responses when the service is unavailable due to database timeouts.
- Chores
  - Internal dependency/import updates to support the improved error handling without changing public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->