### PR TITLE
test: fixes deploy from template links test

### DIFF
--- a/apps/deploy-web/tests/ui/deploy-from-a-template.spec.ts
+++ b/apps/deploy-web/tests/ui/deploy-from-a-template.spec.ts
@@ -5,18 +5,21 @@ test("user can choose a template from the templates page", async ({ page, contex
   const templateListPage = new DeployBasePage(context, page, "new-deployment");
   await templateListPage.goto();
 
-  const templateList = page.locator('[aria-label="Template list"]');
+  const templateList = page.getByLabel("Template list");
 
   await expect(templateList).toBeVisible();
 
   const templateLinks = templateList.getByRole("link");
+  await expect(templateLinks.nth(0)).toBeVisible({ timeout: 15_000 });
+
   const templateCount = await templateLinks.count();
-  expect(templateCount).toBeGreaterThan(0);
 
   for (let i = 0; i < templateCount; i++) {
-    const [newPage] = await Promise.all([context.waitForEvent("page"), templateLinks.nth(i).click({ modifiers: ["Shift"] })]);
+    const link = templateLinks.nth(i);
+    const [newPage] = await Promise.all([context.waitForEvent("page"), link.click({ modifiers: ["Shift"] })]);
 
-    await expect(newPage).toHaveURL(/\/new-deployment\?step=edit-deployment&templateId=.*/);
+    const templateName = await newPage.getByLabel(/Name your deployment/i).inputValue();
+    await expect(link).toContainText(templateName);
     await newPage.close();
   }
 });


### PR DESCRIPTION
## Why

Because after redesign it's broken

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved template deployment test suite: switched to label-based element queries, added explicit visibility waits (15s) for template links, store link elements before interacting, replaced URL assertions with content-based verification of template names, and maintain closing newly opened pages for each iteration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->