### PR TITLE
feat: adds react-query automatic proxy package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10160,6 +10160,10 @@
       "resolved": "apps/provider-proxy",
       "link": true
     },
+    "node_modules/@akashnetwork/react-query-proxy": {
+      "resolved": "packages/react-query-proxy",
+      "link": true
+    },
     "node_modules/@akashnetwork/react-query-sdk": {
       "resolved": "packages/react-query-sdk",
       "link": true
@@ -55134,6 +55138,21 @@
         "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
+      }
+    },
+    "packages/react-query-proxy": {
+      "name": "@akashnetwork/react-query-proxy",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tanstack/react-query": "^5.67.2"
+      },
+      "devDependencies": {
+        "@akashnetwork/dev-config": "*",
+        "jest": "^29.7.0",
+        "prettier": "^3.3.0",
+        "ts-jest": "^29.4.0",
+        "typescript": "~5.8.2"
       }
     },
     "packages/react-query-sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -55149,6 +55149,9 @@
       },
       "devDependencies": {
         "@akashnetwork/dev-config": "*",
+        "eslint": "^8.57.0",
+        "eslint-config-next": "^14.2.3",
+        "eslint-plugin-simple-import-sort": "^12.1.0",
         "jest": "^29.7.0",
         "prettier": "^3.3.0",
         "ts-jest": "^29.4.0",

--- a/packages/react-query-proxy/.eslintrc.js
+++ b/packages/react-query-proxy/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: [require.resolve("@akashnetwork/dev-config/.eslintrc.ts")]
+};

--- a/packages/react-query-proxy/README.md
+++ b/packages/react-query-proxy/README.md
@@ -1,0 +1,106 @@
+# React Query Proxy
+
+> Wrap any async service into fully-typed TanStack React Query hooks at runtime.
+> Works with REST, gRPC, XML-RPC, generated clients, or hand-written APIs — no codegen required.
+
+---
+
+## ✨ Why?
+
+Most teams already have an API client / SDK:
+- generated from OpenAPI / gRPC
+- written by hand
+- shared between frontend, backend, scripts, and tests
+
+This library lets you **reuse that SDK directly in React** by turning it into:
+- `useQuery` hooks
+- `useMutation` hooks
+- stable, predictable query keys
+
+All **at runtime**, without generating code or schemas.
+
+---
+
+## 📦 Installation
+
+```bash
+npm install @akashnetwork/react-query-proxy
+```
+
+> Peer dependencies:
+> - `react >= 18`
+> - `@tanstack/react-query >= 5`
+
+---
+
+## 🚀 Basic usage
+
+### 1. Start with a plain async SDK
+
+```ts
+const sdk = {
+  alerts: {
+    async list(input?: { page?: number }) {
+      return fetchAlerts(input)
+    },
+
+    async create(input: { name: string }) {
+      return createAlert(input)
+    },
+  },
+}
+```
+
+---
+
+### 2. Wrap it with `createProxy`
+
+```ts
+import { createProxy } from '@akashnetwork/react-query-proxy'
+
+export const api = createProxy(sdk)
+```
+
+---
+
+### 3. Use queries
+
+```tsx
+function AlertsList() {
+  const q = api.alerts.list.useQuery({ page: 1 })
+
+  if (q.isLoading) return <div>Loading…</div>
+  if (q.isError) return <div>Error</div>
+
+  return <pre>{JSON.stringify(q.data, null, 2)}</pre>
+}
+```
+
+---
+
+### 4. Use mutations
+
+```tsx
+function CreateAlert() {
+  const m = api.alerts.create.useMutation()
+
+  return (
+    <button onClick={() => m.mutate({ name: 'CPU High' })} disabled={m.isPending}>
+      Create
+    </button>
+  )
+}
+```
+
+---
+
+## 🔑 Query keys & invalidation
+
+```ts
+api.alerts.list.getKey({ page: 1 })
+// → ['alerts', 'list', { page: 1 }]
+```
+
+## 📄 License
+
+Apache 2.0

