### PR TITLE
fix: removes allowUrls because it excludes valid relative urls

### DIFF
--- a/apps/deploy-web/sentry.client.config.ts
+++ b/apps/deploy-web/sentry.client.config.ts
@@ -14,7 +14,6 @@ initSentry({
   tracePropagationTargets: [/^\/api\//],
   integrations: [
     eventFiltersIntegration({
-      allowUrls: [/https?:\/\/[^.]+\.akash\.network/],
       denyUrls: [/^chrome-extension:\/\//]
     }),
     thirdPartyErrorFilterIntegration({


### PR DESCRIPTION
## Why

Right now when sentry decides whether to report error or not it checks the exception URL and in case url starts with `/` it rejects it because of our configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified error tracking event URL filtering configuration to remove the explicit URL allowlist, while retaining filtering for blocked schemes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->