### PR TITLE
fix: adds handling of 422 error on manifest creation in deploy-web

### DIFF
--- a/apps/deploy-web/src/components/deployments/LeaseRow.tsx
+++ b/apps/deploy-web/src/components/deployments/LeaseRow.tsx
@@ -31,7 +31,7 @@ import { getGpusFromAttributes } from "@src/utils/deploymentUtils";
 import { udenomToDenom } from "@src/utils/mathHelpers";
 import { sshVmImages } from "@src/utils/sdl/data";
 import { CopyTextToClipboardButton } from "../shared/CopyTextToClipboardButton";
-import { ManifestErrorSnackbar } from "../shared/ManifestErrorSnackbar";
+import { ManifestErrorSnackbar } from "../shared/ManifestErrorSnackbar/ManifestErrorSnackbar";
 import { ProviderName } from "../shared/ProviderName";
 
 type Props = {

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate.tsx
@@ -19,7 +19,7 @@ import type { ApiProviderList } from "@src/types/provider";
 import { deploymentData } from "@src/utils/deploymentData";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
 import RemoteDeployUpdate from "../remote-deploy/update/RemoteDeployUpdate";
-import { ManifestErrorSnackbar } from "../shared/ManifestErrorSnackbar";
+import { ManifestErrorSnackbar } from "../shared/ManifestErrorSnackbar/ManifestErrorSnackbar";
 import { Title } from "../shared/Title";
 import { CreateCredentialsButton } from "./CreateCredentialsButton/CreateCredentialsButton";
 

--- a/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
@@ -56,7 +56,7 @@ import { useLocalNotes } from "../../../context/LocalNoteProvider";
 import { CustomDropdownLinkItem } from "../../shared/CustomDropdownLinkItem";
 import { CustomNextSeo } from "../../shared/CustomNextSeo";
 import { LinearLoadingSkeleton } from "../../shared/LinearLoadingSkeleton";
-import { ManifestErrorSnackbar } from "../../shared/ManifestErrorSnackbar";
+import { ManifestErrorSnackbar } from "../../shared/ManifestErrorSnackbar/ManifestErrorSnackbar";
 import ViewPanel from "../../shared/ViewPanel";
 import { BidCountdownTimer } from "../BidCountdownTimer";
 import { BidGroup } from "../BidGroup";

--- a/apps/deploy-web/src/components/shared/ManifestErrorSnackbar/ManifestErrorSnackbar.spec.tsx
+++ b/apps/deploy-web/src/components/shared/ManifestErrorSnackbar/ManifestErrorSnackbar.spec.tsx
@@ -1,0 +1,167 @@
+import { AxiosError, AxiosHeaders } from "axios";
+
+import { ManifestErrorSnackbar } from "./ManifestErrorSnackbar";
+
+import { render, screen } from "@testing-library/react";
+
+describe(ManifestErrorSnackbar.name, () => {
+  it("renders 401 error message when certificate is missing", () => {
+    const err = createAxiosError(401);
+    setup({ err });
+
+    expect(screen.queryByText(/You don't have local certificate/)).toBeInTheDocument();
+  });
+
+  it("renders default error message for 400 error without issues", () => {
+    const err = createAxiosError(400, { error: {} });
+    setup({ err });
+
+    expect(screen.queryByText(/Something went wrong/)).toBeInTheDocument();
+  });
+
+  it("renders expired certificate error for 400 with expired cert issue", () => {
+    const err = createAxiosError(400, {
+      error: {
+        issues: [{ path: ["certPem"], params: { reason: "expired" } }]
+      }
+    });
+    setup({ err });
+
+    expect(screen.queryByText(/Your certificate has expired/)).toBeInTheDocument();
+  });
+
+  it("renders missing cert pair error for 400 with missingCertPair issue", () => {
+    const err = createAxiosError(400, {
+      error: {
+        issues: [{ path: ["certPem"], params: { reason: "missingCertPair" } }]
+      }
+    });
+    setup({ err });
+
+    expect(screen.queryByText(/Please provide both public and private key/)).toBeInTheDocument();
+  });
+
+  it("renders invalid certificate error for 400 with invalid cert issue", () => {
+    const err = createAxiosError(400, {
+      error: {
+        issues: [{ path: ["certPem"], params: { reason: "invalid" } }]
+      }
+    });
+    setup({ err });
+
+    expect(screen.queryByText(/Provider rejected your certificate/)).toBeInTheDocument();
+  });
+
+  it("renders custom error message when provided in messages prop", () => {
+    const err = createAxiosError(400, {
+      error: {
+        issues: [{ path: ["custom", "path"], params: { reason: "customReason" } }]
+      }
+    });
+    const messages = { "custom.path.customReason": "Custom error message" };
+    setup({ err, messages });
+
+    expect(screen.queryByText(/Custom error message/)).toBeInTheDocument();
+  });
+
+  it("renders default error message for unknown 400 issue", () => {
+    const err = createAxiosError(400, {
+      error: {
+        issues: [{ path: ["unknown"], params: { reason: "unknownReason" } }]
+      }
+    });
+    setup({ err });
+
+    expect(screen.queryByText(/Something went wrong/)).toBeInTheDocument();
+  });
+
+  it("renders unique errors only for multiple identical issues", () => {
+    const err = createAxiosError(400, {
+      error: {
+        issues: [
+          { path: ["certPem"], params: { reason: "expired" } },
+          { path: ["certPem"], params: { reason: "expired" } }
+        ]
+      }
+    });
+    const { container } = setup({ err });
+
+    const matches = container.textContent?.match(/Your certificate has expired/g);
+    expect(matches).toHaveLength(1);
+  });
+
+  it("renders multiple different errors for 400 with multiple issues", () => {
+    const err = createAxiosError(400, {
+      error: {
+        issues: [
+          { path: ["certPem"], params: { reason: "expired" } },
+          { path: ["certPem"], params: { reason: "invalid" } }
+        ]
+      }
+    });
+    setup({ err });
+
+    expect(screen.queryByText(/Your certificate has expired/)).toBeInTheDocument();
+    expect(screen.queryByText(/Provider rejected your certificate/)).toBeInTheDocument();
+  });
+
+  it("renders string response data for 422 error", () => {
+    const err = createAxiosError(422, "Provider returned an error");
+    setup({ err });
+
+    expect(screen.queryByText(/Provider returned an error/)).toBeInTheDocument();
+  });
+
+  it("renders message from response data object for 422 error", () => {
+    const err = createAxiosError(422, { message: "Manifest validation failed" });
+    setup({ err });
+
+    expect(screen.queryByText(/Manifest validation failed/)).toBeInTheDocument();
+  });
+
+  it("renders JSON stringified response for 422 error without message", () => {
+    const err = createAxiosError(422, { code: "INVALID_MANIFEST" });
+    setup({ err });
+
+    expect(screen.queryByText(/INVALID_MANIFEST/)).toBeInTheDocument();
+  });
+
+  it("renders raw error for non-HTTP errors", () => {
+    const err = "Some raw error";
+    setup({ err });
+
+    expect(screen.queryByText(/Some raw error/)).toBeInTheDocument();
+  });
+
+  it("renders error title", () => {
+    setup({ err: "test" });
+
+    expect(screen.queryByText("Error")).toBeInTheDocument();
+  });
+
+  it("renders error prefix in subtitle", () => {
+    setup({ err: "test" });
+
+    expect(screen.queryByText(/Error while sending manifest to provider/)).toBeInTheDocument();
+  });
+
+  function setup(input: TestInput) {
+    return render(<ManifestErrorSnackbar err={input.err} messages={input.messages} />);
+  }
+
+  interface TestInput {
+    err: unknown;
+    messages?: Record<string, string>;
+  }
+});
+
+function createAxiosError<T>(status: number, data?: T): AxiosError<T> {
+  const error = new AxiosError<T>("Request failed", AxiosError.ERR_BAD_REQUEST, undefined, undefined, {
+    status,
+    statusText: "Error",
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+    data: data as T
+  });
+  return error;
+}

--- a/apps/deploy-web/src/components/shared/ManifestErrorSnackbar/ManifestErrorSnackbar.tsx
+++ b/apps/deploy-web/src/components/shared/ManifestErrorSnackbar/ManifestErrorSnackbar.tsx
@@ -1,5 +1,5 @@
+import { isHttpError } from "@akashnetwork/http-sdk";
 import { Snackbar } from "@akashnetwork/ui/components";
-import { isAxiosError } from "axios";
 
 export type ManifestErrorSnackbarProps = {
   err: unknown;
@@ -11,11 +11,11 @@ export const ManifestErrorSnackbar = ({ err, messages }: ManifestErrorSnackbarPr
 };
 
 function generateErrorText(err: unknown, customMessages?: Record<string, string>) {
-  if (isAxiosError(err) && err.response?.status === 401) {
+  if (isHttpError(err) && err.response?.status === 401) {
     return `You don't have local certificate. Please create a new one.`;
   }
 
-  if (isAxiosError(err) && err.response?.status === 400) {
+  if (isHttpError(err) && err.response?.status === 400) {
     if (!err.response.data?.error?.issues) return DEFAULT_ERROR_MESSAGE;
 
     const errors = new Set<string>();
@@ -29,6 +29,11 @@ function generateErrorText(err: unknown, customMessages?: Record<string, string>
       }
     });
     return Array.from(errors).join("\n ");
+  }
+
+  if (isHttpError(err) && err.response?.status === 422) {
+    // raw error message from provider. It returns error in text/plain format.
+    return typeof err.response.data === "string" ? err.response.data : err.response.data.message || JSON.stringify(err.response.data);
   }
 
   return err;

--- a/apps/deploy-web/src/services/error-handler/error-handler.service.spec.ts
+++ b/apps/deploy-web/src/services/error-handler/error-handler.service.spec.ts
@@ -16,6 +16,7 @@ describe(ErrorHandlerService.name, () => {
 
     expect(captureException).toHaveBeenCalledWith(error, {
       extra: { message: "test message" },
+      level: "error",
       tags: { category: "test", event: "TEST_ERROR" }
     });
     expect(logger.error).toHaveBeenCalledWith({ error, category: "test", event: "TEST_ERROR", message: "test message" });
@@ -49,6 +50,7 @@ describe(ErrorHandlerService.name, () => {
     errorHandler.reportError({ error: httpError });
 
     expect(captureException).toHaveBeenCalledWith(httpError, {
+      level: "error",
       extra: {
         headers: {
           "content-type": "application/json",
@@ -128,6 +130,7 @@ describe(ErrorHandlerService.name, () => {
       expect(result).toBe("fallback");
       expect(captureException).toHaveBeenCalledWith(error, {
         extra: {},
+        level: "error",
         tags: { category: "test" }
       });
     });
@@ -151,6 +154,7 @@ describe(ErrorHandlerService.name, () => {
       expect(result).toBe("fallback");
       expect(captureException).toHaveBeenCalledWith(error, {
         extra: {},
+        level: "error",
         tags: { category: "test" }
       });
     });

--- a/apps/deploy-web/src/services/error-handler/error-handler.service.ts
+++ b/apps/deploy-web/src/services/error-handler/error-handler.service.ts
@@ -32,7 +32,7 @@ export class ErrorHandlerService {
 
     this.logger.error({ ...extra, ...finalTags, error });
     this.captureException(error, {
-      level: severity,
+      level: severity || "error",
       extra,
       tags: finalTags
     });


### PR DESCRIPTION
## Why

To show meaningful error to the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and unified HTTP error message handling (including additional status formats and provider-specific details) for clearer in-app error displays.
  * Ensured error reporting always includes a sensible default logging level for consistent diagnostics.

* **Tests**
  * Added comprehensive tests covering varied HTTP error formats, deduplication, aggregation, and custom message overrides.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->