--- a/packages/react-query-proxy/jest.config.ts
+++ b/packages/react-query-proxy/jest.config.ts
@@ -1,0 +1,8 @@
+import type { Config } from "jest";
+
+export default {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/src/**/*.spec.ts"],
+  verbose: true
+} satisfies Config;

--- a/packages/react-query-proxy/package.json
+++ b/packages/react-query-proxy/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@akashnetwork/react-query-proxy",
+  "version": "1.0.0",
+  "description": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/akash-network/console"
+  },
+  "license": "Apache-2.0",
+  "author": "Akash Network",
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "jest",
+    "validate:types": "tsc --noEmit && echo"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.67.2"
+  },
+  "devDependencies": {
+    "@akashnetwork/dev-config": "*",
+    "jest": "^29.7.0",
+    "prettier": "^3.3.0",
+    "ts-jest": "^29.4.0",
+    "typescript": "~5.8.2"
+  }
+}

--- a/packages/react-query-proxy/package.json
+++ b/packages/react-query-proxy/package.json
@@ -10,6 +10,8 @@
   "author": "Akash Network",
   "main": "src/index.ts",
   "scripts": {
+    "format": "prettier --write ./*.{ts,json} **/*.{ts,json}",
+    "lint": "eslint .",
     "test": "jest",
     "validate:types": "tsc --noEmit && echo"
   },
