### PR TITLE
feat: can multi-select deployments when pressing shift

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentList.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.tsx
@@ -64,7 +64,7 @@ export const DeploymentList: React.FunctionComponent = () => {
   const [isSignedInWithTrial] = useAtom(walletStore.isSignedInWithTrial);
   const { user } = useCustomUser();
 
-  const { selectedItemIds, onSelectItem, clearSelection } = useListSelection<string>({
+  const { selectedItemIds, selectItem, clearSelection } = useListSelection<string>({
     ids: currentPageDeployments.map(deployment => deployment.dseq)
   });
 
@@ -290,7 +290,7 @@ export const DeploymentList: React.FunctionComponent = () => {
                   refreshDeployments={getDeployments}
                   providers={providers}
                   isSelectable
-                  onSelectDeployment={onSelectItem}
+                  onSelectDeployment={selectItem}
                   checked={selectedItemIds.includes(deployment.dseq)}
                 />
               ))}

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -50,10 +50,10 @@ import { LeaseChip } from "./LeaseChip";
 type Props = {
   deployment: NamedDeploymentDto;
   isSelectable?: boolean;
-  onSelectDeployment?: (isChecked: boolean, dseq: string) => void;
+  onSelectDeployment?: (isChecked: boolean, dseq: string, eventShiftPressed: boolean) => void;
   checked?: boolean;
   providers: Array<ApiProviderList> | undefined;
-  refreshDeployments: any;
+  refreshDeployments: () => void;
   children?: ReactNode;
 };
 
@@ -132,7 +132,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
     const response = await signAndBroadcastTx([message]);
     if (response) {
       if (onSelectDeployment) {
-        onSelectDeployment(false, deployment.dseq);
+        onSelectDeployment(false, deployment.dseq, false);
       }
 
       refreshDeployments();
@@ -296,9 +296,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
                 checked={checked}
                 onClick={event => {
                   event.stopPropagation();
-                }}
-                onCheckedChange={value => {
-                  onSelectDeployment && onSelectDeployment(value as boolean, deployment.dseq);
+                  onSelectDeployment?.(!checked, deployment.dseq, event.shiftKey);
                 }}
               />
             )}

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -50,7 +50,7 @@ import { LeaseChip } from "./LeaseChip";
 type Props = {
   deployment: NamedDeploymentDto;
   isSelectable?: boolean;
-  onSelectDeployment?: (isChecked: boolean, dseq: string, eventShiftPressed: boolean) => void;
+  onSelectDeployment?: ({ id, isShiftPressed }: { id: string; isShiftPressed: boolean }) => void;
   checked?: boolean;
   providers: Array<ApiProviderList> | undefined;
   refreshDeployments: () => void;
@@ -132,7 +132,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
     const response = await signAndBroadcastTx([message]);
     if (response) {
       if (onSelectDeployment) {
-        onSelectDeployment(false, deployment.dseq, false);
+        onSelectDeployment({ id: deployment.dseq, isShiftPressed: false });
       }
 
       refreshDeployments();
@@ -296,7 +296,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
                 checked={checked}
                 onClick={event => {
                   event.stopPropagation();
-                  onSelectDeployment?.(!checked, deployment.dseq, event.shiftKey);
+                  onSelectDeployment?.({ id: deployment.dseq, isShiftPressed: event.shiftKey });
                 }}
               />
             )}

