### PR TITLE
chore: adds permission to stats-web release workflow

### DIFF
--- a/.github/workflows/stats-web-release.yml
+++ b/.github/workflows/stats-web-release.yml
@@ -55,6 +55,7 @@ jobs:
   deploy-prod:
     permissions:
       contents: read
+      pull-requests: read
     needs:
       - build-prod
       - deploy-beta


### PR DESCRIPTION
## Why

Bug: 
> The workflow is not valid. .github/workflows/stats-web-release.yml (Line: 55, Col: 3): Error calling workflow 'akash-network/console/.github/workflows/reusable-deploy-k8s.yml@adae126f86b55250412a93f5a96e7505c0bf36df'. The nested job 'notify-about-pending-deployment' is requesting 'pull-requests: read', but is only allowed 'pull-requests: none'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow permissions to enable additional operations during production releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->