### PR TITLE
refactor: upgrade pgboss to v11 on api

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -95,7 +95,7 @@
     "memory-cache": "^0.2.0",
     "murmurhash": "^2.0.1",
     "pg": "^8.12.0",
-    "pg-boss": "^10.3.2",
+    "pg-boss": "^11.0.4",
     "pg-hstore": "^2.3.4",
     "postgres": "^3.4.4",
     "protobufjs": "^6.11.2",

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -198,12 +198,12 @@ describe(JobQueueService.name, () => {
       const mockError = new Error("PgBoss connection failed");
 
       let errorHandler: (error: Error) => void;
-      jest.spyOn(pgBoss, "on").mockImplementation((event: string, handler: (error: Error) => void) => {
+      jest.spyOn(pgBoss, "on").mockImplementation(((event, handler) => {
         if (event === "error") {
-          errorHandler = handler;
+          errorHandler = handler as (error: Error) => void;
         }
         return pgBoss;
-      });
+      }) as PgBoss["on"]);
 
       await service.setup();
       errorHandler!(mockError);
@@ -228,11 +228,9 @@ describe(JobQueueService.name, () => {
   describe("ping", () => {
     it("pings PgBoss", async () => {
       const { service, pgBoss } = setup();
-      // @ts-expect-error - getDb is not typed, see https://github.com/timgit/pg-boss/issues/552#issuecomment-3213043039
       jest.spyOn(pgBoss, "getDb").mockReturnValue({ executeSql: jest.fn().mockResolvedValue(undefined) });
       await service.ping();
 
-      // @ts-expect-error - getDb is not typed, see https://github.com/timgit/pg-boss/issues/552#issuecomment-3213043039
       expect(pgBoss.getDb().executeSql).toHaveBeenCalledWith("SELECT 1");
     });
   });

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -231,7 +231,7 @@ describe(JobQueueService.name, () => {
       jest.spyOn(pgBoss, "getDb").mockReturnValue({ executeSql: jest.fn().mockResolvedValue(undefined) });
       await service.ping();
 
-      expect(pgBoss.getDb().executeSql).toHaveBeenCalledWith("SELECT 1");
+      expect(pgBoss.getDb().executeSql).toHaveBeenCalledWith("SELECT 1", []);
     });
   });
 

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -142,8 +142,7 @@ export class JobQueueService implements Disposable {
   }
 
   async ping(): Promise<void> {
-    // @ts-expect-error - getDb is not typed, see https://github.com/timgit/pg-boss/issues/552#issuecomment-3213043039
-    await this.pgBoss.getDb().executeSql("SELECT 1");
+    await this.pgBoss.getDb().executeSql("SELECT 1", []);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "memory-cache": "^0.2.0",
         "murmurhash": "^2.0.1",
         "pg": "^8.12.0",
-        "pg-boss": "^10.3.2",
+        "pg-boss": "^11.0.4",
         "pg-hstore": "^2.3.4",
         "postgres": "^3.4.4",
         "protobufjs": "^6.11.2",
@@ -793,6 +793,20 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "apps/api/node_modules/pg-boss": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/pg-boss/-/pg-boss-11.0.4.tgz",
+      "integrity": "sha512-G+MXscT6bCap5/AwQId0MN9syStdFE0uKDUnbvNF5AGhMZf5OlV/62Xp9Flyo9CRDXMYvtEzZByCfj3a1xrgZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cron-parser": "^4.9.0",
+        "pg": "^8.16.3",
+        "serialize-error": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "apps/api/node_modules/pg-types": {


### PR DESCRIPTION
## Why

because pgboss v11 has major breaking changes on database level and we want to avoid doing this migration on production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved job queue health-check reliability.

- Chores
  - Upgraded job-queue dependency to a newer major version for improved stability and compatibility.

- Tests
  - Strengthened test suite to align with stricter type-safety and ensure reliable job-queue integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->