### PR TITLE
refactor: sanitizes invalid UTF characters to prevent Loki crashes

### DIFF
--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -87,7 +87,7 @@ export class StripeController {
       }
 
       return { data: { success: true } };
-    } catch (error: unknown) {
+    } catch (error) {
       if (this.stripeErrorService.isKnownError(error, "payment")) {
         throw this.stripeErrorService.toAppError(error, "payment");
       }

--- a/apps/api/src/billing/lib/batch-signing-client/batch-signing-client.service.ts
+++ b/apps/api/src/billing/lib/batch-signing-client/batch-signing-client.service.ts
@@ -318,7 +318,7 @@ export class BatchSigningClientService {
             this.logger.error({
               event: "TX_BROADCAST_ERROR",
               txIndex,
-              error: errorMessage
+              error
             });
             throw error;
           }

--- a/apps/api/src/billing/services/stripe/stripe.service.spec.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.spec.ts
@@ -1084,7 +1084,7 @@ describe(StripeService.name, () => {
         id: "pi_test_123",
         status: "succeeded",
         amount: 100
-      } as Partial<Stripe.PaymentIntent> as Stripe.PaymentIntent;
+      } as Stripe.PaymentIntent;
 
       // Override default payment intent mock
       jest.spyOn(service.paymentIntents, "create").mockResolvedValue(mockPaymentIntent as any);

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -260,7 +260,7 @@ export class StripeService extends Stripe {
             event: "COUPON_APPLICATION_ROLLBACK_SUCCESS",
             userId: currentUser.id,
             couponId: updateId,
-            error: error instanceof Error ? error.message : String(error)
+            error
           });
         } catch (rollbackError) {
           logger.error({
@@ -680,7 +680,7 @@ export class StripeService extends Stripe {
         customerId,
         paymentMethodId,
         paymentIntentId,
-        error: error instanceof Error ? error.message : String(error)
+        error
       });
       throw error;
     }
@@ -736,7 +736,7 @@ export class StripeService extends Stripe {
         event: "PAYMENT_METHOD_VALIDATION_UPDATE_FAILED",
         customerId,
         paymentMethodId,
-        error: validationError instanceof Error ? validationError.message : String(validationError)
+        error: validationError
       });
       // Don't fail the test charge if validation update fails - the card is still valid
     }

--- a/packages/logging/src/services/logger/logger.service.spec.ts
+++ b/packages/logging/src/services/logger/logger.service.spec.ts
@@ -1,13 +1,11 @@
 import createHttpError from "http-errors";
-import { Transform } from "node:stream";
+import { Transform, Writable } from "node:stream";
 import type { LoggerOptions } from "pino";
 import pino from "pino";
 
 import { config } from "../../config";
 import type { Logger } from "./logger.service";
 import { LoggerService } from "./logger.service";
