### PR TITLE
feat: adds forget password form to embedded login page

### DIFF
--- a/apps/deploy-web/src/components/auth/ForgotPasswordForm/ForgotPasswordForm.spec.tsx
+++ b/apps/deploy-web/src/components/auth/ForgotPasswordForm/ForgotPasswordForm.spec.tsx
@@ -1,0 +1,101 @@
+import type { ComponentProps } from "react";
+
+import { ForgotPasswordForm, type ForgotPasswordFormValues } from "./ForgotPasswordForm";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(ForgotPasswordForm.name, () => {
+  it("submits form with valid email", async () => {
+    const { onSubmit } = setup();
+
+    await userEvent.type(screen.getByLabelText("Email"), "alice@example.com");
+    await userEvent.click(screen.getByRole("button", { name: "Send reset email" }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit).toHaveBeenCalledWith({ email: "alice@example.com" });
+    });
+  });
+
+  it("validates email when submitted with invalid email", async () => {
+    const { onSubmit } = setup();
+
+    await userEvent.type(screen.getByLabelText("Email"), "invalid-email");
+    await userEvent.click(screen.getByRole("button", { name: "Send reset email" }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.queryByText("Invalid email")).toBeInTheDocument();
+  });
+
+  it("validates email when submitted with empty email", async () => {
+    const { onSubmit } = setup();
+
+    await userEvent.click(screen.getByRole("button", { name: "Send reset email" }));
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText(/Invalid email/i)).toBeInTheDocument();
+  });
+
+  it("pre-fills email input when `defaultEmail` is provided", () => {
+    setup({ defaultEmail: "bob@example.com" });
+
+    expect(screen.getByLabelText("Email")).toHaveValue("bob@example.com");
+  });
+
+  it("calls `onGoBack` when go back button is clicked", async () => {
+    const { onGoBack } = setup();
+
+    await userEvent.click(screen.getByRole("button", { name: "Go Back to Log in" }));
+
+    expect(onGoBack).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables submit button and shows spinner when status is pending", () => {
+    const { props, rerender } = setup();
+
+    rerender(<ForgotPasswordForm {...props} status="pending" />);
+
+    expect(screen.getByRole("button", { name: /send reset email/i })).toBeDisabled();
+    expect(screen.queryByRole("status")).toBeInTheDocument();
+  });
+
+  it("displays success message when status prop is `success`", () => {
+    setup({ status: "success" });
+
+    expect(screen.getByText(/Check your email for password reset instructions/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Go Back to Log in" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Email")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Send reset email" })).not.toBeInTheDocument();
+  });
+
+  it("maintains email value when rerendered with different status", async () => {
+    const { props, rerender } = setup({});
+
+    await userEvent.type(screen.getByLabelText("Email"), "test@example.com");
+
+    rerender(<ForgotPasswordForm {...props} status="pending" />);
+
+    expect(screen.getByLabelText("Email")).toHaveValue("test@example.com");
+  });
+
+  function setup(input: Partial<ComponentProps<typeof ForgotPasswordForm>> = {}) {
+    const onSubmit = input.onSubmit ?? jest.fn<void, [ForgotPasswordFormValues]>();
+    const onGoBack = input.onGoBack ?? jest.fn<void, []>();
+    const props: ComponentProps<typeof ForgotPasswordForm> = {
+      status: "idle",
+      ...input,
+      onSubmit,
+      onGoBack
+    };
+
+    const renderResult = render(<ForgotPasswordForm {...props} />);
+
+    return {
+      ...renderResult,
+      onSubmit,
+      onGoBack,
+      props
+    };
+  }
+});

