### PR TITLE
feat: disable some features when blockchain is down

### DIFF
--- a/apps/deploy-web/src/components/deployments/CreateCertificateButton/CreateCertificateButton.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/CreateCertificateButton/CreateCertificateButton.spec.tsx
@@ -39,9 +39,10 @@ describe(CreateCertificateButton.name, () => {
       isCreatingCert?: boolean;
       isLocalCertExpired?: boolean;
       localCert?: LocalCert;
+      isBlockchainDown?: boolean;
     }
   ) {
-    const { createCertificate, isCreatingCert, isLocalCertExpired, localCert, ...props } = input ?? {};
+    const { createCertificate, isCreatingCert, isLocalCertExpired, localCert, isBlockchainDown, ...props } = input ?? {};
 
     return render(
       <CreateCertificateButton
@@ -53,7 +54,23 @@ describe(CreateCertificateButton.name, () => {
             isCreatingCert: isCreatingCert ?? false,
             isLocalCertExpired: isLocalCertExpired ?? false,
             localCert: localCert ?? null
-          })) as (typeof CREATE_CERTIFICATE_BUTTON_DEPENDENCIES)["useCertificate"]
+          })) as (typeof CREATE_CERTIFICATE_BUTTON_DEPENDENCIES)["useCertificate"],
+          useSettings: () => ({
+            settings: {
+              apiEndpoint: "https://api.example.com",
+              rpcEndpoint: "https://rpc.example.com",
+              isCustomNode: false,
+              nodes: [],
+              selectedNode: null,
+              customNode: null,
+              isBlockchainDown: isBlockchainDown ?? false
+            },
+            setSettings: jest.fn(),
+            isLoadingSettings: false,
+            isSettingsInit: true,
+            refreshNodeStatuses: jest.fn(),
+            isRefreshingNodeStatus: false
+          })
         }}
       />
     );

--- a/apps/deploy-web/src/components/deployments/CreateCertificateButton/CreateCertificateButton.tsx
+++ b/apps/deploy-web/src/components/deployments/CreateCertificateButton/CreateCertificateButton.tsx
@@ -5,12 +5,14 @@ import { Alert, Button, Spinner } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 
 import { useCertificate } from "@src/context/CertificateProvider";
