### PR TITLE
feat: adds CF-Ray to our application logging

### DIFF
--- a/apps/api/nginx.conf
+++ b/apps/api/nginx.conf
@@ -26,6 +26,7 @@ http {
             proxy_set_header X-Forwarded-Proto https;
             proxy_set_header X-Forwarded-Ssl on;
             proxy_set_header Host $http_host;
+            proxy_set_header CF-Ray $http_cf_ray;
             proxy_redirect off;
             proxy_pass http://127.0.0.1:3000;
             proxy_buffers 8 16k;

--- a/apps/deploy-web/nginx.conf
+++ b/apps/deploy-web/nginx.conf
@@ -28,6 +28,7 @@ http {
             proxy_set_header X-Forwarded-Proto https;
             proxy_set_header X-Forwarded-Ssl on;
             proxy_set_header Host $http_host;
+            proxy_set_header CF-Ray $http_cf_ray;
             proxy_redirect off;
             proxy_pass http://127.0.0.1:3000;
             proxy_buffers 8 16k;

--- a/apps/provider-proxy/nginx.conf
+++ b/apps/provider-proxy/nginx.conf
@@ -26,6 +26,8 @@ http {
         ssl_certificate /etc/nginx/ssl/my_ssl_cert.crt;
         ssl_certificate_key /etc/nginx/ssl/my_ssl_key.key;
 
+        large_client_header_buffers 4 16k;
+
         location / {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto https;
@@ -33,6 +35,7 @@ http {
             proxy_set_header Host $http_host;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
+            proxy_set_header CF-Ray $http_cf_ray;
             proxy_redirect off;
             proxy_pass http://127.0.0.1:3000;
             proxy_buffers 8 16k;

--- a/packages/logging/src/hono/http-logger/http-logger.service.ts
+++ b/packages/logging/src/hono/http-logger/http-logger.service.ts
@@ -12,6 +12,7 @@ type HttpRequestLog = {
     protocol?: string;
     remoteIp?: string;
     duration: string;
+    cfRay?: string;
   };
   fingerprint?: string;
   userId?: string;
@@ -44,6 +45,7 @@ export class HttpLoggerIntercepter {
         if (clientInfo) {
           log.httpRequest.userAgent = clientInfo.userAgent;
           log.httpRequest.remoteIp = clientInfo.ip;
+          log.httpRequest.cfRay = c.req.header("cf-ray");
           log.fingerprint = clientInfo.fingerprint;
         }
 


### PR DESCRIPTION
## Why

To link CF-RAY (CF trace id) with our application logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * HTTP proxies now forward Cloudflare Ray ID headers to upstream services.
  * Increased header buffer size on SSL endpoints to better handle large request headers.

* **Logging**
  * Request logs optionally include the Cloudflare Ray ID when present, improving traceability across services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->