### PR TITLE
refactor: adjusts authz and provider services to work when blockchain is down

### DIFF
--- a/apps/api/src/core/providers/http-sdk.provider.ts
+++ b/apps/api/src/core/providers/http-sdk.provider.ts
@@ -24,10 +24,10 @@ container.register(CHAIN_API_HTTP_CLIENT, {
   useFactory: () => createHttpClient({ baseURL: apiNodeUrl })
 });
 
-const SERVICES = [BalanceHttpService, AuthzHttpService, BlockHttpService, BidHttpService, ProviderHttpService];
+const SERVICES = [BalanceHttpService, BlockHttpService, BidHttpService, ProviderHttpService];
 SERVICES.forEach(Service => container.register(Service, { useValue: new Service({ baseURL: apiNodeUrl }) }));
 
-const NON_AXIOS_SERVICES: Array<new (httpClient: HttpClient) => unknown> = [DeploymentHttpService, LeaseHttpService, CosmosHttpService];
+const NON_AXIOS_SERVICES: Array<new (httpClient: HttpClient) => unknown> = [DeploymentHttpService, LeaseHttpService, CosmosHttpService, AuthzHttpService];
 NON_AXIOS_SERVICES.forEach(Service => container.register(Service, { useFactory: c => new Service(c.resolve(CHAIN_API_HTTP_CLIENT)) }));
 
 container.register(GitHubHttpService, { useValue: new GitHubHttpService({ baseURL: "https://raw.githubusercontent.com" }) });

--- a/apps/api/src/provider/services/provider/provider.service.ts
+++ b/apps/api/src/provider/services/provider/provider.service.ts
@@ -87,9 +87,7 @@ export class ProviderService {
         owner: providerAddress
       }
     });
