### PR TITLE
refactor: migrates jwt signing in accordance to chain-sdk

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@akashnetwork/akash-api": "^1.3.0",
     "@akashnetwork/akashjs": "^0.11.1",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.7",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.9",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/api/src/billing/lib/wallet/wallet.ts
+++ b/apps/api/src/billing/lib/wallet/wallet.ts
@@ -1,4 +1,5 @@
-import { stringToPath } from "@cosmjs/crypto";
+import type { AminoSignResponse, OfflineAminoSigner, StdSignDoc } from "@cosmjs/amino";
+import { makeCosmoshubPath, Secp256k1HdWallet } from "@cosmjs/amino";
 import type { OfflineDirectSigner } from "@cosmjs/proto-signing";
 import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import type { DirectSecp256k1HdWalletOptions } from "@cosmjs/proto-signing/build/directsecp256k1hdwallet";
@@ -11,11 +12,12 @@ export class Wallet implements OfflineDirectSigner {
 
   private readonly PREFIX = "akash";
 
-  private readonly HD_PATH = "m/44'/118'/0'/0";
-
   private readonly instanceAsPromised: Promise<DirectSecp256k1HdWallet>;
+  private aminoSignerPromise?: Promise<OfflineAminoSigner>;
+  private readonly walletIndex?: number;
 
   constructor(mnemonic?: string, index?: number) {
+    this.walletIndex = index;
     if (typeof mnemonic === "undefined") {
       this.instanceAsPromised = DirectSecp256k1HdWallet.generate(24, this.getInstanceOptions(index));
     } else {
@@ -30,7 +32,7 @@ export class Wallet implements OfflineDirectSigner {
 
     return {
       prefix: this.PREFIX,
-      hdPaths: [stringToPath(`${this.HD_PATH}/${index}`)]
+      hdPaths: [makeCosmoshubPath(index)]
     };
   }
 
@@ -40,6 +42,13 @@ export class Wallet implements OfflineDirectSigner {
 
   async signDirect(signerAddress: string, signDoc: SignDoc) {
     return (await this.instanceAsPromised).signDirect(signerAddress, signDoc);
+  }
+
+  async signAmino(address: string, data: StdSignDoc): Promise<AminoSignResponse> {
+    const wallet = await this.instanceAsPromised;
+    this.aminoSignerPromise ??= Secp256k1HdWallet.fromMnemonic(wallet.mnemonic, this.getInstanceOptions(this.walletIndex));
+    const aminoSigner = await this.aminoSignerPromise;
+    return aminoSigner.signAmino(address, data);
   }
 
   async getFirstAddress() {

--- a/apps/api/src/provider/providers/jwt.provider.ts
+++ b/apps/api/src/provider/providers/jwt.provider.ts
@@ -1,9 +1,8 @@
-import { createSignArbitraryAkashWallet, JwtTokenManager } from "@akashnetwork/chain-sdk";
+import { JwtTokenManager } from "@akashnetwork/chain-sdk";
 import type { InjectionToken } from "tsyringe";
 import { container } from "tsyringe";
 
 const jwt = {
-  createSignArbitraryAkashWallet,
   JwtTokenManager
 };
 

--- a/apps/api/src/provider/services/provider-jwt-token/provider-jwt-token.service.spec.ts
+++ b/apps/api/src/provider/services/provider-jwt-token/provider-jwt-token.service.spec.ts
@@ -14,14 +14,14 @@ import { createAkashAddress } from "@test/seeders";
 describe(ProviderJwtTokenService.name, () => {
   describe("generateJwtToken", () => {
     it("should generate a JWT token successfully", async () => {
-      const { providerJwtTokenService, walletId, accessRules, jwtTokenValue, jwtToken, walletFactory, masterWalletMnemonic, jwtModule, akashWallet, address } =
+      const { providerJwtTokenService, walletId, accessRules, jwtTokenValue, jwtToken, walletFactory, masterWalletMnemonic, jwtModule, address, wallet } =
         setup();
 
       const result = await providerJwtTokenService.generateJwtToken({ walletId, leases: accessRules });
 
       expect(result.unwrap()).toEqual(jwtTokenValue);
       expect(walletFactory).toHaveBeenCalledWith(masterWalletMnemonic, walletId);
-      expect(jwtModule.JwtTokenManager).toHaveBeenCalledWith(akashWallet);
+      expect(jwtModule.JwtTokenManager).toHaveBeenCalledWith(wallet);
       expect(jwtToken.generateToken).toHaveBeenCalledWith({
         version: "v1",
         exp: expect.any(Number),
@@ -40,7 +40,6 @@ describe(ProviderJwtTokenService.name, () => {
       await providerJwtTokenService.generateJwtToken({ walletId, leases: accessRules });
 
       expect(walletFactory).toHaveBeenCalledTimes(1);
-      expect(jwtModule.createSignArbitraryAkashWallet).toHaveBeenCalledTimes(1);
       expect(jwtModule.JwtTokenManager).toHaveBeenCalledTimes(1);
     });
 
@@ -74,14 +73,15 @@ describe(ProviderJwtTokenService.name, () => {
     const directSecp256k1HdWallet = mock<DirectSecp256k1HdWallet>();
     directSecp256k1HdWallet.getAccounts.mockResolvedValue([{ address, pubkey: new Uint8Array([1, 2, 3]), algo: "secp256k1" }]);
 
-    const wallet = mock<Wallet>();
-    wallet.getInstance.mockResolvedValue(directSecp256k1HdWallet);
-
-    const akashWallet = {
-      address,
-      pubkey: new Uint8Array([1, 2, 3]),
-      signArbitrary: jest.fn().mockResolvedValue({ signature: "test-signature" })
-    };
+    const wallet = mock<Wallet>({
+      getInstance: jest.fn().mockResolvedValue(directSecp256k1HdWallet),
+      getFirstAddress: jest.fn().mockResolvedValue(address),
+      signAmino: jest.fn().mockResolvedValue({
+        signature: {
+          signature: "test-signature"
+        }
+      })
+    });
 
     const jwtToken = mock<JwtTokenManager>({
       validatePayload: jest.fn().mockReturnValue({ errors: undefined }),
@@ -89,7 +89,6 @@ describe(ProviderJwtTokenService.name, () => {
     });
 
     const jwtModule = mock<JWTModule>({
-      createSignArbitraryAkashWallet: jest.fn(async () => akashWallet),
       JwtTokenManager: jest.fn(() => jwtToken)
     });
 
@@ -118,7 +117,6 @@ describe(ProviderJwtTokenService.name, () => {
       jwtTokenValue,
       masterWalletMnemonic,
       jwtModule,
-      akashWallet,
       jwtToken,
       address,
       walletFactory,

--- a/apps/api/src/provider/services/provider-jwt-token/provider-jwt-token.service.ts
+++ b/apps/api/src/provider/services/provider-jwt-token/provider-jwt-token.service.ts
@@ -55,10 +55,10 @@ export class ProviderJwtTokenService {
   @Memoize({ ttlInSeconds: minutesToSeconds(5) })
   private async getJwtToken(walletId: number): Promise<JwtTokenWithAddress> {
     const wallet = this.walletFactory(this.billingConfigService.get("MASTER_WALLET_MNEMONIC"), walletId);
-    const akashWallet = await this.jwtModule.createSignArbitraryAkashWallet((await wallet.getInstance()) as any, walletId);
-    const jwtTokenManager = new this.jwtModule.JwtTokenManager(akashWallet);
+    const jwtTokenManager = new this.jwtModule.JwtTokenManager(wallet);
+    const address = await wallet.getFirstAddress();
 
-    return { jwtTokenManager, address: akashWallet.address };
+    return { jwtTokenManager, address };
   }
 
   getGranularLeases({ provider, scope }: { provider: string; scope: AccessScope[] }): JwtTokenPayload["leases"] {

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@akashnetwork/akash-api": "^1.3.0",
     "@akashnetwork/akashjs": "^0.11.1",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.8",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.9",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -22,7 +22,7 @@
     "test:unit": "jest --selectProjects unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.7",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.9",
     "@akashnetwork/logging": "*",
     "@akashnetwork/net": "*",
     "@cosmjs/encoding": "^0.32.4",
@@ -41,7 +41,7 @@
     "@akashnetwork/dev-config": "*",
     "@akashnetwork/docker": "*",
     "@akashnetwork/releaser": "*",
-    "@cosmjs/proto-signing": "^0.33.1",
+    "@cosmjs/amino": "^0.33.1",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.16",
     "@types/node": "^22.13.11",

--- a/apps/provider-proxy/src/utils/schema.ts
+++ b/apps/provider-proxy/src/utils/schema.ts
@@ -31,10 +31,6 @@ export const providerRequestSchema = z.object({
   keyPem: z.string().describe('Deprecated key. Use mtls auth type  with "auth.keyPem" instead.').optional()
 });
 
-// we need just validation and decoding that's why signer is not provided
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const jwtTokenManager = new JwtTokenManager({} as any);
-
 export type ProviderRequestSchema = Omit<z.infer<typeof providerRequestSchema>, "chainNetwork" | "certPem" | "keyPem">;
 
 /** this can be attached as .superRefine in zod v4 */
@@ -81,6 +77,11 @@ export function addProviderAuthValidation<T extends z.ZodType<any>>(schema: T): 
     }) as unknown as z.ZodEffects<T>;
 }
 
+const jwtTokenManager = new JwtTokenManager({
+  signArbitrary: () => {
+    throw new Error("Cannot generate token: it was created for payload validation only");
+  }
+});
 function validateJwtPayload(token: string): { isValid: boolean; errors?: string[] } {
   try {
     return jwtTokenManager.validatePayload(jwtTokenManager.decodeToken(token));

--- a/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
@@ -1,6 +1,6 @@
-import { createSignArbitraryAkashWallet, JwtTokenManager } from "@akashnetwork/chain-sdk";
+import { JwtTokenManager } from "@akashnetwork/chain-sdk";
 import type { SupportedChainNetworks } from "@akashnetwork/net";
-import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
+import { Secp256k1HdWallet } from "@cosmjs/amino";
 import { setTimeout as wait } from "timers/promises";
 import type { TLSSocket } from "tls";
 
@@ -681,8 +681,8 @@ describe("Provider HTTP proxy", () => {
 
     const testMnemonic =
       "body letter input area umbrella develop shuffle gentle regular gold twice truly giant dawn nerve ocean wine wonder toe melt grid leader blush few";
-    const wallet = await DirectSecp256k1HdWallet.fromMnemonic(testMnemonic, { prefix: "akash" });
-    const tokenManager = new JwtTokenManager(await createSignArbitraryAkashWallet(wallet));
+    const wallet = await Secp256k1HdWallet.fromMnemonic(testMnemonic, { prefix: "akash" });
+    const tokenManager = new JwtTokenManager(wallet);
     const token = await tokenManager.generateToken({
       iss: (await wallet.getAccounts())[0].address,
       exp: Math.floor(Date.now() / 1000) + 3600,

--- a/apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts
@@ -1,5 +1,5 @@
-import { createSignArbitraryAkashWallet, JwtTokenManager } from "@akashnetwork/chain-sdk";
-import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
+import { JwtTokenManager } from "@akashnetwork/chain-sdk";
+import { Secp256k1HdWallet } from "@cosmjs/amino";
 import { setTimeout } from "timers/promises";
 import type { TLSSocket } from "tls";
 import WebSocket from "ws";
@@ -312,8 +312,8 @@ describe("Provider proxy ws", () => {
 
     const testMnemonic =
       "body letter input area umbrella develop shuffle gentle regular gold twice truly giant dawn nerve ocean wine wonder toe melt grid leader blush few";
-    const wallet = await DirectSecp256k1HdWallet.fromMnemonic(testMnemonic, { prefix: "akash" });
-    const tokenManager = new JwtTokenManager(await createSignArbitraryAkashWallet(wallet));
+    const wallet = await Secp256k1HdWallet.fromMnemonic(testMnemonic, { prefix: "akash" });
+    const tokenManager = new JwtTokenManager(wallet);
     const token = await tokenManager.generateToken({
       iss: (await wallet.getAccounts())[0].address,
       exp: Math.floor(Date.now() / 1000) + 3600,

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
         "@akashnetwork/akashjs": "^0.11.1",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.7",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.9",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -894,7 +894,7 @@
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
         "@akashnetwork/akashjs": "^0.11.1",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.8",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.9",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/logging": "*",
@@ -1054,177 +1054,6 @@
         "whatwg-fetch": "^3.6.20"
       }
     },
-    "apps/deploy-web/node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.8.tgz",
-      "integrity": "sha512-xKclgXCmLPbOddULJviZMuxfWNNYgfVj8k6zq6BE6oVfncmcnMKJ/htlD9l/RHGHZAvOGKm1kbHV1cMV77HpYg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@bufbuild/protobuf": "^2.2.3",
-        "@connectrpc/connect": "^2.0.1",
-        "@connectrpc/connect-node": "^2.0.1",
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/math": "^0.33.1",
-        "@cosmjs/proto-signing": "^0.33.1",
-        "@cosmjs/stargate": "^0.33.1",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify": "^1.3.0",
-        "jsrsasign": "^11.1.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": "22.14.0"
-      }
-    },
-    "apps/deploy-web/node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/encoding": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.33.1.tgz",
-      "integrity": "sha512-nuNxf29fUcQE14+1p//VVQDwd1iau5lhaW/7uMz7V2AH3GJbFJoJVaKvVyZvdFk+Cnu+s3wCqgq4gJkhRCJfKw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "apps/deploy-web/node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/math": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.33.1.tgz",
-      "integrity": "sha512-ytGkWdKFCPiiBU5eqjHNd59djPpIsOjbr2CkNjlnI1Zmdj+HDkSoD9MUGpz9/RJvRir5IvsXqdE05x8EtoQkJA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "apps/deploy-web/node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/proto-signing": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.33.1.tgz",
-      "integrity": "sha512-Sv4W+MxX+0LVnd+2rU4Fw1HRsmMwSVSYULj7pRkij3wnPwUlTVoJjmKFgKz13ooIlfzPrz/dnNjGp/xnmXChFQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.33.1",
-        "@cosmjs/crypto": "^0.33.1",
-        "@cosmjs/encoding": "^0.33.1",
-        "@cosmjs/math": "^0.33.1",
-        "@cosmjs/utils": "^0.33.1",
-        "cosmjs-types": "^0.9.0"
-      }
-    },
-    "apps/deploy-web/node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/proto-signing/node_modules/@cosmjs/amino": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.33.1.tgz",
-      "integrity": "sha512-WfWiBf2EbIWpwKG9AOcsIIkR717SY+JdlXM/SL/bI66BdrhniAF+/ZNis9Vo9HF6lP2UU5XrSmFA4snAvEgdrg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.33.1",
-        "@cosmjs/encoding": "^0.33.1",
-        "@cosmjs/math": "^0.33.1",
-        "@cosmjs/utils": "^0.33.1"
-      }
-    },
-    "apps/deploy-web/node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/stargate": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.33.1.tgz",
-      "integrity": "sha512-CnJ1zpSiaZgkvhk+9aTp5IPmgWn2uo+cNEBN8VuD9sD6BA0V4DMjqe251cNFLiMhkGtiE5I/WXFERbLPww3k8g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.33.1",
-        "@cosmjs/encoding": "^0.33.1",
-        "@cosmjs/math": "^0.33.1",
-        "@cosmjs/proto-signing": "^0.33.1",
-        "@cosmjs/stream": "^0.33.1",
-        "@cosmjs/tendermint-rpc": "^0.33.1",
-        "@cosmjs/utils": "^0.33.1",
-        "cosmjs-types": "^0.9.0"
-      }
-    },
-    "apps/deploy-web/node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/stargate/node_modules/@cosmjs/amino": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.33.1.tgz",
-      "integrity": "sha512-WfWiBf2EbIWpwKG9AOcsIIkR717SY+JdlXM/SL/bI66BdrhniAF+/ZNis9Vo9HF6lP2UU5XrSmFA4snAvEgdrg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.33.1",
-        "@cosmjs/encoding": "^0.33.1",
-        "@cosmjs/math": "^0.33.1",
-        "@cosmjs/utils": "^0.33.1"
-      }
-    },
-    "apps/deploy-web/node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/stream": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.33.1.tgz",
-      "integrity": "sha512-bMUvEENjeQPSTx+YRzVsWT1uFIdHRcf4brsc14SOoRQ/j5rOJM/aHfsf/BmdSAnYbdOQ3CMKj/8nGAQ7xUdn7w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "apps/deploy-web/node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.33.1.tgz",
-      "integrity": "sha512-22klDFq2MWnf//C8+rZ5/dYatr6jeGT+BmVbutXYfAK9fmODbtFcumyvB6uWaEORWfNukl8YK1OLuaWezoQvxA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.33.1",
-        "@cosmjs/encoding": "^0.33.1",
-        "@cosmjs/json-rpc": "^0.33.1",
-        "@cosmjs/math": "^0.33.1",
-        "@cosmjs/socket": "^0.33.1",
-        "@cosmjs/stream": "^0.33.1",
-        "@cosmjs/utils": "^0.33.1",
-        "axios": "^1.6.0",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "apps/deploy-web/node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/utils": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.33.1.tgz",
-      "integrity": "sha512-UnLHDY6KMmC+UXf3Ufyh+onE19xzEXjT4VZ504Acmk4PXxqyvG4cCPprlKUFnGUX7f0z8Or9MAOHXBx41uHBcg==",
-      "license": "Apache-2.0"
-    },
-    "apps/deploy-web/node_modules/@cosmjs/crypto": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.33.1.tgz",
-      "integrity": "sha512-U4kGIj/SNBzlb2FGgA0sMR0MapVgJUg8N+oIAiN5+vl4GZ3aefmoL1RDyTrFS/7HrB+M+MtHsxC0tvEu4ic/zA==",
-      "deprecated": "This uses elliptic for cryptographic operations, which contains several security-relevant bugs. To what degree this affects your application is something you need to carefully investigate. See https://github.com/cosmos/cosmjs/issues/1708 for further pointers. Starting with version 0.34.0 the cryptographic library has been replaced. However, private keys might still be at risk.",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.33.1",
-        "@cosmjs/math": "^0.33.1",
-        "@cosmjs/utils": "^0.33.1",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.6.1",
-        "libsodium-wrappers-sumo": "^0.7.11"
-      }
-    },
-    "apps/deploy-web/node_modules/@cosmjs/crypto/node_modules/@cosmjs/encoding": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.33.1.tgz",
-      "integrity": "sha512-nuNxf29fUcQE14+1p//VVQDwd1iau5lhaW/7uMz7V2AH3GJbFJoJVaKvVyZvdFk+Cnu+s3wCqgq4gJkhRCJfKw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "apps/deploy-web/node_modules/@cosmjs/crypto/node_modules/@cosmjs/math": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.33.1.tgz",
-      "integrity": "sha512-ytGkWdKFCPiiBU5eqjHNd59djPpIsOjbr2CkNjlnI1Zmdj+HDkSoD9MUGpz9/RJvRir5IvsXqdE05x8EtoQkJA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "apps/deploy-web/node_modules/@cosmjs/crypto/node_modules/@cosmjs/utils": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.33.1.tgz",
-      "integrity": "sha512-UnLHDY6KMmC+UXf3Ufyh+onE19xzEXjT4VZ504Acmk4PXxqyvG4cCPprlKUFnGUX7f0z8Or9MAOHXBx41uHBcg==",
-      "license": "Apache-2.0"
-    },
     "apps/deploy-web/node_modules/@cosmjs/encoding": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
@@ -1235,52 +1064,12 @@
         "readonly-date": "^1.0.0"
       }
     },
-    "apps/deploy-web/node_modules/@cosmjs/json-rpc": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.33.1.tgz",
-      "integrity": "sha512-T6VtWzecpmuTuMRGZWuBYHsMF/aznWCYUt/cGMWNSz7DBPipVd0w774PKpxXzpEbyt5sr61NiuLXc+Az15S/Cw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.33.1",
-        "xstream": "^11.14.0"
-      }
-    },
-    "apps/deploy-web/node_modules/@cosmjs/json-rpc/node_modules/@cosmjs/stream": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.33.1.tgz",
-      "integrity": "sha512-bMUvEENjeQPSTx+YRzVsWT1uFIdHRcf4brsc14SOoRQ/j5rOJM/aHfsf/BmdSAnYbdOQ3CMKj/8nGAQ7xUdn7w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
     "apps/deploy-web/node_modules/@cosmjs/math": {
       "version": "0.32.4",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
       "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
       "dependencies": {
         "bn.js": "^5.2.0"
-      }
-    },
-    "apps/deploy-web/node_modules/@cosmjs/socket": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.33.1.tgz",
-      "integrity": "sha512-KzAeorten6Vn20sMiM6NNWfgc7jbyVo4Zmxev1FXa5EaoLCZy48cmT3hJxUJQvJP/lAy8wPGEjZ/u4rmF11x9A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.33.1",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "apps/deploy-web/node_modules/@cosmjs/socket/node_modules/@cosmjs/stream": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.33.1.tgz",
-      "integrity": "sha512-bMUvEENjeQPSTx+YRzVsWT1uFIdHRcf4brsc14SOoRQ/j5rOJM/aHfsf/BmdSAnYbdOQ3CMKj/8nGAQ7xUdn7w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xstream": "^11.14.0"
       }
     },
     "apps/deploy-web/node_modules/@cosmjs/stargate": {
@@ -2330,27 +2119,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "apps/deploy-web/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "apps/deploy-web/node_modules/xtend": {
@@ -4798,7 +4566,7 @@
       "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.7",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.9",
         "@akashnetwork/logging": "*",
         "@akashnetwork/net": "*",
         "@cosmjs/encoding": "^0.32.4",
@@ -4817,7 +4585,7 @@
         "@akashnetwork/dev-config": "*",
         "@akashnetwork/docker": "*",
         "@akashnetwork/releaser": "*",
-        "@cosmjs/proto-signing": "^0.33.1",
+        "@cosmjs/amino": "^0.33.1",
         "@types/cors": "^2.8.13",
         "@types/express": "^4.17.16",
         "@types/node": "^22.13.11",
@@ -4912,33 +4680,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bn.js": "^5.2.0"
-      }
-    },
-    "apps/provider-proxy/node_modules/@cosmjs/proto-signing": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.33.1.tgz",
-      "integrity": "sha512-Sv4W+MxX+0LVnd+2rU4Fw1HRsmMwSVSYULj7pRkij3wnPwUlTVoJjmKFgKz13ooIlfzPrz/dnNjGp/xnmXChFQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.33.1",
-        "@cosmjs/crypto": "^0.33.1",
-        "@cosmjs/encoding": "^0.33.1",
-        "@cosmjs/math": "^0.33.1",
-        "@cosmjs/utils": "^0.33.1",
-        "cosmjs-types": "^0.9.0"
-      }
-    },
-    "apps/provider-proxy/node_modules/@cosmjs/proto-signing/node_modules/@cosmjs/encoding": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.33.1.tgz",
-      "integrity": "sha512-nuNxf29fUcQE14+1p//VVQDwd1iau5lhaW/7uMz7V2AH3GJbFJoJVaKvVyZvdFk+Cnu+s3wCqgq4gJkhRCJfKw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
       }
     },
     "apps/provider-proxy/node_modules/@cosmjs/utils": {
@@ -6395,9 +6136,9 @@
       }
     },
     "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.7.tgz",
