### PR TITLE
feat(notifications): merges notifications swagger spec into api spec

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -146,6 +146,7 @@
     "nock": "^13.5.4",
     "nodemon": "^2.0.7",
     "nodemon-webpack-plugin": "^4.8.2",
+    "openapi3-ts": "^4.5.0",
     "prettier": "^3.3.0",
     "prettier-plugin-tailwindcss": "^0.6.1",
     "supertest": "^6.1.5",

--- a/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
+++ b/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
@@ -1,7 +1,11 @@
 import { LoggerService } from "@akashnetwork/logging";
+import axios from "axios";
+import type { ComponentsObject, OpenAPIObject, PathsObject, ReferenceObject } from "openapi3-ts/oas30";
 import { inject, singleton } from "tsyringe";
 
 import { CORE_CONFIG, CoreConfig } from "@src/core/providers/config.provider";
+import type { NotificationsConfig } from "@src/notifications/config/env.config";
+import { NOTIFICATIONS_CONFIG } from "@src/notifications/providers/notifications-config.provider";
 import type { OpenApiHonoHandler } from "../open-api-hono-handler/open-api-hono-handler";
 
 const logger = LoggerService.forContext("OpenApiDocsService");
@@ -9,12 +13,16 @@ const logger = LoggerService.forContext("OpenApiDocsService");
 @singleton()
 export class OpenApiDocsService {
   readonly #serverOrigin: string;
+  #externalSpecLoadPromise: Promise<OpenAPIObject | null> | null = null;
 
-  constructor(@inject(CORE_CONFIG) coreConfig: CoreConfig) {
+  constructor(
+    @inject(CORE_CONFIG) coreConfig: CoreConfig,
+    @inject(NOTIFICATIONS_CONFIG) private readonly notificationsConfig: NotificationsConfig | null = null
+  ) {
     this.#serverOrigin = coreConfig.SERVER_ORIGIN;
   }
 
-  generateDocs(handlers: OpenApiHonoHandler[]) {
+  async generateDocs(handlers: OpenApiHonoHandler[]) {
     const version = "v1";
     const docs = {
       openapi: "3.0.0",
@@ -26,6 +34,7 @@ export class OpenApiDocsService {
       },
       paths: {},
       components: {
+        schemas: {},
         securitySchemes: {
           BearerAuth: {
             type: "http",
@@ -62,6 +71,178 @@ export class OpenApiDocsService {
       }
     }
 
+    const externalDocs = await this.#loadExternalNotificationsSpec();
+    if (externalDocs?.paths) {
+      const { filteredPaths, usedSchemaRefs } = this.#filterPrivateRoutes(externalDocs.paths);
+      Object.assign(docs.paths, filteredPaths);
+
+      if (externalDocs?.components?.schemas) {
+        const filteredSchemas = this.#filterSchemasByReferences(externalDocs.components.schemas, usedSchemaRefs);
+
+        docs.components.schemas = {
+          ...docs.components.schemas,
+          ...filteredSchemas
+        };
+        docs.components.securitySchemes = {
+          ...docs.components.securitySchemes,
+          ...(externalDocs.components.securitySchemes || {})
+        };
+      } else if (externalDocs?.components) {
+        docs.components.securitySchemes = {
+          ...docs.components.securitySchemes,
+          ...(externalDocs.components.securitySchemes || {})
+        };
+      }
+    }
+
     return docs;
+  }
+
+  async #loadExternalNotificationsSpec(): Promise<OpenAPIObject | null> {
+    if (!this.notificationsConfig) {
+      return null;
+    }
+
+    if (this.#externalSpecLoadPromise) {
+      return this.#externalSpecLoadPromise;
+    }
+
+    const externalOpenApiUrl = `${this.notificationsConfig.NOTIFICATIONS_API_BASE_URL}/api-json`;
+
+    this.#externalSpecLoadPromise = (async () => {
+      try {
+        const response = await axios.get(externalOpenApiUrl, { timeout: 5000 });
+        return response.data;
+      } catch (error) {
+        logger.warn({ event: "EXTERNAL_OPENAPI_FETCH_ERROR", error, url: externalOpenApiUrl });
+        return null;
+      }
+    })();
+
+    return this.#externalSpecLoadPromise;
+  }
+
+  /**
+   * Filters out private/internal routes and their schemas from external OpenAPI spec.
+   * Excludes routes with the "Jobs" tag or paths matching /v1/jobs/*
+   */
+  #filterPrivateRoutes(paths: PathsObject): { filteredPaths: PathsObject; usedSchemaRefs: Set<string> } {
+    const excludedPathPrefixes = ["/v1/jobs"];
+    const excludedTags = ["Jobs"];
+
+    const filteredPaths: PathsObject = {};
+    const usedSchemaRefs = new Set<string>();
+    const httpMethods = new Set(["get", "post", "put", "patch", "delete", "head", "options", "trace"]);
+
+    const extractSchemaRefs = (obj: unknown): void => {
+      if (!obj || typeof obj !== "object") {
+        return;
+      }
+
+      if (Array.isArray(obj)) {
+        obj.forEach(item => extractSchemaRefs(item));
+        return;
+      }
+
+      const objWithRef = obj as ReferenceObject | { $ref?: string };
+      if (objWithRef.$ref && typeof objWithRef.$ref === "string" && objWithRef.$ref.startsWith("#/components/schemas/")) {
+        const schemaName = objWithRef.$ref.replace("#/components/schemas/", "");
+        usedSchemaRefs.add(schemaName);
+      }
+
+      Object.values(obj).forEach(value => extractSchemaRefs(value));
+    };
+
+    for (const [path, pathItem] of Object.entries(paths)) {
+      if (excludedPathPrefixes.some(prefix => path.startsWith(prefix))) {
+        continue;
+      }
+
+      const filteredPathItem: PathsObject[string] = {} as PathsObject[string];
+      let hasOperations = false;
+
+      for (const [key, value] of Object.entries(pathItem)) {
+        const lowerKey = key.toLowerCase();
+
+        if (!httpMethods.has(lowerKey)) {
+          (filteredPathItem as Record<string, unknown>)[key] = value;
+          extractSchemaRefs(value);
+          continue;
+        }
+
+        const operation = value as { tags?: string[] };
+        if (operation?.tags && operation.tags.some(tag => excludedTags.includes(tag))) {
+          continue;
+        }
+
+        (filteredPathItem as Record<string, unknown>)[key] = value;
+        extractSchemaRefs(value);
+        hasOperations = true;
+      }
+
+      if (hasOperations) {
+        filteredPaths[path] = filteredPathItem;
+      }
+    }
+
+    return { filteredPaths, usedSchemaRefs };
+  }
+
+  /**
+   * Filters schemas to only include those referenced by the provided schema references set.
+   * Also extracts nested schema references (if SchemaA references SchemaB, includes SchemaB).
+   *
+   * @param schemas - All available schemas from external OpenAPI spec
+   * @param usedSchemaRefs - Set of schema names that are referenced by filtered routes
+   * @returns Filtered schemas object containing only referenced schemas
+   */
+  #filterSchemasByReferences(schemas: ComponentsObject["schemas"], usedSchemaRefs: Set<string>): ComponentsObject["schemas"] {
+    if (!schemas) {
+      return {};
+    }
+
+    const visitedSchemas = new Set<string>();
+    const extractNestedSchemaRefs = (obj: unknown): void => {
+      if (!obj || typeof obj !== "object") {
+        return;
+      }
+
+      if (Array.isArray(obj)) {
+        obj.forEach(item => extractNestedSchemaRefs(item));
+        return;
+      }
+
+      const objWithRef = obj as ReferenceObject | { $ref?: string };
+      if (objWithRef.$ref && typeof objWithRef.$ref === "string" && objWithRef.$ref.startsWith("#/components/schemas/")) {
+        const schemaName = objWithRef.$ref.replace("#/components/schemas/", "");
+        if (!visitedSchemas.has(schemaName) && schemas[schemaName]) {
+          visitedSchemas.add(schemaName);
+          usedSchemaRefs.add(schemaName);
+          extractNestedSchemaRefs(schemas[schemaName]);
+        }
+      }
+
+      Object.values(obj).forEach(value => extractNestedSchemaRefs(value));
+    };
+
+    const initialRefs = Array.from(usedSchemaRefs);
+    for (const schemaName of initialRefs) {
+      if (!visitedSchemas.has(schemaName)) {
+        visitedSchemas.add(schemaName);
+        const schema = schemas?.[schemaName];
+        if (schema) {
+          extractNestedSchemaRefs(schema);
+        }
+      }
+    }
+
+    const filteredSchemas: ComponentsObject["schemas"] = {};
+    for (const [schemaName, schema] of Object.entries(schemas)) {
+      if (usedSchemaRefs.has(schemaName)) {
+        filteredSchemas[schemaName] = schema;
+      }
+    }
+
+    return filteredSchemas;
   }
 }

