### PR TITLE
fix(auth): ignores additional index name during login/registration

### DIFF
--- a/apps/api/src/user/services/user/user.service.ts
+++ b/apps/api/src/user/services/user/user.service.ts
@@ -57,7 +57,10 @@ export class UserService {
         );
         isAnonymous = !!user;
       } catch (error) {
-        if (!isUniqueViolation(error) || !error.constraint_name?.includes("userSetting_userId_unique")) {
+        if (
+          !isUniqueViolation(error) ||
+          (!error.constraint_name?.includes("userSetting_userId_unique") && !error.constraint_name?.includes("user_setting_user_id"))
+        ) {
           throw error;
         }
       }


### PR DESCRIPTION
## Why

Because there is a difference in names of this index in migrations and in prod db

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during user registration to enhance system robustness and prevent incorrect error propagation in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->