### PR TITLE
chore(dx): ensures DEPLOYMENT_ENV is loaded when it's an empty string

### DIFF
--- a/packages/env-loader/src/index.js
+++ b/packages/env-loader/src/index.js
@@ -26,9 +26,14 @@ const config = path => {
   }
 };
 
+if (process.env.DEPLOYMENT_ENV === "") {
+  delete process.env.DEPLOYMENT_ENV;
+}
+
 if (!process.env.DEPLOYMENT_ENV) {
   config("../../.env.local");
 }
+
 config(`env/.env.${process.env.DEPLOYMENT_ENV || "local"}`);
 config(`env/.env.${process.env.NETWORK}`);
 config("env/.env");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Treats an empty DEPLOYMENT_ENV value as unset so local environment is selected correctly.
  * Ensures local environment file from the parent directory is loaded before environment-specific files.
  * Continues loading environment-specific and default env files in the existing order to preserve compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->