### PR TITLE
refactor: removes chainNetwork parameter when communicate to provider-proxy

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
@@ -29,7 +29,7 @@ type Props = {
 const textDecoder = new TextDecoder("utf-8");
 
 export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases }) => {
-  const { providerProxy, networkStore, errorHandler } = useServices();
+  const { providerProxy, errorHandler } = useServices();
 
   const [isConnectionEstablished, setIsConnectionEstablished] = useState(false);
   const [isLoadingData, setIsLoadingData] = useState(true);
@@ -85,7 +85,6 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
       dseq: selectedLease.dseq,
       gseq: selectedLease.gseq,
       oseq: selectedLease.oseq,
-      chainNetwork: networkStore.selectedNetworkId,
       service: selectedService,
       useStdIn: true,
       useTTY: true,

--- a/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
@@ -34,7 +34,7 @@ type Props = {
 };
 
 export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selectedLogsMode }) => {
-  const { analyticsService, providerProxy, networkStore, errorHandler } = useServices();
+  const { analyticsService, providerProxy, errorHandler } = useServices();
   const [isLoadingLogs, setIsLoadingLogs] = useState(true);
   const [isConnectionEstablished, setIsConnectionEstablished] = useState(false);
   // TODO Type
@@ -131,7 +131,6 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
         oseq: selectedLease.oseq,
         type: selectedLogsMode,
         follow: true,
-        chainNetwork: networkStore.selectedNetworkId,
         services: selectedServices.length < services.length ? selectedServices : undefined,
         signal: abortController.signal
       }),

--- a/apps/deploy-web/src/components/deployments/LeaseRow.tsx
+++ b/apps/deploy-web/src/components/deployments/LeaseRow.tsx
@@ -23,7 +23,6 @@ import { useBidInfo } from "@src/queries/useBidQuery";
 import type { LeaseStatusDto } from "@src/queries/useLeaseQuery";
 import { useLeaseStatus } from "@src/queries/useLeaseQuery";
 import { useProviderStatus } from "@src/queries/useProvidersQuery";
-import networkStore from "@src/store/networkStore";
 import type { LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { copyTextToClipboard } from "@src/utils/copyClipboard";
@@ -116,13 +115,12 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(
       loadLeaseStatus();
     }, [lease, provider, providerCredentials.details, loadLeaseStatus]);
 
