### PR TITLE
fix: sets lower values for template fetching runtime concurrency

### DIFF
--- a/apps/api/scripts/buildAkashTemplatesCache.ts
+++ b/apps/api/scripts/buildAkashTemplatesCache.ts
@@ -12,7 +12,9 @@ if (!githubPAT) {
 
 const templateGalleryService = new TemplateGalleryService({
   githubPAT,
-  dataFolderPath
+  dataFolderPath,
+  categoryProcessingConcurrency: 30,
+  templateSourceProcessingConcurrency: 30
 });
 
 templateGalleryService.getTemplateGallery().catch(err => {

--- a/apps/api/src/services/external/templates/template-gallery.service.ts
+++ b/apps/api/src/services/external/templates/template-gallery.service.ts
@@ -10,6 +10,8 @@ import { TemplateProcessorService } from "./template-processor.service";
 type Options = {
   githubPAT?: string;
   dataFolderPath: string;
+  categoryProcessingConcurrency?: number;
+  templateSourceProcessingConcurrency?: number;
 };
 
 export class TemplateGalleryService {
@@ -21,7 +23,11 @@ export class TemplateGalleryService {
 
   constructor(private readonly options: Options) {
     this.templateProcessor = new TemplateProcessorService();
-    this.templateFetcher = new TemplateFetcherService(this.templateProcessor, this.options.githubPAT);
+    this.templateFetcher = new TemplateFetcherService(this.templateProcessor, {
+      githubPAT: this.options.githubPAT,
+      categoryProcessingConcurrency: this.options.categoryProcessingConcurrency,
+      templateSourceProcessingConcurrency: this.options.templateSourceProcessingConcurrency
+    });
   }
 
   @Memoize({ ttlInSeconds: minutesToSeconds(5) })


### PR DESCRIPTION
## Why

Because right now when templates are rebuilding, console-api is restarted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Added configurable concurrency controls for template and category processing to optimize Akash templates cache operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->