### PR TITLE
refactor: optimized session storag for loggd in user

### DIFF
--- a/apps/deploy-web/src/components/auth/AuthPage/AuthPage.spec.tsx
+++ b/apps/deploy-web/src/components/auth/AuthPage/AuthPage.spec.tsx
@@ -216,11 +216,11 @@ describe(AuthPage.name, () => {
     const authService = mock<AuthService>();
     const router = mock<NextRouter>();
     const checkSession = jest.fn(async () => undefined);
-    const useUserMock = () => ({
+    const useUserMock: typeof DEPENDENCIES.useUser = () => ({
       checkSession,
       isLoading: false,
       error: undefined,
-      user: undefined
+      user: {}
     });
 
     const params = new URLSearchParams();

--- a/apps/deploy-web/src/components/auth/AuthPage/AuthPage.tsx
+++ b/apps/deploy-web/src/components/auth/AuthPage/AuthPage.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useState } from "react";
 import { Separator, Tabs, TabsContent, TabsList, TabsTrigger } from "@akashnetwork/ui/components";
-import { useUser } from "@auth0/nextjs-auth0/client";
 import { useMutation } from "@tanstack/react-query";
 import { DollarSignIcon, RocketIcon, ZapIcon } from "lucide-react";
 import { useSearchParams } from "next/navigation";
@@ -12,6 +11,7 @@ import { NextSeo } from "next-seo";
 import { AkashConsoleLogo } from "@src/components/icons/AkashConsoleLogo";
 import { RemoteApiError } from "@src/components/shared/RemoteApiError/RemoteApiError";
 import { useServices } from "@src/context/ServicesProvider";
+import { useUser } from "@src/hooks/useUser";
 import { AuthLayout } from "../AuthLayout/AuthLayout";
 import { ForgotPasswordForm } from "../ForgotPasswordForm/ForgotPasswordForm";
 import type { SignInFormValues } from "../SignInForm/SignInForm";

--- a/apps/deploy-web/src/components/user/UserProviders/UserProviders.spec.tsx
+++ b/apps/deploy-web/src/components/user/UserProviders/UserProviders.spec.tsx
@@ -55,7 +55,7 @@ describe(UserProviders.name, () => {
 
     expect(userTracker.track).toHaveBeenCalledWith(undefined);
     expect(userTracker.track).toHaveBeenCalledWith(anonymousUser);
-    expect(analyticsService.identify).toHaveBeenCalledTimes(2);
+    expect(analyticsService.identify).toHaveBeenCalledTimes(3);
     expect(analyticsService.identify).toHaveBeenCalledWith({
       id: anonymousUser.id,
       anonymous: !anonymousUser.userId,

--- a/apps/deploy-web/src/hooks/useUser.ts
+++ b/apps/deploy-web/src/hooks/useUser.ts
@@ -7,15 +7,17 @@ import type { CustomUserProfile } from "@src/types/user";
 export const useUser = (): {
   user: CustomUserProfile;
   isLoading: boolean;
+  checkSession: () => Promise<void>;
 } => {
-  const { user: registeredUser, isLoading: isLoadingRegisteredUser } = useCustomUser();
+  const { user: registeredUser, isLoading: isLoadingRegisteredUser, checkSession } = useCustomUser();
   const { user: anonymousUser, isLoading: isLoadingAnonymousUser } = useStoredAnonymousUser();
   const user = useMemo(() => registeredUser || anonymousUser, [registeredUser, anonymousUser]);
   const isLoading = useMemo(() => isLoadingRegisteredUser || isLoadingAnonymousUser, [isLoadingRegisteredUser, isLoadingAnonymousUser]);
 
   return {
     user,
-    isLoading
+    isLoading,
+    checkSession
   };
 };
 

--- a/apps/deploy-web/src/queries/useAnonymousUserQuery/useAnonymousUserQuery.ts
+++ b/apps/deploy-web/src/queries/useAnonymousUserQuery/useAnonymousUserQuery.ts
@@ -31,7 +31,7 @@ export const DEFAULT_RETRY_AFTER_SECONDS = 60 * 60;
 export function useAnonymousUserQuery(id?: string, options?: { enabled?: boolean }): AnonymousUserState {
   const store = useStore();
   const { user: userService, errorHandler } = useServices();
-  const [userState] = useAtom(userStateAtom);
+  const [userState, setUserState] = useAtom(userStateAtom);
 
   const fetchAnonymousUser = useAtomCallback(
     useCallback(
@@ -58,6 +58,8 @@ export function useAnonymousUserQuery(id?: string, options?: { enabled?: boolean
     options?.enabled && !userState.user && !userState.isLoading && (!userState.retryAfter || userState.retryAfter.getTime() < Date.now()),
     fetchAnonymousUser
   );
+
+  useWhen(!options?.enabled, () => setUserState({ isLoading: false }));
 
   return userState;
 }

--- a/apps/deploy-web/src/services/session/session.service.ts
+++ b/apps/deploy-web/src/services/session/session.service.ts
@@ -18,23 +18,7 @@ export class SessionService {
     this.#config = config;
   }
 
-  async signIn(input: { email: string; password: string }): Promise<Result<Session, { message: string; code: string; cause: unknown }>> {
-    const result = await this.#signInOnProvider(input);
-    if (result.ok) {
-      const session = result.val;
-      const userSettings = await this.getLocalUserDetails(session);
-
-      session.user = { ...session.user, ...userSettings };
-      return Ok(session);
-    }
-
-    return result;
-  }
-
-  async #signInOnProvider(input: {
-    email: string;
-    password: string;
-  }): Promise<Result<Session, { code: "invalid_credentials"; message: string; cause: unknown }>> {
+  async signIn(input: { email: string; password: string }): Promise<Result<Session, { code: "invalid_credentials"; message: string; cause: unknown }>> {
     const oauthIssuerUrl = new URL(this.#config.ISSUER_BASE_URL);
 
     const tokenResponse = await this.#externalHttpClient.post(
@@ -139,7 +123,7 @@ export class SessionService {
       });
     }
 
-    const result = await this.#signInOnProvider({
+    const result = await this.signIn({
       email: input.email,
       password: input.password
     });
@@ -147,7 +131,7 @@ export class SessionService {
     if (result.ok) {
       const session = result.val;
       const userSettings = await this.createLocalUser(result.val);
-      session.user = { ...session.user, ...userSettings };
+      session.user = { ...session.user, nickname: userSettings.username };
       return Ok(session);
     }
 


### PR DESCRIPTION
## Why

optimized session cookie storage. No need to store the whole user profile in session because we fetch it on every page reload

After this change, session cookie is about 3+Kb
<img width="579" height="58" alt="Screenshot 2025-12-29 at 04 15 22" src="https://github.com/user-attachments/assets/45e4a1ac-00f1-4092-968f-33ff17e152eb" />

Before this change:
<img width="562" height="51" alt="Screenshot 2025-12-29 at 04 16 47" src="https://github.com/user-attachments/assets/602174ed-b079-4640-b09f-56f7b8cad740" />
