### PR TITLE
fix: ensure provider address in managed wapi /leases is bech32

### DIFF
--- a/apps/api/src/deployment/http-schemas/lease.schema.ts
+++ b/apps/api/src/deployment/http-schemas/lease.schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { DseqSchema } from "@src/utils/schema";
+import { AkashAddressSchema, DseqSchema } from "@src/utils/schema";
 
 export const CreateLeaseRequestSchema = z.object({
   manifest: z.string(),
@@ -15,7 +15,7 @@ export const CreateLeaseRequestSchema = z.object({
       dseq: DseqSchema,
       gseq: z.number(),
       oseq: z.number(),
-      provider: z.string()
+      provider: AkashAddressSchema
     })
   )
 });


### PR DESCRIPTION
## Why

to fail early

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for the provider field in lease creation requests to enforce proper address format requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->