### PR TITLE
feat(deployment): add fallback deployment list endpoint

### DIFF
--- a/apps/api/src/deployment/http-schemas/deployment-rpc.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment-rpc.schema.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 
-// Fallback API schemas for database deployment list
 export const FallbackDeploymentListQuerySchema = z.object({
   "filters.owner": z.string().optional(),
   "filters.state": z.enum(["active", "closed"]).optional(),

--- a/apps/api/src/deployment/http-schemas/deployment-rpc.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment-rpc.schema.ts
@@ -1,0 +1,152 @@
+import { z } from "zod";
+
+// Fallback API schemas for database deployment list
+export const FallbackDeploymentListQuerySchema = z.object({
+  "filters.owner": z.string().optional(),
+  "filters.state": z.enum(["active", "closed"]).optional(),
+  "pagination.offset": z.coerce.number().optional(),
+  "pagination.limit": z.coerce.number().optional(),
+  "pagination.key": z.string().optional(),
+  "pagination.count_total": z.coerce.boolean().optional(),
+  "pagination.reverse": z.coerce.boolean().optional()
+});
+
+const DeploymentIdSchema = z.object({
+  owner: z.string(),
+  dseq: z.string()
+});
+
+const GroupIdSchema = z.object({
+  owner: z.string(),
+  dseq: z.string(),
+  gseq: z.number()
+});
+
+const SignedBySchema = z.object({
+  all_of: z.array(z.string()),
+  any_of: z.array(z.string())
+});
+
+const AttributeSchema = z.object({
+  key: z.string(),
+  value: z.string()
+});
+
+const RequirementsSchema = z.object({
+  signed_by: SignedBySchema,
+  attributes: z.array(AttributeSchema)
+});
+
+const UnitsSchema = z.object({
+  val: z.string()
+});
+
+const QuantitySchema = z.object({
+  val: z.string()
+});
+
+const CpuSchema = z.object({
+  units: UnitsSchema,
+  attributes: z.array(AttributeSchema)
+});
+
+const MemorySchema = z.object({
+  quantity: QuantitySchema,
+  attributes: z.array(AttributeSchema)
+});
+
+const StorageItemSchema = z.object({
+  name: z.string(),
+  quantity: QuantitySchema,
+  attributes: z.array(AttributeSchema)
+});
+
+const GpuSchema = z.object({
+  units: UnitsSchema,
+  attributes: z.array(AttributeSchema)
+});
+
+const EndpointSchema = z.object({
+  kind: z.string(),
+  sequence_number: z.number()
+});
+
+const ResourceSchema = z.object({
+  id: z.number(),
+  cpu: CpuSchema,
+  memory: MemorySchema,
+  storage: z.array(StorageItemSchema),
+  gpu: GpuSchema,
+  endpoints: z.array(EndpointSchema)
+});
+
+const PriceSchema = z.object({
+  denom: z.string(),
+  amount: z.string()
+});
+
+const ResourceWithCountSchema = z.object({
+  resource: ResourceSchema,
+  count: z.number(),
+  price: PriceSchema
+});
+
+const GroupSpecSchema = z.object({
+  name: z.string(),
+  requirements: RequirementsSchema,
+  resources: z.array(ResourceWithCountSchema)
+});
+
+const GroupSchema = z.object({
+  group_id: GroupIdSchema,
+  state: z.string(),
+  group_spec: GroupSpecSchema,
+  created_at: z.string()
+});
+
+const DeploymentSchema = z.object({
+  deployment_id: DeploymentIdSchema,
+  state: z.string(),
+  version: z.string(),
+  created_at: z.string()
+});
+
+const EscrowIdSchema = z.object({
+  scope: z.string(),
+  xid: z.string()
+});
+
+const BalanceSchema = z.object({
+  denom: z.string(),
+  amount: z.string()
+});
+
+const EscrowAccountSchema = z.object({
+  id: EscrowIdSchema,
+  owner: z.string(),
+  state: z.string(),
+  balance: BalanceSchema,
+  transferred: BalanceSchema,
+  settled_at: z.string(),
+  depositor: z.string(),
+  funds: BalanceSchema
+});
+
+const DeploymentWithGroupsSchema = z.object({
+  deployment: DeploymentSchema,
+  groups: z.array(GroupSchema),
+  escrow_account: EscrowAccountSchema
+});
+
+const PaginationSchema = z.object({
+  next_key: z.string().nullable(),
+  total: z.string()
+});
+
+export const FallbackDeploymentListResponseSchema = z.object({
+  deployments: z.array(DeploymentWithGroupsSchema),
+  pagination: PaginationSchema
+});
+
+export type FallbackDeploymentListQuery = z.infer<typeof FallbackDeploymentListQuerySchema>;
+export type FallbackDeploymentListResponse = z.infer<typeof FallbackDeploymentListResponseSchema>;

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -23,7 +23,7 @@ import {
   UpdateDeploymentResponseSchema
 } from "@src/deployment/http-schemas/deployment.schema";
 import { FallbackDeploymentListQuerySchema, FallbackDeploymentListResponseSchema } from "@src/deployment/http-schemas/deployment-rpc.schema";
-import { DatabaseDeploymentReaderService } from "@src/deployment/services/deployment-reader/database-deployment-reader.service";
+import { DatabaseDeploymentReaderService } from "@src/deployment/services/deployment-reader/db-deployment-reader.service";
 
 const getRoute = createRoute({
   method: "get",
@@ -216,7 +216,6 @@ const getByOwnerAndDseqRoute = createRoute({
   }
 });
 
-// Fallback route that matches the node API signature
 const fallbackListRoute = createRoute({
   method: "get",
   path: "/akash/deployment/v1beta3/deployments/list",

--- a/apps/api/src/deployment/services/deployment-reader/database-deployment-reader.service.ts
+++ b/apps/api/src/deployment/services/deployment-reader/database-deployment-reader.service.ts
@@ -1,0 +1,180 @@
+import { Deployment, DeploymentGroup, DeploymentGroupResource } from "@akashnetwork/database/dbSchemas/akash";
+import { Op } from "sequelize";
+import { singleton } from "tsyringe";
+
+import { RestAkashDeploymentListResponse } from "@src/types/rest/akashDeploymentListResponse";
+
+export interface DatabaseDeploymentListParams {
+  owner?: string;
+  state?: "active" | "closed";
+  skip?: number;
+  limit?: number;
+  key?: string;
+  countTotal?: boolean;
+  reverse?: boolean;
+}
+
+// For the values that are not stored in the database
+export const FALLBACK_VALUE = "FALLBACK";
+
+@singleton()
+export class DatabaseDeploymentReaderService {
+  async listDeployments(params: DatabaseDeploymentListParams): Promise<RestAkashDeploymentListResponse> {
+    const { owner, state, skip = 0, limit = 100, key, countTotal = true, reverse = false } = params;
+
+    const whereClause: Record<string, unknown> = {};
+    if (owner) {
+      whereClause.owner = owner;
+    }
+    if (state === "active") {
+      whereClause.closedHeight = null;
+    } else if (state === "closed") {
+      whereClause.closedHeight = { [Op.ne]: null };
+    }
+
+    // Handle pagination similar to HTTP service
+    // If key is provided, use it as offset (simplified key-based pagination)
+    const offset = key ? parseInt(key, 10) || 0 : skip;
+
+    const queryOptions: Record<string, unknown> = {
+      where: whereClause,
+      include: [
+        {
+          model: DeploymentGroup,
+          include: [
+            {
+              model: DeploymentGroupResource,
+              separate: true
+            }
+          ]
+        }
+      ],
+      offset,
+      limit,
+      order: [["createdHeight", reverse ? "DESC" : "ASC"]]
+    };
+
+    // Only count total if countTotal is true or if offset is used (matching HTTP service behavior)
+    const shouldCountTotal = countTotal || offset !== undefined;
+
+    const { count: total, rows: deployments } = await Deployment.findAndCountAll(queryOptions);
+
+    const transformedDeployments = await Promise.all(
+      (deployments || []).map(async deployment => {
+        const groups =
+          deployment.deploymentGroups?.map(group => ({
+            group_id: {
+              owner: group.owner || "",
+              dseq: group.dseq || "",
+              gseq: group.gseq || 0
+            },
+            state: deployment.closedHeight ? "closed" : "open",
+            group_spec: {
+              name: FALLBACK_VALUE,
+              requirements: {
+                signed_by: {
+                  all_of: [],
+                  any_of: []
+                },
+                attributes: []
+              },
+              resources:
+                group.deploymentGroupResources?.map((resource, i) => {
+                  return {
+                    resource: {
+                      id: i + 1,
+                      cpu: {
+                        units: {
+                          val: (resource.cpuUnits || 0).toString()
+                        },
+                        attributes: []
+                      },
+                      memory: {
+                        quantity: {
+                          val: (resource.memoryQuantity || 0).toString()
+                        },
+                        attributes: []
+                      },
+                      storage: [
+                        {
+                          name: "default",
+                          quantity: {
+                            val: (resource.ephemeralStorageQuantity + resource.persistentStorageQuantity || 0).toString()
+                          },
+                          attributes: []
+                        }
+                      ],
+                      gpu: {
+                        units: {
+                          val: (resource.gpuUnits || 0).toString()
+                        },
+                        attributes: []
+                      },
+                      endpoints: [
+                        {
+                          kind: "SHARED_HTTP",
+                          sequence_number: 0
+                        }
+                      ]
+                    },
+                    count: resource.count || 1,
+                    price: {
+                      denom: deployment.denom || "uakt",
+                      amount: (resource.price || 0).toFixed(18)
+                    }
+                  };
+                }) || []
+            },
+            created_at: (deployment.createdHeight || 0).toString()
+          })) || [];
+
+        return {
+          deployment: {
+            deployment_id: {
+              owner: deployment.owner || "",
+              dseq: deployment.dseq || ""
+            },
+            state: deployment.closedHeight ? "closed" : "active",
+            version: FALLBACK_VALUE,
+            created_at: (deployment.createdHeight || 0).toString()
+          },
+          groups,
+          escrow_account: {
+            id: {
+              scope: "deployment",
+              xid: `${deployment.owner || ""}/${deployment.dseq || ""}`
+            },
+            owner: deployment.owner || "",
+            state: deployment.closedHeight ? "closed" : "open",
+            balance: {
+              denom: deployment.denom || "uakt",
+              amount: (deployment.balance || 0).toFixed(18)
+            },
+            transferred: {
+              denom: deployment.denom || "uakt",
+              amount: (deployment.withdrawnAmount || 0).toFixed(18)
+            },
+            settled_at: (deployment.lastWithdrawHeight || deployment.createdHeight || 0).toString(),
+            depositor: deployment.owner || "",
+            funds: {
+              denom: deployment.denom || "uakt",
+              amount: "0.000000000000000000"
+            }
+          }
+        };
+      })
+    );
+
+    // Calculate next_key similar to HTTP service
+    const hasMore = offset + limit < total;
+    const nextKey = hasMore ? (offset + limit).toString() : null;
+
+    return {
+      deployments: transformedDeployments,
+      pagination: {
+        next_key: nextKey,
+        total: shouldCountTotal ? total.toString() : "0"
+      }
+    };
+  }
+}

--- a/apps/api/src/types/rest/akashDeploymentListResponse.ts
+++ b/apps/api/src/types/rest/akashDeploymentListResponse.ts
@@ -40,22 +40,13 @@ export type RestAkashDeploymentListResponse = {
               };
               attributes: { key: string; value: string }[];
             };
-            storage: [
-              {
-                name: string;
-                quantity: {
-                  val: string;
-                };
-                attributes: { key: string; value: string }[];
-              },
-              {
-                name: string;
-                quantity: {
-                  val: string;
-                };
-                attributes: { key: string; value: string }[];
-              }
-            ];
+            storage: {
+              name: string;
+              quantity: {
+                val: string;
+              };
+              attributes: { key: string; value: string }[];
+            }[];
             gpu: {
               units: {
                 val: string;

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -10,6 +10,573 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
   },
   "openapi": "3.0.0",
   "paths": {
+    "/akash/deployment/v1beta3/deployments/list": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filters.owner",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "filters.state",
+            "required": false,
+            "schema": {
+              "enum": [
+                "active",
+                "closed",
+              ],
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "pagination.offset",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "pagination.limit",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "pagination.key",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "pagination.count_total",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean",
+            },
+          },
+          {
+            "in": "query",
+            "name": "pagination.reverse",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "deployments": {
+                      "items": {
+                        "properties": {
+                          "deployment": {
+                            "properties": {
+                              "created_at": {
+                                "type": "string",
+                              },
+                              "deployment_id": {
+                                "properties": {
+                                  "dseq": {
+                                    "type": "string",
+                                  },
+                                  "owner": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                ],
+                                "type": "object",
+                              },
+                              "state": {
+                                "type": "string",
+                              },
+                              "version": {
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "deployment_id",
+                              "state",
+                              "version",
+                              "created_at",
+                            ],
+                            "type": "object",
+                          },
+                          "escrow_account": {
+                            "properties": {
+                              "balance": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                              "depositor": {
+                                "type": "string",
+                              },
+                              "funds": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                              "id": {
+                                "properties": {
+                                  "scope": {
+                                    "type": "string",
+                                  },
+                                  "xid": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "scope",
+                                  "xid",
+                                ],
+                                "type": "object",
+                              },
+                              "owner": {
+                                "type": "string",
+                              },
+                              "settled_at": {
+                                "type": "string",
+                              },
+                              "state": {
+                                "type": "string",
+                              },
+                              "transferred": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                            },
+                            "required": [
+                              "id",
+                              "owner",
+                              "state",
+                              "balance",
+                              "transferred",
+                              "settled_at",
+                              "depositor",
+                              "funds",
+                            ],
+                            "type": "object",
+                          },
+                          "groups": {
+                            "items": {
+                              "properties": {
+                                "created_at": {
+                                  "type": "string",
+                                },
+                                "group_id": {
+                                  "properties": {
+                                    "dseq": {
+                                      "type": "string",
+                                    },
+                                    "gseq": {
+                                      "type": "number",
+                                    },
+                                    "owner": {
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "owner",
+                                    "dseq",
+                                    "gseq",
+                                  ],
+                                  "type": "object",
+                                },
+                                "group_spec": {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string",
+                                    },
+                                    "requirements": {
+                                      "properties": {
+                                        "attributes": {
+                                          "items": {
+                                            "properties": {
+                                              "key": {
+                                                "type": "string",
+                                              },
+                                              "value": {
+                                                "type": "string",
+                                              },
+                                            },
+                                            "required": [
+                                              "key",
+                                              "value",
+                                            ],
+                                            "type": "object",
+                                          },
+                                          "type": "array",
+                                        },
+                                        "signed_by": {
+                                          "properties": {
+                                            "all_of": {
+                                              "items": {
+                                                "type": "string",
+                                              },
+                                              "type": "array",
+                                            },
+                                            "any_of": {
+                                              "items": {
+                                                "type": "string",
+                                              },
+                                              "type": "array",
+                                            },
+                                          },
+                                          "required": [
+                                            "all_of",
+                                            "any_of",
+                                          ],
+                                          "type": "object",
+                                        },
+                                      },
+                                      "required": [
+                                        "signed_by",
+                                        "attributes",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    "resources": {
+                                      "items": {
+                                        "properties": {
+                                          "count": {
+                                            "type": "number",
+                                          },
+                                          "price": {
+                                            "properties": {
+                                              "amount": {
+                                                "type": "string",
+                                              },
+                                              "denom": {
+                                                "type": "string",
+                                              },
+                                            },
+                                            "required": [
+                                              "denom",
+                                              "amount",
+                                            ],
+                                            "type": "object",
+                                          },
+                                          "resource": {
+                                            "properties": {
+                                              "cpu": {
+                                                "properties": {
+                                                  "attributes": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string",
+                                                        },
+                                                        "value": {
+                                                          "type": "string",
+                                                        },
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "value",
+                                                      ],
+                                                      "type": "object",
+                                                    },
+                                                    "type": "array",
+                                                  },
+                                                  "units": {
+                                                    "properties": {
+                                                      "val": {
+                                                        "type": "string",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "val",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "units",
+                                                  "attributes",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              "endpoints": {
+                                                "items": {
+                                                  "properties": {
+                                                    "kind": {
+                                                      "type": "string",
+                                                    },
+                                                    "sequence_number": {
+                                                      "type": "number",
+                                                    },
+                                                  },
+                                                  "required": [
+                                                    "kind",
+                                                    "sequence_number",
+                                                  ],
+                                                  "type": "object",
+                                                },
+                                                "type": "array",
+                                              },
+                                              "gpu": {
+                                                "properties": {
+                                                  "attributes": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string",
+                                                        },
+                                                        "value": {
+                                                          "type": "string",
+                                                        },
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "value",
+                                                      ],
+                                                      "type": "object",
+                                                    },
+                                                    "type": "array",
+                                                  },
+                                                  "units": {
+                                                    "properties": {
+                                                      "val": {
+                                                        "type": "string",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "val",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "units",
+                                                  "attributes",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              "id": {
+                                                "type": "number",
+                                              },
+                                              "memory": {
+                                                "properties": {
+                                                  "attributes": {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string",
+                                                        },
+                                                        "value": {
+                                                          "type": "string",
+                                                        },
+                                                      },
+                                                      "required": [
+                                                        "key",
+                                                        "value",
+                                                      ],
+                                                      "type": "object",
+                                                    },
+                                                    "type": "array",
+                                                  },
+                                                  "quantity": {
+                                                    "properties": {
+                                                      "val": {
+                                                        "type": "string",
+                                                      },
+                                                    },
+                                                    "required": [
+                                                      "val",
+                                                    ],
+                                                    "type": "object",
+                                                  },
+                                                },
+                                                "required": [
+                                                  "quantity",
+                                                  "attributes",
+                                                ],
+                                                "type": "object",
+                                              },
+                                              "storage": {
+                                                "items": {
+                                                  "properties": {
+                                                    "attributes": {
+                                                      "items": {
+                                                        "properties": {
+                                                          "key": {
+                                                            "type": "string",
+                                                          },
+                                                          "value": {
+                                                            "type": "string",
+                                                          },
+                                                        },
+                                                        "required": [
+                                                          "key",
+                                                          "value",
+                                                        ],
+                                                        "type": "object",
+                                                      },
+                                                      "type": "array",
+                                                    },
+                                                    "name": {
+                                                      "type": "string",
+                                                    },
+                                                    "quantity": {
+                                                      "properties": {
+                                                        "val": {
+                                                          "type": "string",
+                                                        },
+                                                      },
+                                                      "required": [
+                                                        "val",
+                                                      ],
+                                                      "type": "object",
+                                                    },
+                                                  },
+                                                  "required": [
+                                                    "name",
+                                                    "quantity",
+                                                    "attributes",
+                                                  ],
+                                                  "type": "object",
+                                                },
+                                                "type": "array",
+                                              },
+                                            },
+                                            "required": [
+                                              "id",
+                                              "cpu",
+                                              "memory",
+                                              "storage",
+                                              "gpu",
+                                              "endpoints",
+                                            ],
+                                            "type": "object",
+                                          },
+                                        },
+                                        "required": [
+                                          "resource",
+                                          "count",
+                                          "price",
+                                        ],
+                                        "type": "object",
+                                      },
+                                      "type": "array",
+                                    },
+                                  },
+                                  "required": [
+                                    "name",
+                                    "requirements",
+                                    "resources",
+                                  ],
+                                  "type": "object",
+                                },
+                                "state": {
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "group_id",
+                                "state",
+                                "group_spec",
+                                "created_at",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
+                        },
+                        "required": [
+                          "deployment",
+                          "groups",
+                          "escrow_account",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "pagination": {
+                      "properties": {
+                        "next_key": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "total": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "next_key",
+                        "total",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "deployments",
+                    "pagination",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns paginated list of deployments from database",
+          },
+        },
+        "summary": "List deployments (database fallback)",
+        "tags": [
+          "Deployments",
+        ],
+      },
+    },
     "/v1/addresses/{address}": {
       "get": {
         "parameters": [

--- a/apps/api/test/functional/deployment-fallback.spec.ts
+++ b/apps/api/test/functional/deployment-fallback.spec.ts
@@ -1,0 +1,316 @@
+import Long from "long";
+
+import { closeConnections } from "@src/core";
+import { app, initDb } from "@src/rest-app";
+
+import { createAkashBlock, createDay, createDeployment, createDeploymentGroup, createDeploymentGroupResource, createTransaction } from "@test/seeders";
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+
+describe("Deployment Fallback API", () => {
+  const now = new Date();
+  const date = now.toISOString().split("T")[0];
+
+  afterAll(async () => {
+    await closeConnections();
+  });
+
+  describe("GET /akash/deployment/v1beta3/deployments/list", () => {
+    it("should return correct response structure with seeded data", async () => {
+      const { addresses } = await setup();
+
+      const result = await makeRequest({
+        owner: addresses![0],
+        state: "active"
+      });
+
+      expect(result).toHaveProperty("deployments");
+      expect(result).toHaveProperty("pagination");
+      expect(Array.isArray(result.deployments)).toBe(true);
+      expect(result.pagination).toHaveProperty("next_key");
+      expect(result.pagination).toHaveProperty("total");
+
+      // Should have at least one deployment
+      expect(result.deployments.length).toBeGreaterThan(0);
+
+      // Check deployment structure
+      const deployment = result.deployments[0];
+      expect(deployment).toHaveProperty("deployment");
+      expect(deployment).toHaveProperty("groups");
+      expect(deployment).toHaveProperty("escrow_account");
+
+      // Check deployment details
+      expect(deployment.deployment).toHaveProperty("deployment_id");
+      expect(deployment.deployment).toHaveProperty("state");
+      expect(deployment.deployment).toHaveProperty("version");
+      expect(deployment.deployment).toHaveProperty("created_at");
+
+      // Check groups structure
+      expect(Array.isArray(deployment.groups)).toBe(true);
+      if (deployment.groups.length > 0) {
+        const group = deployment.groups[0];
+        expect(group).toHaveProperty("group_id");
+        expect(group).toHaveProperty("state");
+        expect(group).toHaveProperty("group_spec");
+        expect(group).toHaveProperty("created_at");
+
+        // Check group_spec structure
+        expect(group.group_spec).toHaveProperty("name");
+        expect(group.group_spec).toHaveProperty("requirements");
+        expect(group.group_spec).toHaveProperty("resources");
+
+        // Check resources structure
+        if (group.group_spec.resources.length > 0) {
+          const resource = group.group_spec.resources[0];
+          expect(resource).toHaveProperty("resource");
+          expect(resource).toHaveProperty("count");
+          expect(resource).toHaveProperty("price");
+
+          // Check resource details
+          expect(resource.resource).toHaveProperty("id");
+          expect(resource.resource).toHaveProperty("cpu");
+          expect(resource.resource).toHaveProperty("memory");
+          expect(resource.resource).toHaveProperty("storage");
+          expect(resource.resource).toHaveProperty("gpu");
+          expect(resource.resource).toHaveProperty("endpoints");
+        }
+      }
+    });
+
+    it("should handle pagination parameters correctly", async () => {
+      await setup();
+
+      const result = await makeRequest({
+        skip: 0,
+        limit: 5,
+        countTotal: true
+      });
+
+      expect(result).toHaveProperty("deployments");
+      expect(result).toHaveProperty("pagination");
+      expect(result.pagination.total).toBeDefined();
+      expect(parseInt(result.pagination.total)).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should handle reverse sorting", async () => {
+      await setup();
+
+      const result = await makeRequest({
+        reverse: true,
+        limit: 5
+      });
+
+      expect(result).toHaveProperty("deployments");
+      expect(result).toHaveProperty("pagination");
+    });
+
+    it("should handle key-based pagination", async () => {
+      await setup();
+
+      const result = await makeRequest({
+        key: "0",
+        limit: 5
+      });
+
+      expect(result).toHaveProperty("deployments");
+      expect(result).toHaveProperty("pagination");
+    });
+
+    it("should filter by owner when provided", async () => {
+      const { addresses } = await setup();
+
+      const result = await makeRequest({
+        owner: addresses![0],
+        state: "active"
+      });
+
+      expect(result).toHaveProperty("deployments");
+      expect(result).toHaveProperty("pagination");
+
+      // All deployments should belong to the specified owner
+      result.deployments.forEach((deployment: any) => {
+        expect(deployment.deployment.deployment_id.owner).toBe(addresses![0]);
+      });
+    });
+
+    it("should filter by state when provided", async () => {
+      await setup();
+
+      const result = await makeRequest({
+        state: "active"
+      });
+
+      expect(result).toHaveProperty("deployments");
+      expect(result).toHaveProperty("pagination");
+
+      // All deployments should be active
+      result.deployments.forEach((deployment: any) => {
+        expect(deployment.deployment.state).toBe("active");
+      });
+    });
+
+    it("should return 200 status for valid requests", async () => {
+      await setup();
+
+      const response = await app.request("/akash/deployment/v1beta3/deployments/list");
+      expect(response.status).toBe(200);
+    });
+
+    it("should handle empty results gracefully", async () => {
+      const result = await makeRequest({
+        owner: "akash1nonexistent123456789",
+        state: "active"
+      });
+
+      expect(result).toHaveProperty("deployments");
+      expect(result).toHaveProperty("pagination");
+      expect(Array.isArray(result.deployments)).toBe(true);
+      expect(result.pagination).toHaveProperty("next_key");
+      expect(result.pagination).toHaveProperty("total");
+    });
+  });
+
+  const testData: {
+    day?: any;
+    addresses?: string[];
+    deployments?: any[];
+    deploymentGroups?: any[];
+    deploymentGroupResources?: any[];
+    blocks?: any[];
+    transactions?: any[];
+  } = {};
+  let isDbInitialized = false;
+
+  async function setup() {
+    if (isDbInitialized) {
+      return testData;
+    }
+
+    await initDb();
+
+    testData.day = await createDay({
+      date,
+      aktPrice: 1,
+      firstBlockHeight: 1,
+      lastBlockHeight: 100,
+      lastBlockHeightYet: 100
+    });
+
+    testData.addresses = [createAkashAddress(), createAkashAddress()];
+
+    testData.blocks = await Promise.all([
+      createAkashBlock({
+        dayId: testData.day.id,
+        datetime: now,
+        height: 100
+      }),
+      createAkashBlock({
+        dayId: testData.day.id,
+        datetime: now,
+        height: 101
+      })
+    ]);
+
+    testData.deployments = await Promise.all([
+      createDeployment({
+        owner: testData.addresses[0],
+        createdHeight: testData.blocks[0].height,
+        dseq: Long.fromNumber(1).toString(),
+        denom: "uakt",
+        balance: 1000000,
+        withdrawnAmount: 500000,
+        lastWithdrawHeight: testData.blocks[0].height
+      }),
+      createDeployment({
+        owner: testData.addresses[1],
+        createdHeight: testData.blocks[1].height,
+        dseq: Long.fromNumber(2).toString(),
+        denom: "uakt",
+        balance: 2000000,
+        withdrawnAmount: 1000000,
+        lastWithdrawHeight: testData.blocks[1].height
+      })
+    ]);
+
+    testData.deploymentGroups = await Promise.all([
+      createDeploymentGroup({
+        deploymentId: testData.deployments[0].id,
+        owner: testData.addresses[0],
+        dseq: testData.deployments[0].dseq,
+        gseq: 1
+      }),
+      createDeploymentGroup({
+        deploymentId: testData.deployments[1].id,
+        owner: testData.addresses[1],
+        dseq: testData.deployments[1].dseq,
+        gseq: 1
+      })
+    ]);
+
+    testData.deploymentGroupResources = await Promise.all([
+      createDeploymentGroupResource({
+        deploymentGroupId: testData.deploymentGroups[0].id,
+        cpuUnits: 1000,
+        gpuUnits: 0,
+        gpuVendor: "nvidia",
+        gpuModel: "gpu0",
+        memoryQuantity: 524288000,
+        ephemeralStorageQuantity: 524288000,
+        persistentStorageQuantity: 0,
+        count: 1,
+        price: 1000
+      }),
+      createDeploymentGroupResource({
+        deploymentGroupId: testData.deploymentGroups[1].id,
+        cpuUnits: 500,
+        gpuUnits: 1,
+        gpuVendor: "amd",
+        gpuModel: "gpu1",
+        memoryQuantity: 536870912,
+        ephemeralStorageQuantity: 536870912,
+        persistentStorageQuantity: 0,
+        count: 1,
+        price: 10000
+      })
+    ]);
+
+    testData.transactions = await Promise.all([
+      createTransaction({
+        height: testData.blocks[0].height
+      }),
+      createTransaction({
+        height: testData.blocks[1].height
+      })
+    ]);
+
+    isDbInitialized = true;
+
+    return testData;
+  }
+
+  async function makeRequest(input: {
+    owner?: string;
+    state?: "active" | "closed";
+    skip?: number;
+    limit?: number;
+    key?: string;
+    countTotal?: boolean;
+    reverse?: boolean;
+  }) {
+    const queryParams = new URLSearchParams();
+
+    if (input.owner) queryParams.append("filters.owner", input.owner);
+    if (input.state) queryParams.append("filters.state", input.state);
+    if (input.skip !== undefined) queryParams.append("pagination.offset", input.skip.toString());
+    if (input.limit !== undefined) queryParams.append("pagination.limit", input.limit.toString());
+    if (input.key) queryParams.append("pagination.key", input.key);
+    if (input.countTotal !== undefined) queryParams.append("pagination.count_total", input.countTotal.toString());
+    if (input.reverse !== undefined) queryParams.append("pagination.reverse", input.reverse.toString());
+
+    const queryString = queryParams.toString();
+    const url = `/akash/deployment/v1beta3/deployments/list${queryString ? `?${queryString}` : ""}`;
+
+    const response = await app.request(url);
+    expect(response.status).toBe(200);
+    return await response.json();
+  }
+});


### PR DESCRIPTION
https://github.com/akash-network/console/issues/1947

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a database-backed fallback endpoint to list deployments with filtering (owner, state) and pagination (offset/limit, key-based, reverse). Responses include deployment details, groups, and escrow information.
* **Improvements**
  * Standardized request/response validation for the fallback deployments list.
  * Resource storage in responses now supports any number of entries (was fixed-size).
* **Tests**
  * Added functional tests covering response structure, filtering, and pagination (offset, key-based, reverse, totals).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->