### PR TITLE
chore: removes extra header addition to all requests in e2e tests

### DIFF
--- a/apps/deploy-web/playwright.config.ts
+++ b/apps/deploy-web/playwright.config.ts
@@ -4,12 +4,6 @@ import path from "path";
 
 dotenv.config({ path: path.resolve(__dirname, "env/.env.test") });
 
-if (!process.env.E2E_TESTING_CLIENT_TOKEN && !process.env.BASE_URL?.includes("localhost")) {
-  throw new Error(
-    "E2E_TESTING_CLIENT_TOKEN is a required env variable. Without it, tests will be blocked by captcha verification. Should be set to the same value as app's E2E_TESTING_CLIENT_TOKEN env variable."
-  );
-}
-
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
@@ -32,10 +26,7 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "retain-on-failure",
     video: "retain-on-failure",
-    actionTimeout: 15_000,
-    extraHTTPHeaders: {
-      "X-Testing-Client-Token": process.env.E2E_TESTING_CLIENT_TOKEN || ""
-    }
+    actionTimeout: 15_000
   },
 
   /* Configure projects for major browsers */

--- a/apps/deploy-web/tests/ui/fixture/test-env.config.ts
+++ b/apps/deploy-web/tests/ui/fixture/test-env.config.ts
@@ -9,13 +9,17 @@ export const testEnvSchema = z.object({
     .transform(url => url.replace(/\/+$/, "")),
   TEST_WALLET_MNEMONIC: z.string(),
   NETWORK_ID: z.enum(["mainnet", "sandbox", "testnet"]).default("sandbox"),
-  USER_DATA_DIR: z.string().default(path.join(tmpdir(), "akash-console-web-ui-tests", crypto.randomUUID()))
+  USER_DATA_DIR: z.string().default(path.join(tmpdir(), "akash-console-web-ui-tests", crypto.randomUUID())),
+  E2E_TESTING_CLIENT_TOKEN: z.string({
+    required_error: "This token is used to adjust configuration of the app for e2e testing. Can be any random string but should match the one used by app."
+  })
 });
 
 export const testEnvConfig = testEnvSchema.parse({
   BASE_URL: process.env.BASE_URL,
   TEST_WALLET_MNEMONIC: process.env.TEST_WALLET_MNEMONIC,
-  USER_DATA_DIR: process.env.USER_DATA_DIR
+  USER_DATA_DIR: process.env.USER_DATA_DIR,
+  E2E_TESTING_CLIENT_TOKEN: process.env.E2E_TESTING_CLIENT_TOKEN
 });
 
 export const PROVIDERS_WHITELIST = {


### PR DESCRIPTION
## Why

this header is needed only during login/signup/reset password flows but right now we don't have tests for those. And we can't add it to all requests because then we have CORS failures in e2e testing flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated E2E testing configuration with simplified token management. Removed runtime validation guard and header injection from main Playwright configuration, centralizing token handling in test environment setup instead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->