### PR TITLE
fix: proper handling of useFactory instances in console-api

### DIFF
--- a/apps/api/src/billing/providers/wallet.provider.ts
+++ b/apps/api/src/billing/providers/wallet.provider.ts
@@ -1,23 +1,25 @@
 import type { InjectionToken } from "tsyringe";
-import { container, inject } from "tsyringe";
+import { container, inject, instancePerContainerCachingFactory } from "tsyringe";
 
 import { config } from "@src/billing/config";
-import type { WalletFactory } from "@src/billing/lib/wallet/wallet";
-import { Wallet, walletFactory } from "@src/billing/lib/wallet/wallet";
+import type { Wallet, WalletFactory } from "@src/billing/lib/wallet/wallet";
+import { walletFactory } from "@src/billing/lib/wallet/wallet";
 import type { MasterWalletType } from "@src/billing/types/wallet.type";
 
-export const MANAGED_MASTER_WALLET = "MANAGED_MASTER_WALLET";
-container.register(MANAGED_MASTER_WALLET, { useFactory: () => new Wallet(config.MASTER_WALLET_MNEMONIC) });
+export const MANAGED_MASTER_WALLET: InjectionToken<Wallet> = "MANAGED_MASTER_WALLET";
+container.register(MANAGED_MASTER_WALLET, { useFactory: instancePerContainerCachingFactory(c => c.resolve(WALLET_FACTORY)(config.MASTER_WALLET_MNEMONIC)) });
 
-export const UAKT_TOP_UP_MASTER_WALLET = "UAKT_TOP_UP_MASTER_WALLET";
-container.register(UAKT_TOP_UP_MASTER_WALLET, { useFactory: () => new Wallet(config.UAKT_TOP_UP_MASTER_WALLET_MNEMONIC) });
+export const UAKT_TOP_UP_MASTER_WALLET: InjectionToken<Wallet> = "UAKT_TOP_UP_MASTER_WALLET";
+container.register(UAKT_TOP_UP_MASTER_WALLET, {
+  useFactory: instancePerContainerCachingFactory(c => c.resolve(WALLET_FACTORY)(config.UAKT_TOP_UP_MASTER_WALLET_MNEMONIC))
+});
 
-export const USDC_TOP_UP_MASTER_WALLET = "USDC_TOP_UP_MASTER_WALLET";
-container.register(USDC_TOP_UP_MASTER_WALLET, { useFactory: () => new Wallet(config.USDC_TOP_UP_MASTER_WALLET_MNEMONIC) });
+export const USDC_TOP_UP_MASTER_WALLET: InjectionToken<Wallet> = "USDC_TOP_UP_MASTER_WALLET";
+container.register(USDC_TOP_UP_MASTER_WALLET, {
+  useFactory: instancePerContainerCachingFactory(c => c.resolve(WALLET_FACTORY)(config.USDC_TOP_UP_MASTER_WALLET_MNEMONIC))
+});
 
 export const InjectWallet = (walletType: MasterWalletType) => inject(`${walletType}_MASTER_WALLET`);
