### PR TITLE
fix: drop deprecated prop so no JS error is shown

### DIFF
--- a/apps/deploy-web/src/components/shared/SelectCheckbox.tsx
+++ b/apps/deploy-web/src/components/shared/SelectCheckbox.tsx
@@ -17,7 +17,6 @@ const MenuProps = {
       width: 250
     }
   },
-  getContentAnchorEl: null,
   anchorOrigin: {
     vertical: "bottom" as const,
     horizontal: "center" as const


### PR DESCRIPTION
closes #2105

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed menu anchoring for select-style checkboxes so dropdowns now rely on default anchoring. This improves dropdown positioning and visual alignment across different layouts and screen sizes, reducing occasional misplacement of menu content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->