### PR TITLE
fix: uses formatDistanceToNow instead of differenceInX to calc time left

### DIFF
--- a/apps/api/src/notifications/services/notification-templates/before-close-trial-deployment.ts
+++ b/apps/api/src/notifications/services/notification-templates/before-close-trial-deployment.ts
@@ -1,4 +1,4 @@
-import { differenceInHours } from "date-fns";
+import { formatDistanceToNow } from "date-fns";
 
 import type { UserOutput } from "@src/user/repositories";
 import type { CreateNotificationInput } from "../notification/notification.service";
@@ -8,12 +8,12 @@ export function beforeCloseTrialDeploymentNotification(
   vars: { deploymentClosedAt: string; dseq: string; owner: string }
 ): CreateNotificationInput {
   const deploymentClosedAt = new Date(vars.deploymentClosedAt);
-  const timeLeft = deploymentClosedAt.getTime() < Date.now() ? 0 : differenceInHours(deploymentClosedAt, new Date());
+  const timeLeft = deploymentClosedAt.getTime() < Date.now() ? "in a few seconds" : formatDistanceToNow(deploymentClosedAt, { addSuffix: true });
   return {
-    notificationId: `beforeCloseTrialDeployment.${timeLeft}.${vars.dseq}.${vars.owner}`,
+    notificationId: `beforeCloseTrialDeployment.${deploymentClosedAt.toISOString()}.${vars.dseq}.${vars.owner}`,
     payload: {
       summary: "Your Trial Deployment Ends Soon",
-      description: `Your trial deployment will end in ${timeLeft} hours. To keep your deployment running, please add a payment method and top up your account before then.`
+      description: `Your trial deployment will end ${timeLeft}. To keep your deployment running, please add a payment method and top up your account before then.`
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/before-trial-ends-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/before-trial-ends-notification.ts
@@ -1,4 +1,4 @@
-import { differenceInDays } from "date-fns";
+import { formatDistanceToNow } from "date-fns";
 
 import type { ResolvedValue } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import type { UserOutput } from "@src/user/repositories";
@@ -9,13 +9,13 @@ export function beforeTrialEndsNotification(
   vars: { trialEndsAt: string; paymentLink: string; remainingCredits: ResolvedValue<number>; activeDeployments: ResolvedValue<number> }
 ): CreateNotificationInput {
   const trialEndsDate = new Date(vars.trialEndsAt);
-  const daysLeft = trialEndsDate.getTime() < Date.now() ? 0 : differenceInDays(trialEndsDate, new Date());
+  const timeLeft = trialEndsDate.getTime() < Date.now() ? "in a few seconds" : formatDistanceToNow(trialEndsDate, { addSuffix: true });
   return {
-    notificationId: `beforeTrialEnds.${daysLeft}.${user.id}`,
+    notificationId: `beforeTrialEnds.${trialEndsDate.toISOString()}.${user.id}`,
     payload: {
       summary: "Your Free Trial is Ending Soon",
       description:
-        `Your free trial with Akash Network will end in ${daysLeft} days. You still have $${vars.remainingCredits} in free credits available and, ` +
+        `Your free trial with Akash Network will end ${timeLeft}. You still have $${vars.remainingCredits} in free credits available and, ` +
         `${vars.activeDeployments} deployments that will be lost when your free trial ends. ` +
         `To retain the remaining free credits and to ensure your deployments keep running when the trial ends, purchase some credits today by visiting <a href="${vars.paymentLink}">Akash Console Payment Setup</a>.`
     },

--- a/apps/stats-web/deploy.yml
+++ b/apps/stats-web/deploy.yml
@@ -3,8 +3,8 @@ version: "2.0"
 
 services:
   web:
-    image: baktun/akash-stats:<version>
-    env:
+    image: ghcr.io/akash-network/stats-web:<version>
+#    env:
 #      - API_BASE_URL=<API_URL_OVERRIDE>
 #      - NEXT_PUBLIC_GA_MEASUREMENT_ID=<GA_MEASUREMENT_ID>
 #      - NEXT_PUBLIC_SENTRY_DSN=<SENTRY_DSN>


### PR DESCRIPTION
## Why

To ensure proper time left is displayed to the end user in spite of small differences between dates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced trial and deployment notification messages with more human-readable relative time formatting.

* **Chores**
  * Updated deployment infrastructure configuration and container image registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->