### PR TITLE
chore: fixes double notification for required approvals

### DIFF
--- a/.github/actions/slack-pending-deployment-approval/action.yml
+++ b/.github/actions/slack-pending-deployment-approval/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: Title of the message
     required: false
     default: "Deployment requires approval"
+  environment:
+    description: Environment name
+    required: false
+    default: "production"
 
 runs:
   using: "composite"
@@ -42,6 +46,6 @@ runs:
 
                   Hey ${{ steps.associated-pr.outputs.slack-user != '' && format('<@{0}>', steps.associated-pr.outputs.slack-user) || steps.associated-pr.outputs.author }},
 
-                  A new version of *${{inputs.new-app-version}}* is ready to be deployed to production. Please test your changes on <${{ inputs.url }}|beta> and <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Confirm> the deployment.
+                  A new version of *${{inputs.new-app-version}}* is ready to be deployed to *${{ inputs.environment }}*. Please test your changes on <${{ inputs.url }}|beta> and <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Confirm> the deployment.
                   This was triggered by the following PR:
                   <${{ github.server_url }}/${{ github.repository }}/pull/${{ steps.associated-pr.outputs.number }}|${{ steps.associated-pr.outputs.title }}>

--- a/.github/workflows/reusable-deploy-k8s.yml
+++ b/.github/workflows/reusable-deploy-k8s.yml
@@ -99,7 +99,6 @@ jobs:
       can_deploy: ${{ steps.beta-deployment-status.outputs.can_deploy }}
       require_approval: ${{ steps.approval-status.outputs.require_approval }}
       environment: ${{ steps.determine-environment.outputs.environment }}