--- a/apps/deploy-web/src/components/auth/ForgotPasswordForm/ForgotPasswordForm.tsx
+++ b/apps/deploy-web/src/components/auth/ForgotPasswordForm/ForgotPasswordForm.tsx
@@ -1,0 +1,68 @@
+import { useForm } from "react-hook-form";
+import { Alert, AlertDescription, Button, Form, FormField, FormInput, Spinner } from "@akashnetwork/ui/components";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Mail, Undo2 } from "lucide-react";
+import { z } from "zod";
+
+type Props = {
+  defaultEmail?: string;
+  status?: "success" | "error" | "idle" | "pending";
+  onSubmit: (values: ForgotPasswordFormValues) => void;
+  onGoBack: () => void;
+};
+
+const formSchema = z.object({
+  email: z.string().email().min(1, { message: "Email is required" })
+});
+
+export type ForgotPasswordFormValues = z.infer<typeof formSchema>;
+
+export const ForgotPasswordForm = (props: Props) => {
+  const form = useForm<ForgotPasswordFormValues>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      email: props.defaultEmail || ""
+    }
+  });
+
+  const emitSubmit = form.handleSubmit(values => props.onSubmit(values));
+
+  return (
+    <Form {...form}>
+      <form noValidate={true} autoComplete="on" onSubmit={emitSubmit} className="flex flex-col items-center justify-start gap-5 self-stretch">
+        {(props.status === "success" && (
+          <Alert variant="success" className="mb-5">
+            <AlertDescription>Check your email for password reset instructions. If you don't see the email, check your spam folder.</AlertDescription>
+          </Alert>
+        )) || (
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormInput
+                className="w-full"
+                type="email"
+                label="Email"
+                placeholder="m@example.com"
+                value={field.value}
+                onChange={event => field.onChange(event.target.value)}
+              />
+            )}
+          />
+        )}
+        <div className="flex flex-col-reverse gap-5 self-stretch sm:flex-row">
+          <Button type="button" onClick={props.onGoBack} variant="outline" className="h-9 flex-1 border-neutral-200 dark:border-neutral-800">
+            <Undo2 className="mr-2 h-4 w-4" />
+            Go Back to Log in
+          </Button>
+          {props.status !== "success" && (
+            <Button type="submit" disabled={props.status === "pending"} className="h-9 flex-1" aria-label="Send reset email">
+              <Mail className="mr-2 h-4 w-4" />
+              {props.status === "pending" ? <Spinner size="small" /> : "Send reset email"}
+            </Button>
+          )}
+        </div>
+      </form>
+    </Form>
+  );
+};