--- a/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
+++ b/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
@@ -22,7 +22,7 @@ export class OpenApiDocsService {
     this.#serverOrigin = coreConfig.SERVER_ORIGIN;
   }
 
-  async generateDocs(handlers: OpenApiHonoHandler[]) {
+  async generateDocs(handlers: OpenApiHonoHandler[], options: { scope: string }) {
     const version = "v1";
     const docs = {
       openapi: "3.0.0",
@@ -71,27 +71,29 @@ export class OpenApiDocsService {
       }
     }
 
-    const externalDocs = await this.#loadExternalNotificationsSpec();
-    if (externalDocs?.paths) {
-      const { filteredPaths, usedSchemaRefs } = this.#filterPrivateRoutes(externalDocs.paths);
-      Object.assign(docs.paths, filteredPaths);
+    if (options.scope === "full") {
+      const externalDocs = await this.#loadExternalNotificationsSpec();
+      if (externalDocs?.paths) {
+        const { filteredPaths, usedSchemaRefs } = this.#filterPrivateRoutes(externalDocs.paths);
+        Object.assign(docs.paths, filteredPaths);
 
-      if (externalDocs?.components?.schemas) {
-        const filteredSchemas = this.#filterSchemasByReferences(externalDocs.components.schemas, usedSchemaRefs);
+        if (externalDocs?.components?.schemas) {
+          const filteredSchemas = this.#filterSchemasByReferences(externalDocs.components.schemas, usedSchemaRefs);
 
-        docs.components.schemas = {
-          ...docs.components.schemas,
-          ...filteredSchemas
-        };
-        docs.components.securitySchemes = {
-          ...docs.components.securitySchemes,
-          ...(externalDocs.components.securitySchemes || {})
-        };
-      } else if (externalDocs?.components) {
-        docs.components.securitySchemes = {
-          ...docs.components.securitySchemes,
-          ...(externalDocs.components.securitySchemes || {})
-        };
+          docs.components.schemas = {
+            ...docs.components.schemas,
+            ...filteredSchemas
+          };
+          docs.components.securitySchemes = {
+            ...docs.components.securitySchemes,
+            ...(externalDocs.components.securitySchemes || {})
+          };
+        } else if (externalDocs?.components) {
+          docs.components.securitySchemes = {
+            ...docs.components.securitySchemes,
+            ...(externalDocs.components.securitySchemes || {})
+          };
+        }
       }
     }
 

--- a/apps/api/src/rest-app.ts
+++ b/apps/api/src/rest-app.ts
@@ -176,8 +176,8 @@ appHono.get("/status", c => {
   return c.json({ version, memory });
 });
 
-appHono.get("/v1/doc", c => {
-  return c.json(container.resolve(OpenApiDocsService).generateDocs(openApiHonoHandlers));
+appHono.get("/v1/doc", async c => {
+  return c.json(await container.resolve(OpenApiDocsService).generateDocs(openApiHonoHandlers));
 });
 appHono.get("/v1/swagger", swaggerUI({ url: "/v1/doc" }));
 

--- a/apps/api/src/rest-app.ts
+++ b/apps/api/src/rest-app.ts
@@ -6,6 +6,7 @@ import { otel } from "@hono/otel";
 import { swaggerUI } from "@hono/swagger-ui";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import assert from "http-assert";
 import { container } from "tsyringe";
 
 import packageJson from "../package.json";
@@ -177,7 +178,9 @@ appHono.get("/status", c => {
 });
 
 appHono.get("/v1/doc", async c => {
-  return c.json(await container.resolve(OpenApiDocsService).generateDocs(openApiHonoHandlers));
+  const scope = c.req.query("scope") || "full";
+  assert(["full", "console"].includes(scope), 403, '"scope" query is invalid. Valid options: "full", "api"');
+  return c.json(await container.resolve(OpenApiDocsService).generateDocs(openApiHonoHandlers, { scope }));
 });
 appHono.get("/v1/swagger", swaggerUI({ url: "/v1/doc" }));
 

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
 {
   "components": {
+    "schemas": {},
     "securitySchemes": {
       "ApiKeyAuth": {
         "description": "API key for programmatic access.",

--- a/apps/api/test/functional/docs.spec.ts
+++ b/apps/api/test/functional/docs.spec.ts
@@ -6,7 +6,7 @@ describe("API Docs", () => {
       jest.useFakeTimers();
       jest.setSystemTime(new Date("2025-07-03T12:00:00.000Z"));
 
-      const response = await app.request(`/v1/doc`);
+      const response = await app.request(`/v1/doc?scope=console`);
 
       expect(response.status).toBe(200);
       const data = await response.json();

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,6 +147,7 @@
         "nock": "^13.5.4",
         "nodemon": "^2.0.7",
         "nodemon-webpack-plugin": "^4.8.2",
+        "openapi3-ts": "^4.5.0",
         "prettier": "^3.3.0",
         "prettier-plugin-tailwindcss": "^0.6.1",
         "supertest": "^6.1.5",
@@ -47007,22 +47008,27 @@
       }
     },
     "node_modules/openapi3-ts": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.4.0.tgz",
-      "integrity": "sha512-9asTNB9IkKEzWMcHmVZE7Ts3kC9G7AFHfs8i7caD8HbI76gEjdkId4z/AkP83xdZsH7PLAnnbl47qZkXuxpArw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.5.0.tgz",
+      "integrity": "sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==",
+      "license": "MIT",
       "dependencies": {
-        "yaml": "^2.5.0"
+        "yaml": "^2.8.0"
       }
     },
     "node_modules/openapi3-ts/node_modules/yaml": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
-      "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/opener": {


### PR DESCRIPTION
<img width="1504" height="921" alt="image" src="https://github.com/user-attachments/assets/1cc7894f-48e8-4356-a72f-b58eab982cab" />
<img width="1531" height="1318" alt="image" src="https://github.com/user-attachments/assets/d3042f86-3a24-4237-87f2-c8acbe27cd34" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API docs can now include and merge external notification service OpenAPI specs for more complete documentation.
  * Docs endpoint accepts a new "scope" query parameter (e.g., "console") and validates it before returning scoped docs.

* **Chores**
  * Added caching and filtering to avoid duplicate external fetches and to remove private/internal routes and unused schemas.
  * Added OpenAPI type support dependency; tests updated to request the scoped docs endpoint.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->