### PR TITLE
fix: chain api fallback to indexer

### DIFF
--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -223,7 +223,7 @@ const getByOwnerAndDseqRoute = createRoute({
 
 const fallbackListRoute = createRoute({
   method: "get",
-  path: "/akash/deployment/v1beta3/deployments/list",
+  path: "/akash/deployment/{version}/deployments/list",
   summary: "List deployments (database fallback)",
   tags: ["Deployments"],
   request: {
@@ -243,7 +243,7 @@ const fallbackListRoute = createRoute({
 
 const fallbackInfoRoute = createRoute({
   method: "get",
-  path: "/akash/deployment/v1beta3/deployments/info",
+  path: "/akash/deployment/{version}/deployments/info",
   summary: "Get deployment info (database fallback)",
   tags: ["Deployments"],
   request: {

--- a/apps/api/src/deployment/routes/leases/leases.router.ts
+++ b/apps/api/src/deployment/routes/leases/leases.router.ts
@@ -35,7 +35,7 @@ const createLeaseRoute = createRoute({
 
 const fallbackListRoute = createRoute({
   method: "get",
-  path: "/akash/market/v1beta4/leases/list",
+  path: "/akash/market/{version}/leases/list",
   summary: "List leases (database fallback)",
   tags: ["Leases"],
   request: {


### PR DESCRIPTION
## Why

to support changing version during network upgrade

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Deployment fallback endpoints now accept a version path parameter:
    - /akash/deployment/{version}/deployments/list
    - /akash/deployment/{version}/deployments/info
  * Leases fallback endpoint now accepts a version path parameter:
    - /akash/market/{version}/leases/list
  * Methods, query handling, response schemas, and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->