-      chain-suffix: ${{ steps.determine-environment.outputs.chain-suffix }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -183,8 +182,11 @@ jobs:
           BLOCKCHAIN_NAME: ${{ inputs.chain != 'NA' && inputs.chain || '' }}
           DEPLOYMENT_ENVIRONMENT: ${{ inputs.environment == 'prod' && 'production' || 'beta' }}
         run: |
-          echo "chain-suffix=-$BLOCKCHAIN_NAME" >> "$GITHUB_OUTPUT"
-          echo "environment=$DEPLOYMENT_ENVIRONMENT-$BLOCKCHAIN_NAME" >> "$GITHUB_OUTPUT"
+          environment_suffix=""
+          if [[ -n "$BLOCKCHAIN_NAME" ]]; then
+            environment_suffix="-$BLOCKCHAIN_NAME"
+          fi
+          echo "environment=$DEPLOYMENT_ENVIRONMENT$environment_suffix" >> "$GITHUB_OUTPUT"
 
       - name: Check if approval is required
         id: approval-status
@@ -216,7 +218,8 @@ jobs:
           url: ${{ vars.CONSOLE_WEB_BETA_URL }}
           slack-webhook-url: ${{ secrets.FAILED_E2E_TESTS_SLACK_WEBHOOK_URL }}
           gh-user-to-slack-user: ${{ vars.GH_USER_TO_SLACK_USER }}
-          new-app-version: "${{ inputs.app }}${{ inputs.chain != 'NA' && format('-{0}', inputs.chain) || '' }}@${{ inputs.appVersion }}"
+          new-app-version: "${{ inputs.app }}@${{ inputs.appVersion }}"
+          environment: ${{ needs.deployment-prerequisites.outputs.environment }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-deploy-k8s.yml
+++ b/.github/workflows/reusable-deploy-k8s.yml
@@ -53,12 +53,6 @@ on:
         default: false
         description: >-
           Force a Kubernetes rollout restart even if the Deployment spec is unchanged.
-      notify-about-pending-deployment:
-        type: boolean
-        required: false
-        default: false
-        description: >-
-          Notify in Slack about pending deployment.
 
   workflow_call:
     inputs:
@@ -93,28 +87,25 @@ on:
         default: false
         description: >-
           Force a Kubernetes rollout restart even if the Deployment spec is unchanged.
-      notify-about-pending-deployment:
-        type: boolean
-        required: false
-        default: true
-        description: >-
-          Notify in Slack about pending deployment.
 
 # 1 pending + 1 in-progress workflows
 concurrency:
   group: deploy-${{ inputs.app }}-${{ inputs.environment }}-${{ inputs.chain || 'NA' }}
 
 jobs:
-  beta-deployment-status:
+  deployment-prerequisites:
     runs-on: ubuntu-latest
     outputs:
       can_deploy: ${{ steps.beta-deployment-status.outputs.can_deploy }}
+      require_approval: ${{ steps.approval-status.outputs.require_approval }}
+      environment: ${{ steps.determine-environment.outputs.environment }}
+      chain-suffix: ${{ steps.determine-environment.outputs.chain-suffix }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Notify in Slack if beta deployment check was skipped
-        if: github.event_name == 'workflow_dispatch' && inputs.skip_beta_deployment_check == 'true'
+        if: github.event_name == 'workflow_dispatch' && (inputs.skip_beta_deployment_check == 'true' || inputs.skip_beta_deployment_check == true)
         uses: slackapi/slack-github-action@v2.0.0
         with:
           webhook-type: incoming-webhook
@@ -186,16 +177,37 @@ jobs:
             echo "can_deploy=$can_deploy" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Determine environment
+        id: determine-environment
+        env:
+          BLOCKCHAIN_NAME: ${{ inputs.chain != 'NA' && inputs.chain || '' }}
+          DEPLOYMENT_ENVIRONMENT: ${{ inputs.environment == 'prod' && 'production' || 'beta' }}
+        run: |
+          echo "chain-suffix=-$BLOCKCHAIN_NAME" >> "$GITHUB_OUTPUT"
+          echo "environment=$DEPLOYMENT_ENVIRONMENT-$BLOCKCHAIN_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Check if approval is required
+        id: approval-status
+        env:
+          DEPLOYMENT_ENVIRONMENT: ${{ steps.determine-environment.outputs.environment }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          require_approval=$(gh api "repos/$GITHUB_REPOSITORY/environments/$DEPLOYMENT_ENVIRONMENT" \
+            --jq '.protection_rules | map(.type) | contains(["required_reviewers"])')
+          echo "require_approval=$require_approval" >> "$GITHUB_OUTPUT"
+
+
   notify-about-pending-deployment:
     permissions:
       contents: read
       pull-requests: read
     runs-on: ubuntu-latest
-    needs: beta-deployment-status
+    needs: deployment-prerequisites
     if: >-
-      (inputs.notify-about-pending-deployment == true || inputs.notify-about-pending-deployment == 'true') &&
-      inputs.environment == 'prod' &&
-      (needs.beta-deployment-status.outputs.can_deploy == 'true' || inputs.skip_beta_deployment_check == 'true')
+      github.event_name != 'workflow_dispatch' &&
+      needs.deployment-prerequisites.outputs.can_deploy == 'true' &&
+      needs.deployment-prerequisites.outputs.require_approval == 'true'
+
     steps:
       - uses: actions/checkout@v6
       - name: Notify in Slack about pending deployment
@@ -204,13 +216,13 @@ jobs:
           url: ${{ vars.CONSOLE_WEB_BETA_URL }}
           slack-webhook-url: ${{ secrets.FAILED_E2E_TESTS_SLACK_WEBHOOK_URL }}
           gh-user-to-slack-user: ${{ vars.GH_USER_TO_SLACK_USER }}
-          new-app-version: "${{ inputs.app }}@${{ inputs.appVersion }}"
+          new-app-version: "${{ inputs.app }}${{ inputs.chain != 'NA' && format('-{0}', inputs.chain) || '' }}@${{ inputs.appVersion }}"
 
   deploy:
     runs-on: ubuntu-latest
-    needs: beta-deployment-status
-    if: needs.beta-deployment-status.outputs.can_deploy == 'true' || inputs.skip_beta_deployment_check == 'true'
-    environment: ${{ inputs.environment == 'prod' && (inputs.chain == 'NA' && 'production' || format('production-{0}', inputs.chain)) || (inputs.chain == 'NA' && 'beta' || format('beta-{0}', inputs.chain)) }}
+    needs: deployment-prerequisites
+    if: needs.deployment-prerequisites.outputs.can_deploy == 'true'
+    environment: ${{ needs.deployment-prerequisites.outputs.environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Why

bug in gh workflow. It sends 2 notifications for services that support deployment to different chains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection of whether deployments require approval, exposed to downstream workflow steps.
  * Slack pending-deployment notifications now include the computed environment and respect the approval requirement.
  * Notification action accepts a configurable environment input instead of a hard-coded value.

* **Refactor**
  * Consolidated prerequisite evaluation into a single job and wired notification and deploy steps to consume its outputs for clearer control flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->