### PR TITLE
fix(deployment): filter audited bids for managed wallets

### DIFF
--- a/apps/api/src/bid/services/bid/bid.service.spec.ts
+++ b/apps/api/src/bid/services/bid/bid.service.spec.ts
@@ -1,3 +1,4 @@
+import type { Provider } from "@akashnetwork/database/dbSchemas/akash";
 import type { BidHttpService } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
 import { mock } from "jest-mock-extended";
@@ -23,10 +24,10 @@ describe(BidService.name, () => {
       const userWallet = { address: faker.finance.ethereumAddress(), userId: 1 };
       const mockBids = [BidSeeder.create(), BidSeeder.create(), BidSeeder.create()];
 
-      authService.ability = {} as any;
+      authService.ability = {} as unknown as AuthService["ability"];
       userWalletRepository.accessibleBy.mockReturnValue({
         findFirst: jest.fn().mockResolvedValue(userWallet)
-      } as any);
+      } as unknown as ReturnType<UserWalletRepository["accessibleBy"]>);
       bidHttpService.list.mockResolvedValue(mockBids);
 
       const result = await service.list("123456");
@@ -44,7 +45,11 @@ describe(BidService.name, () => {
       const userWallet = { address: faker.finance.ethereumAddress(), userId: 1 };
       const auditedProvider1 = createProviderWithAttributeSignatures(auditor);
       const auditedProvider2 = createProviderWithAttributeSignatures(auditor);
-      const unauditedProvider = { ...createProviderSeed(), providerAttributeSignatures: [], providerAttributes: [] } as any;
+      const unauditedProvider = {
+        ...createProviderSeed(),
+        providerAttributeSignatures: [],
+        providerAttributes: []
+      } as unknown as Provider;
 
       const mockBids = [
         BidSeeder.create({ provider: auditedProvider1.owner }),
@@ -52,10 +57,10 @@ describe(BidService.name, () => {
         BidSeeder.create({ provider: unauditedProvider.owner })
       ];
 
-      authService.ability = {} as any;
+      authService.ability = {} as unknown as AuthService["ability"];
       userWalletRepository.accessibleBy.mockReturnValue({
         findFirst: jest.fn().mockResolvedValue(userWallet)
-      } as any);
+      } as unknown as ReturnType<UserWalletRepository["accessibleBy"]>);
       bidHttpService.list.mockResolvedValue(mockBids);
       providerRepository.getProvidersByAddressesWithAttributes.mockResolvedValue([auditedProvider1, auditedProvider2, unauditedProvider]);
 
@@ -77,15 +82,23 @@ describe(BidService.name, () => {
       });
 
       const userWallet = { address: faker.finance.ethereumAddress(), userId: 1 };
-      const unauditedProvider1 = { ...createProviderSeed(), providerAttributeSignatures: [], providerAttributes: [] } as any;
-      const unauditedProvider2 = { ...createProviderSeed(), providerAttributeSignatures: [], providerAttributes: [] } as any;
+      const unauditedProvider1 = {
+        ...createProviderSeed(),
+        providerAttributeSignatures: [],
+        providerAttributes: []
+      } as unknown as Provider;
+      const unauditedProvider2 = {
+        ...createProviderSeed(),
+        providerAttributeSignatures: [],
+        providerAttributes: []
+      } as unknown as Provider;
 
       const mockBids = [BidSeeder.create({ provider: unauditedProvider1.owner }), BidSeeder.create({ provider: unauditedProvider2.owner })];
 
-      authService.ability = {} as any;
+      authService.ability = {} as unknown as AuthService["ability"];
       userWalletRepository.accessibleBy.mockReturnValue({
         findFirst: jest.fn().mockResolvedValue(userWallet)
-      } as any);
+      } as unknown as ReturnType<UserWalletRepository["accessibleBy"]>);
       bidHttpService.list.mockResolvedValue(mockBids);
       providerRepository.getProvidersByAddressesWithAttributes.mockResolvedValue([unauditedProvider1, unauditedProvider2]);
 