--- a/apps/deploy-web/src/components/auth/SignInForm/SignInForm.spec.tsx
+++ b/apps/deploy-web/src/components/auth/SignInForm/SignInForm.spec.tsx
@@ -15,7 +15,7 @@ describe(SignInForm.name, () => {
     const { onSubmit } = setup();
 
     await userEvent.type(screen.getByLabelText("Email"), "alice@example.com");
-    await userEvent.type(screen.getByLabelText("Password"), "password123");
+    await userEvent.type(screen.getByLabelText(/Password/i), "password123");
     await userEvent.click(screen.getByRole("button", { name: "Log in" }));
 
     await waitFor(() => {
@@ -48,7 +48,7 @@ describe(SignInForm.name, () => {
     const { onSubmit } = setup();
 
     await userEvent.type(screen.getByLabelText("Email"), "test");
-    await userEvent.type(screen.getByLabelText("Password"), "password123");
+    await userEvent.type(screen.getByLabelText(/Password/i), "password123");
     await userEvent.click(screen.getByRole("button", { name: "Log in" }));
 
     expect(onSubmit).not.toHaveBeenCalled();

--- a/apps/deploy-web/src/components/auth/SignInForm/SignInForm.tsx
+++ b/apps/deploy-web/src/components/auth/SignInForm/SignInForm.tsx
@@ -1,7 +1,9 @@
+import { useCallback } from "react";
 import { useForm } from "react-hook-form";
 import { Button, Form, FormField, FormInput, Spinner } from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { LogIn, Undo2 } from "lucide-react";
+import Link from "next/link";
 import { z } from "zod";
 
 import { useBackNav } from "@src/hooks/useBackNav";
@@ -16,18 +18,29 @@ export type SignInFormValues = z.infer<typeof formSchema>;
 interface Props {
   isLoading?: boolean;
   onSubmit: (values: SignInFormValues) => void;
+  onForgotPasswordClick?: () => void;
+  defaultEmail?: string;
+  onEmailChange?: (email: string) => void;
 }
 
 export function SignInForm(props: Props) {
   const form = useForm<SignInFormValues>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      email: "",
+      email: props.defaultEmail || "",
       password: ""
     }
   });
   const goBack = useBackNav("/");
   const emitSubmit = form.handleSubmit(values => props.onSubmit(values));
+
+  const onForgotPasswordClick = useCallback(
+    (event: React.MouseEvent) => {
+      event.preventDefault();
+      props.onForgotPasswordClick?.();
+    },
+    [props.onForgotPasswordClick]
+  );
 
   return (
     <Form {...form}>
@@ -43,7 +56,10 @@ export function SignInForm(props: Props) {
                 label="Email"
                 placeholder="m@example.com"
                 value={field.value}
-                onChange={event => field.onChange(event.target.value)}
+                onChange={event => {
+                  field.onChange(event.target.value);
+                  props.onEmailChange?.(event.target.value);
+                }}
               />
             )}
           />
@@ -54,7 +70,17 @@ export function SignInForm(props: Props) {
               <FormInput
                 className="w-full"
                 type="password"
-                label="Password"
+                labelClassName="flex items-center justify-between"
+                label={
+                  <>
+                    <div>Password</div>
+                    <div>
+                      <Link className="text-xs text-current underline hover:no-underline" prefetch={false} href="#" onClick={onForgotPasswordClick}>
+                        Forgot password?
+                      </Link>
+                    </div>
+                  </>
+                }
                 placeholder="••••••••"
                 value={field.value}
                 onChange={event => field.onChange(event.target.value)}

--- a/apps/deploy-web/src/components/icons/AkashConsoleLogo.tsx
+++ b/apps/deploy-web/src/components/icons/AkashConsoleLogo.tsx
@@ -1,7 +1,7 @@
 export const AkashConsoleLogo = ({ className = "", size = { width: 170, height: 20 } }: { className?: string; size?: { width: number; height: number } }) => {
   return (
-    <div style={{ width: size.width, height: size.height }}>
-      <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 170 20" fill="none" className={className}>
+    <div style={{ width: size.width, height: size.height }} className={className}>
+      <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 170 20" fill="none">
         <path d="M13.7518 12.0425L17.1474 18.0147H10.2884L6.85693 12.0425H13.7518Z" fill="url(#paint0_linear_868_9890)" />
         <path d="M17.1455 18.0158L20.5713 12.0436L13.7141 0.0961914H6.85693L17.1455 18.0158Z" fill="#FF414C" />
         <path d="M3.42857 6.06689H10.2858L3.43142 18.0143L0 12.042L3.42857 6.06689Z" fill="#FF414C" />

--- a/apps/deploy-web/src/components/shared/RemoteApiError/RemoteApiError.spec.tsx
+++ b/apps/deploy-web/src/components/shared/RemoteApiError/RemoteApiError.spec.tsx
@@ -1,0 +1,36 @@
+import { AxiosError } from "axios";
+
+import { DEPENDENCIES, RemoteApiError } from "./RemoteApiError";
+
+import { render } from "@testing-library/react";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe(RemoteApiError.name, () => {
+  it("renders standard error message for non-HTTP errors", () => {
+    const { getByText } = setup({ error: new Error("Test error") });
+    expect(getByText(/unexpected error/i)).toBeInTheDocument();
+  });
+
+  it("renders error message from HTTP error response", () => {
+    const error = new AxiosError("Test error", "400", undefined, undefined, {
+      status: 400,
+      statusText: "Test error",
+      data: { message: "Error message from API" },
+      headers: {},
+      config: {} as any
+    });
+    const { getByText } = setup({ error });
+    expect(getByText(/Error message from API/i)).toBeInTheDocument();
+  });
+
+  it("does not render anything when error is null or undefined", () => {
+    const result = setup({ error: null });
+    expect(result.container).toBeEmptyDOMElement();
+    const result2 = setup({ error: undefined });
+    expect(result2.container).toBeEmptyDOMElement();
+  });
+
+  function setup(input?: { error?: Error | null }) {
+    return render(<RemoteApiError error={input?.error ?? null} dependencies={MockComponents(DEPENDENCIES)} />);
+  }
+});

--- a/apps/deploy-web/src/components/shared/RemoteApiError/RemoteApiError.tsx
+++ b/apps/deploy-web/src/components/shared/RemoteApiError/RemoteApiError.tsx
@@ -1,0 +1,26 @@
+import { isHttpError } from "@akashnetwork/http-sdk";
+import { Alert, AlertDescription } from "@akashnetwork/ui/components";
+
+interface Props {
+  error: Error | null | undefined;
+  className?: string;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export const DEPENDENCIES = {
+  Alert,
+  AlertDescription
+};
+
+export function RemoteApiError({ error, className, dependencies: d = DEPENDENCIES }: Props) {
+  if (!error) return null;
+  return (
+    <d.Alert variant="destructive" className={className}>
+      <d.AlertDescription>
+        {isHttpError(error) && error.response?.data.message
+          ? error.response.data.message
+          : "An unexpected error occurred. Please try again or contact support if the issue persists."}
+      </d.AlertDescription>
+    </d.Alert>
+  );
+}

--- a/apps/deploy-web/src/pages/api/auth/send-password-reset-email.ts
+++ b/apps/deploy-web/src/pages/api/auth/send-password-reset-email.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+import { defineApiHandler } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
+
+export default defineApiHandler({
+  route: "/api/auth/send-password-reset-email",
+  schema: z.object({
+    body: z.object({
+      email: z.string().email()
+    })
+  }),
+  async handler({ res, req, services }) {
+    if (req.method !== "POST") {
+      return res.status(405).json({ message: "Method not allowed" });
+    }
+
+    try {
+      const result = await services.sessionService.sendPasswordResetEmail({ email: req.body.email });
+      if (result.ok) {
+        res.status(204).end();
+        return;
+      }
+
+      if (result.val.code === "too_many_requests") {
+        res.setHeader("Retry-After", new Date(result.val.retryAfter * 1000).toUTCString());
+        return res.status(429).json(result.val);
+      }
+
+      const { cause, ...errorDetails } = result.val;
+      services.logger.error({
+        event: "SEND_PASSWORD_RESET_EMAIL_ERROR",
+        cause
+      });
+      return res.status(400).json(errorDetails);
+    } catch (error) {
+      services.logger.error({
+        event: "SEND_PASSWORD_RESET_EMAIL_FATAL_ERROR",
+        error
+      });
+      return res.status(503).json({ message: "Service unavailable" });
+    }
+  }
+});

--- a/apps/deploy-web/src/pages/login/index.tsx
+++ b/apps/deploy-web/src/pages/login/index.tsx
@@ -31,7 +31,7 @@ export const getServerSideProps = defineServerSideProps({
   route: "/login",
   schema: z.object({
     query: z.object({
-      tab: z.enum(["login", "signup"]).default("login"),
+      tab: z.enum(["login", "signup", "forgot-password"]).default("login"),
       from: z.string().optional()
     })
   }),

--- a/apps/deploy-web/src/services/auth/auth/auth.service.ts
+++ b/apps/deploy-web/src/services/auth/auth/auth.service.ts
@@ -44,6 +44,12 @@ export class AuthService {
     });
   }
 
+  async sendPasswordResetEmail(input: { email: string }): Promise<void> {
+    await this.internalApiHttpClient.post<void>("/api/auth/send-password-reset-email", {
+      email: input.email
+    });
+  }
+
   logout() {
     this.localStorage.removeItem(ANONYMOUS_USER_TOKEN_KEY);
     this.localStorage.removeItem(ONBOARDING_STEP_KEY);

--- a/packages/ui/components/input.tsx
+++ b/packages/ui/components/input.tsx
@@ -41,6 +41,7 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   endIconClassName?: string;
   error?: boolean;
   inputClassName?: string;
+  labelClassName?: string;
   description?: string;
   label?: string | React.ReactNode;
   isForm?: boolean;
@@ -49,14 +50,26 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
 // TODO Variants
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, startIconClassName, endIconClassName, inputClassName, type, startIcon, endIcon, error, label, isForm, id: inputId, ...props }, ref) => {
+  (
+    { className, startIconClassName, endIconClassName, inputClassName, type, startIcon, endIcon, error, label, isForm, id: inputId, labelClassName, ...props },
+    ref
+  ) => {
     const id = React.useId();
     const formField = useFormField();
     const finalId = inputId ?? formField.id ?? id;
 
     return (
       <div className={cn("space-y-1", className)}>
-        {label && (formField.id ? <FormLabel htmlFor={`${finalId}-input`}>{label}</FormLabel> : <Label htmlFor={`${finalId}-input`}>{label}</Label>)}
+        {label &&
+          (formField.id ? (
+            <FormLabel className={labelClassName} htmlFor={`${finalId}-input`}>
+              {label}
+            </FormLabel>
+          ) : (
+            <Label className={labelClassName} htmlFor={`${finalId}-input`}>
+              {label}
+            </Label>
+          ))}
         <div className="relative flex items-center">
           {startIcon && <div className={cn("absolute inset-y-0 left-0 flex items-center", startIconClassName)}>{startIcon}</div>}
           <input


### PR DESCRIPTION
## Why

#2332 

## What

<img width="636" height="518" alt="Screenshot 2025-12-17 at 14 20 54" src="https://github.com/user-attachments/assets/8a9bdab6-dd01-4ab8-9ba9-6aeab4f9c90f" />
<img width="634" height="376" alt="Screenshot 2025-12-17 at 14 21 06" src="https://github.com/user-attachments/assets/cebe0139-2064-44c1-a61d-25ac8bf58c0b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Forgot Password" authentication flow with dedicated form for password reset requests.
  * Added "Forgot Password" link on the Sign In form for easy access to password recovery.
  * Introduced improved error messaging for authentication API failures via dedicated error component.
  * Extended email input to support pre-filling and cross-form persistence.

* **Tests**
  * Added comprehensive test coverage for new Forgot Password form and error handling components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->