### PR TITLE
feat(alert): implement wallet balance alerts

### DIFF
--- a/apps/notifications/drizzle/0005_left_magus.sql
+++ b/apps/notifications/drizzle/0005_left_magus.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."alert_type" ADD VALUE 'WALLET_BALANCE';

--- a/apps/notifications/drizzle/meta/0005_snapshot.json
+++ b/apps/notifications/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,444 @@
+{
+  "id": "9360dd65-3d4f-40bc-9be1-92015414ec1a",
+  "prevId": "c641f071-e771-44c9-b0b0-7a76c0838240",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.alerts": {
+      "name": "alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_channel_id": {
+          "name": "notification_channel_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "conditions": {
+          "name": "conditions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "type": {
+          "name": "type",
+          "type": "alert_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "alert_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'OK'"
+        },
+        "params": {
+          "name": "params",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_block_height": {
+          "name": "min_block_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_alerts_user_id": {
+          "name": "idx_alerts_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_alerts_notification_channel_id": {
+          "name": "idx_alerts_notification_channel_id",
+          "columns": [
+            {
+              "expression": "notification_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_alerts_status": {
+          "name": "idx_alerts_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_alerts_min_block_height_id": {
+          "name": "idx_alerts_min_block_height_id",
+          "columns": [
+            {
+              "expression": "min_block_height",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_alerts_created_at_id": {
+          "name": "idx_alerts_created_at_id",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_alerts_params": {
+          "name": "idx_alerts_params",
+          "columns": [
+            {
+              "expression": "\"params\" jsonb_path_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "idx_alerts_enabled_type_status": {
+          "name": "idx_alerts_enabled_type_status",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "alerts_notification_channel_id_notification_channels_id_fk": {
+          "name": "alerts_notification_channel_id_notification_channels_id_fk",
+          "tableFrom": "alerts",
+          "tableTo": "notification_channels",
+          "columnsFrom": [
+            "notification_channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_cursor": {
+      "name": "block_cursor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'latest'"
+        },
+        "last_processed_block": {
+          "name": "last_processed_block",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_channels": {
+      "name": "notification_channels",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_channel_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_notification_channels_user_id": {
+          "name": "idx_notification_channels_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_channels_user_id_is_default": {
+          "name": "idx_notification_channels_user_id_is_default",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "is_default = true and deleted_at is null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.alert_status": {
+      "name": "alert_status",
+      "schema": "public",
+      "values": [
+        "OK",
+        "TRIGGERED"
+      ]
+    },
+    "public.alert_type": {
+      "name": "alert_type",
+      "schema": "public",
+      "values": [
+        "CHAIN_MESSAGE",
+        "DEPLOYMENT_BALANCE",
+        "CHAIN_EVENT",
+        "WALLET_BALANCE"
+      ]
+    },
+    "public.notification_channel_type": {
+      "name": "notification_channel_type",
+      "schema": "public",
+      "values": [
+        "email"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/notifications/drizzle/meta/_journal.json
+++ b/apps/notifications/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1755227368663,
       "tag": "0004_add_is_default_column_and_unique_index",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1762440232870,
+      "tag": "0005_left_magus",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/notifications/src/interfaces/alert-events/handlers/chain-events/chain-events.handler.ts
+++ b/apps/notifications/src/interfaces/alert-events/handlers/chain-events/chain-events.handler.ts
@@ -6,12 +6,14 @@ import { ChainBlockCreatedDto } from "@src/modules/alert/dto/chain-block-created
 import { EventClosedDeploymentDto } from "@src/modules/alert/dto/event-closed-deployment.dto";
 import { ChainAlertService } from "@src/modules/alert/services/chain-alert/chain-alert.service";
 import { DeploymentBalanceAlertsService } from "@src/modules/alert/services/deployment-balance-alerts/deployment-balance-alerts.service";
+import { WalletBalanceAlertsService } from "@src/modules/alert/services/wallet-balance-alerts/wallet-balance-alerts.service";
 
 @Injectable()
 export class ChainEventsHandler {
   constructor(
     private readonly chainMessageAlertService: ChainAlertService,
     private readonly deploymentBalanceAlertsService: DeploymentBalanceAlertsService,
+    private readonly walletBalanceAlertsService: WalletBalanceAlertsService,
     private readonly brokerService: BrokerService
   ) {}
 
@@ -20,7 +22,19 @@ export class ChainEventsHandler {
     dto: ChainBlockCreatedDto
   })
   async processBlock(block: ChainBlockCreatedDto) {
-    await this.deploymentBalanceAlertsService.alertFor(block, message => this.brokerService.publish(eventKeyRegistry.createNotification, message));
+    const results = await Promise.allSettled([
+      this.deploymentBalanceAlertsService.alertFor(block, message => this.brokerService.publish(eventKeyRegistry.createNotification, message)),
+      this.walletBalanceAlertsService.alertFor(block, async message => this.brokerService.publish(eventKeyRegistry.createNotification, message))
+    ]);
+
+    const errors = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+
+    if (errors.length > 0) {
+      throw new AggregateError(
+        errors.map(e => e.reason),
+        `Failed process block`
+      );
+    }
   }
 
   @Handler({

--- a/apps/notifications/src/interfaces/rest/http-schemas/alert.http-schema.ts
+++ b/apps/notifications/src/interfaces/rest/http-schemas/alert.http-schema.ts
@@ -3,13 +3,15 @@ import { z } from "zod";
 
 import { toPaginatedResponse } from "@src/lib/http-schema/http-schema";
 import {
+  balanceConditionsSchema,
   chainEventTypeSchema,
   chainMessageTypeSchema,
-  deploymentBalanceConditionsSchema,
   deploymentBalanceParamsSchema,
   deploymentBalanceTypeSchema,
   generalAlertConditionsSchema,
-  generalParamsSchema
+  generalParamsSchema,
+  walletBalanceParamsSchema,
+  walletBalanceTypeSchema
 } from "@src/modules/alert/repositories/alert/alert-json-fields.schema";
 
 export const alertCreateCommonInputSchema = z.object({
@@ -42,22 +44,31 @@ export const chainEventCreateInputSchema = generalAlertCreateInputSchema
 export const deploymentBalanceCreateInputSchema = alertCreateCommonInputSchema
   .extend({
     type: deploymentBalanceTypeSchema,
-    conditions: deploymentBalanceConditionsSchema,
+    conditions: balanceConditionsSchema,
     params: deploymentBalanceParamsSchema
+  })
+  .strict();
+
+export const walletBalanceCreateInputSchema = alertCreateCommonInputSchema
+  .extend({
+    type: walletBalanceTypeSchema,
+    conditions: balanceConditionsSchema,
+    params: walletBalanceParamsSchema
   })
   .strict();
 
 export const alertCreateInputSchema = z.discriminatedUnion("type", [
   chainMessageCreateInputSchema,
   chainEventCreateInputSchema,
-  deploymentBalanceCreateInputSchema
+  deploymentBalanceCreateInputSchema,
+  walletBalanceCreateInputSchema
 ]);
 
 export class AlertCreateInput extends createZodDto(z.object({ data: alertCreateInputSchema })) {}
 
 export const alertPatchInputSchema = alertCreateCommonInputSchema
   .extend({
-    conditions: z.union([generalAlertConditionsSchema, deploymentBalanceConditionsSchema])
+    conditions: z.union([generalAlertConditionsSchema, balanceConditionsSchema])
   })
   .partial();
 
@@ -88,11 +99,22 @@ export const chainEventOutputSchema = generalAlertOutputSchema.extend({
 
 export const deploymentBalanceOutputSchema = alertCommonOutputSchema.extend({
   type: deploymentBalanceTypeSchema,
-  conditions: deploymentBalanceConditionsSchema,
+  conditions: balanceConditionsSchema,
   params: deploymentBalanceParamsSchema
 });
 
-export const alertOutputSchema = z.discriminatedUnion("type", [chainMessageOutputSchema, deploymentBalanceOutputSchema, chainEventOutputSchema]);
+export const walletBalanceOutputSchema = alertCommonOutputSchema.extend({
+  type: walletBalanceTypeSchema,
+  conditions: balanceConditionsSchema,
+  params: walletBalanceParamsSchema
+});
+
+export const alertOutputSchema = z.discriminatedUnion("type", [
+  chainMessageOutputSchema,
+  chainEventOutputSchema,
+  deploymentBalanceOutputSchema,
+  walletBalanceOutputSchema
+]);
 
 export const alertOutputResponseSchema = z.object({ data: alertOutputSchema });
 export class AlertOutputResponse extends createZodDto(alertOutputResponseSchema) {}

--- a/apps/notifications/src/lib/value-backoff/value-backoff.ts
+++ b/apps/notifications/src/lib/value-backoff/value-backoff.ts
@@ -35,7 +35,16 @@ export function valueBackoff<T>(request: () => Promise<T | EmptyResult>, options
     if (isInternalError(error) && options.safe) {
       return emptyResult;
     }
-    return Promise.reject(options.createError ? options.createError() : error);
+    if (options.createError) {
+      try {
+        const customError = options.createError();
+        customError.cause = error;
+        return Promise.reject(customError);
+      } catch (createErrorException) {
+        return Promise.reject(error);
+      }
+    }
+    return Promise.reject(error);
   });
 }
 

--- a/apps/notifications/src/modules/alert/alert.module.ts
+++ b/apps/notifications/src/modules/alert/alert.module.ts
@@ -11,6 +11,7 @@ import { DbHealthzService } from "@src/infrastructure/db/services/db-healthz/db-
 import { AlertRepository } from "@src/modules/alert/repositories/alert/alert.repository";
 import { ChainAlertService } from "@src/modules/alert/services/chain-alert/chain-alert.service";
 import { DeploymentAlertService } from "@src/modules/alert/services/deployment-alert/deployment-alert.service";
+import { WalletBalanceAlertsService } from "@src/modules/alert/services/wallet-balance-alerts/wallet-balance-alerts.service";
 import { HTTP_SDK_PROVIDERS } from "./providers/http-sdk.provider";
 import { AlertMessageService } from "./services/alert-message/alert-message.service";
 import { ConditionsMatcherService } from "./services/conditions-matcher/conditions-matcher.service";
@@ -26,6 +27,7 @@ import * as schema from "./model-schemas";
     AlertRepository,
     ChainAlertService,
     DeploymentBalanceAlertsService,
+    WalletBalanceAlertsService,
     ConditionsMatcherService,
     AlertMessageService,
     DeploymentService,
@@ -34,7 +36,7 @@ import * as schema from "./model-schemas";
     DbHealthzService,
     ...HTTP_SDK_PROVIDERS
   ],
-  exports: [ChainAlertService, DeploymentBalanceAlertsService, AlertRepository, DeploymentAlertService, DbHealthzService]
+  exports: [ChainAlertService, DeploymentBalanceAlertsService, WalletBalanceAlertsService, AlertRepository, DeploymentAlertService, DbHealthzService]
 })
 export class AlertModule implements OnApplicationShutdown {
   constructor(@InjectDrizzle(DRIZZLE_PROVIDER_TOKEN) private readonly db: NodePgDatabase) {}

--- a/apps/notifications/src/modules/alert/model-schemas/alert.schema.ts
+++ b/apps/notifications/src/modules/alert/model-schemas/alert.schema.ts
@@ -5,7 +5,7 @@ import { timestamps } from "@src/lib/db/timestamps";
 import { NotificationChannel } from "@src/modules/notifications/model-schemas";
 
 export const AlertStatus = pgEnum("alert_status", ["OK", "TRIGGERED"]);
-export const AlertType = pgEnum("alert_type", ["CHAIN_MESSAGE", "DEPLOYMENT_BALANCE", "CHAIN_EVENT"]);
+export const AlertType = pgEnum("alert_type", ["CHAIN_MESSAGE", "DEPLOYMENT_BALANCE", "CHAIN_EVENT", "WALLET_BALANCE"]);
 
 export const Alert = pgTable(
   "alerts",

--- a/apps/notifications/src/modules/alert/providers/http-sdk.provider.ts
+++ b/apps/notifications/src/modules/alert/providers/http-sdk.provider.ts
@@ -1,5 +1,5 @@
 import type { HttpClient } from "@akashnetwork/http-sdk";
-import { createHttpClient, DeploymentHttpService, LeaseHttpService } from "@akashnetwork/http-sdk";
+import { BalanceHttpService, createHttpClient, DeploymentHttpService, LeaseHttpService } from "@akashnetwork/http-sdk";
 import type { InjectionToken, Provider } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 
@@ -22,5 +22,10 @@ export const HTTP_SDK_PROVIDERS: Provider[] = [
     provide: LeaseHttpService,
     inject: [CHAIN_API_HTTP_CLIENT_TOKEN],
     useFactory: (httpClient: HttpClient) => new LeaseHttpService(httpClient)
+  },
+  {
+    provide: BalanceHttpService,
+    inject: [ConfigService],
+    useFactory: (configService: ConfigService<AlertConfig>) => new BalanceHttpService({ baseURL: configService.getOrThrow("alert.API_NODE_ENDPOINT") })
   }
 ];

--- a/apps/notifications/src/modules/alert/repositories/alert/alert-json-fields.schema.ts
+++ b/apps/notifications/src/modules/alert/repositories/alert/alert-json-fields.schema.ts
@@ -28,7 +28,7 @@ const deploymentBalanceConditionsShape = {
   value: z.number()
 };
 
-export const deploymentBalanceConditionsSchema = toCompound(z.object(deploymentBalanceConditionsShape));
+export const balanceConditionsSchema = toCompound(z.object(deploymentBalanceConditionsShape));
 
 const dseqSchema = z.string().regex(/^\d+$/, {
   message: "Must be a numeric string"
@@ -37,6 +37,12 @@ const dseqSchema = z.string().regex(/^\d+$/, {
 export const deploymentBalanceParamsSchema = z.object({
   dseq: dseqSchema,
   owner: z.string(),
+  suppressedBySystem: z.boolean().optional()
+});
+
+export const walletBalanceParamsSchema = z.object({
+  owner: z.string(),
+  denom: z.string(),
   suppressedBySystem: z.boolean().optional()
 });
 
@@ -49,6 +55,7 @@ export const generalParamsSchema = z.object({
 export const chainMessageTypeSchema = z.literal("CHAIN_MESSAGE");
 export const chainEventTypeSchema = z.literal("CHAIN_EVENT");
 export const deploymentBalanceTypeSchema = z.literal("DEPLOYMENT_BALANCE");
+export const walletBalanceTypeSchema = z.literal("WALLET_BALANCE");
 
 export const generalJsonFieldsSchema = z.object({
   type: z.union([chainMessageTypeSchema, chainEventTypeSchema]),
@@ -59,8 +66,15 @@ export const generalJsonFieldsSchema = z.object({
 export const deploymentBalanceJsonFieldsSchema = z.object({
   type: deploymentBalanceTypeSchema,
   params: deploymentBalanceParamsSchema,
-  conditions: deploymentBalanceConditionsSchema
+  conditions: balanceConditionsSchema
+});
+
+export const walletBalanceJsonFieldsSchema = z.object({
+  type: walletBalanceTypeSchema,
+  params: walletBalanceParamsSchema,
+  conditions: balanceConditionsSchema
 });
 
 export type GeneralJsonFields = z.infer<typeof generalJsonFieldsSchema>;
 export type DeploymentBalanceJsonFields = z.infer<typeof deploymentBalanceJsonFieldsSchema>;
+export type WalletBalanceJsonFields = z.infer<typeof walletBalanceJsonFieldsSchema>;

--- a/apps/notifications/src/modules/alert/repositories/alert/alert.repository.ts
+++ b/apps/notifications/src/modules/alert/repositories/alert/alert.repository.ts
@@ -11,7 +11,7 @@ import { DRIZZLE_PROVIDER_TOKEN } from "@src/infrastructure/db/config/db.config"
 import { DrizzleAbility } from "@src/lib/drizzle-ability/drizzle-ability";
 import { NotificationChannel } from "@src/modules/notifications/model-schemas";
 import * as schema from "../../model-schemas";
-import type { DeploymentBalanceJsonFields, GeneralJsonFields } from "./alert-json-fields.schema";
+import type { DeploymentBalanceJsonFields, GeneralJsonFields, WalletBalanceJsonFields } from "./alert-json-fields.schema";
 import * as jsonFieldsSchemas from "./alert-json-fields.schema";
 
 type AbilityParams = [AnyAbility, Parameters<AnyAbility["can"]>[0]];
@@ -25,19 +25,24 @@ export type GeneralAlertOutput = Omit<InternalAlertOutput, "conditions" | "param
 export type DeploymentBalanceAlertInput = Omit<InternalAlertInput, "conditions" | "params" | "type"> & DeploymentBalanceJsonFields;
 export type DeploymentBalanceAlertOutput = Omit<InternalAlertOutput, "conditions" | "params" | "type"> & DeploymentBalanceJsonFields;
 
-export type AlertInput = GeneralAlertInput | DeploymentBalanceAlertInput;
-export type AlertOutput = GeneralAlertOutput | DeploymentBalanceAlertOutput;
+export type WalletBalanceAlertInput = Omit<InternalAlertInput, "conditions" | "params" | "type"> & WalletBalanceJsonFields;
+export type WalletBalanceAlertOutput = Omit<InternalAlertOutput, "conditions" | "params" | "type"> & WalletBalanceJsonFields;
+
+export type AlertInput = GeneralAlertInput | DeploymentBalanceAlertInput | WalletBalanceAlertInput;
+export type AlertOutput = GeneralAlertOutput | DeploymentBalanceAlertOutput | WalletBalanceAlertOutput;
 
 export type AlertType = AlertOutput["type"];
 
 export type AlertInputTypeMap = {
   DEPLOYMENT_BALANCE: DeploymentBalanceAlertInput;
+  WALLET_BALANCE: WalletBalanceAlertInput;
   CHAIN_MESSAGE: GeneralAlertInput;
   CHAIN_EVENT: GeneralAlertInput;
 };
 
 export type AlertOutputTypeMap = {
   DEPLOYMENT_BALANCE: DeploymentBalanceAlertOutput;
+  WALLET_BALANCE: WalletBalanceAlertOutput;
   CHAIN_MESSAGE: GeneralAlertOutput;
   CHAIN_EVENT: GeneralAlertOutput;
 };
@@ -300,6 +305,13 @@ export class AlertRepository {
       return {
         ...rest,
         ...jsonFieldsSchemas.deploymentBalanceJsonFieldsSchema.parse({ type, conditions, params })
+      } as AlertOutputTypeMap[T];
+    }
+
+    if (type === "WALLET_BALANCE") {
+      return {
+        ...rest,
+        ...jsonFieldsSchemas.walletBalanceJsonFieldsSchema.parse({ type, conditions, params })
       } as AlertOutputTypeMap[T];
     }
 

--- a/apps/notifications/src/modules/alert/services/wallet-balance-alerts/wallet-balance-alerts.service.spec.ts
+++ b/apps/notifications/src/modules/alert/services/wallet-balance-alerts/wallet-balance-alerts.service.spec.ts
@@ -1,0 +1,267 @@
+import { BalanceHttpService, type Denom } from "@akashnetwork/http-sdk";
+import { Test, type TestingModule } from "@nestjs/testing";
+import type { MockProxy } from "jest-mock-extended";
+
+import { LoggerService } from "@src/common/services/logger/logger.service";
+import type { AlertOutput, WalletBalanceAlertOutput } from "@src/modules/alert/repositories/alert/alert.repository";
+import { AlertRepository } from "@src/modules/alert/repositories/alert/alert.repository";
+import { AlertMessageService } from "@src/modules/alert/services/alert-message/alert-message.service";
+import { TemplateService } from "@src/modules/alert/services/template/template.service";
+import { ConditionsMatcherService } from "../conditions-matcher/conditions-matcher.service";
+import { WalletBalanceAlertsService } from "./wallet-balance-alerts.service";
+
+import { MockProvider } from "@test/mocks/provider.mock";
+import { mockAkashAddress } from "@test/seeders/akash-address.seeder";
+import { generateAlertMessage } from "@test/seeders/alert-message.seeder";
+import { generateWalletBalanceAlert } from "@test/seeders/wallet-balance-alert.seeder";
+
+describe(WalletBalanceAlertsService.name, () => {
+  describe("alertFor", () => {
+    it("should alert for a given block and mark it as triggered", async () => {
+      const { service, alertRepository, balanceHttpService, alertMessageService, onMessage } = await setup();
+      const owner = mockAkashAddress();
+      const denom = "uakt";
+      const alert = generateWalletBalanceAlert({
+        params: {
+          owner,
+          denom
+        },
+        conditions: { field: "balance", value: 10000000, operator: "lt" },
+        minBlockHeight: 1000
+      });
+      const alerts: WalletBalanceAlertOutput[] = [alert];
+      alertRepository.paginateAll.mockImplementation(async options => {
+        await options.callback(alerts as any);
+      });
+      alertRepository.updateById.mockImplementation(
+        async (id, update) =>
+          ({
+            ...alert,
+            ...update
+          }) as AlertOutput
+      );
+      const balance = { amount: 9000000, denom: "uakt" as Denom };
+      balanceHttpService.getBalance.mockResolvedValue(balance);
+      const alertMessage = generateAlertMessage({
+        notificationChannelId: alert.notificationChannelId
+      });
+      alertMessageService.getMessage.mockReturnValue(alertMessage.payload);
+
+      await service.alertFor({ height: 1000 }, onMessage);
+
+      expect(balanceHttpService.getBalance).toHaveBeenCalledWith(owner, denom);
+      expect(alertMessageService.getMessage).toHaveBeenCalledWith({
+        summary: alert.summary,
+        description: alert.description,
+        vars: {
+          alert: {
+            prev: expect.objectContaining({ id: alert.id }),
+            next: expect.objectContaining({ id: alert.id })
+          },
+          data: balance
+        }
+      });
+      expect(onMessage).toHaveBeenCalledWith(alertMessage);
+      expect(alertRepository.updateById).toHaveBeenCalledWith(alert.id, {
+        minBlockHeight: 1010,
+        status: "TRIGGERED"
+      });
+    });
+
+    it("should recover an alert for a given block and mark it as OK", async () => {
+      const { service, alertRepository, balanceHttpService, alertMessageService, onMessage } = await setup();
+      const owner = mockAkashAddress();
+      const denom = "uakt";
+      const alert = generateWalletBalanceAlert({
+        params: {
+          owner,
+          denom
+        },
+        conditions: { field: "balance", value: 10000000, operator: "lt" },
+        minBlockHeight: 1000,
+        status: "TRIGGERED"
+      });
+      const alerts: WalletBalanceAlertOutput[] = [alert];
+      alertRepository.paginateAll.mockImplementation(async options => {
+        await options.callback(alerts as any);
+      });
+      alertRepository.updateById.mockImplementation(
+        async (id, update) =>
+          ({
+            ...alert,
+            ...update
+          }) as AlertOutput
+      );
+
+      const balance = { amount: 11000000, denom: "uakt" as Denom };
+      balanceHttpService.getBalance.mockResolvedValue(balance);
+      const alertMessage = generateAlertMessage({
+        notificationChannelId: alert.notificationChannelId
+      });
+      alertMessageService.getMessage.mockReturnValue(alertMessage.payload);
+
+      await service.alertFor({ height: 1000 }, onMessage);
+
+      expect(balanceHttpService.getBalance).toHaveBeenCalledWith(owner, denom);
+      expect(alertMessageService.getMessage).toHaveBeenCalledWith({
+        summary: alert.summary,
+        description: alert.description,
+        vars: {
+          alert: {
+            prev: expect.objectContaining({ id: alert.id }),
+            next: expect.objectContaining({ id: alert.id })
+          },
+          data: balance
+        }
+      });
+      expect(onMessage).toHaveBeenCalledWith(alertMessage);
+      expect(alertRepository.updateById).toHaveBeenCalledWith(alert.id, {
+        minBlockHeight: 1010,
+        status: "OK"
+      });
+    });
+
+    it("should not proceed with an already triggered alert", async () => {
+      const { service, alertRepository, balanceHttpService, alertMessageService } = await setup();
+      const owner = mockAkashAddress();
+      const denom = "uakt";
+      const alert = generateWalletBalanceAlert({
+        params: {
+          owner,
+          denom
+        },
+        conditions: { field: "balance", value: 10000000, operator: "lt" },
+        minBlockHeight: 1000,
+        status: "TRIGGERED"
+      });
+      const alerts: WalletBalanceAlertOutput[] = [alert];
+      alertRepository.paginateAll.mockImplementation(async options => {
+        await options.callback(alerts as any);
+      });
+      alertRepository.updateById.mockImplementation(
+        async (id, update) =>
+          ({
+            ...alert,
+            ...update
+          }) as AlertOutput
+      );
+
+      const balance = { amount: 9000000, denom: "uakt" as Denom };
+      balanceHttpService.getBalance.mockResolvedValue(balance);
+      const onMessage = jest.fn();
+
+      await service.alertFor({ height: 1000 }, onMessage);
+
+      expect(balanceHttpService.getBalance).toHaveBeenCalledWith(owner, denom);
+      expect(alertMessageService.getMessage).not.toHaveBeenCalled();
+      expect(onMessage).not.toHaveBeenCalled();
+      expect(alertRepository.updateById).toHaveBeenCalledWith(alert.id, {
+        minBlockHeight: 1010
+      });
+    });
+
+    it("should log error and return if wallet balance is null", async () => {
+      const { service, alertRepository, balanceHttpService, alertMessageService, loggerService, onMessage } = await setup();
+      const owner = mockAkashAddress();
+      const denom = "uakt";
+      const alert = generateWalletBalanceAlert({
+        params: {
+          owner,
+          denom
+        }
+      });
+      const alerts: WalletBalanceAlertOutput[] = [alert];
+      alertRepository.paginateAll.mockImplementation(async options => {
+        await options.callback(alerts as any);
+      });
+
+      balanceHttpService.getBalance.mockResolvedValue(undefined);
+
+      await service.alertFor({ height: 1000 }, onMessage);
+
+      expect(balanceHttpService.getBalance).toHaveBeenCalledWith(owner, denom);
+      expect(alertMessageService.getMessage).not.toHaveBeenCalled();
+      expect(onMessage).not.toHaveBeenCalled();
+      expect(alertRepository.updateById).not.toHaveBeenCalled();
+      expect(loggerService.error).toHaveBeenCalledWith({
+        event: "ALERT_FAILURE",
+        alert,
+        error: expect.any(Error)
+      });
+    });
+
+    it("should log error if alert repository call fails and reject", async () => {
+      const { service, alertRepository, loggerService, alertMessageService } = await setup();
+      const error = new Error("test");
+      alertRepository.paginateAll.mockRejectedValue(error);
+      const block = { height: 1000 };
+      const onMessage = jest.fn();
+
+      await expect(service.alertFor(block, onMessage)).rejects.toBe(error);
+
+      expect(alertMessageService.getMessage).not.toHaveBeenCalled();
+      expect(onMessage).not.toHaveBeenCalled();
+      expect(alertRepository.updateById).not.toHaveBeenCalled();
+      expect(loggerService.error).toHaveBeenCalledWith({
+        event: "ALERT_FAILURE",
+        block: block.height,
+        error
+      });
+    });
+
+    it("should log a single alert error", async () => {
+      const { service, alertRepository, balanceHttpService, alertMessageService, loggerService } = await setup();
+      const alert = generateWalletBalanceAlert({});
+      const alerts: WalletBalanceAlertOutput[] = [alert];
+      alertRepository.paginateAll.mockImplementation(async options => {
+        await options.callback(alerts as any);
+      });
+      const error = new Error("test");
+      balanceHttpService.getBalance.mockRejectedValue(error);
+      const block = { height: 1000 };
+      const onMessage = jest.fn();
+      await service.alertFor(block, onMessage);
+
+      expect(alertMessageService.getMessage).not.toHaveBeenCalled();
+      expect(onMessage).not.toHaveBeenCalled();
+      expect(loggerService.error).toHaveBeenCalledWith({
+        event: "ALERT_FAILURE",
+        alert,
+        error
+      });
+    });
+  });
+
+  async function setup(): Promise<{
+    service: WalletBalanceAlertsService;
+    loggerService: MockProxy<LoggerService>;
+    alertRepository: MockProxy<AlertRepository>;
+    conditionsMatcherService: ConditionsMatcherService;
+    alertMessageService: MockProxy<AlertMessageService>;
+    balanceHttpService: MockProxy<BalanceHttpService>;
+    onMessage: jest.Mock;
+  }> {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WalletBalanceAlertsService,
+        ConditionsMatcherService,
+        TemplateService,
+        MockProvider(AlertRepository),
+        MockProvider(AlertMessageService),
+        MockProvider(BalanceHttpService),
+        MockProvider(LoggerService)
+      ]
+    }).compile();
+    const onMessage = jest.fn();
+
+    return {
+      service: module.get<WalletBalanceAlertsService>(WalletBalanceAlertsService),
+      loggerService: module.get<MockProxy<LoggerService>>(LoggerService),
+      alertRepository: module.get<MockProxy<AlertRepository>>(AlertRepository),
+      conditionsMatcherService: module.get<ConditionsMatcherService>(ConditionsMatcherService),
+      alertMessageService: module.get<MockProxy<AlertMessageService>>(AlertMessageService),
+      balanceHttpService: module.get<MockProxy<BalanceHttpService>>(BalanceHttpService),
+      onMessage
+    };
+  }
+});

--- a/apps/notifications/src/modules/alert/services/wallet-balance-alerts/wallet-balance-alerts.service.ts
+++ b/apps/notifications/src/modules/alert/services/wallet-balance-alerts/wallet-balance-alerts.service.ts
@@ -1,0 +1,100 @@
+import { BalanceHttpService } from "@akashnetwork/http-sdk";
+import { Injectable } from "@nestjs/common";
+
+import { LoggerService } from "@src/common/services/logger/logger.service";
+import { ChainBlockCreatedDto } from "@src/modules/alert/dto/chain-block-created.dto";
+import { AlertRepository, WalletBalanceAlertOutput } from "@src/modules/alert/repositories/alert/alert.repository";
+import { AlertMessageService } from "@src/modules/alert/services/alert-message/alert-message.service";
+import { ConditionsMatcherService } from "@src/modules/alert/services/conditions-matcher/conditions-matcher.service";
+import type { MessageCallback } from "@src/modules/alert/types/message-callback.type";
+
+type AlertCallback = (alert: WalletBalanceAlertOutput) => Promise<void> | void;
+
+@Injectable()
+export class WalletBalanceAlertsService {
+  private readonly WALLET_BALANCE_BLOCKS_THROTTLE = 10;
+
+  constructor(
+    private readonly alertRepository: AlertRepository,
+    private readonly conditionsMatcher: ConditionsMatcherService,
+    private readonly balanceHttpService: BalanceHttpService,
+    private readonly alertMessageService: AlertMessageService,
+    private readonly loggerService: LoggerService
+  ) {
+    this.loggerService.setContext(WalletBalanceAlertsService.name);
+  }
+
+  async alertFor(block: ChainBlockCreatedDto, onMessage: MessageCallback): Promise<void> {
+    await this.forEachAlert(block.height, async alert => this.processSingleAlert(block, alert, onMessage));
+  }
+
+  private async forEachAlert(block: number, onAlert: AlertCallback) {
+    try {
+      await this.alertRepository.paginateAll({
+        query: { block, type: "WALLET_BALANCE" },
+        limit: 10,
+        callback: async alerts => {
+          await Promise.all(alerts.map(async alert => onAlert(alert)));
+        }
+      });
+    } catch (error) {
+      this.loggerService.error({
+        event: "ALERT_FAILURE",
+        block,
+        error
+      });
+      throw error;
+    }
+  }
+
+  private async processSingleAlert(block: ChainBlockCreatedDto, alert: WalletBalanceAlertOutput, onMessage: MessageCallback) {
+    try {
+      const balance = await this.balanceHttpService.getBalance(alert.params.owner, alert.params.denom);
+
+      if (!balance) {
+        this.loggerService.error({
+          event: "ALERT_FAILURE",
+          alert,
+          error: new Error("Failed to fetch balance")
+        });
+        return;
+      }
+
+      const isMatching = this.conditionsMatcher.isMatching(alert.conditions, { balance: balance.amount });
+      const update: Partial<WalletBalanceAlertOutput> = {
+        minBlockHeight: block.height + this.WALLET_BALANCE_BLOCKS_THROTTLE
+      };
+
+      if (isMatching && alert.status === "OK") {
+        update.status = "TRIGGERED";
+      } else if (!isMatching && alert.status === "TRIGGERED") {
+        update.status = "OK";
+      }
+
+      const updatedAlert = await this.alertRepository.updateById(alert.id, update);
+
+      if (alert.status !== updatedAlert?.status) {
+        await onMessage({
+          payload: this.alertMessageService.getMessage({
+            summary: alert.summary,
+            description: alert.description,
+            vars: {
+              alert: {
+                prev: alert,
+                next: updatedAlert
+              },
+              data: balance
+            }
+          }),
+          notificationChannelId: alert.notificationChannelId
+        });
+      }
+    } catch (error) {
+      this.loggerService.error({
+        event: "ALERT_FAILURE",
+        alert,
+        error
+      });
+    }
+  }
+}

--- a/apps/notifications/test/functional/balance-alert.spec.ts
+++ b/apps/notifications/test/functional/balance-alert.spec.ts
@@ -125,7 +125,6 @@ describe("balance alerts", () => {
       message.height = CURRENT_HEIGHT;
 
       await controller.processBlock(message);
-      await controller.processBlock(message);
 
       expect(alertsProcessed).toBe(1);
       expect(brokerService.publish).toHaveBeenCalledTimes(1);

--- a/apps/notifications/test/seeders/wallet-balance-alert.seeder.ts
+++ b/apps/notifications/test/seeders/wallet-balance-alert.seeder.ts
@@ -1,0 +1,45 @@
+import { faker } from "@faker-js/faker";
+
+import type { WalletBalanceAlertOutput } from "@src/modules/alert/repositories/alert/alert.repository";
+
+import { mockAkashAddress } from "@test/seeders/akash-address.seeder";
+
+export const generateWalletBalanceAlert = ({
+  id = faker.string.uuid(),
+  userId = faker.string.uuid(),
+  notificationChannelId = faker.string.uuid(),
+  name = faker.lorem.word(),
+  summary = faker.lorem.sentence(),
+  description = faker.lorem.sentence(),
+  conditions = {
+    field: "balance",
+    value: faker.number.int({ min: 0, max: 1000000 }),
+    operator: "lt"
+  },
+  enabled = true,
+  status = "OK",
+  params = {
+    owner: mockAkashAddress(),
+    denom: "uakt"
+  },
+  minBlockHeight = faker.number.int({ min: 0, max: 1000000 }),
+  createdAt = faker.date.recent(),
+  updatedAt = faker.date.recent()
+}: Partial<WalletBalanceAlertOutput>): WalletBalanceAlertOutput => {
+  return {
+    type: "WALLET_BALANCE",
+    id,
+    userId,
+    notificationChannelId,
+    name,
+    summary,
+    description,
+    conditions,
+    enabled,
+    status,
+    params,
+    minBlockHeight,
+    createdAt,
+    updatedAt
+  };
+};


### PR DESCRIPTION
Which besides being another type of supported alerts would serve as auto credit reload.

refs #1779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet balance alerts: create alerts that trigger when wallet balances meet configured conditions; evaluated on new blocks and send notifications.

* **API**
  * Alert schemas and endpoints updated to accept, return, and list wallet-balance alert variants and params; paginated alert list output added.

* **Database**
  * Alert type enum extended to include WALLET_BALANCE; migration snapshot updated.

* **Tests**
  * New unit and functional tests plus test seeder covering wallet balance alert flows.

* **Reliability**
  * Improved error handling and provider integration for balance fetching and alert processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->