### PR TITLE
fix: do not log chrome-extension errors to sentry

### DIFF
--- a/apps/deploy-web/sentry.client.config.ts
+++ b/apps/deploy-web/sentry.client.config.ts
@@ -13,12 +13,13 @@ initSentry({
   // everything else will be done with custom interceptor
   tracePropagationTargets: [/^\/api\//],
   integrations: [
+    eventFiltersIntegration({
+      allowUrls: [/https?:\/\/[^.]+\.akash\.network/],
+      denyUrls: [/^chrome-extension:\/\//]
+    }),
     thirdPartyErrorFilterIntegration({
       filterKeys: [process.env.NEXT_PUBLIC_SENTRY_APPLICATION_KEY!],
       behaviour: "drop-error-if-exclusively-contains-third-party-frames"
-    }),
-    eventFiltersIntegration({
-      allowUrls: [/https?:\/\/[^.]+\.akash\.network/]
     })
   ]
   // ...


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated error monitoring configuration to exclude chrome extension-related errors while maintaining comprehensive tracking for Akash network operations, improving the quality and relevance of error reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->