### PR TITLE
feat: adds support for jwt auth to provider-proxy

### DIFF
--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -6,7 +6,7 @@
   "author": "Akash Network",
   "main": "main.js",
   "scripts": {
-    "build": "rm -rf dist/* && npx tsc && esbuild src/server.ts --bundle --sourcemap --platform=node --target=$(node -v | sed 's/^v/node/') --outdir=dist",
+    "build": "rm -rf dist/* && tsc && esbuild src/server.ts --bundle --sourcemap --packages=external --platform=node --target=$(node -v | sed 's/^v/node/') --outdir=dist",
     "dev": "nodemon src/server.ts",
     "dev:inspect": "nodemon --exec node --inspect -r ts-node/register src/server.ts",
     "dev-nodc": "npm run dev",
@@ -22,6 +22,7 @@
     "test:unit": "jest --selectProjects unit"
   },
   "dependencies": {
+    "@akashnetwork/jwt": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/net": "*",
     "@cosmjs/encoding": "^0.32.4",
@@ -40,6 +41,7 @@
     "@akashnetwork/dev-config": "*",
     "@akashnetwork/docker": "*",
     "@akashnetwork/releaser": "*",
+    "@cosmjs/proto-signing": "^0.32.4",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.16",
     "@types/node": "^22.13.11",

--- a/apps/provider-proxy/src/container.ts
+++ b/apps/provider-proxy/src/container.ts
@@ -3,7 +3,7 @@ import { HttpLoggerIntercepter } from "@akashnetwork/logging/hono";
 import type { SupportedChainNetworks } from "@akashnetwork/net";
 import { netConfig } from "@akashnetwork/net";
 
-import { CertificateValidator, createCertificateValidatorInstrumentation } from "./services/CertificateValidator";
+import { CertificateValidator, createCertificateValidatorInstrumentation } from "./services/CertificateValidator/CertificateValidator";
 import { ProviderProxy } from "./services/ProviderProxy";
 import { ProviderService } from "./services/ProviderService/ProviderService";
 import { WebsocketStats } from "./services/WebsocketStats";

--- a/apps/provider-proxy/src/services/CertificateValidator/CertificateValidator.spec.ts
+++ b/apps/provider-proxy/src/services/CertificateValidator/CertificateValidator.spec.ts
@@ -1,10 +1,10 @@
 import type { X509Certificate } from "crypto";
 import { setTimeout } from "timers/promises";
 
-import type { CertificateValidatorIntrumentation, CertValidationResultError } from "../../src/services/CertificateValidator";
-import { CertificateValidator } from "../../src/services/CertificateValidator";
-import type { ProviderService } from "../../src/services/ProviderService";
-import { createX509CertPair } from "../seeders/createX509CertPair";
+import { createX509CertPair } from "../../../test/seeders/createX509CertPair";
+import type { ProviderService } from "../ProviderService/ProviderService";
+import type { CertificateValidatorIntrumentation, CertValidationResultError } from "./CertificateValidator";
+import { CertificateValidator } from "./CertificateValidator";
 
 describe(CertificateValidator.name, () => {
   const ONE_MINUTE = 60 * 1000;

--- a/apps/provider-proxy/src/services/CertificateValidator/CertificateValidator.ts
+++ b/apps/provider-proxy/src/services/CertificateValidator/CertificateValidator.ts
@@ -3,8 +3,8 @@ import type { SupportedChainNetworks } from "@akashnetwork/net";
 import type { X509Certificate } from "crypto";
 import { LRUCache } from "lru-cache";
 
-import { validateCertificateAttrs } from "../utils/validateCertificateAttrs";
-import type { ProviderService } from "./ProviderService/ProviderService";
+import { validateCertificateAttrs } from "../../utils/validateCertificateAttrs";
+import type { ProviderService } from "../ProviderService/ProviderService";
 
 export class CertificateValidator {
   private readonly knownCertificatesCache = new LRUCache<string, X509Certificate>({

--- a/apps/provider-proxy/src/services/ProviderProxy.ts
+++ b/apps/provider-proxy/src/services/ProviderProxy.ts
@@ -123,6 +123,7 @@ export class ProviderProxy {
         "Content-Type": "application/json",
         ...options.headers
       },
+      timeout: options.timeout,
       agentCacheKey: `${options.network}:${options.providerAddress}`
     };
     const agentOptions: https.AgentOptions = {

--- a/apps/provider-proxy/src/utils/schema.ts
+++ b/apps/provider-proxy/src/utils/schema.ts
@@ -1,3 +1,4 @@
+import { JwtToken } from "@akashnetwork/jwt";
 import type { SupportedChainNetworks } from "@akashnetwork/net";
 import { netConfig } from "@akashnetwork/net";
 import { z } from "@hono/zod-openapi";
@@ -6,40 +7,84 @@ import { isValidBech32Address } from "./isValidBech32";
 import { validateClientCertificateAttrs } from "./validateClientCertificateAttrs";
 
 export const providerRequestSchema = z.object({
-  certPem: z.string().optional(),
-  keyPem: z.string().optional(),
+  auth: z
+    .discriminatedUnion("type", [
+      z.object({
+        type: z.literal("mtls"),
+        certPem: z.string(),
+        keyPem: z.string()
+      }),
+      z.object({
+        type: z.literal("jwt"),
+        token: z.string()
+      })
+    ])
+    .optional(),
   url: z.string().url(),
-  providerAddress: z.string().refine(isValidBech32Address, "is not bech32 address").describe("Bech32 representation of provider wallet address")
+  network: z.enum(netConfig.getSupportedNetworks() as [SupportedChainNetworks]).describe("Blockchain network"),
+  providerAddress: z.string().refine(isValidBech32Address, "is not bech32 address").describe("Bech32 representation of provider wallet address"),
+  chainNetwork: z
+    .enum(netConfig.getSupportedNetworks() as [SupportedChainNetworks])
+    .describe('Deprecated blockchain network. Use "network" instead.')
+    .optional(),
+  certPem: z.string().describe('Deprecated certificate. Use mtls auth type  with "auth.certPem" instead.').optional(),
+  keyPem: z.string().describe('Deprecated key. Use mtls auth type  with "auth.keyPem" instead.').optional()
 });
 
-export const chainNetworkSchema = z.enum(netConfig.getSupportedNetworks() as [SupportedChainNetworks]).describe("Blockchain network");
+// we need just validation and decoding that's why signer is not provided
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const jwtTokenManager = new JwtToken({} as any);
+
+export type ProviderRequestSchema = Omit<z.infer<typeof providerRequestSchema>, "chainNetwork" | "certPem" | "keyPem">;
 
 /** this can be attached as .superRefine in zod v4 */
-export function addCertificateValidation(schema: z.ZodType<any>) {
-  return schema.superRefine((data, ctx) => {
-    if ((!data.certPem && data.keyPem) || (data.certPem && !data.keyPem)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "certPem and keyPem either both must be provider or both must be empty",
-        path: ["certPem"],
-        params: {
-          reason: "missingCertPair"
-        }
-      });
-    }
-
-    if (data.certPem && data.keyPem) {
-      const validationResult = validateClientCertificateAttrs(data.certPem);
-      if (!validationResult.ok) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "is not a valid certificate",
-          path: ["certPem"],
-          params: {
-            reason: validationResult.code
-          }
-        });
+export function addProviderAuthValidation<T extends z.ZodType<any>>(schema: T): z.ZodEffects<T> {
+  return z
+    .preprocess(data => {
+      const { chainNetwork, certPem, keyPem, ...normalizedData } = data as z.infer<typeof providerRequestSchema>;
+      if (chainNetwork) {
+        normalizedData.network = chainNetwork;
       }
-    }
-  });
+      if (!normalizedData.auth && (certPem || keyPem)) {
+        normalizedData.auth = { type: "mtls", certPem: certPem || "", keyPem: keyPem || "" };
+      }
+      return normalizedData;
+    }, schema)
+    .superRefine((data, ctx) => {
+      if (data.auth?.type === "mtls" && data.auth.certPem) {
+        const validationResult = validateClientCertificateAttrs(data.auth.certPem);
+        if (!validationResult.ok) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "is not a valid certificate",
+            path: ["auth", "certPem"],
+            params: {
+              reason: validationResult.code
+            }
+          });
+        }
+      }
+
+      if (data.auth?.type === "jwt" && data.auth.token) {
+        const validationResult = validateJwtPayload(data.auth.token);
+        if (!validationResult.isValid) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "is not a valid JWT token",
+            path: ["auth", "token"],
+            params: {
+              errors: validationResult.errors
+            }
+          });
+        }
+      }
+    }) as unknown as z.ZodEffects<T>;
+}
+
+function validateJwtPayload(token: string): { isValid: boolean; errors?: string[] } {
+  try {
+    return jwtTokenManager.validatePayload(jwtTokenManager.decodeToken(token));
+  } catch (error) {
+    return { isValid: false, errors: ["Invalid token"] };
+  }
 }

