### PR TITLE
fix: update 'Help from Expert' link to new hsforms URL

### DIFF
--- a/apps/deploy-web/src/components/layout/Sidebar.tsx
+++ b/apps/deploy-web/src/components/layout/Sidebar.tsx
@@ -227,7 +227,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
           {
             title: "Help from Expert",
             icon: props => <HeadsetHelp {...props} />,
-            url: "https://share.hsforms.com/1gQOaeJXgQ-GMc7MnsTOmsAsaima",
+            url: "https://share.hsforms.com/29tSLilX9Qye5Rxrlsz7WPwsaima",
             activeRoutes: [],
             target: "_blank",
             isNew: true


### PR DESCRIPTION
## Fix: Update "Help from Expert" Link

Fixes #2056

Updates the "Help from Expert" link in the sidebar to point to the new HubSpot form URL.

### Changes
- Updated URL in `apps/deploy-web/src/components/layout/Sidebar.tsx` from the old hsforms link to `https://share.hsforms.com/29tSLilX9Qye5Rxrlsz7WPwsaima`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Help from Expert sidebar link URL to direct to the correct resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->