### PR TITLE
fix(deployment): uses proper button image link

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/ShareDeployButton/ShareDeployButton.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ShareDeployButton/ShareDeployButton.spec.tsx
@@ -86,8 +86,8 @@ describe(ShareDeployButton.name, () => {
     const message = callArgs.message as React.ReactElement;
 
     const expectedDeployUrl = "https://console.akash.network/new-deployment?repoUrl=https%3A%2F%2Fgithub.com%2Ftest%2Frepo&branch=main";
-    const expectedMarkdownSnippet = `[![Deploy on Akash](https://raw.githubusercontent.com/akash-network/support/main/deploy-with-akash-btn.svg)](${expectedDeployUrl})`;
-    const expectedHtmlSnippet = `<a href="${expectedDeployUrl}"><img src="https://raw.githubusercontent.com/akash-network/support/main/deploy-with-akash-btn.svg" alt="Deploy on Akash"></a>`;
+    const expectedMarkdownSnippet = `[![Deploy on Akash](https://raw.githubusercontent.com/akash-network/console/refs/heads/main/apps/deploy-web/public/images/deploy-with-akash-btn.svg)](${expectedDeployUrl})`;
+    const expectedHtmlSnippet = `<a href="${expectedDeployUrl}"><img src="https://raw.githubusercontent.com/akash-network/console/refs/heads/main/apps/deploy-web/public/images/deploy-with-akash-btn.svg" alt="Deploy on Akash"></a>`;
 
     render(message);
 

--- a/apps/deploy-web/src/components/new-deployment/ShareDeployButton/ShareDeployButton.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ShareDeployButton/ShareDeployButton.tsx
@@ -214,7 +214,7 @@ export const ShareDeployButton: FC<ShareDeployButtonProps> = ({ services, depend
     if (nodeVersion) urlParams.nodeVersion = nodeVersion;
 
     const deployUrl = `${d.getBaseUrl()}${UrlService.newDeployment(urlParams)}`;
-    const buttonImageUrl = "https://raw.githubusercontent.com/akash-network/support/main/deploy-with-akash-btn.svg";
+    const buttonImageUrl = "https://raw.githubusercontent.com/akash-network/console/refs/heads/main/apps/deploy-web/public/images/deploy-with-akash-btn.svg";
     const markdownSnippet = `[![Deploy on Akash](${buttonImageUrl})](${deployUrl})`;
     const htmlSnippet = `<a href="${deployUrl}"><img src="${buttonImageUrl}" alt="Deploy on Akash"></a>`;
 


### PR DESCRIPTION
refs #2470

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed image links used in deployment sharing snippets so the deploy button image displays correctly in both Markdown and HTML share outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->