### PR TITLE
refactor: moves analyticsService creation to DI container

### DIFF
--- a/apps/deploy-web/src/components/api-keys/CreateApiKeyModal.tsx
+++ b/apps/deploy-web/src/components/api-keys/CreateApiKeyModal.tsx
@@ -7,8 +7,8 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useSnackbar } from "notistack";
 import { z } from "zod";
 
+import { useServices } from "@src/context/ServicesProvider";
 import { useCreateApiKey } from "@src/queries";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 
 interface Props {
   isOpen: boolean;
@@ -27,6 +27,7 @@ const formSchema = z.object({
 });
 
 export const CreateApiKeyModal = ({ isOpen, onClose }: Props) => {
+  const { analyticsService } = useServices();
   const { enqueueSnackbar } = useSnackbar();
   const { mutate: createApiKey, data: createdApiKey, isPending } = useCreateApiKey();
   const formRef = useRef<HTMLFormElement | null>(null);

--- a/apps/deploy-web/src/components/authorizations/AllowanceModal.tsx
+++ b/apps/deploy-web/src/components/authorizations/AllowanceModal.tsx
@@ -10,9 +10,9 @@ import { z } from "zod";
 
 import { LinkTo } from "@src/components/shared/LinkTo";
 import { UAKT_DENOM } from "@src/config/denom.config";
+import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useDenomData } from "@src/hooks/useWalletBalance";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 import type { AllowanceType } from "@src/types/grant";
 import { aktToUakt, coinToDenom } from "@src/utils/priceUtils";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
@@ -32,6 +32,7 @@ const formSchema = z.object({
 });
 
 export const AllowanceModal: React.FunctionComponent<Props> = ({ editingAllowance, address, onClose }) => {
+  const { analyticsService } = useServices();
   const formRef = useRef<HTMLFormElement>(null);
   const [error, setError] = useState("");
   const { signAndBroadcastTx } = useWallet();

--- a/apps/deploy-web/src/components/authorizations/GrantModal.tsx
+++ b/apps/deploy-web/src/components/authorizations/GrantModal.tsx
@@ -23,10 +23,10 @@ import { z } from "zod";
 
 import { LinkTo } from "@src/components/shared/LinkTo";
 import { UAKT_DENOM } from "@src/config/denom.config";
+import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useUsdcDenom } from "@src/hooks/useDenom";
 import { useDenomData } from "@src/hooks/useWalletBalance";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 import type { GrantType } from "@src/types/grant";
 import { denomToUdenom } from "@src/utils/mathHelpers";
 import { aktToUakt, coinToDenom, getUsdcDenom } from "@src/utils/priceUtils";
@@ -52,6 +52,7 @@ const formSchema = z.object({
 });
 
 export const GrantModal: React.FunctionComponent<Props> = ({ editingGrant, address, onClose }) => {
+  const { analyticsService } = useServices();
   const formRef = useRef<HTMLFormElement>(null);
   const [error, setError] = useState("");
   const { signAndBroadcastTx } = useWallet();

--- a/apps/deploy-web/src/components/deployments/DeploymentDepositModal.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDepositModal.tsx
@@ -9,11 +9,11 @@ import { useRouter } from "next/navigation";
 import { z } from "zod";
 
 import { UAKT_DENOM } from "@src/config/denom.config";
+import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useAddFundsVerifiedLoginRequiredEventHandler } from "@src/hooks/useAddFundsVerifiedLoginRequiredEventHandler";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useDenomData, useWalletBalance } from "@src/hooks/useWalletBalance";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 import type { ServiceType } from "@src/types";
 import { denomToUdenom } from "@src/utils/mathHelpers";
 import { UrlService } from "@src/utils/urlUtils";
@@ -48,6 +48,7 @@ export const DeploymentDepositModal: React.FunctionComponent<DeploymentDepositMo
   infoText = null,
   services = []
 }) => {
+  const { analyticsService } = useServices();
   const formRef = useRef<HTMLFormElement>(null);
   const [error, setError] = useState("");
   const { isManaged } = useWallet();

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar.tsx
@@ -15,6 +15,7 @@ import { useRouter } from "next/navigation";
 import { CustomDropdownLinkItem } from "@src/components/shared/CustomDropdownLinkItem";
 import { browserEnvConfig } from "@src/config/browser-env.config";
 import { useLocalNotes } from "@src/context/LocalNoteProvider";
+import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useCurrencyFormatter } from "@src/hooks/useCurrencyFormatter/useCurrencyFormatter";
 import { useDeploymentMetrics } from "@src/hooks/useDeploymentMetrics";