+import { useSettings } from "@src/context/SettingsProvider";
 
 export const DEPENDENCIES = {
   Alert,
   Button,
   Spinner,
-  useCertificate
+  useCertificate,
+  useSettings
 };
 
 export interface Props extends Omit<ButtonProps, "onClick"> {
@@ -20,6 +22,7 @@ export interface Props extends Omit<ButtonProps, "onClick"> {
 }
 
 export const CreateCertificateButton: FC<Props> = ({ afterCreate, containerClassName, dependencies: d = DEPENDENCIES, ...buttonProps }) => {
+  const { settings } = d.useSettings();
   const { isCreatingCert, createCertificate, isLocalCertExpired, localCert } = d.useCertificate();
 
   const _createCertificate = useCallback(async () => {
@@ -38,7 +41,12 @@ export const CreateCertificateButton: FC<Props> = ({ afterCreate, containerClass
       <d.Alert variant="warning" className={cn({ "py-2 text-sm": buttonProps?.size === "sm" }, "truncate")}>
         {warningText}
       </d.Alert>
-      <d.Button className={warningText ? "mt-4" : ""} {...buttonProps} disabled={buttonProps?.disabled || isCreatingCert} onClick={_createCertificate}>
+      <d.Button
+        className={warningText ? "mt-4" : ""}
+        {...buttonProps}
+        disabled={buttonProps?.disabled || settings.isBlockchainDown || isCreatingCert}
+        onClick={_createCertificate}
+      >
         {isCreatingCert ? <d.Spinner size="small" /> : buttonText}
       </d.Button>
     </div>

--- a/apps/deploy-web/src/components/deployments/DeploymentList.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.tsx
@@ -224,7 +224,12 @@ export const DeploymentList: React.FunctionComponent = () => {
               {isSignedInWithTrial && !user && <p className="text-sm">If you are expecting to see some, you may need to sign-in or connect a wallet</p>}
 
               {isWalletConnected ? (
-                <Link href={UrlService.newDeployment()} className={cn(buttonVariants({ variant: "default", size: "lg" }), "mt-4")} onClick={onDeployClick}>
+                <Link
+                  href={UrlService.newDeployment()}
+                  className={cn(buttonVariants({ variant: "default", size: "lg" }), "mt-4")}
+                  onClick={onDeployClick}
+                  aria-disabled={settings.isBlockchainDown}
+                >
                   Deploy
                   <Rocket className="ml-4 rotate-45 text-sm" />
                 </Link>

--- a/apps/deploy-web/src/components/home/YourAccount.tsx
+++ b/apps/deploy-web/src/components/home/YourAccount.tsx
@@ -13,6 +13,7 @@ import { AddFundsLink } from "@src/components/user/AddFundsLink";
 import { browserEnvConfig } from "@src/config/browser-env.config";
 import { UAKT_DENOM } from "@src/config/denom.config";
 import { usePricing } from "@src/context/PricingProvider";
+import { useSettings } from "@src/context/SettingsProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useUsdcDenom } from "@src/hooks/useDenom";
 import { useFlag } from "@src/hooks/useFlag";
@@ -41,6 +42,7 @@ type Props = {
 };
 
 export const YourAccount: React.FunctionComponent<Props> = ({ isLoadingBalances, walletBalance, activeDeployments, leases, providers }) => {
+  const { settings } = useSettings();
   const { resolvedTheme } = useTheme();
   const tw = useTailwind();
   const { address, isManaged: isManagedWallet, isTrialing } = useWallet();
@@ -229,7 +231,12 @@ export const YourAccount: React.FunctionComponent<Props> = ({ isLoadingBalances,
               )}
 
               <div className="mt-4 flex gap-2">
-                <Link href={UrlService.newDeployment()} className={cn(buttonVariants({ variant: "default" }))} onClick={onDeployClick}>
+                <Link
+                  href={UrlService.newDeployment()}
+                  className={cn(buttonVariants({ variant: "default" }))}
+                  onClick={onDeployClick}
+                  aria-disabled={settings.isBlockchainDown}
+                >
                   Deploy
                   <Rocket className="ml-2 rotate-45 text-sm" />
                 </Link>

--- a/apps/deploy-web/src/components/layout/Layout.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.tsx
@@ -10,13 +10,12 @@ import { millisecondsInMinute } from "date-fns/constants";
 
 import { ACCOUNT_BAR_HEIGHT } from "@src/config/ui.config";
 import { useSettings } from "@src/context/SettingsProvider";
+import { TopBannerProvider, useTopBanner } from "@src/context/TopBannerProvider/TopBannerProvider";
 import { useWallet } from "@src/context/WalletProvider";
-import { useHasCreditCardBanner } from "@src/hooks/useHasCreditCardBanner";
-import { useVariant } from "@src/hooks/useVariant";
 import { LinearLoadingSkeleton } from "../shared/LinearLoadingSkeleton";
 import { Nav } from "./Nav";
 import { Sidebar } from "./Sidebar";
-import { CreditCardBanner, MaintenanceBanner, NetworkDownBanner } from "./TopBanner";
+import { TopBanner } from "./TopBanner";
 import { TrackingScripts } from "./TrackingScripts";
 import { WelcomeToTrialModal } from "./WelcomeToTrialModal";
 
@@ -40,21 +39,22 @@ const Layout: React.FunctionComponent<Props> = ({ children, isLoading, isUsingSe
 
   return (
     <IntlProvider locale={locale} defaultLocale="en-US">
-      <LayoutApp
-        isLoading={isLoading}
-        isUsingSettings={isUsingSettings}
-        isUsingWallet={isUsingWallet}
-        disableContainer={disableContainer}
-        containerClassName={containerClassName}
-      >
-        {children}
-      </LayoutApp>
+      <TopBannerProvider>
+        <LayoutApp
+          isLoading={isLoading}
+          isUsingSettings={isUsingSettings}
+          isUsingWallet={isUsingWallet}
+          disableContainer={disableContainer}
+          containerClassName={containerClassName}
+        >
+          {children}
+        </LayoutApp>
+      </TopBannerProvider>
     </IntlProvider>
   );
 };
 
 const LayoutApp: React.FunctionComponent<Props> = ({ children, isLoading, isUsingSettings, isUsingWallet, disableContainer, containerClassName = "" }) => {
-  const maintenanceBannerFlag = useVariant("maintenance_banner");
   const muiTheme = useMuiTheme();
   const smallScreen = useMediaQuery(muiTheme.breakpoints.down("md"));
   const [isNavOpen, setIsNavOpen] = useState(() => {
@@ -67,11 +67,9 @@ const LayoutApp: React.FunctionComponent<Props> = ({ children, isLoading, isUsin
     return true;
   });
   const [isMobileOpen, setIsMobileOpen] = useState(false);
-  const [isMaintenanceBannerOpen, setIsMaintenanceBannerOpen] = useState(!!maintenanceBannerFlag.enabled);
-  const { settings, refreshNodeStatuses, isSettingsInit } = useSettings();
+  const { refreshNodeStatuses, isSettingsInit } = useSettings();
   const { isWalletLoaded } = useWallet();
-  const hasCreditCardBanner = useHasCreditCardBanner(isMaintenanceBannerOpen);
-  const hasBanner = hasCreditCardBanner || isMaintenanceBannerOpen || settings.isBlockchainDown;
+  const { hasBanner } = useTopBanner();
 
   useEffect(() => {
     const refreshNodeIntervalId = setInterval(async () => {
@@ -99,13 +97,7 @@ const LayoutApp: React.FunctionComponent<Props> = ({ children, isLoading, isUsin
 
   return (
     <div className="flex h-full">
-      {hasCreditCardBanner && <CreditCardBanner />}
-      {settings.isBlockchainDown && (
-        <>
-          <NetworkDownBanner />
-        </>
-      )}
-      {isMaintenanceBannerOpen && <MaintenanceBanner onClose={() => setIsMaintenanceBannerOpen(false)} />}
+      <TopBanner />
 
       <div className="w-full flex-1" style={{ marginTop: `${ACCOUNT_BAR_HEIGHT + (hasBanner ? 40 : 0)}px` }}>
         <div className="h-full">

--- a/apps/deploy-web/src/components/layout/Layout.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.tsx
@@ -16,7 +16,7 @@ import { useVariant } from "@src/hooks/useVariant";
 import { LinearLoadingSkeleton } from "../shared/LinearLoadingSkeleton";
 import { Nav } from "./Nav";
 import { Sidebar } from "./Sidebar";
-import { CreditCardBanner, MaintenanceBanner } from "./TopBanner";
+import { CreditCardBanner, MaintenanceBanner, NetworkDownBanner } from "./TopBanner";
 import { TrackingScripts } from "./TrackingScripts";
 import { WelcomeToTrialModal } from "./WelcomeToTrialModal";
 
@@ -68,10 +68,10 @@ const LayoutApp: React.FunctionComponent<Props> = ({ children, isLoading, isUsin
   });
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const [isMaintenanceBannerOpen, setIsMaintenanceBannerOpen] = useState(!!maintenanceBannerFlag.enabled);
-  const { refreshNodeStatuses, isSettingsInit } = useSettings();
+  const { settings, refreshNodeStatuses, isSettingsInit } = useSettings();
   const { isWalletLoaded } = useWallet();
   const hasCreditCardBanner = useHasCreditCardBanner(isMaintenanceBannerOpen);
-  const hasBanner = hasCreditCardBanner || isMaintenanceBannerOpen;
+  const hasBanner = hasCreditCardBanner || isMaintenanceBannerOpen || settings.isBlockchainDown;
 
   useEffect(() => {
     const refreshNodeIntervalId = setInterval(async () => {
@@ -100,6 +100,11 @@ const LayoutApp: React.FunctionComponent<Props> = ({ children, isLoading, isUsin
   return (
     <div className="flex h-full">
       {hasCreditCardBanner && <CreditCardBanner />}
+      {settings.isBlockchainDown && (
+        <>
+          <NetworkDownBanner />
+        </>
+      )}
       {isMaintenanceBannerOpen && <MaintenanceBanner onClose={() => setIsMaintenanceBannerOpen(false)} />}
 
       <div className="w-full flex-1" style={{ marginTop: `${ACCOUNT_BAR_HEIGHT + (hasBanner ? 40 : 0)}px` }}>

--- a/apps/deploy-web/src/components/layout/Sidebar.tsx
+++ b/apps/deploy-web/src/components/layout/Sidebar.tsx
@@ -36,6 +36,7 @@ import { useAtom } from "jotai";
 import Image from "next/image";
 import Link from "next/link";
 
+import { useSettings } from "@src/context/SettingsProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useFlag } from "@src/hooks/useFlag";
 import { useUser } from "@src/hooks/useUser";
@@ -60,6 +61,7 @@ const DRAWER_WIDTH = 240;
 const CLOSED_DRAWER_WIDTH = 57;
 
 export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDrawerToggle, isNavOpen, onOpenMenuClick, mdDrawerClassName }) => {
+  const { settings } = useSettings();
   const [, setDeploySdl] = useAtom(sdlStore.deploySdl);
   const muiTheme = useMuiTheme();
   const smallScreen = useMediaQuery(muiTheme.breakpoints.down("md"));
@@ -310,6 +312,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
           href={UrlService.newDeployment()}
           onClick={onDeployClick}
           data-testid="sidebar-deploy-button"
+          aria-disabled={settings.isBlockchainDown}
         >
           {isNavOpen && "Deploy "}
           <Rocket className={cn("rotate-45", { ["ml-4"]: isNavOpen })} fontSize="small" />

--- a/apps/deploy-web/src/components/layout/TopBanner.tsx
+++ b/apps/deploy-web/src/components/layout/TopBanner.tsx
@@ -2,11 +2,12 @@ import { FormattedDate } from "react-intl";
 import { Button } from "@akashnetwork/ui/components";
 import { Xmark } from "iconoir-react";
 
+import { useTopBanner } from "@src/context/TopBannerProvider";
 import { useWallet } from "@src/context/WalletProvider/WalletProvider";
 import { useVariant } from "@src/hooks/useVariant";
 import { ConnectManagedWalletButton } from "../wallet/ConnectManagedWalletButton";
 
-export function CreditCardBanner() {
+function CreditCardBanner() {
   const { hasManagedWallet } = useWallet();
 
   return (
@@ -18,7 +19,7 @@ export function CreditCardBanner() {
   );
 }
 
-export function NetworkDownBanner() {
+function NetworkDownBanner() {
   return (
     <div className="fixed top-0 z-10 flex h-[40px] w-full items-center justify-center bg-primary px-3 py-2 md:space-x-4">
       <span className="text-xs font-semibold text-white md:text-sm">The network is down. Unable to change deployments at the moment.</span>
@@ -26,7 +27,7 @@ export function NetworkDownBanner() {
   );
 }
 
-export function MaintenanceBanner({ onClose }: { onClose: () => void }) {
+function MaintenanceBanner({ onClose }: { onClose: () => void }) {
   const maintenanceBannerFlag = useVariant("maintenance_banner");
 
   const { message, date } = maintenanceBannerFlag.enabled
@@ -43,4 +44,22 @@ export function MaintenanceBanner({ onClose }: { onClose: () => void }) {
       </Button>
     </div>
   );
+}
+
+export function TopBanner() {
+  const { isMaintenanceBannerOpen, setIsMaintenanceBannerOpen, isBlockchainDown, hasCreditCardBanner } = useTopBanner();
+
+  if (isMaintenanceBannerOpen) {
+    return <MaintenanceBanner onClose={() => setIsMaintenanceBannerOpen(false)} />;
+  }
+
+  if (isBlockchainDown) {
+    return <NetworkDownBanner />;
+  }
+
+  if (hasCreditCardBanner) {
+    return <CreditCardBanner />;
+  }
+
+  return null;
 }

--- a/apps/deploy-web/src/components/layout/TopBanner.tsx
+++ b/apps/deploy-web/src/components/layout/TopBanner.tsx
@@ -18,6 +18,14 @@ export function CreditCardBanner() {
   );
 }
 
+export function NetworkDownBanner() {
+  return (
+    <div className="fixed top-0 z-10 flex h-[40px] w-full items-center justify-center bg-primary px-3 py-2 md:space-x-4">
+      <span className="text-xs font-semibold text-white md:text-sm">The network is down. Unable to change deployments at the moment.</span>
+    </div>
+  );
+}
+
 export function MaintenanceBanner({ onClose }: { onClose: () => void }) {
   const maintenanceBannerFlag = useVariant("maintenance_banner");
 

--- a/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.spec.tsx
@@ -168,13 +168,21 @@ describe(CreateLease.name, () => {
         }
       })
     ];
-    const { getByRole } = setup({
+    setup({
       BidGroup,
       bids,
       isBlockchainDown: true
     });
+
     await waitFor(() => {
-      expect(getByRole("button", { name: /Accept Bid/i })).toHaveAttribute("disabled");
+      expect((BidGroup as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+    });
+    const bidGroupProps = (BidGroup as jest.Mock).mock.calls[0][0];
+    act(() => {
+      bidGroupProps.handleBidSelected(mapToBidDto(bids[0]));
+    });
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: /Accept Bid/i })).toBeDisabled();
     });
   });
 

--- a/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.spec.tsx
@@ -148,6 +148,36 @@ describe(CreateLease.name, () => {
     jest.useRealTimers();
   });
 
+  it("disables Accept Bid button when blockchain is down", async () => {
+    const BidGroup = jest.fn(ComponentMock);
+    const bids = [
+      buildRpcBid({
+        bid: {
+          bid_id: {
+            gseq: 1
+          },
+          state: "open"
+        }
+      }),
+      buildRpcBid({
+        bid: {
+          bid_id: {
+            gseq: 1
+          },
+          state: "open"
+        }
+      })
+    ];
+    const { getByRole } = setup({
+      BidGroup,
+      bids,
+      isBlockchainDown: true
+    });
+    await waitFor(() => {
+      expect(getByRole("button", { name: /Accept Bid/i })).toHaveAttribute("disabled");
+    });
+  });
+
   describe("lease creation", () => {
     it("creates lease on chain and submits manifest to provider", async () => {
       const signAndBroadcastTx = jest.fn().mockResolvedValue({ code: 0 });
@@ -362,6 +392,7 @@ describe(CreateLease.name, () => {
     updateSelectedCertificate?: (cert: CertificatePem) => Promise<LocalCert>;
     isTrialWallet?: boolean;
     getBlock?: () => Promise<BlockDetail>;
+    isBlockchainDown?: boolean;
   }) {
     const favoriteProviders: string[] = [];
     const useLocalNotes = (() => ({
@@ -456,6 +487,22 @@ describe(CreateLease.name, () => {
             useRouter: () => mock(),
             useManagedDeploymentConfirm: () => ({
               closeDeploymentConfirm: () => Promise.resolve(true)
+            }),
+            useSettings: () => ({
+              settings: {
+                apiEndpoint: "https://api.example.com",
+                rpcEndpoint: "https://rpc.example.com",
+                isCustomNode: false,
+                nodes: [],
+                selectedNode: null,
+                customNode: null,
+                isBlockchainDown: input?.isBlockchainDown ?? false
+              },
+              setSettings: jest.fn(),
+              isLoadingSettings: false,
+              isSettingsInit: true,
+              refreshNodeStatuses: jest.fn(),
+              isRefreshingNodeStatus: false
             })
           }}
         />

--- a/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
@@ -31,6 +31,7 @@ import { SignUpButton } from "@src/components/auth/SignUpButton/SignUpButton";
 import { browserEnvConfig } from "@src/config/browser-env.config";
 import type { LocalCert } from "@src/context/CertificateProvider/CertificateProviderContext";
 import { useServices } from "@src/context/ServicesProvider";
+import { useSettings } from "@src/context/SettingsProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useWhen } from "@src/hooks/useWhen";
@@ -98,7 +99,8 @@ export const DEPENDENCIES = {
   useSnackbar,
   useManagedDeploymentConfirm,
   useRouter,
-  useBlock
+  useBlock,
+  useSettings
 };
 
 // Refresh bids every 7 seconds;
@@ -110,6 +112,7 @@ const WARNING_NUM_OF_BID_REQUESTS = Math.round((60 * 1000) / REFRESH_BIDS_INTERV
 const TRIAL_SIGNUP_WARNING_TIMEOUT = 33_000;
 
 export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies: d = DEPENDENCIES }) => {
+  const { settings } = d.useSettings();
   const { providerProxy, analyticsService, errorHandler, networkStore } = d.useServices();
 
   const [isSendingManifest, setIsSendingManifest] = useState(false);
@@ -409,7 +412,7 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
                   </div>
                 </d.DropdownMenuTrigger>
                 <d.DropdownMenuContent>
-                  <d.CustomDropdownLinkItem onClick={() => handleCloseDeployment()} icon={<Bin />}>
+                  <d.CustomDropdownLinkItem onClick={() => handleCloseDeployment()} icon={<Bin />} disabled={settings.isBlockchainDown}>
                     Close Deployment
                   </d.CustomDropdownLinkItem>
                 </d.DropdownMenuContent>
@@ -422,7 +425,9 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
                 color="secondary"
                 onClick={createLease}
                 className="w-full whitespace-nowrap md:w-auto"
-                disabled={hasActiveBid ? false : dseqList.some(gseq => !selectedBids[gseq]) || isSendingManifest || isCreatingLeases}
+                disabled={
+                  hasActiveBid ? false : settings.isBlockchainDown || dseqList.some(gseq => !selectedBids[gseq]) || isSendingManifest || isCreatingLeases
+                }
                 data-testid="create-lease-button"
               >
                 {isCreatingLeases || isSendingManifest ? (
@@ -442,7 +447,7 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
         )}
 
         {!isLoadingBids && allClosed && (
-          <d.Button variant="default" color="secondary" onClick={handleCloseDeployment} size="sm">
+          <d.Button variant="default" color="secondary" onClick={handleCloseDeployment} size="sm" disabled={settings.isBlockchainDown}>
             Close Deployment
           </d.Button>
         )}
@@ -594,7 +599,14 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
                   recommend signing up and adding funds to your account.
                 </p>
                 <p>
-                  <d.Button onClick={() => handleCloseDeployment()} variant="outline" type="button" size="sm" className="mr-4">
+                  <d.Button
+                    onClick={() => handleCloseDeployment()}
+                    variant="outline"
+                    type="button"
+                    size="sm"
+                    className="mr-4"
+                    disabled={settings.isBlockchainDown}
+                  >
                     Close Deployment
                   </d.Button>
                   <d.SignUpButton wrapper="button" color="secondary" variant="default" type="button" size="sm" />

--- a/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
@@ -425,9 +425,7 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
                 color="secondary"
                 onClick={createLease}
                 className="w-full whitespace-nowrap md:w-auto"
-                disabled={
-                  hasActiveBid ? false : settings.isBlockchainDown || dseqList.some(gseq => !selectedBids[gseq]) || isSendingManifest || isCreatingLeases
-                }
+                disabled={settings.isBlockchainDown || isSendingManifest || isCreatingLeases || (!hasActiveBid && dseqList.some(gseq => !selectedBids[gseq]))}
                 data-testid="create-lease-button"
               >
                 {isCreatingLeases || isSendingManifest ? (

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit.tsx
@@ -351,7 +351,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
             <div className="flex-grow">
               <Button
                 variant="default"
-                disabled={trialDeploymentLimitReached || isCreatingDeployment || !!parsingError || !editedManifest}
+                disabled={settings.isBlockchainDown || trialDeploymentLimitReached || isCreatingDeployment || !!parsingError || !editedManifest}
                 onClick={() => handleCreateDeployment()}
                 className="w-full whitespace-nowrap sm:w-auto"
                 data-testid="create-deployment-btn"

--- a/apps/deploy-web/src/components/settings/SettingsContainer.tsx
+++ b/apps/deploy-web/src/components/settings/SettingsContainer.tsx
@@ -9,6 +9,7 @@ import { AutoTopUpSettingContainer } from "@src/components/settings/AutoTopUpSet
 import { LocalDataManager } from "@src/components/settings/LocalDataManager";
 import { Fieldset } from "@src/components/shared/Fieldset";
 import { LabelValue } from "@src/components/shared/LabelValue";
+import { useSettings } from "@src/context/SettingsProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useFlag } from "@src/hooks/useFlag";
 import { useWhen } from "@src/hooks/useWhen";
@@ -21,6 +22,7 @@ import { SettingsForm } from "./SettingsForm";
 import { SettingsLayout, SettingsTabs } from "./SettingsLayout";
 
 export const SettingsContainer: React.FunctionComponent = () => {
+  const { settings } = useSettings();
   const [isSelectingNetwork, setIsSelectingNetwork] = useState(false);
   const selectedNetwork = networkStore.useSelectedNetwork();
   const wallet = useWallet();
@@ -68,9 +70,11 @@ export const SettingsContainer: React.FunctionComponent = () => {
           )}
         </div>
 
-        <Fieldset label="Certificates" className="mb-4">
-          <CertificateList />
-        </Fieldset>
+        {!settings.isBlockchainDown && (
+          <Fieldset label="Certificates" className="mb-4">
+            <CertificateList />
+          </Fieldset>
+        )}
       </SettingsLayout>
     </Layout>
   );

--- a/apps/deploy-web/src/components/wallet/ConnectManagedWalletButton.spec.tsx
+++ b/apps/deploy-web/src/components/wallet/ConnectManagedWalletButton.spec.tsx
@@ -1,0 +1,54 @@
+import { mock } from "jest-mock-extended";
+
+import type { useFlag } from "@src/hooks/useFlag";
+import { ConnectManagedWalletButton } from "./ConnectManagedWalletButton";
+
+import { render } from "@testing-library/react";
+
+describe(ConnectManagedWalletButton.name, () => {
+  it("renders button enabled when blockchain is up", () => {
+    const { getByText } = setup({ isBlockchainDown: false });
+
+    expect(getByText("Start Trial").parentElement).not.toHaveAttribute("disabled");
+  });
+
+  it("renders button disabled when blockchain is down", () => {
+    const { getByText } = setup({ isBlockchainDown: true });
+
+    expect(getByText("Start Trial").parentElement).toHaveAttribute("disabled");
+  });
+
+  function setup(input?: { isRegistered?: boolean; isBlockchainDown?: boolean }) {
+    const mockUseFlag = jest.fn((flag: string) => {
+      if (flag === "notifications_general_alerts_update") {
+        return true;
+      }
+      return false;
+    }) as unknown as ReturnType<typeof useFlag>;
+
+    return render(
+      <ConnectManagedWalletButton
+        dependencies={{
+          useFlag: () => mockUseFlag,
+          useRouter: () => mock(),
+          useSettings: () => ({
+            settings: {
+              apiEndpoint: "https://api.example.com",
+              rpcEndpoint: "https://rpc.example.com",
+              isCustomNode: false,
+              nodes: [],
+              selectedNode: null,
+              customNode: null,
+              isBlockchainDown: input?.isBlockchainDown ?? false
+            },
+            setSettings: jest.fn(),
+            isLoadingSettings: false,
+            isSettingsInit: true,
+            refreshNodeStatuses: jest.fn(),
+            isRefreshingNodeStatus: false
+          })
+        }}
+      />
+    );
+  }
+});

--- a/apps/deploy-web/src/components/wallet/ConnectManagedWalletButton.tsx
+++ b/apps/deploy-web/src/components/wallet/ConnectManagedWalletButton.tsx
@@ -7,19 +7,28 @@ import { cn } from "@akashnetwork/ui/utils";
 import { Rocket } from "iconoir-react";
 import { useRouter } from "next/navigation";
 
+import { useSettings } from "@src/context/SettingsProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useFlag } from "@src/hooks/useFlag";
 import { UrlService } from "@src/utils/urlUtils";
 
+const DEPENDENCIES = {
+  useFlag,
+  useRouter,
+  useSettings
+};
+
 interface Props extends ButtonProps {
   children?: ReactNode;
   className?: string;
+  dependencies?: typeof DEPENDENCIES;
 }
 
-export const ConnectManagedWalletButton: React.FunctionComponent<Props> = ({ className = "", ...rest }) => {
+export const ConnectManagedWalletButton: React.FunctionComponent<Props> = ({ className = "", dependencies: d = DEPENDENCIES, ...rest }) => {
+  const { settings } = d.useSettings();
   const { connectManagedWallet, hasManagedWallet, isWalletLoading } = useWallet();
-  const allowAnonymousUserTrial = useFlag("anonymous_free_trial");
-  const router = useRouter();
+  const allowAnonymousUserTrial = d.useFlag("anonymous_free_trial");
+  const router = d.useRouter();
 
   const startTrial: React.MouseEventHandler = useCallback(() => {
     if (allowAnonymousUserTrial) {
@@ -35,7 +44,7 @@ export const ConnectManagedWalletButton: React.FunctionComponent<Props> = ({ cla
       onClick={startTrial}
       className={cn("border-primary bg-primary/10 dark:bg-primary", className)}
       {...rest}
-      disabled={isWalletLoading}
+      disabled={settings.isBlockchainDown || isWalletLoading}
     >
       {isWalletLoading ? <Spinner size="small" className="mr-2" variant="dark" /> : <Rocket className="rotate-45 text-xs" />}
       <span className="m-2 whitespace-nowrap">{hasManagedWallet ? "Switch to USD Payments" : "Start Trial"}</span>

--- a/apps/deploy-web/src/context/SettingsProvider/SettingsProviderContext.tsx
+++ b/apps/deploy-web/src/context/SettingsProvider/SettingsProviderContext.tsx
@@ -40,7 +40,7 @@ type ContextType = {
 
 export type SettingsContextType = ContextType;
 
-const SettingsProviderContext = React.createContext<ContextType>({} as ContextType);
+export const SettingsProviderContext = React.createContext<ContextType>({} as ContextType);
 
 const defaultSettings: Settings = {
   apiEndpoint: "",

--- a/apps/deploy-web/src/context/TopBannerProvider/TopBannerProvider.tsx
+++ b/apps/deploy-web/src/context/TopBannerProvider/TopBannerProvider.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from "react";
 
 import { useHasCreditCardBanner } from "@src/hooks/useHasCreditCardBanner";
 import { useVariant } from "@src/hooks/useVariant";
+import { useWhen } from "@src/hooks/useWhen";
 import type { FCWithChildren } from "@src/types/component";
 import { useSettings } from "../SettingsProvider";
 
@@ -21,6 +22,7 @@ export const TopBannerProvider: FCWithChildren = ({ children }) => {
   const hasCreditCardBanner = useHasCreditCardBanner();
 
   const [isMaintenanceBannerOpen, setIsMaintenanceBannerOpen] = useState(!!maintenanceBannerFlag.enabled);
+  useWhen(maintenanceBannerFlag.enabled, () => setIsMaintenanceBannerOpen(true));
 
   const hasBanner = useMemo(
     () => isMaintenanceBannerOpen || settings.isBlockchainDown || hasCreditCardBanner,

--- a/apps/deploy-web/src/context/TopBannerProvider/TopBannerProvider.tsx
+++ b/apps/deploy-web/src/context/TopBannerProvider/TopBannerProvider.tsx
@@ -1,0 +1,41 @@
+import React, { useMemo, useState } from "react";
+
+import { useHasCreditCardBanner } from "@src/hooks/useHasCreditCardBanner";
+import { useVariant } from "@src/hooks/useVariant";
+import type { FCWithChildren } from "@src/types/component";
+import { useSettings } from "../SettingsProvider";
+
+interface ITopBannerContext {
+  hasBanner: boolean;
+  setIsMaintenanceBannerOpen: (isMaintenanceBannerOpen: boolean) => void;
+  isMaintenanceBannerOpen: boolean;
+  isBlockchainDown: boolean;
+  hasCreditCardBanner: boolean;
+}
+
+const TopBannerContext = React.createContext<ITopBannerContext>({} as ITopBannerContext);
+
+export const TopBannerProvider: FCWithChildren = ({ children }) => {
+  const maintenanceBannerFlag = useVariant("maintenance_banner");
+  const { settings } = useSettings();
+  const hasCreditCardBanner = useHasCreditCardBanner();
+
+  const [isMaintenanceBannerOpen, setIsMaintenanceBannerOpen] = useState(!!maintenanceBannerFlag.enabled);
+
+  const hasBanner = useMemo(
+    () => isMaintenanceBannerOpen || settings.isBlockchainDown || hasCreditCardBanner,
+    [isMaintenanceBannerOpen, settings.isBlockchainDown, hasCreditCardBanner]
+  );
+
+  const value = {
+    hasBanner,
+    isMaintenanceBannerOpen,
+    setIsMaintenanceBannerOpen,
+    isBlockchainDown: settings.isBlockchainDown,
+    hasCreditCardBanner
+  };
+
+  return <TopBannerContext.Provider value={value}>{children}</TopBannerContext.Provider>;
+};
+
+export const useTopBanner = () => ({ ...React.useContext(TopBannerContext) });

--- a/apps/deploy-web/src/context/TopBannerProvider/index.ts
+++ b/apps/deploy-web/src/context/TopBannerProvider/index.ts
@@ -1,0 +1,1 @@
+export { useTopBanner, TopBannerProvider } from "./TopBannerProvider";

--- a/apps/deploy-web/src/hooks/useHasCreditCardBanner.ts
+++ b/apps/deploy-web/src/hooks/useHasCreditCardBanner.ts
@@ -8,15 +8,15 @@ import { useUser } from "./useUser";
 
 const withBilling = browserEnvConfig.NEXT_PUBLIC_BILLING_ENABLED;
 
-export function useHasCreditCardBanner(isMaintenanceBannerOpen: boolean) {
+export function useHasCreditCardBanner() {
   const { user } = useUser();
   const [isBannerVisible, setIsBannerVisible] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
   const { hasManagedWallet, isWalletLoading } = useWallet();
   const [isSignedInWithTrial] = useAtom(walletStore.isSignedInWithTrial);
   const shouldShowBanner = useMemo(
-    () => !isMaintenanceBannerOpen && isInitialized && withBilling && !hasManagedWallet && !isWalletLoading && !isSignedInWithTrial,
-    [isInitialized, hasManagedWallet, isWalletLoading, isSignedInWithTrial, isMaintenanceBannerOpen]
+    () => isInitialized && withBilling && !hasManagedWallet && !isWalletLoading && !isSignedInWithTrial,
+    [isInitialized, hasManagedWallet, isWalletLoading, isSignedInWithTrial]
   );
 
   useEffect(() => {

--- a/apps/deploy-web/src/queries/useGrantsQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useGrantsQuery.spec.tsx
@@ -3,10 +3,36 @@ import { faker } from "@faker-js/faker";
 import type { AxiosInstance } from "axios";
 import { mock } from "jest-mock-extended";
 
+import type { SettingsContextType } from "@src/context/SettingsProvider/SettingsProviderContext";
+import { SettingsProviderContext } from "@src/context/SettingsProvider/SettingsProviderContext";
 import { useAllowancesGranted, useAllowancesIssued, useGranteeGrants, useGranterGrants } from "./useGrantsQuery";
 
 import { waitFor } from "@testing-library/react";
 import { setupQuery } from "@tests/unit/query-client";
+
+const createMockSettingsContext = (): SettingsContextType =>
+  mock({
+    settings: {
+      apiEndpoint: "https://api.example.com",
+      rpcEndpoint: "https://rpc.example.com",
+      isCustomNode: false,
+      nodes: [],
+      selectedNode: null,
+      customNode: null,
+      isBlockchainDown: false
+    },
+    setSettings: jest.fn(),
+    isLoadingSettings: false,
+    isSettingsInit: true,
+    refreshNodeStatuses: jest.fn(),
+    isRefreshingNodeStatus: false
+  });
+
+const MockSettingsProvider = ({ children }: { children: React.ReactNode }) => {
+  const mockSettings = createMockSettingsContext();
+
+  return <SettingsProviderContext.Provider value={mockSettings}>{children}</SettingsProviderContext.Provider>;
+};
 
 describe("useGrantsQuery", () => {
   describe(useGranterGrants.name, () => {
@@ -34,7 +60,8 @@ describe("useGrantsQuery", () => {
       const { result } = setupQuery(() => useGranterGrants("test-address", 0, 1000), {
         services: {
           authzHttpService: () => authzHttpService
-        }
+        },
+        wrapper: ({ children }) => <MockSettingsProvider>{children}</MockSettingsProvider>
       });
 
       await waitFor(() => {
@@ -52,7 +79,8 @@ describe("useGrantsQuery", () => {
       setupQuery(() => useGranterGrants("", 0, 1000), {
         services: {
           authzHttpService: () => authzHttpService
-        }
+        },
+        wrapper: ({ children }) => <MockSettingsProvider>{children}</MockSettingsProvider>
       });
 
       expect(authzHttpService.getPaginatedDepositDeploymentGrants).not.toHaveBeenCalled();
@@ -76,7 +104,8 @@ describe("useGrantsQuery", () => {
       const { result } = setupQuery(() => useGranteeGrants("test-address"), {
         services: {
           authzHttpService: () => authzHttpService
-        }
+        },
+        wrapper: ({ children }) => <MockSettingsProvider>{children}</MockSettingsProvider>
       });
 
       await waitFor(() => {
@@ -94,7 +123,8 @@ describe("useGrantsQuery", () => {
       setupQuery(() => useGranteeGrants(""), {
         services: {
           authzHttpService: () => authzHttpService
-        }
+        },
+        wrapper: ({ children }) => <MockSettingsProvider>{children}</MockSettingsProvider>
       });
 
       expect(authzHttpService.getAllDepositDeploymentGrants).not.toHaveBeenCalled();
@@ -115,7 +145,8 @@ describe("useGrantsQuery", () => {
       const { result } = setupQuery(() => useAllowancesIssued("test-address", 0, 1000), {
         services: {
           authzHttpService: () => authzHttpService
-        }
+        },
+        wrapper: ({ children }) => <MockSettingsProvider>{children}</MockSettingsProvider>
       });
 
       await waitFor(() => {
@@ -133,7 +164,8 @@ describe("useGrantsQuery", () => {
       setupQuery(() => useAllowancesIssued("", 0, 1000), {
         services: {
           authzHttpService: () => authzHttpService
-        }
+        },
+        wrapper: ({ children }) => <MockSettingsProvider>{children}</MockSettingsProvider>
       });
 
       expect(authzHttpService.getPaginatedFeeAllowancesForGranter).not.toHaveBeenCalled();
@@ -156,7 +188,8 @@ describe("useGrantsQuery", () => {
       const { result } = setupQuery(() => useAllowancesGranted("test-address"), {
         services: {
           chainApiHttpClient: () => chainApiHttpClient
-        }
+        },
+        wrapper: ({ children }) => <MockSettingsProvider>{children}</MockSettingsProvider>
       });
 
       await waitFor(() => {
@@ -178,7 +211,9 @@ describe("useGrantsQuery", () => {
           }
         })
       } as any);
-      setupQuery(() => useAllowancesGranted(""));
+      setupQuery(() => useAllowancesGranted(""), {
+        wrapper: ({ children }) => <MockSettingsProvider>{children}</MockSettingsProvider>
+      });
 
       expect(chainApiHttpClient.get).not.toHaveBeenCalled();
     });

--- a/apps/deploy-web/src/queries/useGrantsQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useGrantsQuery.spec.tsx
@@ -212,6 +212,9 @@ describe("useGrantsQuery", () => {
         })
       } as any);
       setupQuery(() => useAllowancesGranted(""), {
+        services: {
+          chainApiHttpClient: () => chainApiHttpClient
+        },
         wrapper: ({ children }) => <MockSettingsProvider>{children}</MockSettingsProvider>
       });
 

--- a/apps/deploy-web/src/queries/useGrantsQuery.ts
+++ b/apps/deploy-web/src/queries/useGrantsQuery.ts
@@ -4,6 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import type { AxiosInstance } from "axios";
 
 import { useServices } from "@src/context/ServicesProvider";
+import { useSettings } from "@src/context/SettingsProvider/SettingsProviderContext";
 import type { AllowanceType, PaginatedAllowanceType, PaginatedGrantType } from "@src/types/grant";
 import { ApiUrlService, loadWithPagination } from "@src/utils/apiUtils";
 import { QueryKeys } from "./queryKeys";
@@ -14,10 +15,11 @@ export function useGranterGrants(
   limit: number,
   options: Omit<UseQueryOptions<PaginatedGrantType>, "queryKey" | "queryFn"> = {}
 ) {
+  const { settings } = useSettings();
   const { authzHttpService } = useServices();
   const offset = page * limit;
 
-  options.enabled = options.enabled !== false && !!address && authzHttpService.isReady;
+  options.enabled = options.enabled !== false && !!address && authzHttpService.isReady && !settings.isBlockchainDown;
 
   return useQuery({
     queryKey: QueryKeys.getGranterGrants(address, page, offset),
@@ -27,9 +29,10 @@ export function useGranterGrants(
 }
 
 export function useGranteeGrants(address: string, options: Omit<UseQueryOptions<DepositDeploymentGrant[]>, "queryKey" | "queryFn"> = {}) {
+  const { settings } = useSettings();
   const { authzHttpService } = useServices();
 
-  options.enabled = options.enabled !== false && !!address && authzHttpService.isReady;
+  options.enabled = options.enabled !== false && !!address && authzHttpService.isReady && !settings.isBlockchainDown;
 
   return useQuery({
     queryKey: QueryKeys.getGranteeGrants(address || "UNDEFINED"),
@@ -44,10 +47,11 @@ export function useAllowancesIssued(
   limit: number,
   options: Omit<UseQueryOptions<PaginatedAllowanceType>, "queryKey" | "queryFn"> = {}
 ) {
+  const { settings } = useSettings();
   const { authzHttpService } = useServices();
   const offset = page * limit;
 
-  options.enabled = options.enabled !== false && !!address && authzHttpService.isReady;
+  options.enabled = options.enabled !== false && !!address && authzHttpService.isReady && !settings.isBlockchainDown;
 
   return useQuery({
     queryKey: QueryKeys.getAllowancesIssued(address, page, offset),
@@ -61,9 +65,10 @@ async function getAllowancesGranted(chainApiHttpClient: AxiosInstance, address: 
 }
 
 export function useAllowancesGranted(address: string, options: Omit<UseQueryOptions<AllowanceType[]>, "queryKey" | "queryFn"> = {}) {
+  const { settings } = useSettings();
   const { chainApiHttpClient } = useServices();
 
-  options.enabled = options.enabled !== false && !!address && !!chainApiHttpClient.defaults.baseURL;
+  options.enabled = options.enabled !== false && !!address && !!chainApiHttpClient.defaults.baseURL && !settings.isBlockchainDown;
 
   return useQuery({
     queryKey: address ? QueryKeys.getAllowancesGranted(address) : [],

--- a/packages/ui/components/button.tsx
+++ b/packages/ui/components/button.tsx
@@ -6,7 +6,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../utils/cn";
 
 const buttonVariants = cva(
-  "ring-offset-background focus-visible:ring-ring relative inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "ring-offset-background focus-visible:ring-ring relative inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 aria-[disabled='true']:pointer-events-none aria-[disabled='true']:opacity-50",
   {
     variants: {
       variant: {


### PR DESCRIPTION
closes #1948

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App-wide "Network Down" handling: shows a top banner and replaces/full-suppresses impacted UI (Authorizations displays a minimal notice) and disables actions (Deploy, Create Deployment/Certificate, Connect Managed Wallet, Accept Bid, Close Deployment); Settings hides Certificates when down.

* **Refactor**
  * Consolidated top-banner system into a single provider/component to centralize banner logic and prioritization.

* **Style**
  * Improved ARIA-disabled styling for buttons/links for better accessibility.

* **Tests**
  * Added tests for disabled states and network-down scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->