### PR TITLE
fix: set unleash-session-id into cookie

### DIFF
--- a/apps/deploy-web/src/context/FlagProvider/FlagProvider.tsx
+++ b/apps/deploy-web/src/context/FlagProvider/FlagProvider.tsx
@@ -22,7 +22,10 @@ export const UserAwareFlagProvider: FCWithChildren<Props> = ({ children, compone
   return (
     <c.FlagProvider
       config={{
-        context: { userId: user?.id },
+        context: {
+          userId: user?.id,
+          sessionId: getSessionId()
+        },
         fetch: isEnableAll ? () => new Response(JSON.stringify({ toggles: [] })) : undefined
       }}
     >
@@ -66,4 +69,9 @@ function WaitForFeatureFlags({ children }: { children: ReactNode }) {
     return <Loading text="Loading application..." />;
   }
   return <>{children}</>;
+}
+
+function getSessionId(): string | undefined {
+  const m = document.cookie.match(/(?:^|; )unleash-session-id=([^;]+)/);
+  return m?.[1];
 }

--- a/apps/deploy-web/src/middleware.ts
+++ b/apps/deploy-web/src/middleware.ts
@@ -20,7 +20,23 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL(returnPath, request.url), 307); // 307 - temporary redirect
   }
 
-  return NextResponse.next();
+  const res = NextResponse.next();
+
+  const cookieName = "unleash-session-id";
+  let sessionId = request.cookies.get(cookieName)?.value;
+
+  if (!sessionId) {
+    sessionId = crypto.randomUUID();
+    res.cookies.set(cookieName, sessionId, {
+      path: "/",
+      httpOnly: false, // MUST be readable on the client
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      maxAge: 60 * 60 * 24 * 365 // 1 year
+    });
+  }
+
+  return res;
 }
 
 function getReturnPath(request: NextRequest) {

--- a/apps/deploy-web/src/utils/localStorage.ts
+++ b/apps/deploy-web/src/utils/localStorage.ts
@@ -5,7 +5,10 @@ import { gt, neq } from "semver";
 const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || "0.0.0";
 
 const migrations: Record<string, () => void> = {
-  "0.14.0": () => {}
+  "0.14.0": () => {},
+  "3.11.1": () => {
+    localStorage.removeItem("unleash:repository:sessionId");
+  }
 };
 
 // Store latestUpdatedVersion in localStorage


### PR DESCRIPTION
## Why

It's important to have the same session id on FE, SSR, API to have stable feature flag selection in case of gradual FF rollout or when specifying strategy with filters by sessionId

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session tracking now uses a client-readable session cookie and exposes a session identifier to the app for more consistent session behavior.

* **Chores**
  * Migrated session persistence away from local browser storage to cookies.
  * Added a migration that removes the legacy session key from local storage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->