### PR TITLE
fix: removes AUTHORIZING_WALLET_MNEMONIC env var from UI tests

### DIFF
--- a/.github/actions/console-web-ui-testing/action.yml
+++ b/.github/actions/console-web-ui-testing/action.yml
@@ -38,7 +38,6 @@ runs:
         TEST_WALLET_MNEMONIC: ${{ inputs.test-wallet-mnemonic }}
         BASE_URL: ${{ inputs.url }}
         UI_CONFIG_SIGNATURE_PRIVATE_KEY: ${{ inputs.ui-config-signature-private-key }}
-        DEBUG: "pw:browser"
         CI: "true"
       shell: bash
       continue-on-error: true

--- a/apps/deploy-web/tests/ui/fixture/test-env.config.ts
+++ b/apps/deploy-web/tests/ui/fixture/test-env.config.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 export const testEnvSchema = z.object({
   BASE_URL: z.string().default("http://localhost:3000"),
   TEST_WALLET_MNEMONIC: z.string(),
-  AUTHORIZING_WALLET_MNEMONIC: z.string(),
   UI_CONFIG_SIGNATURE_PRIVATE_KEY: z.string().optional(),
   NETWORK_ID: z.enum(["mainnet", "sandbox"]).default("sandbox")
 });
@@ -11,7 +10,6 @@ export const testEnvSchema = z.object({
 export const testEnvConfig = testEnvSchema.parse({
   BASE_URL: process.env.BASE_URL,
   TEST_WALLET_MNEMONIC: process.env.TEST_WALLET_MNEMONIC,
-  AUTHORIZING_WALLET_MNEMONIC: process.env.AUTHORIZING_WALLET_MNEMONIC,
   UI_CONFIG_SIGNATURE_PRIVATE_KEY: process.env.UI_CONFIG_SIGNATURE_PRIVATE_KEY
 });
 


### PR DESCRIPTION
## Why

because it's unused

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed browser debugging flag from end-to-end testing workflow.
  * Removed unused field from test configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->