-
-export const resolveWallet = (walletType: MasterWalletType) => container.resolve<Wallet>(`${walletType}_MASTER_WALLET`);
 
 export const WALLET_FACTORY: InjectionToken<WalletFactory> = "WALLET_FACTORY";
 container.register(WALLET_FACTORY, {

--- a/apps/api/src/core/providers/amplitude.provider.ts
+++ b/apps/api/src/core/providers/amplitude.provider.ts
@@ -1,16 +1,16 @@
 import * as amplitude from "@amplitude/analytics-node";
-import { container } from "tsyringe";
+import { container, instancePerContainerCachingFactory } from "tsyringe";
 
 import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
 
 export const AMPLITUDE = "AMPLITUDE";
 
 container.register(AMPLITUDE, {
-  useFactory: c => {
+  useFactory: instancePerContainerCachingFactory(c => {
     const config = c.resolve(CoreConfigService);
     amplitude.init(config.get("AMPLITUDE_API_KEY"));
     return amplitude;
-  }
+  })
 });
 
 export type Amplitude = {

--- a/apps/api/src/core/providers/auth.provider.ts
+++ b/apps/api/src/core/providers/auth.provider.ts
@@ -1,14 +1,14 @@
 import { ManagementClient } from "auth0";
-import { container } from "tsyringe";
+import { container, instancePerContainerCachingFactory } from "tsyringe";
 
 import { AuthConfigService } from "@src/auth/services/auth-config/auth-config.service";
 
 let managementClientInstance: ManagementClient | null = null;
 
 container.register(ManagementClient, {
-  useFactory: () => {
+  useFactory: instancePerContainerCachingFactory(c => {
     if (!managementClientInstance) {
-      const authConfig = container.resolve(AuthConfigService);
+      const authConfig = c.resolve(AuthConfigService);
 
       managementClientInstance = new ManagementClient({
         domain: authConfig.get("AUTH0_M2M_DOMAIN"),
@@ -18,5 +18,5 @@ container.register(ManagementClient, {
     }
 
     return managementClientInstance;
-  }
+  })
 });

--- a/apps/api/src/core/providers/http-sdk.provider.ts
+++ b/apps/api/src/core/providers/http-sdk.provider.ts
@@ -14,26 +14,28 @@ import {
   ProviderHttpService
 } from "@akashnetwork/http-sdk";
 import type { InjectionToken } from "tsyringe";
-import { container } from "tsyringe";
+import { container, instancePerContainerCachingFactory } from "tsyringe";
 
 import { apiNodeUrl, nodeApiBasePath } from "@src/utils/constants";
 
 export const CHAIN_API_HTTP_CLIENT: InjectionToken<HttpClient> = Symbol("CHAIN_API_HTTP_CLIENT");
 
 container.register(CHAIN_API_HTTP_CLIENT, {
-  useFactory: () => createHttpClient({ baseURL: apiNodeUrl })
+  useFactory: instancePerContainerCachingFactory(() => createHttpClient({ baseURL: apiNodeUrl }))
 });
 
 const SERVICES = [BalanceHttpService, BlockHttpService, BidHttpService, ProviderHttpService];
 SERVICES.forEach(Service => container.register(Service, { useValue: new Service({ baseURL: apiNodeUrl }) }));
 
 const NON_AXIOS_SERVICES: Array<new (httpClient: HttpClient) => unknown> = [DeploymentHttpService, LeaseHttpService, CosmosHttpService, AuthzHttpService];
-NON_AXIOS_SERVICES.forEach(Service => container.register(Service, { useFactory: c => new Service(c.resolve(CHAIN_API_HTTP_CLIENT)) }));
+NON_AXIOS_SERVICES.forEach(Service =>
+  container.register(Service, { useFactory: instancePerContainerCachingFactory(c => new Service(c.resolve(CHAIN_API_HTTP_CLIENT))) })
+);
 
 container.register(GitHubHttpService, { useValue: new GitHubHttpService({ baseURL: "https://raw.githubusercontent.com" }) });
 container.register(CoinGeckoHttpService, {
-  useFactory: () => new CoinGeckoHttpService(createHttpClient({ baseURL: "https://api.coingecko.com" }))
+  useFactory: instancePerContainerCachingFactory(() => new CoinGeckoHttpService(createHttpClient({ baseURL: "https://api.coingecko.com" })))
 });
 container.register(NodeHttpService, {
-  useFactory: () => new NodeHttpService(createHttpClient({ baseURL: nodeApiBasePath }))
+  useFactory: instancePerContainerCachingFactory(() => new NodeHttpService(createHttpClient({ baseURL: nodeApiBasePath })))
 });

--- a/apps/api/src/core/providers/job-queue-healthcheck.ts
+++ b/apps/api/src/core/providers/job-queue-healthcheck.ts
@@ -1,5 +1,5 @@
 import type { InjectionToken } from "tsyringe";
-import { container } from "tsyringe";
+import { container, instancePerContainerCachingFactory } from "tsyringe";
 
 import { JobQueueService } from "../services/job-queue/job-queue.service";
 
@@ -8,10 +8,10 @@ export type JobQueueHealthcheck = {
 };
 export const JOB_QUEUE_HEALTHCHECK: InjectionToken<JobQueueHealthcheck> = "JOB_QUEUE_HEALTHCHECK";
 container.register(JOB_QUEUE_HEALTHCHECK, {
-  useFactory: c => {
+  useFactory: instancePerContainerCachingFactory(c => {
     const jobQueueService = c.resolve(JobQueueService);
     return {
       ping: () => jobQueueService.ping()
     };
-  }
+  })
 });

--- a/apps/api/src/notifications/providers/notification-data-resolvers.provider.ts
+++ b/apps/api/src/notifications/providers/notification-data-resolvers.provider.ts
@@ -1,5 +1,5 @@
 import type { InjectionToken } from "tsyringe";
-import { container } from "tsyringe";
+import { container, instancePerContainerCachingFactory } from "tsyringe";
 
 import type { Resolver } from "@src/core/providers/resolvers.provider";
 import { DATA_RESOLVER } from "@src/core/providers/resolvers.provider";
@@ -8,12 +8,12 @@ export type NotificationDataResolvers = Record<string, Resolver>;
 export const NOTIFICATION_DATA_RESOLVERS: InjectionToken<NotificationDataResolvers> = Symbol("NOTIFICATION_DATA_RESOLVERS");
 
 container.register(NOTIFICATION_DATA_RESOLVERS, {
-  useFactory: c => {
+  useFactory: instancePerContainerCachingFactory(c => {
     const resolvers = c.resolveAll(DATA_RESOLVER);
 
     return resolvers.reduce((acc, resolver) => {
       acc[resolver.key] = resolver;
       return acc;
     }, {} as NotificationDataResolvers);
-  }
+  })
 });

--- a/apps/api/src/notifications/providers/notifications-api.provider.ts
+++ b/apps/api/src/notifications/providers/notifications-api.provider.ts
@@ -1,7 +1,7 @@
 import { createAPIClient } from "@akashnetwork/react-query-sdk/notifications";
 import { requestFn } from "@openapi-qraft/react";
 import type { InjectionToken } from "tsyringe";
-import { container } from "tsyringe";
+import { container, instancePerContainerCachingFactory } from "tsyringe";
 
 import type { NotificationsConfig } from "../config/env.config";
 import { NOTIFICATIONS_CONFIG } from "./notifications-config.provider";
@@ -10,7 +10,7 @@ export type NotificationsApiClient = ReturnType<typeof createNotificationsApiCli
 export const NOTIFICATIONS_API_CLIENT: InjectionToken<NotificationsApiClient> = Symbol("NOTIFICATIONS_API_CLIENT");
 
 container.register(NOTIFICATIONS_API_CLIENT, {
-  useFactory: c => createNotificationsApiClient(c.resolve(NOTIFICATIONS_CONFIG))
+  useFactory: instancePerContainerCachingFactory(c => createNotificationsApiClient(c.resolve(NOTIFICATIONS_CONFIG)))
 });
 
 function createNotificationsApiClient(config: NotificationsConfig) {

--- a/apps/api/src/notifications/providers/notifications-config.provider.ts
+++ b/apps/api/src/notifications/providers/notifications-config.provider.ts
@@ -1,5 +1,5 @@
 import type { InjectionToken } from "tsyringe";
-import { container } from "tsyringe";
+import { container, instancePerContainerCachingFactory } from "tsyringe";
 
 import type { NotificationsConfig } from "../config/env.config";
 import { envSchema } from "../config/env.config";
@@ -7,5 +7,5 @@ import { envSchema } from "../config/env.config";
 export const NOTIFICATIONS_CONFIG: InjectionToken<NotificationsConfig> = Symbol("NOTIFICATIONS_CONFIG");
 
 container.register(NOTIFICATIONS_CONFIG, {
-  useFactory: () => envSchema.parse(process.env)
+  useFactory: instancePerContainerCachingFactory(() => envSchema.parse(process.env))
 });

--- a/apps/api/test/functional/stale-anonymous-users-cleanup.spec.ts
+++ b/apps/api/test/functional/stale-anonymous-users-cleanup.spec.ts
@@ -3,7 +3,7 @@ import subDays from "date-fns/subDays";
 import { container } from "tsyringe";
 
 import { AuthInterceptor } from "@src/auth/services/auth.interceptor";
-import { resolveWallet } from "@src/billing/providers/wallet.provider";
+import { MANAGED_MASTER_WALLET } from "@src/billing/providers/wallet.provider";
 import { UserWalletRepository } from "@src/billing/repositories";
 import { app } from "@src/rest-app";
 import { UserController } from "@src/user/controllers/user/user.controller";
@@ -19,7 +19,7 @@ describe("Users", () => {
   const walletService = new WalletTestingService(app);
   const controller = container.resolve(UserController);
   const authzHttpService = container.resolve(AuthzHttpService);
-  const masterWalletService = resolveWallet("MANAGED");
+  const masterWalletService = container.resolve(MANAGED_MASTER_WALLET);
   let masterAddress: string;
 
   beforeAll(async () => {

--- a/apps/api/test/functional/start-trial.spec.ts
+++ b/apps/api/test/functional/start-trial.spec.ts
@@ -6,7 +6,7 @@ import { container } from "tsyringe";
 
 import type { BillingConfig } from "@src/billing/providers";
 import { BILLING_CONFIG } from "@src/billing/providers";
-import { resolveWallet } from "@src/billing/providers/wallet.provider";
+import { MANAGED_MASTER_WALLET } from "@src/billing/providers/wallet.provider";
 import type { ApiPgDatabase } from "@src/core";
 import { POSTGRES_DB, resolveTable } from "@src/core";
 import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
@@ -47,7 +47,7 @@ describe("start trial", () => {
         });
         const getWalletsResponse = await app.request(`/v1/wallets?userId=${userId}`, { headers });
         const userWallet = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, userId) });
-        const masterWalletAddress = await resolveWallet("MANAGED").getFirstAddress();
+        const masterWalletAddress = await container.resolve(MANAGED_MASTER_WALLET).getFirstAddress();
         if (!userWallet?.address) throw new Error("User wallet address is null-ish");
 
         const allowances = await Promise.all([

--- a/apps/api/test/services/test-wallet.service.ts
+++ b/apps/api/test/services/test-wallet.service.ts
@@ -54,11 +54,11 @@ export class TestWalletService {
     this.saveCache();
   }
 
-  private async prepareWallets(faucetWallet: Wallet, totalDistibutionAmount: number) {
+  private async prepareWallets(faucetWallet: Wallet, totalDistributionAmount: number) {
     const specPaths = fs.readdirSync(path.join(__dirname, "../functional")).filter(spec => spec.endsWith(".spec.ts"));
     const faucetAddress = await faucetWallet.getFirstAddress();
     const totalMinAmount = Object.values(MIN_AMOUNTS).reduce((acc, curr) => acc + curr, 0);
-    const amount = (totalDistibutionAmount - totalMinAmount - totalDistibutionAmount * 0.01) / specPaths.length;
+    const amount = (totalDistributionAmount - totalMinAmount - totalDistributionAmount * 0.01) / specPaths.length;
 
     const configs = await Promise.all(
       specPaths.map(async path => {


### PR DESCRIPTION
## Why

to ensure we have only 1 instance of service created with `useFactory` fn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal service initialization patterns to improve performance and reliability across core services.
  * Upgraded wallet provider infrastructure for better service integration.

* **Tests**
  * Updated test utilities and infrastructure for improved compatibility with updated service patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->