-
-jest.mock("pino");
 
 describe("LoggerService", () => {
   const defaultLogFormat = config.STD_OUT_LOG_FORMAT;
@@ -17,27 +15,29 @@ describe("LoggerService", () => {
     timestamp: expect.any(Function),
     formatters: {
       level: expect.any(Function)
-    }
+    },
+    serializers: expect.any(Object)
   };
 
   afterEach(() => {
     config.STD_OUT_LOG_FORMAT = defaultLogFormat;
-    jest.clearAllMocks();
   });
 
   describe("prototype.initPino", () => {
     it("should initialize pino with pretty formatting when STD_OUT_LOG_FORMAT is 'pretty'", () => {
       config.STD_OUT_LOG_FORMAT = "pretty";
-      new LoggerService();
+      const pinoMock = jest.fn();
+      new LoggerService({ createPino: pinoMock });
 
-      expect(pino).toHaveBeenCalledWith(COMMON_EXPECTED_OPTIONS, expect.any(Transform));
+      expect(pinoMock).toHaveBeenCalledWith(COMMON_EXPECTED_OPTIONS, expect.any(Transform));
     });
 
     it("should initialize pino without pretty formatting for other formats", () => {
       config.STD_OUT_LOG_FORMAT = "json";
-      new LoggerService();
+      const pinoMock = jest.fn();
+      new LoggerService({ createPino: pinoMock });
 
-      expect(pino).toHaveBeenCalledWith(COMMON_EXPECTED_OPTIONS);
+      expect(pinoMock).toHaveBeenCalledWith(COMMON_EXPECTED_OPTIONS);
     });
 
     it("should initialize pino with global mixin", () => {
@@ -45,10 +45,10 @@ describe("LoggerService", () => {
         return {};
       }
       LoggerService.mixin = globalMixin;
-      new LoggerService();
+      const pinoMock = jest.fn();
+      new LoggerService({ createPino: pinoMock });
 
-      expect(pino).toHaveBeenCalledWith({ ...COMMON_EXPECTED_OPTIONS, mixin: globalMixin });
-
+      expect(pinoMock).toHaveBeenCalledWith({ ...COMMON_EXPECTED_OPTIONS, mixin: globalMixin });
       LoggerService.mixin = undefined;
     });
 
@@ -60,139 +60,237 @@ describe("LoggerService", () => {
         return {};
       }
       LoggerService.mixin = globalMixin;
-      new LoggerService({ mixin: localMixin });
+      const pinoMock = jest.fn();
+      new LoggerService({ mixin: localMixin, createPino: pinoMock });
 
-      expect(pino).toHaveBeenCalledWith({ ...COMMON_EXPECTED_OPTIONS, mixin: localMixin });
+      expect(pinoMock).toHaveBeenCalledWith({ ...COMMON_EXPECTED_OPTIONS, mixin: localMixin });
 
       LoggerService.mixin = undefined;
     });
 
     it("should initialize pino with provided log level overriding global log level", () => {
-      new LoggerService({ level: "debug" });
+      const pinoMock = jest.fn();
+      new LoggerService({ level: "debug", createPino: pinoMock });
 
-      expect(pino).toHaveBeenCalledWith({ ...COMMON_EXPECTED_OPTIONS, level: "debug" });
+      expect(pinoMock).toHaveBeenCalledWith({ ...COMMON_EXPECTED_OPTIONS, level: "debug" });
 
       LoggerService.mixin = undefined;
     });
   });
 
   describe("methods", () => {
-    let loggerService: LoggerService;
-    let mockLogger: jest.Mocked<Logger>;
-
-    beforeEach(() => {
-      mockLogger = {
-        info: jest.fn(),
-        error: jest.fn(),
-        warn: jest.fn(),
-        debug: jest.fn(),
-        child: jest.fn().mockReturnThis()
-      } as unknown as jest.Mocked<Logger>;
-
-      (pino as unknown as jest.Mock).mockReturnValue(mockLogger);
-      loggerService = new LoggerService();
-    });
-
-    const methods: (keyof Logger)[] = ["info", "error", "warn", "debug"];
-    describe.each(methods)("prototype.%s", method => {
-      const logMessage = "Test message";
-
-      it(`should call pino.${method} on info method`, () => {
-        loggerService[method](logMessage);
-        expect(mockLogger[method]).toHaveBeenCalledWith(logMessage);
+    (["info", "error", "warn", "debug", "fatal"] satisfies Array<keyof Logger>).forEach(method => {
+      it(`should call pino.${method} when calling ${method} method`, () => {
+        const pinoLogger = {
+          info: jest.fn(),
+          error: jest.fn(),
+          warn: jest.fn(),
+          debug: jest.fn(),
+          log: jest.fn(),
+          fatal: jest.fn(),
+          child: jest.fn().mockReturnThis()
+        } as unknown as pino.Logger;
+        const logger = new LoggerService({
+          createPino: () => pinoLogger
+        });
+        logger[method]("Test message");
+        expect(pinoLogger[method]).toHaveBeenCalledWith("Test message");
       });
     });
+  });
 
-    describe("prototype.toLoggableInput", () => {
-      it("should return detailed information about HttpError", () => {
-        const httpError = createHttpError(404, {
+  describe("logging output", () => {
+    it("should return detailed information about HttpError", () => {
+      const { logger, logs } = setup();
+      const httpError = createHttpError(404, {
+        status: 404,
+        message: "Not found",
+        stack: "stack trace",
+        data: { key: "value" }
+      });
+
+      logger.info(httpError);
+      expect(logs[0]).toEqual(
+        expect.objectContaining({
           status: 404,
           message: "Not found",
           stack: "stack trace",
           data: { key: "value" }
-        });
+        })
+      );
+    });
 
-        const loggable = loggerService["toLoggableInput"](httpError);
-        expect(loggable).toEqual({
-          status: 404,
-          message: "Not found",
-          stack: "stack trace",
-          data: { key: "value" }
-        });
+    it("should return detailed stack trace information about cause, errors, and original error for HttpError", () => {
+      const { logger, logs } = setup();
+      const httpError = createHttpError(404, {
+        status: 404,
+        message: "Not found",
+        stack: "stack trace",
+        data: { key: "value" },
+        originalError: new Error("Original error"),
+        cause: new Error("Cause error")
       });
 
-      it("should return detailed stack trace information about cause, errors, and original error for HttpError", () => {
-        const httpError = createHttpError(404, {
-          status: 404,
-          message: "Not found",
-          stack: "stack trace",
-          data: { key: "value" },
-          originalError: new Error("Original error"),
-          cause: new Error("Cause error")
-        });
-
-        const loggable = loggerService["toLoggableInput"](httpError);
-        expect(loggable).toEqual({
+      logger.info(httpError);
+      expect(logs[0]).toEqual(
+        expect.objectContaining({
           status: 404,
           message: "Not found",
           stack: expect.stringContaining("stack trace\n\nCaused by:\n  Error: Cause error"),
           data: { key: "value" },
           originalError: expect.stringContaining("Error: Original error")
-        });
+        })
+      );
+    });
+
+    it("should return cause for HttpError", () => {
+      const { logger, logs } = setup();
+      const httpError = createHttpError(404, {
+        status: 404,
+        message: "Not found",
+        stack: "stack trace",
+        data: { key: "value" },
+        originalError: new Error("Original error")
       });
 
-      it("should return cause for HttpError", () => {
-        const httpError = createHttpError(404, {
-          status: 404,
-          message: "Not found",
-          stack: "stack trace",
-          data: { key: "value" },
-          originalError: new Error("Original error")
-        });
-
-        const loggable = loggerService["toLoggableInput"](httpError);
-        expect(loggable).toEqual({
+      logger.info(httpError);
+      expect(logs[0]).toEqual(
+        expect.objectContaining({
           status: 404,
           message: "Not found",
           stack: "stack trace",
           data: { key: "value" },
           originalError: expect.stringContaining("Error: Original error")
-        });
-      });
-
-      it("should include error cause in stack trace for Error instance", () => {
-        const error = new Error("Test error");
-        Object.assign(error, { cause: new Error("Cause error") });
-        const loggable = loggerService["toLoggableInput"](error);
-
-        expect(loggable).toContain("Cause error");
-        expect(loggable).toContain("Test error");
-      });
-
-      it("should return stack for general Error instance", () => {
-        const error = new Error("Test error");
-        const loggable = loggerService["toLoggableInput"](error);
-        expect(loggable).toBe(error.stack);
-      });
-
-      it("should return the original message if it is not an error", () => {
-        const message = "Test message";
-        const loggable = loggerService["toLoggableInput"](message);
-        expect(loggable).toBe(message);
-      });
-
-      it('should return stack trace for "error" and "err" property in object', () => {
-        const error = new Error("Test error");
-        Object.assign(error, { cause: new Error("Cause error") });
-
-        let loggable = loggerService["toLoggableInput"]({ error });
-        expect(loggable.error).toContain("Test error");
-        expect(loggable.error).toContain("Cause error");
-
-        loggable = loggerService["toLoggableInput"]({ err: error });
-        expect(loggable.err).toContain("Test error");
-        expect(loggable.err).toContain("Cause error");
-      });
+        })
+      );
     });
+
+    it("should include error cause in stack trace for Error instance", () => {
+      const { logger, logs } = setup();
+      const error = new Error("Test error");
+      Object.assign(error, { cause: new Error("Cause error") });
+      logger.info(error);
+      expect(logs[0]).toEqual(
+        expect.objectContaining({
+          err: expect.stringContaining("Cause error"),
+          msg: "Test error"
+        })
+      );
+    });
+
+    it("should return stack for general Error instance", () => {
+      const { logger, logs } = setup();
+      const error = new Error("Test error");
+      logger.info(error);
+      expect(logs[0]).toEqual(
+        expect.objectContaining({
+          err: error.stack,
+          msg: "Test error"
+        })
+      );
+    });
+
+    it("should return the original message if it is not an error", () => {
+      const message = "Test message";
+      const { logger, logs } = setup();
+      logger.info(message);
+      expect(logs[0]).toEqual(
+        expect.objectContaining({
+          msg: message
+        })
+      );
+    });
+
+    it('should return stack trace for "error" and "err" property in object', () => {
+      const { logger, logs } = setup();
+      const error = new Error("Test error");
+      Object.assign(error, { cause: new Error("Cause error") });
+
+      logger.info({ error });
+      expect(logs[0]).toEqual(
+        expect.objectContaining({
+          error: expect.stringContaining("Test error")
+        })
+      );
+      expect(logs[0]).toEqual(
+        expect.objectContaining({
+          error: expect.stringContaining("Cause error")
+        })
+      );
+
+      logger.info({ err: error });
+      expect(logs[1]).toEqual(
+        expect.objectContaining({
+          err: expect.stringContaining("Test error")
+        })
+      );
+      expect(logs[1]).toEqual(
+        expect.objectContaining({
+          err: expect.stringContaining("Cause error")
+        })
+      );
+    });
+
+    it("should return stack trace for AggregateError", () => {
+      const { logger, logs } = setup();
+      const error = new AggregateError([new Error("Test1 error"), new Error("Test2 error")]);
+      logger.info(error);
+      expect(logs[0]).toEqual(
+        expect.objectContaining({
+          err: expect.stringContaining("Test1 error")
+        })
+      );
+      expect(logs[0]).toEqual(
+        expect.objectContaining({
+          err: expect.stringContaining("Test2 error")
+        })
+      );
+    });
+
+    it("should sanitize invalid UTF message", () => {
+      const { logger, logs } = setup();
+      logger.info(
+        "Error: Broadcasting transaction failed with code 2 (codespace: feegrant). Log: \rl�dqz\u0015M�J�\t���\\�ͺ� does not allow to pay fees for �|������z6�\u0010���M�ӧ�: basic allowance: fee limit exceeded (code: 2)"
+      );
+      expect(logs[0]).toEqual(
+        expect.objectContaining({
+          msg: "Error: Broadcasting transaction failed with code 2 (codespace: feegrant). Log: \\rl\\uFFFD+dqz\\u0015M\\uFFFD+J\\uFFFD+\\t\\uFFFD+\\\\uFFFD+ͺ\\uFFFD+ does not allow to pay fees for \\uFFFD+|\\uFFFD+z6\\uFFFD+\\u0010\\uFFFD+M\\uFFFD+ӧ\\uFFFD+: basic allowance: fee limit exceeded (code: 2)"
+        })
+      );
+    });
+
+    it("should sanitize invalid UTF in error", () => {
+      const { logger, logs } = setup();
+      logger.info(
+        new Error(
+          "Error: Broadcasting transaction failed with code 2 (codespace: feegrant). Log: \rl�dqz\u0015M�J�\t���\\�ͺ� does not allow to pay fees for �|������z6�\u0010���M�ӧ�: basic allowance: fee limit exceeded (code: 2)"
+        )
+      );
+      expect(logs[0]).toEqual(
+        expect.objectContaining({
+          err: expect.stringContaining(
+            "Error: Broadcasting transaction failed with code 2 (codespace: feegrant). Log: \\rl\\uFFFD+dqz\\u0015M\\uFFFD+J\\uFFFD+\\t\\uFFFD+\\\\uFFFD+ͺ\\uFFFD+ does not allow to pay fees for \\uFFFD+|\\uFFFD+z6\\uFFFD+\\u0010\\uFFFD+M\\uFFFD+ӧ\\uFFFD+: basic allowance: fee limit exceeded (code: 2)"
+          )
+        })
+      );
+    });
+
+    function setup() {
+      const logs: unknown[] = [];
+      const logger = new LoggerService({
+        createPino: options =>
+          pino(
+            options,
+            new Writable({
+              write(chunk, _enc, cb) {
+                logs.push(JSON.parse(chunk.toString()));
+                cb();
+              }
+            })
+          )
+      });
+
+      return { logger, logs };
+    }
   });
 });

--- a/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.spec.ts
+++ b/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.spec.ts
@@ -121,4 +121,9 @@ describe(collectFullErrorStack.name, () => {
     const result = collectFullErrorStack(error);
     expect(result).toContain("test error (code: TEST_ERROR)");
   });
+
+  it("returns sanitized string for string input", () => {
+    const result = collectFullErrorStack("Log: \rl�dqz\u0015M�J�\t���\\�ͺ� does not allow");
+    expect(result).toBe("Log: \\rl\\uFFFD+dqz\\u0015M\\uFFFD+J\\uFFFD+\\t\\uFFFD+\\\\uFFFD+ͺ\\uFFFD+ does not allow");
+  });
 });


### PR DESCRIPTION
## Why

Because Loki crashes during search when we log invalid UTF chars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Injectable logger backend to allow custom logger factories.

* **Improvements**
  * Sanitizes and normalizes error messages (handles invalid UTF and control chars).
  * More consistent logging input shapes, improved stack/error formatting, and better pretty/json output handling.
  * Some logs now include full error objects rather than only error messages.

* **Breaking Changes**
  * Logger constructor/options and public log function signatures changed.

* **Tests**
  * Expanded tests covering formats, levels, error types, and sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->