-    if (!provider) {
-      throw new Error(`Provider ${providerAddress} not found`);
-    }
+    assert(provider, 404, `Provider ${providerAddress} not found`);
 
     const providerIdentity: ProviderIdentity = {
       owner: providerAddress,

--- a/apps/api/src/provider/services/provider/provider.service.ts
+++ b/apps/api/src/provider/services/provider/provider.service.ts
@@ -1,6 +1,5 @@
 import { Provider, ProviderAttribute, ProviderAttributeSignature, ProviderSnapshotNode, ProviderSnapshotNodeGPU } from "@akashnetwork/database/dbSchemas/akash";
 import { ProviderSnapshot } from "@akashnetwork/database/dbSchemas/akash/providerSnapshot";
-import { ProviderHttpService } from "@akashnetwork/http-sdk";
 import { SupportedChainNetworks } from "@akashnetwork/net";
 import { AxiosError } from "axios";
 import { add } from "date-fns";
@@ -27,7 +26,6 @@ export class ProviderService {
 
   constructor(
     private readonly providerProxy: ProviderProxyService,
-    private readonly providerHttpService: ProviderHttpService,
     private readonly providerAttributesSchemaService: ProviderAttributesSchemaService,
     private readonly auditorsService: AuditorService,
     @InjectBillingConfig() private readonly config: BillingConfig
@@ -35,16 +33,16 @@ export class ProviderService {
     this.chainNetwork = this.config.NETWORK as SupportedChainNetworks;
   }
 
-  async sendManifest(provider: string, dseq: string, manifest: string, options: { certPem: string; keyPem: string }) {
+  async sendManifest(providerAddress: string, dseq: string, manifest: string, options: { certPem: string; keyPem: string }) {
     const jsonStr = manifest.replace(/"quantity":{"val/g, '"size":{"val');
 
-    const providerResponse = await this.providerHttpService.getProvider(provider);
+    const provider = await Provider.findOne({ where: { owner: providerAddress } });
 
-    assert(providerResponse, 404, `Provider ${provider} not found`);
+    assert(provider, 404, `Provider ${providerAddress} not found`);
 
     const providerIdentity: ProviderIdentity = {
-      owner: provider,
-      hostUri: providerResponse.provider.host_uri
+      owner: providerAddress,
+      hostUri: provider.hostUri
     };
 
     return await this.sendManifestToProvider(dseq, jsonStr, options, providerIdentity);
@@ -77,15 +75,25 @@ export class ProviderService {
     }
   }
 
-  async getLeaseStatus(provider: string, dseq: string, gseq: number, oseq: number, options: { certPem: string; keyPem: string }): Promise<LeaseStatusResponse> {
-    const providerResponse = await this.providerHttpService.getProvider(provider);
-    if (!providerResponse) {
-      throw new Error(`Provider ${provider} not found`);
+  async getLeaseStatus(
+    providerAddress: string,
+    dseq: string,
+    gseq: number,
+    oseq: number,
+    options: { certPem: string; keyPem: string }
+  ): Promise<LeaseStatusResponse> {
+    const provider = await Provider.findOne({
+      where: {
+        owner: providerAddress
+      }
+    });
+    if (!provider) {
+      throw new Error(`Provider ${providerAddress} not found`);
     }
 
     const providerIdentity: ProviderIdentity = {
-      owner: provider,
-      hostUri: providerResponse.provider.host_uri
+      owner: providerAddress,
+      hostUri: provider.hostUri
     };
 
     return await this.providerProxy.fetchProviderUrl<LeaseStatusResponse>(`/lease/${dseq}/${gseq}/${oseq}/status`, {

--- a/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
+++ b/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
@@ -31,7 +31,7 @@ export function useServices() {
 
 function createAppContainer<T extends Factories>(settingsState: SettingsContextType, services: T) {
   const di = createChildContainer(rootContainer, {
-    authzHttpService: () => new AuthzHttpService({ baseURL: settingsState.settings?.apiEndpoint, adapter: "fetch" }),
+    authzHttpService: () => new AuthzHttpService(di.chainApiHttpClient),
     walletBalancesService: () => new WalletBalancesService(di.authzHttpService, di.chainApiHttpClient, di.appConfig.NEXT_PUBLIC_MASTER_WALLET_ADDRESS),
     certificatesService: () => new CertificatesService(di.chainApiHttpClient),
     chainApiHttpClient: () =>

--- a/apps/deploy-web/src/queries/useBalancesQuery.ts
+++ b/apps/deploy-web/src/queries/useBalancesQuery.ts
@@ -10,7 +10,7 @@ export function useBalances(address?: string, options?: Omit<UseQueryOptions<Bal
   return useQuery({
     queryKey: QueryKeys.getBalancesKey(address) as QueryKey,
     queryFn: () => (address ? di.walletBalancesService.getBalances(address) : null),
-    enabled: !!address && !!di.authzHttpService.getUri(),
+    enabled: !!address && di.authzHttpService.isReady,
     ...options
   });
 }

--- a/apps/deploy-web/src/queries/useGrantsQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useGrantsQuery.spec.tsx
@@ -28,7 +28,7 @@ describe("useGrantsQuery", () => {
       };
 
       const authzHttpService = mock<AuthzHttpService>({
-        defaults: { baseURL: "https://api.akash.network" },
+        isReady: true,
         getPaginatedDepositDeploymentGrants: jest.fn().mockResolvedValue(mockData)
       });
       const { result } = setupQuery(() => useGranterGrants("test-address", 0, 1000), {
@@ -46,7 +46,7 @@ describe("useGrantsQuery", () => {
 
     it("does not fetch when address is not provided", () => {
       const authzHttpService = mock<AuthzHttpService>({
-        defaults: { baseURL: "https://api.akash.network" },
+        isReady: true,
         getPaginatedDepositDeploymentGrants: jest.fn().mockResolvedValue([])
       });
       setupQuery(() => useGranterGrants("", 0, 1000), {
@@ -69,7 +69,7 @@ describe("useGrantsQuery", () => {
         }
       ];
       const authzHttpService = mock<AuthzHttpService>({
-        defaults: { baseURL: "https://api.akash.network" },
+        isReady: true,
         getAllDepositDeploymentGrants: jest.fn().mockResolvedValue(mockData)
       });
 
@@ -88,7 +88,7 @@ describe("useGrantsQuery", () => {
 
     it("does not fetch when address is not provided", () => {
       const authzHttpService = mock<AuthzHttpService>({
-        defaults: { baseURL: "https://api.akash.network" },
+        isReady: true,
         getAllDepositDeploymentGrants: jest.fn().mockResolvedValue([])
       });
       setupQuery(() => useGranteeGrants(""), {
@@ -108,7 +108,7 @@ describe("useGrantsQuery", () => {
         pagination: { total: 1 }
       };
       const authzHttpService = mock<AuthzHttpService>({
-        defaults: { baseURL: "https://api.akash.network" },
+        isReady: true,
         getPaginatedFeeAllowancesForGranter: jest.fn().mockResolvedValue(mockData)
       });
 
@@ -127,7 +127,7 @@ describe("useGrantsQuery", () => {
 
     it("does not fetch when address is not provided", () => {
       const authzHttpService = mock<AuthzHttpService>({
-        defaults: { baseURL: "https://api.akash.network" },
+        isReady: true,
         getPaginatedFeeAllowancesForGranter: jest.fn().mockResolvedValue([])
       });
       setupQuery(() => useAllowancesIssued("", 0, 1000), {

--- a/apps/deploy-web/src/queries/useGrantsQuery.ts
+++ b/apps/deploy-web/src/queries/useGrantsQuery.ts
@@ -17,7 +17,7 @@ export function useGranterGrants(
   const { authzHttpService } = useServices();
   const offset = page * limit;
 
-  options.enabled = options.enabled !== false && !!address && !!authzHttpService.defaults.baseURL;
+  options.enabled = options.enabled !== false && !!address && authzHttpService.isReady;
 
   return useQuery({
     queryKey: QueryKeys.getGranterGrants(address, page, offset),
@@ -29,7 +29,7 @@ export function useGranterGrants(
 export function useGranteeGrants(address: string, options: Omit<UseQueryOptions<DepositDeploymentGrant[]>, "queryKey" | "queryFn"> = {}) {
   const { authzHttpService } = useServices();
 
-  options.enabled = options.enabled !== false && !!address && !!authzHttpService.defaults.baseURL;
+  options.enabled = options.enabled !== false && !!address && authzHttpService.isReady;
 
   return useQuery({
     queryKey: QueryKeys.getGranteeGrants(address || "UNDEFINED"),
@@ -47,7 +47,7 @@ export function useAllowancesIssued(
   const { authzHttpService } = useServices();
   const offset = page * limit;
 
-  options.enabled = options.enabled !== false && !!address && !!authzHttpService.defaults.baseURL;
+  options.enabled = options.enabled !== false && !!address && authzHttpService.isReady;
 
   return useQuery({
     queryKey: QueryKeys.getAllowancesIssued(address, page, offset),

--- a/packages/http-sdk/src/authz/authz-http.service.ts
+++ b/packages/http-sdk/src/authz/authz-http.service.ts
@@ -1,8 +1,8 @@
 import { isFuture } from "date-fns";
-import type { HttpClient } from "src/utils/httpClient";
 
 import { extractData } from "../http/http.service";
 import type { Denom } from "../types/denom.type";
+import type { HttpClient } from "../utils/httpClient";
 import { isHttpError } from "../utils/isHttpError";
 
 export interface SpendLimit {

--- a/packages/http-sdk/src/authz/authz-http.service.ts
+++ b/packages/http-sdk/src/authz/authz-http.service.ts
@@ -1,7 +1,7 @@
-import type { AxiosRequestConfig } from "axios";
 import { isFuture } from "date-fns";
+import type { HttpClient } from "src/utils/httpClient";
 
-import { HttpService } from "../http/http.service";
+import { extractData } from "../http/http.service";
 import type { Denom } from "../types/denom.type";
 import { isHttpError } from "../utils/isHttpError";
 
@@ -53,18 +53,20 @@ interface DepositDeploymentGrantResponse<T extends ExactDepositDeploymentGrant =
   };
 }
 
-export class AuthzHttpService extends HttpService {
+export class AuthzHttpService {
   private readonly DEPOSIT_DEPLOYMENT_GRANT_TYPE: ExactDepositDeploymentGrant["authorization"]["@type"] =
     "/akash.deployment.v1beta3.DepositDeploymentAuthorization";
 
   private readonly FEE_ALLOWANCE_TYPE: FeeAllowance["allowance"]["@type"] = "/cosmos.feegrant.v1beta1.BasicAllowance";
 
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL" | "adapter">) {
-    super(config);
+  constructor(private readonly httpClient: HttpClient) {}
+
+  get isReady(): boolean {
+    return !!this.httpClient.defaults.baseURL;
   }
 
   async getFeeAllowancesForGrantee(address: string) {
-    const allowances = this.extractData(await this.get<FeeAllowanceListResponse>(`cosmos/feegrant/v1beta1/allowances/${address}`));
+    const allowances = extractData(await this.httpClient.get<FeeAllowanceListResponse>(`cosmos/feegrant/v1beta1/allowances/${address}`));
     return allowances.allowances;
   }
 
@@ -74,8 +76,8 @@ export class AuthzHttpService extends HttpService {
   }
 
   async getPaginatedFeeAllowancesForGranter(address: string, limit: number, offset: number) {
-    const allowances = this.extractData(
-      await this.get<FeeAllowanceListResponse>(`cosmos/feegrant/v1beta1/issued/${address}`, {
+    const allowances = extractData(
+      await this.httpClient.get<FeeAllowanceListResponse>(`cosmos/feegrant/v1beta1/issued/${address}`, {
         params: {
           "pagination.limit": limit,
           "pagination.offset": offset,
@@ -95,7 +97,7 @@ export class AuthzHttpService extends HttpService {
 
   async getFeeAllowanceForGranterAndGrantee(granter: string, grantee: string): Promise<FeeAllowance | undefined> {
     try {
-      const response = this.extractData(await this.get<FeeAllowanceResponse>(`cosmos/feegrant/v1beta1/allowance/${granter}/${grantee}`));
+      const response = extractData(await this.httpClient.get<FeeAllowanceResponse>(`cosmos/feegrant/v1beta1/allowance/${granter}/${grantee}`));
       return this.isValidFeeAllowance(response.allowance) ? response.allowance : undefined;
     } catch (error) {
       if (isHttpError(error) && error.response?.data.message?.includes("fee-grant not found")) {
@@ -107,8 +109,8 @@ export class AuthzHttpService extends HttpService {
   }
 
   async getDepositDeploymentGrantsForGranterAndGrantee(granter: string, grantee: string): Promise<ExactDepositDeploymentGrant | undefined> {
-    const response = this.extractData(
-      await this.get<DepositDeploymentGrantResponse<ExactDepositDeploymentGrant>>("cosmos/authz/v1beta1/grants", {
+    const response = extractData(
+      await this.httpClient.get<DepositDeploymentGrantResponse<ExactDepositDeploymentGrant>>("cosmos/authz/v1beta1/grants", {
         params: {
           grantee: grantee,
           granter: granter
@@ -119,8 +121,8 @@ export class AuthzHttpService extends HttpService {
   }
 
   async getValidDepositDeploymentGrantsForGranterAndGrantee(granter: string, grantee: string): Promise<ExactDepositDeploymentGrant | undefined> {
-    const response = this.extractData(
-      await this.get<DepositDeploymentGrantResponse<ExactDepositDeploymentGrant>>("cosmos/authz/v1beta1/grants", {
+    const response = extractData(
+      await this.httpClient.get<DepositDeploymentGrantResponse<ExactDepositDeploymentGrant>>("cosmos/authz/v1beta1/grants", {
         params: {
           grantee: grantee,
           granter: granter
@@ -157,8 +159,8 @@ export class AuthzHttpService extends HttpService {
     const address = "granter" in options ? options.granter : options.grantee;
 
     do {
-      const response = this.extractData(
-        await this.get<DepositDeploymentGrantResponse>(`cosmos/authz/v1beta1/grants/${side}/${address}`, {
+      const response = extractData(
+        await this.httpClient.get<DepositDeploymentGrantResponse>(`cosmos/authz/v1beta1/grants/${side}/${address}`, {
           params: { "pagination.key": nextPageKey, "pagination.limit": options.limit }
         })
       );
@@ -184,8 +186,8 @@ export class AuthzHttpService extends HttpService {
     const limit = options.limit;
     const offset = options.offset;
 
-    const grants = this.extractData(
-      await this.get<DepositDeploymentGrantResponse>(`cosmos/authz/v1beta1/grants/${side}/${address}`, {
+    const grants = extractData(
+      await this.httpClient.get<DepositDeploymentGrantResponse>(`cosmos/authz/v1beta1/grants/${side}/${address}`, {
         params: {
           "pagination.limit": limit,
           "pagination.offset": offset,


### PR DESCRIPTION
## Why

to ensure that blockchain related services will fallback to indexerHttpClient and eventually fail with 404. ref #1950 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queries now wait for the authorization service's isReady flag before running, reducing errors and unnecessary calls.

* **Bug Fixes**
  * Provider discovery for sending manifests and checking lease status now uses direct database lookup by provider address.

* **Refactor**
  * Authorization client unified to use a shared HTTP client; service construction simplified and dependency wiring adjusted.

* **Tests**
  * Grants query tests updated to use the readiness flag instead of baseURL mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->