### PR TITLE
refactor(billing): removes autoReloadThreshold and autoReloadAmount from wallet settings

### DIFF
--- a/apps/api/src/billing/controllers/wallet-settings/wallet-settings.controller.spec.ts
+++ b/apps/api/src/billing/controllers/wallet-settings/wallet-settings.controller.spec.ts
@@ -38,9 +38,7 @@ describe(WalletSettingController.name, () => {
 
       const result = await controller.createWalletSettings({
         data: {
-          autoReloadEnabled: true,
-          autoReloadThreshold: 10.5,
-          autoReloadAmount: 50.0
+          autoReloadEnabled: true
         }
       });
 
@@ -48,9 +46,7 @@ describe(WalletSettingController.name, () => {
         data: walletSetting
       });
       expect(walletSettingService.upsertWalletSetting).toHaveBeenCalledWith(user.id, {
-        autoReloadEnabled: true,
-        autoReloadThreshold: 10.5,
-        autoReloadAmount: 50.0
+        autoReloadEnabled: true
       });
     });
   });
@@ -63,8 +59,7 @@ describe(WalletSettingController.name, () => {
 
       const result = await controller.updateWalletSettings({
         data: {
-          autoReloadEnabled: false,
-          autoReloadThreshold: 20.75
+          autoReloadEnabled: false
         }
       });
 
@@ -72,8 +67,7 @@ describe(WalletSettingController.name, () => {
         data: walletSetting
       });
       expect(walletSettingService.upsertWalletSetting).toHaveBeenCalledWith(user.id, {
-        autoReloadEnabled: false,
-        autoReloadThreshold: 20.75
+        autoReloadEnabled: false
       });
     });
   });

