### PR TITLE
fix(deployment): use targetHeight for deployment filtering in cost calculation

### DIFF
--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -400,7 +400,7 @@ describe(DrainingDeploymentService.name, () => {
         { predictedClosedHeight: baseSetup.currentHeight + 200, blockRate: blockRate2 }
       ];
 
-      const { service, address, targetDate } = await setupCalculateCost({
+      const { service, address, targetDate, leaseRepository } = await setupCalculateCost({
         deployments
       });
 
@@ -409,10 +409,12 @@ describe(DrainingDeploymentService.name, () => {
       const hoursInWeek = 7 * 24;
       const expectedBlocksNeeded = Math.floor(averageBlockCountInAnHour * hoursInWeek);
       const expectedTotal = (blockRate1 + blockRate2) * expectedBlocksNeeded;
+      const expectedTargetHeight = 1100799;
 
       // Allow for small differences in date calculations (±2 blocks = ±250 with total rate of 125)
       expect(result).toBeGreaterThanOrEqual(expectedTotal - 250);
       expect(result).toBeLessThanOrEqual(expectedTotal + 250);
+      expect(leaseRepository.findManyByDseqAndOwner).toHaveBeenCalledWith(expectedTargetHeight, address, expect.any(Array));
     });
 
     it("returns 0 when user wallet not found", async () => {

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -141,7 +141,7 @@ export class DrainingDeploymentService {
     const now = new Date();
     const hoursUntilTarget = (targetDate.getTime() - now.getTime()) / (1000 * 60 * 60);
     const targetHeight = Math.floor(currentHeight + averageBlockCountInAnHour * hoursUntilTarget);
-    const drainingDeployments = await this.#findDrainingDeployments(deploymentSettings, address, currentHeight);
+    const drainingDeployments = await this.#findDrainingDeployments(deploymentSettings, address, targetHeight);
 
     return await this.#accumulateDeploymentCost(drainingDeployments, ({ predictedClosedHeight, blockRate }) => {
       if (predictedClosedHeight && predictedClosedHeight >= currentHeight && predictedClosedHeight <= targetHeight) {


### PR DESCRIPTION


refs #1779

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment cost calculation accuracy by using projected heights for future date scenarios instead of current heights.

* **Tests**
  * Enhanced test coverage for cost calculation paths with tighter assertions on lease lookups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->