@@ -23,7 +24,6 @@ import { usePreviousRoute } from "@src/hooks/usePreviousRoute";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useUser } from "@src/hooks/useUser";
 import { useDeploymentSettingQuery } from "@src/queries/deploymentSettingsQuery";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import { averageBlockTime } from "@src/utils/priceUtils";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
@@ -48,6 +48,7 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
   deployment,
   leases
 }) => {
+  const { analyticsService } = useServices();
   const { changeDeploymentName, getDeploymentData, getDeploymentName } = useLocalNotes();
   const { udenomToUsd } = usePricing();
   const router = useRouter();

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -21,6 +21,7 @@ import { CalendarArrowDown, Coins, Edit, MoreHoriz, NavArrowRight, Plus, Upload,
 import { keyBy } from "lodash";
 import { useRouter } from "next/navigation";
 
+import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useFlag } from "@src/hooks/useFlag";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
@@ -28,7 +29,6 @@ import { useProviderCredentials } from "@src/hooks/useProviderCredentials/usePro
 import { useRealTimeLeft } from "@src/hooks/useRealTimeLeft";
 import { useDenomData } from "@src/hooks/useWalletBalance";
 import { useAllLeases, useLeaseStatus } from "@src/queries/useLeaseQuery";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 import type { NamedDeploymentDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { udenomToDenom } from "@src/utils/mathHelpers";
@@ -60,6 +60,7 @@ type Props = {
 
 export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, isSelectable, onSelectDeployment, checked, providers, refreshDeployments }) => {
   const router = useRouter();
+  const { analyticsService } = useServices();
   const [open, setOpen] = useState(false);
   const [isDepositingDeployment, setIsDepositingDeployment] = useState(false);
   const { changeDeploymentName, getDeploymentData } = useLocalNotes();

--- a/apps/deploy-web/src/components/deployments/DeploymentSubHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentSubHeader.tsx
@@ -37,7 +37,7 @@ export const DeploymentSubHeader: React.FunctionComponent<Props> = ({ deployment
   const denomData = useDenomData(deployment.escrowAccount.state.funds[0]?.denom || "");
   const { isCustodial, isTrialing } = useWallet();
   const isAnonymousFreeTrialEnabled = useFlag("anonymous_free_trial");
-  const { appConfig } = useServices();
+  const { publicConfig: appConfig } = useServices();
 
   const trialDuration = appConfig.NEXT_PUBLIC_TRIAL_DEPLOYMENTS_DURATION_HOURS;
   const { timeRemainingText: trialTimeRemaining } = useTrialDeploymentTimeRemaining({

--- a/apps/deploy-web/src/components/deployments/ShellDownloadModal.tsx
+++ b/apps/deploy-web/src/components/deployments/ShellDownloadModal.tsx
@@ -5,8 +5,8 @@ import { Alert, Form, FormField, FormInput, Popup } from "@akashnetwork/ui/compo
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 
+import { useServices } from "@src/context/ServicesProvider";
 import { type ProviderInfo, useProviderApiActions } from "@src/hooks/useProviderApiActions";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 import type { LeaseDto } from "@src/types/deployment";
 
 type Props = {
@@ -30,6 +30,7 @@ const formSchema = z.object({
 type FormData = z.infer<typeof formSchema>;
 
 export const ShellDownloadModal = ({ selectedLease, onCloseClick, selectedService, providerInfo }: Props) => {
+  const { analyticsService } = useServices();
   const formRef = useRef<HTMLFormElement | null>(null);
   const { downloadFileFromShell } = useProviderApiActions();
   const form = useForm<FormData>({

--- a/apps/deploy-web/src/components/liquidity-modal/index.tsx
+++ b/apps/deploy-web/src/components/liquidity-modal/index.tsx
@@ -6,12 +6,13 @@ import { useWallet as useConnectedWallet, useWalletClient } from "@cosmos-kit/re
 // import * as Elements from "@leapwallet/elements-umd-types";
 import { Modal } from "@mui/material";
 
+import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 
 export type NonUndefined<T> = T extends undefined ? never : T;
 
 const ToggleLiquidityModalButton: React.FC<{ onClick: () => void }> = ({ onClick }) => {
+  const { analyticsService } = useServices();
   const _onClick = () => {
     analyticsService.track("leap_get_more_tokens", {
       category: "wallet",
@@ -106,6 +107,7 @@ const getTabsConfig = (txnLifecycleHooks: any) => {
 type Props = { address: string; aktBalance: number; refreshBalances: () => void };
 
 const LiquidityModal: React.FC<Props> = ({ refreshBalances }) => {
+  const { analyticsService } = useServices();
   const [isOpen, setIsOpen] = useState(false);
   const [isElementsReady, setIsElementsReady] = useState(false);
   const isElementsMounted = useRef(false);

--- a/apps/deploy-web/src/components/new-deployment/BidRow/BidRow.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/BidRow/BidRow.spec.tsx
@@ -1,7 +1,9 @@
 import type { RadioGroupItem } from "@akashnetwork/ui/components";
+import { mock } from "jest-mock-extended";
 
 import { LocalNoteProvider } from "@src/context/LocalNoteProvider/LocalNoteContext";
 import { queryClient } from "@src/queries/queryClient";
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import type { ProviderProxyService } from "@src/services/provider-proxy/provider-proxy.service";
 import type { BidDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
@@ -109,7 +111,7 @@ describe(BidRow.name, () => {
         })
       }) as unknown as ProviderProxyService;
     return render(
-      <TestContainerProvider services={{ providerProxy, queryClient: () => queryClient }}>
+      <TestContainerProvider services={{ providerProxy, queryClient: () => queryClient, analyticsService: () => mock<AnalyticsService>() }}>
         <LocalNoteProvider>
           <BidRow
             bid={props?.bid ?? buildDeploymentBid()}

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit.tsx
@@ -72,7 +72,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
   const [sdlDenom, setSdlDenom] = useState("uakt");
   const isAnonymousFreeTrialEnabled = useFlag("anonymous_free_trial");
 
-  const { analyticsService, chainApiHttpClient, appConfig, deploymentLocalStorage } = useServices();
+  const { analyticsService, chainApiHttpClient, publicConfig: appConfig, deploymentLocalStorage } = useServices();
   const { settings } = useSettings();
   const { address, signAndBroadcastTx, isManaged, isTrialing, isOnboarding } = useWallet();
   const router = useRouter();

--- a/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
+++ b/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
@@ -8,9 +8,9 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 import { CI_CD_TEMPLATE_ID } from "@src/config/remote-deploy.config";
+import { useServices } from "@src/context/ServicesProvider";
 import type { TemplateOutputSummaryWithCategory } from "@src/queries/useTemplateQuery";
 import { useTemplates } from "@src/queries/useTemplateQuery";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 import sdlStore from "@src/store/sdlStore";
 import type { TemplateCreation } from "@src/types";
 import { RouteStep } from "@src/types/route-steps.type";
@@ -44,6 +44,7 @@ type Props = {
 };
 
 export const TemplateList: React.FunctionComponent<Props> = ({ onChangeGitProvider, onTemplateSelected, setEditedManifest }) => {
+  const { analyticsService } = useServices();
   const { templates } = useTemplates();
   const router = useRouter();
   const [previewTemplates, setPreviewTemplates] = useState<TemplateOutputSummaryWithCategory[]>([]);

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
@@ -288,7 +288,7 @@ describe("OnboardingContainer", () => {
       authService,
       chainApiHttpClient: mockChainApiHttpClient,
       deploymentLocalStorage: mockDeploymentLocalStorage,
-      appConfig: mockAppConfig,
+      publicConfig: mockAppConfig,
       errorHandler: mockErrorHandler,
       windowLocation,
       windowHistory
@@ -375,8 +375,7 @@ describe("OnboardingContainer", () => {
       validateDeploymentData: mockValidateDeploymentData,
       appendAuditorRequirement: mockAppendAuditorRequirement,
       helloWorldTemplate: mockHelloWorldTemplate,
-      TransactionMessageData: mockTransactionMessageData as unknown as typeof TransactionMessageData,
-      UrlService
+      TransactionMessageData: mockTransactionMessageData as unknown as typeof TransactionMessageData
     };
 
     const mockChildren = jest.fn().mockReturnValue(<div>Test</div>);

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
@@ -21,7 +21,6 @@ import { appendAuditorRequirement } from "@src/utils/deploymentData/v1beta3";
 import { validateDeploymentData } from "@src/utils/deploymentUtils";
 import { helloWorldTemplate } from "@src/utils/templates";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
-import { UrlService } from "@src/utils/urlUtils";
 import { type OnboardingStep } from "../OnboardingStepper/OnboardingStepper";
 
 export enum OnboardingStepIndex {
@@ -61,8 +60,7 @@ const DEPENDENCIES = {
   validateDeploymentData,
   appendAuditorRequirement,
   helloWorldTemplate,
-  TransactionMessageData,
-  UrlService
+  TransactionMessageData
 };
 
 export const OnboardingContainer: React.FunctionComponent<OnboardingContainerProps> = ({ children, dependencies: d = DEPENDENCIES }) => {
@@ -74,7 +72,16 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
   const { user } = d.useUser();
   const { data: paymentMethods = [] } = d.usePaymentMethodsQuery({ enabled: !!user?.stripeCustomerId });
   const { data: depositParams } = d.useDepositParams();
-  const { analyticsService, urlService, chainApiHttpClient, deploymentLocalStorage, appConfig, errorHandler, windowLocation, windowHistory } = d.useServices();
+  const {
+    analyticsService,
+    urlService,
+    chainApiHttpClient,
+    deploymentLocalStorage,
+    publicConfig: appConfig,
+    errorHandler,
+    windowLocation,
+    windowHistory
+  } = d.useServices();
   const { hasManagedWallet, isWalletLoading, connectManagedWallet, address, signAndBroadcastTx } = d.useWallet();
   const { templates } = d.useTemplates();
   const { genNewCertificateIfLocalIsInvalid, updateSelectedCertificate } = d.useCertificate();
@@ -282,7 +289,7 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
 
           d.localStorage?.removeItem(ONBOARDING_STEP_KEY);
           connectManagedWallet();
-          router.push(d.UrlService.newDeployment({ step: RouteStep.createLeases, dseq: dd.deploymentId.dseq }));
+          router.push(urlService.newDeployment({ step: RouteStep.createLeases, dseq: dd.deploymentId.dseq }));
         }
       } catch (error) {
         enqueueSnackbar("Failed to deploy template. Please try again.", { variant: "error" });

--- a/apps/deploy-web/src/components/sdl/ImportSdlModal.tsx
+++ b/apps/deploy-web/src/components/sdl/ImportSdlModal.tsx
@@ -9,7 +9,7 @@ import type { editor } from "monaco-editor";
 import { useTheme } from "next-themes";
 import { useSnackbar } from "notistack";
 
-import { analyticsService } from "@src/services/analytics/analytics.service";
+import { useServices } from "@src/context/ServicesProvider";
 import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { importSimpleSdl } from "@src/utils/sdl/sdlImport";
 import { Timer } from "@src/utils/timer";
@@ -21,6 +21,7 @@ type Props = {
 };
 
 export const ImportSdlModal: React.FunctionComponent<Props> = ({ onClose, setValue }) => {
+  const { analyticsService } = useServices();
   const [sdl, setSdl] = useState<string | undefined>("");
   const [parsingError, setParsingError] = useState<string | null>(null);
   const { enqueueSnackbar } = useSnackbar();

--- a/apps/deploy-web/src/components/sdl/RentGpusForm.tsx
+++ b/apps/deploy-web/src/components/sdl/RentGpusForm.tsx
@@ -46,7 +46,7 @@ import { RegionSelect } from "./RegionSelect";
 import { TokenFormControl } from "./TokenFormControl";
 
 export const RentGpusForm: React.FunctionComponent = () => {
-  const { chainApiHttpClient, analyticsService, appConfig, deploymentLocalStorage } = useServices();
+  const { chainApiHttpClient, analyticsService, publicConfig: appConfig, deploymentLocalStorage } = useServices();
   const [error, setError] = useState<string | null>(null);
   // const [templateMetadata, setTemplateMetadata] = useState<ITemplate>(null);
   const [isQueryInit, setIsQuertInit] = useState(false);

--- a/apps/deploy-web/src/components/sdl/SaveTemplateModal.tsx
+++ b/apps/deploy-web/src/components/sdl/SaveTemplateModal.tsx
@@ -10,10 +10,10 @@ import { useSnackbar } from "notistack";
 import { z } from "zod";
 
 import { MustConnect } from "@src/components/shared/MustConnect";
+import { useServices } from "@src/context/ServicesProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
 import { getShortText } from "@src/hooks/useShortText";
 import { useSaveUserTemplate } from "@src/queries/useTemplateQuery";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 import sdlStore from "@src/store/sdlStore";
 import type { EnvironmentVariableType, ITemplate, ServiceType } from "@src/types";
 import { UrlService } from "@src/utils/urlUtils";
@@ -42,6 +42,7 @@ export const SaveTemplateModal: React.FunctionComponent<Props> = ({
   services,
   clearFormStorage
 }) => {
+  const { analyticsService } = useServices();
   const [publicEnvs, setPublicEnvs] = useState<EnvironmentVariableType[]>([]);
   const { enqueueSnackbar } = useSnackbar();
   const formRef = useRef<HTMLFormElement>(null);

--- a/apps/deploy-web/src/components/settings/ExportCertificate.tsx
+++ b/apps/deploy-web/src/components/settings/ExportCertificate.tsx
@@ -3,11 +3,12 @@ import { useEffect } from "react";
 import { Alert, Popup } from "@akashnetwork/ui/components";
 
 import { CodeSnippet } from "@src/components/shared/CodeSnippet";
-import { analyticsService } from "@src/services/analytics/analytics.service";
+import { useServices } from "@src/context/ServicesProvider";
 import { useSelectedWalletFromStorage } from "@src/utils/walletUtils";
 
 export function ExportCertificate({ isOpen, onClose }: React.PropsWithChildren<{ isOpen: boolean; onClose: () => void }>) {
   const selectedWallet = useSelectedWalletFromStorage();
+  const { analyticsService } = useServices();
 
   useEffect(() => {
     async function init() {

--- a/apps/deploy-web/src/components/templates/UserTemplate.tsx
+++ b/apps/deploy-web/src/components/templates/UserTemplate.tsx
@@ -12,10 +12,10 @@ import { LeaseSpecDetail } from "@src/components/shared/LeaseSpecDetail";
 import { Title } from "@src/components/shared/Title";
 import { UserFavoriteButton } from "@src/components/shared/UserFavoriteButton";
 import { USER_TEMPLATE_CODE } from "@src/config/deploy.config";
+import { useServices } from "@src/context/ServicesProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
 import { getShortText } from "@src/hooks/useShortText";
 import { useDeleteTemplate } from "@src/queries/useTemplateQuery";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 import sdlStore from "@src/store/sdlStore";
 import type { ITemplate } from "@src/types";
 import { RouteStep } from "@src/types/route-steps.type";
@@ -31,6 +31,7 @@ type Props = {
 };
 
 export const UserTemplate: React.FunctionComponent<Props> = ({ id, template }) => {
+  const { analyticsService } = useServices();
   const [description, setDescription] = useState("");
   const [isShowingDelete, setIsShowingDelete] = useState(false);
   const [isEditingDescription, setIsEditingDescription] = useState(false);

--- a/apps/deploy-web/src/components/user/AddFundsLink.tsx
+++ b/apps/deploy-web/src/components/user/AddFundsLink.tsx
@@ -3,8 +3,8 @@ import { Button } from "@akashnetwork/ui/components";
 import type { LinkProps } from "next/link";
 import Link from "next/link";
 
+import { useServices } from "@src/context/ServicesProvider";
 import { useAddFundsVerifiedLoginRequiredEventHandler } from "@src/hooks/useAddFundsVerifiedLoginRequiredEventHandler";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 import type { FCWithChildren } from "@src/types/component";
 
 export const AddFundsLink: FCWithChildren<
@@ -14,6 +14,7 @@ export const AddFundsLink: FCWithChildren<
       disabled?: boolean;
     } & React.RefAttributes<HTMLAnchorElement>
 > = props => {
+  const { analyticsService } = useServices();
   const whenLoggedInAndVerified = useAddFundsVerifiedLoginRequiredEventHandler();
 
   return props.disabled ? (

--- a/apps/deploy-web/src/components/user/UserFavorites.tsx
+++ b/apps/deploy-web/src/components/user/UserFavorites.tsx
@@ -3,12 +3,13 @@ import { NextSeo } from "next-seo";
 
 import { TemplateGridButton } from "@src/components/shared/TemplateGridButton";
 import { UserProfileLayout } from "@src/components/user/UserProfileLayout";
+import { useServices } from "@src/context/ServicesProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
 import { useUserFavoriteTemplates } from "@src/queries/useTemplateQuery";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 import Layout from "../layout/Layout";
 
 export const UserFavorites: React.FunctionComponent = () => {
+  const { analyticsService } = useServices();
   const { data: favoriteTemplates, isLoading: isLoadingTemplates } = useUserFavoriteTemplates();
   const { user, isLoading } = useCustomUser();
 

--- a/apps/deploy-web/src/components/user/UserProfile.tsx
+++ b/apps/deploy-web/src/components/user/UserProfile.tsx
@@ -5,11 +5,10 @@ import Link from "next/link";
 
 import { TemplateGridButton } from "@src/components/shared/TemplateGridButton";
 import { UserProfileLayout } from "@src/components/user/UserProfileLayout";
+import { useServices } from "@src/context/ServicesProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
 import { useUserTemplates } from "@src/queries/useTemplateQuery";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 import type { IUserSetting } from "@src/types/user";
-import { UrlService } from "@src/utils/urlUtils";
 import Layout from "../layout/Layout";
 
 type Props = {
@@ -18,6 +17,7 @@ type Props = {
 };
 
 export const UserProfile: React.FunctionComponent<Props> = ({ username, user }) => {
+  const { analyticsService, urlService } = useServices();
   const { data: userTemplates, isLoading: isLoadingTemplates } = useUserTemplates(username);
   const { user: _user, isLoading } = useCustomUser();
 
@@ -38,7 +38,7 @@ export const UserProfile: React.FunctionComponent<Props> = ({ username, user }) 
               {username === _user?.username && (
                 <Link
                   className={cn(buttonVariants({ variant: "default", size: "sm" }), "mt-4")}
-                  href={UrlService.sdlBuilder()}
+                  href={urlService.sdlBuilder()}
                   onClick={() => {
                     analyticsService.track("create_sdl_template_link", {
                       category: "profile",

--- a/apps/deploy-web/src/components/user/UserProfileLayout.tsx
+++ b/apps/deploy-web/src/components/user/UserProfileLayout.tsx
@@ -4,9 +4,8 @@ import { ErrorBoundary } from "react-error-boundary";
 import { ErrorFallback, Tabs, TabsList, TabsTrigger } from "@akashnetwork/ui/components";
 import { useRouter } from "next/router";
 
+import { useServices } from "@src/context/ServicesProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
-import { analyticsService } from "@src/services/analytics/analytics.service";
-import { UrlService } from "@src/utils/urlUtils";
 
 type UserProfileTab = "templates" | "favorites" | "settings";
 type Props = {
@@ -19,6 +18,7 @@ type Props = {
 export const UserProfileLayout: React.FunctionComponent<Props> = ({ page, children, username = "", bio }) => {
   const router = useRouter();
   const { user } = useCustomUser();
+  const { analyticsService, urlService } = useServices();
 
   const handleTabChange = (newValue: string) => {
     analyticsService.track("user_profile_template_tab", {
@@ -28,13 +28,13 @@ export const UserProfileLayout: React.FunctionComponent<Props> = ({ page, childr
 
     switch (newValue) {
       case "templates":
-        router.push(UrlService.userProfile(username));
+        router.push(urlService.userProfile(username));
         break;
       case "favorites":
-        router.push(UrlService.userFavorites());
+        router.push(urlService.userFavorites());
         break;
       case "settings":
-        router.push(UrlService.userSettings());
+        router.push(urlService.userSettings());
         break;
     }
   };

--- a/apps/deploy-web/src/components/user/UserProviders/UserProviders.tsx
+++ b/apps/deploy-web/src/components/user/UserProviders/UserProviders.tsx
@@ -12,7 +12,7 @@ import type { FCWithChildren } from "@src/types/component";
  * which is a client only component.
  */
 export const UserProviders: FCWithChildren = ({ children }) => {
-  const { internalApiHttpClient, appConfig } = useServices();
+  const { internalApiHttpClient, publicConfig: appConfig } = useServices();
   return appConfig.NEXT_PUBLIC_BILLING_ENABLED ? (
     <UserProvider fetcher={url => internalApiHttpClient.get(url).then(response => response.data)}>
       <UserInitLoader>

--- a/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
@@ -73,7 +73,7 @@ const MESSAGE_STATES: Record<string, LoadingState> = {
  * WalletProvider is a client only component
  */
 export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { analyticsService, tx: txHttpService, appConfig, urlService, windowLocation } = useServices();
+  const { analyticsService, tx: txHttpService, publicConfig: appConfig, urlService, windowLocation } = useServices();
 
   const [, setSettingsId] = useAtom(settingsIdAtom);
   const [isWalletLoaded, setIsWalletLoaded] = useState<boolean>(true);
@@ -366,7 +366,7 @@ export function useIsManagedWalletUser() {
 }
 
 const TransactionSnackbarContent: React.FC<{ snackMessage: string; transactionHash: string }> = ({ snackMessage, transactionHash }) => {
-  const { appConfig } = useServices();
+  const { publicConfig: appConfig } = useServices();
   const selectedNetworkId = networkStore.useSelectedNetworkId();
   const txUrl = transactionHash && `${appConfig.NEXT_PUBLIC_STATS_APP_URL}/transactions/${transactionHash}?network=${selectedNetworkId}`;
 

--- a/apps/deploy-web/src/hooks/useStoredAnonymousUser.ts
+++ b/apps/deploy-web/src/hooks/useStoredAnonymousUser.ts
@@ -16,7 +16,7 @@ const storedAnonymousUserStr = typeof window !== "undefined" && localStorage.get
 const storedAnonymousUser: UserOutput | undefined = storedAnonymousUserStr ? JSON.parse(storedAnonymousUserStr) : undefined;
 
 export const useStoredAnonymousUser = (): UseApiUserResult => {
-  const { appConfig } = useServices();
+  const { publicConfig: appConfig } = useServices();
   const { user: registeredUser, isLoading: isLoadingRegisteredUser } = useCustomUser();
   const { user, isLoading, token, error } = useAnonymousUserQuery(storedAnonymousUser?.id, {
     enabled: appConfig.NEXT_PUBLIC_BILLING_ENABLED && !registeredUser && !isLoadingRegisteredUser

--- a/apps/deploy-web/src/hooks/useTrialBalance.ts
+++ b/apps/deploy-web/src/hooks/useTrialBalance.ts
@@ -17,7 +17,7 @@ export const useTrialBalance = (): TrialBalance => {
   const { creditAmount } = useWallet();
   const { balance: walletBalance, isLoading } = useWalletBalance();
   const { wallet: managedWallet } = useManagedWallet();
-  const { appConfig } = useServices();
+  const { publicConfig: appConfig } = useServices();
 
   const TRIAL_TOTAL = appConfig.NEXT_PUBLIC_TRIAL_CREDITS_AMOUNT;
   const TRIAL_DURATION_DAYS = appConfig.NEXT_PUBLIC_TRIAL_DURATION_DAYS;

--- a/apps/deploy-web/src/pages/user/api-keys/index.tsx
+++ b/apps/deploy-web/src/pages/user/api-keys/index.tsx
@@ -6,10 +6,11 @@ import { enqueueSnackbar } from "notistack";
 import { ApiKeyList } from "@src/components/api-keys/ApiKeyList";
 import Layout from "@src/components/layout/Layout";
 import { RequiredUserContainer } from "@src/components/user/RequiredUserContainer";
+import { useServices } from "@src/context/ServicesProvider";
 import { useDeleteApiKey, useUserApiKeys } from "@src/queries/useApiKeysQuery";
-import { analyticsService } from "@src/services/analytics/analytics.service";
 
 export default function ApiKeysPage() {
+  const { analyticsService } = useServices();
   const [apiKeyToDelete, setApiKeyToDelete] = useState<ApiKeyResponse | null>(null);
   const { data: apiKeys, isLoading: isLoadingApiKeys } = useUserApiKeys();
   const { mutate: deleteApiKey, isPending: isDeleting } = useDeleteApiKey(apiKeyToDelete?.id ?? "", () => {

--- a/apps/deploy-web/src/services/app-di-container/browser-di-container.ts
+++ b/apps/deploy-web/src/services/app-di-container/browser-di-container.ts
@@ -36,7 +36,7 @@ export const services = createChildContainer(rootContainer, {
       request: [withAnonymousUserToken]
     }),
   consoleApiHttpClient: () =>
-    services.applyAxiosInterceptors(services.createAxios({ baseURL: services.appConfig.NEXT_PUBLIC_BASE_API_MAINNET_URL }), {
+    services.applyAxiosInterceptors(services.createAxios({ baseURL: services.publicConfig.NEXT_PUBLIC_BASE_API_MAINNET_URL }), {
       request: [withUserToken]
     }),
   /** TODO: https://github.com/akash-network/console/issues/1720 */
@@ -50,7 +50,6 @@ export const services = createChildContainer(rootContainer, {
         }
       ]
     }),
-  appConfig: () => browserEnvConfig,
   authService: () => new AuthService(services.urlService, services.internalApiHttpClient),
   storedWalletsService: () => walletUtils,
   deploymentLocalStorage: () => new DeploymentStorageService(localStorage, services.networkStore),

--- a/apps/deploy-web/src/services/stripe/stripe.service.spec.ts
+++ b/apps/deploy-web/src/services/stripe/stripe.service.spec.ts
@@ -1,7 +1,6 @@
 import type { Stripe } from "@stripe/stripe-js";
 import { mock } from "jest-mock-extended";
 
-import type { BrowserEnvConfig } from "@src/config/browser-env.config";
 import type { StripeServiceDependencies } from "./stripe.service";
 import { StripeService } from "./stripe.service";
 
@@ -74,22 +73,20 @@ describe("StripeService", () => {
   });
 
   function setup(input: { publishableKey: string }) {
-    const mockLoadStripe = jest.fn() as jest.MockedFunction<StripeServiceDependencies["loadStripe"]>;
+    const mockLoadStripe = jest.fn() as jest.MockedFunction<Required<StripeServiceDependencies>["loadStripe"]>;
     const mockStripeInstance = mock<Stripe>();
-    const mockBrowserEnvConfig = mock<BrowserEnvConfig>();
-
-    mockBrowserEnvConfig.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY = input.publishableKey;
 
     const stripeService = new StripeService({
       loadStripe: mockLoadStripe,
-      browserEnvConfig: mockBrowserEnvConfig
+      config: {
+        publishableKey: input.publishableKey
+      }
     });
 
     return {
       stripeService,
       mockLoadStripe,
-      mockStripeInstance,
-      mockBrowserEnvConfig
+      mockStripeInstance
     };
   }
 });

--- a/apps/deploy-web/src/services/stripe/stripe.service.ts
+++ b/apps/deploy-web/src/services/stripe/stripe.service.ts
@@ -1,20 +1,19 @@
 import { loadStripe, type Stripe } from "@stripe/stripe-js";
 
-import { browserEnvConfig } from "@src/config/browser-env.config";
-
 export interface StripeServiceDependencies {
-  loadStripe: typeof loadStripe;
-  browserEnvConfig: typeof browserEnvConfig;
+  loadStripe?: typeof loadStripe;
+  config: {
+    publishableKey: string;
+  };
 }
 
 export class StripeService {
   private stripeInstance: Stripe | null = null;
-  private dependencies: StripeServiceDependencies;
+  private dependencies: Required<StripeServiceDependencies>;
 
-  constructor(dependencies?: Partial<StripeServiceDependencies>) {
+  constructor(dependencies: StripeServiceDependencies) {
     this.dependencies = {
       loadStripe,
-      browserEnvConfig,
       ...dependencies
     };
   }
@@ -24,7 +23,7 @@ export class StripeService {
       return this.stripeInstance;
     }
 
-    const publishableKey = this.dependencies.browserEnvConfig.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+    const publishableKey = this.dependencies.config.publishableKey;
     if (!publishableKey) {
       console.warn("Stripe publishable key is not configured");
       return null;


### PR DESCRIPTION
## Why

to reduce amount of uncontrolled side effects and improve testability of the app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched analytics, URL and config access to a centralized dependency-injected provider (publicConfig) across the app; no UI or behavioral changes.
  * Reworked analytics and payment wiring: removed legacy singleton, analytics now provided from DI container; Stripe client now gets publishable key via unified config shape.

* **Tests**
  * Updated tests to inject and mock analytics via the DI/test container for reliable analytics-related coverage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->