### PR TITLE
fix(billing): defers succeeded payment intent status update to process payments reliably

### DIFF
--- a/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
+++ b/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
@@ -78,7 +78,7 @@ export class StripeTransactionRepository extends BaseRepository<Table, StripeTra
     return item ? this.toOutput(item) : undefined;
   }
 
-  async updateStatusByPaymentIntentId(paymentIntentId: string, update: Partial<StripeTransactionInput>): Promise<StripeTransactionOutput | undefined> {
+  async updateByPaymentIntentId(paymentIntentId: string, update: Partial<StripeTransactionInput>): Promise<StripeTransactionOutput | undefined> {
     const existing = await this.findByPaymentIntentId(paymentIntentId);
     if (!existing) return undefined;
 

--- a/apps/api/src/billing/services/stripe/stripe.service.spec.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.spec.ts
@@ -81,6 +81,9 @@ describe(StripeService.name, () => {
         automatic_payment_methods: {
           enabled: true,
           allow_redirects: "never"
+        },
+        metadata: {
+          internal_transaction_id: "test-transaction-id"
         }
       });
       expect(result).toEqual({

--- a/apps/api/test/functional/stripe-webhook.spec.ts
+++ b/apps/api/test/functional/stripe-webhook.spec.ts
@@ -92,7 +92,8 @@ describe("Stripe webhook", () => {
               amount,
               amount_received: amount,
               latest_charge: chargeId,
-              payment_method_types: ["card"]
+              payment_method_types: ["card"],
+              metadata: {}
             }
           },
           type: "payment_intent.succeeded"
@@ -157,7 +158,8 @@ describe("Stripe webhook", () => {
               amount,
               amount_received: amount,
               latest_charge: chargeId,
-              payment_method_types: ["card"]
+              payment_method_types: ["card"],
+              metadata: {}
             }
           },
           type: "payment_intent.succeeded"


### PR DESCRIPTION
We assign credits via webhook which in turn skips this is transaction is succeeded already. So succeeded status should be assigned by a webhook handler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Defer certain payment status updates until webhook confirmation to avoid premature state changes.
  * Attach and use internal transaction IDs on payment intents so webhooks reliably reconcile payments, populate receipt and card details, and include receipt URLs.
  * Improve idempotent webhook handling by preferring internal-transaction-based lookup and skipping payment-method-validation events early.

* **Tests**
  * Updated tests to cover deferred status flow, internal-transaction lookup, and updated webhook payloads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->