### PR TITLE
feat(deployment): adds port configuration to build & deploy

### DIFF
--- a/apps/deploy-web/src/components/remote-deploy/deployment-configurations/RemoteBuildInstallConfig.tsx
+++ b/apps/deploy-web/src/components/remote-deploy/deployment-configurations/RemoteBuildInstallConfig.tsx
@@ -87,6 +87,18 @@ const RemoteBuildInstallConfig = ({ services, setValue }: { services: ServiceTyp
                 label="Node Version"
                 placeholder="21"
               />
+              <BoxTextInput
+                value={currentService?.expose?.[0]?.port !== undefined ? String(currentService.expose[0].port) : ""}
+                onChange={e => {
+                  const parsedPort = e.target.value ? Number(e.target.value) : undefined;
+                  if (Number.isNaN(parsedPort)) {
+                    return;
+                  }
+                  setValue("services.0.expose.0.port", parsedPort || 3000);
+                }}
+                label="Port"
+                placeholder="3000"
+              />
               <div className="flex flex-col gap-3 rounded border bg-card px-6 py-6 text-card-foreground">
                 <div className="flex items-center justify-between gap-5">
                   <Label htmlFor="disable-pull" className="text-base">


### PR DESCRIPTION
refs #2475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Port field to Build & Install Configurations so users can specify the deployment port for a service. Input is validated as a number and defaults to 3000 when empty; invalid entries are ignored. This enhances port configuration without changing existing form behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->