### PR TITLE
test: an attempt to fix provider-proxy flaky tests

### DIFF
--- a/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
@@ -257,11 +257,12 @@ describe("Provider HTTP proxy", () => {
     const { providerUrl } = await startProviderServer({ certPair: validCertPair });
     let isRespondedWith502 = false;
     await startChainApiServer([validCertPair.cert], {
-      interceptRequest(_, res) {
+      interceptRequest(req, res) {
         if (isRespondedWith502) return false;
         isRespondedWith502 = true;
-        res.writeHead(502);
+        res.writeHead(502, { Connection: "close" });
         res.end();
+        req.socket.destroy();
         return true;
       }
     });

--- a/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
@@ -262,7 +262,6 @@ describe("Provider HTTP proxy", () => {
         isRespondedWith502 = true;
         res.writeHead(502, { Connection: "close" });
         res.end();
-        req.socket.destroy();
         return true;
       }
     });

--- a/apps/provider-proxy/test/setup/chainApiServer.ts
+++ b/apps/provider-proxy/test/setup/chainApiServer.ts
@@ -16,7 +16,7 @@ export function startChainApiServer(certificates: X509Certificate[], options?: C
       if (options?.interceptRequest?.(req, res)) return;
 
       if (!/\/akash\/cert\/(v1|v1beta3)\/certificates\/list/.test(req.url || "")) {
-        res.writeHead(404, "Not Found");
+        res.writeHead(404, { Connection: "close" });
         res.end("");
         return;
       }
@@ -25,7 +25,7 @@ export function startChainApiServer(certificates: X509Certificate[], options?: C
       const serialNumber = BigInt(url.searchParams.get("filter.serial")!).toString(16).toUpperCase();
       const providerAddress = url.searchParams.get("filter.owner")!;
 
-      res.writeHead(200, "OK");
+      res.writeHead(200, { "Content-Type": "application/json", Connection: "close" });
       res.end(
         JSON.stringify({
           certificates: certificates


### PR DESCRIPTION
## Why

Sometimes provider-proxy tests fail with ECONNRESET

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved HTTP test behavior to better simulate connection closures and error responses.
* **Bug Fixes / Stability**
  * More robust proxy streaming: aborted connections and stream errors are now handled gracefully to reduce noise and prevent premature failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->