### PR TITLE
fix: ensure templates fallback to stale cache in case GH_TOKEN expired

### DIFF
--- a/apps/api/src/services/external/templates/template-fetcher.service.ts
+++ b/apps/api/src/services/external/templates/template-fetcher.service.ts
@@ -71,14 +71,10 @@ export class TemplateFetcherService {
     this.setGithubRequestsRemaining(response.headers["x-ratelimit-remaining"]);
 
     if (response.status !== 200) {
-      throw new Error(`Failed to fetch latest version of ${repoOwner}/${repoName} from github`);
+      throw new Error(`Failed to fetch latest version of ${repoOwner}/${repoName} from github`, { cause: response });
     }
 
-    return {
-      repoOwner,
-      repoName,
-      repoVersion: response.data.commit.sha
-    };
+    return response.data.commit.sha;
   }
 
   private async fetchFileContent(owner: string, repo: string, path: string, ref: string): Promise<string> {


### PR DESCRIPTION
## Why

Useful for templates resilience and for local development

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling: errors now include richer response details for easier diagnosis.
  * More resilient caching: falls back to existing cache files when remote metadata is unavailable.

* **Refactor**
  * Cache naming and lookup now use repository identifiers with commit SHA suffixes for consistent cache paths.
  * Simplified fetching and generation flow with clearer diagnostic logging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->