### PR TITLE
feat(deployment): add lease list fallback

### DIFF
--- a/apps/api/src/deployment/controllers/lease/lease.controller.ts
+++ b/apps/api/src/deployment/controllers/lease/lease.controller.ts
@@ -5,6 +5,8 @@ import { AuthService, Protected } from "@src/auth/services/auth.service";
 import { UserWalletRepository } from "@src/billing/repositories";
 import { type GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
 import { type CreateLeaseRequest } from "@src/deployment/http-schemas/lease.schema";
+import { type FallbackLeaseListResponse } from "@src/deployment/http-schemas/lease-rpc.schema";
+import { DatabaseLeaseListParams } from "@src/deployment/repositories/lease/lease.repository";
 import { LeaseService } from "@src/deployment/services/lease/lease.service";
 
 @singleton()
@@ -25,5 +27,9 @@ export class LeaseController {
     const result = await this.leaseService.createLeasesAndSendManifest(userWallet, input);
 
     return { data: result };
+  }
+
+  async listLeasesFallback(params: DatabaseLeaseListParams): Promise<FallbackLeaseListResponse> {
+    return await this.leaseService.listLeasesFallback(params);
   }
 }

--- a/apps/api/src/deployment/http-schemas/deployment-rpc.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment-rpc.schema.ts
@@ -138,7 +138,10 @@ export const FallbackDeploymentListQuerySchema = z.object({
   "pagination.offset": z.coerce.number().optional(),
   "pagination.limit": z.coerce.number().optional(),
   "pagination.key": z.string().optional(),
-  "pagination.count_total": z.coerce.boolean().optional(),
+  "pagination.count_total": z
+    .string()
+    .optional()
+    .transform(val => val === "true"),
   "pagination.reverse": z.coerce.boolean().optional()
 });
 

--- a/apps/api/src/deployment/http-schemas/lease-rpc.schema.ts
+++ b/apps/api/src/deployment/http-schemas/lease-rpc.schema.ts
@@ -56,7 +56,10 @@ export const FallbackLeaseListQuerySchema = z.object({
   "pagination.offset": z.coerce.number().optional(),
   "pagination.limit": z.coerce.number().optional(),
   "pagination.key": z.string().optional(),
-  "pagination.count_total": z.coerce.boolean().optional(),
+  "pagination.count_total": z
+    .string()
+    .optional()
+    .transform(val => val === "true"),
   "pagination.reverse": z.coerce.boolean().optional()
 });
 

--- a/apps/api/src/deployment/http-schemas/lease-rpc.schema.ts
+++ b/apps/api/src/deployment/http-schemas/lease-rpc.schema.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+const LeaseIdSchema = z.object({
+  owner: z.string(),
+  dseq: z.string(),
+  gseq: z.number(),
+  oseq: z.number(),
+  provider: z.string()
+});
+
+const PriceSchema = z.object({
+  denom: z.string(),
+  amount: z.string()
+});
+
+const LeaseSchema = z.object({
+  lease_id: LeaseIdSchema,
+  state: z.string(),
+  price: PriceSchema,
+  created_at: z.string(),
+  closed_on: z.string()
+});
+
+const EscrowAccountIdSchema = z.object({
+  scope: z.string(),
+  xid: z.string()
+});
+
+const EscrowPaymentSchema = z.object({
+  account_id: EscrowAccountIdSchema,
+  payment_id: z.string(),
+  owner: z.string(),
+  state: z.string(),
+  rate: PriceSchema,
+  balance: PriceSchema,
+  withdrawn: PriceSchema
+});
+
+const LeaseWithEscrowSchema = z.object({
+  lease: LeaseSchema,
+  escrow_payment: EscrowPaymentSchema
+});
+
+const PaginationSchema = z.object({
+  next_key: z.string().nullable(),
+  total: z.string()
+});
+
+export const FallbackLeaseListQuerySchema = z.object({
+  "filters.owner": z.string().optional(),
+  "filters.dseq": z.string().optional(),
+  "filters.gseq": z.coerce.number().optional(),
+  "filters.oseq": z.coerce.number().optional(),
+  "filters.provider": z.string().optional(),
+  "filters.state": z.string().optional(),
+  "pagination.offset": z.coerce.number().optional(),
+  "pagination.limit": z.coerce.number().optional(),
+  "pagination.key": z.string().optional(),
+  "pagination.count_total": z.coerce.boolean().optional(),
+  "pagination.reverse": z.coerce.boolean().optional()
+});
+
+export const FallbackLeaseListResponseSchema = z.object({
+  leases: z.array(LeaseWithEscrowSchema),
+  pagination: PaginationSchema
+});
+
+export type FallbackLeaseListQuery = z.infer<typeof FallbackLeaseListQuerySchema>;
+export type FallbackLeaseListResponse = z.infer<typeof FallbackLeaseListResponseSchema>;

--- a/apps/api/src/deployment/repositories/lease/lease.repository.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.ts
@@ -1,5 +1,5 @@
 import { Lease } from "@akashnetwork/database/dbSchemas/akash";
