### PR TITLE
refactor: network version is now taken from /net package in network-store

### DIFF
--- a/apps/deploy-web/next.config.js
+++ b/apps/deploy-web/next.config.js
@@ -44,7 +44,7 @@ const nextConfig = {
   },
   output: "standalone",
   typescript: {
-    tsconfigPath: "./tsconfig.json"
+    tsconfigPath: "./tsconfig.build.json"
   },
   eslint: {
     ignoreDuringBuilds: true

--- a/apps/deploy-web/tests/ui/fixture/test-env.config.ts
+++ b/apps/deploy-web/tests/ui/fixture/test-env.config.ts
@@ -18,5 +18,6 @@ export const testEnvConfig = testEnvSchema.parse({
 export const PROVIDERS_WHITELIST = {
   mainnet: ["provider.hurricane.akash.pub", "provider.europlots.com"],
   sandbox: ["provider.europlots-sandbox.com"],
-  "testnet-02": []
+  "testnet-02": [],
+  "testnet-7": []
 } satisfies Record<SupportedChainNetworks, string[]>;

--- a/apps/deploy-web/tests/ui/fixture/wallet-setup.ts
+++ b/apps/deploy-web/tests/ui/fixture/wallet-setup.ts
@@ -112,13 +112,17 @@ async function topUpWallet(wallet: DirectSecp256k1HdWallet) {
       return;
     }
 
-    const faucetUrl = netConfig.getFaucetUrl(testEnvConfig.NETWORK_ID);
+    let faucetUrl = netConfig.getFaucetUrl(testEnvConfig.NETWORK_ID);
     if (!faucetUrl) {
       console.error(`Faucet URL is not set for this network: ${testEnvConfig.NETWORK_ID}. Cannot auto top up wallet`);
       return;
     }
 
-    const response = await fetch(faucetUrl, {
+    if (faucetUrl.endsWith("/")) {
+      faucetUrl = faucetUrl.slice(0, -1);
+    }
+
+    const response = await fetch(`${faucetUrl}/faucet`, {
       method: "POST",
       headers: {
         "Content-Type": "application/x-www-form-urlencoded"

--- a/apps/deploy-web/tsconfig.build.json
+++ b/apps/deploy-web/tsconfig.build.json
@@ -4,8 +4,12 @@
     "baseUrl": ".",
     "moduleResolution": "Bundler",
     "paths": {
-      "@src/*": ["./src/*"],
-      "@tests/*": ["./tests/*"]
+      "@src/*": [
+        "./src/*"
+      ],
+      "@tests/*": [
+        "./tests/*"
+      ]
     },
     "plugins": [
       {
@@ -14,5 +18,14 @@
     ],
     "strict": true
   },
-  "extends": "@akashnetwork/dev-config/tsconfig.base-next.json"
+  "extends": "@akashnetwork/dev-config/tsconfig.base-next.json",
+  "include": [
+    "next-env.d.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -54624,9 +54624,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akashjs": "^0.11.1",
-        "axios": "^1.7.2",
-        "jotai": "^2.9.2",
-        "lodash": "^4.17.21"
+        "@akashnetwork/net": "*",
+        "jotai": "^2.9.2"
       }
     },
     "packages/react-query-sdk": {

--- a/packages/net/src/NetConfig/NetConfig.spec.ts
+++ b/packages/net/src/NetConfig/NetConfig.spec.ts
@@ -18,9 +18,9 @@ describe("NetConfig", () => {
   it("returns faucet URL for sandbox network", () => {
     const netConfig = setup();
 
-    expect(netConfig.getFaucetUrl("sandbox")).toBe("https://faucet.sandbox-01.aksh.pw/faucet");
+    expect(netConfig.getFaucetUrl("sandbox")).toBe("http://faucet.sandbox-01.aksh.pw/");
     expect(netConfig.getFaucetUrl("mainnet")).toBeNull();
-    expect(netConfig.getFaucetUrl("testnet-02")).toBeNull();
+    expect(netConfig.getFaucetUrl("testnet-02")).toBeDefined();
   });
 
   function setup() {

--- a/packages/net/src/NetConfig/NetConfig.ts
+++ b/packages/net/src/NetConfig/NetConfig.ts
@@ -3,6 +3,10 @@ import { netConfigData } from "../generated/netConfigData";
 export type SupportedChainNetworks = keyof typeof netConfigData;
 
 export class NetConfig {
+  getVersion(network: SupportedChainNetworks): string | null {
+    return netConfigData[network].version;
+  }
+
   getBaseAPIUrl(network: SupportedChainNetworks): string {
     const apiUrls = netConfigData[network].apiUrls;
     return apiUrls[0];
@@ -13,12 +17,7 @@ export class NetConfig {
   }
 
   getFaucetUrl(network: SupportedChainNetworks): string | null {
-    switch (network) {
-      case "sandbox":
-        return "https://faucet.sandbox-01.aksh.pw/faucet";
-      default:
-        return null;
-    }
+    return netConfigData[network].faucetUrl;
   }
 
   getBaseRpcUrl(network: SupportedChainNetworks): string {

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -1,6 +1,7 @@
 export const netConfigData = {
   mainnet: {
     version: "0.38.0",
+    faucetUrl: null,
     apiUrls: [
       "https://api.akashnet.net:443",
       "https://akash-api.polkachu.com:443",
@@ -17,12 +18,20 @@ export const netConfigData = {
   },
   sandbox: {
     version: "0.38.0",
+    faucetUrl: "http://faucet.sandbox-01.aksh.pw/",
     apiUrls: ["https://api.sandbox-01.aksh.pw:443"],
     rpcUrls: ["https://rpc.sandbox-01.aksh.pw:443"]
   },
   "testnet-02": {
     version: "0.23.1-rc0",
+    faucetUrl: "https://faucet.testnet-02.aksh.pw",
     apiUrls: ["https://api.testnet-02.aksh.pw:443", "https://akash-testnet-rest.cosmonautstakes.com:443"],
     rpcUrls: ["https://rpc.testnet-02.aksh.pw:443", "https://akash-testnet-rpc.cosmonautstakes.com:443"]
+  },
+  "testnet-7": {
+    version: null,
+    faucetUrl: "https://faucet.dev.akash.pub/",
+    apiUrls: ["https://testnetapi.akashnet.net"],
+    rpcUrls: ["https://testnetrpc.akashnet.net:443"]
   }
 };

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -13,8 +13,7 @@
   },
   "dependencies": {
     "@akashnetwork/akashjs": "^0.11.1",
-    "axios": "^1.7.2",
-    "jotai": "^2.9.2",
-    "lodash": "^4.17.21"
+    "@akashnetwork/net": "*",
+    "jotai": "^2.9.2"
   }
 }

--- a/packages/network-store/src/network.config.ts
+++ b/packages/network-store/src/network.config.ts
@@ -1,4 +1,5 @@
 import type { MainnetNetworkId, SandboxNetworkId, TestnetNetworkId } from "@akashnetwork/akashjs/build/types/network";
+import { netConfig } from "@akashnetwork/net";
 
 import type { Network } from "./network.type";
 
@@ -6,45 +7,45 @@ export const MAINNET_ID: MainnetNetworkId = "mainnet";
 export const SANDBOX_ID: SandboxNetworkId = "sandbox";
 export const TESTNET_ID: TestnetNetworkId = "testnet";
 
-export const INITIAL_NETWORKS_CONFIG: Network[] = [
+export const getInitialNetworksConfig = ({ apiBaseUrl }: { apiBaseUrl: string }): Network[] => [
   {
     id: MAINNET_ID,
     title: "Mainnet",
     description: "Akash Network mainnet network.",
-    nodesUrl: "/v1/nodes/mainnet",
+    nodesUrl: `${apiBaseUrl}/v1/nodes/mainnet`,
     chainId: "akashnet-2",
     chainRegistryName: "akash",
-    versionUrl: "/v1/version/mainnet",
-    rpcEndpoint: "https://rpc.cosmos.directory/akash",
+    versionUrl: `${apiBaseUrl}/v1/version/mainnet`,
+    rpcEndpoint: netConfig.getBaseRpcUrl(MAINNET_ID),
     enabled: true,
     apiVersion: "v1beta3",
     marketApiVersion: "v1beta4",
-    version: null
+    version: netConfig.getVersion(MAINNET_ID)
   },
   {
     id: TESTNET_ID,
     title: "GPU Testnet",
     description: "Testnet of the new GPU features.",
-    nodesUrl: "/v1/nodes/testnet",
+    nodesUrl: `${apiBaseUrl}/v1/nodes/testnet`,
     chainId: "testnet-02",
     chainRegistryName: "akash-testnet",
-    versionUrl: "/v1/version/testnet",
-    rpcEndpoint: "https://rpc.testnet-02.aksh.pw:443",
+    versionUrl: `${apiBaseUrl}/v1/version/testnet`,
+    rpcEndpoint: netConfig.getBaseRpcUrl("testnet-02"),
     enabled: false,
     apiVersion: "v1beta3",
     marketApiVersion: "v1beta3",
-    version: null
+    version: netConfig.getVersion("testnet-02")
   },
   {
     id: SANDBOX_ID,
     title: "Sandbox",
     description: "Sandbox of the mainnet version.",
-    nodesUrl: "/v1/nodes/sandbox",
+    nodesUrl: `${apiBaseUrl}/v1/nodes/sandbox`,
     chainId: "sandbox-01",
     chainRegistryName: "akash-sandbox",
-    versionUrl: "/v1/version/sandbox",
-    rpcEndpoint: "https://rpc.sandbox-01.aksh.pw:443",
-    version: null,
+    versionUrl: `${apiBaseUrl}/v1/version/sandbox`,
+    rpcEndpoint: netConfig.getBaseRpcUrl(SANDBOX_ID),
+    version: netConfig.getVersion(SANDBOX_ID),
     enabled: true,
     apiVersion: "v1beta3",
     marketApiVersion: "v1beta4"

--- a/packages/network-store/src/network.store.ts
+++ b/packages/network-store/src/network.store.ts
@@ -24,7 +24,7 @@ export class NetworkStore {
 
   private readonly STORAGE_KEY = "selectedNetworkId";
 
-  private readonly allNetworks: Network[] = [];
+  private readonly allNetworks: Network[];
   readonly networksStore = atom<NetworksStore>({ isLoading: true, error: undefined, data: [] });
 
   private readonly selectedNetworkIdStore = atomWithStorage<Network["id"]>(this.STORAGE_KEY, this.options.defaultNetworkId, undefined, {


### PR DESCRIPTION
## Why

Closes #1774


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Testnet-7 support.
  - Faucet links exposed for networks; network version is now retrievable per network.

- Refactor
  - Network config generated at runtime from a base URL; endpoints derived dynamically.
  - Network selection initialized from URL and in-memory config for faster startup.

- Bug Fixes
  - Robust handling when version or faucet data cannot be fetched.

- Chores
  - Updated network-store dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->