### PR TITLE
fix(onboarding): properly handles a non-registered user during email validation

### DIFF
--- a/apps/api/src/auth/routes/verify-email/verify-email.router.ts
+++ b/apps/api/src/auth/routes/verify-email/verify-email.router.ts
@@ -37,9 +37,7 @@ const route = createRoute({
   }
 });
 
-verifyEmailRouter.post(route.path, async function verifyEmail(c) {
-  const data = VerifyEmailRequestSchema.parse(await c.req.json());
-
-  const result = await container.resolve(AuthController).syncEmailVerified(data);
+verifyEmailRouter.openapi(route, async function verifyEmail(c) {
+  const result = await container.resolve(AuthController).syncEmailVerified(c.req.valid("json"));
   return c.json(result, 200);
 });

--- a/apps/api/src/core/repositories/base.repository.ts
+++ b/apps/api/src/core/repositories/base.repository.ts
@@ -147,7 +147,7 @@ export abstract class BaseRepository<
       .where(inArray(this.table.id, ids));
   }
 
-  async updateBy(query: Partial<Output>, payload: Partial<Input>, options?: MutationOptions): Promise<Output>;
+  async updateBy(query: Partial<Output>, payload: Partial<Input>, options?: MutationOptions): Promise<undefined | Output>;
   async updateBy(query: Partial<Output>, payload: Partial<Input>): Promise<void>;
   async updateBy(query: Partial<Output>, payload: Partial<Input>, options?: MutationOptions): Promise<void | Output> {
     const cursor = this.cursor

--- a/apps/api/src/user/services/user/user.service.ts
+++ b/apps/api/src/user/services/user/user.service.ts
@@ -128,11 +128,11 @@ export class UserService {
     }
   }
 
-  async syncEmailVerified({ email }: { email: string }) {
+  async syncEmailVerified({ email }: { email: string }): Promise<UserOutput> {
     const auth0User = await this.auth0.getUserByEmail(email);
     assert(auth0User, 404);
 
-    return await this.userRepository.updateBy(
+    const user = await this.userRepository.updateBy(
       {
         email
       },
@@ -143,6 +143,10 @@ export class UserService {
         returning: true
       }
     );
+
+    assert(user, 404);
+
+    return user;
   }
 }
 

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -14203,6 +14203,75 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
         ],
       },
     },
+    "/v1/verify-email": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "email": {
+                        "format": "email",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "email",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "required": true,
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "emailVerified": {
+                          "type": "boolean",
+                        },
+                      },
+                      "required": [
+                        "emailVerified",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns email verification status",
+          },
+          "401": {
+            "description": "Unauthorized",
+          },
+          "404": {
+            "description": "User not found",
+          },
+        },
+        "summary": "Checks if the email is verified",
+        "tags": [
+          "Users",
+        ],
+      },
+    },
     "/v1/version/{network}": {
       "get": {
         "description": "Provide a cached version of one of these files: [https://raw.githubusercontent.com/akash-network/net/master/mainnet/version.txt](https://raw.githubusercontent.com/akash-network/net/master/mainnet/version.txt), [https://raw.githubusercontent.com/akash-network/net/master/sandbox/version.txt](https://raw.githubusercontent.com/akash-network/net/master/sandbox/version.txt), [https://raw.githubusercontent.com/akash-network/net/master/testnet-02/version.txt](https://raw.githubusercontent.com/akash-network/net/master/testnet-02/version.txt)",

--- a/apps/api/test/functional/verify-email.spec.ts
+++ b/apps/api/test/functional/verify-email.spec.ts
@@ -1,10 +1,11 @@
-import type { ApiResponse, GetUsers200ResponseOneOfInner, GetUsersByEmailRequest } from "auth0";
+import type { ApiResponse, GetUsers200ResponseOneOfInner } from "auth0";
 import { ManagementClient } from "auth0";
 import { container } from "tsyringe";
 
 import { Auth0Service } from "@src/auth/services/auth0/auth0.service";
 import { UserAuthTokenService } from "@src/auth/services/user-auth-token/user-auth-token.service";
 import { app } from "@src/rest-app";
+import { UserRepository } from "@src/user/repositories";
 
 import { WalletTestingService } from "@test/services/wallet-testing.service";
 
@@ -69,7 +70,28 @@ describe("Syncing 'email verified' from auth0", () => {
     it("throws 404 when user is not found in auth0", async () => {
       const { user, token } = await setup({ emailVerified: false });
       const auth0Service = container.resolve(Auth0Service);
-      jest.spyOn(auth0Service, "getUserByEmail").mockResolvedValue(null);
+      jest.spyOn(auth0Service, "getUserByEmail").mockResolvedValueOnce(null);
+
+      const response = await app.request("/v1/verify-email", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token}`,
+          "content-type": "application/json"
+        },
+        body: JSON.stringify({
+          data: {
+            email: user.email
+          }
+        })
+      });
+
+      expect(response.status).toBe(404);
+    });
+
+    it("throws 404 when user is not registered", async () => {
+      const { user, token } = await setup({ emailVerified: false });
+      const userRepository = await container.resolve(UserRepository);
+      await userRepository.deleteById(user.id);
 
       const response = await app.request("/v1/verify-email", {
         method: "POST",
@@ -95,22 +117,14 @@ describe("Syncing 'email verified' from auth0", () => {
     });
 
     const managementClient = container.resolve(ManagementClient);
-    jest
-      .spyOn(managementClient.usersByEmail, "getByEmail")
-      .mockImplementation(async ({ email }: GetUsersByEmailRequest): Promise<ApiResponse<GetUsers200ResponseOneOfInner[]>> => {
-        if (email.toLowerCase() === user.email.toLowerCase()) {
-          return Promise.resolve({
-            data: [
-              {
-                user_id: user.userId,
-                email_verified: input.emailVerified
-              }
-            ]
-          } as ApiResponse<GetUsers200ResponseOneOfInner[]>);
+    jest.spyOn(managementClient.usersByEmail, "getByEmail").mockResolvedValueOnce({
+      data: [
+        {
+          user_id: user.userId,
+          email_verified: input.emailVerified
         }
-
-        return Promise.resolve({ data: [] as GetUsers200ResponseOneOfInner[] } as ApiResponse<GetUsers200ResponseOneOfInner[]>);
-      });
+      ]
+    } as ApiResponse<GetUsers200ResponseOneOfInner[]>);
 
     const userAuthTokenService = container.resolve(UserAuthTokenService);
     jest.spyOn(userAuthTokenService, "getValidUserId").mockResolvedValue(user.userId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
-        "@akashnetwork/jwt": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/net": "*",
         "@akashnetwork/react-query-sdk": "*",
@@ -895,7 +894,6 @@
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
         "@akashnetwork/akashjs": "^0.11.1",
-        "@akashnetwork/chain-sdk": "^1.0.0-alpha.3",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/jwt": "*",


### PR DESCRIPTION
closes #1972

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Verify Email now reliably returns 404 when an email is not registered and consistently returns a 200 JSON response when verified.
  * Ensures updated user data is validated and non-null before being returned.

* **Refactor**
  * Verify Email endpoint migrated to OpenAPI-driven handling for standardized request validation and response flow.

* **Tests**
  * Simplified and strengthened functional tests covering not-registered (404) and verified scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->