-import { col, fn, Op } from "sequelize";
+import { col, fn, Op, WhereOptions } from "sequelize";
 import { singleton } from "tsyringe";
 
 export interface DrainingDeploymentOutput {
@@ -78,7 +78,7 @@ export class LeaseRepository {
   async findLeasesWithPagination(params: DatabaseLeaseListParams): Promise<{ count: number; rows: Lease[] }> {
     const { skip = 0, limit = 100, owner, dseq, gseq, oseq, provider, state, reverse = false } = params;
 
-    const whereConditions: any = {};
+    const whereConditions: WhereOptions = {};
 
     if (owner) {
       whereConditions.owner = owner;

--- a/apps/api/src/deployment/routes/leases/leases.router.ts
+++ b/apps/api/src/deployment/routes/leases/leases.router.ts
@@ -5,6 +5,7 @@ import { OpenApiHonoHandler } from "@src/core/services/open-api-hono-handler/ope
 import { LeaseController } from "@src/deployment/controllers/lease/lease.controller";
 import { GetDeploymentResponseSchema } from "@src/deployment/http-schemas/deployment.schema";
 import { CreateLeaseRequestSchema } from "@src/deployment/http-schemas/lease.schema";
+import { FallbackLeaseListQuerySchema, FallbackLeaseListResponseSchema } from "@src/deployment/http-schemas/lease-rpc.schema";
 
 const createLeaseRoute = createRoute({
   method: "post",
@@ -32,10 +33,48 @@ const createLeaseRoute = createRoute({
   }
 });
 
+const fallbackListRoute = createRoute({
+  method: "get",
+  path: "/akash/market/v1beta4/leases/list",
+  summary: "List leases (database fallback)",
+  tags: ["Leases"],
+  request: {
+    query: FallbackLeaseListQuerySchema
+  },
+  responses: {
+    200: {
+      description: "Returns paginated list of leases from database",
+      content: {
+        "application/json": {
+          schema: FallbackLeaseListResponseSchema
+        }
+      }
+    }
+  }
+});
+
 export const leasesRouter = new OpenApiHonoHandler();
 
 leasesRouter.openapi(createLeaseRoute, async function routeCreateLease(c) {
   const input = c.req.valid("json");
   const result = await container.resolve(LeaseController).createLeasesAndSendManifest(input);
+  return c.json(result, 200);
+});
+
+leasesRouter.openapi(fallbackListRoute, async function routeFallbackListLeases(c) {
+  const query = c.req.valid("query");
+  const result = await container.resolve(LeaseController).listLeasesFallback({
+    owner: query["filters.owner"],
+    dseq: query["filters.dseq"],
+    gseq: query["filters.gseq"],
+    oseq: query["filters.oseq"],
+    provider: query["filters.provider"],
+    state: query["filters.state"],
+    skip: query["pagination.offset"],
+    limit: query["pagination.limit"],
+    key: query["pagination.key"],
+    countTotal: query["pagination.count_total"],
+    reverse: query["pagination.reverse"]
+  });
   return c.json(result, 200);
 });

--- a/apps/api/src/deployment/services/lease/lease.service.ts
+++ b/apps/api/src/deployment/services/lease/lease.service.ts
@@ -1,3 +1,4 @@
+import { Lease } from "@akashnetwork/database/dbSchemas/akash";
 import { singleton } from "tsyringe";
 
 import { USDC_IBC_DENOMS } from "@src/billing/config/network.config";
@@ -67,7 +68,7 @@ export class LeaseService {
     };
   }
 
-  private transformLease(lease: any) {
+  private transformLease(lease: Lease) {
     const isActive = !lease.closedHeight;
     const state = isActive ? "active" : "closed";
     const mappedDenom = this.mapDenom(lease.denom);

--- a/apps/api/src/deployment/services/lease/lease.service.ts
+++ b/apps/api/src/deployment/services/lease/lease.service.ts
@@ -1,10 +1,14 @@
 import { singleton } from "tsyringe";
 
+import { USDC_IBC_DENOMS } from "@src/billing/config/network.config";
 import { UserWalletOutput } from "@src/billing/repositories";
 import { ManagedSignerService, RpcMessageService } from "@src/billing/services";
 import { GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
 import { CreateLeaseRequest } from "@src/deployment/http-schemas/lease.schema";
+import { type FallbackLeaseListResponse } from "@src/deployment/http-schemas/lease-rpc.schema";
+import { DatabaseLeaseListParams, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
+import { env } from "@src/utils/env";
 import { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
 
 @singleton()
@@ -13,7 +17,8 @@ export class LeaseService {
     private readonly signerService: ManagedSignerService,
     private readonly rpcMessageService: RpcMessageService,
     private readonly providerService: ProviderService,
-    private readonly deploymentReaderService: DeploymentReaderService
+    private readonly deploymentReaderService: DeploymentReaderService,
+    private readonly leaseRepository: LeaseRepository
   ) {}
 
   public async createLeasesAndSendManifest(wallet: UserWalletOutput, input: CreateLeaseRequest): Promise<GetDeploymentResponse["data"]> {
@@ -39,5 +44,86 @@ export class LeaseService {
     return await this.deploymentReaderService.findByOwnerAndDseq(wallet.address!, input.leases[0].dseq, {
       certificate: { certPem: input.certificate.certPem, keyPem: input.certificate.keyPem }
     });
+  }
+
+  public async listLeasesFallback(params: DatabaseLeaseListParams): Promise<FallbackLeaseListResponse> {
+    const { skip = 0, limit = 100, key, countTotal = true } = params;
+
+    const { count: total, rows: leases } = await this.leaseRepository.findLeasesWithPagination(params);
+
+    const transformedLeases = (leases || []).map(lease => this.transformLease(lease));
+
+    // Calculate next_key similar to HTTP service
+    const offset = key ? parseInt(key, 10) || 0 : skip;
+    const hasMore = offset + limit < total;
+    const nextKey = hasMore ? (offset + limit).toString() : null;
+
+    return {
+      leases: transformedLeases,
+      pagination: {
+        next_key: nextKey,
+        total: countTotal ? total.toString() : "0"
+      }
+    };
+  }
+
+  private transformLease(lease: any) {
+    const isActive = !lease.closedHeight;
+    const state = isActive ? "active" : "closed";
+    const mappedDenom = this.mapDenom(lease.denom);
+
+    return {
+      lease: {
+        lease_id: {
+          owner: lease.owner,
+          dseq: lease.dseq,
+          gseq: lease.gseq,
+          oseq: lease.oseq,
+          provider: lease.providerAddress
+        },
+        state,
+        price: {
+          denom: mappedDenom,
+          amount: lease.price.toFixed(18)
+        },
+        created_at: lease.createdHeight.toString(),
+        closed_on: lease.closedHeight?.toString() || "0"
+      },
+      escrow_payment: {
+        account_id: {
+          scope: "deployment",
+          xid: `${lease.owner}/${lease.dseq}`
+        },
+        payment_id: `${lease.gseq}/${lease.oseq}/${lease.providerAddress}`,
+        owner: lease.providerAddress,
+        state: isActive ? "open" : "closed",
+        rate: {
+          denom: mappedDenom,
+          amount: lease.price.toFixed(18)
+        },
+        balance: {
+          denom: mappedDenom,
+          amount: "0.000000000000000000"
+        },
+        withdrawn: {
+          denom: mappedDenom,
+          amount: lease.withdrawnAmount.toFixed(18)
+        }
+      }
+    };
+  }
+
+  private mapDenom(denom: string): string {
+    if (denom === "uusdc") {
+      const network = env.NETWORK;
+      if (network === "mainnet") {
+        return USDC_IBC_DENOMS.mainnetId;
+      } else if (network === "sandbox") {
+        return USDC_IBC_DENOMS.sandboxId;
+      }
+      // Default to mainnet if network is not recognized
+      return USDC_IBC_DENOMS.mainnetId;
+    }
+    return denom;
   }
 }

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -1097,6 +1097,301 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
         ],
       },
     },
+    "/akash/market/v1beta4/leases/list": {
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filters.owner",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "filters.dseq",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "filters.gseq",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "filters.oseq",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "filters.provider",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "filters.state",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "pagination.offset",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "pagination.limit",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "number",
+            },
+          },
+          {
+            "in": "query",
+            "name": "pagination.key",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "pagination.count_total",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "pagination.reverse",
+            "required": false,
+            "schema": {
+              "nullable": true,
+              "type": "boolean",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "leases": {
+                      "items": {
+                        "properties": {
+                          "escrow_payment": {
+                            "properties": {
+                              "account_id": {
+                                "properties": {
+                                  "scope": {
+                                    "type": "string",
+                                  },
+                                  "xid": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "scope",
+                                  "xid",
+                                ],
+                                "type": "object",
+                              },
+                              "balance": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                              "owner": {
+                                "type": "string",
+                              },
+                              "payment_id": {
+                                "type": "string",
+                              },
+                              "rate": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                              "state": {
+                                "type": "string",
+                              },
+                              "withdrawn": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                            },
+                            "required": [
+                              "account_id",
+                              "payment_id",
+                              "owner",
+                              "state",
+                              "rate",
+                              "balance",
+                              "withdrawn",
+                            ],
+                            "type": "object",
+                          },
+                          "lease": {
+                            "properties": {
+                              "closed_on": {
+                                "type": "string",
+                              },
+                              "created_at": {
+                                "type": "string",
+                              },
+                              "lease_id": {
+                                "properties": {
+                                  "dseq": {
+                                    "type": "string",
+                                  },
+                                  "gseq": {
+                                    "type": "number",
+                                  },
+                                  "oseq": {
+                                    "type": "number",
+                                  },
+                                  "owner": {
+                                    "type": "string",
+                                  },
+                                  "provider": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "owner",
+                                  "dseq",
+                                  "gseq",
+                                  "oseq",
+                                  "provider",
+                                ],
+                                "type": "object",
+                              },
+                              "price": {
+                                "properties": {
+                                  "amount": {
+                                    "type": "string",
+                                  },
+                                  "denom": {
+                                    "type": "string",
+                                  },
+                                },
+                                "required": [
+                                  "denom",
+                                  "amount",
+                                ],
+                                "type": "object",
+                              },
+                              "state": {
+                                "type": "string",
+                              },
+                            },
+                            "required": [
+                              "lease_id",
+                              "state",
+                              "price",
+                              "created_at",
+                              "closed_on",
+                            ],
+                            "type": "object",
+                          },
+                        },
+                        "required": [
+                          "lease",
+                          "escrow_payment",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                    "pagination": {
+                      "properties": {
+                        "next_key": {
+                          "nullable": true,
+                          "type": "string",
+                        },
+                        "total": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "next_key",
+                        "total",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "leases",
+                    "pagination",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns paginated list of leases from database",
+          },
+        },
+        "summary": "List leases (database fallback)",
+        "tags": [
+          "Leases",
+        ],
+      },
+    },
     "/v1/addresses/{address}": {
       "get": {
         "parameters": [

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -584,8 +584,7 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
             "name": "pagination.count_total",
             "required": false,
             "schema": {
-              "nullable": true,
-              "type": "boolean",
+              "type": "string",
             },
           },
           {

--- a/apps/api/test/functional/lease-fallback.spec.ts
+++ b/apps/api/test/functional/lease-fallback.spec.ts
@@ -9,139 +9,11 @@ import { createAkashBlock } from "@test/seeders/akash-block.seeder";
 
 describe("Lease Fallback API", () => {
   describe("GET /akash/market/v1beta4/leases/list", () => {
-    let isDbInitialized = false;
-
-    async function setup({ createTestData = false } = {}) {
-      if (isDbInitialized) {
-        return { addresses: [], providers: [], leases: [] };
-      }
-
-      await initDb();
-
-      const addresses = [createAkashAddress(), createAkashAddress(), createAkashAddress()];
-
-      const providers = [createAkashAddress(), createAkashAddress()];
-
-      const blocks = await Promise.all([
-        createAkashBlock({ height: 1000 }),
-        createAkashBlock({ height: 2000 }),
-        createAkashBlock({ height: 3000 }),
-        createAkashBlock({ height: 4000 }),
-        createAkashBlock({ height: 5000 })
-      ]);
-
-      let leases: any[] = [];
-
-      if (createTestData) {
-        // Create deployments and deployment groups first
-        const deployments = await Promise.all([
-          createDeployment({
-            owner: addresses[0],
-            dseq: "1001",
-            createdHeight: blocks[0].height
-          }),
-          createDeployment({
-            owner: addresses[0],
-            dseq: "1002",
-            createdHeight: blocks[1].height
-          }),
-          createDeployment({
-            owner: addresses[1],
-            dseq: "2001",
-            createdHeight: blocks[2].height
-          })
-        ]);
-
-        const deploymentGroups = await Promise.all([
-          createDeploymentGroup({
-            owner: addresses[0],
-            dseq: "1001",
-            gseq: 1,
-            deploymentId: deployments[0].id
-          }),
-          createDeploymentGroup({
-            owner: addresses[0],
-            dseq: "1002",
-            gseq: 1,
-            deploymentId: deployments[1].id
-          }),
-          createDeploymentGroup({
-            owner: addresses[1],
-            dseq: "2001",
-            gseq: 1,
-            deploymentId: deployments[2].id
-          })
-        ]);
-
-        // Create test leases
-        leases = await Promise.all([
-          createLease({
-            owner: addresses[0],
-            dseq: "1001",
-            gseq: 1,
-            oseq: 1,
-            providerAddress: providers[0],
-            createdHeight: blocks[0].height,
-            closedHeight: blocks[2].height, // closed
-            deploymentId: deployments[0].id,
-            deploymentGroupId: deploymentGroups[0].id,
-            price: 1.5,
-            denom: "uakt",
-            withdrawnAmount: 0.5
-          }),
-          createLease({
-            owner: addresses[0],
-            dseq: "1002",
-            gseq: 1,
-            oseq: 1,
-            providerAddress: providers[1],
-            createdHeight: blocks[1].height,
-            closedHeight: null, // active
-            deploymentId: deployments[1].id,
-            deploymentGroupId: deploymentGroups[1].id,
-            price: 2.0,
-            denom: "uusdc",
-            withdrawnAmount: 0.0
-          }),
-          createLease({
-            owner: addresses[1],
-            dseq: "2001",
-            gseq: 1,
-            oseq: 1,
-            providerAddress: providers[0],
-            createdHeight: blocks[2].height,
-            closedHeight: null, // active
-            deploymentId: deployments[2].id,
-            deploymentGroupId: deploymentGroups[2].id,
-            price: 3.0,
-            denom: "uakt",
-            withdrawnAmount: 1.0
-          })
-        ]);
-      }
-
-      isDbInitialized = true;
-
-      return { addresses, providers, leases };
-    }
-
-    async function makeRequest(params: Record<string, any> = {}): Promise<FallbackLeaseListResponse> {
-      const queryParams = new URLSearchParams();
-      Object.entries(params).forEach(([key, value]) => {
-        if (value !== undefined && value !== null) {
-          queryParams.append(key, value.toString());
-        }
-      });
-
-      const response = await app.request(`/akash/market/v1beta4/leases/list?${queryParams.toString()}`);
-      return await response.json();
-    }
-
     it("should return correct response structure with seeded data", async () => {
       const { addresses } = await setup({ createTestData: true });
 
       const result = await makeRequest({
-        "filters.owner": addresses[0]
+        owner: addresses[0]
       });
 
       expect(result).toHaveProperty("leases");
@@ -202,7 +74,7 @@ describe("Lease Fallback API", () => {
       const { addresses } = await setup({ createTestData: true });
 
       const result = await makeRequest({
-        "filters.owner": addresses[0]
+        owner: addresses[0]
       });
 
       expect(result.leases.length).toBeGreaterThan(0);
@@ -215,8 +87,8 @@ describe("Lease Fallback API", () => {
       const { addresses } = await setup({ createTestData: true });
 
       const result = await makeRequest({
-        "filters.owner": addresses[0],
-        "filters.dseq": "1001"
+        owner: addresses[0],
+        dseq: "1001"
       });
 
       expect(result.leases.length).toBeGreaterThan(0);
@@ -229,8 +101,8 @@ describe("Lease Fallback API", () => {
       const { addresses } = await setup({ createTestData: true });
 
       const result = await makeRequest({
-        "filters.owner": addresses[0],
-        "filters.state": "active"
+        owner: addresses[0],
+        state: "active"
       });
 
       result.leases.forEach(lease => {
@@ -243,8 +115,8 @@ describe("Lease Fallback API", () => {
       const { addresses } = await setup({ createTestData: true });
 
       const result = await makeRequest({
-        "filters.owner": addresses[0],
-        "filters.state": "closed"
+        owner: addresses[0],
+        state: "closed"
       });
 
       result.leases.forEach(lease => {
@@ -257,8 +129,8 @@ describe("Lease Fallback API", () => {
       const { addresses, providers } = await setup({ createTestData: true });
 
       const result = await makeRequest({
-        "filters.owner": addresses[0],
-        "filters.provider": providers[0]
+        owner: addresses[0],
+        provider: providers[0]
       });
 
       result.leases.forEach(lease => {
@@ -270,8 +142,8 @@ describe("Lease Fallback API", () => {
       const { addresses } = await setup({ createTestData: true });
 
       const result = await makeRequest({
-        "filters.owner": addresses[0],
-        "filters.gseq": 1
+        owner: addresses[0],
+        gseq: 1
       });
 
       result.leases.forEach(lease => {
@@ -283,8 +155,8 @@ describe("Lease Fallback API", () => {
       const { addresses } = await setup({ createTestData: true });
 
       const result = await makeRequest({
-        "filters.owner": addresses[0],
-        "filters.oseq": 1
+        owner: addresses[0],
+        oseq: 1
       });
 
       result.leases.forEach(lease => {
@@ -296,8 +168,8 @@ describe("Lease Fallback API", () => {
       const { addresses } = await setup({ createTestData: true });
 
       const result = await makeRequest({
-        "filters.owner": addresses[0],
-        "pagination.limit": 1
+        owner: addresses[0],
+        limit: 1
       });
 
       expect(result.leases.length).toBeLessThanOrEqual(1);
@@ -309,9 +181,9 @@ describe("Lease Fallback API", () => {
       const { addresses } = await setup({ createTestData: true });
 
       const result = await makeRequest({
-        "filters.owner": addresses[0],
-        "pagination.offset": 0,
-        "pagination.limit": 1
+        owner: addresses[0],
+        skip: 0,
+        limit: 1
       });
 
       expect(result.leases.length).toBeLessThanOrEqual(1);
@@ -321,8 +193,8 @@ describe("Lease Fallback API", () => {
       const { addresses } = await setup({ createTestData: true });
 
       const result = await makeRequest({
-        "filters.owner": addresses[0],
-        "pagination.reverse": true
+        owner: addresses[0],
+        reverse: true
       });
 
       expect(result.leases.length).toBeGreaterThan(0);
@@ -333,7 +205,7 @@ describe("Lease Fallback API", () => {
       const nonExistentOwner = createAkashAddress();
 
       const result = await makeRequest({
-        "filters.owner": nonExistentOwner
+        owner: nonExistentOwner
       });
 
       expect(result.leases).toEqual([]);
@@ -345,8 +217,8 @@ describe("Lease Fallback API", () => {
       const { addresses } = await setup({ createTestData: true });
 
       const result = await makeRequest({
-        "filters.owner": addresses[0],
-        "filters.dseq": "999999"
+        owner: addresses[0],
+        dseq: "999999"
       });
 
       expect(result.leases).toEqual([]);
@@ -358,13 +230,13 @@ describe("Lease Fallback API", () => {
       const { addresses } = await setup({ createTestData: true });
 
       const resultWithCount = await makeRequest({
-        "filters.owner": addresses[0],
-        "pagination.count_total": true
+        owner: addresses[0],
+        countTotal: true
       });
 
       const resultWithoutCount = await makeRequest({
-        "filters.owner": addresses[0],
-        "pagination.count_total": false
+        owner: addresses[0],
+        countTotal: false
       });
 
       expect(resultWithCount.pagination.total).not.toBe("0");
@@ -375,10 +247,10 @@ describe("Lease Fallback API", () => {
       const { addresses, providers } = await setup({ createTestData: true });
 
       const result = await makeRequest({
-        "filters.owner": addresses[0],
-        "filters.provider": providers[0],
-        "filters.state": "closed",
-        "pagination.limit": 10
+        owner: addresses[0],
+        provider: providers[0],
+        state: "closed",
+        limit: 10
       });
 
       result.leases.forEach(lease => {
@@ -392,7 +264,7 @@ describe("Lease Fallback API", () => {
       const { addresses } = await setup({ createTestData: true });
 
       const result = await makeRequest({
-        "filters.owner": addresses[0]
+        owner: addresses[0]
       });
 
       expect(result.leases.length).toBeGreaterThan(0);
@@ -420,4 +292,203 @@ describe("Lease Fallback API", () => {
       expect(typeof lease.escrow_payment.withdrawn.amount).toBe("string");
     });
   });
+
+  async function setup(
+    options: {
+      initDatabase?: boolean;
+      createTestData?: boolean;
+      uniqueId?: string;
+    } = {}
+  ) {
+    const { initDatabase = true, createTestData = false, uniqueId = Date.now().toString() } = options;
+
+    if (initDatabase) {
+      await initDb();
+    }
+
+    if (!createTestData) {
+      return {
+        addresses: [createAkashAddress(), createAkashAddress(), createAkashAddress()],
+        providers: [createAkashAddress(), createAkashAddress()],
+        leases: []
+      };
+    }
+
+    // Generate random height numbers
+    const height1 = 1000 + parseInt(uniqueId.slice(-3));
+    const height2 = 2000 + parseInt(uniqueId.slice(-3));
+    const height3 = 3000 + parseInt(uniqueId.slice(-3));
+    const height4 = 4000 + parseInt(uniqueId.slice(-3));
+    const height5 = 5000 + parseInt(uniqueId.slice(-3));
+
+    const testData: {
+      addresses: string[];
+      providers: string[];
+      leases?: any[];
+    } = {
+      addresses: [createAkashAddress(), createAkashAddress(), createAkashAddress()],
+      providers: [createAkashAddress(), createAkashAddress()]
+    };
+
+    // Create blocks first
+    const blocks = await Promise.all([
+      createAkashBlock({
+        datetime: new Date(),
+        height: height1
+      }),
+      createAkashBlock({
+        datetime: new Date(),
+        height: height2
+      }),
+      createAkashBlock({
+        datetime: new Date(),
+        height: height3
+      }),
+      createAkashBlock({
+        datetime: new Date(),
+        height: height4
+      }),
+      createAkashBlock({
+        datetime: new Date(),
+        height: height5
+      })
+    ]);
+
+    // Create deployments and deployment groups first
+    const deployments = await Promise.all([
+      createDeployment({
+        owner: testData.addresses[0],
+        dseq: "1001",
+        createdHeight: blocks[0].height
+      }),
+      createDeployment({
+        owner: testData.addresses[0],
+        dseq: "1002",
+        createdHeight: blocks[1].height
+      }),
+      createDeployment({
+        owner: testData.addresses[1],
+        dseq: "2001",
+        createdHeight: blocks[2].height
+      })
+    ]);
+
+    const deploymentGroups = await Promise.all([
+      createDeploymentGroup({
+        owner: testData.addresses[0],
+        dseq: "1001",
+        gseq: 1,
+        deploymentId: deployments[0].id
+      }),
+      createDeploymentGroup({
+        owner: testData.addresses[0],
+        dseq: "1002",
+        gseq: 1,
+        deploymentId: deployments[1].id
+      }),
+      createDeploymentGroup({
+        owner: testData.addresses[1],
+        dseq: "2001",
+        gseq: 1,
+        deploymentId: deployments[2].id
+      })
+    ]);
+
+    // Create test leases
+    testData.leases = await Promise.all([
+      createLease({
+        owner: testData.addresses[0],
+        dseq: "1001",
+        gseq: 1,
+        oseq: 1,
+        providerAddress: testData.providers[0],
+        createdHeight: blocks[0].height,
+        closedHeight: blocks[2].height, // closed
+        deploymentId: deployments[0].id,
+        deploymentGroupId: deploymentGroups[0].id,
+        price: 1.5,
+        denom: "uakt",
+        withdrawnAmount: 0.5,
+        cpuUnits: 1000,
+        gpuUnits: 0,
+        memoryQuantity: 1024 * 1024 * 1024,
+        ephemeralStorageQuantity: 1024 * 1024 * 1024,
+        persistentStorageQuantity: 0
+      }),
+      createLease({
+        owner: testData.addresses[0],
+        dseq: "1002",
+        gseq: 1,
+        oseq: 1,
+        providerAddress: testData.providers[1],
+        createdHeight: blocks[1].height,
+        closedHeight: null, // active
+        deploymentId: deployments[1].id,
+        deploymentGroupId: deploymentGroups[1].id,
+        price: 2.0,
+        denom: "uusdc",
+        withdrawnAmount: 0.0,
+        cpuUnits: 2000,
+        gpuUnits: 1,
+        memoryQuantity: 2 * 1024 * 1024 * 1024,
+        ephemeralStorageQuantity: 2 * 1024 * 1024 * 1024,
+        persistentStorageQuantity: 0
+      }),
+      createLease({
+        owner: testData.addresses[1],
+        dseq: "2001",
+        gseq: 1,
+        oseq: 1,
+        providerAddress: testData.providers[0],
+        createdHeight: blocks[2].height,
+        closedHeight: null, // active
+        deploymentId: deployments[2].id,
+        deploymentGroupId: deploymentGroups[2].id,
+        price: 3.0,
+        denom: "uakt",
+        withdrawnAmount: 1.0,
+        cpuUnits: 3000,
+        gpuUnits: 2,
+        memoryQuantity: 4 * 1024 * 1024 * 1024,
+        ephemeralStorageQuantity: 4 * 1024 * 1024 * 1024,
+        persistentStorageQuantity: 0
+      })
+    ]);
+
+    return testData;
+  }
+
+  async function makeRequest(input: {
+    owner?: string;
+    dseq?: string;
+    gseq?: number;
+    oseq?: number;
+    provider?: string;
+    state?: string;
+    skip?: number;
+    limit?: number;
+    key?: string;
+    countTotal?: boolean;
+    reverse?: boolean;
+  }): Promise<FallbackLeaseListResponse> {
+    const queryParams = new URLSearchParams();
+
+    if (input.owner) queryParams.append("filters.owner", input.owner);
+    if (input.dseq) queryParams.append("filters.dseq", input.dseq);
+    if (input.gseq !== undefined) queryParams.append("filters.gseq", input.gseq.toString());
+    if (input.oseq !== undefined) queryParams.append("filters.oseq", input.oseq.toString());
+    if (input.provider) queryParams.append("filters.provider", input.provider);
+    if (input.state) queryParams.append("filters.state", input.state);
+    if (input.skip !== undefined) queryParams.append("pagination.offset", input.skip.toString());
+    if (input.limit !== undefined) queryParams.append("pagination.limit", input.limit.toString());
+    if (input.key) queryParams.append("pagination.key", input.key);
+    if (input.countTotal !== undefined) queryParams.append("pagination.count_total", input.countTotal.toString());
+    if (input.reverse !== undefined) queryParams.append("pagination.reverse", input.reverse.toString());
+
+    const queryString = queryParams.toString();
+    const url = `/akash/market/v1beta4/leases/list${queryString ? `?${queryString}` : ""}`;
+
+    const response = await app.request(url);
+    return await response.json();
+  }
 });

--- a/apps/api/test/functional/lease-fallback.spec.ts
+++ b/apps/api/test/functional/lease-fallback.spec.ts
@@ -1,0 +1,423 @@
+import type { FallbackLeaseListResponse } from "@src/deployment/http-schemas/lease-rpc.schema";
+import { app, initDb } from "@src/rest-app";
+
+import { createLease } from "@test/seeders";
+import { createDeployment } from "@test/seeders";
+import { createDeploymentGroup } from "@test/seeders";
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { createAkashBlock } from "@test/seeders/akash-block.seeder";
+
+describe("Lease Fallback API", () => {
+  describe("GET /akash/market/v1beta4/leases/list", () => {
+    let isDbInitialized = false;
+
+    async function setup({ createTestData = false } = {}) {
+      if (isDbInitialized) {
+        return { addresses: [], providers: [], leases: [] };
+      }
+
+      await initDb();
+
+      const addresses = [createAkashAddress(), createAkashAddress(), createAkashAddress()];
+
+      const providers = [createAkashAddress(), createAkashAddress()];
+
+      const blocks = await Promise.all([
+        createAkashBlock({ height: 1000 }),
+        createAkashBlock({ height: 2000 }),
+        createAkashBlock({ height: 3000 }),
+        createAkashBlock({ height: 4000 }),
+        createAkashBlock({ height: 5000 })
+      ]);
+
+      let leases: any[] = [];
+
+      if (createTestData) {
+        // Create deployments and deployment groups first
+        const deployments = await Promise.all([
+          createDeployment({
+            owner: addresses[0],
+            dseq: "1001",
+            createdHeight: blocks[0].height
+          }),
+          createDeployment({
+            owner: addresses[0],
+            dseq: "1002",
+            createdHeight: blocks[1].height
+          }),
+          createDeployment({
+            owner: addresses[1],
+            dseq: "2001",
+            createdHeight: blocks[2].height
+          })
+        ]);
+
+        const deploymentGroups = await Promise.all([
+          createDeploymentGroup({
+            owner: addresses[0],
+            dseq: "1001",
+            gseq: 1,
+            deploymentId: deployments[0].id
+          }),
+          createDeploymentGroup({
+            owner: addresses[0],
+            dseq: "1002",
+            gseq: 1,
+            deploymentId: deployments[1].id
+          }),
+          createDeploymentGroup({
+            owner: addresses[1],
+            dseq: "2001",
+            gseq: 1,
+            deploymentId: deployments[2].id
+          })
+        ]);
+
+        // Create test leases
+        leases = await Promise.all([
+          createLease({
+            owner: addresses[0],
+            dseq: "1001",
+            gseq: 1,
+            oseq: 1,
+            providerAddress: providers[0],
+            createdHeight: blocks[0].height,
+            closedHeight: blocks[2].height, // closed
+            deploymentId: deployments[0].id,
+            deploymentGroupId: deploymentGroups[0].id,
+            price: 1.5,
+            denom: "uakt",
+            withdrawnAmount: 0.5
+          }),
+          createLease({
+            owner: addresses[0],
+            dseq: "1002",
+            gseq: 1,
+            oseq: 1,
+            providerAddress: providers[1],
+            createdHeight: blocks[1].height,
+            closedHeight: null, // active
+            deploymentId: deployments[1].id,
+            deploymentGroupId: deploymentGroups[1].id,
+            price: 2.0,
+            denom: "uusdc",
+            withdrawnAmount: 0.0
+          }),
+          createLease({
+            owner: addresses[1],
+            dseq: "2001",
+            gseq: 1,
+            oseq: 1,
+            providerAddress: providers[0],
+            createdHeight: blocks[2].height,
+            closedHeight: null, // active
+            deploymentId: deployments[2].id,
+            deploymentGroupId: deploymentGroups[2].id,
+            price: 3.0,
+            denom: "uakt",
+            withdrawnAmount: 1.0
+          })
+        ]);
+      }
+
+      isDbInitialized = true;
+
+      return { addresses, providers, leases };
+    }
+
+    async function makeRequest(params: Record<string, any> = {}): Promise<FallbackLeaseListResponse> {
+      const queryParams = new URLSearchParams();
+      Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined && value !== null) {
+          queryParams.append(key, value.toString());
+        }
+      });
+
+      const response = await app.request(`/akash/market/v1beta4/leases/list?${queryParams.toString()}`);
+      return await response.json();
+    }
+
+    it("should return correct response structure with seeded data", async () => {
+      const { addresses } = await setup({ createTestData: true });
+
+      const result = await makeRequest({
+        "filters.owner": addresses[0]
+      });
+
+      expect(result).toHaveProperty("leases");
+      expect(result).toHaveProperty("pagination");
+      expect(Array.isArray(result.leases)).toBe(true);
+      expect(result.pagination).toHaveProperty("next_key");
+      expect(result.pagination).toHaveProperty("total");
+
+      // Should have at least one lease
+      expect(result.leases.length).toBeGreaterThan(0);
+
+      // Check lease structure
+      const lease = result.leases[0];
+      expect(lease).toHaveProperty("lease");
+      expect(lease).toHaveProperty("escrow_payment");
+
+      // Check lease details
+      expect(lease.lease).toHaveProperty("lease_id");
+      expect(lease.lease).toHaveProperty("state");
+      expect(lease.lease).toHaveProperty("price");
+      expect(lease.lease).toHaveProperty("created_at");
+      expect(lease.lease).toHaveProperty("closed_on");
+
+      // Check lease_id structure
+      expect(lease.lease.lease_id).toHaveProperty("owner");
+      expect(lease.lease.lease_id).toHaveProperty("dseq");
+      expect(lease.lease.lease_id).toHaveProperty("gseq");
+      expect(lease.lease.lease_id).toHaveProperty("oseq");
+      expect(lease.lease.lease_id).toHaveProperty("provider");
+
+      // Check price structure
+      expect(lease.lease.price).toHaveProperty("denom");
+      expect(lease.lease.price).toHaveProperty("amount");
+
+      // Check escrow_payment structure
+      expect(lease.escrow_payment).toHaveProperty("account_id");
+      expect(lease.escrow_payment).toHaveProperty("payment_id");
+      expect(lease.escrow_payment).toHaveProperty("owner");
+      expect(lease.escrow_payment).toHaveProperty("state");
+      expect(lease.escrow_payment).toHaveProperty("rate");
+      expect(lease.escrow_payment).toHaveProperty("balance");
+      expect(lease.escrow_payment).toHaveProperty("withdrawn");
+
+      // Check account_id structure
+      expect(lease.escrow_payment.account_id).toHaveProperty("scope");
+      expect(lease.escrow_payment.account_id).toHaveProperty("xid");
+
+      // Check rate, balance, and withdrawn structures
+      expect(lease.escrow_payment.rate).toHaveProperty("denom");
+      expect(lease.escrow_payment.rate).toHaveProperty("amount");
+      expect(lease.escrow_payment.balance).toHaveProperty("denom");
+      expect(lease.escrow_payment.balance).toHaveProperty("amount");
+      expect(lease.escrow_payment.withdrawn).toHaveProperty("denom");
+      expect(lease.escrow_payment.withdrawn).toHaveProperty("amount");
+    });
+
+    it("should filter by owner", async () => {
+      const { addresses } = await setup({ createTestData: true });
+
+      const result = await makeRequest({
+        "filters.owner": addresses[0]
+      });
+
+      expect(result.leases.length).toBeGreaterThan(0);
+      result.leases.forEach(lease => {
+        expect(lease.lease.lease_id.owner).toBe(addresses[0]);
+      });
+    });
+
+    it("should filter by dseq", async () => {
+      const { addresses } = await setup({ createTestData: true });
+
+      const result = await makeRequest({
+        "filters.owner": addresses[0],
+        "filters.dseq": "1001"
+      });
+
+      expect(result.leases.length).toBeGreaterThan(0);
+      result.leases.forEach(lease => {
+        expect(lease.lease.lease_id.dseq).toBe("1001");
+      });
+    });
+
+    it("should filter by state active", async () => {
+      const { addresses } = await setup({ createTestData: true });
+
+      const result = await makeRequest({
+        "filters.owner": addresses[0],
+        "filters.state": "active"
+      });
+
+      result.leases.forEach(lease => {
+        expect(lease.lease.state).toBe("active");
+        expect(lease.escrow_payment.state).toBe("open");
+      });
+    });
+
+    it("should filter by state closed", async () => {
+      const { addresses } = await setup({ createTestData: true });
+
+      const result = await makeRequest({
+        "filters.owner": addresses[0],
+        "filters.state": "closed"
+      });
+
+      result.leases.forEach(lease => {
+        expect(lease.lease.state).toBe("closed");
+        expect(lease.escrow_payment.state).toBe("closed");
+      });
+    });
+
+    it("should filter by provider", async () => {
+      const { addresses, providers } = await setup({ createTestData: true });
+
+      const result = await makeRequest({
+        "filters.owner": addresses[0],
+        "filters.provider": providers[0]
+      });
+
+      result.leases.forEach(lease => {
+        expect(lease.lease.lease_id.provider).toBe(providers[0]);
+      });
+    });
+
+    it("should filter by gseq", async () => {
+      const { addresses } = await setup({ createTestData: true });
+
+      const result = await makeRequest({
+        "filters.owner": addresses[0],
+        "filters.gseq": 1
+      });
+
+      result.leases.forEach(lease => {
+        expect(lease.lease.lease_id.gseq).toBe(1);
+      });
+    });
+
+    it("should filter by oseq", async () => {
+      const { addresses } = await setup({ createTestData: true });
+
+      const result = await makeRequest({
+        "filters.owner": addresses[0],
+        "filters.oseq": 1
+      });
+
+      result.leases.forEach(lease => {
+        expect(lease.lease.lease_id.oseq).toBe(1);
+      });
+    });
+
+    it("should handle pagination with limit", async () => {
+      const { addresses } = await setup({ createTestData: true });
+
+      const result = await makeRequest({
+        "filters.owner": addresses[0],
+        "pagination.limit": 1
+      });
+
+      expect(result.leases.length).toBeLessThanOrEqual(1);
+      expect(result.pagination).toHaveProperty("next_key");
+      expect(result.pagination).toHaveProperty("total");
+    });
+
+    it("should handle pagination with offset", async () => {
+      const { addresses } = await setup({ createTestData: true });
+
+      const result = await makeRequest({
+        "filters.owner": addresses[0],
+        "pagination.offset": 0,
+        "pagination.limit": 1
+      });
+
+      expect(result.leases.length).toBeLessThanOrEqual(1);
+    });
+
+    it("should handle reverse sorting", async () => {
+      const { addresses } = await setup({ createTestData: true });
+
+      const result = await makeRequest({
+        "filters.owner": addresses[0],
+        "pagination.reverse": true
+      });
+
+      expect(result.leases.length).toBeGreaterThan(0);
+      // Note: We can't easily test the actual order without more complex setup
+    });
+
+    it("should return empty result for non-existent owner", async () => {
+      const nonExistentOwner = createAkashAddress();
+
+      const result = await makeRequest({
+        "filters.owner": nonExistentOwner
+      });
+
+      expect(result.leases).toEqual([]);
+      expect(result.pagination.total).toBe("0");
+      expect(result.pagination.next_key).toBeNull();
+    });
+
+    it("should return empty result for non-existent dseq", async () => {
+      const { addresses } = await setup({ createTestData: true });
+
+      const result = await makeRequest({
+        "filters.owner": addresses[0],
+        "filters.dseq": "999999"
+      });
+
+      expect(result.leases).toEqual([]);
+      expect(result.pagination.total).toBe("0");
+      expect(result.pagination.next_key).toBeNull();
+    });
+
+    it("should handle count_total parameter", async () => {
+      const { addresses } = await setup({ createTestData: true });
+
+      const resultWithCount = await makeRequest({
+        "filters.owner": addresses[0],
+        "pagination.count_total": true
+      });
+
+      const resultWithoutCount = await makeRequest({
+        "filters.owner": addresses[0],
+        "pagination.count_total": false
+      });
+
+      expect(resultWithCount.pagination.total).not.toBe("0");
+      expect(resultWithoutCount.pagination.total).toBe("0");
+    });
+
+    it("should handle multiple filters together", async () => {
+      const { addresses, providers } = await setup({ createTestData: true });
+
+      const result = await makeRequest({
+        "filters.owner": addresses[0],
+        "filters.provider": providers[0],
+        "filters.state": "closed",
+        "pagination.limit": 10
+      });
+
+      result.leases.forEach(lease => {
+        expect(lease.lease.lease_id.owner).toBe(addresses[0]);
+        expect(lease.lease.lease_id.provider).toBe(providers[0]);
+        expect(lease.lease.state).toBe("closed");
+      });
+    });
+
+    it("should return correct data types", async () => {
+      const { addresses } = await setup({ createTestData: true });
+
+      const result = await makeRequest({
+        "filters.owner": addresses[0]
+      });
+
+      expect(result.leases.length).toBeGreaterThan(0);
+      const lease = result.leases[0];
+
+      // Check data types
+      expect(typeof lease.lease.lease_id.owner).toBe("string");
+      expect(typeof lease.lease.lease_id.dseq).toBe("string");
+      expect(typeof lease.lease.lease_id.gseq).toBe("number");
+      expect(typeof lease.lease.lease_id.oseq).toBe("number");
+      expect(typeof lease.lease.lease_id.provider).toBe("string");
+      expect(typeof lease.lease.state).toBe("string");
+      expect(typeof lease.lease.price.denom).toBe("string");
+      expect(typeof lease.lease.price.amount).toBe("string");
+      expect(typeof lease.lease.created_at).toBe("string");
+      expect(typeof lease.lease.closed_on).toBe("string");
+      expect(typeof lease.escrow_payment.payment_id).toBe("string");
+      expect(typeof lease.escrow_payment.owner).toBe("string");
+      expect(typeof lease.escrow_payment.state).toBe("string");
+      expect(typeof lease.escrow_payment.rate.denom).toBe("string");
+      expect(typeof lease.escrow_payment.rate.amount).toBe("string");
+      expect(typeof lease.escrow_payment.balance.denom).toBe("string");
+      expect(typeof lease.escrow_payment.balance.amount).toBe("string");
+      expect(typeof lease.escrow_payment.withdrawn.denom).toBe("string");
+      expect(typeof lease.escrow_payment.withdrawn.amount).toBe("string");
+    });
+  });
+});

--- a/apps/api/test/functional/lease-fallback.spec.ts
+++ b/apps/api/test/functional/lease-fallback.spec.ts
@@ -28,6 +28,7 @@ type LeaseListTestParams = {
 
 describe("Lease Fallback API", () => {
   let isDbInitialized = false;
+  let cachedOwners: string[] = [];
 
   describe("GET /akash/market/v1beta4/leases/list", () => {
     it("should return correct response structure with seeded data", async () => {
@@ -315,6 +316,8 @@ describe("Lease Fallback API", () => {
   });
 
   async function setup() {
+    await initDb();
+
     const now = new Date();
     now.setHours(12, 0, 0, 0);
 
@@ -322,7 +325,13 @@ describe("Lease Fallback API", () => {
 
     const providers = await Promise.all([createProvider({ deletedHeight: null }), createProvider({ deletedHeight: null })]);
 
-    const owners = [createAkashAddress(), createAkashAddress(), createAkashAddress()];
+    let owners: string[];
+    if (isDbInitialized) {
+      owners = cachedOwners;
+    } else {
+      owners = [createAkashAddress(), createAkashAddress(), createAkashAddress()];
+      cachedOwners = owners;
+    }
 
     if (isDbInitialized) {
       return {
@@ -332,8 +341,6 @@ describe("Lease Fallback API", () => {
         providers
       };
     }
-
-    await initDb();
 
     await Promise.all([
       createDay({
@@ -568,6 +575,7 @@ describe("Lease Fallback API", () => {
     ]);
 
     isDbInitialized = true;
+    cachedOwners = owners;
 
     return {
       now,

--- a/apps/api/test/functional/lease-fallback.spec.ts
+++ b/apps/api/test/functional/lease-fallback.spec.ts
@@ -1,5 +1,21 @@
+import type { Lease } from "@akashnetwork/database/dbSchemas/akash";
+
 import type { FallbackLeaseListResponse } from "@src/deployment/http-schemas/lease-rpc.schema";
 import { app, initDb } from "@src/rest-app";
+
+type LeaseListTestParams = {
+  owner?: string;
+  dseq?: string;
+  gseq?: number;
+  oseq?: number;
+  provider?: string;
+  state?: string;
+  skip?: number;
+  limit?: number;
+  key?: string;
+  countTotal?: boolean;
+  reverse?: boolean;
+};
 
 import { createLease } from "@test/seeders";
 import { createDeployment } from "@test/seeders";
@@ -324,7 +340,7 @@ describe("Lease Fallback API", () => {
     const testData: {
       addresses: string[];
       providers: string[];
-      leases?: any[];
+      leases?: Lease[];
     } = {
       addresses: [createAkashAddress(), createAkashAddress(), createAkashAddress()],
       providers: [createAkashAddress(), createAkashAddress()]
@@ -458,19 +474,7 @@ describe("Lease Fallback API", () => {
     return testData;
   }
 
-  async function makeRequest(input: {
-    owner?: string;
-    dseq?: string;
-    gseq?: number;
-    oseq?: number;
-    provider?: string;
-    state?: string;
-    skip?: number;
-    limit?: number;
-    key?: string;
-    countTotal?: boolean;
-    reverse?: boolean;
-  }): Promise<FallbackLeaseListResponse> {
+  async function makeRequest(input: LeaseListTestParams): Promise<FallbackLeaseListResponse> {
     const queryParams = new URLSearchParams();
 
     if (input.owner) queryParams.append("filters.owner", input.owner);

--- a/apps/api/test/seeders/lease.seeder.ts
+++ b/apps/api/test/seeders/lease.seeder.ts
@@ -1,6 +1,7 @@
 import { Lease } from "@akashnetwork/database/dbSchemas/akash";
 import { faker } from "@faker-js/faker";
 import type { CreationAttributes } from "sequelize";
+
 export const createLease = async (overrides: Partial<CreationAttributes<Lease>> = {}): Promise<Lease> => {
   return await Lease.create({
     id: overrides.id || faker.string.uuid(),


### PR DESCRIPTION
https://github.com/akash-network/console/issues/1947

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a leases listing endpoint (database fallback) with filtering (owner, dseq/gseq/oseq, provider, state), pagination (limit/offset), next_key cursoring, reverse sorting, and optional total count.
  * Responses include lease + escrow payment details and network-aware USDC denomination mapping.
  * Added request/response schemas for the fallback leases API.

* **Bug Fixes**
  * Deployment list query parsing: count_total now accepts "true"/"false" strings correctly.

* **Tests**
  * Added comprehensive functional tests and test data helpers seeding realistic leases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->