### PR TITLE
chore: adds local eslint plugin and rule that can detect mnemonics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36123,6 +36123,10 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-plugin-akash": {
+      "resolved": "packages/dev-config/eslint-plugin-akash",
+      "link": true
+    },
     "node_modules/eslint-plugin-import": {
       "version": "2.31.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
@@ -57367,10 +57371,17 @@
         "eslint": "^8.57.0",
         "eslint-config-next": "^14.2.3",
         "eslint-import-resolver-typescript": "^4.4.4",
+        "eslint-plugin-akash": "file:./eslint-plugin-akash",
         "eslint-plugin-import-x": "4.10.0",
         "eslint-plugin-simple-import-sort": "^12.1.0",
         "prettier": "^3.3.0",
         "prettier-plugin-tailwindcss": "^0.6.1"
+      }
+    },
+    "packages/dev-config/eslint-plugin-akash": {
+      "version": "1.0.0",
+      "dependencies": {
+        "bip39": "3.1.0"
       }
     },
     "packages/dev-config/node_modules/eslint-import-resolver-typescript": {

--- a/packages/dev-config/.eslintrc.base.js
+++ b/packages/dev-config/.eslintrc.base.js
@@ -4,7 +4,7 @@ module.exports = {
     es2021: true
   },
   extends: ["eslint:recommended"],
-  plugins: ["simple-import-sort", "import-x"],
+  plugins: ["simple-import-sort", "import-x", "akash"],
   settings: {
     "import-x/resolver": {
       typescript: {
@@ -33,7 +33,8 @@ module.exports = {
     "import-x/no-extraneous-dependencies": ["error"],
     "import-x/no-cycle": ["error", { ignoreExternal: true }],
     "import-x/no-self-import": ["error"],
-    "import-x/no-useless-path-segments": ["error"]
+    "import-x/no-useless-path-segments": ["error"],
+    "akash/no-mnemonic": ["error"]
   },
   overrides: [
     {

--- a/packages/dev-config/eslint-plugin-akash/index.js
+++ b/packages/dev-config/eslint-plugin-akash/index.js
@@ -1,0 +1,7 @@
+const noMnemonic = require("./rules/no-mnemonic");
+
+module.exports = {
+  rules: {
+    "no-mnemonic": noMnemonic
+  }
+};

--- a/packages/dev-config/eslint-plugin-akash/package.json
+++ b/packages/dev-config/eslint-plugin-akash/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "eslint-plugin-akash",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "bip39": "3.1.0"
+  }
+}

--- a/packages/dev-config/eslint-plugin-akash/rules/no-mnemonic.js
+++ b/packages/dev-config/eslint-plugin-akash/rules/no-mnemonic.js
@@ -11,7 +11,7 @@ module.exports = {
             node,
             message:
               "Hardcoded mnemonic phrase detected. " +
-              "Don't hardcode mnemonic phrases because it's impossible to distinguish whether its production or test mnemonic. " +
+              "Don't hardcode mnemonic phrases because it's impossible to distinguish whether it's production or test mnemonic. " +
               "Use generated mnemonic for test purposes and hide production mnemonic in secret store."
           });
         }

--- a/packages/dev-config/eslint-plugin-akash/rules/no-mnemonic.js
+++ b/packages/dev-config/eslint-plugin-akash/rules/no-mnemonic.js
@@ -1,0 +1,21 @@
+const bip39 = require("bip39");
+
+module.exports = {
+  create: context => ({
+    Literal(node) {
+      if (typeof node.value === "string") {
+        const mnemonicRegex = /^([a-z]{3,}\s+){11,23}[a-z]{3,}$/;
+        const possibleMnemonic = node.value.trim();
+        if (mnemonicRegex.test(possibleMnemonic) && bip39.validateMnemonic(possibleMnemonic)) {
+          context.report({
+            node,
+            message:
+              "Hardcoded mnemonic phrase detected. " +
+              "Don't hardcode mnemonic phrases because it's impossible to distinguish whether its production or test mnemonic. " +
+              "Use generated mnemonic for test purposes and hide production mnemonic in secret store."
+          });
+        }
+      }
+    }
+  })
+};

--- a/packages/dev-config/package.json
+++ b/packages/dev-config/package.json
@@ -19,6 +19,7 @@
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.3",
     "eslint-import-resolver-typescript": "^4.4.4",
+    "eslint-plugin-akash": "file:./eslint-plugin-akash",
     "eslint-plugin-import-x": "4.10.0",
     "eslint-plugin-simple-import-sort": "^12.1.0",
     "prettier": "^3.3.0",


### PR DESCRIPTION
## Why

To warn us early on possible mnemonic leak in the development cycle.

## Example

```
console/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
  700:22  error  Hardcoded mnemonic phrase detected. Don't hardcode mnemonic phrases because it's impossible to distinguish whether its production or test mnemonic. Use generated mnemonic for test purposes and hide production mnemonic in secret store  akash/no-mnemonic
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new linting plugin to the development configuration and registered it for use.

* **New Features**
  * Introduced a lint rule that detects and flags hardcoded mnemonic phrases in source code, encouraging use of generated keys or secure secret storage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->