@@ -97,10 +110,10 @@ describe(BidService.name, () => {
     it("throws error when user wallet not found", async () => {
       const { service, userWalletRepository, authService } = setup({});
 
-      authService.ability = {} as any;
+      authService.ability = {} as unknown as AuthService["ability"];
       userWalletRepository.accessibleBy.mockReturnValue({
         findFirst: jest.fn().mockResolvedValue(null)
-      } as any);
+      } as unknown as ReturnType<UserWalletRepository["accessibleBy"]>);
 
       await expect(service.list("123456")).rejects.toMatchObject({
         status: 404,
@@ -116,10 +129,10 @@ describe(BidService.name, () => {
 
       const userWallet = { address: faker.finance.ethereumAddress(), userId: 1 };
 
-      authService.ability = {} as any;
+      authService.ability = {} as unknown as AuthService["ability"];
       userWalletRepository.accessibleBy.mockReturnValue({
         findFirst: jest.fn().mockResolvedValue(userWallet)
-      } as any);
+      } as unknown as ReturnType<UserWalletRepository["accessibleBy"]>);
       bidHttpService.list.mockResolvedValue([]);
 
       const result = await service.list("123456");

--- a/apps/api/src/bid/services/bid/bid.service.spec.ts
+++ b/apps/api/src/bid/services/bid/bid.service.spec.ts
@@ -1,0 +1,154 @@
+import type { BidHttpService } from "@akashnetwork/http-sdk";
+import { faker } from "@faker-js/faker";
+import { mock } from "jest-mock-extended";
+
+import type { AuthService } from "@src/auth/services/auth.service";
+import type { UserWalletRepository } from "@src/billing/repositories";
+import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import type { ProviderRepository } from "@src/provider/repositories/provider/provider.repository";
+import type { ProviderService } from "@src/provider/services/provider/provider.service";
+import { BidService } from "./bid.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+import { BidSeeder } from "@test/seeders/bid.seeder";
+import { createProviderSeed, createProviderWithAttributeSignatures } from "@test/seeders/provider.seeder";
+
+describe(BidService.name, () => {
+  describe("list", () => {
+    it("returns all bids when no auditor filter is configured", async () => {
+      const { service, bidHttpService, userWalletRepository, authService } = setup({
+        allowedAuditors: []
+      });
+
+      const userWallet = { address: faker.finance.ethereumAddress(), userId: 1 };
+      const mockBids = [BidSeeder.create(), BidSeeder.create(), BidSeeder.create()];
+
+      authService.ability = {} as any;
+      userWalletRepository.accessibleBy.mockReturnValue({
+        findFirst: jest.fn().mockResolvedValue(userWallet)
+      } as any);
+      bidHttpService.list.mockResolvedValue(mockBids);
+
+      const result = await service.list("123456");
+
+      expect(result).toHaveLength(3);
+      expect(bidHttpService.list).toHaveBeenCalledWith(userWallet.address, "123456");
+    });
+
+    it("filters bids to only include audited providers", async () => {
+      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
+      const { service, bidHttpService, userWalletRepository, authService, providerRepository } = setup({
+        allowedAuditors: [auditor]
+      });
+
+      const userWallet = { address: faker.finance.ethereumAddress(), userId: 1 };
+      const auditedProvider1 = createProviderWithAttributeSignatures(auditor);
+      const auditedProvider2 = createProviderWithAttributeSignatures(auditor);
+      const unauditedProvider = { ...createProviderSeed(), providerAttributeSignatures: [], providerAttributes: [] } as any;
+
+      const mockBids = [
+        BidSeeder.create({ provider: auditedProvider1.owner }),
+        BidSeeder.create({ provider: auditedProvider2.owner }),
+        BidSeeder.create({ provider: unauditedProvider.owner })
+      ];
+
+      authService.ability = {} as any;
+      userWalletRepository.accessibleBy.mockReturnValue({
+        findFirst: jest.fn().mockResolvedValue(userWallet)
+      } as any);
+      bidHttpService.list.mockResolvedValue(mockBids);
+      providerRepository.getProvidersByAddressesWithAttributes.mockResolvedValue([auditedProvider1, auditedProvider2, unauditedProvider]);
+
+      const result = await service.list("123456");
+
+      expect(result).toHaveLength(2);
+      expect(result.map(r => r.bid.id.provider)).toEqual([auditedProvider1.owner, auditedProvider2.owner]);
+      expect(providerRepository.getProvidersByAddressesWithAttributes).toHaveBeenCalledWith([
+        auditedProvider1.owner,
+        auditedProvider2.owner,
+        unauditedProvider.owner
+      ]);
+    });
+
+    it("returns empty array when no bids match auditor requirements", async () => {
+      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
+      const { service, bidHttpService, userWalletRepository, authService, providerRepository } = setup({
+        allowedAuditors: [auditor]
+      });
+
+      const userWallet = { address: faker.finance.ethereumAddress(), userId: 1 };
+      const unauditedProvider1 = { ...createProviderSeed(), providerAttributeSignatures: [], providerAttributes: [] } as any;
+      const unauditedProvider2 = { ...createProviderSeed(), providerAttributeSignatures: [], providerAttributes: [] } as any;
+
+      const mockBids = [BidSeeder.create({ provider: unauditedProvider1.owner }), BidSeeder.create({ provider: unauditedProvider2.owner })];
+
+      authService.ability = {} as any;
+      userWalletRepository.accessibleBy.mockReturnValue({
+        findFirst: jest.fn().mockResolvedValue(userWallet)
+      } as any);
+      bidHttpService.list.mockResolvedValue(mockBids);
+      providerRepository.getProvidersByAddressesWithAttributes.mockResolvedValue([unauditedProvider1, unauditedProvider2]);
+
+      const result = await service.list("123456");
+
+      expect(result).toHaveLength(0);
+    });
+
+    it("throws error when user wallet not found", async () => {
+      const { service, userWalletRepository, authService } = setup({});
+
+      authService.ability = {} as any;
+      userWalletRepository.accessibleBy.mockReturnValue({
+        findFirst: jest.fn().mockResolvedValue(null)
+      } as any);
+
+      await expect(service.list("123456")).rejects.toMatchObject({
+        status: 404,
+        message: "UserWallet Not Found"
+      });
+    });
+
+    it("handles empty bids array", async () => {
+      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
+      const { service, bidHttpService, userWalletRepository, authService, providerRepository } = setup({
+        allowedAuditors: [auditor]
+      });
+
+      const userWallet = { address: faker.finance.ethereumAddress(), userId: 1 };
+
+      authService.ability = {} as any;
+      userWalletRepository.accessibleBy.mockReturnValue({
+        findFirst: jest.fn().mockResolvedValue(userWallet)
+      } as any);
+      bidHttpService.list.mockResolvedValue([]);
+
+      const result = await service.list("123456");
+
+      expect(result).toHaveLength(0);
+      expect(providerRepository.getProvidersByAddressesWithAttributes).not.toHaveBeenCalled();
+    });
+  });
+
+  function setup(config: { allowedAuditors?: string[] }) {
+    const bidHttpService = mock<BidHttpService>();
+    const authService = mock<AuthService>();
+    const userWalletRepository = mock<UserWalletRepository>();
+    const providerService = mock<ProviderService>();
+    const billingConfig = mockConfigService<BillingConfigService>({
+      MANAGED_WALLET_LEASE_ALLOWED_AUDITORS: config.allowedAuditors || []
+    });
+    const providerRepository = mock<ProviderRepository>();
+
+    const service = new BidService(bidHttpService, authService, userWalletRepository, providerService, billingConfig, providerRepository);
+
+    return {
+      service,
+      bidHttpService,
+      authService,
+      userWalletRepository,
+      providerService,
+      billingConfig,
+      providerRepository
+    };
+  }
+});

--- a/apps/api/src/bid/services/bid/bid.service.ts
+++ b/apps/api/src/bid/services/bid/bid.service.ts
@@ -5,6 +5,8 @@ import { singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
 import { UserWalletRepository } from "@src/billing/repositories";
+import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { ProviderRepository } from "@src/provider/repositories/provider/provider.repository";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 
 @singleton()
@@ -15,7 +17,9 @@ export class BidService {
     private readonly bidHttpService: BidHttpService,
     private readonly authService: AuthService,
     private readonly userWalletRepository: UserWalletRepository,
-    private readonly providerService: ProviderService
+    private readonly providerService: ProviderService,
+    private readonly billingConfig: BillingConfigService,
+    private readonly providerRepository: ProviderRepository
   ) {}
 
   async list(dseq: string): Promise<(Bid & { isCertificateRequired: boolean })[]> {
@@ -26,7 +30,34 @@ export class BidService {
 
     const bids = await this.bidHttpService.list(userWallet.address, dseq);
 
-    return await Promise.all(bids.map(bid => this.decorateWithCertRequirement(bid)));
+    const filteredBids = await this.filterBidsByAuditedProviders(bids);
+
+    return await Promise.all(filteredBids.map(bid => this.decorateWithCertRequirement(bid)));
+  }
+
+  private async filterBidsByAuditedProviders(bids: Bid[]): Promise<Bid[]> {
+    const allowedAuditors = this.billingConfig.get("MANAGED_WALLET_LEASE_ALLOWED_AUDITORS");
+
+    if (!allowedAuditors || allowedAuditors.length === 0) {
+      return bids;
+    }
+
+    if (bids.length === 0) {
+      return bids;
+    }
+
+    const providerAddresses = Array.from(new Set(bids.map(bid => bid.bid.id.provider)));
+    const providers = await this.providerRepository.getProvidersByAddressesWithAttributes(providerAddresses);
+    const auditedProviderAddresses = new Set(
+      providers
+        .filter(provider => {
+          const providerAuditors = provider.providerAttributeSignatures.map(signature => signature.auditor);
+          return providerAuditors.some(auditor => allowedAuditors.includes(auditor));
+        })
+        .map(provider => provider.owner)
+    );
+
+    return bids.filter(bid => auditedProviderAddresses.has(bid.bid.id.provider));
   }
 
   private async decorateWithCertRequirement<T extends Bid>(bid: T): Promise<T & { isCertificateRequired: boolean }> {

--- a/apps/api/src/bid/services/bid/bid.service.ts
+++ b/apps/api/src/bid/services/bid/bid.service.ts
@@ -51,7 +51,8 @@ export class BidService {
     const auditedProviderAddresses = new Set(
       providers
         .filter(provider => {
-          const providerAuditors = provider.providerAttributeSignatures.map(signature => signature.auditor);
+          const signatures = provider.providerAttributeSignatures ?? [];
+          const providerAuditors = signatures.map(signature => signature.auditor);
           return providerAuditors.some(auditor => allowedAuditors.includes(auditor));
         })
         .map(provider => provider.owner)

--- a/apps/api/src/bid/services/bid/bid.service.ts
+++ b/apps/api/src/bid/services/bid/bid.service.ts
@@ -38,11 +38,7 @@ export class BidService {
   private async filterBidsByAuditedProviders(bids: Bid[]): Promise<Bid[]> {
     const allowedAuditors = this.billingConfig.get("MANAGED_WALLET_LEASE_ALLOWED_AUDITORS");
 
-    if (!allowedAuditors || allowedAuditors.length === 0) {
-      return bids;
-    }
-
-    if (bids.length === 0) {
+    if (!allowedAuditors || allowedAuditors.length === 0 || bids.length === 0) {
       return bids;
     }
 

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -43,6 +43,11 @@ export class DeploymentWriterService {
       sdl = sdl.replace(/uakt/g, deploymentGrantDenom);
     }
 
+    const allowedAuditors = this.billingConfig.get("MANAGED_WALLET_LEASE_ALLOWED_AUDITORS");
+    if (allowedAuditors && allowedAuditors.length > 0) {
+      sdl = this.sdlService.appendAuditorRequirement(sdl, allowedAuditors);
+    }
+
     const dseq = await this.blockHttpService.getCurrentHeight();
     const groups = this.sdlService.getDeploymentGroups(sdl, "beta3");
     const manifestVersion = await this.sdlService.getManifestVersion(sdl, "beta3");

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -101,9 +101,15 @@ export class DeploymentWriterService {
 
   public async updateByUserIdAndDseq(userId: string, dseq: string, input: UpdateDeploymentRequest["data"]): Promise<GetDeploymentResponse["data"]> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
-    const { sdl, certificate } = input;
+    let sdl = input.sdl;
+    const { certificate } = input;
 
     assert(this.sdlService.validateSdl(sdl), 400, "Invalid SDL");
+
+    const allowedAuditors = this.billingConfig.get("MANAGED_WALLET_LEASE_ALLOWED_AUDITORS");
+    if (allowedAuditors && allowedAuditors.length > 0) {
+      sdl = this.sdlService.appendAuditorRequirement(sdl, allowedAuditors);
+    }
 
     const deployment = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
     const manifestVersion = await this.sdlService.getManifestVersion(sdl, "beta3");

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -1,0 +1,305 @@
+import yaml from "js-yaml";
+
+import type { BillingConfig } from "@src/billing/providers";
+import { SdlService } from "./sdl.service";
+
+describe(SdlService.name, () => {
+  describe("appendAuditorRequirement", () => {
+    it("adds auditor to signedBy anyOf when not present", () => {
+      const { service } = setup();
+      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
+
+      const inputSdl = `---
+version: "2.0"
+
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 1Gi
+  placement:
+    westcoast:
+      attributes:
+        region: us-west
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1
+`;
+
+      const result = service.appendAuditorRequirement(inputSdl, [auditor]);
+      const parsedResult = yaml.load(result) as any;
+
+      expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor);
+    });
+
+    it("does not duplicate auditor if already present in anyOf", () => {
+      const { service } = setup();
+      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
+
+      const inputSdl = `---
+version: "2.0"
+
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 1Gi
+  placement:
+    westcoast:
+      attributes:
+        region: us-west
+      signedBy:
+        anyOf:
+          - ${auditor}
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1
+`;
+
+      const result = service.appendAuditorRequirement(inputSdl, [auditor]);
+      const parsedResult = yaml.load(result) as any;
+
+      const anyOfCount = parsedResult.profiles.placement.westcoast.signedBy.anyOf.filter((a: string) => a === auditor).length;
+      expect(anyOfCount).toBe(1);
+    });
+
+    it("adds multiple auditors to signedBy anyOf", () => {
+      const { service } = setup();
+      const auditor1 = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
+      const auditor2 = "akash1another7awdyj3n2sav7xfx76adc6dnmlx64";
+
+      const inputSdl = `---
+version: "2.0"
+
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 1Gi
+  placement:
+    westcoast:
+      attributes:
+        region: us-west
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1
+`;
+
+      const result = service.appendAuditorRequirement(inputSdl, [auditor1, auditor2]);
+      const parsedResult = yaml.load(result) as any;
+
+      expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor1);
+      expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor2);
+    });
+
+    it("preserves existing signedBy allOf when adding anyOf", () => {
+      const { service } = setup();
+      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
+      const existingAllOf = "akash1existingauditor";
+
+      const inputSdl = `---
+version: "2.0"
+
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 1Gi
+  placement:
+    westcoast:
+      attributes:
+        region: us-west
+      signedBy:
+        allOf:
+          - ${existingAllOf}
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1
+`;
+
+      const result = service.appendAuditorRequirement(inputSdl, [auditor]);
+      const parsedResult = yaml.load(result) as any;
+
+      expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor);
+      expect(parsedResult.profiles.placement.westcoast.signedBy.allOf).toContain(existingAllOf);
+    });
+
+    it("applies auditor requirement to all placement profiles", () => {
+      const { service } = setup();
+      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
+
+      const inputSdl = `---
+version: "2.0"
+
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+  api:
+    image: node
+    expose:
+      - port: 3000
+        as: 3000
+        to:
+          - global: true
+
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 1Gi
+    api:
+      resources:
+        cpu:
+          units: 1
+        memory:
+          size: 1Gi
+        storage:
+          size: 2Gi
+  placement:
+    westcoast:
+      attributes:
+        region: us-west
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+        api:
+          denom: uakt
+          amount: 2000
+    eastcoast:
+      attributes:
+        region: us-east
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+        api:
+          denom: uakt
+          amount: 2000
+
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1
+  api:
+    eastcoast:
+      profile: api
+      count: 1
+`;
+
+      const result = service.appendAuditorRequirement(inputSdl, [auditor]);
+      const parsedResult = yaml.load(result) as any;
+
+      expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor);
+      expect(parsedResult.profiles.placement.eastcoast.signedBy.anyOf).toContain(auditor);
+    });
+  });
+
+  function setup() {
+    const config: BillingConfig = {
+      NETWORK: "sandbox"
+    } as BillingConfig;
+
+    const service = new SdlService(config);
+
+    return {
+      service,
+      config
+    };
+  }
+});

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -1,3 +1,4 @@
+import type { v2Sdl } from "@akashnetwork/akashjs/build/sdl/types";
 import yaml from "js-yaml";
 
 import type { BillingConfig } from "@src/billing/providers";
@@ -48,7 +49,7 @@ deployment:
 `;
 
       const result = service.appendAuditorRequirement(inputSdl, [auditor]);
-      const parsedResult = yaml.load(result) as any;
+      const parsedResult = yaml.load(result) as v2Sdl;
 
       expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor);
     });
@@ -99,7 +100,7 @@ deployment:
 `;
 
       const result = service.appendAuditorRequirement(inputSdl, [auditor]);
-      const parsedResult = yaml.load(result) as any;
+      const parsedResult = yaml.load(result) as v2Sdl;
 
       const anyOfCount = parsedResult.profiles.placement.westcoast.signedBy.anyOf.filter((a: string) => a === auditor).length;
       expect(anyOfCount).toBe(1);
@@ -149,7 +150,7 @@ deployment:
 `;
 
       const result = service.appendAuditorRequirement(inputSdl, [auditor1, auditor2]);
-      const parsedResult = yaml.load(result) as any;
+      const parsedResult = yaml.load(result) as v2Sdl;
 
       expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor1);
       expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor2);
@@ -202,7 +203,7 @@ deployment:
 `;
 
       const result = service.appendAuditorRequirement(inputSdl, [auditor]);
-      const parsedResult = yaml.load(result) as any;
+      const parsedResult = yaml.load(result) as v2Sdl;
 
       expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor);
       expect(parsedResult.profiles.placement.westcoast.signedBy.allOf).toContain(existingAllOf);
@@ -283,7 +284,7 @@ deployment:
 `;
 
       const result = service.appendAuditorRequirement(inputSdl, [auditor]);
-      const parsedResult = yaml.load(result) as any;
+      const parsedResult = yaml.load(result) as v2Sdl;
 
       expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor);
       expect(parsedResult.profiles.placement.eastcoast.signedBy.anyOf).toContain(auditor);

--- a/apps/api/test/seeders/provider.seeder.ts
+++ b/apps/api/test/seeders/provider.seeder.ts
@@ -49,3 +49,19 @@ export const createProvider = async (overrides: Partial<CreationAttributes<Provi
 
   return provider;
 };
+
+export const createProviderWithAttributeSignatures = (auditor: string): Provider => {
+  const providerSeed = createProviderSeed();
+  return {
+    ...providerSeed,
+    providerAttributeSignatures: [
+      {
+        provider: providerSeed.owner,
+        auditor,
+        key: "region",
+        value: "us-west"
+      }
+    ] as any,
+    providerAttributes: [] as any
+  } as Provider;
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bids now filter to show only those from auditors allowed by billing configuration.
  * Deployments append configured auditor requirements to manifests on create/update.

* **Tests**
  * Added comprehensive tests for bid auditor-based filtering, related error paths, and provider-auditor handling.
  * Added tests for inserting auditor requirements across placement profiles.

* **Chores**
  * Added a test helper to create providers with auditor signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->