### PR TITLE
refactor: changes default value for AVERAGE_GAS_PRICE

### DIFF
--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -12,7 +12,7 @@ export const envSchema = z.object({
   TRIAL_DEPLOYMENT_CLEANUP_HOURS: z.number({ coerce: true }).default(24),
   DEPLOYMENT_GRANT_DENOM: z.string(),
   GAS_SAFETY_MULTIPLIER: z.number({ coerce: true }).default(1.8),
-  AVERAGE_GAS_PRICE: z.number({ coerce: true }).default(0.0025),
+  AVERAGE_GAS_PRICE: z.number({ coerce: true }).default(0.025),
   FEE_ALLOWANCE_REFILL_THRESHOLD: z.number({ coerce: true }),
   FEE_ALLOWANCE_REFILL_AMOUNT: z.number({ coerce: true }),
   DEPLOYMENT_ALLOWANCE_REFILL_AMOUNT: z.number({ coerce: true }),


### PR DESCRIPTION
## Why

We change this value in deployment config but instead can just update the default value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default gas price configuration value used in billing calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->