-      "integrity": "sha512-HMcNbBgWHN3aVpesJX72AtlN0xstt+ASZsFwaxF/W1XZKdAUU4bRnhXfElTHFRAg7SVIfdflfBXtnR1YR5CX4w==",
+      "version": "1.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.9.tgz",
+      "integrity": "sha512-hwettpxBWK9Ppl3Le0nQQIVLdmsQ3zU5hyaraCQpx1ZTr+2M49id6DYJ64eSRg7p20RmTSo/Rmh20zcgnTIaTw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.3",

--- a/script/safe-deps-install.sh
+++ b/script/safe-deps-install.sh
@@ -33,6 +33,10 @@ print_message() {
 }
 
 npm ci --ignore-scripts "${@}"
+if [ $? -ne 0 ]; then
+  print_message "error" "npm ci failed"
+  exit 1
+fi
 
 echo "\n"
 print_message "important" "Triggering install npm script for trusted packages"


### PR DESCRIPTION
## Why

To adjust to the same signing alg between web and offline signers. Blocked by https://github.com/akash-network/chain-sdk/pull/110

Requires installation of chain-sdk version from that PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for amino/legacy wallet signing, enabling broader wallet compatibility for authentication.
* Bug Fixes
  * Improved handling when the blockchain is down to prevent repeated checks and unnecessary refreshes, resulting in a smoother experience during outages.
  * Streamlined JWT token generation across services for more reliable authentication.
* Chores
  * Updated blockchain SDK dependencies for compatibility and stability.
  * Hardened dependency installation script to fail fast with clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->