### PR TITLE
fix: propagate sentry-trace to SSR requests in deploy-web

### DIFF
--- a/apps/deploy-web/sentry.client.config.ts
+++ b/apps/deploy-web/sentry.client.config.ts
@@ -11,7 +11,7 @@ initSentry({
   enabled: process.env.NEXT_PUBLIC_SENTRY_ENABLED === "true",
   // propagate sentry-trace and baggage headers to internal API only
   // everything else will be done with custom interceptor
-  tracePropagationTargets: [/^\/api\//],
+  tracePropagationTargets: [/^\/api\//, /^\/_next\//],
   integrations: [
     eventFiltersIntegration({
       denyUrls: [/^chrome-extension:\/\//]


### PR DESCRIPTION
## Why

To ensure we have trace on SSR requests like FE -> SSR BE -> console API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error tracking configuration to extend monitoring coverage for Next.js internal resources, ensuring more comprehensive diagnostic data collection across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->