### PR TITLE
revert: load certificate from gRPC (#2256)

### DIFF
--- a/apps/provider-proxy/env/.env.mainnet
+++ b/apps/provider-proxy/env/.env.mainnet
@@ -1,1 +1,1 @@
-GRPC_NODE_URL=https://akash.lavenderfive.com:443
+REST_API_NODE_URL=https://consoleapi.akashnet.net

--- a/apps/provider-proxy/env/.env.sample
+++ b/apps/provider-proxy/env/.env.sample
@@ -1,1 +1,1 @@
-GRPC_NODE_URL=http://grpc.sandbox-2.aksh.pw:9090
+REST_API_NODE_URL=https://api.sandbox-2.aksh.pw:443

--- a/apps/provider-proxy/env/.env.sandbox
+++ b/apps/provider-proxy/env/.env.sandbox
@@ -1,1 +1,1 @@
-GRPC_NODE_URL=http://grpc.sandbox-2.aksh.pw:9090
+REST_API_NODE_URL=https://api.sandbox-2.aksh.pw:443

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -22,7 +22,7 @@
     "test:unit": "jest --selectProjects unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.18",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.12",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/net": "*",
@@ -32,7 +32,6 @@
     "@hono/zod-openapi": "^0.18.4",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/auto-instrumentations-node": "^0.57.1",
-    "cockatiel": "^3.2.1",
     "hono": "4.6.12",
     "lru-cache": "^11.0.2",
     "uuid": "^9.0.0",

--- a/apps/provider-proxy/src/config/env.config.ts
+++ b/apps/provider-proxy/src/config/env.config.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const appConfigSchema = z.object({
-  GRPC_NODE_URL: z.string().url(),
+  REST_API_NODE_URL: z.string().url(),
   PORT: z.number({ coerce: true }).min(0).optional().default(3040)
 });
 

--- a/apps/provider-proxy/src/container.ts
+++ b/apps/provider-proxy/src/container.ts
@@ -1,4 +1,3 @@
-import { createChainNodeSDK } from "@akashnetwork/chain-sdk";
 import { HttpLoggerIntercepter } from "@akashnetwork/logging/hono";
 import { createOtelLogger } from "@akashnetwork/logging/otel";
 
@@ -14,14 +13,7 @@ export function createContainer(untrustedConfig: Record<string, unknown>) {
 
   const wsStats = new WebsocketStats();
   const appLogger = isLoggingDisabled ? undefined : createOtelLogger({ name: "app" });
-  const providerService = new ProviderService(
-    createChainNodeSDK({
-      query: {
-        baseUrl: appConfig.GRPC_NODE_URL
-      }
-    }),
-    appLogger
-  );
+  const providerService = new ProviderService(appConfig.REST_API_NODE_URL, fetch, appLogger);
   const certificateValidator = new CertificateValidator(
     Date.now,
     providerService,

--- a/apps/provider-proxy/src/services/ProviderService/ProviderService.ts
+++ b/apps/provider-proxy/src/services/ProviderService/ProviderService.ts
@@ -1,68 +1,50 @@
-import type { createChainNodeSDK, QueryInput } from "@akashnetwork/chain-sdk";
-import { SDKErrorCode } from "@akashnetwork/chain-sdk";
-import type { QueryCertificatesRequest, QueryCertificatesResponse } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import type { LoggerService } from "@akashnetwork/logging";
-import { ExponentialBackoff, handleWhen, retry } from "cockatiel";
 import { X509Certificate } from "crypto";
 
-type ChainNodeSDK = ReturnType<typeof createChainNodeSDK>;
-
-const RETRIABLE_ERROR_CODES = [SDKErrorCode.Internal, SDKErrorCode.Unavailable];
-
-interface ErrorWithCode {
-  code?: number;
-}
-
-function hasErrorCode(error: unknown): error is ErrorWithCode {
-  return typeof error === "object" && error !== null && "code" in error;
-}
+import { httpRetry } from "../../utils/retry";
 
 export class ProviderService {
-  private retryPolicy = retry(
-    handleWhen(error => {
-      return hasErrorCode(error) && RETRIABLE_ERROR_CODES.includes(error.code!);
-    }),
-    {
-      maxAttempts: 3,
-      backoff: new ExponentialBackoff()
-    }
-  );
+  private certApiModuleVersion = "v1";
 
   constructor(
-    private readonly chainSdkClient: ChainNodeSDK,
+    private readonly chainBaseUrl: string,
+    private readonly fetch: typeof global.fetch,
     private readonly logger?: LoggerService
   ) {}
 
   async getCertificate(providerAddress: string, serialNumber: string): Promise<X509Certificate | null> {
-    const queryParams: QueryInput<QueryCertificatesRequest> = {
-      filter: {
-        state: "valid",
-        owner: providerAddress,
-        serial: BigInt(`0x${serialNumber}`).toString(10)
-      },
-      pagination: {
-        limit: 1
-      }
-    };
+    const queryParams = new URLSearchParams({
+      "filter.state": "valid",
+      "filter.owner": providerAddress,
+      "filter.serial": BigInt(`0x${serialNumber}`).toString(10),
+      "pagination.limit": "1"
+    });
 
-    try {
-      const response = await this.fetchCertificate(queryParams);
-      if (response.certificates.length === 1) {
-        const cert = response.certificates[0]?.certificate?.cert;
-        return cert ? new X509Certificate(cert) : null;
-      }
+    const response = await this.fetchCertificate(this.chainBaseUrl, queryParams);
 
-      return null;
-    } catch (error: unknown) {
-      this.logger?.error({ event: "CERTIFICATE_FETCH_ERROR", providerAddress, serialNumber, error });
-      return null;
+    if (response.status >= 200 && response.status < 300) {
+      const body = (await response.json()) as KnownCertificatesResponseBody;
+      return body.certificates.length === 1 ? new X509Certificate(atob(body.certificates[0].certificate.cert)) : null;
     }
+
+    return null;
   }
 
-  private async fetchCertificate(getCertificatesParams: QueryInput<QueryCertificatesRequest>): Promise<QueryCertificatesResponse> {
-    return this.retryPolicy.execute(async () => {
-      return await this.chainSdkClient.akash.cert.v1.getCertificates(getCertificatesParams);
-    });
+  private async fetchCertificate(baseUrl: string, queryParams: URLSearchParams): Promise<Response> {
+    const response = await httpRetry(
+      () => this.fetch(`${baseUrl}/akash/cert/${this.certApiModuleVersion}/certificates/list?${queryParams}`, { signal: AbortSignal.timeout(5_000) }),
+      {
+        retryIf: response => response.status !== 501 && response.status >= 500,
+        logger: this.logger
+      }
+    );
+
+    if (response.status === 501) {
+      this.certApiModuleVersion = this.certApiModuleVersion === "v1" ? "v1beta3" : "v1";
+      return this.fetchCertificate(baseUrl, queryParams);
+    }
+
+    return response;
   }
 
   isValidationServerError(rawBody: unknown): boolean {
@@ -70,4 +52,12 @@ export class ProviderService {
     const body = rawBody.trim();
     return body.startsWith("manifest cross-validation error:") || body.startsWith("hostname not allowed:") || body.includes("validation failed");
   }
+}
+
+interface KnownCertificatesResponseBody {
+  certificates: Array<{
+    certificate: {
+      cert: string;
+    };
+  }>;
 }

--- a/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
@@ -5,7 +5,7 @@ import { setTimeout as wait } from "timers/promises";
 import type { TLSSocket } from "tls";
 
 import { createX509CertPair } from "../seeders/createX509CertPair";
-import { generateBech32, startChainApiServer, stopChainApiServer } from "../setup/chainApiServer";
+import { generateBech32, startChainApiServer, stopChainAPIServer } from "../setup/chainApiServer";
 import { startProviderServer, stopProviderServer } from "../setup/providerServer";
 import { request } from "../setup/proxyServer";
 import { startServer, stopServer } from "../setup/proxyServer";
@@ -15,16 +15,16 @@ describe("Provider HTTP proxy", () => {
   const ONE_HOUR = 60 * 60 * 1000;
 
   afterEach(async () => {
-    await Promise.all([stopServer(), stopProviderServer(), stopChainApiServer()]);
+    await Promise.all([stopServer(), stopProviderServer(), stopChainAPIServer()]);
   });
 
   it("proxies request if provider uses self-signed certificate which is available on chain", async () => {
     const providerAddress = generateBech32();
     const validCertPair = createX509CertPair({ commonName: providerAddress, validFrom: new Date(Date.now() - ONE_HOUR) });
 
-    const grpcServer = await startChainApiServer([validCertPair.cert]);
+    const chainServer = await startChainApiServer([validCertPair.cert]);
     const { providerUrl } = await startProviderServer({ certPair: validCertPair });
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const response = await request("/", {
       method: "POST",
@@ -47,9 +47,9 @@ describe("Provider HTTP proxy", () => {
     const providerAddress = generateBech32();
     const validCertPair = createX509CertPair({ commonName: providerAddress, validFrom: new Date(Date.now() - ONE_HOUR) });
 
-    const grpcServer = await startChainApiServer([validCertPair.cert]);
+    const chainServer = await startChainApiServer([validCertPair.cert]);
     const { providerUrl } = await startProviderServer({ certPair: validCertPair });
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const response = await request("/", {
       method: "POST",
@@ -69,13 +69,13 @@ describe("Provider HTTP proxy", () => {
     expect(body).toBe(JSON.stringify({ ok: true }));
   });
 
-  it("can work without gRPC by using cached certificates", async () => {
+  it("can work without chain API by using cached certificates", async () => {
     const providerAddress = generateBech32();
     const validCertPair = createX509CertPair({ commonName: providerAddress, validFrom: new Date(Date.now() - ONE_HOUR) });
 
-    const grpcServer = await startChainApiServer([validCertPair.cert]);
+    const chainServer = await startChainApiServer([validCertPair.cert]);
     const { providerUrl } = await startProviderServer({ certPair: validCertPair });
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     let response = await request("/", {
       method: "POST",
@@ -86,7 +86,7 @@ describe("Provider HTTP proxy", () => {
         network
       })
     });
-    await stopChainApiServer();
+    await chainServer.close();
 
     response = await request("/", {
       method: "POST",
@@ -108,7 +108,7 @@ describe("Provider HTTP proxy", () => {
     const providerAddress = generateBech32();
     const validCertPair = createX509CertPair({ commonName: providerAddress, validFrom: new Date(Date.now() - ONE_HOUR) });
 
-    const grpcServer = await startChainApiServer([
+    const chainServer = await startChainApiServer([
       createX509CertPair({
         commonName: providerAddress,
         validFrom: new Date(Date.now() + ONE_HOUR),
@@ -126,7 +126,7 @@ describe("Provider HTTP proxy", () => {
           network
         })
       });
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     let response = await requestProvider();
     expect(response.status).toBe(495);
@@ -149,12 +149,12 @@ describe("Provider HTTP proxy", () => {
       validTo: new Date(Date.now() - ONE_HOUR)
     });
 
-    const grpcServer = await startChainApiServer([
+    const chainServer = await startChainApiServer([
       createX509CertPair({ commonName: providerAddress, validFrom: new Date(Date.now() + ONE_HOUR) }).cert,
       validCertPair.cert
     ]);
     const { providerUrl } = await startProviderServer({ certPair: validCertPair });
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const requestProvider = () =>
       request("/", {
@@ -185,11 +185,11 @@ describe("Provider HTTP proxy", () => {
     const providerAddress = generateBech32();
     const validCertPair = createX509CertPair({ commonName: providerAddress, validFrom: new Date(Date.now() - ONE_HOUR) });
 
-    const grpcServer = await startChainApiServer([validCertPair.cert]);
+    const chainServer = await startChainApiServer([validCertPair.cert]);
     const { providerUrl } = await startProviderServer({
       certPair: validCertPair
     });
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const response = await request("/", {
       method: "POST",
@@ -225,7 +225,7 @@ describe("Provider HTTP proxy", () => {
     );
   });
 
-  it("retries fetching chain certificates if gRPC is unavailable", async () => {
+  it("retries fetching chain certificates if chain API is unavailable", async () => {
     const providerAddress = generateBech32();
     const validCertPair = createX509CertPair({
       commonName: providerAddress
@@ -233,10 +233,10 @@ describe("Provider HTTP proxy", () => {
 
     const { providerUrl } = await startProviderServer({ certPair: validCertPair });
     // start server early to reserve port
-    const grpcServer = await startChainApiServer([validCertPair.cert]);
-    await stopChainApiServer();
+    const chainServer = await startChainApiServer([validCertPair.cert]);
+    await chainServer.close();
 
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const responsePromise = request("/", {
       method: "POST",
@@ -248,8 +248,8 @@ describe("Provider HTTP proxy", () => {
       })
     });
     await wait(200); // intentional delay to ensure retry logic works
-    const grpcServerUrl = new URL(grpcServer.url);
-    await startChainApiServer([validCertPair.cert], { port: Number(grpcServerUrl.port) });
+    const chainServerUrl = new URL(chainServer.url);
+    await startChainApiServer([validCertPair.cert], { port: Number(chainServerUrl.port) });
 
     const response = await responsePromise;
 
@@ -258,25 +258,24 @@ describe("Provider HTTP proxy", () => {
     expect(body).toBe("Hello, World!");
   });
 
-  it("retries if gRPC responds with error 14/unavailable", async () => {
+  it("retries if chain API responds with 5xx request", async () => {
     const providerAddress = generateBech32();
     const validCertPair = createX509CertPair({
       commonName: providerAddress
     });
 
     const { providerUrl } = await startProviderServer({ certPair: validCertPair });
-    let isRespondedWithGrpc14 = false;
-    const grpcServer = await startChainApiServer([validCertPair.cert], {
-      interceptRequest() {
-        if (isRespondedWithGrpc14) {
-          return false;
-        }
-
-        isRespondedWithGrpc14 = true;
+    let isRespondedWith502 = false;
+    const chainServer = await startChainApiServer([validCertPair.cert], {
+      interceptRequest(req, res) {
+        if (isRespondedWith502) return false;
+        isRespondedWith502 = true;
+        res.writeHead(502, { Connection: "close" });
+        res.end();
         return true;
       }
     });
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const response = await request("/", {
       method: "POST",
@@ -316,8 +315,8 @@ describe("Provider HTTP proxy", () => {
         }
       }
     });
-    const grpcServer = await startChainApiServer([validCertPair.cert]);
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    const chainServer = await startChainApiServer([validCertPair.cert]);
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const response = await request("/", {
       method: "POST",
@@ -361,8 +360,8 @@ describe("Provider HTTP proxy", () => {
         }
       }
     });
-    const grpcServer = await startChainApiServer([validCertPair.cert]);
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    const chainServer = await startChainApiServer([validCertPair.cert]);
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const response = await request("/", {
       method: "POST",
@@ -395,8 +394,8 @@ describe("Provider HTTP proxy", () => {
         }
       }
     });
-    const grpcServer = await startChainApiServer([validCertPair.cert]);
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    const chainServer = await startChainApiServer([validCertPair.cert]);
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const response = await request("/", {
       method: "POST",
@@ -419,8 +418,8 @@ describe("Provider HTTP proxy", () => {
       commonName: providerAddress
     });
 
-    const grpcServer = await startChainApiServer([validCertPair.cert]);
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    const chainServer = await startChainApiServer([validCertPair.cert]);
+    await startServer({ REST_API_NODE_URL: chainServer.url });
     const providerUrl = `https://some-unknown-host-${Date.now()}.com/200`;
 
     const response = await request("/", {
@@ -453,8 +452,8 @@ describe("Provider HTTP proxy", () => {
         }
       }
     });
-    const grpcServer = await startChainApiServer([validCertPair.cert]);
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    const chainServer = await startChainApiServer([validCertPair.cert]);
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const response = await request("/", {
       method: "POST",
@@ -485,8 +484,8 @@ describe("Provider HTTP proxy", () => {
     const { providerUrl } = await startProviderServer({
       certPair: validCertPair
     });
-    const grpcServer = await startChainApiServer([invalidClientCertPair.cert]);
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    const chainServer = await startChainApiServer([invalidClientCertPair.cert]);
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const response = await request("/", {
       method: "POST",
@@ -527,7 +526,7 @@ describe("Provider HTTP proxy", () => {
     const validCertPair = createX509CertPair({
       commonName: providerAddress
     });
-    const grpcServer = await startChainApiServer([validCertPair.cert]);
+    const chainServer = await startChainApiServer([validCertPair.cert]);
 
     const providerStreamingBegun = Promise.withResolvers<void>();
     const providerResponseEnded = jest.fn();
@@ -548,7 +547,7 @@ describe("Provider HTTP proxy", () => {
         }
       }
     });
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const requestController = new AbortController();
     const responsePromise = request("/", {
@@ -580,7 +579,7 @@ describe("Provider HTTP proxy", () => {
     const validCertPair = createX509CertPair({
       commonName: providerAddress
     });
-    const grpcServer = await startChainApiServer([validCertPair.cert]);
+    const chainServer = await startChainApiServer([validCertPair.cert]);
 
     const { providerUrl } = await startProviderServer({
       certPair: validCertPair,
@@ -597,7 +596,7 @@ describe("Provider HTTP proxy", () => {
         }
       }
     });
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const requestController = new AbortController();
     const response = await request("/", {
@@ -627,7 +626,7 @@ describe("Provider HTTP proxy", () => {
     const validCertPair = createX509CertPair({ commonName: providerAddress, validFrom: new Date(Date.now() - ONE_HOUR) });
     const clientCertPair = createX509CertPair({ commonName: generateBech32() });
 
-    const grpcServer = await startChainApiServer([validCertPair.cert]);
+    const chainServer = await startChainApiServer([validCertPair.cert]);
     const { providerUrl } = await startProviderServer({
       certPair: validCertPair,
       requireClientCertificate: true,
@@ -639,7 +638,7 @@ describe("Provider HTTP proxy", () => {
         }
       }
     });
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const response = await request("/", {
       method: "POST",
@@ -697,7 +696,7 @@ describe("Provider HTTP proxy", () => {
     const providerAddress = generateBech32();
     const validCertPair = createX509CertPair({ commonName: providerAddress, validFrom: new Date(Date.now() - ONE_HOUR) });
 
-    const grpcServer = await startChainApiServer([validCertPair.cert]);
+    const chainServer = await startChainApiServer([validCertPair.cert]);
     const { providerUrl } = await startProviderServer({
       certPair: validCertPair,
       requireClientCertificate: true,
@@ -708,7 +707,7 @@ describe("Provider HTTP proxy", () => {
         }
       }
     });
-    await startServer({ GRPC_NODE_URL: grpcServer.url });
+    await startServer({ REST_API_NODE_URL: chainServer.url });
 
     const wallet = await Secp256k1HdWallet.generate(24, { prefix: "akash" });
     const tokenManager = new JwtTokenManager(wallet);

--- a/apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts
@@ -5,13 +5,15 @@ import type { TLSSocket } from "tls";
 import WebSocket from "ws";
 
 import { createX509CertPair } from "../seeders/createX509CertPair";
-import { generateBech32, startChainApiServer, stopChainApiServer } from "../setup/chainApiServer";
+import { generateBech32, startChainApiServer, stopChainAPIServer } from "../setup/chainApiServer";
 import { startProviderServer, stopProviderServer } from "../setup/providerServer";
 import { startServer, stopServer } from "../setup/proxyServer";
 
 describe("Provider proxy ws", () => {
-  afterEach(async () => {
-    await Promise.all([stopServer(), stopProviderServer(), stopChainApiServer()]);
+  afterEach(() => {
+    stopProviderServer();
+    stopServer();
+    stopChainAPIServer();
   });
 
   it("proxies provider websocket messages", async () => {
@@ -34,7 +36,7 @@ describe("Provider proxy ws", () => {
         }
       }
     });
-    const proxyServerUrl = await startServer({ GRPC_NODE_URL: chainServer.url });
+    const proxyServerUrl = await startServer({ REST_API_NODE_URL: chainServer.url });
     const ws = new WebSocket(`${proxyServerUrl}/ws`);
 
     await new Promise(resolve => ws.once("open", resolve));
@@ -65,7 +67,7 @@ describe("Provider proxy ws", () => {
         }
       }
     });
-    const proxyServerUrl = await startServer({ GRPC_NODE_URL: chainServer.url });
+    const proxyServerUrl = await startServer({ REST_API_NODE_URL: chainServer.url });
     const ws = new WebSocket(`${proxyServerUrl}/ws`);
 
     await new Promise(resolve => ws.once("open", resolve));
@@ -85,7 +87,7 @@ describe("Provider proxy ws", () => {
         onConnection: pws => pws.send("connected")
       }
     });
-    const proxyServerUrl = await startServer({ GRPC_NODE_URL: chainServer.url });
+    const proxyServerUrl = await startServer({ REST_API_NODE_URL: chainServer.url });
     const ws = new WebSocket(`${proxyServerUrl}/ws`);
 
     const [providerMessageOnConnect] = await Promise.all([
@@ -113,7 +115,7 @@ describe("Provider proxy ws", () => {
           })
       }
     });
-    const proxyServerUrl = await startServer({ GRPC_NODE_URL: chainServer.url });
+    const proxyServerUrl = await startServer({ REST_API_NODE_URL: chainServer.url });
     const ws = new WebSocket(`${proxyServerUrl}/ws`);
 
     await new Promise(resolve => ws.once("open", resolve));
@@ -136,7 +138,7 @@ describe("Provider proxy ws", () => {
         onConnection: pws => pws.on("close", onProviderWsClose)
       }
     });
-    const proxyServerUrl = await startServer({ GRPC_NODE_URL: chainServer.url });
+    const proxyServerUrl = await startServer({ REST_API_NODE_URL: chainServer.url });
     const ws = new WebSocket(`${proxyServerUrl}/ws`);
 
     await new Promise(resolve => ws.once("open", resolve));
@@ -164,7 +166,7 @@ describe("Provider proxy ws", () => {
           })
       }
     });
-    const proxyServerUrl = await startServer({ GRPC_NODE_URL: chainServer.url });
+    const proxyServerUrl = await startServer({ REST_API_NODE_URL: chainServer.url });
     const ws = new WebSocket(`${proxyServerUrl}/ws`);
 
     await new Promise(resolve => ws.once("open", resolve)), ws.send(JSON.stringify(ourMessage("please_close", providerUrl, { providerAddress })));
@@ -191,7 +193,7 @@ describe("Provider proxy ws", () => {
         }
       }
     });
-    const proxyServerUrl = await startServer({ GRPC_NODE_URL: chainServer.url });
+    const proxyServerUrl = await startServer({ REST_API_NODE_URL: chainServer.url });
     const ws = new WebSocket(`${proxyServerUrl}/ws`);
     await new Promise(resolve => ws.once("open", resolve));
 
@@ -239,7 +241,7 @@ describe("Provider proxy ws", () => {
         }
       }
     });
-    const proxyServerUrl = await startServer({ GRPC_NODE_URL: chainServer.url });
+    const proxyServerUrl = await startServer({ REST_API_NODE_URL: chainServer.url });
     const ws = new WebSocket(`${proxyServerUrl}/ws`);
 
     await new Promise(resolve => ws.once("open", resolve));
@@ -302,7 +304,7 @@ describe("Provider proxy ws", () => {
         }
       }
     });
-    const proxyServerUrl = await startServer({ GRPC_NODE_URL: chainServer.url });
+    const proxyServerUrl = await startServer({ REST_API_NODE_URL: chainServer.url });
     const ws = new WebSocket(`${proxyServerUrl}/ws`);
 
     await new Promise(resolve => ws.once("open", resolve));

--- a/apps/provider-proxy/test/setup/chainApiServer.ts
+++ b/apps/provider-proxy/test/setup/chainApiServer.ts
@@ -1,184 +1,72 @@
-import { QueryCertificatesRequest, QueryCertificatesResponse, State } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { toBech32 } from "@cosmjs/encoding";
 import type { X509Certificate } from "crypto";
-import http2 from "http2";
+import http from "http";
 import type { AddressInfo } from "net";
 
-let grpcServer: http2.Http2Server | undefined;
-const sessions: http2.ServerHttp2Session[] = [];
+import { shutdownServer } from "../../src/utils/shutdownServer";
 
+let chainServer: http.Server | undefined;
+/**
+ * Cannot mock blockchain API using nock and msw that's why have a separate server
+ * @see https://github.com/mswjs/msw/discussions/2416
+ */
 export function startChainApiServer(
   certificates: X509Certificate[],
-  options?: GrpcServerOptions
+  options?: ChainApiOptions
 ): Promise<{
   close: () => Promise<void>;
   url: string;
 }> {
   return new Promise(resolve => {
-    const server = http2.createServer();
+    const server = http.createServer((req, res) => {
+      if (options?.interceptRequest?.(req, res)) return;
 
-    server.on("session", session => {
-      sessions.push(session);
-    });
-
-    server.on("stream", (stream, headers) => {
-      if (options?.interceptRequest?.()) {
-        stream.respond({
-          ":status": 200,
-          "content-type": "application/grpc+proto",
-          "grpc-status": "14",
-          "grpc-message": "unavailable"
-        });
-        stream.end();
+      if (!/\/akash\/cert\/(v1|v1beta3)\/certificates\/list/.test(req.url || "")) {
+        res.writeHead(404, { Connection: "close" });
+        res.end("");
         return;
       }
 
-      const path = headers[":path"];
+      const url = new URL(`http://localhost${req.url || "/"}`);
+      const serialNumber = BigInt(url.searchParams.get("filter.serial")!).toString(16).toUpperCase();
+      const providerAddress = url.searchParams.get("filter.owner")!;
 
-      if (path !== "/akash.cert.v1.Query/Certificates") {
-        stream.respond({
-          ":status": 404
-        });
-        stream.end("Not found");
-        return;
-      }
-
-      const chunks: Buffer[] = [];
-      stream.on("data", chunk => {
-        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-      });
-
-      stream.on("end", () => {
-        const requestData = Buffer.concat(chunks);
-
-        let requestedOwner: string | undefined;
-        let requestedSerial: string | undefined;
-
-        if (requestData.length > 5) {
-          const protoData = requestData.slice(5);
-          const certRequest = QueryCertificatesRequest.decode(protoData);
-          requestedOwner = certRequest.filter?.owner;
-          requestedSerial = certRequest.filter?.serial;
-        }
-
-        let cert: X509Certificate | undefined;
-        if (requestedSerial || requestedOwner) {
-          cert = certificates.find(cert => {
-            const certOwner = cert.toLegacyObject().subject.CN;
-            const serial = BigInt(`0x${cert.serialNumber}`).toString(10);
-
-            const ownerMatches = !requestedOwner || certOwner === requestedOwner;
-            const serialMatches = !requestedSerial || serial === requestedSerial;
-
-            return ownerMatches && serialMatches;
-          });
-        }
-
-        sendResponse(stream, buildCertificatesResponse(cert));
-      });
+      res.writeHead(200, { "Content-Type": "application/json", Connection: "close" });
+      res.end(
+        JSON.stringify({
+          certificates: certificates
+            .filter(cert => cert.serialNumber === serialNumber && cert.toLegacyObject().subject.CN === providerAddress)
+            .map(cert => ({
+              serial: BigInt(`0x${cert.serialNumber}`).toString(10),
+              certificate: {
+                cert: btoa(cert.toJSON()),
+                pubkey: cert.publicKey.export({ type: "pkcs1", format: "pem" })
+              }
+            }))
+        })
+      );
     });
 
     server.listen(options?.port ?? 0, () => {
-      grpcServer = server;
+      chainServer = server;
       resolve({
         url: `http://localhost:${(server.address() as AddressInfo).port}`,
-        close: () =>
-          new Promise<void>((resolve, reject) => {
-            destroyAllSessions();
-
-            server.close(error => {
-              error ? reject(error) : resolve();
-            });
-          })
+        close: () => new Promise<void>((resolve, reject) => server.close(err => (err ? reject(err) : resolve())))
       });
     });
   });
 }
 
-export async function stopChainApiServer(): Promise<void> {
-  if (!grpcServer?.listening) {
-    return;
-  }
-
-  return new Promise<void>((resolve, reject) => {
-    destroyAllSessions();
-
-    grpcServer?.close(error => {
-      if (error) {
-        reject(error);
-      } else {
-        resolve();
-      }
-    });
-  });
+export function stopChainAPIServer(): Promise<void> {
+  return shutdownServer(chainServer);
 }
 
-export interface GrpcServerOptions {
+export interface ChainApiOptions {
   port?: number;
-  interceptRequest?: () => boolean;
+  interceptRequest?(req: http.IncomingMessage, res: http.ServerResponse): boolean;
 }
 
+let index = 0;
 export function generateBech32() {
-  const addressData = new Uint8Array(20);
-
-  for (let i = 0; i < 20; i++) {
-    addressData[i] = Math.floor(Math.random() * 256);
-  }
-
-  return toBech32("akash", addressData);
-}
-
-function destroyAllSessions() {
-  let session;
-  while ((session = sessions.pop())) {
-    session.destroy();
-  }
-}
-
-function getCertificates(cert?: X509Certificate) {
-  if (!cert) {
-    return [];
-  }
-
-  const certPem = cert.toString();
-  const pubkey = cert.publicKey.export({ type: "spki", format: "pem" }) as string;
-  const serial = BigInt(`0x${cert.serialNumber}`).toString(10);
-
-  return [
-    {
-      certificate: {
-        cert: Buffer.from(certPem, "utf8"),
-        pubkey: Buffer.from(pubkey, "utf8"),
-        state: State.valid
-      },
-      serial: serial
-    }
-  ];
-}
-
-function buildCertificatesResponse(cert?: X509Certificate): Buffer {
-  const certificates = getCertificates(cert);
-
-  return Buffer.from(
-    QueryCertificatesResponse.encode(
-      QueryCertificatesResponse.fromPartial({
-        certificates,
-        pagination: { total: certificates.length }
-      })
-    ).finish()
-  );
-}
-
-function sendResponse(stream: http2.ServerHttp2Stream, response: Buffer) {
-  const frame = Buffer.alloc(5 + response.length);
-  frame.writeUInt8(0, 0);
-  frame.writeUInt32BE(response.length, 1);
-  response.copy(frame, 5);
-
-  stream.respond({
-    ":status": 200,
-    "content-type": "application/grpc+proto",
-    "grpc-status": "0"
-  });
-  stream.end(frame);
+  return toBech32("akash", Buffer.from(`test${++index}`, "utf8"));
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6848,7 +6848,7 @@
       "version": "2.5.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.18",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.12",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/net": "*",
@@ -6858,7 +6858,6 @@
         "@hono/zod-openapi": "^0.18.4",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.57.1",
-        "cockatiel": "^3.2.1",
         "hono": "4.6.12",
         "lru-cache": "^11.0.2",
         "uuid": "^9.0.0",
@@ -6892,83 +6891,39 @@
         "typescript": "~5.8.2"
       }
     },
-    "apps/provider-proxy/node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.18.tgz",
-      "integrity": "sha512-HQEhAUih0Nv8CLtGJOrjsSgqofF+BsoYLixB37kiT7Vf9u3WaCdJ55XzGqfA+9kJ+5eWXkGaEpvLi5SmOdjygw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@bufbuild/protobuf": "^2.2.3",
-        "@connectrpc/connect": "^2.0.1",
-        "@connectrpc/connect-node": "^2.0.1",
-        "@cosmjs/amino": "~0.36.1",
-        "@cosmjs/math": "~0.36.1",
-        "@cosmjs/proto-signing": "~0.36.1",
-        "@cosmjs/stargate": "~0.36.1",
-        "base64-js": "^1.5.1",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify": "^1.3.0",
-        "jsrsasign": "^11.1.0",
-        "long": "^5.3.2"
-      },
-      "engines": {
-        "node": "22.14.0"
-      }
-    },
-    "apps/provider-proxy/node_modules/@connectrpc/connect": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
-      "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^2.7.0"
-      }
-    },
-    "apps/provider-proxy/node_modules/@connectrpc/connect-node": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.1.tgz",
-      "integrity": "sha512-s3TfsI1XF+n+1z6MBS9rTnFsxxR4Rw5wmdEnkQINli81ESGxcsfaEet8duzq8LVuuCupmhUsgpRo0Nv9pZkufg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^2.7.0",
-        "@connectrpc/connect": "2.1.1"
-      }
-    },
     "apps/provider-proxy/node_modules/@cosmjs/amino": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.36.2.tgz",
-      "integrity": "sha512-r4yV1bhl412gwHGlyaUaJHIJnmldtyGsAwyz3oHHVxduiECj06Rv6wqeyLZfQa9W6hU+MlZwy7LabSUkkyGwjA==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.36.1.tgz",
+      "integrity": "sha512-JRAtBA0bcIlhYZ5AXMT8VYUaxqVfEDiQbcEg0FLEIFofssj3V4aXFO93lsPI3AeWwRSZhWA+guGd/iHFC05UbQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@cosmjs/crypto": "^0.36.2",
-        "@cosmjs/encoding": "^0.36.2",
-        "@cosmjs/math": "^0.36.2",
-        "@cosmjs/utils": "^0.36.2"
+        "@cosmjs/crypto": "^0.36.1",
+        "@cosmjs/encoding": "^0.36.1",
+        "@cosmjs/math": "^0.36.1",
+        "@cosmjs/utils": "^0.36.1"
       }
     },
     "apps/provider-proxy/node_modules/@cosmjs/crypto": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.36.2.tgz",
-      "integrity": "sha512-QL4NHtcqR6DEKIN200aLeR8gKO433K0f5avKV0TVFP/g12UtnEGSk79PJq5Gv1PLc9GtATHgLLQI/3D8TEe+ig==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.36.1.tgz",
+      "integrity": "sha512-7vx9rZAuboyMxs9zv3hZhNA0JAFMpaW+fFgRDQzZzfIVj0z4h8RW4dJu0xx5cv3KBQXmoRUzWklpnFuMQYiGdg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@cosmjs/encoding": "^0.36.2",
-        "@cosmjs/math": "^0.36.2",
-        "@cosmjs/utils": "^0.36.2",
+        "@cosmjs/encoding": "^0.36.1",
+        "@cosmjs/math": "^0.36.1",
+        "@cosmjs/utils": "^0.36.1",
         "@noble/ciphers": "^1.3.0",
         "@noble/curves": "^1.9.2",
-        "@noble/hashes": "^1.8.0",
+        "@noble/hashes": "^1",
         "hash-wasm": "^4.12.0"
       }
     },
     "apps/provider-proxy/node_modules/@cosmjs/encoding": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.36.2.tgz",
-      "integrity": "sha512-i3+P1EKYoLcONAsmpJPhDAc3Wh3ajZNRHt/hczi/JEQXmleTJLVzv2mXUyllM6Qa+B6ybbr3Z2lnEFa8L3yLqg==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.36.1.tgz",
+      "integrity": "sha512-i5dTiOdSAfyU76lmOm0+VLEIDEtmINtpOeAuzzBJP1er5fDJvpBysgY9MefVwXNBY/P46W10Uta9zQc98ehBXg==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -6976,94 +6931,18 @@
         "readonly-date": "^1.0.0"
       }
     },
-    "apps/provider-proxy/node_modules/@cosmjs/json-rpc": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.36.2.tgz",
-      "integrity": "sha512-3IRamylHVCxBevXGlnIoWUdJCLsP5LwHbXYUsBnC9T8UttZ5oYRN5gDf6+2dQEPk+p9xOv2i8xrCwNWxo7675Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.36.2",
-        "xstream": "^11.14.0"
-      }
-    },
     "apps/provider-proxy/node_modules/@cosmjs/math": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.36.2.tgz",
-      "integrity": "sha512-uJZRzxqnBk3MgxFgeyUwLgUzWkAIcmznWSB/tgGCjGCnUNebzI+44dA3ncEDCMqQysi/MZ+cSwAcDU7IY2PFeA==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.36.1.tgz",
+      "integrity": "sha512-ML5X5iupmTUV6bik+YEShrmK49ikB8jMQfgzdQV7qeBMN2Rc4ijd1/sFya5AiyJzxtBlYe7yv0i5NyNzZPqKpQ==",
+      "dev": true,
       "license": "Apache-2.0"
     },
-    "apps/provider-proxy/node_modules/@cosmjs/proto-signing": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.36.2.tgz",
-      "integrity": "sha512-dyZsgZBQgGkaE4cazHVX8GDwrRJVKUVDnrODkyFXVNbxMnm4t6nxpK1qwgY9GHlWUhck3Dh9NT3BoMbXiMYTZQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.2",
-        "@cosmjs/crypto": "^0.36.2",
-        "@cosmjs/encoding": "^0.36.2",
-        "@cosmjs/math": "^0.36.2",
-        "@cosmjs/utils": "^0.36.2",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "apps/provider-proxy/node_modules/@cosmjs/socket": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.36.2.tgz",
-      "integrity": "sha512-Pb7JcTFWnq6yfY0IEejHrpSxNDJYcqjjAa1D29a6b/obk4qa4o3oIV5bIx6zAbdRq8uLoBfvWs0bHTNnVuBWJg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.36.2",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "apps/provider-proxy/node_modules/@cosmjs/stargate": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.36.2.tgz",
-      "integrity": "sha512-vnNK4dXF+s2v1aKPfYxKVrvXPcnBQb8rPoBScnTpPWnRt3XXbLw7Oo6fTQQWwKYNKQzi6DOApeEB+bCYcaPAAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.2",
-        "@cosmjs/encoding": "^0.36.2",
-        "@cosmjs/math": "^0.36.2",
-        "@cosmjs/proto-signing": "^0.36.2",
-        "@cosmjs/stream": "^0.36.2",
-        "@cosmjs/tendermint-rpc": "^0.36.2",
-        "@cosmjs/utils": "^0.36.2",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "apps/provider-proxy/node_modules/@cosmjs/stream": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.36.2.tgz",
-      "integrity": "sha512-FlZx2Buovem837LdTLPkPFcxzuQ7zierAqSXwMPr/MG3k+qMxHNfLFTTCXMNWQ4ZlbYedud8ZqCL3/HKdS5mig==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "apps/provider-proxy/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.36.2.tgz",
-      "integrity": "sha512-76Z99C1NVf/Yv/1bWU0wul8MhRwVdqiZxqU5bcHqvJLoQ2nKUfGpSSYRdbMHfZ63J8ryRqQ95uPvPTfrBb+agw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.36.2",
-        "@cosmjs/encoding": "^0.36.2",
-        "@cosmjs/json-rpc": "^0.36.2",
-        "@cosmjs/math": "^0.36.2",
-        "@cosmjs/socket": "^0.36.2",
-        "@cosmjs/stream": "^0.36.2",
-        "@cosmjs/utils": "^0.36.2",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
     "apps/provider-proxy/node_modules/@cosmjs/utils": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.36.2.tgz",
-      "integrity": "sha512-OOr2HU/Ph+/GI1Fx2UCf3LOyX9YTCP51d2HitTOjjEJRYnkfKXP3lMBl1FZo5QaFWxnfuBc+Cj+cSoiQUJRyzQ==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.36.1.tgz",
+      "integrity": "sha512-kjdDD6t7dMLRUtbRCRskP7sNpyNf6cxVgaM2z7n64e6upXwE+bsoKfKrG+iY2ABT57oH6UxJYgcB+7ACmPxZCg==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "apps/provider-proxy/node_modules/@esbuild/aix-ppc64": {
@@ -7473,6 +7352,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
@@ -7485,6 +7365,7 @@
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -7994,12 +7875,6 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true
-    },
-    "apps/provider-proxy/node_modules/cosmjs-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.10.1.tgz",
-      "integrity": "sha512-CENXb4O5GN+VyB68HYXFT2SOhv126Z59631rZC56m8uMWa6/cSlFeai8BwZGT1NMepw0Ecf+U8XSOnBzZUWh9Q==",
-      "license": "Apache-2.0"
     },
     "apps/provider-proxy/node_modules/esbuild": {
       "version": "0.24.2",
@@ -54501,19 +54376,19 @@
       "license": "Apache-2.0"
     },
     "node_modules/ts-jest": {
-      "version": "29.4.5",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.5.tgz",
-      "integrity": "sha512-HO3GyiWn2qvTQA4kTgjDcXiMwYQt68a1Y8+JuLRVpdIzm+UOLSHgl/XqR4c6nzJkq5rOkjc02O2I7P7l/Yof0Q==",
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.0.tgz",
+      "integrity": "sha512-d423TJMnJGu80/eSgfQ5w/R+0zFJvdtTxwtF9KzFFunOpSeD+79lHJQIiAhluJoyGRbvj9NZJsl9WjCUo0ND7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
+        "ejs": "^3.1.10",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.7.2",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -54554,9 +54429,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {


### PR DESCRIPTION
## Why

This reverts commit 801830391682088c2a8001d4ac74b62b7df4f360. Revert https://github.com/akash-network/console/pull/2256 because @cloud-j-luna said that RPC-proxy doesn't support gRPC at the moment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Changes**
  * Migrated from gRPC-based to REST API-based communication for node endpoints.
  * Updated all environment configurations to use REST API endpoints with HTTPS protocol.

* **Configuration Updates**
  * Renamed node URL configuration variable across all environments (mainnet, sandbox, sample).
  * Updated endpoint addresses and protocols accordingly.

* **Dependencies**
  * Updated chain SDK version and removed cockatiel dependency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->