### PR TITLE
feat: can accept base64 payload while proxying to provider

### DIFF
--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
@@ -942,7 +942,7 @@ describe(ProviderProxyService.name, () => {
       await dispatchWsEvent(websocket, new Event("open"));
 
       const sentMessage = JSON.parse((websocket.send as jest.Mock).mock.calls[0][0]);
-      expect(sentMessage.data).toBe(encoder.encode("echo hello").toString());
+      expect(sentMessage.data).toBe("ZWNobyBoZWxsbw==");
     });
 
     it("does not include data field when message is empty", async () => {
@@ -1015,8 +1015,8 @@ describe(ProviderProxyService.name, () => {
       const firstMessage = JSON.parse((websocket.send as jest.Mock).mock.calls[0][0]);
       const secondMessage = JSON.parse((websocket.send as jest.Mock).mock.calls[1][0]);
 
-      expect(firstMessage.data).toBe(encoder.encode("first").toString());
-      expect(secondMessage.data).toBe(encoder.encode("second").toString());
+      expect(firstMessage.data).toBe("Zmlyc3Q=");
+      expect(secondMessage.data).toBe("c2Vjb25k");
     });
 
     it("receives shell messages through async iterator", async () => {

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
@@ -303,11 +303,12 @@ export class ProviderProxyService {
           url,
           auth: providerCredentialsToApiCredentials(input.providerCredentials),
           chainNetwork: this.netConfig.mapped(input.chainNetwork),
-          providerAddress: input.providerAddress
+          providerAddress: input.providerAddress,
+          isBase64: true
         };
 
         if (message.length > 0) {
-          remoteMessage.data = message.toString();
+          remoteMessage.data = btoa(String.fromCharCode(...message));
         }
 
         return JSON.stringify(remoteMessage);

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
@@ -6,6 +6,7 @@ import saveFileInBrowser from "file-saver";
 
 import { WebsocketSession } from "@src/lib/websocket/WebsocketSession";
 import type { ApiProviderList } from "@src/types/provider";
+import { toBase64 } from "@src/utils/encoding";
 import { wait } from "@src/utils/timer";
 import { formatK8sEvent, formatLogMessage } from "./logFormatters";
 
@@ -308,12 +309,7 @@ export class ProviderProxyService {
         };
 
         if (message.length > 0) {
-          let binaryString = '';
-          for (let i = 0; i < message.length; i++) {
-            binaryString += String.fromCharCode(message[i]);
-          }
-
-          remoteMessage.data = btoa(binaryString);
+          remoteMessage.data = toBase64(message);
         }
 
         return JSON.stringify(remoteMessage);

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
@@ -308,7 +308,12 @@ export class ProviderProxyService {
         };
 
         if (message.length > 0) {
-          remoteMessage.data = btoa(String.fromCharCode(...message));
+          let binaryString = '';
+          for (let i = 0; i < message.length; i++) {
+            binaryString += String.fromCharCode(message[i]);
+          }
+
+          remoteMessage.data = btoa(binaryString);
         }
 
         return JSON.stringify(remoteMessage);

--- a/apps/provider-proxy/src/services/WebsocketServer.ts
+++ b/apps/provider-proxy/src/services/WebsocketServer.ts
@@ -234,7 +234,7 @@ export class WebsocketServer {
       return;
     }
 
-    const data = Buffer.from(message.data.split(",") as any);
+    const data = message.isBase64 ? Buffer.from(message.data, "base64") : Buffer.from(message.data.split(",") as any);
     const callback = propagateTracingContext((error?: Error) => {
       if (error) {
         this.logger?.error({

--- a/apps/provider-proxy/src/utils/schema.ts
+++ b/apps/provider-proxy/src/utils/schema.ts
@@ -28,7 +28,12 @@ export const providerRequestSchema = z.object({
     .describe('Deprecated blockchain network. Use "network" instead.')
     .optional(),
   certPem: z.string().describe('Deprecated certificate. Use mtls auth type  with "auth.certPem" instead.').optional(),
-  keyPem: z.string().describe('Deprecated key. Use mtls auth type  with "auth.keyPem" instead.').optional()
+  keyPem: z.string().describe('Deprecated key. Use mtls auth type  with "auth.keyPem" instead.').optional(),
+  isBase64: z
+    .boolean()
+    .describe("Temporary field for the time when some clients are sending comma-separated data, while some are sending base64.")
+    .optional()
+    .default(false)
 });
 
 export type ProviderRequestSchema = Omit<z.infer<typeof providerRequestSchema>, "chainNetwork" | "certPem" | "keyPem">;


### PR DESCRIPTION
refs #2178

A follow-up change in a week or so should remove the new field and old version of decoding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Binary message payloads are now encoded as base64 when sent and are conditionally decoded on receipt to ensure accurate transmission and reconstruction.
  * Configuration/schema includes an optional flag to mark payloads as base64, enabling interoperable handling across services.

* **Tests**
  * Test expectations updated to assert concrete base64-encoded payloads to reflect the new encoding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->