### PR TITLE
refactor: removes legacy format for auth in provider-proxy

### DIFF
--- a/apps/provider-proxy/src/app.ts
+++ b/apps/provider-proxy/src/app.ts
@@ -7,7 +7,7 @@ import { RegExpRouter } from "hono/router/reg-exp-router";
 import type http from "http";
 import type { AddressInfo } from "net";
 
-import type { AppConfig } from "./config/env.config";
+import type { AppConfigInput } from "./config/env.config";
 import { getAppStatus, statusRoute } from "./routes/getAppStatus";
 import { proxyProviderRequest, proxyRoute } from "./routes/proxyProviderRequest";
 import { HonoErrorHandlerService } from "./services/HonoErrorHandlerService/HonoErrorHandlerService";
@@ -50,7 +50,7 @@ export function createApp(container: Container): Hono<AppEnv> {
   return app;
 }
 
-export async function startAppServer(untrustedConfig: Record<string, unknown> | AppConfig): Promise<AppServer> {
+export async function startAppServer(untrustedConfig: Record<string, unknown> | AppConfigInput): Promise<AppServer> {
   let appContainer: Container | undefined;
   try {
     const container = createContainer(untrustedConfig);

--- a/apps/provider-proxy/src/config/env.config.ts
+++ b/apps/provider-proxy/src/config/env.config.ts
@@ -6,3 +6,4 @@ export const appConfigSchema = z.object({
 });
 
 export type AppConfig = z.infer<typeof appConfigSchema>;
+export type AppConfigInput = z.input<typeof appConfigSchema>;

--- a/apps/provider-proxy/src/routes/proxyProviderRequest.ts
+++ b/apps/provider-proxy/src/routes/proxyProviderRequest.ts
@@ -60,7 +60,8 @@ export async function proxyProviderRequest(ctx: AppContext): Promise<Response | 
     url,
     method,
     providerAddress,
-    timeout
+    timeout,
+    authenticationType: auth?.type
   });
   const clientAbortSignal = ctx.req.raw.signal;
   const proxyResult = await httpRetry(

--- a/apps/provider-proxy/src/services/WebsocketServer.ts
+++ b/apps/provider-proxy/src/services/WebsocketServer.ts
@@ -132,8 +132,7 @@ export class WebsocketServer {
               attributes.providerUrl = message.url;
               attributes.providerAddress = message.providerAddress;
               attributes.function = getWebSocketUsage(message);
-              attributes.authenticated =
-                (message.auth?.type === "mtls" && message.auth.certPem && message.auth.keyPem) || (message.auth?.type === "jwt" && message.auth.token);
+              attributes.authenticationType = message.auth?.type;
             }
 
             span.setAttributes(attributes);

--- a/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
@@ -198,8 +198,11 @@ describe("Provider HTTP proxy", () => {
         url: `${providerUrl}/200.txt`,
         providerAddress,
         network,
-        certPem: "-----BEGIN CERTIFICATE-----\r\ninvalid  certificate\r\n-----END CERTIFICATE-----\r\n",
-        keyPem: "-----BEGIN PRIVATE KEY-----\r\ninvalid private key\r\n-----END PRIVATE KEY-----\r\n"
+        auth: {
+          type: "mtls",
+          certPem: "-----BEGIN CERTIFICATE-----\r\ninvalid  certificate\r\n-----END CERTIFICATE-----\r\n",
+          keyPem: "-----BEGIN PRIVATE KEY-----\r\ninvalid private key\r\n-----END PRIVATE KEY-----\r\n"
+        }
       })
     });
 
@@ -491,8 +494,11 @@ describe("Provider HTTP proxy", () => {
         url: `${providerUrl}/200.txt`,
         providerAddress,
         network,
-        certPem: invalidClientCertPair.cert.toString(),
-        keyPem: invalidClientCertPair.key
+        auth: {
+          type: "mtls",
+          certPem: invalidClientCertPair.cert.toString(),
+          keyPem: invalidClientCertPair.key
+        }
       })
     });
 
@@ -551,8 +557,11 @@ describe("Provider HTTP proxy", () => {
         url: `${providerUrl}/long-response`,
         providerAddress,
         network,
-        certPem: validCertPair.cert.toString(),
-        keyPem: validCertPair.key
+        auth: {
+          type: "mtls",
+          certPem: validCertPair.cert.toString(),
+          keyPem: validCertPair.key
+        }
       }),
       signal: requestController.signal
     }).catch(error => ({ error }));
@@ -597,8 +606,11 @@ describe("Provider HTTP proxy", () => {
         url: `${providerUrl}/long-response`,
         providerAddress,
         network,
-        certPem: validCertPair.cert.toString(),
-        keyPem: validCertPair.key
+        auth: {
+          type: "mtls",
+          certPem: validCertPair.cert.toString(),
+          keyPem: validCertPair.key
+        }
       }),
       signal: requestController.signal
     });

--- a/apps/provider-proxy/test/setup/proxyServer.ts
+++ b/apps/provider-proxy/test/setup/proxyServer.ts
@@ -1,10 +1,10 @@
 import type { AppServer } from "../../src/app";
 import { startAppServer } from "../../src/app";
-import type { AppConfig } from "../../src/config/env.config";
+import type { AppConfigInput } from "../../src/config/env.config";
 
 let server: AppServer | undefined;
 
-export async function startServer(untrustedConfig: AppConfig): Promise<string> {
+export async function startServer(untrustedConfig: AppConfigInput): Promise<string> {
   server = await startAppServer({ ...untrustedConfig, PORT: 0 });
   return server.host;
 }


### PR DESCRIPTION
## Why

cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket and proxy logging now record the authentication type (e.g., "mtls", "jwt") instead of a boolean flag.

* **Chores**
  * Request format for MTLS credentials moved from top-level fields to a nested auth object; clients should supply MTLS credentials under auth.
  * Internal config typing adjusted (no runtime behavior changes).

* **Tests**
  * Test cases updated to use the nested auth format for MTLS.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->