### PR TITLE
fix: do not fetch lease status for closed deployments and return null in case of 404

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -92,7 +92,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
   const lease = filteredLeases?.find(lease => !!(lease?.provider && providersByOwner[lease.provider]));
   const provider = providersByOwner[lease?.provider || ""];
   const providerCredentials = useProviderCredentials();
-  const { data: leaseStatus } = useLeaseStatus({ provider, lease, enabled: !!(provider && lease && providerCredentials.details.usable) });
+  const { data: leaseStatus } = useLeaseStatus({ provider, lease, enabled: !!(provider && lease?.state === "active" && providerCredentials.details.usable) });
   const isAnonymousFreeTrialEnabled = useFlag("anonymous_free_trial");
 
   const viewDeployment = useCallback(() => {

--- a/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
@@ -1,5 +1,6 @@
 import type { CertificatesService } from "@akashnetwork/http-sdk";
 import { useQueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
 import { mock } from "jest-mock-extended";
 
 import type { Props as ServicesProviderProps } from "@src/context/ServicesProvider";
@@ -285,6 +286,33 @@ describe("useLeaseQuery", () => {
         }
       });
 
+      await waitFor(() => {
+        expect(result.current.data).toBeNull();
+      });
+    });
+
+    it("returns null when lease is not active", async () => {
+      const { result } = setupLeaseStatus({
+        lease: { ...mockLease, state: "closed" },
+        services: {
+          providerProxy: () => mock<ProviderProxyService>()
+        }
+      });
+      await waitFor(() => {
+        expect(result.current.data).toBeNull();
+      });
+    });
+
+    it("returns null when fetching lease status fails with 404", async () => {
+      const providerProxy = mock<ProviderProxyService>({
+        request: jest.fn().mockRejectedValue(new AxiosError("Not Found", "404", undefined, undefined, { status: 404 } as any))
+      });
+      const { result } = setupLeaseStatus({
+        lease: mockLease,
+        services: {
+          providerProxy: () => providerProxy
+        }
+      });
       await waitFor(() => {
         expect(result.current.data).toBeNull();
       });


### PR DESCRIPTION
## Why

because it generates many useless sentry errors. Closes https://github.com/akash-network/console/issues/2420

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lease status now only loads when leases are in an active state.
  * Improved error handling for failed lease status requests, preventing application crashes when requests return 404 errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->