@@ -18,6 +20,9 @@
   },
   "devDependencies": {
     "@akashnetwork/dev-config": "*",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.3",
+    "eslint-plugin-simple-import-sort": "^12.1.0",
     "jest": "^29.7.0",
     "prettier": "^3.3.0",
     "ts-jest": "^29.4.0",

--- a/packages/react-query-proxy/src/createProxy/createProxy.spec.ts
+++ b/packages/react-query-proxy/src/createProxy/createProxy.spec.ts
@@ -23,19 +23,19 @@ describe(createProxy.name, () => {
     it("returns path segments with input when input is provided", () => {
       const { proxy } = setup();
       const key = proxy.users.getById.getKey({ id: 123 });
-      expect(key).toEqual(["users", { id: 123 }]);
+      expect(key).toEqual(["users", "getById", { id: 123 }]);
     });
 
     it("returns path segments without input when input is undefined", () => {
       const { proxy } = setup();
       const key = proxy.users.list.getKey(undefined);
-      expect(key).toEqual(["users"]);
+      expect(key).toEqual(["users", "list"]);
     });
 
     it("returns path segments without input when input is null", () => {
       const { proxy } = setup();
       const key = proxy.users.list.getKey(null as unknown as undefined);
-      expect(key).toEqual(["users"]);
+      expect(key).toEqual(["users", "list"]);
     });
   });
 
@@ -46,7 +46,7 @@ describe(createProxy.name, () => {
 
       expect(useQuery).toHaveBeenCalledWith(
         expect.objectContaining({
-          queryKey: ["users", { id: 42 }]
+          queryKey: ["users", "getById", { id: 42 }]
         })
       );
 
@@ -61,7 +61,7 @@ describe(createProxy.name, () => {
 
       expect(useQuery).toHaveBeenCalledWith(
         expect.objectContaining({
-          queryKey: ["users", { id: 1 }, "extra", "key"]
+          queryKey: ["users", "getById", { id: 1 }, "extra", "key"]
         })
       );
     });
@@ -84,7 +84,7 @@ describe(createProxy.name, () => {
 
       expect(useQuery).toHaveBeenCalledWith(
         expect.objectContaining({
-          queryKey: ["users"]
+          queryKey: ["users", "list"]
         })
       );
 
@@ -118,7 +118,7 @@ describe(createProxy.name, () => {
 
       expect(useMutation).toHaveBeenCalledWith(
         expect.objectContaining({
-          mutationKey: ["users"]
+          mutationKey: ["users", "create"]
         })
       );
 
@@ -133,7 +133,7 @@ describe(createProxy.name, () => {
 
       expect(useMutation).toHaveBeenCalledWith(
         expect.objectContaining({
-          mutationKey: ["users", "custom"]
+          mutationKey: ["users", "create", "custom"]
         })
       );
     });
@@ -158,7 +158,7 @@ describe(createProxy.name, () => {
 
       expect(useQuery).toHaveBeenCalledWith(
         expect.objectContaining({
-          queryKey: ["admin", "settings", { theme: "dark" }]
+          queryKey: ["admin", "settings", "update", { theme: "dark" }]
         })
       );
 
@@ -170,7 +170,7 @@ describe(createProxy.name, () => {
     it("generates correct getKey for nested methods", () => {
       const { proxy } = setup();
       const key = proxy.admin.settings.update.getKey({ theme: "light" });
-      expect(key).toEqual(["admin", "settings", { theme: "light" }]);
+      expect(key).toEqual(["admin", "settings", "update", { theme: "light" }]);
     });
   });
 
@@ -213,7 +213,7 @@ describe(createProxy.name, () => {
       });
 
       const key = proxy.users.getById.getKey({ id: 99 });
-      expect(key).toEqual(["users", 99]);
+      expect(key).toEqual(["users", "getById", 99]);
     });
 
     it("applies custom inputToKey in useQuery", () => {
@@ -228,7 +228,7 @@ describe(createProxy.name, () => {
 
       expect(useQuery).toHaveBeenCalledWith(
         expect.objectContaining({
-          queryKey: ["users", '{"id":5}']
+          queryKey: ["users", "getById", '{"id":5}']
         })
       );
     });

--- a/packages/react-query-proxy/src/createProxy/createProxy.spec.ts
+++ b/packages/react-query-proxy/src/createProxy/createProxy.spec.ts
@@ -1,0 +1,284 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import { createProxy } from "./createProxy";
+
+jest.mock("@tanstack/react-query", () => ({
+  useQuery: jest.fn(),
+  useMutation: jest.fn()
+}));
+
+const useQueryMock = useQuery as jest.Mock;
+const useMutationMock = useMutation as jest.Mock;
+
+interface User {
+  id: number;
+  name?: string;
+}
+
+interface Sdk {
+  users: {
+    list: (input?: { page?: number }) => Promise<User[]>;
+    getById: (input: { id: number }) => Promise<User>;
+    create: (input: { name: string }) => Promise<User>;
+  };
+  admin: {
+    settings: {
+      update: (input: { theme: string }) => Promise<{ success: boolean }>;
+    };
+  };
+}
+
+describe(createProxy.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useQueryMock.mockReturnValue({ data: undefined, isLoading: true });
+    useMutationMock.mockReturnValue({ mutate: jest.fn(), isPending: false });
+  });
+
+  describe("getKey", () => {
+    it("returns path segments with input when input is provided", () => {
+      const { proxy } = setup();
+      const key = proxy.users.getById.getKey({ id: 123 });
+      expect(key).toEqual(["users", { id: 123 }]);
+    });
+
+    it("returns path segments without input when input is undefined", () => {
+      const { proxy } = setup();
+      const key = proxy.users.list.getKey(undefined);
+      expect(key).toEqual(["users"]);
+    });
+
+    it("returns path segments without input when input is null", () => {
+      const { proxy } = setup();
+      const key = proxy.users.list.getKey(null as unknown as undefined);
+      expect(key).toEqual(["users"]);
+    });
+  });
+
+  describe("useQuery", () => {
+    it("calls useQuery with correct queryKey and queryFn", () => {
+      const { proxy, sdk } = setup();
+      proxy.users.getById.useQuery({ id: 42 });
+
+      expect(useQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: ["users", { id: 42 }]
+        })
+      );
+
+      const queryFn = useQueryMock.mock.calls[0][0].queryFn;
+      queryFn();
+      expect(sdk.users.getById).toHaveBeenCalledWith({ id: 42 });
+    });
+
+    it("appends custom queryKey to the generated key", () => {
+      const { proxy } = setup();
+      proxy.users.getById.useQuery({ id: 1 }, { queryKey: ["extra", "key"] });
+
+      expect(useQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: ["users", { id: 1 }, "extra", "key"]
+        })
+      );
+    });
+
+    it("passes through additional options to useQuery", () => {
+      const { proxy } = setup();
+      proxy.users.getById.useQuery({ id: 1 }, { enabled: false, staleTime: 5000 });
+
+      expect(useQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabled: false,
+          staleTime: 5000
+        })
+      );
+    });
+
+    it("handles undefined input for optional parameters", () => {
+      const { proxy, sdk } = setup();
+      proxy.users.list.useQuery(undefined);
+
+      expect(useQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: ["users"]
+        })
+      );
+
+      const queryFn = useQueryMock.mock.calls[0][0].queryFn;
+      queryFn();
+      expect(sdk.users.list).toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  describe("useMutation", () => {
+    it("calls useMutation with correct mutationKey and mutationFn", () => {
+      const { proxy, sdk } = setup();
+      proxy.users.create.useMutation();
+
+      expect(useMutationMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mutationKey: ["users"]
+        })
+      );
+
+      const mutationFn = useMutationMock.mock.calls[0][0].mutationFn;
+      mutationFn({ name: "John" });
+      expect(sdk.users.create).toHaveBeenCalledWith({ name: "John" });
+    });
+
+    it("appends custom mutationKey to the generated key", () => {
+      const { proxy } = setup();
+      proxy.users.create.useMutation({ mutationKey: ["custom"] });
+
+      expect(useMutationMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mutationKey: ["users", "custom"]
+        })
+      );
+    });
+
+    it("passes through additional options to useMutation", () => {
+      const onSuccess = jest.fn();
+      const { proxy } = setup();
+      proxy.users.create.useMutation({ onSuccess });
+
+      expect(useMutationMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onSuccess
+        })
+      );
+    });
+  });
+
+  describe("nested objects", () => {
+    it("creates proxy for deeply nested methods", () => {
+      const { proxy, sdk } = setup();
+      proxy.admin.settings.update.useQuery({ theme: "dark" });
+
+      expect(useQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: ["admin", "settings", { theme: "dark" }]
+        })
+      );
+
+      const queryFn = useQueryMock.mock.calls[0][0].queryFn;
+      queryFn();
+      expect(sdk.admin.settings.update).toHaveBeenCalledWith({ theme: "dark" });
+    });
+
+    it("generates correct getKey for nested methods", () => {
+      const { proxy } = setup();
+      const key = proxy.admin.settings.update.getKey({ theme: "light" });
+      expect(key).toEqual(["admin", "settings", { theme: "light" }]);
+    });
+  });
+
+  describe("caching", () => {
+    it("returns the same proxy instance for the same object", () => {
+      const sdk = createSdk();
+      const proxy1 = createProxy(sdk);
+      const proxy2 = createProxy(sdk);
+
+      expect(proxy1).toBe(proxy2);
+    });
+
+    it("returns the same nested proxy for repeated access", () => {
+      const { proxy } = setup();
+      const users1 = proxy.users;
+      const users2 = proxy.users;
+
+      expect(users1).toBe(users2);
+    });
+
+    it("returns the same hooks object for repeated method access", () => {
+      const { proxy } = setup();
+      const getById1 = proxy.users.getById;
+      const getById2 = proxy.users.getById;
+
+      expect(getById1).toBe(getById2);
+    });
+  });
+
+  describe("inputToKey option", () => {
+    it("uses custom inputToKey function for query keys", () => {
+      const sdk = createSdk();
+      const proxy = createProxy(sdk, {
+        inputToKey: (input: unknown) => {
+          if (input && typeof input === "object" && "id" in input) {
+            return [(input as { id: number }).id];
+          }
+          return [];
+        }
+      });
+
+      const key = proxy.users.getById.getKey({ id: 99 });
+      expect(key).toEqual(["users", 99]);
+    });
+
+    it("applies custom inputToKey in useQuery", () => {
+      const sdk = createSdk();
+      const proxy = createProxy(sdk, {
+        inputToKey: (input: unknown) => (input ? [JSON.stringify(input)] : [])
+      });
+
+      proxy.users.getById.useQuery({ id: 5 });
+
+      expect(useQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: ["users", '{"id":5}']
+        })
+      );
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns undefined for non-existent properties", () => {
+      const { proxy } = setup();
+      expect((proxy as Record<string, unknown>).nonExistent).toBeUndefined();
+    });
+
+    it("returns primitive values as-is", () => {
+      const sdk = {
+        version: "1.0.0",
+        count: 42
+      };
+      const proxy = createProxy(sdk);
+
+      expect(proxy.version).toBe("1.0.0");
+      expect(proxy.count).toBe(42);
+    });
+
+    it("handles null values in object", () => {
+      const sdk = {
+        nullValue: null as null,
+        users: {
+          list: jest.fn()
+        }
+      };
+      const proxy = createProxy(sdk);
+
+      expect(proxy.nullValue).toBeNull();
+    });
+  });
+
+  function setup() {
+    const sdk = createSdk();
+    const proxy = createProxy(sdk);
+    return { sdk, proxy };
+  }
+
+  function createSdk(): Sdk {
+    return {
+      users: {
+        list: jest.fn().mockResolvedValue([]),
+        getById: jest.fn().mockResolvedValue({ id: 1 }),
+        create: jest.fn().mockResolvedValue({ id: 1 })
+      },
+      admin: {
+        settings: {
+          update: jest.fn().mockResolvedValue({ success: true })
+        }
+      }
+    };
+  }
+});

