### PR TITLE
fix: changes the order of buttons in mobile view

### DIFF
--- a/apps/deploy-web/src/components/auth/SignInForm/SignInForm.tsx
+++ b/apps/deploy-web/src/components/auth/SignInForm/SignInForm.tsx
@@ -62,7 +62,7 @@ export function SignInForm(props: Props) {
             )}
           />
         </div>
-        <div className="flex flex-col gap-5 self-stretch sm:flex-row">
+        <div className="flex flex-col-reverse gap-5 self-stretch sm:flex-row">
           <Button type="button" onClick={goBack} variant="outline" className="h-9 flex-1 border-neutral-200 dark:border-neutral-800">
             <Undo2 className="mr-2 h-4 w-4" />
             Go Back

--- a/apps/deploy-web/src/components/auth/SignUpForm/SignUpForm.tsx
+++ b/apps/deploy-web/src/components/auth/SignUpForm/SignUpForm.tsx
@@ -106,7 +106,7 @@ export function SignUpForm(props: Props) {
           />
         </div>
 
-        <div className="flex flex-col gap-5 self-stretch sm:flex-row">
+        <div className="flex flex-col-reverse gap-5 self-stretch sm:flex-row">
           <Button type="button" onClick={goBack} variant="outline" className="h-9 flex-1 border-neutral-200 dark:border-neutral-800">
             <Undo2 className="mr-2 h-4 w-4" />
             Go Back


### PR DESCRIPTION
## Why

#2332 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reversed the visual order of action buttons on mobile screens in Sign In and Sign Up forms for improved UX consistency. Desktop layout unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->