-    const chainNetwork = networkStore.useSelectedNetworkId();
     async function sendManifest() {
       setIsSendingManifest(true);
       try {
         const manifest = deploymentData.getManifest(parsedManifest, true);
 
-        await providerProxy.sendManifest(provider, manifest, { dseq, credentials: providerCredentials.details, chainNetwork });
+        await providerProxy.sendManifest(provider, manifest, { dseq, credentials: providerCredentials.details });
 
         enqueueSnackbar(<Snackbar title="Manifest sent!" iconVariant="success" />, { variant: "success", autoHideDuration: 10_000 });
 

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate.tsx
@@ -14,7 +14,6 @@ import { useSettings } from "@src/context/SettingsProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { useProviderList } from "@src/queries/useProvidersQuery";
-import networkStore from "@src/store/networkStore";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { deploymentData } from "@src/utils/deploymentData";
@@ -121,13 +120,11 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     window.open("https://akash.network/docs/deployments/akash-cli/installation/#update-the-deployment", "_blank");
   }
 
-  const chainNetwork = networkStore.useSelectedNetworkId();
   async function sendManifest(providerInfo: ApiProviderList, manifest: any) {
     try {
       return await providerProxy.sendManifest(providerInfo, manifest, {
         dseq: deployment.dseq,
-        credentials: providerCredentials.details,
-        chainNetwork
+        credentials: providerCredentials.details
       });
     } catch (err) {
       enqueueSnackbar(<ManifestErrorSnackbar err={err} />, { variant: "error", autoHideDuration: null });

--- a/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.spec.tsx
@@ -206,7 +206,6 @@ describe(CreateLease.name, () => {
         ]);
         expect(sendManifest).toHaveBeenCalledWith(selectedProvider, expect.any(Array), {
           dseq,
-          chainNetwork: "mainnet",
           credentials: {
             type: "mtls",
             value: {
@@ -263,7 +262,6 @@ describe(CreateLease.name, () => {
         );
         expect(sendManifest).toHaveBeenCalledWith(selectedProvider, expect.any(Array), {
           dseq,
-          chainNetwork: "mainnet",
           credentials: {
             type: "mtls",
             value: {
@@ -326,7 +324,6 @@ describe(CreateLease.name, () => {
         ]);
         expect(sendManifest).toHaveBeenCalledWith(selectedProvider, expect.any(Array), {
           dseq,
-          chainNetwork: "mainnet",
           credentials: {
             type: "mtls",
             value: {

--- a/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
@@ -118,7 +118,7 @@ const TRIAL_SIGNUP_WARNING_TIMEOUT = 33_000;
 
 export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies: d = DEPENDENCIES }) => {
   const { settings } = d.useSettings();
-  const { providerProxy, analyticsService, errorHandler, networkStore, urlService, deploymentLocalStorage } = d.useServices();
+  const { providerProxy, analyticsService, errorHandler, urlService, deploymentLocalStorage } = d.useServices();
 
   const [isSendingManifest, setIsSendingManifest] = useState(false);
   const [isFilteringFavorites, setIsFilteringFavorites] = useState(false);
@@ -189,7 +189,6 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
     }
   });
 
-  const chainNetwork = networkStore.useSelectedNetworkId();
   const sendManifest = useCallback(
     async (cert: LocalCert) => {
       setIsSendingManifest(true);
@@ -224,8 +223,7 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
               cert: cert.certPem,
               key: cert.keyPem
             }
-          },
-          chainNetwork
+          }
         };
 
         for (let i = 0; i < bidKeys.length; i++) {
@@ -274,7 +272,7 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
         setIsSendingManifest(false);
       }
     },
-    [selectedBids, dseq, providers, isManaged, enqueueSnackbar, closeSnackbar, router, chainNetwork, address, deploymentLocalStorage]
+    [selectedBids, dseq, providers, isManaged, enqueueSnackbar, closeSnackbar, router, address, deploymentLocalStorage]
   );
 
   // Filter bids

--- a/apps/deploy-web/src/hooks/useProviderApiActions.tsx
+++ b/apps/deploy-web/src/hooks/useProviderApiActions.tsx
@@ -6,7 +6,6 @@ import { useSnackbar } from "notistack";
 import { useServices } from "@src/context/ServicesProvider";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import type { DownloadMessagesResult } from "@src/services/provider-proxy/provider-proxy.service";
-import networkStore from "@src/store/networkStore";
 import type { ApiProviderList } from "@src/types/provider";
 
 export type ProviderInfo = Pick<ApiProviderList, "owner" | "hostUri">;
@@ -22,7 +21,6 @@ type ProviderApiActions = {
 export const useProviderApiActions = (): ProviderApiActions => {
   const providerCredentials = useProviderCredentials();
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
-  const chainNetwork = networkStore.useSelectedNetworkId();
   const { providerProxy, logger } = useServices();
 
   const showSnackbar = useCallback(
@@ -64,7 +62,6 @@ export const useProviderApiActions = (): ProviderApiActions => {
           providerBaseUrl: provider.hostUri,
           providerAddress: provider.owner,
           providerCredentials: providerCredentials.details,
-          chainNetwork,
           dseq,
           gseq,
           oseq,
@@ -83,7 +80,7 @@ export const useProviderApiActions = (): ProviderApiActions => {
         closeSnackbar(snackbarKey);
       }
     },
-    [providerCredentials.details, chainNetwork, providerProxy, showSnackbar, closeSnackbar, displayResult]
+    [providerCredentials.details, providerProxy, showSnackbar, closeSnackbar, displayResult]
   );
 
   const downloadFileFromShell: ProviderApiActions["downloadFileFromShell"] = useCallback(
@@ -94,7 +91,6 @@ export const useProviderApiActions = (): ProviderApiActions => {
           providerBaseUrl: provider.hostUri,
           providerAddress: provider.owner,
           providerCredentials: providerCredentials.details,
-          chainNetwork,
           dseq,
           gseq,
           oseq,
@@ -114,7 +110,7 @@ export const useProviderApiActions = (): ProviderApiActions => {
         closeSnackbar(snackbarKey);
       }
     },
-    [providerCredentials.details, chainNetwork, providerProxy, showSnackbar, closeSnackbar, displayResult]
+    [providerCredentials.details, providerProxy, showSnackbar, closeSnackbar, displayResult]
   );
 
   return useMemo(

--- a/apps/deploy-web/src/hooks/useScopedFetchProviderUrl.ts
+++ b/apps/deploy-web/src/hooks/useScopedFetchProviderUrl.ts
@@ -3,23 +3,20 @@ import type { AxiosResponse } from "axios";
 
 import { useServices } from "@src/context/ServicesProvider";
 import type { ProviderIdentity, ProviderProxyPayload } from "@src/services/provider-proxy/provider-proxy.service";
-import networkStore from "@src/store/networkStore";
 
 export function useScopedFetchProviderUrl(provider: ProviderIdentity | undefined | null): ScopedFetchProviderUrl {
-  const chainNetwork = networkStore.useSelectedNetworkId();
   const { providerProxy } = useServices();
   return useCallback(
     (url, options) => {
       if (!provider) return new Promise(() => {});
       return providerProxy.request(url, {
         ...options,
-        chainNetwork,
         providerIdentity: provider
       });
     },
-    [provider?.hostUri, provider?.owner, chainNetwork]
+    [provider?.hostUri, provider?.owner]
   );
 }
 
-export type ScopedFetchProviderUrlOptions = Omit<ProviderProxyPayload, "chainNetwork" | "providerIdentity">;
+export type ScopedFetchProviderUrlOptions = Omit<ProviderProxyPayload, "providerIdentity">;
 export type ScopedFetchProviderUrl = <T>(url: string, options?: ScopedFetchProviderUrlOptions) => Promise<AxiosResponse<T>>;

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
@@ -69,7 +69,6 @@ describe(ProviderProxyService.name, () => {
           method: "PUT",
           url: `${provider.hostUri}/deployment/${dseq}/manifest`,
           providerAddress: provider.owner,
-          network: "mainnet",
           auth: {
             type: "mtls",
             certPem: credentials.value?.cert,
@@ -106,8 +105,6 @@ describe(ProviderProxyService.name, () => {
         { timeout: expect.any(Number) }
       );
       expect(result).toBe(response);
-
-      jest.useRealTimers();
     });
   });
 

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
@@ -16,7 +16,7 @@ describe(ProviderProxyService.name, () => {
   describe("sendManifest", () => {
     it("does nothing if provider is undefined", () => {
       const { service, httpClient } = setup();
-      service.sendManifest(undefined, {}, { dseq: "1", chainNetwork: "akash" });
+      service.sendManifest(undefined, {}, { dseq: "1" });
       expect(httpClient.post).not.toHaveBeenCalled();
     });
 
@@ -59,7 +59,7 @@ describe(ProviderProxyService.name, () => {
         }
       ];
       const credentials: ProviderCredentials = { type: "mtls", value: { cert: "certPem", key: "keyPem" } };
-      const promise = service.sendManifest(provider, manifest, { dseq, chainNetwork: "mainnet", credentials });
+      const promise = service.sendManifest(provider, manifest, { dseq, credentials });
 
       const [result] = await Promise.all([promise, jest.runAllTimersAsync()]);
 
@@ -119,7 +119,6 @@ describe(ProviderProxyService.name, () => {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
         providerCredentials: { type: "mtls" as const, value: { cert: "cert", key: "key" } },
-        chainNetwork: "mainnet",
         dseq: "123",
         gseq: 1,
         oseq: 1
@@ -175,8 +174,7 @@ describe(ProviderProxyService.name, () => {
         dseq: "456",
         gseq: 2,
         oseq: 3,
-        type: "events" as const,
-        chainNetwork: "testnet"
+        type: "events" as const
       };
 
       const promise = service.downloadLogs(input);
@@ -219,7 +217,6 @@ describe(ProviderProxyService.name, () => {
         gseq: 1,
         oseq: 1,
         type: "logs" as const,
-        chainNetwork: "mainnet",
         signal: abortController.signal
       };
 
@@ -244,8 +241,7 @@ describe(ProviderProxyService.name, () => {
         dseq: "111",
         gseq: 1,
         oseq: 1,
-        type: "logs" as const,
-        chainNetwork: "mainnet"
+        type: "logs" as const
       };
 
       const promise = service.downloadLogs(input);
@@ -287,8 +283,7 @@ describe(ProviderProxyService.name, () => {
         dseq: "222",
         gseq: 1,
         oseq: 1,
-        type: "logs" as const,
-        chainNetwork: "mainnet"
+        type: "logs" as const
       };
 
       const promise = service.downloadLogs(input);
@@ -314,8 +309,7 @@ describe(ProviderProxyService.name, () => {
         dseq: "111",
         gseq: 1,
         oseq: 1,
-        type: "logs" as const,
-        chainNetwork: "mainnet"
+        type: "logs" as const
       };
 
       const promise = service.downloadLogs(input);
@@ -343,7 +337,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "123",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web",
         filePath: "/app/config.json"
       };
@@ -387,7 +380,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "456",
         gseq: 2,
         oseq: 3,
-        chainNetwork: "testnet",
         service: "api",
         filePath: "/data/largefile.txt"
       };
@@ -427,7 +419,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "789",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web",
         filePath: "/nonexistent/file.txt"
       };
@@ -461,7 +452,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "999",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web",
         filePath: "/app/file.txt",
         signal: abortController.signal
@@ -488,7 +478,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "111",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web",
         filePath: "/app/file.txt"
       };
@@ -522,7 +511,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "222",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web",
         filePath: "/very/long/path/to/myfile.log"
       };
@@ -564,8 +552,7 @@ describe(ProviderProxyService.name, () => {
         dseq: "123",
         gseq: 1,
         oseq: 1,
-        type: "logs" as const,
-        chainNetwork: "mainnet"
+        type: "logs" as const
       };
 
       const stream = service.getLogsStream(input);
@@ -609,8 +596,7 @@ describe(ProviderProxyService.name, () => {
         dseq: "456",
         gseq: 2,
         oseq: 3,
-        type: "events" as const,
-        chainNetwork: "testnet"
+        type: "events" as const
       };
 
       const stream = service.getLogsStream(input);
@@ -656,8 +642,7 @@ describe(ProviderProxyService.name, () => {
         dseq: "789",
         gseq: 1,
         oseq: 1,
-        type: "logs" as const,
-        chainNetwork: "mainnet"
+        type: "logs" as const
       };
 
       const stream = service.getLogsStream(input);
@@ -712,7 +697,6 @@ describe(ProviderProxyService.name, () => {
         gseq: 1,
         oseq: 1,
         type: "logs" as const,
-        chainNetwork: "mainnet",
         signal: abortController.signal
       };
 
@@ -736,7 +720,6 @@ describe(ProviderProxyService.name, () => {
         gseq: 1,
         oseq: 1,
         type: "logs" as const,
-        chainNetwork: "mainnet",
         tail: 200,
         services: ["web", "api"],
         follow: true
@@ -763,8 +746,7 @@ describe(ProviderProxyService.name, () => {
         dseq: "111",
         gseq: 1,
         oseq: 1,
-        type: "logs" as const,
-        chainNetwork: "mainnet"
+        type: "logs" as const
       };
 
       const stream = service.getLogsStream(input);
@@ -791,7 +773,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "100",
         gseq: 2,
         oseq: 3,
-        chainNetwork: "mainnet",
         service: "web-service"
       };
 
@@ -812,7 +793,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "456",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "api",
         command: "cat /app/config.json"
       };
@@ -835,7 +815,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "789",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web",
         useStdIn: true,
         useTTY: true
@@ -859,7 +838,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "333",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web",
         command: "ls -la /app"
       };
@@ -883,7 +861,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "444",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web"
       };
 
@@ -908,7 +885,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "555",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web"
       };
 
@@ -932,7 +908,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "666",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web"
       };
 
@@ -954,7 +929,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "777",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web"
       };
 
@@ -976,7 +950,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "888",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web",
         signal: abortController.signal
       };
@@ -999,7 +972,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "1000",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web"
       };
 
@@ -1028,7 +1000,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "1111",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web"
       };
 
@@ -1070,7 +1041,6 @@ describe(ProviderProxyService.name, () => {
         dseq: "1111",
         gseq: 1,
         oseq: 1,
-        chainNetwork: "mainnet",
         service: "web"
       };
 

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -1,6 +1,6 @@
 export const netConfigData = {
   mainnet: {
-    version: "v1.0.0",
+    version: "v1.1.0",
     faucetUrl: null,
     apiUrls: [
       "https://rest-akash.ecostake.com",
@@ -29,7 +29,7 @@ export const netConfigData = {
     ]
   },
   "sandbox-2": {
-    version: "v1.0.0",
+    version: "v1.1.0",
     faucetUrl: "http://faucet.sandbox-2.aksh.pw/",
     apiUrls: ["https://api.sandbox-2.aksh.pw:443"],
     rpcUrls: ["https://rpc.sandbox-2.aksh.pw:443"]


### PR DESCRIPTION
## Why

Provider-proxy doesn't accept network parameter anymore and we have 1 instance per network

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed explicit network selection from provider interactions — manifest submissions, log streaming, file downloads, and shell sessions no longer include a network field; provider calls now rely on internal defaults.
  * Simplified and reduced public API surface by removing network-related options and payload properties.

* **Tests**
  * Updated test expectations to align with the simplified provider API (no explicit network field).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->