--- a/apps/api/src/billing/http-schemas/wallet.schema.ts
+++ b/apps/api/src/billing/http-schemas/wallet.schema.ts
@@ -47,9 +47,7 @@ export const StartTrialRequestInputSchema = z.object({
 });
 
 export const WalletSettingsSchema = z.object({
-  autoReloadEnabled: z.boolean().openapi({}),
-  autoReloadThreshold: z.number().min(20).optional().openapi({}),
-  autoReloadAmount: z.number().min(20).optional().openapi({})
+  autoReloadEnabled: z.boolean().openapi({})
 });
 
 export const WalletSettingsResponseSchema = z.object({
@@ -61,7 +59,7 @@ export const CreateWalletSettingsRequestSchema = z.object({
 });
 
 export const UpdateWalletSettingsRequestSchema = z.object({
-  data: WalletSettingsSchema.partial()
+  data: WalletSettingsSchema
 });
 
 export type WalletOutputResponse = z.infer<typeof WalletResponseOutputSchema>;

--- a/apps/api/src/billing/routes/stripe-payment-methods/stripe-payment-methods.router.ts
+++ b/apps/api/src/billing/routes/stripe-payment-methods/stripe-payment-methods.router.ts
@@ -44,7 +44,7 @@ stripePaymentMethodsRouter.openapi(setupIntentRoute, async function createSetupI
 
 const markAsDefaultRoute = createRoute({
   method: "post",
-  path: `/v1/stripe/payment-methods/default`,
+  path: "/v1/stripe/payment-methods/default",
   summary: "Marks a payment method as the default.",
   tags: ["Payment"],
   security: SECURITY_BEARER_OR_API_KEY,

--- a/apps/api/src/billing/services/balances/balances.service.ts
+++ b/apps/api/src/billing/services/balances/balances.service.ts
@@ -11,6 +11,12 @@ import { averageBlockTime } from "@src/utils/constants";
 
 @singleton()
 export class BalancesService {
+  #currencyFormatter = new Intl.NumberFormat("en-US", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+    useGrouping: false
+  });
+
   constructor(
     @InjectBillingConfig() private readonly config: BillingConfig,
     private readonly userWalletRepository: UserWalletRepository,
@@ -138,6 +144,6 @@ export class BalancesService {
   }
 
   ensure2floatingDigits(amount: number) {
-    return parseFloat(amount.toFixed(2));
+    return Number(this.#currencyFormatter.format(amount));
   }
 }

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -327,7 +327,9 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     };
 
     const walletSettingRepository = mock<WalletSettingRepository>();
-    const balancesService = mock<BalancesService>();
+    const balancesService = mock<BalancesService>({
+      ensure2floatingDigits: jest.fn().mockImplementation((amount: number) => amount)
+    });
     const walletReloadJobService = mock<WalletReloadJobService>();
     const drainingDeploymentService = mock<DrainingDeploymentService>();
     const stripeService = mock<StripeService>();

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -166,7 +166,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
     const reloadTargetDate = addMilliseconds(new Date(), this.#RELOAD_COVERAGE_PERIOD_IN_MS);
     const costUntilTargetDateInDenom = await this.drainingDeploymentService.calculateAllDeploymentCostUntilDate(resources.wallet.address, reloadTargetDate);
     const costUntilTargetDateInFiat = await this.balancesService.toFiatAmount(costUntilTargetDateInDenom);
-    const threshold = this.#MIN_COVERAGE_PERCENTAGE * costUntilTargetDateInFiat;
+    const threshold = this.balancesService.ensure2floatingDigits(this.#MIN_COVERAGE_PERCENTAGE * costUntilTargetDateInFiat);
     const log = {
       walletAddress: resources.wallet.address,
       balance: resources.balance,

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -64,7 +64,7 @@ export class WalletSettingService {
       return {};
     }
 
-    await this.#validate({ next: settings, prev, userId });
+    await this.#validate({ next: settings, userId });
     const next = await this.walletSettingRepository.accessibleBy(ability, "update").updateById(prev.id, settings, { returning: true });
 
     if (!next) {
@@ -104,17 +104,8 @@ export class WalletSettingService {
     }
   }
 
-  async #validate({ prev, next, userId }: { next: WalletSettingInput; prev?: WalletSettingOutput; userId: string }) {
+  async #validate({ next, userId }: { next: WalletSettingInput; userId: string }) {
     if (next.autoReloadEnabled) {
-      const threshold = next.autoReloadThreshold ?? prev?.autoReloadThreshold;
-      const amount = next.autoReloadAmount ?? prev?.autoReloadAmount;
-
-      assert(
-        typeof threshold === "number" && typeof amount === "number",
-        400,
-        '"autoReloadThreshold" and "autoReloadAmount" are required when "autoReloadEnabled" is true'
-      );
-
       const user = await this.userRepository.findById(userId);
       assert(user, 404, "User Not Found");
 

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -15199,16 +15199,8 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                   "properties": {
                     "data": {
                       "properties": {
-                        "autoReloadAmount": {
-                          "minimum": 20,
-                          "type": "number",
-                        },
                         "autoReloadEnabled": {
                           "type": "boolean",
-                        },
-                        "autoReloadThreshold": {
-                          "minimum": 20,
-                          "type": "number",
                         },
                       },
                       "required": [
@@ -15252,16 +15244,8 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                 "properties": {
                   "data": {
                     "properties": {
-                      "autoReloadAmount": {
-                        "minimum": 20,
-                        "type": "number",
-                      },
                       "autoReloadEnabled": {
                         "type": "boolean",
-                      },
-                      "autoReloadThreshold": {
-                        "minimum": 20,
-                        "type": "number",
                       },
                     },
                     "required": [
@@ -15286,16 +15270,8 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                   "properties": {
                     "data": {
                       "properties": {
-                        "autoReloadAmount": {
-                          "minimum": 20,
-                          "type": "number",
-                        },
                         "autoReloadEnabled": {
                           "type": "boolean",
-                        },
-                        "autoReloadThreshold": {
-                          "minimum": 20,
-                          "type": "number",
                         },
                       },
                       "required": [
@@ -15339,18 +15315,13 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                 "properties": {
                   "data": {
                     "properties": {
-                      "autoReloadAmount": {
-                        "minimum": 20,
-                        "type": "number",
-                      },
                       "autoReloadEnabled": {
                         "type": "boolean",
                       },
-                      "autoReloadThreshold": {
-                        "minimum": 20,
-                        "type": "number",
-                      },
                     },
+                    "required": [
+                      "autoReloadEnabled",
+                    ],
                     "type": "object",
                   },
                 },
@@ -15370,16 +15341,8 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                   "properties": {
                     "data": {
                       "properties": {
-                        "autoReloadAmount": {
-                          "minimum": 20,
-                          "type": "number",
-                        },
                         "autoReloadEnabled": {
                           "type": "boolean",
-                        },
-                        "autoReloadThreshold": {
-                          "minimum": 20,
-                          "type": "number",
                         },
                       },
                       "required": [


### PR DESCRIPTION
- Remove threshold/amount fields from WalletSettingsSchema
- Simplify wallet settings validation to only check payment method
- Update tests to reflect removed validation
- Fix payment method default marking order
- Use Intl.NumberFormat for currency formatting

refs #1779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured only one payment method can be marked default at a time.
  * Improved numeric precision for balance checks and formatting.

* **Refactor**
  * Simplified wallet auto-reload to a single enable/disable toggle; threshold and amount removed.
  * Update requests now require the enable/disable field (threshold/amount no longer optional).
  * Auto-reload jobs are cancelled when wallet settings are deleted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->