### PR TITLE
chore: use tsx instead of ts-node to run close deployments script after ui tests

### DIFF
--- a/.github/actions/console-web-ui-testing/action.yml
+++ b/.github/actions/console-web-ui-testing/action.yml
@@ -48,7 +48,7 @@ runs:
       env:
         TEST_WALLET_MNEMONIC: ${{ inputs.test-wallet-mnemonic }}
       run: |
-        npx ts-node -P packages/dev-config/tsconfig.base-node.json apps/deploy-web/script/closeDeployments.ts
+        npx --yes tsx@4.20.6 apps/deploy-web/script/closeDeployments.ts
     - uses: actions/upload-artifact@v4
       id: playwright-report
       if: ${{ !cancelled() }}

--- a/apps/deploy-web/script/closeDeployments.ts
+++ b/apps/deploy-web/script/closeDeployments.ts
@@ -50,8 +50,8 @@ async function main() {
   console.log("Closing deployments...");
   const gas = await txClient.simulate(account.address, closeDeploymentsMessages, "close deployments via script");
   const tx = await txClient.signAndBroadcast(account.address, closeDeploymentsMessages, {
-    amount: [{ amount: "2500", denom: "uakt" }],
-    gas: Math.floor(1.2 * gas).toString()
+    amount: [{ amount: Math.ceil(2500 * closeDeploymentsMessages.length).toString(), denom: "uakt" }],
+    gas: Math.floor(1.3 * gas).toString()
   });
 
   if (tx.code !== 0) {


### PR DESCRIPTION
## Why

ts-node fails with the error and requires a separate tsconfig file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Optimizations**
  * Enhanced deployment closure transaction handling with dynamic fee scaling that adjusts based on the number of messages being processed
  * Increased gas multiplier threshold to improve transaction reliability during deployment cleanup

* **Chores**
  * Updated testing infrastructure tooling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->