### PR TITLE
fix: ensure we do not send otel to 3rd party origins in browser

### DIFF
--- a/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
+++ b/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
@@ -75,7 +75,7 @@ function createAppContainer<T extends Factories>(settingsState: SettingsContextT
               });
             return inflightPingRequest.then(result => {
               if (!result.isBlockchainDown) {
-                // if blockchain is available, then we have an issue wit some endpoint
+                // if blockchain is available, then we have an issue with some endpoint
                 // and want the original request to fail and NOT fallback to fallbackChainApiHttpClient
                 return Promise.reject(error);
               }


### PR DESCRIPTION
## Why

Right now blockchain nodes do not allow Traceparent and Baggage headers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented trace headers from being attached to cross-origin browser requests, avoiding unnecessary header transmission across different domains.

* **Chores**
  * Corrected a comment typo in the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->