### PR TITLE
feat(deployment): add RPC support with database fallback for draining deployments

### DIFF
--- a/apps/api/src/console.ts
+++ b/apps/api/src/console.ts
@@ -35,7 +35,6 @@ program
 program
   .command("top-up-deployments")
   .description("Refill deployments with auto top up enabled")
-  .option("-c, --concurrency <number>", "How many wallets are processed concurrently", value => z.number({ coerce: true }).optional().default(10).parse(value))
   .option("-d, --dry-run", "Dry run the top up deployments", false)
   .action(async (options, command) => {
     await executeCliHandler(command.name(), async () => {

--- a/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.ts
+++ b/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.ts
@@ -1,8 +1,8 @@
 import { singleton } from "tsyringe";
 
+import type { DryRunOptions } from "@src/core/types/console";
 import { StaleManagedDeploymentsCleanerService } from "@src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service";
 import { TopUpManagedDeploymentsService } from "@src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service";
-import { TopUpDeploymentsOptions } from "@src/deployment/types/deployments-refiller";
 import { CleanUpStaleDeploymentsParams } from "@src/deployment/types/state-deployments";
 
 @singleton()
@@ -12,7 +12,7 @@ export class TopUpDeploymentsController {
     private readonly staleDeploymentsCleanerService: StaleManagedDeploymentsCleanerService
   ) {}
 
-  async topUpDeployments(options: TopUpDeploymentsOptions) {
+  async topUpDeployments(options: DryRunOptions) {
     await this.topUpManagedDeploymentsService.topUpDeployments(options);
   }
 

--- a/apps/api/src/deployment/repositories/lease/lease.repository.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.ts
@@ -44,6 +44,18 @@ export class LeaseRepository implements DrainingDeploymentLeaseSource {
     return null;
   }
 
+  /**
+   * Finds multiple draining deployments by dseqs and owner from the database.
+   * Filters by closure height, aggregates lease data by summing block rates (price)
+   * and taking minimum predicted closure height and closed height.
+   * This implementation assumes that denom is always the same for managed wallets
+   * for which these methods are used, allowing direct summation of price values.
+   *
+   * @param closureHeight - The block height threshold for filtering draining deployments
+   * @param owner - Owner address
+   * @param dseqs - Array of deployment sequence numbers to filter by
+   * @returns Array of draining deployment outputs
+   */
   async findManyByDseqAndOwner(closureHeight: number, owner: string, dseqs: string[]): Promise<DrainingDeploymentOutput[]> {
     if (!dseqs.length) return [];
 
@@ -76,6 +88,14 @@ export class LeaseRepository implements DrainingDeploymentLeaseSource {
     return [];
   }
 
+  /**
+   * Finds leases with pagination support and optional filtering.
+   * Supports filtering by owner, dseq, gseq, oseq, provider, and state.
+   * Includes associated deployment data in the results.
+   *
+   * @param params - Query parameters for filtering and pagination
+   * @returns Object with total count and array of lease rows
+   */
   async findLeasesWithPagination(params: DatabaseLeaseListParams): Promise<{ count: number; rows: Lease[] }> {
     const { skip = 0, limit = 100, owner, dseq, gseq, oseq, provider, state, reverse = false } = params;
 

--- a/apps/api/src/deployment/repositories/lease/lease.repository.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.ts
@@ -42,15 +42,14 @@ export class LeaseRepository {
     return null;
   }
 
-  async findManyByDseqAndOwner(closureHeight: number, pairs: { dseq: string; owner: string }[]): Promise<DrainingDeploymentOutput[]> {
-    if (!pairs.length) return [];
+  async findManyByDseqAndOwner(closureHeight: number, owner: string, dseqs: string[]): Promise<DrainingDeploymentOutput[]> {
+    if (!dseqs.length) return [];
 
     const leaseOrLeases = await Lease.findAll({
       where: {
         predictedClosedHeight: { [Op.lte]: closureHeight },
-        [Op.or]: pairs.map(({ dseq, owner }) => ({
-          [Op.and]: [{ dseq, owner }]
-        }))
+        owner,
+        dseq: { [Op.in]: dseqs }
       },
       attributes: [
         "dseq",

--- a/apps/api/src/deployment/repositories/lease/lease.repository.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.ts
@@ -2,6 +2,8 @@ import { Lease } from "@akashnetwork/database/dbSchemas/akash";
 import { col, fn, Op, WhereOptions } from "sequelize";
 import { singleton } from "tsyringe";
 
+import { DrainingDeploymentLeaseSource } from "@src/deployment/types/draining-deployment";
+
 export interface DrainingDeploymentOutput {
   dseq: number;
   owner: string;
@@ -26,7 +28,7 @@ export interface DatabaseLeaseListParams {
 }
 
 @singleton()
-export class LeaseRepository {
+export class LeaseRepository implements DrainingDeploymentLeaseSource {
   async findOneByDseqAndOwner(dseq: string, owner: string): Promise<DrainingDeploymentOutput | null> {
     const leases = await Lease.findAll({
       where: { dseq, owner },

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
@@ -2,7 +2,7 @@ import { singleton } from "tsyringe";
 
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 
-class CachedBalance {
+export class CachedBalance {
   constructor(private value: number) {}
 
   public reserveSufficientAmount(desiredAmount: number) {

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
@@ -223,7 +223,7 @@ describe(DrainingDeploymentRpcService.name, () => {
     const deployments: ReturnType<typeof DeploymentListResponseSeeder.create>[] = [];
 
     inputs.forEach(input => {
-      const dseq = input.deployment?.dseq ?? faker.string.numeric(6);
+      const dseq = input.deployment?.dseq ?? faker.string.numeric({ length: 6, allowLeadingZeros: false });
       dseqs.push(dseq);
 
       input.leases.forEach((lease, leaseIdx) => {

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
@@ -1,0 +1,289 @@
+import "@test/mocks/logger-service.mock";
+
+import type { DeploymentHttpService, DeploymentListResponse, LeaseHttpService } from "@akashnetwork/http-sdk";
+import { faker } from "@faker-js/faker";
+import { mock } from "jest-mock-extended";
+
+import type { LoggerService } from "@src/core";
+import { DrainingDeploymentRpcService } from "./draining-deployment-rpc.service";
+
+import { createAkashAddress } from "@test/seeders";
+import { DeploymentListResponseSeeder } from "@test/seeders/deployment-list-response.seeder";
+import { LeaseApiResponseSeeder } from "@test/seeders/lease-api-response.seeder";
+
+describe(DrainingDeploymentRpcService.name, () => {
+  describe("findManyByDseqAndOwner", () => {
+    it("returns draining deployments with predicted closed height", async () => {
+      const input = {
+        leases: [{ blockRate: 50 }],
+        deployment: {
+          createdHeight: 995000,
+          funds: 40000,
+          transferred: 20000
+        }
+      };
+
+      const { service, owner, dseqs, closureHeight } = setup({
+        inputs: [input]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        dseq: Number(dseqs[0]),
+        owner,
+        denom: "uakt",
+        blockRate: input.leases[0].blockRate,
+        predictedClosedHeight: Math.ceil(input.deployment.createdHeight + (input.deployment.funds + input.deployment.transferred) / input.leases[0].blockRate)
+      });
+    });
+
+    it("filters deployments by closureHeight", async () => {
+      const activeInput = {
+        leases: [{ blockRate: 50 }],
+        deployment: {
+          dseq: faker.string.numeric(6),
+          createdHeight: 995000,
+          funds: 40000,
+          transferred: 20000
+        }
+      };
+      const filteredInput = {
+        leases: [{ blockRate: 50 }],
+        deployment: {
+          createdHeight: 995000,
+          funds: 250000,
+          transferred: 20000
+        }
+      };
+
+      const { service, owner, dseqs, closureHeight } = setup({
+        inputs: [activeInput, filteredInput]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].dseq).toBe(Number(activeInput.deployment.dseq));
+    });
+
+    it("sums block rates for multiple leases with same dseq", async () => {
+      const input = {
+        leases: [
+          { blockRate: 30, gseq: 0 },
+          { blockRate: 20, gseq: 1 }
+        ],
+        deployment: {
+          createdHeight: 995000,
+          funds: 40000,
+          transferred: 20000
+        }
+      };
+      const totalBlockRate = input.leases[0].blockRate + input.leases[1].blockRate;
+
+      const { service, owner, dseqs, closureHeight } = setup({
+        inputs: [input]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].blockRate).toBe(totalBlockRate);
+    });
+
+    it("excludes deployments without matching lease data", async () => {
+      const { service, loggerService, owner, dseqs, closureHeight } = setup({
+        inputs: [
+          {
+            leases: [{ blockRate: 50 }],
+            deployment: undefined
+          }
+        ]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toHaveLength(0);
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "DEPLOYMENT_NOT_FOUND",
+          dseq: Number(dseqs[0]),
+          owner
+        })
+      );
+    });
+
+    it("excludes deployments with zero balance", async () => {
+      const { service, loggerService, owner, dseqs, closureHeight } = setup({
+        inputs: [
+          {
+            leases: [{ blockRate: 50 }],
+            deployment: {
+              createdHeight: 995000,
+              funds: 0,
+              transferred: 0
+            }
+          }
+        ]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toHaveLength(0);
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "DEPLOYMENT_HAS_NO_BALANCE",
+          dseq: Number(dseqs[0]),
+          owner
+        })
+      );
+    });
+
+    it("excludes deployments with invalid block rate", async () => {
+      const { service, loggerService, owner, dseqs, closureHeight } = setup({
+        inputs: [
+          {
+            leases: [{ blockRate: 0 }],
+            deployment: {
+              createdHeight: 995000,
+              funds: 40000,
+              transferred: 20000
+            }
+          }
+        ]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toHaveLength(0);
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "DEPLOYMENT_BLOCK_RATE_INVALID",
+          dseq: Number(dseqs[0]),
+          owner
+        })
+      );
+    });
+
+    it("sets closedHeight when lease is closed", async () => {
+      const input = {
+        leases: [
+          {
+            blockRate: 50,
+            state: "closed" as const,
+            closedHeight: 999000
+          }
+        ],
+        deployment: {
+          createdHeight: 995000,
+          funds: 40000,
+          transferred: 20000
+        }
+      };
+
+      const { service, owner, dseqs, closureHeight } = setup({
+        inputs: [input]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].closedHeight).toBe(input.leases[0].closedHeight);
+    });
+  });
+
+  function setup({
+    inputs = []
+  }: {
+    inputs?: Array<{
+      leases: Array<{
+        blockRate: number;
+        gseq?: number;
+        state?: string;
+        closedHeight?: number;
+      }>;
+      deployment?: {
+        dseq?: string;
+        createdHeight?: number;
+        funds?: number;
+        transferred?: number;
+      };
+    }>;
+  } = {}) {
+    const leaseHttpService = mock<LeaseHttpService>();
+    const deploymentHttpService = mock<DeploymentHttpService>();
+    const loggerService = mock<LoggerService>();
+
+    const owner = createAkashAddress();
+    const closureHeight = 1000000;
+
+    const dseqs: string[] = [];
+    const leases: ReturnType<typeof LeaseApiResponseSeeder.create>[] = [];
+    const deployments: ReturnType<typeof DeploymentListResponseSeeder.create>[] = [];
+
+    inputs.forEach(input => {
+      const dseq = input.deployment?.dseq ?? faker.string.numeric(6);
+      dseqs.push(dseq);
+
+      input.leases.forEach((lease, leaseIdx) => {
+        leases.push(
+          LeaseApiResponseSeeder.create({
+            owner,
+            dseq,
+            gseq: lease.gseq ?? leaseIdx,
+            state: lease.state ?? "active",
+            closed_on: lease.closedHeight ? String(lease.closedHeight) : undefined,
+            price: { denom: "uakt", amount: String(lease.blockRate) }
+          })
+        );
+      });
+
+      if (input.deployment) {
+        const createdHeight = input.deployment.createdHeight ?? 995000;
+        const funds = input.deployment.funds ?? 40000;
+        const transferred = input.deployment.transferred ?? 20000;
+
+        const deployment = DeploymentListResponseSeeder.create(
+          {
+            owner,
+            dseq,
+            createdAt: String(createdHeight)
+          },
+          1
+        );
+        const deploymentInfo = deployment.deployments[0];
+        if ("escrow_account" in deploymentInfo) {
+          deploymentInfo.escrow_account.state.funds = [{ denom: "uakt", amount: String(funds) }];
+          deploymentInfo.escrow_account.state.transferred = [{ denom: "uakt", amount: String(transferred) }];
+        }
+        deployments.push(deployment);
+      }
+    });
+
+    const leaseList = leases;
+    const deploymentList = deployments.flatMap(d => d.deployments);
+
+    leaseHttpService.list.mockResolvedValue({
+      leases: leaseList,
+      pagination: { next_key: null, total: String(leaseList.length) }
+    });
+
+    deploymentHttpService.findAll.mockResolvedValue({
+      deployments: deploymentList,
+      pagination: { next_key: null, total: String(deploymentList.length) }
+    } as unknown as DeploymentListResponse);
+
+    const service = new DrainingDeploymentRpcService(leaseHttpService, deploymentHttpService, loggerService);
+
+    return {
+      service,
+      leaseHttpService,
+      deploymentHttpService,
+      loggerService,
+      owner,
+      dseqs,
+      closureHeight
+    };
+  }
+});

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
@@ -92,7 +92,7 @@ describe(DrainingDeploymentRpcService.name, () => {
       expect(result[0].blockRate).toBe(totalBlockRate);
     });
 
-    it("excludes deployments without matching lease data", async () => {
+    it("excludes deployments when deployment is missing (DEPLOYMENT_NOT_FOUND)", async () => {
       const { service, loggerService, owner, dseqs, closureHeight } = setup({
         inputs: [
           {

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
@@ -1,0 +1,151 @@
+import { DeploymentHttpService, LeaseHttpService, type RpcLease } from "@akashnetwork/http-sdk";
+import { singleton } from "tsyringe";
+
+import { LoggerService } from "@src/core";
+import { DrainingDeploymentOutput } from "@src/deployment/repositories/lease/lease.repository";
+import { DrainingDeploymentLeaseSource, RpcDeploymentInfo } from "@src/deployment/types/draining-deployment";
+
+@singleton()
+export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSource {
+  constructor(
+    private readonly leaseHttpService: LeaseHttpService,
+    private readonly deploymentHttpService: DeploymentHttpService,
+    private readonly loggerService: LoggerService
+  ) {
+    loggerService.setContext(DrainingDeploymentRpcService.name);
+  }
+
+  async findManyByDseqAndOwner(closureHeight: number, owner: string, dseqs: string[]): Promise<DrainingDeploymentOutput[]> {
+    const dseqSet = new Set(dseqs);
+    const [leases, deployments] = await Promise.all([this.#fetchLeases(owner, dseqSet), this.#fetchDeployments(owner, dseqSet)]);
+    const leaseMap = this.#createDrainingDeploymentMap(leases);
+    const deploymentMap = this.#createDeploymentMap(deployments);
+    const outputs = this.#addPredictedClosedHeight(leaseMap, deploymentMap);
+    return outputs.filter(output => output.predictedClosedHeight <= closureHeight);
+  }
+
+  async #fetchLeases(owner: string, dseqSet: Set<string>): Promise<RpcLease[]> {
+    const allItems: RpcLease[] = [];
+    let nextKey: string | null = null;
+
+    do {
+      const response = await this.leaseHttpService.list({
+        owner,
+        pagination: { limit: 1000, key: nextKey || undefined }
+      });
+
+      const filteredItems = response.leases.filter(lease => dseqSet.has(lease.lease.id.dseq));
+      allItems.push(...filteredItems);
+      nextKey = response.pagination.next_key;
+    } while (nextKey);
+
+    return allItems;
+  }
+
+  async #fetchDeployments(owner: string, dseqSet: Set<string>): Promise<RpcDeploymentInfo[]> {
+    const allItems: RpcDeploymentInfo[] = [];
+    let nextKey: string | null = null;
+
+    do {
+      const response = await this.deploymentHttpService.findAll({
+        owner,
+        pagination: { limit: 1000, key: nextKey || undefined }
+      });
+
+      const filteredItems = response.deployments
+        .filter(deployment => dseqSet.has(deployment.deployment.id.dseq))
+        .map(deployment => ({
+          dseq: deployment.deployment.id.dseq,
+          createdHeight: Number(deployment.deployment.created_at),
+          escrowBalance: this.#sumAmounts(deployment.escrow_account.state.funds) + this.#sumAmounts(deployment.escrow_account.state.transferred)
+        }));
+
+      allItems.push(...filteredItems);
+      nextKey = response.pagination.next_key;
+    } while (nextKey);
+
+    return allItems;
+  }
+
+  #sumAmounts(items: Array<{ amount: string }>): number {
+    return items.reduce((sum, item) => sum + parseFloat(item.amount), 0);
+  }
+
+  #createDrainingDeploymentMap(rpcLeases: RpcLease[]): Map<string, Omit<DrainingDeploymentOutput, "predictedClosedHeight">> {
+    const leaseMap = new Map<string, Omit<DrainingDeploymentOutput, "predictedClosedHeight">>();
+
+    for (const rpcLease of rpcLeases) {
+      const dseq = rpcLease.lease.id.dseq;
+      const owner = rpcLease.lease.id.owner;
+
+      const denom = rpcLease.escrow_payment.state.rate.denom;
+      const rateAmount = Number(rpcLease.escrow_payment.state.rate.amount);
+
+      const existing = leaseMap.get(dseq);
+      if (existing) {
+        existing.blockRate += rateAmount;
+      } else {
+        leaseMap.set(dseq, {
+          dseq: Number(dseq),
+          owner,
+          denom,
+          blockRate: rateAmount,
+          closedHeight: rpcLease.lease.closed_on && rpcLease.lease.closed_on !== "0" ? Number(rpcLease.lease.closed_on) : undefined
+        });
+      }
+    }
+
+    return leaseMap;
+  }
+
+  #createDeploymentMap(deployments: RpcDeploymentInfo[]): Map<string, RpcDeploymentInfo> {
+    const deploymentMap = new Map<string, RpcDeploymentInfo>();
+
+    for (const deployment of deployments) {
+      const key = deployment.dseq;
+      deploymentMap.set(key, deployment);
+    }
+
+    return deploymentMap;
+  }
+
+  #addPredictedClosedHeight(
+    leaseMap: Map<string, Omit<DrainingDeploymentOutput, "predictedClosedHeight">>,
+    deploymentMap: Map<string, RpcDeploymentInfo>
+  ): DrainingDeploymentOutput[] {
+    return Array.from(leaseMap.values()).reduce((acc, drainingDeployment) => {
+      const deployment = deploymentMap.get(drainingDeployment.dseq.toString());
+
+      if (!deployment) {
+        this.loggerService.warn({
+          event: "DEPLOYMENT_NOT_FOUND",
+          dseq: drainingDeployment.dseq,
+          owner: drainingDeployment.owner
+        });
+        return acc;
+      }
+
+      if (deployment.escrowBalance <= 0) {
+        this.loggerService.warn({
+          event: "DEPLOYMENT_HAS_NO_BALANCE",
+          dseq: drainingDeployment.dseq,
+          owner: drainingDeployment.owner
+        });
+        return acc;
+      }
+
+      if (drainingDeployment.blockRate <= 0) {
+        this.loggerService.warn({
+          event: "DEPLOYMENT_BLOCK_RATE_INVALID",
+          dseq: drainingDeployment.dseq,
+          owner: drainingDeployment.owner
+        });
+        return acc;
+      }
+
+      const predictedClosedHeight = Math.ceil(deployment.createdHeight + deployment.escrowBalance / drainingDeployment.blockRate);
+
+      return [...acc, { ...drainingDeployment, predictedClosedHeight }];
+    }, [] as DrainingDeploymentOutput[]);
+  }
+}

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
@@ -102,7 +102,7 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
     const deploymentMap = new Map<string, RpcDeploymentInfo>();
 
     for (const deployment of deployments) {
-      const key = deployment.dseq;
+      const key = String(Number(deployment.dseq));
       deploymentMap.set(key, deployment);
     }
 

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -1,126 +1,77 @@
 import "@test/mocks/logger-service.mock";
 
-import type { DeploymentHttpService, DeploymentListResponse, LeaseHttpService } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
 import { addWeeks } from "date-fns";
 import { mock } from "jest-mock-extended";
+import { groupBy } from "lodash";
 
 import type { UserWalletRepository } from "@src/billing/repositories";
 import type { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
 import type { LoggerService } from "@src/core";
 import type { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
-import type { LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
+import type { DrainingDeploymentOutput, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
 import { averageBlockCountInAnHour } from "@src/utils/constants";
 import type { DeploymentConfigService } from "../deployment-config/deployment-config.service";
+import type { DrainingDeploymentRpcService } from "../draining-deployment-rpc/draining-deployment-rpc.service";
 import { DrainingDeploymentService } from "./draining-deployment.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createAkashAddress } from "@test/seeders";
 import { AutoTopUpDeploymentSeeder } from "@test/seeders/auto-top-up-deployment.seeder";
 import { DrainingDeploymentSeeder } from "@test/seeders/draining-deployment.seeder";
-import { LeaseApiResponseSeeder } from "@test/seeders/lease-api-response.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
 describe(DrainingDeploymentService.name, () => {
   describe("findDrainingDeploymentsByOwner", () => {
-    const CURRENT_HEIGHT = 1000000;
-    const BLOCK_RATE_1 = 50;
-    const BLOCK_RATE_2 = 75;
-    const PREDICTED_CLOSURE_OFFSET_1 = 100;
-    const PREDICTED_CLOSURE_OFFSET_2 = 200;
-
     it("paginates draining deployments by owner and marks closed ones as such", async () => {
-      const { service, blockHttpService, leaseHttpService, deploymentSettingRepository, loggerService, leaseRepository, deploymentHttpService } = setup({
-        currentHeight: CURRENT_HEIGHT
-      });
+      const { service, deploymentSettingRepository, leaseRepository, loggerService, currentHeight } = setup();
       const deploymentSettings = AutoTopUpDeploymentSeeder.createMany(4);
       const addresses = deploymentSettings.map(s => s.address);
       const dseqs = deploymentSettings.map(s => Number(s.dseq));
 
-      const rpcLeases = [
-        LeaseApiResponseSeeder.create({
-          owner: addresses[0],
-          dseq: String(dseqs[0]),
-          gseq: 0,
-          oseq: 0,
-          state: "active",
-          price: { denom: "uakt", amount: String(BLOCK_RATE_1) }
-        }),
-        LeaseApiResponseSeeder.create({
+      const activeBatches: DrainingDeploymentOutput[][] = [
+        [
+          {
+            dseq: dseqs[0],
+            owner: addresses[0],
+            denom: "uakt",
+            blockRate: faker.number.int({ min: 50, max: 100 }),
+            predictedClosedHeight: faker.number.int({ min: 900000, max: 1000000 })
+          }
+        ],
+        [
+          {
+            dseq: dseqs[3],
+            owner: addresses[3],
+            denom: "uakt",
+            blockRate: faker.number.int({ min: 50, max: 100 }),
+            predictedClosedHeight: faker.number.int({ min: 900000, max: 1000000 })
+          }
+        ]
+      ];
+
+      const closedBatch: DrainingDeploymentOutput[] = [
+        {
+          dseq: dseqs[1],
           owner: addresses[1],
-          dseq: String(dseqs[1]),
-          gseq: 0,
-          oseq: 0,
-          state: "closed",
-          price: { denom: "uakt", amount: String(BLOCK_RATE_2) },
-          closed_on: String(CURRENT_HEIGHT - 100)
-        }),
-        LeaseApiResponseSeeder.create({
-          owner: addresses[3],
-          dseq: String(dseqs[3]),
-          gseq: 0,
-          oseq: 0,
-          state: "active",
-          price: { denom: "uakt", amount: String(BLOCK_RATE_1) }
-        })
+          denom: "uakt",
+          blockRate: faker.number.int({ min: 50, max: 100 }),
+          predictedClosedHeight: currentHeight + 1000,
+          closedHeight: currentHeight - 100
+        }
       ];
 
-      const CREATED_HEIGHT_1 = CURRENT_HEIGHT - 5000;
-      const CREATED_HEIGHT_2 = CURRENT_HEIGHT - 3000;
-      const CREATED_HEIGHT_3 = CURRENT_HEIGHT - 4000;
-      const deploymentBalances = [
-        { dseq: String(dseqs[0]), funds: 40000, transferred: 20000, createdHeight: CREATED_HEIGHT_1 },
-        { dseq: String(dseqs[1]), funds: 50000, transferred: 35000, createdHeight: CREATED_HEIGHT_2 },
-        { dseq: String(dseqs[3]), funds: 30000, transferred: 30000, createdHeight: CREATED_HEIGHT_3 }
-      ];
-      const expectedPredictedHeight1 = 996200; // Math.ceil(995000 + 60000 / 50)
-      const expectedPredictedHeight3 = 997200; // Math.ceil(996000 + 60000 / 50)
+      jest
+        .spyOn(service, "findLeases")
+        .mockResolvedValueOnce(activeBatches[0])
+        .mockResolvedValueOnce(closedBatch)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(activeBatches[1]);
 
-      leaseHttpService.list.mockImplementation(params => {
-        const ownerLeases = rpcLeases.filter(l => l.lease.id.owner === params.owner);
-        return Promise.resolve({
-          leases: ownerLeases,
-          pagination: { next_key: null, total: String(ownerLeases.length) }
-        });
-      });
-
-      deploymentHttpService.findAll.mockImplementation(params => {
-        const ownerDeployments = deploymentBalances
-          .filter(d => deploymentSettings.some(s => s.dseq === d.dseq && s.address === params.owner))
-          .map(d => ({
-            deployment: {
-              id: {
-                dseq: d.dseq
-              },
-              created_at: String(d.createdHeight)
-            },
-            escrow_account: {
-              state: {
-                funds: [{ denom: "uakt", amount: String(d.funds) }],
-                transferred: [{ denom: "uakt", amount: String(d.transferred) }]
-              }
-            }
-          }));
-        return Promise.resolve({
-          deployments: ownerDeployments,
-          pagination: { next_key: null, total: String(ownerDeployments.length) }
-        } as unknown as DeploymentListResponse);
-      });
-
+      const deploymentSettingsByAddress = groupBy(deploymentSettings, "address");
       deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
         (async function* () {
-          const byAddress = deploymentSettings.reduce(
-            (acc, deployment) => {
-              if (!acc[deployment.address]) {
-                acc[deployment.address] = [];
-              }
-              acc[deployment.address].push(deployment);
-              return acc;
-            },
-            {} as Record<string, typeof deploymentSettings>
-          );
-
-          for (const [address, settings] of Object.entries(byAddress)) {
+          for (const [address, settings] of Object.entries(deploymentSettingsByAddress)) {
             yield { address, deploymentSettings: settings };
           }
         })()
@@ -130,157 +81,87 @@ describe(DrainingDeploymentService.name, () => {
       for await (const result of service.findDrainingDeploymentsByOwner()) {
         callback(result);
       }
-
-      expect(blockHttpService.getCurrentHeight).toHaveBeenCalledTimes(1);
-      expect(deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively).toHaveBeenCalled();
-      expect(leaseHttpService.list).toHaveBeenCalledWith({
-        owner: addresses[0],
-        pagination: { limit: 1000, key: undefined }
-      });
 
       expect(leaseRepository.findManyByDseqAndOwner).not.toHaveBeenCalled();
       expect(loggerService.error).not.toHaveBeenCalled();
-      expect(deploymentSettingRepository.updateManyById).toHaveBeenCalledWith(expect.arrayContaining([deploymentSettings[1].id]), { closed: true });
-      expect(deploymentHttpService.findAll).toHaveBeenCalled();
+      expect(deploymentSettingRepository.updateManyById).toHaveBeenCalledWith(expect.arrayContaining([expect.any(String)]), { closed: true });
 
-      expect(callback).toHaveBeenCalledTimes(2);
-      expect(callback).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({
-          address: addresses[0],
-          deployments: expect.arrayContaining([
-            expect.objectContaining({
-              dseq: dseqs[0].toString(),
-              address: addresses[0],
-              predictedClosedHeight: expectedPredictedHeight1,
-              blockRate: BLOCK_RATE_1
-            })
-          ])
-        })
-      );
-      expect(callback).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          address: addresses[3],
-          deployments: expect.arrayContaining([
-            expect.objectContaining({
-              dseq: dseqs[3].toString(),
-              address: addresses[3],
-              predictedClosedHeight: expectedPredictedHeight3,
-              blockRate: BLOCK_RATE_1
-            })
-          ])
-        })
-      );
-    });
-
-    it("paginates draining deployments by owner using database fallback when RPC fails", async () => {
-      const { service, blockHttpService, leaseRepository, deploymentSettingRepository, config, leaseHttpService, loggerService } = setup({
-        currentHeight: CURRENT_HEIGHT
+      expect(callback).toHaveBeenCalledTimes(activeBatches.length);
+      activeBatches.forEach((batch, index) => {
+        const deployment = batch[0];
+        expect(callback).toHaveBeenNthCalledWith(
+          index + 1,
+          expect.objectContaining({
+            address: deployment.owner,
+            deployments: expect.arrayContaining([
+              expect.objectContaining({
+                dseq: deployment.dseq.toString(),
+                address: deployment.owner
+              })
+            ])
+          })
+        );
       });
-      const deploymentSettings = AutoTopUpDeploymentSeeder.createMany(4);
-      const addresses = deploymentSettings.map(s => s.address);
-      const dseqs = deploymentSettings.map(s => Number(s.dseq));
+    });
+  });
 
-      const drainingDeployments = [
-        DrainingDeploymentSeeder.create({
-          dseq: dseqs[0],
-          owner: addresses[0],
-          predictedClosedHeight: CURRENT_HEIGHT + PREDICTED_CLOSURE_OFFSET_1,
-          blockRate: BLOCK_RATE_1
-        }),
-        DrainingDeploymentSeeder.create({
-          dseq: dseqs[1],
-          owner: addresses[1],
-          predictedClosedHeight: CURRENT_HEIGHT + PREDICTED_CLOSURE_OFFSET_2,
-          blockRate: BLOCK_RATE_2,
-          closedHeight: CURRENT_HEIGHT - 100
-        }),
-        DrainingDeploymentSeeder.create({
-          dseq: dseqs[3],
-          owner: addresses[3],
-          predictedClosedHeight: CURRENT_HEIGHT + PREDICTED_CLOSURE_OFFSET_1,
-          blockRate: BLOCK_RATE_1
-        })
+  describe("findLeases", () => {
+    it("returns leases from RPC service when successful", async () => {
+      const { service, rpcService } = setup();
+      const closureHeight = 1007200;
+      const owner = createAkashAddress();
+      const dseqs = [faker.string.numeric(6), faker.string.numeric(6)];
+      const expectedLeases: DrainingDeploymentOutput[] = [
+        DrainingDeploymentSeeder.create({ owner, dseq: Number(dseqs[0]) }),
+        DrainingDeploymentSeeder.create({ owner, dseq: Number(dseqs[1]) })
       ];
 
+      rpcService.findManyByDseqAndOwner.mockResolvedValue(expectedLeases);
+
+      const result = await service.findLeases(closureHeight, owner, dseqs);
+
+      expect(rpcService.findManyByDseqAndOwner).toHaveBeenCalledWith(closureHeight, owner, dseqs);
+      expect(result).toEqual(expectedLeases);
+    });
+
+    it("falls back to database when RPC fails", async () => {
+      const { service, rpcService, leaseRepository, loggerService } = setup();
+      const closureHeight = 1007200;
+      const owner = createAkashAddress();
+      const dseqs = [faker.string.numeric(6), faker.string.numeric(6)];
       const rpcError = new Error("RPC error");
-      leaseHttpService.list.mockRejectedValue(rpcError);
+      const expectedLeases: DrainingDeploymentOutput[] = [
+        DrainingDeploymentSeeder.create({ owner, dseq: Number(dseqs[0]) }),
+        DrainingDeploymentSeeder.create({ owner, dseq: Number(dseqs[1]) })
+      ];
 
-      deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
-        (async function* () {
-          const byAddress = deploymentSettings.reduce(
-            (acc, deployment) => {
-              if (!acc[deployment.address]) {
-                acc[deployment.address] = [];
-              }
-              acc[deployment.address].push(deployment);
-              return acc;
-            },
-            {} as Record<string, typeof deploymentSettings>
-          );
+      rpcService.findManyByDseqAndOwner.mockRejectedValue(rpcError);
+      leaseRepository.findManyByDseqAndOwner.mockResolvedValue(expectedLeases);
 
-          for (const [address, settings] of Object.entries(byAddress)) {
-            yield { address, deploymentSettings: settings };
-          }
-        })()
-      );
+      const result = await service.findLeases(closureHeight, owner, dseqs);
 
-      leaseRepository.findManyByDseqAndOwner.mockImplementation((_closureHeight, owner, dseqs) => {
-        return Promise.resolve(drainingDeployments.filter(d => d.owner === owner && dseqs.includes(String(d.dseq))));
-      });
-
-      const callback = jest.fn();
-      for await (const result of service.findDrainingDeploymentsByOwner()) {
-        callback(result);
-      }
-
-      const expectedClosureHeight = Math.floor(CURRENT_HEIGHT + averageBlockCountInAnHour * 2 * config.get("AUTO_TOP_UP_JOB_INTERVAL_IN_H"));
-
-      expect(blockHttpService.getCurrentHeight).toHaveBeenCalledTimes(1);
-      expect(deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively).toHaveBeenCalled();
-      expect(leaseHttpService.list).toHaveBeenCalled();
-      expect(leaseRepository.findManyByDseqAndOwner).toHaveBeenCalledWith(expectedClosureHeight, addresses[0], expect.arrayContaining([String(dseqs[0])]));
+      expect(rpcService.findManyByDseqAndOwner).toHaveBeenCalledWith(closureHeight, owner, dseqs);
       expect(loggerService.error).toHaveBeenCalledWith(
         expect.objectContaining({
           event: "LEASE_RPC_QUERY_FAILED_FALLBACK_TO_DB",
           message: expect.stringContaining("RPC query failed for owner"),
-          owner: addresses[0],
+          owner,
           error: rpcError
         })
       );
+      expect(leaseRepository.findManyByDseqAndOwner).toHaveBeenCalledWith(closureHeight, owner, dseqs);
+      expect(result).toEqual(expectedLeases);
+    });
 
-      expect(deploymentSettingRepository.updateManyById).toHaveBeenCalledWith(expect.arrayContaining([deploymentSettings[1].id]), { closed: true });
+    it("returns empty array when dseqs is empty", async () => {
+      const { service, rpcService } = setup();
+      const closureHeight = 1007200;
+      const owner = createAkashAddress();
 
-      expect(callback).toHaveBeenCalledTimes(2);
-      expect(callback).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({
-          address: addresses[0],
-          deployments: expect.arrayContaining([
-            expect.objectContaining({
-              dseq: dseqs[0].toString(),
-              address: addresses[0],
-              predictedClosedHeight: CURRENT_HEIGHT + PREDICTED_CLOSURE_OFFSET_1,
-              blockRate: BLOCK_RATE_1
-            })
-          ])
-        })
-      );
-      expect(callback).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          address: addresses[3],
-          deployments: expect.arrayContaining([
-            expect.objectContaining({
-              dseq: dseqs[3].toString(),
-              address: addresses[3],
-              predictedClosedHeight: CURRENT_HEIGHT + PREDICTED_CLOSURE_OFFSET_1,
-              blockRate: BLOCK_RATE_1
-            })
-          ])
-        })
-      );
+      const result = await service.findLeases(closureHeight, owner, []);
+
+      expect(rpcService.findManyByDseqAndOwner).not.toHaveBeenCalled();
+      expect(result).toEqual([]);
     });
   });
 
@@ -351,37 +232,24 @@ describe(DrainingDeploymentService.name, () => {
   });
 
   describe("calculateAllDeploymentCostUntilDate", () => {
-    const CURRENT_HEIGHT = 1000000;
-    const BLOCK_RATE_1 = 50;
-    const BLOCK_RATE_2 = 75;
-
     it("calculates total cost for deployments closing within target date", async () => {
-      // Given: 2 deployments that will close before target date
-      // - Deployment 1: closes at height 1000100 (100 blocks from now), blockRate 50
-      // - Deployment 2: closes at height 1000200 (200 blocks from now), blockRate 75
-      // Target date is 1 week from now
-      // The method calculates blocksNeeded = targetHeight - currentHeight for all deployments
-      // Expected: blocksNeeded = targetHeight - currentHeight
-      //           amount1 = 50 * blocksNeeded, amount2 = 75 * blocksNeeded
-      //           total = (50 + 75) * blocksNeeded = 125 * blocksNeeded
+      const blockRate1 = 50;
+      const blockRate2 = 75;
+      const baseSetup = setup();
       const deployments = [
-        { predictedClosedHeight: CURRENT_HEIGHT + 100, blockRate: BLOCK_RATE_1 },
-        { predictedClosedHeight: CURRENT_HEIGHT + 200, blockRate: BLOCK_RATE_2 }
+        { predictedClosedHeight: baseSetup.currentHeight + 100, blockRate: blockRate1 },
+        { predictedClosedHeight: baseSetup.currentHeight + 200, blockRate: blockRate2 }
       ];
 
       const { service, address, targetDate } = await setupCalculateCost({
-        currentHeight: CURRENT_HEIGHT,
         deployments
       });
 
       const result = await service.calculateAllDeploymentCostUntilDate(address, targetDate);
 
-      // Calculate expected: blocksNeeded = targetHeight - currentHeight
-      // For 1 week: targetHeight = currentHeight + averageBlockCountInAnHour * (7 * 24)
-      // blocksNeeded = averageBlockCountInAnHour * 168
       const hoursInWeek = 7 * 24;
       const expectedBlocksNeeded = Math.floor(averageBlockCountInAnHour * hoursInWeek);
-      const expectedTotal = (BLOCK_RATE_1 + BLOCK_RATE_2) * expectedBlocksNeeded;
+      const expectedTotal = (blockRate1 + blockRate2) * expectedBlocksNeeded;
 
       // Allow for small differences in date calculations (±2 blocks = ±250 with total rate of 125)
       expect(result).toBeGreaterThanOrEqual(expectedTotal - 250);
@@ -389,11 +257,9 @@ describe(DrainingDeploymentService.name, () => {
     });
 
     it("returns 0 when user wallet not found", async () => {
-      const deployments = [{ predictedClosedHeight: CURRENT_HEIGHT + 100, blockRate: BLOCK_RATE_1 }];
-
       const { service, address, targetDate } = await setupCalculateCost({
         userWallet: undefined,
-        deployments
+        deployments: [{ predictedClosedHeight: 1000100, blockRate: 50 }]
       });
 
       const result = await service.calculateAllDeploymentCostUntilDate(address, targetDate);
@@ -402,11 +268,9 @@ describe(DrainingDeploymentService.name, () => {
     });
 
     it("returns 0 when user wallet has no address", async () => {
-      const deployments = [{ predictedClosedHeight: CURRENT_HEIGHT + 100, blockRate: BLOCK_RATE_1 }];
-
       const { service, address, targetDate } = await setupCalculateCost({
         userWallet: UserWalletSeeder.create({ address: null }),
-        deployments
+        deployments: [{ predictedClosedHeight: 1000100, blockRate: 50 }]
       });
 
       const result = await service.calculateAllDeploymentCostUntilDate(address, targetDate);
@@ -416,7 +280,6 @@ describe(DrainingDeploymentService.name, () => {
 
     it("returns 0 when no deployments found", async () => {
       const { service, address, targetDate } = await setupCalculateCost({
-        currentHeight: CURRENT_HEIGHT,
         deployments: []
       });
 
@@ -426,11 +289,8 @@ describe(DrainingDeploymentService.name, () => {
     });
 
     it("excludes deployments with null predictedClosedHeight", async () => {
-      const deployments = [{ predictedClosedHeight: null as unknown as number, blockRate: BLOCK_RATE_1 }];
-
       const { service, address, targetDate } = await setupCalculateCost({
-        currentHeight: CURRENT_HEIGHT,
-        deployments
+        deployments: [{ predictedClosedHeight: null as unknown as number, blockRate: 50 }]
       });
 
       const result = await service.calculateAllDeploymentCostUntilDate(address, targetDate);
@@ -439,12 +299,8 @@ describe(DrainingDeploymentService.name, () => {
     });
 
     it("excludes deployments closing before currentHeight", async () => {
-      // Given: deployment closes 100 blocks before current height
-      const deployments = [{ predictedClosedHeight: CURRENT_HEIGHT - 100, blockRate: BLOCK_RATE_1 }];
-
       const { service, address, targetDate } = await setupCalculateCost({
-        currentHeight: CURRENT_HEIGHT,
-        deployments
+        deployments: [{ predictedClosedHeight: 999900, blockRate: 50 }]
       });
 
       const result = await service.calculateAllDeploymentCostUntilDate(address, targetDate);
@@ -453,12 +309,8 @@ describe(DrainingDeploymentService.name, () => {
     });
 
     it("excludes deployments closing after targetHeight", async () => {
-      // Given: deployment closes way after target date (2M blocks later)
-      const deployments = [{ predictedClosedHeight: CURRENT_HEIGHT + 2000000, blockRate: BLOCK_RATE_1 }];
-
       const { service, address, targetDate } = await setupCalculateCost({
-        currentHeight: CURRENT_HEIGHT,
-        deployments
+        deployments: [{ predictedClosedHeight: 3000000, blockRate: 50 }]
       });
 
       const result = await service.calculateAllDeploymentCostUntilDate(address, targetDate);
@@ -467,24 +319,21 @@ describe(DrainingDeploymentService.name, () => {
     });
 
     async function setupCalculateCost(input: {
-      currentHeight?: number;
       userWallet?: ReturnType<typeof UserWalletSeeder.create> | undefined;
       deployments: Array<{ predictedClosedHeight: number | null; blockRate: number }>;
     }) {
-      const currentHeight = input.currentHeight ?? CURRENT_HEIGHT;
       const address = createAkashAddress();
       const userWallet = "userWallet" in input ? input.userWallet : UserWalletSeeder.create({ address });
       const now = new Date();
       const targetDate = addWeeks(now, 1);
 
-      const baseSetup = setup({ currentHeight });
+      const baseSetup = setup();
       baseSetup.userWalletRepository.findOneBy.mockResolvedValue(userWallet);
 
-      const deployments = input.deployments;
-      const deploymentSettings = AutoTopUpDeploymentSeeder.createMany(deployments.length, { address });
+      const deploymentSettings = AutoTopUpDeploymentSeeder.createMany(input.deployments.length, { address });
 
       const drainingDeployments = deploymentSettings.map((setting, idx) => {
-        const deployment = deployments[idx];
+        const deployment = input.deployments[idx];
         const predictedClosedHeight = deployment?.predictedClosedHeight ?? undefined;
         return DrainingDeploymentSeeder.create({
           dseq: Number(setting.dseq),
@@ -496,7 +345,7 @@ describe(DrainingDeploymentService.name, () => {
 
       baseSetup.deploymentSettingRepository.findAutoTopUpDeploymentsByOwner.mockResolvedValue(deploymentSettings);
 
-      baseSetup.leaseHttpService.list.mockRejectedValue(new Error("RPC error"));
+      baseSetup.rpcService.findManyByDseqAndOwner.mockRejectedValue(new Error("RPC error"));
       baseSetup.leaseRepository.findManyByDseqAndOwner.mockImplementation((_closureHeight, _owner, _dseqs) => Promise.resolve(drainingDeployments));
 
       return {
@@ -507,9 +356,8 @@ describe(DrainingDeploymentService.name, () => {
     }
   });
 
-  function setup(input?: { currentHeight?: number }) {
-    const CURRENT_BLOCK_HEIGHT = 7481457;
-    const currentHeight = input?.currentHeight ?? CURRENT_BLOCK_HEIGHT;
+  function setup() {
+    const currentHeight = 1000000;
 
     const blockHttpService = mock<BlockHttpService>();
     blockHttpService.getCurrentHeight.mockResolvedValue(currentHeight);
@@ -518,19 +366,10 @@ describe(DrainingDeploymentService.name, () => {
     const userWalletRepository = mock<UserWalletRepository>();
     userWalletRepository.findOneBy.mockResolvedValue(undefined);
     const deploymentSettingRepository = mock<DeploymentSettingRepository>();
-    const leaseHttpService = mock<LeaseHttpService>();
-    const deploymentHttpService = mock<DeploymentHttpService>();
+    const rpcService = mock<DrainingDeploymentRpcService>();
     const loggerService = mock<LoggerService>();
 
-    leaseHttpService.list.mockResolvedValue({
-      leases: [],
-      pagination: { next_key: null, total: "0" }
-    });
-
-    deploymentHttpService.findAll.mockResolvedValue({
-      deployments: [],
-      pagination: { next_key: null, total: "0" }
-    });
+    rpcService.findManyByDseqAndOwner.mockResolvedValue([]);
 
     const config = mockConfigService<DeploymentConfigService>({
       AUTO_TOP_UP_JOB_INTERVAL_IN_H: 1,
@@ -543,9 +382,8 @@ describe(DrainingDeploymentService.name, () => {
       userWalletRepository,
       deploymentSettingRepository,
       config,
-      leaseHttpService,
       loggerService,
-      deploymentHttpService
+      rpcService
     );
 
     return {
@@ -554,10 +392,10 @@ describe(DrainingDeploymentService.name, () => {
       leaseRepository,
       userWalletRepository,
       deploymentSettingRepository,
-      leaseHttpService,
-      deploymentHttpService,
+      rpcService,
       loggerService,
-      config
+      config,
+      currentHeight
     };
   }
 });

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -1,25 +1,17 @@
-import { DeploymentHttpService, LeaseHttpService, type RpcLease } from "@akashnetwork/http-sdk";
 import keyBy from "lodash/keyBy";
 import { singleton } from "tsyringe";
 
 import { UserWalletRepository } from "@src/billing/repositories";
 import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
 import { LoggerService } from "@src/core";
-import { AutoTopUpDeployment, DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DrainingDeploymentOutput, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
+import { DrainingDeployment, DrainingDeploymentLeaseSource } from "@src/deployment/types/draining-deployment";
 import { averageBlockCountInAnHour } from "@src/utils/constants";
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
+import { DrainingDeploymentRpcService } from "../draining-deployment-rpc/draining-deployment-rpc.service";
 
-export type DrainingDeployment = AutoTopUpDeployment & {
-  predictedClosedHeight: number;
-  blockRate: number;
-};
-
-export type RpcDeploymentInfo = {
-  dseq: string;
-  escrowBalance: number;
-  createdHeight: number;
-};
+export type { DrainingDeployment } from "@src/deployment/types/draining-deployment";
 
 @singleton()
 export class DrainingDeploymentService {
@@ -29,9 +21,8 @@ export class DrainingDeploymentService {
     private readonly userWalletRepository: UserWalletRepository,
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
     private readonly config: DeploymentConfigService,
-    private readonly leaseHttpService: LeaseHttpService,
     private readonly loggerService: LoggerService,
-    private readonly deploymentHttpService: DeploymentHttpService
+    private readonly rpcService: DrainingDeploymentRpcService
   ) {
     loggerService.setContext(DrainingDeploymentService.name);
   }
@@ -46,7 +37,7 @@ export class DrainingDeploymentService {
       }
 
       const dseqs = deploymentSettings.map(deployment => deployment.dseq);
-      const drainingDeployments = await this.#findLeases(expectedClosureHeight, address, dseqs);
+      const drainingDeployments = await this.findLeases(expectedClosureHeight, address, dseqs);
 
       if (drainingDeployments.length) {
         const byDseqOwner = keyBy(drainingDeployments, "dseq");
@@ -132,7 +123,7 @@ export class DrainingDeploymentService {
     }
 
     const dseqs = deploymentSettings.map(deployment => deployment.dseq);
-    const drainingDeployments = await this.#findLeases(targetHeight, address, dseqs);
+    const drainingDeployments = await this.findLeases(targetHeight, address, dseqs);
 
     if (drainingDeployments.length === 0) {
       return totalAmount;
@@ -149,9 +140,14 @@ export class DrainingDeploymentService {
     return totalAmount;
   }
 
-  async #findLeases(closureHeight: number, owner: string, dseqs: string[]): Promise<DrainingDeploymentOutput[]> {
+  async findLeases(closureHeight: number, owner: string, dseqs: string[]): Promise<DrainingDeploymentOutput[]> {
+    if (!dseqs.length) {
+      return [];
+    }
+
+    const leaseSource: DrainingDeploymentLeaseSource = this.rpcService;
     try {
-      return dseqs.length ? await this.#queryLeasesFromRpc(closureHeight, owner, dseqs) : [];
+      return await leaseSource.findManyByDseqAndOwner(closureHeight, owner, dseqs);
     } catch (error) {
       this.loggerService.error({
         event: "LEASE_RPC_QUERY_FAILED_FALLBACK_TO_DB",
@@ -161,140 +157,5 @@ export class DrainingDeploymentService {
       });
       return await this.leaseRepository.findManyByDseqAndOwner(closureHeight, owner, dseqs);
     }
-  }
-
-  async #queryLeasesFromRpc(closureHeight: number, owner: string, dseqs: string[]): Promise<DrainingDeploymentOutput[]> {
-    const dseqSet = new Set(dseqs);
-    const [leases, deployments] = await Promise.all([this.#fetchAndFilterLeases(owner, dseqSet), this.#fetchAndFilterDeployments(owner, dseqSet)]);
-    const leaseMap = this.#createDrainingDeploymentMap(leases);
-    const deploymentMap = this.#createDeploymentMap(deployments);
-    const outputs = this.#addPredictedClosedHeight(leaseMap, deploymentMap);
-
-    return outputs.filter(output => output.predictedClosedHeight <= closureHeight);
-  }
-
-  async #fetchAndFilterLeases(owner: string, dseqSet: Set<string>): Promise<RpcLease[]> {
-    const allItems: RpcLease[] = [];
-    let nextKey: string | null = null;
-
-    do {
-      const response = await this.leaseHttpService.list({
-        owner,
-        pagination: { limit: 1000, key: nextKey || undefined }
-      });
-
-      const filteredItems = response.leases.filter(lease => dseqSet.has(lease.lease.id.dseq));
-      allItems.push(...filteredItems);
-      nextKey = response.pagination.next_key;
-    } while (nextKey);
-
-    return allItems;
-  }
-
-  async #fetchAndFilterDeployments(owner: string, dseqSet: Set<string>): Promise<RpcDeploymentInfo[]> {
-    const allItems: RpcDeploymentInfo[] = [];
-    let nextKey: string | null = null;
-
-    do {
-      const response = await this.deploymentHttpService.findAll({
-        owner,
-        pagination: { limit: 1000, key: nextKey || undefined }
-      });
-
-      const filteredItems = response.deployments
-        .filter(deployment => dseqSet.has(deployment.deployment.id.dseq))
-        .map(deployment => ({
-          dseq: deployment.deployment.id.dseq,
-          createdHeight: Number(deployment.deployment.created_at),
-          escrowBalance: this.#sumAmounts(deployment.escrow_account.state.funds) + this.#sumAmounts(deployment.escrow_account.state.transferred)
-        }));
-
-      allItems.push(...filteredItems);
-      nextKey = response.pagination.next_key;
-    } while (nextKey);
-
-    return allItems;
-  }
-
-  #sumAmounts(items: Array<{ amount: string }>): number {
-    return items.reduce((sum, item) => sum + parseFloat(item.amount), 0);
-  }
-
-  #createDrainingDeploymentMap(rpcLeases: RpcLease[]): Map<string, Omit<DrainingDeploymentOutput, "predictedClosedHeight">> {
-    const leaseMap = new Map<string, Omit<DrainingDeploymentOutput, "predictedClosedHeight">>();
-
-    for (const rpcLease of rpcLeases) {
-      const dseq = rpcLease.lease.id.dseq;
-      const owner = rpcLease.lease.id.owner;
-
-      const denom = rpcLease.escrow_payment.state.rate.denom;
-      const rateAmount = Number(rpcLease.escrow_payment.state.rate.amount);
-
-      const existing = leaseMap.get(dseq);
-      if (existing) {
-        existing.blockRate += rateAmount;
-      } else {
-        leaseMap.set(dseq, {
-          dseq: Number(dseq),
-          owner,
-          denom,
-          blockRate: rateAmount,
-          closedHeight: rpcLease.lease.closed_on && rpcLease.lease.closed_on !== "0" ? Number(rpcLease.lease.closed_on) : undefined
-        });
-      }
-    }
-
-    return leaseMap;
-  }
-
-  #createDeploymentMap(deployments: RpcDeploymentInfo[]): Map<string, RpcDeploymentInfo> {
-    const deploymentMap = new Map<string, RpcDeploymentInfo>();
-
-    for (const deployment of deployments) {
-      const key = deployment.dseq;
-      deploymentMap.set(key, deployment);
-    }
-
-    return deploymentMap;
-  }
-
-  #addPredictedClosedHeight(
-    leaseMap: Map<string, Omit<DrainingDeploymentOutput, "predictedClosedHeight">>,
-    deploymentMap: Map<string, RpcDeploymentInfo>
-  ): DrainingDeploymentOutput[] {
-    return Array.from(leaseMap.values()).reduce((acc, drainingDeployment) => {
-      const deployment = deploymentMap.get(drainingDeployment.dseq.toString());
-
-      if (!deployment) {
-        this.loggerService.warn({
-          event: "DEPLOYMENT_NOT_FOUND",
-          dseq: drainingDeployment.dseq,
-          owner: drainingDeployment.owner
-        });
-        return acc;
-      }
-
-      if (deployment.escrowBalance <= 0) {
-        this.loggerService.warn({
-          event: "DEPLOYMENT_HAS_NO_BALANCE",
-          dseq: drainingDeployment.dseq,
-          owner: drainingDeployment.owner
-        });
-        return acc;
-      }
-
-      if (drainingDeployment.blockRate <= 0) {
-        this.loggerService.warn({
-          event: "DEPLOYMENT_BLOCK_RATE_INVALID",
-          dseq: drainingDeployment.dseq,
-          owner: drainingDeployment.owner
-        });
-        return acc;
-      }
-
-      const predictedClosedHeight = Math.ceil(deployment.createdHeight + deployment.escrowBalance / drainingDeployment.blockRate);
-
-      return [...acc, { ...drainingDeployment, predictedClosedHeight }];
-    }, [] as DrainingDeploymentOutput[]);
   }
 }

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -1,8 +1,10 @@
+import { DeploymentHttpService, LeaseHttpService, type RpcLease } from "@akashnetwork/http-sdk";
 import keyBy from "lodash/keyBy";
 import { singleton } from "tsyringe";
 
 import { UserWalletRepository } from "@src/billing/repositories";
 import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
+import { LoggerService } from "@src/core";
 import { AutoTopUpDeployment, DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DrainingDeploymentOutput, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
 import { averageBlockCountInAnHour } from "@src/utils/constants";
@@ -19,24 +21,31 @@ export class DrainingDeploymentService {
     private readonly leaseRepository: LeaseRepository,
     private readonly userWalletRepository: UserWalletRepository,
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
-    private readonly config: DeploymentConfigService
-  ) {}
+    private readonly config: DeploymentConfigService,
+    private readonly leaseHttpService: LeaseHttpService,
+    private readonly loggerService: LoggerService,
+    private readonly deploymentHttpService: DeploymentHttpService
+  ) {
+    loggerService.setContext(DrainingDeploymentService.name);
+  }
 
-  async *paginate(params: { limit: number }): AsyncGenerator<DrainingDeployment[]> {
-    for await (const deploymentSettings of this.deploymentSettingRepository.paginateAutoTopUpDeployments({ limit: params.limit })) {
-      const currentHeight = await this.blockHttpService.getCurrentHeight();
-      const expectedClosureHeight = Math.floor(currentHeight + averageBlockCountInAnHour * 2 * this.config.get("AUTO_TOP_UP_JOB_INTERVAL_IN_H"));
+  async *findDrainingDeploymentsByOwner(): AsyncGenerator<{ address: string; deployments: DrainingDeployment[] }> {
+    const currentHeight = await this.blockHttpService.getCurrentHeight();
+    const expectedClosureHeight = Math.floor(currentHeight + averageBlockCountInAnHour * 2 * this.config.get("AUTO_TOP_UP_JOB_INTERVAL_IN_H"));
 
-      const drainingDeployments = await this.leaseRepository.findManyByDseqAndOwner(
-        expectedClosureHeight,
-        deploymentSettings.map(deployment => ({ dseq: deployment.dseq, owner: deployment.address }))
-      );
+    for await (const { address, deploymentSettings } of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwner()) {
+      if (deploymentSettings.length === 0) {
+        continue;
+      }
+
+      const dseqs = deploymentSettings.map(deployment => deployment.dseq);
+      const drainingDeployments = await this.#findLeases(expectedClosureHeight, address, dseqs);
 
       if (drainingDeployments.length) {
-        const byDseqOwner = keyBy(drainingDeployments, ({ dseq, owner }) => `${dseq}-${owner}`);
+        const byDseqOwner = keyBy(drainingDeployments, "dseq");
         const [active, missingIds] = deploymentSettings.reduce<[DrainingDeployment[], string[]]>(
           (acc, deploymentSetting) => {
-            const deployment = byDseqOwner[`${deploymentSetting.dseq}-${deploymentSetting.address}`];
+            const deployment = byDseqOwner[Number(deploymentSetting.dseq)];
 
             if (!deployment) {
               return acc;
@@ -47,8 +56,8 @@ export class DrainingDeploymentService {
             } else {
               acc[0].push({
                 ...deploymentSetting,
-                predictedClosedHeight: deployment?.predictedClosedHeight,
-                blockRate: deployment?.blockRate
+                predictedClosedHeight: deployment.predictedClosedHeight,
+                blockRate: deployment.blockRate
               });
             }
             return acc;
@@ -60,7 +69,7 @@ export class DrainingDeploymentService {
           await this.deploymentSettingRepository.updateManyById(missingIds, { closed: true });
         }
 
-        yield active;
+        yield { address, deployments: active };
       }
     }
   }
@@ -112,10 +121,10 @@ export class DrainingDeploymentService {
         continue;
       }
 
-      const drainingDeployments = await this.leaseRepository.findManyByDseqAndOwner(
-        targetHeight,
-        deploymentSettings.map(deployment => ({ dseq: deployment.dseq, owner: deployment.address }))
-      );
+      const owner = deploymentSettings[0].address;
+      const dseqs = deploymentSettings.map(deployment => deployment.dseq);
+
+      const drainingDeployments = await this.leaseRepository.findManyByDseqAndOwner(targetHeight, owner, dseqs);
 
       if (drainingDeployments.length === 0) {
         continue;
@@ -131,5 +140,128 @@ export class DrainingDeploymentService {
     }
 
     return totalAmount;
+  }
+
+  async #findLeases(closureHeight: number, owner: string, dseqs: string[]): Promise<DrainingDeploymentOutput[]> {
+    if (!dseqs.length) {
+      return [];
+    }
+
+    try {
+      return await this.#queryLeasesFromRpc(closureHeight, owner, dseqs);
+    } catch (error) {
+      this.loggerService.error({
+        event: "LEASE_RPC_QUERY_FAILED_FALLBACK_TO_DB",
+        message: `RPC query failed for owner ${owner}, falling back to database`,
+        owner,
+        error
+      });
+      return await this.leaseRepository.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+    }
+  }
+
+  async #queryLeasesFromRpc(closureHeight: number, owner: string, dseqs: string[]): Promise<DrainingDeploymentOutput[]> {
+    const dseqSet = new Set(dseqs);
+    const [leases, deployments] = await Promise.all([this.#fetchAndFilterLeases(owner, dseqSet), this.#fetchAndFilterDeployments(owner, dseqSet)]);
+    const leaseMap = this.#createDrainingDeploymentMap(leases);
+    const deploymentBalanceMap = this.#createDeploymentBalanceMap(deployments);
+    const outputs = await this.#addPredictedClosedHeight(leaseMap, deploymentBalanceMap);
+
+    return outputs.filter(output => output.predictedClosedHeight <= closureHeight);
+  }
+
+  async #fetchAndFilterLeases(owner: string, dseqSet: Set<string>): Promise<RpcLease[]> {
+    const allItems: RpcLease[] = [];
+    let nextKey: string | null = null;
+
+    do {
+      const response = await this.leaseHttpService.list({
+        owner,
+        pagination: { limit: 1000, key: nextKey || undefined }
+      });
+
+      const filteredItems = response.leases.filter(lease => dseqSet.has(lease.lease.id.dseq));
+      allItems.push(...filteredItems);
+      nextKey = response.pagination.next_key;
+    } while (nextKey);
+
+    return allItems;
+  }
+
+  async #fetchAndFilterDeployments(owner: string, dseqSet: Set<string>): Promise<{ dseq: string; escrowBalance: number }[]> {
+    const allItems: { dseq: string; escrowBalance: number }[] = [];
+    let nextKey: string | null = null;
+
+    do {
+      const response = await this.deploymentHttpService.findAll({
+        owner,
+        pagination: { limit: 1000, key: nextKey || undefined }
+      });
+
+      const filteredItems = response.deployments
+        .filter(deployment => dseqSet.has(deployment.deployment.id.dseq))
+        .map(deployment => ({
+          dseq: deployment.deployment.id.dseq,
+          escrowBalance: deployment.escrow_account.state.funds.reduce((sum, fund) => sum + parseFloat(fund.amount), 0)
+        }));
+
+      allItems.push(...filteredItems);
+      nextKey = response.pagination.next_key;
+    } while (nextKey);
+
+    return allItems;
+  }
+
+  #createDrainingDeploymentMap(rpcLeases: RpcLease[]): Map<string, Omit<DrainingDeploymentOutput, "predictedClosedHeight">> {
+    const leaseMap = new Map<string, Omit<DrainingDeploymentOutput, "predictedClosedHeight">>();
+
+    for (const rpcLease of rpcLeases) {
+      const dseq = rpcLease.lease.id.dseq;
+      const owner = rpcLease.lease.id.owner;
+
+      const denom = rpcLease.escrow_payment.state.rate.denom;
+      const rateAmount = Number(rpcLease.escrow_payment.state.rate.amount);
+
+      const existing = leaseMap.get(dseq);
+      if (existing) {
+        existing.blockRate += rateAmount;
+      } else {
+        leaseMap.set(dseq, {
+          dseq: Number(dseq),
+          owner,
+          denom,
+          blockRate: rateAmount,
+          closedHeight: rpcLease.lease.closed_on && rpcLease.lease.closed_on !== "0" ? Number(rpcLease.lease.closed_on) : undefined
+        });
+      }
+    }
+
+    return leaseMap;
+  }
+
+  #createDeploymentBalanceMap(deployments: { dseq: string; escrowBalance: number }[]): Map<string, number> {
+    const deploymentBalanceMap = new Map<string, number>();
+
+    for (const deployment of deployments) {
+      const key = deployment.dseq;
+      deploymentBalanceMap.set(key, deployment.escrowBalance);
+    }
+
+    return deploymentBalanceMap;
+  }
+
+  async #addPredictedClosedHeight(
+    leaseMap: Map<string, Omit<DrainingDeploymentOutput, "predictedClosedHeight">>,
+    deploymentBalanceMap: Map<string, number>
+  ): Promise<DrainingDeploymentOutput[]> {
+    const currentHeight = await this.blockHttpService.getCurrentHeight();
+    return Array.from(leaseMap.values()).map(drainingDeployment => {
+      const deploymentBalance = deploymentBalanceMap.get(drainingDeployment.dseq.toString()) ?? 0;
+
+      const predictedClosedHeight =
+        drainingDeployment.blockRate > 0 && deploymentBalance > 0 ? Math.ceil(currentHeight + deploymentBalance / drainingDeployment.blockRate) : currentHeight;
+
+      return { ...drainingDeployment, predictedClosedHeight };
+    });
   }
 }

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -6,7 +6,7 @@ import { BlockHttpService } from "@src/chain/services/block-http/block-http.serv
 import { LoggerService } from "@src/core";
 import { DeploymentSettingRepository } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { DrainingDeploymentOutput, LeaseRepository } from "@src/deployment/repositories/lease/lease.repository";
-import { DrainingDeployment, DrainingDeploymentLeaseSource } from "@src/deployment/types/draining-deployment";
+import { DrainingDeployment } from "@src/deployment/types/draining-deployment";
 import { averageBlockCountInAnHour } from "@src/utils/constants";
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import { DrainingDeploymentRpcService } from "../draining-deployment-rpc/draining-deployment-rpc.service";
@@ -180,9 +180,8 @@ export class DrainingDeploymentService {
       return [];
     }
 
-    const leaseSource: DrainingDeploymentLeaseSource = this.rpcService;
     try {
-      return await leaseSource.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+      return await this.rpcService.findManyByDseqAndOwner(closureHeight, owner, dseqs);
     } catch (error) {
       this.loggerService.error({
         event: "LEASE_RPC_QUERY_FAILED_FALLBACK_TO_DB",

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -1,109 +1,78 @@
 import "@test/mocks/logger-service.mock";
 
 import { Scope, Source } from "@akashnetwork/chain-sdk/private-types/akash.v1";
-import { LoggerService } from "@akashnetwork/logging";
+import type { IndexedTx } from "@cosmjs/stargate";
 import { faker } from "@faker-js/faker";
-import type { MockProxy } from "jest-mock-extended";
+import { mock } from "jest-mock-extended";
 
 import { RpcMessageService } from "@src/billing/services";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import type { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
-import type { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
+import type { DrainingDeployment, DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { mockConfigService } from "../../../../test/mocks/config-service.mock";
-import type { CachedBalanceService } from "../cached-balance/cached-balance.service";
+import type { LoggerService } from "../../../core";
+import type { CachedBalance, CachedBalanceService } from "../cached-balance/cached-balance.service";
 import { TopUpManagedDeploymentsService } from "./top-up-managed-deployments.service";
 
 import { createAkashAddress } from "@test/seeders";
 import { AutoTopUpDeploymentSeeder } from "@test/seeders/auto-top-up-deployment.seeder";
 import { DrainingDeploymentSeeder } from "@test/seeders/draining-deployment.seeder";
-import { stub } from "@test/services/stub";
 
-jest.mock("@akashnetwork/logging", () => ({
-  LoggerService: {
-    forContext: jest.fn().mockReturnValue({
-      info: jest.fn(),
-      error: jest.fn()
-    })
-  }
-}));
+jest.mock("@akashnetwork/logging");
 
 describe(TopUpManagedDeploymentsService.name, () => {
-  let managedSignerService: jest.Mocked<ManagedSignerService>;
-  let billingConfig: MockProxy<BillingConfigService>;
-  let drainingDeploymentService: jest.Mocked<DrainingDeploymentService>;
-  let rpcMessageService: RpcMessageService;
-  let cachedBalanceService: jest.Mocked<CachedBalanceService>;
-  let blockHttpService: jest.Mocked<BlockHttpService>;
-  let chainErrorService: jest.Mocked<ChainErrorService>;
-  let service: TopUpManagedDeploymentsService;
-  let logger: jest.Mocked<LoggerService>;
-
   const DEPLOYMENT_GRANT_DENOM = "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1";
   const CURRENT_BLOCK_HEIGHT = 7481457;
 
-  beforeEach(() => {
-    managedSignerService = stub<ManagedSignerService>({ executeDerivedTx: jest.fn() });
-    billingConfig = mockConfigService<BillingConfigService>({
-      DEPLOYMENT_GRANT_DENOM,
-      USDC_IBC_DENOMS: {
-        mainnetId: DEPLOYMENT_GRANT_DENOM,
-        sandboxId: DEPLOYMENT_GRANT_DENOM
-      }
-    });
-    drainingDeploymentService = stub<DrainingDeploymentService>({
-      paginate: jest.fn(),
-      calculateTopUpAmount: jest.fn()
-    });
-    rpcMessageService = new RpcMessageService();
-    cachedBalanceService = stub<CachedBalanceService>({ get: jest.fn() });
-    blockHttpService = stub<BlockHttpService>({ getCurrentHeight: jest.fn().mockResolvedValue(CURRENT_BLOCK_HEIGHT) });
-    chainErrorService = stub<ChainErrorService>({
-      isMasterWalletInsufficientFundsError: jest.fn().mockResolvedValue(false)
-    });
-    logger = (LoggerService.forContext as jest.Mock)() as jest.Mocked<LoggerService>;
-
-    service = new TopUpManagedDeploymentsService(
-      managedSignerService,
-      billingConfig,
-      drainingDeploymentService,
-      rpcMessageService,
-      cachedBalanceService,
-      blockHttpService,
-      chainErrorService
-    );
-  });
+  function createMockCachedBalance(reserveSufficientAmount: (desiredAmount: number) => number) {
+    const balance = mock<CachedBalance>();
+    balance.reserveSufficientAmount.mockImplementation(reserveSufficientAmount);
+    return balance;
+  }
 
   describe("topUpDeployments", () => {
     it("should top up draining deployments", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, logger } = setup();
       const deployments = AutoTopUpDeploymentSeeder.createMany(2);
       const desiredAmount = faker.number.int({ min: 3500000, max: 4000000 });
       const sufficientAmount = faker.number.int({ min: 1000000, max: 2000000 });
       const predictedClosedHeight1 = CURRENT_BLOCK_HEIGHT + 1500;
       const predictedClosedHeight2 = CURRENT_BLOCK_HEIGHT + 1700;
 
-      (drainingDeploymentService.paginate as jest.Mock).mockImplementation((_params: { limit: number }) =>
+      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
         (async function* () {
-          const items = deployments.map((deployment, index) => ({
-            ...deployment,
-            ...DrainingDeploymentSeeder.create({
-              dseq: Number(deployment.dseq),
-              owner: deployment.address,
-              predictedClosedHeight: index === 0 ? predictedClosedHeight1 : predictedClosedHeight2,
-              denom: DEPLOYMENT_GRANT_DENOM
-            })
-          }));
-          yield items;
+          const byAddress = deployments.reduce(
+            (acc, deployment, index) => {
+              if (!acc[deployment.address]) {
+                acc[deployment.address] = [];
+              }
+              acc[deployment.address].push({
+                ...deployment,
+                ...DrainingDeploymentSeeder.create({
+                  dseq: Number(deployment.dseq),
+                  owner: deployment.address,
+                  predictedClosedHeight: index === 0 ? predictedClosedHeight1 : predictedClosedHeight2,
+                  denom: DEPLOYMENT_GRANT_DENOM
+                }),
+                dseq: deployment.dseq
+              } as DrainingDeployment);
+              return acc;
+            },
+            {} as Record<string, DrainingDeployment[]>
+          );
+
+          for (const [address, items] of Object.entries(byAddress)) {
+            yield { address, deployments: items };
+          }
         })()
       );
 
-      (drainingDeploymentService.calculateTopUpAmount as jest.Mock).mockResolvedValue(desiredAmount);
-      (cachedBalanceService.get as jest.Mock).mockImplementation(async () => ({
-        reserveSufficientAmount: () => sufficientAmount
-      }));
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(desiredAmount);
+      cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => sufficientAmount));
 
-      await service.topUpDeployments({ concurrency: 10, dryRun: false });
+      await service.topUpDeployments({ dryRun: false });
 
       expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(deployments.length);
       deployments.forEach((deployment, index) => {
@@ -140,10 +109,11 @@ describe(TopUpManagedDeploymentsService.name, () => {
                   blockRate: expect.any(Number),
                   closedHeight: undefined,
                   denom: DEPLOYMENT_GRANT_DENOM,
-                  dseq: Number(deployment.dseq),
+                  dseq: deployment.dseq,
                   id: deployment.id,
                   owner: deployment.address,
                   address: deployment.address,
+                  isOldWallet: deployment.isOldWallet,
                   predictedClosedHeight: index === 0 ? predictedClosedHeight1 : predictedClosedHeight2,
                   walletId: deployment.walletId
                 }),
@@ -184,72 +154,96 @@ describe(TopUpManagedDeploymentsService.name, () => {
     });
 
     it("should handle errors and continue processing", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService } = setup();
       const deployments = AutoTopUpDeploymentSeeder.createMany(2);
       const predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500;
 
-      (drainingDeploymentService.paginate as jest.Mock).mockImplementation((_params: { limit: number }) =>
+      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
         (async function* () {
-          const items = deployments.map(deployment => ({
-            ...deployment,
-            ...DrainingDeploymentSeeder.create({
-              dseq: Number(deployment.dseq),
-              owner: deployment.address,
-              predictedClosedHeight
-            })
-          }));
-          yield items;
+          const byAddress = deployments.reduce(
+            (acc, deployment) => {
+              if (!acc[deployment.address]) {
+                acc[deployment.address] = [];
+              }
+              acc[deployment.address].push({
+                ...deployment,
+                ...DrainingDeploymentSeeder.create({
+                  dseq: Number(deployment.dseq),
+                  owner: deployment.address,
+                  predictedClosedHeight
+                }),
+                dseq: deployment.dseq
+              } as DrainingDeployment);
+              return acc;
+            },
+            {} as Record<string, DrainingDeployment[]>
+          );
+
+          for (const [address, items] of Object.entries(byAddress)) {
+            yield { address, deployments: items };
+          }
         })()
       );
 
-      (drainingDeploymentService.calculateTopUpAmount as jest.Mock)
-        .mockResolvedValueOnce(1000000)
-        .mockRejectedValueOnce(new Error("Failed to calculate amount"));
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValueOnce(1000000).mockRejectedValueOnce(new Error("Failed to calculate amount"));
 
-      (cachedBalanceService.get as jest.Mock).mockImplementation(async () => ({
-        reserveSufficientAmount: () => 500000
-      }));
+      cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 500000));
 
-      await service.topUpDeployments({ concurrency: 10, dryRun: false });
+      await service.topUpDeployments({ dryRun: false });
 
       expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(1);
     });
 
     it("should not execute transactions in dry run mode", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService } = setup();
       const deployments = AutoTopUpDeploymentSeeder.createMany(2);
       const predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500;
 
-      (drainingDeploymentService.paginate as jest.Mock).mockImplementation((_params: { limit: number }) =>
+      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
         (async function* () {
-          const items = deployments.map(deployment => ({
-            ...deployment,
-            ...DrainingDeploymentSeeder.create({
-              dseq: Number(deployment.dseq),
-              owner: deployment.address,
-              predictedClosedHeight
-            })
-          }));
-          yield items;
+          const byAddress = deployments.reduce(
+            (acc, deployment) => {
+              if (!acc[deployment.address]) {
+                acc[deployment.address] = [];
+              }
+              acc[deployment.address].push({
+                ...deployment,
+                ...DrainingDeploymentSeeder.create({
+                  dseq: Number(deployment.dseq),
+                  owner: deployment.address,
+                  predictedClosedHeight
+                }),
+                dseq: deployment.dseq
+              } as DrainingDeployment);
+              return acc;
+            },
+            {} as Record<string, DrainingDeployment[]>
+          );
+
+          for (const [address, items] of Object.entries(byAddress)) {
+            yield { address, deployments: items };
+          }
         })()
       );
-      (drainingDeploymentService.calculateTopUpAmount as jest.Mock).mockResolvedValue(1000000);
-      (cachedBalanceService.get as jest.Mock).mockImplementation(async () => ({
-        reserveSufficientAmount: () => 500000
-      }));
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 500000));
 
-      await service.topUpDeployments({ concurrency: 10, dryRun: true });
+      await service.topUpDeployments({ dryRun: true });
 
       expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
     });
 
     it("should not execute transactions if no draining deployments", async () => {
-      (drainingDeploymentService.paginate as jest.Mock).mockImplementation((_params: { limit: number }) => (async function* () {})());
+      const { service, drainingDeploymentService, managedSignerService } = setup();
+      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() => (async function* () {})());
 
-      await service.topUpDeployments({ concurrency: 10, dryRun: false });
+      await service.topUpDeployments({ dryRun: false });
 
       expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
     });
 
     it("should top up draining deployments for the same owner in the same tx", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService } = setup();
       const owner = createAkashAddress();
       const walletId = faker.number.int({ min: 1000000, max: 9999999 });
       const deployments = [AutoTopUpDeploymentSeeder.create({ address: owner, walletId }), AutoTopUpDeploymentSeeder.create({ address: owner, walletId })];
@@ -257,26 +251,37 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const sufficientAmount = faker.number.int({ min: 1000000, max: 2000000 });
       const predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500;
 
-      (drainingDeploymentService.paginate as jest.Mock).mockImplementation((_params: { limit: number }) =>
+      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
         (async function* () {
-          const items = deployments.map(deployment => ({
-            ...deployment,
-            ...DrainingDeploymentSeeder.create({
-              dseq: Number(deployment.dseq),
-              owner: deployment.address,
-              predictedClosedHeight
-            })
-          }));
-          yield items;
+          const byAddress = deployments.reduce(
+            (acc, deployment) => {
+              if (!acc[deployment.address]) {
+                acc[deployment.address] = [];
+              }
+              acc[deployment.address].push({
+                ...deployment,
+                ...DrainingDeploymentSeeder.create({
+                  dseq: Number(deployment.dseq),
+                  owner: deployment.address,
+                  predictedClosedHeight
+                }),
+                dseq: deployment.dseq
+              } as DrainingDeployment);
+              return acc;
+            },
+            {} as Record<string, DrainingDeployment[]>
+          );
+
+          for (const [address, items] of Object.entries(byAddress)) {
+            yield { address, deployments: items };
+          }
         })()
       );
 
-      (drainingDeploymentService.calculateTopUpAmount as jest.Mock).mockResolvedValue(desiredAmount);
-      (cachedBalanceService.get as jest.Mock).mockImplementation(async () => ({
-        reserveSufficientAmount: () => sufficientAmount
-      }));
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(desiredAmount);
+      cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => sufficientAmount));
 
-      await service.topUpDeployments({ concurrency: 10, dryRun: false });
+      await service.topUpDeployments({ dryRun: false });
 
       expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(1);
       expect(managedSignerService.executeDerivedTx).toHaveBeenCalledWith(
@@ -322,28 +327,30 @@ describe(TopUpManagedDeploymentsService.name, () => {
     });
 
     it("should log errors when message preparation fails", async () => {
+      const { service, drainingDeploymentService, logger } = setup();
       const deployment = AutoTopUpDeploymentSeeder.create();
       const error = new Error("Failed to calculate amount");
 
-      (drainingDeploymentService.paginate as jest.Mock).mockImplementation((_params: { limit: number }) =>
+      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
         (async function* () {
-          const items = [
+          const items: DrainingDeployment[] = [
             {
               ...deployment,
               ...DrainingDeploymentSeeder.create({
                 dseq: Number(deployment.dseq),
                 owner: deployment.address,
                 predictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500
-              })
-            }
+              }),
+              dseq: deployment.dseq
+            } as DrainingDeployment
           ];
-          yield items;
+          yield { address: deployment.address, deployments: items };
         })()
       );
 
-      (drainingDeploymentService.calculateTopUpAmount as jest.Mock).mockRejectedValue(error);
+      drainingDeploymentService.calculateTopUpAmount.mockRejectedValue(error);
 
-      await service.topUpDeployments({ concurrency: 10, dryRun: false });
+      await service.topUpDeployments({ dryRun: false });
 
       expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -380,31 +387,44 @@ describe(TopUpManagedDeploymentsService.name, () => {
     });
 
     it("should handle master wallet insufficient funds error and stop processing", async () => {
+      const { service, chainErrorService, managedSignerService, drainingDeploymentService, cachedBalanceService, logger } = setup();
       const deployments = AutoTopUpDeploymentSeeder.createMany(3);
       const error = new Error(`insufficient funds: 10uakt is smaller than 20uakt`);
+      const mockTx = mock<IndexedTx>({ code: 0, hash: "tx-hash", rawLog: "success" });
 
-      (chainErrorService.isMasterWalletInsufficientFundsError as jest.Mock).mockResolvedValueOnce(true);
-      (managedSignerService.executeDerivedTx as jest.Mock).mockRejectedValueOnce(error);
-      (drainingDeploymentService.calculateTopUpAmount as jest.Mock).mockResolvedValue(1000000);
-      (drainingDeploymentService.paginate as jest.Mock).mockImplementation((_params: { limit: number }) =>
+      chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValueOnce(true).mockResolvedValue(false);
+      managedSignerService.executeDerivedTx.mockRejectedValueOnce(error).mockResolvedValue(mockTx);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
         (async function* () {
-          const items = deployments.map(deployment => ({
-            ...deployment,
-            ...DrainingDeploymentSeeder.create({
-              dseq: Number(deployment.dseq),
-              owner: deployment.address,
-              predictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500,
-              denom: DEPLOYMENT_GRANT_DENOM
-            })
-          }));
-          yield items;
+          const byAddress = deployments.reduce(
+            (acc, deployment) => {
+              if (!acc[deployment.address]) {
+                acc[deployment.address] = [];
+              }
+              acc[deployment.address].push({
+                ...deployment,
+                ...DrainingDeploymentSeeder.create({
+                  dseq: Number(deployment.dseq),
+                  owner: deployment.address,
+                  predictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500,
+                  denom: DEPLOYMENT_GRANT_DENOM
+                }),
+                dseq: deployment.dseq
+              } as DrainingDeployment);
+              return acc;
+            },
+            {} as Record<string, DrainingDeployment[]>
+          );
+
+          for (const [address, items] of Object.entries(byAddress)) {
+            yield { address, deployments: items };
+          }
         })()
       );
-      (cachedBalanceService.get as jest.Mock).mockImplementation(async () => ({
-        reserveSufficientAmount: () => 500000
-      }));
+      cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 500000));
 
-      await expect(service.topUpDeployments({ concurrency: 10, dryRun: false })).resolves.toEqual(
+      await expect(service.topUpDeployments({ dryRun: false })).resolves.toEqual(
         expect.objectContaining({
           err: true,
           ok: false,
@@ -420,21 +440,21 @@ describe(TopUpManagedDeploymentsService.name, () => {
           dryRun: false
         })
       );
-      expect(logger.info).toHaveBeenCalledWith(
+      expect(logger.error).toHaveBeenCalledWith(
         expect.objectContaining({
           event: "TOP_UP_DEPLOYMENTS_SUMMARY",
           summary: expect.objectContaining({
             startBlockHeight: CURRENT_BLOCK_HEIGHT,
             endBlockHeight: CURRENT_BLOCK_HEIGHT,
-            deploymentCount: 2,
+            deploymentCount: 3,
             deploymentTopUpCount: 2,
-            deploymentTopUpErrorCount: 0,
+            deploymentTopUpErrorCount: 1,
             insufficientBalanceCount: 0,
-            walletsCount: 2,
+            walletsCount: 3,
             walletsTopUpCount: 2,
-            walletsTopUpErrorCount: 0,
+            walletsTopUpErrorCount: 1,
             minPredictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500,
-            maxPredictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1700,
+            maxPredictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500,
             totalTopUpAmount: expect.any(Number)
           }),
           dryRun: false
@@ -443,31 +463,48 @@ describe(TopUpManagedDeploymentsService.name, () => {
     });
 
     it("should handle user wallet insufficient funds error and continue processing", async () => {
+      const { service, chainErrorService, managedSignerService, drainingDeploymentService, cachedBalanceService, logger } = setup();
       const deployments = AutoTopUpDeploymentSeeder.createMany(3);
       const error = new Error(`insufficient funds: 10uakt is smaller than 20uakt`);
 
-      (chainErrorService.isMasterWalletInsufficientFundsError as jest.Mock).mockResolvedValue(false);
-      (managedSignerService.executeDerivedTx as jest.Mock).mockRejectedValueOnce(error).mockResolvedValueOnce(undefined).mockResolvedValueOnce(undefined);
-      (drainingDeploymentService.calculateTopUpAmount as jest.Mock).mockResolvedValue(1000000);
-      (drainingDeploymentService.paginate as jest.Mock).mockImplementation((_params: { limit: number }) =>
+      chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(false);
+      const mockTx = mock<IndexedTx>({
+        code: 0,
+        hash: "tx-hash",
+        rawLog: "success"
+      });
+      managedSignerService.executeDerivedTx.mockRejectedValueOnce(error).mockResolvedValueOnce(mockTx).mockResolvedValueOnce(mockTx);
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
         (async function* () {
-          const items = deployments.map(deployment => ({
-            ...deployment,
-            ...DrainingDeploymentSeeder.create({
-              dseq: Number(deployment.dseq),
-              owner: deployment.address,
-              predictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500,
-              denom: DEPLOYMENT_GRANT_DENOM
-            })
-          }));
-          yield items;
+          const byAddress = deployments.reduce(
+            (acc, deployment) => {
+              if (!acc[deployment.address]) {
+                acc[deployment.address] = [];
+              }
+              acc[deployment.address].push({
+                ...deployment,
+                ...DrainingDeploymentSeeder.create({
+                  dseq: Number(deployment.dseq),
+                  owner: deployment.address,
+                  predictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500,
+                  denom: DEPLOYMENT_GRANT_DENOM
+                }),
+                dseq: deployment.dseq
+              } as DrainingDeployment);
+              return acc;
+            },
+            {} as Record<string, DrainingDeployment[]>
+          );
+
+          for (const [address, items] of Object.entries(byAddress)) {
+            yield { address, deployments: items };
+          }
         })()
       );
-      (cachedBalanceService.get as jest.Mock).mockImplementation(async () => ({
-        reserveSufficientAmount: () => 500000
-      }));
+      cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 500000));
 
-      await service.topUpDeployments({ concurrency: 10, dryRun: false });
+      await service.topUpDeployments({ dryRun: false });
 
       expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(3);
       expect(logger.error).toHaveBeenCalledWith(
@@ -499,4 +536,48 @@ describe(TopUpManagedDeploymentsService.name, () => {
       );
     });
   });
+
+  function setup(input?: { currentBlockHeight?: number }) {
+    const currentBlockHeight = input?.currentBlockHeight ?? CURRENT_BLOCK_HEIGHT;
+
+    const managedSignerService = mock<ManagedSignerService>();
+    const billingConfig = mockConfigService<BillingConfigService>({
+      DEPLOYMENT_GRANT_DENOM,
+      USDC_IBC_DENOMS: {
+        mainnetId: DEPLOYMENT_GRANT_DENOM,
+        sandboxId: DEPLOYMENT_GRANT_DENOM
+      }
+    });
+    const drainingDeploymentService = mock<DrainingDeploymentService>();
+    const rpcMessageService = new RpcMessageService();
+    const cachedBalanceService = mock<CachedBalanceService>();
+    const blockHttpService = mock<BlockHttpService>();
+    blockHttpService.getCurrentHeight.mockResolvedValue(currentBlockHeight);
+    const chainErrorService = mock<ChainErrorService>();
+    chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(false);
+    const logger = mock<LoggerService>();
+
+    const service = new TopUpManagedDeploymentsService(
+      managedSignerService,
+      billingConfig,
+      drainingDeploymentService,
+      rpcMessageService,
+      cachedBalanceService,
+      blockHttpService,
+      chainErrorService,
+      logger
+    );
+
+    return {
+      service,
+      managedSignerService,
+      billingConfig,
+      drainingDeploymentService,
+      rpcMessageService,
+      cachedBalanceService,
+      blockHttpService,
+      chainErrorService,
+      logger
+    };
+  }
 });

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -20,8 +20,6 @@ import { createAkashAddress } from "@test/seeders";
 import { AutoTopUpDeploymentSeeder } from "@test/seeders/auto-top-up-deployment.seeder";
 import { DrainingDeploymentSeeder } from "@test/seeders/draining-deployment.seeder";
 
-jest.mock("@akashnetwork/logging");
-
 describe(TopUpManagedDeploymentsService.name, () => {
   const DEPLOYMENT_GRANT_DENOM = "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1";
   const CURRENT_BLOCK_HEIGHT = 7481457;

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -60,7 +60,7 @@ export class TopUpManagedDeploymentsService {
       }
     }
 
-    this.finalizeSummary(options);
+    await this.finalizeSummary(options);
 
     return errors.length > 0 ? Err(errors) : Ok(undefined);
   }

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -1,6 +1,4 @@
 import { MsgAccountDeposit } from "@akashnetwork/chain-sdk/private-types/akash.v1";
-import { LoggerService } from "@akashnetwork/logging";
-import groupBy from "lodash/groupBy";
 import { Err, Ok, Result } from "ts-results";
 import { singleton } from "tsyringe";
 
@@ -9,10 +7,11 @@ import { BillingConfigService } from "@src/billing/services/billing-config/billi
 import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
+import { LoggerService } from "@src/core";
+import type { DryRunOptions } from "@src/core/types/console";
 import { TopUpSummarizer } from "@src/deployment/lib/top-up-summarizer/top-up-summarizer";
 import { DrainingDeployment } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
-import { DeploymentsRefiller, TopUpDeploymentsOptions } from "@src/deployment/types/deployments-refiller";
 import { CachedBalanceService } from "../cached-balance/cached-balance.service";
 
 type CollectedMessage = {
@@ -22,9 +21,7 @@ type CollectedMessage = {
 };
 
 @singleton()
-export class TopUpManagedDeploymentsService implements DeploymentsRefiller {
-  private readonly logger = LoggerService.forContext(TopUpManagedDeploymentsService.name);
-
+export class TopUpManagedDeploymentsService {
   private readonly summarizer = new TopUpSummarizer();
 
   constructor(
@@ -34,43 +31,39 @@ export class TopUpManagedDeploymentsService implements DeploymentsRefiller {
     private readonly rpcClientService: RpcMessageService,
     private readonly cachedBalanceService: CachedBalanceService,
     private readonly blockHttpService: BlockHttpService,
-    private readonly chainErrorService: ChainErrorService
-  ) {}
+    private readonly chainErrorService: ChainErrorService,
+    private readonly logger: LoggerService
+  ) {
+    this.logger.setContext(TopUpManagedDeploymentsService.name);
+  }
 
-  async topUpDeployments(options: TopUpDeploymentsOptions): Promise<Result<void, Error[]>> {
+  async topUpDeployments(options: DryRunOptions): Promise<Result<void, unknown[]>> {
     const startBlockHeight = await this.blockHttpService.getCurrentHeight();
     this.summarizer.set("startBlockHeight", startBlockHeight);
+    const errors: unknown[] = [];
 
-    for await (const deployments of this.drainingDeploymentService.paginate({ limit: options.concurrency || 10 })) {
-      const messageInputs = await this.collectMessages(deployments, options);
-      const byOwner = groupBy(messageInputs, "deployment.address");
-      const results = await Promise.allSettled(Object.values(byOwner).map(ownerInputs => this.topUpForOwner(ownerInputs, options)));
-
-      const rejectedErrors = results
-        .filter((result: PromiseSettledResult<unknown>): result is PromiseRejectedResult => {
-          return result.status === "rejected";
-        })
-        .map(result => result.reason);
-
-      if (rejectedErrors.length) {
-        this.finalizeSummary(options);
-        return Err(rejectedErrors);
+    for await (const { address, deployments } of this.drainingDeploymentService.findDrainingDeploymentsByOwner()) {
+      try {
+        const messageInputs = await this.collectMessages(deployments, options);
+        await this.topUpForOwner(address, messageInputs, options);
+      } catch (error: unknown) {
+        errors.push(error);
       }
     }
 
     this.finalizeSummary(options);
 
-    return Ok(undefined);
+    return errors.length > 0 ? Err(errors) : Ok(undefined);
   }
 
-  private async finalizeSummary(options: TopUpDeploymentsOptions) {
+  private async finalizeSummary(options: DryRunOptions) {
     const endBlockHeight = await this.blockHttpService.getCurrentHeight();
     this.summarizer.set("endBlockHeight", endBlockHeight);
 
     this.logSummary(options);
   }
 
-  private async collectMessages(deployments: DrainingDeployment[], options: TopUpDeploymentsOptions): Promise<CollectedMessage[]> {
+  private async collectMessages(deployments: DrainingDeployment[], options: DryRunOptions): Promise<CollectedMessage[]> {
     const denom = this.billingConfig.get("DEPLOYMENT_GRANT_DENOM");
 
     const messageInputs = await Promise.all(
@@ -136,8 +129,7 @@ export class TopUpManagedDeploymentsService implements DeploymentsRefiller {
     return messageInputs.filter(x => !!x);
   }
 
-  private async topUpForOwner(ownerInputs: CollectedMessage[], options: TopUpDeploymentsOptions) {
-    const owner = ownerInputs[0].deployment.address;
+  private async topUpForOwner(owner: string, ownerInputs: CollectedMessage[], options: DryRunOptions) {
     const logItems = ownerInputs.map(({ deployment, input }) => ({
       deployment,
       input
@@ -195,7 +187,7 @@ export class TopUpManagedDeploymentsService implements DeploymentsRefiller {
     }
   }
 
-  private logSummary(options: TopUpDeploymentsOptions) {
+  private logSummary(options: DryRunOptions) {
     const summary = this.summarizer.summarize();
     const log = { event: "TOP_UP_DEPLOYMENTS_SUMMARY", summary, dryRun: options.dryRun };
     const hasErrors = summary.deploymentTopUpErrorCount - summary.insufficientBalanceCount > 0;

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -45,6 +45,15 @@ export class TopUpManagedDeploymentsService {
     for await (const { address, deployments } of this.drainingDeploymentService.findDrainingDeploymentsByOwner()) {
       try {
         const messageInputs = await this.collectMessages(deployments, options);
+        if (!messageInputs.length) {
+          this.logger.info({
+            event: "TOP_UP_SKIPPED_NOTHING_TO_TOP_UP",
+            owner: address,
+            deploymentCount: deployments.length,
+            dryRun: options.dryRun
+          });
+          continue;
+        }
         await this.topUpForOwner(address, messageInputs, options);
       } catch (error: unknown) {
         errors.push(error);

--- a/apps/api/src/deployment/types/deployments-refiller.ts
+++ b/apps/api/src/deployment/types/deployments-refiller.ts
@@ -1,9 +1,0 @@
-import type { Result } from "ts-results";
-
-import type { ConcurrencyOptions, DryRunOptions } from "@src/core/types/console";
-
-export interface TopUpDeploymentsOptions extends DryRunOptions, ConcurrencyOptions {}
-
-export interface DeploymentsRefiller {
-  topUpDeployments(options: TopUpDeploymentsOptions): Promise<Result<void, Error[]>>;
-}

--- a/apps/api/src/deployment/types/draining-deployment.ts
+++ b/apps/api/src/deployment/types/draining-deployment.ts
@@ -8,7 +8,7 @@ export type DrainingDeployment = AutoTopUpDeployment & {
 
 export type RpcDeploymentInfo = {
   dseq: string;
-  escrowBalance: bigint;
+  escrowBalance: number;
   createdHeight: number;
 };
 

--- a/apps/api/src/deployment/types/draining-deployment.ts
+++ b/apps/api/src/deployment/types/draining-deployment.ts
@@ -1,0 +1,17 @@
+import type { AutoTopUpDeployment } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
+import type { DrainingDeploymentOutput } from "@src/deployment/repositories/lease/lease.repository";
+
+export type DrainingDeployment = AutoTopUpDeployment & {
+  predictedClosedHeight: number;
+  blockRate: number;
+};
+
+export type RpcDeploymentInfo = {
+  dseq: string;
+  escrowBalance: number;
+  createdHeight: number;
+};
+
+export interface DrainingDeploymentLeaseSource {
+  findManyByDseqAndOwner(closureHeight: number, owner: string, dseqs: string[]): Promise<DrainingDeploymentOutput[]>;
+}

--- a/apps/api/src/deployment/types/draining-deployment.ts
+++ b/apps/api/src/deployment/types/draining-deployment.ts
@@ -8,7 +8,7 @@ export type DrainingDeployment = AutoTopUpDeployment & {
 
 export type RpcDeploymentInfo = {
   dseq: string;
-  escrowBalance: number;
+  escrowBalance: bigint;
   createdHeight: number;
 };
 

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -1,5 +1,5 @@
 export type FeatureFlag =
-  | "alerts" // keep new line
+  | "alerts"
   | "anonymous_free_trial"
   | "notifications_general_alerts_update"
   | "ui_deployment_closed_alert"


### PR DESCRIPTION

- Query lease/deployment data from RPC endpoints with automatic DB fallback
- Group deployments by owner for efficient per-owner processing
- Add findAutoTopUpDeploymentsByOwner() for owner-based queries
- Update LeaseRepository signature for better RPC fallback integration
- Remove concurrency CLI option
- Update all tests and mocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * CLI concurrency option for top-up deployments (-c / --concurrency) removed — update scripts/automations.

* **New Features**
  * RPC-backed lease/deployment lookups for improved predicted-closure and balance accuracy.
  * Streaming, per-owner draining/top-up processing that yields owner-scoped results.
  * Exposed cached-balance and draining-deployment types for reuse.

* **Improvements**
  * Sequential per-owner top-ups with aggregated error reporting and RPC→DB fallback.
  * Enhanced logging, summaries, and updated tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->