--- a/packages/react-query-proxy/src/createProxy/createProxy.ts
+++ b/packages/react-query-proxy/src/createProxy/createProxy.ts
@@ -1,0 +1,96 @@
+import type { QueryKey, UseMutationOptions, UseMutationResult, UseQueryOptions, UseQueryResult } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+export function createProxy<T extends Record<string, any>>(object: T, proxyOptions?: CreateProxyOptions): RecursiveHooksProxy<T> {
+  return createRecursiveProxyImpl(object, proxyOptions);
+}
+
+export interface CreateProxyOptions {
+  inputToKey?: (input: unknown) => PropertyKey[];
+}
+
+const proxyCache = new WeakMap<object, Record<string, any>>();
+const defaultInputToKey = (input: unknown): unknown[] => (input == null ? [] : [input]);
+
+function createRecursiveProxyImpl<T extends Record<string, any>>(
+  object: T,
+  proxyOptions?: CreateProxyOptions,
+  fullPath: PropertyKey[] = []
+): RecursiveHooksProxy<T> {
+  if (!proxyCache.has(object)) {
+    proxyCache.set(object, new Map());
+  }
+
+  const inputToKey = proxyOptions?.inputToKey ?? defaultInputToKey;
+  const valueByPath = proxyCache.get(object)!;
+  const stringifiedPath = fullPath.join(".");
+  if (!valueByPath[stringifiedPath]) {
+    valueByPath[stringifiedPath] = new Proxy(object, {
+      get(target, prop) {
+        if (!Object.hasOwn(target, prop)) return undefined;
+
+        const value = (target as any)[prop];
+        if ((typeof value !== "function" && typeof value !== "object") || value === null) {
+          return value;
+        }
+
+        if (typeof value === "function") {
+          const key = `${stringifiedPath}.${prop as string}`;
+          const getKey = (input: unknown) => fullPath.concat(inputToKey(input) as PropertyKey[]);
+          valueByPath[key] ??= {
+            getKey,
+            useQuery: (input, options) => {
+              const queryKey = getKey(input);
+              if (options?.queryKey) {
+                queryKey.push(...(options.queryKey as PropertyKey[]));
+              }
+              return useQuery({
+                ...options,
+                queryKey,
+                queryFn: () => (target as any)[prop](input)
+              });
+            },
+            useMutation: options => {
+              const mutationKey = fullPath;
+              if (options?.mutationKey) {
+                mutationKey.push(...(options.mutationKey as PropertyKey[]));
+              }
+              return useMutation({
+                ...options,
+                mutationKey,
+                mutationFn: input => (target as any)[prop](input)
+              });
+            }
+          } satisfies HooksProxy<typeof value>;
+          return valueByPath[key];
+        }
+
+        return createRecursiveProxyImpl(value, proxyOptions, fullPath.concat(prop));
+      }
+    });
+  }
+
+  return valueByPath[stringifiedPath];
+}
+
+type RecursiveHooksProxy<T> = {
+  [K in keyof T]: T[K] extends (...args: any[]) => any ? HooksProxy<T[K]> : RecursiveHooksProxy<T[K]>;
+};
+
+type HooksProxy<T extends (...args: any[]) => any> = undefined extends Parameters<T>[0]
+  ? {
+      getKey: (input?: undefined) => PropertyKey[];
+      useQuery: (
+        input?: undefined,
+        options?: Omit<UseQueryOptions<ReturnType<T>, Error, any, QueryKey>, "queryFn" | "queryKey"> & { queryKey?: QueryKey }
+      ) => UseQueryResult<Awaited<ReturnType<T>>>;
+      useMutation: (options?: Omit<UseMutationOptions<ReturnType<T>, Error, any, any>, "mutationFn">) => UseMutationResult<Awaited<ReturnType<T>>>;
+    }
+  : {
+      getKey: (input: Parameters<T>[0]) => PropertyKey[];
+      useQuery: (
+        input: Parameters<T>[0],
+        options?: Omit<UseQueryOptions<ReturnType<T>, Error, any, QueryKey>, "queryFn" | "queryKey"> & { queryKey?: QueryKey }
+      ) => UseQueryResult<Awaited<ReturnType<T>>>;
+      useMutation: (options?: Omit<UseMutationOptions<ReturnType<T>, Error, any, any>, "mutationFn">) => UseMutationResult<Awaited<ReturnType<T>>>;
+    };

