### PR TITLE
fix: ensure provider-proxy coerse the PORT variable

### DIFF
--- a/apps/provider-proxy/src/config/env.config.ts
+++ b/apps/provider-proxy/src/config/env.config.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const appConfigSchema = z.object({
   REST_API_NODE_URL: z.string().url(),
-  PORT: z.number().default(3040).optional()
+  PORT: z.number({ coerce: true }).min(0).default(3040).optional()
 });
 
 export type AppConfig = z.infer<typeof appConfigSchema>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced server port configuration validation to automatically convert string inputs to numeric values and enforce non-negative port numbers for improved configuration reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->