### PR TITLE
fix: set "User-Agent" header only in server env

### DIFF
--- a/apps/deploy-web/src/services/app-di-container/app-di-container.ts
+++ b/apps/deploy-web/src/services/app-di-container/app-di-container.ts
@@ -110,14 +110,19 @@ export const createAppRootContainer = (config: ServicesConfig) => {
       container.applyAxiosInterceptors(new ApiKeyHttpService(apiConfig), {
         request: [withUserToken]
       }),
-    externalApiHttpClient: () =>
-      container.createAxios({
-        headers: {
-          "Content-Type": "application/json",
-          Accept: "application/json",
-          "User-Agent": "AkashConsole/1.0 (https://console.akash.network)"
-        }
-      }),
+    externalApiHttpClient: () => {
+      const headers: Record<string, string> = {
+        Accept: "application/json",
+        "Content-Type": "application/json"
+      };
+      if (config.runtimeEnv === "nodejs") {
+        headers["User-Agent"] = "AkashConsole/1.0 (https://console.akash.network)";
+      }
+
+      return container.createAxios({
+        headers
+      });
+    },
     createAxios:
       () =>
       (options?: CreateAxiosDefaults): AxiosInstance =>


### PR DESCRIPTION
## Why

It seems that custom User-Agent header fail the request to chain rpc /status inside service worker in Firefox

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * HTTP client now sets headers conditionally based on runtime environment, ensuring the right header set is used in browser vs server contexts for improved compatibility and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->