--- a/packages/react-query-proxy/tsconfig.build.json
+++ b/packages/react-query-proxy/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "noImplicitAny": true,
+    "strict": true,
+    "module": "esnext",
+    "moduleResolution": "bundler"
+  },
+  "extends": "@akashnetwork/dev-config/tsconfig.base-node.json"
+}

--- a/packages/react-query-proxy/tsconfig.json
+++ b/packages/react-query-proxy/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "exclude": ["node_modules", "dist", "**/*spec.ts"],
+  "extends": "./tsconfig.build.json",
+  "include": ["src/**/*"]
+}

--- a/packages/react-query-sdk/.eslintrc.js
+++ b/packages/react-query-sdk/.eslintrc.js
@@ -1,12 +1,3 @@
 module.exports = {
-  extends: [require.resolve("@akashnetwork/dev-config/.eslintrc.ts")],
-  overrides: [
-    {
-      files: ["*.ts", "*.tsx"],
-      parserOptions: {
-        emitDecoratorMetadata: true,
-        experimentalDecorators: true
-      }
-    }
-  ]
+  extends: [require.resolve("@akashnetwork/dev-config/.eslintrc.ts")]
 };


### PR DESCRIPTION
## Why

to have a way to automatically convert service into react-query observable hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new react-query-proxy package providing a proxy-based integration to useQuery/useMutation for async SDKs, with nested support and customizable query-key mapping.

* **Documentation**
  * Added a README with installation, usage examples, query key/invalidation guidance, and license.

* **Tests**
  * Added comprehensive tests covering key generation, query/mutation flows, nested proxies, caching, and edge cases.

* **Chores**
  * Added package metadata and project configs (linting, testing, TypeScript) and simplified ESLint in the query-sdk package.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->