### PR TITLE
feat(config): uses correct sdk53 testnet config

### DIFF
--- a/config/testnet-02-nodes.json
+++ b/config/testnet-02-nodes.json
@@ -1,7 +1,0 @@
-[
-  {
-    "id": "testnet-02.aksh.pw",
-    "api": "https://api.testnet-02.aksh.pw:443",
-    "rpc": "https://rpc.testnet-02.aksh.pw:443"
-  }
-]

--- a/packages/net/src/NetConfig/NetConfig.ts
+++ b/packages/net/src/NetConfig/NetConfig.ts
@@ -5,7 +5,7 @@ export type SupportedChainNetworks = keyof typeof netConfigData;
 export class NetConfig {
   readonly networkMap: Partial<Record<string, SupportedChainNetworks>> = {
     sandbox: "sandbox-2",
-    testnet: "testnet-02"
+    testnet: "testnet-7"
   };
 
   mapped(network: string): SupportedChainNetworks {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated default testnet mapping from “testnet-02” to “testnet-7” to align with the current network.
- **Chores**
  - Removed legacy testnet-02 node configuration from the app.

User impact:
- Connections and references now target testnet-7.
- testnet-02 is no longer available via the built-in configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->