--- a/apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts
@@ -291,7 +291,7 @@ describe("Provider proxy ws", () => {
     );
   });
 
-  fit("supports jwt authentication", async () => {
+  it("supports jwt authentication", async () => {
     const proxyServerUrl = await startServer();
     const providerAddress = generateBech32();
     const certPair = createX509CertPair({ commonName: providerAddress });

--- a/apps/provider-proxy/test/setup/providerServer.ts
+++ b/apps/provider-proxy/test/setup/providerServer.ts
@@ -19,6 +19,11 @@ export function startProviderServer(options: ProviderServerOptions): Promise<Pro
       cert: certPair.cert.toJSON()
     };
 
+    if (options.requireClientCertificate) {
+      httpServerOptions.requestCert = true;
+      httpServerOptions.rejectUnauthorized = false;
+    }
+
     let cleanupHandlers = new Set<() => void>();
     const handlers: RequestHandlers = {
       "/200.txt"(_, res) {
@@ -71,11 +76,12 @@ export function stopProviderServer(): Promise<void> {
 
 type RequestHandlers = Record<string, (req: IncomingMessage, res: ServerResponse) => (() => void) | undefined | void>;
 export interface ProviderServerOptions {
+  requireClientCertificate?: boolean;
   certPair?: CertPair;
   handlers?: RequestHandlers;
   websocketServer?: {
     enable: boolean;
-    onConnection?(ws: WebSocket): void;
+    onConnection?(ws: WebSocket, req: IncomingMessage): void;
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4546,6 +4546,7 @@
       "version": "1.17.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@akashnetwork/jwt": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/net": "*",
         "@cosmjs/encoding": "^0.32.4",
@@ -4564,6 +4565,7 @@
         "@akashnetwork/dev-config": "*",
         "@akashnetwork/docker": "*",
         "@akashnetwork/releaser": "*",
+        "@cosmjs/proto-signing": "^0.32.4",
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.16",
         "@types/node": "^22.13.11",


### PR DESCRIPTION
## Why

#1952 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added provider authentication via mTLS client certificates and JWT tokens for both HTTP and WebSocket proxying.
  - Unified request/message schema with auth and network fields; legacy payloads are auto-normalized.

- Deprecations
  - Deprecated chainNetwork, certPem, and keyPem fields. Use network and auth instead.

- Tests
  - Added functional tests covering mTLS and JWT flows for HTTP and WebSocket.

- Chores
  - Updated build configuration for reliability.
  - Added authentication-related dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->