### PR TITLE
feat: run bg jobs in execution context

### DIFF
--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -3,6 +3,7 @@ import type PgBoss from "pg-boss";
 
 import type { LoggerService } from "@src/core/providers/logging.provider";
 import type { CoreConfigService } from "../core-config/core-config.service";
+import type { ExecutionContextService } from "../execution-context/execution-context.service";
 import { type Job, JOB_NAME, type JobHandler, JobQueueService } from "./job-queue.service";
 
 describe(JobQueueService.name, () => {
@@ -249,10 +250,19 @@ describe(JobQueueService.name, () => {
           work: jest.fn().mockResolvedValue(undefined),
           start: jest.fn().mockResolvedValue(undefined),
           stop: jest.fn().mockResolvedValue(undefined)
-        })
+        }),
+      executionContextService: mock<ExecutionContextService>({
+        set: jest.fn().mockResolvedValue(undefined),
+        runWithContext: jest.fn(async (cb: () => Promise<any>) => await cb())
+      })
     };
 
-    const service = new JobQueueService(mocks.logger, mocks.coreConfig, input && Object.hasOwn(input, "pgBoss") ? input?.pgBoss : mocks.pgBoss);
+    const service = new JobQueueService(
+      mocks.logger,
+      mocks.coreConfig,
+      mocks.executionContextService,
+      input && Object.hasOwn(input, "pgBoss") ? input?.pgBoss : mocks.pgBoss
+    );
 
     return { service, ...mocks };
   }

--- a/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.spec.ts
@@ -17,7 +17,9 @@ describe(JobQueueService.name, () => {
 
       expect(pgBoss.createQueue).toHaveBeenCalledWith("test", {
         name: "test",
-        retryLimit: 10
+        retryBackoff: true,
+        retryDelayMax: 300,
+        retryLimit: 5
       });
     });
 
@@ -47,11 +49,15 @@ describe(JobQueueService.name, () => {
       expect(pgBoss.createQueue).toHaveBeenCalledTimes(2);
       expect(pgBoss.createQueue).toHaveBeenCalledWith("test", {
         name: "test",
-        retryLimit: 10
+        retryBackoff: true,
+        retryDelayMax: 300,
+        retryLimit: 5
       });
       expect(pgBoss.createQueue).toHaveBeenCalledWith("another", {
         name: "another",
-        retryLimit: 10
+        retryBackoff: true,
+        retryDelayMax: 300,
+        retryLimit: 5
       });
     });
   });
@@ -122,7 +128,9 @@ describe(JobQueueService.name, () => {
 
       expect(pgBoss.createQueue).toHaveBeenCalledWith("test", {
         name: "test",
-        retryLimit: 10
+        retryBackoff: true,
+        retryDelayMax: 300,
+        retryLimit: 5
       });
       expect(pgBoss.work).toHaveBeenCalledTimes(5);
       expect(pgBoss.work).toHaveBeenCalledWith("test", { batchSize: 1 }, expect.any(Function));

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -1,8 +1,10 @@
+import { createMongoAbility, MongoAbility } from "@casl/ability";
 import PgBoss from "pg-boss";
 import { Disposable, inject, InjectionToken, singleton } from "tsyringe";
 
 import { LoggerService } from "@src/core/providers/logging.provider";
 import { CoreConfigService } from "../core-config/core-config.service";
+import { ExecutionContextService } from "../execution-context/execution-context.service";
 
 export const PG_BOSS_TOKEN: InjectionToken<PgBoss> = Symbol("pgBoss");
 
@@ -14,6 +16,7 @@ export class JobQueueService implements Disposable {
   constructor(
     private readonly logger: LoggerService,
     private readonly coreConfig: CoreConfigService,
+    private readonly executionContextService: ExecutionContextService,
     @inject(PG_BOSS_TOKEN, { isOptional: true }) pgBoss?: PgBoss
   ) {
     this.pgBoss =
@@ -35,7 +38,9 @@ export class JobQueueService implements Disposable {
       seenJobs.add(queueName);
       await this.pgBoss.createQueue(queueName, {
         name: queueName,
-        retryLimit: 10
+        retryLimit: 5,
+        retryBackoff: true,
+        retryDelayMax: 5 * 60
       });
     });
     await Promise.all(promises);
@@ -98,24 +103,46 @@ export class JobQueueService implements Disposable {
       const queueName = handler.accepts[JOB_NAME];
       const workersPromises = Array.from({ length: handler.concurrency ?? concurrency ?? 2 }).map(() =>
         this.pgBoss.work<JobPayload<Job>>(queueName, workerOptions, async ([job]) => {
-          this.logger.info({
-            event: "JOB_STARTED",
-            jobId: job.id
-          });
-          try {
-            await handler.handle(job.data);
+          await this.executionContextService.runWithContext(async () => {
+            this.executionContextService.set("CURRENT_USER", {
+              id: "bg-job-user",
+              bio: "",
+              email: "bg-job-user@akash.network",
+              emailVerified: false,
+              stripeCustomerId: "",
+              subscribedToNewsletter: false,
+              createdAt: new Date(),
+              lastActiveAt: new Date(),
+              lastIp: null,
+              lastUserAgent: null,
+              lastFingerprint: null,
+              youtubeUsername: null,
+              twitterUsername: null,
+              githubUsername: null,
+              userId: "system:bg-job-user",
+              username: "___bg_job_user___",
+              trial: false
+            });
+            this.executionContextService.set("ABILITY", createMongoAbility<MongoAbility>());
             this.logger.info({
-              event: "JOB_DONE",
+              event: "JOB_STARTED",
               jobId: job.id
             });
-          } catch (error) {
-            this.logger.error({
-              event: "JOB_FAILED",
-              jobId: job.id,
-              error
-            });
-            throw error;
-          }
+            try {
+              await handler.handle(job.data);
+              this.logger.info({
+                event: "JOB_DONE",
+                jobId: job.id
+              });
+            } catch (error) {
+              this.logger.error({
+                event: "JOB_FAILED",
+                jobId: job.id,
+                error
+              });
+              throw error;
+            }
+          });
         })
       );
 

--- a/apps/api/src/notifications/services/notification-handler/notification.handler.ts
+++ b/apps/api/src/notifications/services/notification-handler/notification.handler.ts
@@ -32,7 +32,7 @@ type NotificationTemplates = typeof notificationTemplates;
 type GenericNotificationTemplate = (user: UserOutput, vars?: Record<string, unknown>) => CreateNotificationInput;
 
 export class NotificationJob<T extends keyof NotificationTemplates = keyof NotificationTemplates> implements Job {
-  static readonly [JOB_NAME] = "notifications";
+  static readonly [JOB_NAME] = "NotificationJob";
   readonly name = NotificationJob[JOB_NAME];
   readonly version = 1;
 


### PR DESCRIPTION
## Why

Due to the nature of nodejs and DI, we need to run bg jobs in execution context to ensure that it's safe to use application services (which may depend on executionContext) inside background jobs.

For now, use empty ability (to ensure nothing bad happens) and fake user (to ensure feature flags service will produce stable values during gradual rollout). Just to minimize the changes because the final/proper decision in this regard should be done via a discussion proposal with enforcement on CI level. See https://github.com/akash-network/console/issues/1997


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Background jobs now run inside an execution context that provides a system user and permission checks per job.
  - Job retry behavior updated: retry backoff enabled, max retry delay added (up to 5 minutes), and retry limit reduced for controlled retries.
  - Notification job name standardized for clearer naming and observability.
  - Per-job logging now occurs within the execution context.

- Tests
  - Tests updated to cover context-aware job execution, logging, and adjusted queue retry configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->