### PR TITLE
test: can start a trial and see a welcome modal

### DIFF
--- a/apps/deploy-web/src/components/layout/WelcomeToTrialModal.tsx
+++ b/apps/deploy-web/src/components/layout/WelcomeToTrialModal.tsx
@@ -54,6 +54,7 @@ export const WelcomeToTrialModal: React.FunctionComponent = () => {
           maxWidth="sm"
           enableCloseOnBackdropClick
           title="Welcome to Your Free Trial!"
+          testId="welcome-to-trial-modal"
         >
           <>
             <p className="mb-4">

--- a/apps/deploy-web/src/components/wallet/ConnectManagedWalletButton.tsx
+++ b/apps/deploy-web/src/components/wallet/ConnectManagedWalletButton.tsx
@@ -45,6 +45,7 @@ export const ConnectManagedWalletButton: React.FunctionComponent<Props> = ({ cla
       className={cn("border-primary bg-primary/10 dark:bg-primary", className)}
       {...rest}
       disabled={settings.isBlockchainDown || isWalletLoading}
+      aria-label="Start Trial"
     >
       {isWalletLoading ? <Spinner size="small" className="mr-2" variant="dark" /> : <Rocket className="rotate-45 text-xs" />}
       <span className="m-2 whitespace-nowrap">{hasManagedWallet ? "Switch to USD Payments" : "Start Trial"}</span>

--- a/apps/deploy-web/tests/ui/pages/FrontPage.tsx
+++ b/apps/deploy-web/tests/ui/pages/FrontPage.tsx
@@ -1,0 +1,29 @@
+import type { BrowserContext as Context, Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+
+import { testEnvConfig } from "../fixture/test-env.config";
+
+export type FeeType = "low" | "medium" | "high";
+export class FrontPage {
+  protected readonly feeType: FeeType = "low";
+
+  constructor(
+    readonly context: Context = context,
+    readonly page: Page
+  ) {}
+
+  async goto() {
+    await this.page.goto(`${testEnvConfig.BASE_URL}`);
+  }
+
+  async startTrial() {
+    const startTrialButton = this.page.locator('button[aria-label="Start Trial"]');
+    await expect(startTrialButton).toBeVisible();
+    await startTrialButton.click();
+  }
+
+  async closeWelcomeToTrialModal() {
+    await expect(this.page.getByTestId("welcome-to-trial-modal")).toBeVisible();
+    await this.page.locator('button[aria-label="Close"]').click();
+  }
+}

--- a/apps/deploy-web/tests/ui/start-trial.spec.ts
+++ b/apps/deploy-web/tests/ui/start-trial.spec.ts
@@ -1,0 +1,10 @@
+import { test } from "./fixture/base-test";
+import { FrontPage } from "./pages/FrontPage";
+
+test("can start trial", async ({ page, context }) => {
+  const templateListPage = new FrontPage(context, page);
+  await templateListPage.goto();
+
+  await templateListPage.startTrial();
+  await templateListPage.closeWelcomeToTrialModal();
+});

--- a/packages/ui/components/custom/popup.tsx
+++ b/packages/ui/components/custom/popup.tsx
@@ -249,7 +249,7 @@ export function Popup(props: React.PropsWithChildren<PopupProps>) {
         props.actions
           .filter(x => x.side === "left")
           .map(({ isLoading, side, label, ...rest }, idx) => (
-            <Button key={`dialog-action-button-${idx}`} {...rest}>
+            <Button key={`dialog-action-button-${idx}`} {...rest} aria-label={`${label}`}>
               {isLoading ? <Spinner size="small" /> : label}
             </Button>
           ));
@@ -258,7 +258,7 @@ export function Popup(props: React.PropsWithChildren<PopupProps>) {
         props.actions
           .filter(x => x.side === "right")
           .map(({ isLoading, side, label, ...rest }, idx) => (
-            <Button key={`dialog-action-button-${idx}`} {...rest}>
+            <Button key={`dialog-action-button-${idx}`} {...rest} aria-label={`${label}`}>
               {isLoading ? <Spinner size="small" /> : label}
             </Button>
           ));


### PR DESCRIPTION
closes #2000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Accessibility
  - Improved screen-reader support by adding an aria-label to the Start Trial button.
  - Added aria-labels to action buttons within popups for clearer assistive technology narration.

- Tests
  - Introduced a Front Page test helper to streamline UI interactions (navigation, starting trial, closing modal).
  - Added an end-to-end test validating the Start Trial flow.
  - Added a test identifier to the Welcome to Trial modal to enable reliable UI targeting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->