### PR TITLE
test: add e2e test proving user can choose a template

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
+++ b/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
@@ -162,7 +162,7 @@ export const TemplateList: React.FunctionComponent<Props> = ({ onChangeGitProvid
               </Link>
             </div>
 
-            <div className="grid grid-cols-1 gap-2 md:grid-cols-2 md:gap-4 lg:grid-cols-3">
+            <div className="grid grid-cols-1 gap-2 md:grid-cols-2 md:gap-4 lg:grid-cols-3" aria-label="Template list">
               {previewTemplates.map(template => (
                 <TemplateBox
                   key={template.id}

--- a/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
+++ b/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
@@ -162,7 +162,7 @@ export const TemplateList: React.FunctionComponent<Props> = ({ onChangeGitProvid
               </Link>
             </div>
 
-            <div className="grid grid-cols-1 gap-2 md:grid-cols-2 md:gap-4 lg:grid-cols-3" aria-label="Template list">
+            <section className="grid grid-cols-1 gap-2 md:grid-cols-2 md:gap-4 lg:grid-cols-3" aria-label="Template list">
               {previewTemplates.map(template => (
                 <TemplateBox
                   key={template.id}
@@ -170,7 +170,7 @@ export const TemplateList: React.FunctionComponent<Props> = ({ onChangeGitProvid
                   linkHref={UrlService.newDeployment({ step: RouteStep.editDeployment, templateId: template?.id })}
                 />
               ))}
-            </div>
+            </section>
           </CardContent>
         </Card>
       </div>

--- a/apps/deploy-web/tests/ui/deploy-from-a-template.spec.ts
+++ b/apps/deploy-web/tests/ui/deploy-from-a-template.spec.ts
@@ -1,5 +1,3 @@
-import random from "lodash/random";
-
 import { expect, test } from "./fixture/base-test";
 import { DeployBasePage } from "./pages/DeployBasePage";
 
@@ -11,9 +9,14 @@ test("user can choose a template from the templates page", async ({ page, contex
 
   await expect(templateList).toBeVisible();
 
-  const templateLinks = templateList.locator("> a");
-  expect(await templateLinks.count()).toBeGreaterThan(0);
-  await templateLinks.nth(random(0, (await templateLinks.count()) - 1)).click();
+  const templateLinks = templateList.getByRole("link");
+  const templateCount = await templateLinks.count();
+  expect(templateCount).toBeGreaterThan(0);
 
-  await expect(page).toHaveURL(/\/new-deployment\?step=edit-deployment&templateId=.*/);
+  for (let i = 0; i < templateCount; i++) {
+    const [newPage] = await Promise.all([context.waitForEvent("page"), templateLinks.nth(i).click({ modifiers: ["Shift"] })]);
+
+    await expect(newPage).toHaveURL(/\/new-deployment\?step=edit-deployment&templateId=.*/);
+    await newPage.close();
+  }
 });

--- a/apps/deploy-web/tests/ui/deploy-from-a-template.spec.ts
+++ b/apps/deploy-web/tests/ui/deploy-from-a-template.spec.ts
@@ -1,0 +1,19 @@
+import random from "lodash/random";
+
+import { expect, test } from "./fixture/base-test";
+import { DeployBasePage } from "./pages/DeployBasePage";
+
+test("user can choose a template from the templates page", async ({ page, context }) => {
+  const templateListPage = new DeployBasePage(context, page, "new-deployment");
+  await templateListPage.goto();
+
+  const templateList = page.locator('[aria-label="Template list"]');
+
+  await expect(templateList).toBeVisible();
+
+  const templateLinks = templateList.locator("> a");
+  expect(await templateLinks.count()).toBeGreaterThan(0);
+  await templateLinks.nth(random(0, (await templateLinks.count()) - 1)).click();
+
+  await expect(page).toHaveURL(/\/new-deployment\?step=edit-deployment&templateId=.*/);
+});


### PR DESCRIPTION
closes #2004

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Added a screen-reader label (aria-label="Template list") to the template list in the new deployment flow for improved navigation with assistive technologies.

* **Tests**
  * Updated the end-to-end UI test to find the labeled template list and iterate over every template (opening each in a new page) to confirm navigation to the deployment edit step for each template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->