### PR TITLE
fix: omit userId from update

### DIFF
--- a/apps/api/src/user/repositories/user/user.repository.ts
+++ b/apps/api/src/user/repositories/user/user.repository.ts
@@ -94,12 +94,15 @@ export class UserRepository extends BaseRepository<ApiPgTables["Users"], UserInp
   }
 
   async upsertByUserId(data: UserInput): Promise<UserOutput> {
+    const insertData = this.toInput(data);
+    const { userId, ...updateData } = insertData;
+
     const [item] = await this.cursor
       .insert(this.table)
-      .values(this.toInput(data))
+      .values(insertData)
       .onConflictDoUpdate({
         target: [this.table.userId],
-        set: data
+        set: updateData
       })
       .returning();
     return this.toOutput(item);


### PR DESCRIPTION
refs #1934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where user ID was being unintentionally overwritten during record updates, ensuring user identifiers remain stable and properly preserved across operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->