### PR TITLE
fix: uses Decimal to convert denom to udenom value

### DIFF
--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -35,6 +35,7 @@
     "@amplitude/analytics-browser": "^2.11.11",
     "@auth0/nextjs-auth0": "^3.5.0",
     "@cosmjs/encoding": "~0.36.1",
+    "@cosmjs/math": "~0.36.1",
     "@cosmjs/proto-signing": "~0.36.1",
     "@cosmjs/stargate": "~0.36.1",
     "@cosmos-kit/core": "^2.16.6",

--- a/apps/deploy-web/src/utils/mathHelpers.ts
+++ b/apps/deploy-web/src/utils/mathHelpers.ts
@@ -1,3 +1,5 @@
+import { Decimal } from "@cosmjs/math";
+
 export function nFormatter(num: number, digits: number) {
   const lookup = [
     { value: 1, symbol: "" },
@@ -23,8 +25,14 @@ export function udenomToDenom(_amount: string | number, precision = 6, decimals:
   return roundDecimal(amount / decimals, precision);
 }
 
-export function denomToUdenom(amount: number, decimals: number = 1_000_000) {
-  return amount * decimals;
+/**
+ * @deprecated don't use JS floating point number to represent a denom amount.
+ * use the string representation instead and use `Decimal` from `@cosmjs/math` to do manipulation on amounts.
+ */
+export function denomToUdenom(amount: number): number;
+export function denomToUdenom(amount: string): number;
+export function denomToUdenom(amount: string | number) {
+  return Number(Decimal.fromUserInput(amount.toString(), 6).atomics);
 }
 
 export function roundDecimal(value: number, precision = 2) {

--- a/apps/deploy-web/src/utils/priceUtils.ts
+++ b/apps/deploy-web/src/utils/priceUtils.ts
@@ -21,7 +21,7 @@ export function coinToUDenom(coin: Coin) {
   const usdcDenom = getUsdcDenom();
 
   if (coin.denom === "akt") {
-    value = denomToUdenom(parseFloat(coin.amount));
+    value = denomToUdenom(coin.amount);
   } else if (coin.denom === UAKT_DENOM || coin.denom === usdcDenom) {
     value = parseFloat(coin.amount);
   } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1036,6 +1036,7 @@
         "@amplitude/analytics-browser": "^2.11.11",
         "@auth0/nextjs-auth0": "^3.5.0",
         "@cosmjs/encoding": "~0.36.1",
+        "@cosmjs/math": "~0.36.1",
         "@cosmjs/proto-signing": "~0.36.1",
         "@cosmjs/stargate": "~0.36.1",
         "@cosmos-kit/core": "^2.16.6",


### PR DESCRIPTION
## Why

Because in JS 
```js
> 32.73969 * 1000_000
32739690.000000004
```

Fixes https://github.com/akash-network/console/issues/2229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision for amount conversions by eliminating reliance on floating-point arithmetic and better handling of string-formatted amounts.

* **Chores**
  * Added a math library dependency to support more accurate numeric operations.

* **Documentation**
  * Marked floating-point amount usage as deprecated; prefer string-based amount representations for calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->