--- a/apps/deploy-web/src/hooks/useListSelection/useListSelection.spec.ts
+++ b/apps/deploy-web/src/hooks/useListSelection/useListSelection.spec.ts
@@ -1,0 +1,134 @@
+import { range } from "lodash";
+
+import type { UseListSelectionProps } from "./useListSelection";
+import { useListSelection } from "./useListSelection";
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+const expectSelectedItems = (actualIds: number[], expectedIds: number[]) => {
+  expect(actualIds.length).toBe(expectedIds.length);
+  expect(expectedIds.every(id => actualIds.includes(id))).toBe(true);
+};
+
+describe(useListSelection.name, () => {
+  it("should not explode for an empty list", () => {
+    const hook = setup({ ids: [] });
+
+    expect(hook.selectedItemIds).toEqual([]);
+  });
+
+  [
+    {
+      name: "can set a single item as selected",
+      clicks: [{ id: 2, isShiftPressed: false }],
+      expectedItems: [2]
+    },
+    {
+      name: "can select multiple items, toggling back and forth",
+      clicks: [
+        { id: 2, isShiftPressed: false },
+        { id: 3, isShiftPressed: false },
+        { id: 4, isShiftPressed: false },
+        { id: 3, isShiftPressed: false }
+      ],
+      expectedItems: [2, 4]
+    },
+    {
+      name: "can shift-select first item",
+      clicks: [{ id: 2, isShiftPressed: true }],
+      expectedItems: [2]
+    },
+    {
+      name: "can shift-select items down",
+      clicks: [
+        { id: 2, isShiftPressed: false },
+        { id: 4, isShiftPressed: true }
+      ],
+      expectedItems: [2, 3, 4]
+    },
+    {
+      name: "can shift-select items up",
+      clicks: [
+        { id: 4, isShiftPressed: false },
+        { id: 2, isShiftPressed: true }
+      ],
+      expectedItems: [2, 3, 4]
+    },
+    {
+      name: "can shift-select down and then up",
+      clicks: [
+        { id: 2, isShiftPressed: false },
+        { id: 4, isShiftPressed: true },
+        { id: 0, isShiftPressed: true }
+      ],
+      expectedItems: [0, 1, 2, 3, 4]
+    },
+    {
+      name: "can shift-select up and then down",
+      clicks: [
+        { id: 2, isShiftPressed: false },
+        { id: 0, isShiftPressed: true },
+        { id: 4, isShiftPressed: true }
+      ],
+      expectedItems: [0, 1, 2, 3, 4]
+    },
+    {
+      name: "can deselect the whole range up",
+      clicks: [
+        { id: 2, isShiftPressed: false },
+        { id: 4, isShiftPressed: true },
+        { id: 2, isShiftPressed: true }
+      ],
+      expectedItems: []
+    },
+    {
+      name: "can deselect the whole range down",
+      clicks: [
+        { id: 4, isShiftPressed: false },
+        { id: 2, isShiftPressed: true },
+        { id: 4, isShiftPressed: true }
+      ],
+      expectedItems: []
+    },
+    {
+      name: "can mark even more items down",
+      clicks: [
+        { id: 2, isShiftPressed: false },
+        { id: 4, isShiftPressed: true },
+        { id: 0, isShiftPressed: true },
+        { id: 6, isShiftPressed: true }
+      ],
+      expectedItems: [0, 1, 2, 3, 4, 5, 6]
+    },
+    {
+      name: "can mark even more items up",
+      clicks: [
+        { id: 4, isShiftPressed: false },
+        { id: 6, isShiftPressed: true },
+        { id: 2, isShiftPressed: true },
+        { id: 0, isShiftPressed: true }
+      ],
+      expectedItems: [0, 1, 2, 3, 4, 5, 6]
+    }
+  ].forEach(({ name, clicks, expectedItems }) => {
+    it(name, async () => {
+      const { result } = renderHook(() => useListSelection({ ids: range(0, 10) }));
+
+      clicks.forEach(({ id, isShiftPressed }) => {
+        act(() => {
+          result.current.onSelectItem({ id, isShiftPressed });
+        });
+      });
+
+      await waitFor(() => {
+        expectSelectedItems(result.current.selectedItemIds, expectedItems);
+      });
+    });
+  });
+
+  function setup({ ids }: UseListSelectionProps<number> = { ids: range(0, 10) }) {
+    const res = renderHook(() => useListSelection({ ids }));
+
+    return res.result.current;
+  }
+});

