### PR TITLE
fix(analytics): filter cookies in Amplitude proxy to prevent request rejections

### DIFF
--- a/apps/deploy-web/next.config.js
+++ b/apps/deploy-web/next.config.js
@@ -23,17 +23,6 @@ const withPWA = require("next-pwa")({
 const { withSentryConfig } = require("@sentry/nextjs");
 const path = require("path");
 
-let browserEnv;
-try {
-  const { browserEnvSchema } = require("./env-config.schema");
-
-  browserEnv = browserEnvSchema.parse(process.env);
-} catch (error) {
-  if (error.message.includes("Cannot find module")) {
-    console.warn("No env-config.schema.js found, skipping env validation");
-  }
-}
-
 const transpilePackages = ["geist", "@akashnetwork/ui", "@auth0/nextjs-auth0"];
 
 if (process.env.NODE_ENV === "test") {
@@ -170,16 +159,7 @@ const nextConfig = {
         permanent: false
       }
     ];
-  },
-  rewrites: async () =>
-    browserEnv.NEXT_PUBLIC_AMPLITUDE_PROXY_URL
-      ? [
-          {
-            source: browserEnv.NEXT_PUBLIC_AMPLITUDE_PROXY_URL,
-            destination: "https://api2.amplitude.com/2/httpapi"
-          }
-        ]
-      : []
+  }
 };
 
 const REPOSITORY_URL = new URL(repository.url);

--- a/apps/deploy-web/src/pages/api/collect/index.ts
+++ b/apps/deploy-web/src/pages/api/collect/index.ts
@@ -1,0 +1,57 @@
+import { defineApiHandler } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
+import type { AppServices } from "@src/services/app-di-container/server-di-container.service";
+
+let amplitudeProxy: ReturnType<AppServices["httpProxy"]["createProxyServer"]> | null = null;
+
+function getAmplitudeProxy(services: AppServices) {
+  if (!amplitudeProxy) {
+    amplitudeProxy = services.httpProxy.createProxyServer({
+      changeOrigin: true,
+      target: "https://api2.amplitude.com",
+      secure: true,
+      autoRewrite: false
+    });
+  }
+
+  return amplitudeProxy;
+}
+
+export default defineApiHandler({
+  route: "/api/collect",
+  async handler({ req, res, services }) {
+    delete req.headers.cookie;
+
+    req.url = "/2/httpapi";
+
+    const proxy = getAmplitudeProxy(services);
+
+    return new Promise<void>((resolve, reject) => {
+      const onProxyRes = (_proxyRes: unknown, _req: unknown, proxyRes: unknown) => {
+        if (proxyRes === res) {
+          proxy.off("error", onError);
+          resolve();
+        }
+      };
+      const onError = (error: Error, _req: unknown, errorRes: unknown) => {
+        if (errorRes === res) {
+          proxy.off("proxyRes", onProxyRes);
+          services.logger.error({ error, event: "AMPLITUDE_PROXY_ERROR" });
+          if (!res.headersSent) {
+            res.status(502).json({ error: "Proxy error" });
+          }
+          reject(error);
+        }
+      };
+      proxy.on("proxyRes", onProxyRes);
+      proxy.on("error", onError);
+      proxy.web(req, res);
+    });
+  }
+});
+
+export const config = {
+  api: {
+    externalResolver: true,
+    bodyParser: false
+  }
+};


### PR DESCRIPTION


Create custom API route handler for /api/collect that removes all cookies before proxying to Amplitude's API. This prevents Amplitude from rejecting requests due to excessive or irrelevant cookies while maintaining analytics functionality.

- Add /api/collect API route that proxies to Amplitude with cookie filtering
- Rewrite URL path from /api/collect to /2/httpapi to match Amplitude endpoint
- Initialize proxy server once and reuse for better performance
- Remove Next.js rewrite rule as API route takes precedence
<img width="638" height="216" alt="image" src="https://github.com/user-attachments/assets/b41f5c1f-75fa-439a-a27c-dd2d3be45e1f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a server-side API route that proxies external requests and exposes custom API runtime options.

* **Chores**
  * Removed client-side environment validation and the conditional client-side proxy rewrite configuration.
  * Simplified runtime configuration by eliminating the prior env-driven rewrite behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->