### PR TITLE
fix: adds JSON headers to http client used by session service

### DIFF
--- a/apps/deploy-web/src/services/app-di-container/server-di-container.service.ts
+++ b/apps/deploy-web/src/services/app-di-container/server-di-container.service.ts
@@ -37,7 +37,11 @@ export const services = createChildContainer(rootContainer, {
       services.externalApiHttpClient,
       services.applyAxiosInterceptors(
         services.createAxios({
-          baseURL: services.apiUrlService.getBaseApiUrlFor(services.config.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID)
+          baseURL: services.apiUrlService.getBaseApiUrlFor(services.config.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID),
+          headers: {
+            "Content-Type": "application/json; charset=utf-8",
+            Accept: "application/json"
+          }
         })
       ),
       {

--- a/apps/deploy-web/src/services/session/session.service.spec.ts
+++ b/apps/deploy-web/src/services/session/session.service.spec.ts
@@ -97,7 +97,8 @@ describe(SessionService.name, () => {
 
       externalHttpClient.post.mockResolvedValueOnce({
         status: 401,
-        data: { error_description: "Invalid credentials" }
+        data: { error_description: "Invalid credentials" },
+        headers: {}
       });
 
       const result = await service.signIn({ email: "user@example.com", password: "wrong-password" });
@@ -135,7 +136,8 @@ describe(SessionService.name, () => {
           code: "invalid_password",
           policy: "Password must contain at least 8 characters",
           message: "Password is too weak"
-        }
+        },
+        headers: {}
       });
 
       const result = await service.signUp({ email: "user@example.com", password: "weak" });
@@ -171,7 +173,8 @@ describe(SessionService.name, () => {
         status: 409,
         data: {
           description: "User already exists"
-        }
+        },
+        headers: {}
       });
 
       const result = await service.signUp({ email: "user@example.com", password: "Password123!" });

--- a/apps/deploy-web/src/services/session/session.service.ts
+++ b/apps/deploy-web/src/services/session/session.service.ts
@@ -259,6 +259,10 @@ function extractResponseDetails(response: AxiosResponse) {
     url: response.config?.url,
     method: response.config?.method,
     status: response.status,
-    data: response.data
+    data: response.data,
+    headers: {
+      "Content-Type": response.headers["content-type"],
+      server: response.headers["server"]
+    }
   };
 }


### PR DESCRIPTION
## Why

For some reason on beta auth0 returns 403 with HTML page in response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * HTTP requests now include explicit content-type and accept headers to improve API compatibility and reliability.
  * Response handling now surfaces response header details alongside returned data for clearer diagnostics.

* **Tests**
  * Unit tests updated to reflect the presence of response headers in mocked HTTP responses, ensuring test shapes match runtime behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->