--- a/apps/deploy-web/src/hooks/useListSelection/useListSelection.ts
+++ b/apps/deploy-web/src/hooks/useListSelection/useListSelection.ts
@@ -39,13 +39,16 @@ export const useListSelection = <T>({ ids }: UseListSelectionProps<T>) => {
 
   const toggleSingleSelection = useCallback(
     (id: T) => {
-      const isAdding = !selectedItemIds.includes(id);
-      setSelectedItemIds(prev => (isAdding ? [...prev, id] : prev.filter(x => x !== id)));
-      if (isAdding) {
-        setIntervalSelectionAnchor(id);
-      }
+      setSelectedItemIds(prev => {
+        const isAdding = !prev.includes(id);
+        if (isAdding) {
+          setIntervalSelectionAnchor(id);
+        }
+
+        return isAdding ? [...prev, id] : prev.filter(x => x !== id);
+      });
     },
-    [selectedItemIds]
+    []
   );
 
   const changeMultipleSelection = useCallback(
@@ -64,7 +67,7 @@ export const useListSelection = <T>({ ids }: UseListSelectionProps<T>) => {
     [intervalSelectionAnchor, itemsBetween, lastIntervalSelectionIds]
   );
 
-  const onSelectItem = useCallback(
+  const selectItem = useCallback(
     ({ id, isShiftPressed }: { id: T; isShiftPressed: boolean }) => {
       if (intervalSelectionAnchor && isShiftPressed) {
         changeMultipleSelection(id);
@@ -82,10 +85,10 @@ export const useListSelection = <T>({ ids }: UseListSelectionProps<T>) => {
   return useMemo(
     () => ({
       selectedItemIds,
-      onSelectItem,
+      selectItem,
       clearSelection,
       setSelectedItemIds
     }),
-    [selectedItemIds, onSelectItem, clearSelection]
+    [selectedItemIds, selectItem, clearSelection]
   );
 };

--- a/apps/deploy-web/src/hooks/useListSelection/useListSelection.ts
+++ b/apps/deploy-web/src/hooks/useListSelection/useListSelection.ts
@@ -1,0 +1,91 @@
+import { useCallback, useMemo, useState } from "react";
+import { uniq } from "lodash";
+
+export type UseListSelectionProps<T> = {
+  ids: T[];
+};
+
+export const useListSelection = <T>({ ids }: UseListSelectionProps<T>) => {
+  const [selectedItemIds, setSelectedItemIds] = useState<T[]>([]);
+  const [intervalSelectionAnchor, setIntervalSelectionAnchor] = useState<T | null>(null);
+  const [lastIntervalSelectionIds, setLastIntervalSelectionIds] = useState<T[]>([]);
+
+  const indexOfId = useCallback(
+    (id: T) => {
+      return ids?.findIndex(currentId => currentId === id);
+    },
+    [ids]
+  );
+
+  const isBetweenIds = useCallback(
+    (id: T, idA: T, idB: T) => {
+      const idIndex = indexOfId(id);
+      const idAIndex = indexOfId(idA);
+      const idBIndex = indexOfId(idB);
+
+      return (
+        idIndex !== -1 && idAIndex !== -1 && idBIndex !== -1 && ((idAIndex <= idIndex && idIndex <= idBIndex) || (idAIndex >= idIndex && idIndex >= idBIndex))
+      );
+    },
+    [indexOfId]
+  );
+
+  const itemsBetween = useCallback(
+    (idA: T, idB: T) => {
+      return ids.filter(currentId => isBetweenIds(currentId, idA, idB));
+    },
+    [ids, isBetweenIds]
+  );
+
+  const toggleSingleSelection = useCallback(
+    (id: T) => {
+      const isAdding = !selectedItemIds.includes(id);
+      setSelectedItemIds(prev => (isAdding ? [...prev, id] : prev.filter(x => x !== id)));
+      if (isAdding) {
+        setIntervalSelectionAnchor(id);
+      }
+    },
+    [selectedItemIds]
+  );
+
+  const changeMultipleSelection = useCallback(
+    (id: T) => {
+      const newRange = itemsBetween(id, intervalSelectionAnchor!);
+
+      if (id === intervalSelectionAnchor && lastIntervalSelectionIds.length > 0) {
+        setSelectedItemIds(prev => prev.filter(x => !lastIntervalSelectionIds.includes(x)));
+        setLastIntervalSelectionIds([]);
+        return;
+      }
+
+      setSelectedItemIds(prev => uniq([...prev, ...newRange]));
+      setLastIntervalSelectionIds(newRange);
+    },
+    [intervalSelectionAnchor, itemsBetween, lastIntervalSelectionIds]
+  );
+
+  const onSelectItem = useCallback(
+    ({ id, isShiftPressed }: { id: T; isShiftPressed: boolean }) => {
+      if (intervalSelectionAnchor && isShiftPressed) {
+        changeMultipleSelection(id);
+      } else {
+        toggleSingleSelection(id);
+      }
+    },
+    [intervalSelectionAnchor, changeMultipleSelection, toggleSingleSelection]
+  );
+
+  const clearSelection = useCallback(() => {
+    setSelectedItemIds([]);
+  }, []);
+
+  return useMemo(
+    () => ({
+      selectedItemIds,
+      onSelectItem,
+      clearSelection,
+      setSelectedItemIds
+    }),
+    [selectedItemIds, onSelectItem, clearSelection]
+  );
+};


### PR DESCRIPTION
closes #1982

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multi-select capability with Shift+click range selection support for deployments.

* **Refactor**
  * Improved selection state management to provide more consistent and efficient multi-item selection handling across the deployments interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->