### PR TITLE
fix: adds ibc types to default registry

### DIFF
--- a/apps/api/src/billing/providers/type-registry.provider.ts
+++ b/apps/api/src/billing/providers/type-registry.provider.ts
@@ -9,22 +9,27 @@ import * as cosmosv1beta1 from "@akashnetwork/chain-sdk/private-types/cosmos.v1b
 import * as cosmosv2alpha1 from "@akashnetwork/chain-sdk/private-types/cosmos.v2alpha1";
 import type { GeneratedType } from "@cosmjs/proto-signing";
 import { Registry } from "@cosmjs/proto-signing";
+import { defaultRegistryTypes as stargateDefaultRegistryTypes } from "@cosmjs/stargate";
 import type { InjectionToken } from "tsyringe";
 import { container, inject } from "tsyringe";
 
-const newAkashTypes: ReadonlyArray<[string, GeneratedType]> = [
-  ...Object.values(v1),
-  ...Object.values(v1beta4),
-  ...Object.values(v1beta5),
+type DefaultRegistryType = [string, GeneratedType];
+const ibcTypes: DefaultRegistryType[] = stargateDefaultRegistryTypes.filter(([type]) => type.startsWith("/ibc"));
+const defaultRegistryTypes: DefaultRegistryType[] = [
   ...Object.values(cosmosv1),
   ...Object.values(cosmosv1beta1),
   ...Object.values(cosmosv1alpha1),
   ...Object.values(cosmosv2alpha1)
 ]
+  .filter(x => x && "$type" in x)
+  .map(x => ["/" + x.$type, x as unknown as GeneratedType])
+  .concat(ibcTypes) as DefaultRegistryType[];
+
+const newAkashTypes: ReadonlyArray<[string, GeneratedType]> = [...Object.values(v1), ...Object.values(v1beta4), ...Object.values(v1beta5)]
   .filter(x => "$type" in x)
   .map(x => ["/" + x.$type, x as unknown as GeneratedType]);
 
-const registry = new Registry(newAkashTypes);
+const registry = new Registry([...defaultRegistryTypes, ...newAkashTypes]);
 
 export const TYPE_REGISTRY: InjectionToken<Registry> = "TYPE_REGISTRY";
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -116,7 +116,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
           {
             typeUrl: "/akash.escrow.v1.MsgAccountDeposit",
             value: {
-              signer: MANAGED_MASTER_WALLET_ADDRESS,
+              signer: deployment.address,
               id: {
                 scope: Scope.deployment,
                 xid: `${deployment.address}/${deployment.dseq}`
@@ -151,7 +151,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
                 input: expect.objectContaining({
                   amount: sufficientAmount,
                   denom: DEPLOYMENT_GRANT_DENOM,
-                  signer: MANAGED_MASTER_WALLET_ADDRESS,
+                  signer: deployment.address,
                   dseq: Number(deployment.dseq),
                   owner: deployment.address
                 })
@@ -284,7 +284,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         {
           typeUrl: "/akash.escrow.v1.MsgAccountDeposit",
           value: {
-            signer: MANAGED_MASTER_WALLET_ADDRESS,
+            signer: owner,
             id: {
               scope: Scope.deployment,
               xid: `${owner}/${deployments[0].dseq}`
@@ -301,7 +301,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         {
           typeUrl: "/akash.escrow.v1.MsgAccountDeposit",
           value: {
-            signer: MANAGED_MASTER_WALLET_ADDRESS,
+            signer: owner,
             id: {
               scope: Scope.deployment,
               xid: `${owner}/${deployments[1].dseq}`

--- a/apps/api/src/utils/protobuf.ts
+++ b/apps/api/src/utils/protobuf.ts
@@ -10,11 +10,15 @@ import * as cosmosv1alpha1 from "@akashnetwork/chain-sdk/private-types/cosmos.v1
 import * as cosmosv1beta1 from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import type { GeneratedType } from "@cosmjs/proto-signing";
 import { isTsProtoGeneratedType, Registry } from "@cosmjs/proto-signing";
+import { defaultRegistryTypes as stargateDefaultRegistryTypes } from "@cosmjs/stargate";
 import omit from "lodash/omit";
 
-const defaultRegistryTypes: readonly [string, GeneratedType][] = [...Object.values(cosmosv1), ...Object.values(cosmosv1beta1), ...Object.values(cosmosv1alpha1)]
-  .filter(x => "$type" in x)
-  .map(x => ["/" + x.$type, x as unknown as GeneratedType]);
+type DefaultRegistryType = [string, GeneratedType];
+const ibcTypes: DefaultRegistryType[] = stargateDefaultRegistryTypes.filter(([type]) => type.startsWith("/ibc"));
+const defaultRegistryTypes: DefaultRegistryType[] = [...Object.values(cosmosv1), ...Object.values(cosmosv1beta1), ...Object.values(cosmosv1alpha1)]
+  .filter(x => x && "$type" in x)
+  .map(x => ["/" + x.$type, x as unknown as GeneratedType])
+  .concat(ibcTypes) as DefaultRegistryType[];
 
 const akashTypes: ReadonlyArray<[string, GeneratedType]> = [
   ...Object.values(v1beta1),

--- a/apps/deploy-web/src/types/balances.ts
+++ b/apps/deploy-web/src/types/balances.ts
@@ -1,4 +1,4 @@
-import type { Coin } from "@cosmjs/stargate";
+import type { Coin } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 
 export type Grant = {
   granter: string;

--- a/apps/deploy-web/src/utils/customRegistry.ts
+++ b/apps/deploy-web/src/utils/customRegistry.ts
@@ -7,17 +7,22 @@ import * as cosmosv1beta1 from "@akashnetwork/chain-sdk/private-types/cosmos.v1b
 import * as cosmosv2alpha1 from "@akashnetwork/chain-sdk/private-types/cosmos.v2alpha1";
 import type { GeneratedType } from "@cosmjs/proto-signing";
 import { Registry } from "@cosmjs/proto-signing";
+import { defaultRegistryTypes as stargateDefaultRegistryTypes } from "@cosmjs/stargate";
 
-const akashTypes: ReadonlyArray<[string, GeneratedType]> = [
-  ...Object.values(v1),
-  ...Object.values(v1beta4),
-  ...Object.values(v1beta5),
+type DefaultRegistryType = [string, GeneratedType];
+const ibcTypes: DefaultRegistryType[] = stargateDefaultRegistryTypes.filter(([type]) => type.startsWith("/ibc"));
+const defaultRegistryTypes: DefaultRegistryType[] = [
   ...Object.values(cosmosv1),
   ...Object.values(cosmosv1beta1),
   ...Object.values(cosmosv1alpha1),
   ...Object.values(cosmosv2alpha1)
 ]
   .filter(x => x && "$type" in x)
+  .map(x => ["/" + x.$type, x as unknown as GeneratedType])
+  .concat(ibcTypes) as DefaultRegistryType[];
+
+const akashTypes: DefaultRegistryType[] = [...Object.values(v1), ...Object.values(v1beta4), ...Object.values(v1beta5)]
+  .filter(x => x && "$type" in x)
   .map(x => ["/" + x.$type, x as unknown as GeneratedType]);
 
-export const registry = new Registry([...akashTypes]);
+export const registry = new Registry([...defaultRegistryTypes, ...akashTypes]);

--- a/apps/deploy-web/src/utils/priceUtils.ts
+++ b/apps/deploy-web/src/utils/priceUtils.ts
@@ -1,4 +1,4 @@
-import type { Coin } from "@cosmjs/stargate";
+import type { Coin } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import add from "date-fns/add";
 
 import { READABLE_DENOMS, UAKT_DENOM } from "@src/config/denom.config";

--- a/apps/indexer/src/shared/utils/protobuf.ts
+++ b/apps/indexer/src/shared/utils/protobuf.ts
@@ -10,10 +10,14 @@ import * as cosmosv1alpha1 from "@akashnetwork/chain-sdk/private-types/cosmos.v1
 import * as cosmosv1beta1 from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import type { GeneratedType } from "@cosmjs/proto-signing";
 import { isTsProtoGeneratedType, Registry } from "@cosmjs/proto-signing";
+import { defaultRegistryTypes as stargateDefaultRegistryTypes } from "@cosmjs/stargate";
 
-const defaultRegistryTypes: readonly [string, GeneratedType][] = [...Object.values(cosmosv1), ...Object.values(cosmosv1beta1), ...Object.values(cosmosv1alpha1)]
+type DefaultRegistryType = [string, GeneratedType];
+const ibcTypes: DefaultRegistryType[] = stargateDefaultRegistryTypes.filter(([type]) => type.startsWith("/ibc"));
+const defaultRegistryTypes: DefaultRegistryType[] = [...Object.values(cosmosv1), ...Object.values(cosmosv1beta1), ...Object.values(cosmosv1alpha1)]
   .filter(x => "$type" in x)
-  .map(x => ["/" + x.$type, x as unknown as GeneratedType]);
+  .map(x => ["/" + x.$type, x as unknown as GeneratedType])
+  .concat(ibcTypes) as DefaultRegistryType[];
 
 const akashTypes: ReadonlyArray<[string, GeneratedType]> = [
   ...Object.values(v1beta1),


### PR DESCRIPTION
## Why 

Because we have ibc types inside indexer and would like to show stats. Fixes #2131 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API to access the type registry via dependency injection.

* **Refactor**
  * Registry now includes default Cosmos types plus IBC types and consolidates multiple type sources for broader blockchain type support.
  * Type imports standardized across frontend utilities.

* **Tests**
  * Tests updated to use deployment owners as signers where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->