### PR TITLE
fix: converts sentry-trace to w3c traceparent before sending to our APIs

### DIFF
--- a/apps/deploy-web/src/lib/nextjs/pages/api/proxy/path.spec.ts
+++ b/apps/deploy-web/src/lib/nextjs/pages/api/proxy/path.spec.ts
@@ -55,7 +55,11 @@ describe("proxy API handler", () => {
     const req = mock<NextApiRequest>({
       method: "GET",
       url: input.url,
-      headers: input.headers,
+      headers: {
+        "sentry-trace": "",
+        traceparent: "",
+        ...input.headers
+      },
       socket: {
         remoteAddress: "127.0.0.1",
         ...input.socket

--- a/apps/deploy-web/src/pages/api/proxy/[...path].ts
+++ b/apps/deploy-web/src/pages/api/proxy/[...path].ts
@@ -1,4 +1,5 @@
 import { defineApiHandler } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
+import { sentryTraceToW3C } from "@src/services/error-handler/error-handler.service";
 
 export default defineApiHandler({
   route: "/api/proxy/[...path]",
@@ -21,16 +22,26 @@ export default defineApiHandler({
       req.headers.authorization = `Bearer ${session.accessToken}`;
     }
 
+    const headers: Record<string, string> = {
+      "cf-connecting-ip": String(req.headers["cf-connecting-ip"] || req.socket.remoteAddress || "")
+    };
+    if (req.headers["sentry-trace"]) {
+      const traceparent = sentryTraceToW3C(req.headers["sentry-trace"] as string);
+      if (traceparent) headers["traceparent"] = traceparent;
+    } else if (req.headers["traceparent"]) {
+      headers["traceparent"] = req.headers["traceparent"] as string;
+    }
+
+    if (req.headers["baggage"]) {
+      headers["baggage"] = req.headers["baggage"] as string;
+    }
+
     const proxy = services.httpProxy.createProxyServer({
       changeOrigin: true,
       target: services.apiUrlService.getBaseApiUrlFor(services.config.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID),
       secure: false,
       autoRewrite: false,
-      headers: {
-        "cf-connecting-ip": String(req.headers["cf-connecting-ip"] || req.socket.remoteAddress || ""),
-        traceparent: String(req.headers["sentry-trace"] || req.headers["traceparent"] || ""),
-        baggage: String(req.headers["baggage"] || "")
-      }
+      headers
     });
 
     return new Promise((resolve, reject) => {

--- a/apps/deploy-web/src/services/error-handler/error-handler.service.ts
+++ b/apps/deploy-web/src/services/error-handler/error-handler.service.ts
@@ -11,8 +11,11 @@ export class ErrorHandlerService {
 
   getTraceData(): TraceData {
     const data = getTraceData();
+    const traceId = data["sentry-trace"];
+
     return {
-      traceId: data["sentry-trace"],
+      traceId,
+      traceIdW3C: sentryTraceToW3C(traceId),
       baggage: data.baggage
     };
   }
@@ -70,5 +73,24 @@ export interface WrapCallbackOptions<TValue> {
 
 export interface TraceData {
   traceId?: string;
+  traceIdW3C?: string;
   baggage?: string;
+}
+
+/**
+ * Converts Sentry `sentry-trace` header value into a valid W3C `traceparent`.
+ *
+ * Sentry: `<traceId>-<spanId>-<sampled>` where sampled is `0|1` (optional).
+ * W3C:    `00-<traceId>-<parentSpanId>-<flags>` where flags is 2 hex chars (`00|01`).
+ */
+export function sentryTraceToW3C(sentryTrace?: string): string | undefined {
+  const value = sentryTrace?.trim();
+  if (!value) return;
+
+  const [traceId, spanId, sampled] = value.split("-", 3);
+  // W3C spec disallows all-zero ids
+  if (!traceId || !spanId || Number(traceId) === 0 || Number(spanId) === 0) return;
+
+  const flags = Number(sampled) === 1 ? "01" : "00";
+  return `00-${traceId}-${spanId}-${flags}`;
 }


### PR DESCRIPTION
## Why

To improve observability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced request tracing: proxy now forwards client IP, baggage, and normalized trace headers for better cross-service correlation.
  * Added support for converting older trace formats to W3C-style trace headers, improving compatibility across tracing systems.
  * Consistent header casing and propagation to preserve trace context end-to-end.

* **Tests**
  * Added coverage verifying trace format conversion and header propagation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->