### PR TITLE
fix: make StripeInput work on light theme

### DIFF
--- a/apps/deploy-web/src/components/shared/StripeInput/StripeInput.tsx
+++ b/apps/deploy-web/src/components/shared/StripeInput/StripeInput.tsx
@@ -1,11 +1,21 @@
 "use client";
-import React, { type InputHTMLAttributes } from "react";
+import React, { type InputHTMLAttributes, useCallback } from "react";
+import { useTheme } from "next-themes";
 
 interface StripeInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, "style"> {
   label?: string;
 }
 
 export const StripeInput: React.FC<StripeInputProps> = ({ label, id, ...props }) => {
+  const { resolvedTheme } = useTheme();
+
+  const themed = useCallback(
+    (light: string, dark: string) => {
+      return resolvedTheme === "light" ? light : dark;
+    },
+    [resolvedTheme]
+  );
+
   return (
     <div>
       {label && (
@@ -16,7 +26,7 @@ export const StripeInput: React.FC<StripeInputProps> = ({ label, id, ...props })
             marginBottom: "6px",
             fontSize: "14px",
             fontWeight: "400",
-            color: "rgb(255, 255, 255)",
+            color: themed("rgb(48, 49, 61)", "rgb(255, 255, 255)"),
             lineHeight: "20px"
           }}
         >
@@ -30,22 +40,25 @@ export const StripeInput: React.FC<StripeInputProps> = ({ label, id, ...props })
           padding: "10px 12px",
           fontSize: "16px",
           lineHeight: "24px",
-          border: "1px solid rgba(255, 255, 255, 0.1)",
+          border: themed("1px solid rgb(230, 230, 230)", "1px solid rgba(255, 255, 255, 0.1)"),
           borderRadius: "6px",
-          backgroundColor: "#30313d",
-          color: "rgb(255, 255, 255)",
+          backgroundColor: themed("#fff", "#30313d"),
+          color: themed("rgb(48, 49, 61)", "rgb(255, 255, 255)"),
           outline: "none",
-          boxShadow: "0px 2px 4px rgba(0, 0, 0, 0.5), 0px 1px 6px rgba(0, 0, 0, 0.25)",
+          boxShadow: themed("rgba(0, 0, 0, 0.03) 0px 1px 1px 0px", "0px 2px 4px rgba(0, 0, 0, 0.5), 0px 1px 6px rgba(0, 0, 0, 0.25)"),
           transition: "background 0.15s ease, border 0.15s ease, box-shadow 0.15s ease, color 0.15s ease",
           fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
         }}
         onFocus={e => {
-          e.target.style.borderColor = "#ff424c";
-          e.target.style.boxShadow = "0px 2px 4px rgba(0, 0, 0, 0.5), 0px 1px 6px rgba(0, 0, 0, 0.25), 0 0 0 1px #ff424c";
+          e.target.style.borderColor = themed("#ff424c", "#ff424c");
+          e.target.style.boxShadow = themed(
+            "0px 1px 1px rgba(0, 0, 0, 0.03), 0px 3px 6px rgba(0, 0, 0, 0.02), 0 0 0 3px hsla(357, 100%, 63%, 25%), 0 1px 1px 0 rgba(0, 0, 0, 0.08)",
+            "0px 2px 4px rgba(0, 0, 0, 0.5), 0px 1px 6px rgba(0, 0, 0, 0.25), 0 0 0 3px hsla(357, 100%, 63%, 25%), 0 1px 1px 0 rgba(255, 255, 255, 0.12)"
+          );
         }}
         onBlur={e => {
-          e.target.style.borderColor = "rgba(255, 255, 255, 0.1)";
-          e.target.style.boxShadow = "0px 2px 4px rgba(0, 0, 0, 0.5), 0px 1px 6px rgba(0, 0, 0, 0.25)";
+          e.target.style.borderColor = themed("rgb(230, 230, 230)", "rgba(255, 255, 255, 0.1)");
+          e.target.style.boxShadow = themed("rgba(0, 0, 0, 0.03) 0px 1px 1px 0px", "0px 2px 4px rgba(0, 0, 0, 0.5), 0px 1px 6px rgba(0, 0, 0, 0.25)");
         }}
         {...props}
       />


### PR DESCRIPTION
refs #1779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stripe input field now adapts to light and dark themes with automatic styling adjustments for borders, backgrounds, and shadows.
  * Enhanced visual feedback with theme-aware styling during focus and blur interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->