### PR TITLE
fix: update top up signer to owner

### DIFF
--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -73,7 +73,6 @@ export class TopUpManagedDeploymentsService implements DeploymentsRefiller {
   }
 
   private async collectMessages(deployments: DrainingDeployment[], options: TopUpDeploymentsOptions): Promise<CollectedMessage[]> {
-    const depositor = await this.managedMasterWallet.getFirstAddress();
     const denom = this.billingConfig.get("DEPLOYMENT_GRANT_DENOM");
 
     const messageInputs = await Promise.all(
@@ -105,7 +104,7 @@ export class TopUpManagedDeploymentsService implements DeploymentsRefiller {
             amount: sufficientAmount,
             denom,
             owner: deployment.address,
-            signer: depositor
+            signer: deployment.address
           };
 
           const message = this.rpcClientService.getDepositDeploymentMsg(messageInput);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed deposit message signing to correctly use the deployment address as the signer instead of the wallet's depositor address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->