### PR TITLE
refactor: enables serializers in logger by default for browser

### DIFF
--- a/apps/deploy-web/src/services/app-di-container/app-di-container.ts
+++ b/apps/deploy-web/src/services/app-di-container/app-di-container.ts
@@ -159,7 +159,16 @@ export const createAppRootContainer = (config: ServicesConfig) => {
         })
       }),
     errorHandler: () => new ErrorHandlerService(container.logger),
-    logger: () => new LoggerService({ name: `app-${config.runtimeEnv}` }),
+    logger: () =>
+      new LoggerService({
+        name: `app-${config.runtimeEnv}`,
+        browser: {
+          disabled: config.runtimeEnv !== "browser",
+          // enable serialization of log events, so then we can see more details about errors in Sentry
+          serialize: true,
+          asObject: true
+        }
+      }),
     urlService: () => UrlService,
     userTracker: () => new UserTracker()
   });

--- a/packages/logging/src/services/logger/logger.service.spec.ts
+++ b/packages/logging/src/services/logger/logger.service.spec.ts
@@ -16,7 +16,12 @@ describe("LoggerService", () => {
     formatters: {
       level: expect.any(Function)
     },
-    serializers: expect.any(Object)
+    serializers: expect.any(Object),
+    browser: {
+      formatters: {
+        level: expect.any(Function)
+      }
+    }
   };
 
   afterEach(() => {
@@ -75,6 +80,13 @@ describe("LoggerService", () => {
       expect(pinoMock).toHaveBeenCalledWith({ ...COMMON_EXPECTED_OPTIONS, level: "debug" });
 
       LoggerService.mixin = undefined;
+    });
+
+    it("should initialize pino with provided browser options", () => {
+      const pinoMock = jest.fn();
+      new LoggerService({ createPino: pinoMock, browser: { disabled: false } });
+
+      expect(pinoMock).toHaveBeenCalledWith({ ...COMMON_EXPECTED_OPTIONS, browser: { ...COMMON_EXPECTED_OPTIONS.browser, disabled: false } });
     });
   });
 


### PR DESCRIPTION
## Why

because we don't see logged error details in sentry breadcrumbs:

<img width="798" height="245" alt="Screenshot 2025-12-27 at 00 26 20" src="https://github.com/user-attachments/assets/bddab056-9143-4055-93d0-986e4b9971ee" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logger now supports browser-specific configuration options with custom formatting and enhanced log serialization
  * Browser environments benefit from improved log event serialization including object-style logging for richer debugging information
  * Logger behavior is now conditionally activated based on runtime environment
  * Error logging has been enhanced to provide improved context and diagnostics for better troubleshooting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->