### PR TITLE
refactor: replaces LoggerService class with createOtelLogger

### DIFF
--- a/apps/api/src/address/services/address/address.service.ts
+++ b/apps/api/src/address/services/address/address.service.ts
@@ -1,6 +1,6 @@
 import type { Coin } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import { CosmosHttpService } from "@akashnetwork/http-sdk";
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { asset_lists } from "@chain-registry/assets";
 import { AxiosError } from "axios";
 import { singleton } from "tsyringe";
@@ -9,7 +9,7 @@ import type { GetAddressResponse } from "@src/address/http-schemas/address.schem
 import { TransactionService } from "@src/transaction/services/transaction/transaction.service";
 import { ValidatorRepository } from "@src/validator/repositories/validator/validator.repository";
 
-const logger = LoggerService.forContext("AddressService");
+const logger = createOtelLogger({ context: "AddressService" });
 
 @singleton()
 export class AddressService {

--- a/apps/api/src/app/index.ts
+++ b/apps/api/src/app/index.ts
@@ -1,4 +1,3 @@
-import "../open-telemetry";
 import "./providers/jobs.provider";
 import "@src/deployment";
 import "@src/billing";

--- a/apps/api/src/auth/services/auth.interceptor.ts
+++ b/apps/api/src/auth/services/auth.interceptor.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { secondsInMinute } from "date-fns";
 import { Context, Next } from "hono";
 import { Unauthorized } from "http-errors";
@@ -18,7 +18,7 @@ const LAST_USER_ACTIVITY_THROTTLE_TIME_SECONDS = 30 * secondsInMinute;
 
 @singleton()
 export class AuthInterceptor implements HonoInterceptor {
-  private readonly logger = LoggerService.forContext(AuthInterceptor.name);
+  private readonly logger = createOtelLogger({ context: AuthInterceptor.name });
   private readonly lastUserActivityCache = new LRUCache<string, Date>({
     max: 1e5,
     ttl: LAST_USER_ACTIVITY_THROTTLE_TIME_SECONDS * 1000,

--- a/apps/api/src/background-jobs-app.ts
+++ b/apps/api/src/background-jobs-app.ts
@@ -1,9 +1,10 @@
 import "./app";
 
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { Hono } from "hono";
 import { container } from "tsyringe";
 
-import { CORE_CONFIG, JobQueueService, LoggerService, startServer } from "@src/core";
+import { CORE_CONFIG, JobQueueService, startServer } from "@src/core";
 import { healthzRouter } from "@src/healthz/routes/healthz.router";
 
 export async function bootstrap(): Promise<void> {
@@ -11,7 +12,7 @@ export async function bootstrap(): Promise<void> {
 
   app.route("/", healthzRouter);
 
-  const server = await startServer(app, LoggerService.forContext("BACKGROUND_JOBS"), process, { port: container.resolve(CORE_CONFIG).PORT });
+  const server = await startServer(app, createOtelLogger({ context: "BACKGROUND_JOBS" }), process, { port: container.resolve(CORE_CONFIG).PORT });
   if (server) {
     await container.resolve(JobQueueService).startWorkers();
   }

--- a/apps/api/src/billing/lib/batch-signing-client/batch-signing-client.service.ts
+++ b/apps/api/src/billing/lib/batch-signing-client/batch-signing-client.service.ts
@@ -1,5 +1,5 @@
 import { TxRaw } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { sha256 } from "@cosmjs/crypto";
 import { toHex } from "@cosmjs/encoding";
 import type { EncodeObject, Registry } from "@cosmjs/proto-signing";
@@ -126,7 +126,7 @@ export class BatchSigningClientService {
   /**
    * Logger instance for this service.
    */
-  private readonly logger = LoggerService.forContext(this.loggerContext);
+  private readonly logger = createOtelLogger({ context: this.loggerContext });
 
   /**
    * Checks if there are pending transactions waiting to be batched.

--- a/apps/api/src/billing/repositories/usage/usage.repository.ts
+++ b/apps/api/src/billing/repositories/usage/usage.repository.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { QueryTypes } from "sequelize";
 import { singleton } from "tsyringe";
 
@@ -21,7 +21,7 @@ export interface BillingUsageRawResult {
 
 @singleton()
 export class UsageRepository {
-  private readonly logger = LoggerService.forContext(UsageRepository.name);
+  private readonly logger = createOtelLogger({ context: UsageRepository.name });
 
   constructor(
     private readonly userWalletRepository: UserWalletRepository,

--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
@@ -1,5 +1,5 @@
 import { AuthzHttpService } from "@akashnetwork/http-sdk";
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { EncodeObject } from "@cosmjs/proto-signing";
 import add from "date-fns/add";
 import addDays from "date-fns/addDays";
@@ -29,7 +29,7 @@ interface SpendingAuthorizationOptions {
 
 @singleton()
 export class ManagedUserWalletService {
-  private readonly logger = LoggerService.forContext(ManagedUserWalletService.name);
+  private readonly logger = createOtelLogger({ context: ManagedUserWalletService.name });
 
   constructor(
     @InjectBillingConfig() private readonly config: BillingConfig,

--- a/apps/api/src/billing/services/provider-cleanup/provider-cleanup.service.ts
+++ b/apps/api/src/billing/services/provider-cleanup/provider-cleanup.service.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { singleton } from "tsyringe";
 
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
@@ -12,7 +12,7 @@ import { DeploymentRepository } from "@src/deployment/repositories/deployment/de
 
 @singleton()
 export class ProviderCleanupService {
-  private readonly logger = LoggerService.forContext(ProviderCleanupService.name);
+  private readonly logger = createOtelLogger({ context: ProviderCleanupService.name });
 
   constructor(
     @InjectBillingConfig() private readonly config: BillingConfig,

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { PromisePool } from "@supercharge/promise-pool";
 import addDays from "date-fns/addDays";
 import subDays from "date-fns/subDays";
@@ -15,7 +15,7 @@ import { AnalyticsService } from "@src/core/services/analytics/analytics.service
 
 @singleton()
 export class RefillService {
-  private readonly logger = LoggerService.forContext(RefillService.name);
+  private readonly logger = createOtelLogger({ context: RefillService.name });
 
   constructor(
     @InjectBillingConfig() private readonly config: BillingConfig,

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
@@ -1,5 +1,5 @@
-import assert from "http-assert";
 import { createOtelLogger } from "@akashnetwork/logging/otel";
+import assert from "http-assert";
 import Stripe from "stripe";
 import { singleton } from "tsyringe";
 

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
@@ -1,5 +1,5 @@
-import { LoggerService } from "@akashnetwork/logging";
 import assert from "http-assert";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import Stripe from "stripe";
 import { singleton } from "tsyringe";
 
@@ -13,7 +13,7 @@ import { BillingConfigService } from "../billing-config/billing-config.service";
 
 @singleton()
 export class StripeWebhookService {
-  private readonly logger = LoggerService.forContext(StripeWebhookService.name);
+  private readonly logger = createOtelLogger({ context: StripeWebhookService.name });
 
   constructor(
     private readonly stripe: StripeService,

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import type { Counter, Histogram, Meter } from "@opentelemetry/api";
 import { singleton } from "tsyringe";
 
@@ -18,7 +18,7 @@ export class WalletBalanceReloadCheckInstrumentationService {
   private readonly balanceCoverageRatio: Histogram;
   private readonly projectedCost: Histogram;
 
-  private readonly logger = LoggerService.forContext("WalletBalanceReloadCheckHandler");
+  private readonly logger = createOtelLogger({ context: "WalletBalanceReloadCheckHandler" });
 
   constructor(private readonly metricsService: MetricsService) {
     this.meter = this.metricsService.getMeter("wallet-balance-reload-check", "1.0.0");

--- a/apps/api/src/caching/helpers.ts
+++ b/apps/api/src/caching/helpers.ts
@@ -1,9 +1,9 @@
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { differenceInSeconds } from "date-fns";
 
 import MemoryCacheEngine from "./memoryCacheEngine";
 
-const logger = LoggerService.forContext("Caching");
+const logger = createOtelLogger({ context: "Caching" });
 
 export const cacheEngine = new MemoryCacheEngine();
 const pendingRequests = new Map<string, Promise<unknown>>();

--- a/apps/api/src/console.ts
+++ b/apps/api/src/console.ts
@@ -3,7 +3,7 @@ import "@akashnetwork/env-loader";
 import "./app"; // eslint-disable-line import/order
 import "@src/utils/protobuf";
 
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { context, trace } from "@opentelemetry/api";
 import { Command } from "commander";
 import { once } from "lodash";
@@ -73,7 +73,7 @@ program
     });
   });
 
-const logger = LoggerService.forContext("CLI");
+const logger = createOtelLogger({ context: "CLI" });
 
 async function executeCliHandler(name: string, handler: () => Promise<unknown>, options?: { type?: "action" | "daemon" }) {
   await context.with(trace.setSpan(context.active(), tracer.startSpan(name)), async () => {

--- a/apps/api/src/core/providers/logging.provider.ts
+++ b/apps/api/src/core/providers/logging.provider.ts
@@ -1,13 +1,13 @@
 import { LoggerService as LoggerServiceOriginal } from "@akashnetwork/logging";
 import { HttpLoggerInterceptor } from "@akashnetwork/logging/hono";
-import { collectOtel } from "@akashnetwork/logging/otel";
+import { collectOtel, createOtelLogger } from "@akashnetwork/logging/otel";
 import { container, injectable } from "tsyringe";
 
-// Set up OpenTelemetry mixin for all LoggerService instances
-// This collects trace information and adds it to log entries
-LoggerServiceOriginal.mixin = collectOtel;
-
-container.register(HttpLoggerInterceptor, { useValue: new HttpLoggerInterceptor(LoggerServiceOriginal.forContext("HTTP")) });
+container.register(HttpLoggerInterceptor, { useValue: new HttpLoggerInterceptor(createOtelLogger({ context: "HTTP" })) });
 
 @injectable()
-export class LoggerService extends LoggerServiceOriginal {}
+export class LoggerService extends LoggerServiceOriginal {
+  constructor() {
+    super({ mixin: collectOtel });
+  }
+}

--- a/apps/api/src/core/providers/logging.provider.ts
+++ b/apps/api/src/core/providers/logging.provider.ts
@@ -5,6 +5,9 @@ import { container, injectable } from "tsyringe";
 
 container.register(HttpLoggerInterceptor, { useValue: new HttpLoggerInterceptor(createOtelLogger({ context: "HTTP" })) });
 
+/**
+ * Registered in DI as injectable service, so we get new instance on every injection.
+ */
 @injectable()
 export class LoggerService extends LoggerServiceOriginal {
   constructor() {

--- a/apps/api/src/core/providers/postgres.provider.ts
+++ b/apps/api/src/core/providers/postgres.provider.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { DefaultLogger } from "drizzle-orm/logger";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
@@ -15,7 +15,7 @@ import * as userSchemas from "@src/user/model-schemas";
 import type { CoreConfig } from "./config.provider";
 import { CORE_CONFIG } from "./config.provider";
 
-const logger = LoggerService.forContext("POSTGRES");
+const logger = createOtelLogger({ context: "POSTGRES" });
 
 const APP_PG_CLIENT = Symbol("appPgClient") as InjectionToken<postgres.Sql>;
 container.register(APP_PG_CLIENT, {

--- a/apps/api/src/core/services/error/error.service.spec.ts
+++ b/apps/api/src/core/services/error/error.service.spec.ts
@@ -1,17 +1,14 @@
 import "@test/mocks/logger-service.mock";
 
-import { LoggerService } from "@akashnetwork/logging";
+import type { LoggerService } from "@akashnetwork/logging";
 import { faker } from "@faker-js/faker";
+import { mock } from "jest-mock-extended";
 
 import { ErrorService } from "./error.service";
 
 describe(ErrorService.name, () => {
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
   it("should execute callback and return its result", async () => {
-    const service = setup();
+    const { service } = setup();
     const result = faker.lorem.sentence();
     const cb = jest.fn().mockResolvedValue(result);
     const extraLog = { test: "test" };
@@ -23,36 +20,36 @@ describe(ErrorService.name, () => {
   });
 
   it("should handle errors and call onError handler", async () => {
-    const service = setup();
+    const { service, logger } = setup();
     const error = new Error("test");
     const cb = jest.fn().mockRejectedValue(error);
     const extraLog = { test: "test" };
     const onError = jest.fn();
 
-    jest.spyOn(LoggerService.prototype, "error").mockImplementation(() => {});
     const actual = await service.execWithErrorHandler(extraLog, cb, onError);
 
     expect(cb).toHaveBeenCalled();
     expect(onError).toHaveBeenCalledWith(error);
-    expect(LoggerService.prototype.error).toHaveBeenCalledWith(expect.objectContaining({ error, ...extraLog }));
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ error, ...extraLog }));
     expect(actual).toBeUndefined();
   });
 
   it("should handle errors without onError handler", async () => {
-    const service = setup();
+    const { service, logger } = setup();
     const error = new Error("test");
     const cb = jest.fn().mockRejectedValue(error);
     const extraLog = { test: "test" };
 
-    jest.spyOn(LoggerService.prototype, "error").mockImplementation(() => {});
     const actual = await service.execWithErrorHandler(extraLog, cb);
 
     expect(cb).toHaveBeenCalled();
-    expect(LoggerService.prototype.error).toHaveBeenCalledWith(expect.objectContaining({ error, ...extraLog }));
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ error, ...extraLog }));
     expect(actual).toBeUndefined();
   });
 
   function setup() {
-    return new ErrorService();
+    const logger = mock<LoggerService>();
+    const service = new ErrorService(logger);
+    return { service, logger };
   }
 });

--- a/apps/api/src/core/services/error/error.service.ts
+++ b/apps/api/src/core/services/error/error.service.ts
@@ -1,9 +1,9 @@
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { singleton } from "tsyringe";
 
 @singleton()
 export class ErrorService {
-  private readonly logger = LoggerService.forContext(ErrorService.name);
+  private readonly logger = createOtelLogger({ context: ErrorService.name });
 
   async execWithErrorHandler<T>(extraLog: Record<string, unknown>, cb: () => Promise<T>, onError?: (error: unknown) => void): Promise<T | undefined> {
     try {

--- a/apps/api/src/core/services/error/error.service.ts
+++ b/apps/api/src/core/services/error/error.service.ts
@@ -1,9 +1,12 @@
-import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { singleton } from "tsyringe";
+
+import { LoggerService } from "../../providers/logging.provider";
 
 @singleton()
 export class ErrorService {
-  private readonly logger = createOtelLogger({ context: ErrorService.name });
+  constructor(private readonly logger: LoggerService) {
+    this.logger.setContext(ErrorService.name);
+  }
 
   async execWithErrorHandler<T>(extraLog: Record<string, unknown>, cb: () => Promise<T>, onError?: (error: unknown) => void): Promise<T | undefined> {
     try {

--- a/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts
+++ b/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { ForbiddenError } from "@casl/ability";
 import { HTTPException } from "hono/http-exception";
 import { isHttpError } from "http-errors";
@@ -10,7 +10,7 @@ import type { AppContext } from "../../types/app-context";
 
 @singleton()
 export class HonoErrorHandlerService {
-  private readonly logger = LoggerService.forContext("ErrorHandler");
+  private readonly logger = createOtelLogger({ context: "ErrorHandler" });
 
   constructor() {
     this.handle = this.handle.bind(this);

--- a/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
+++ b/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import axios from "axios";
 import type { ComponentsObject, OpenAPIObject, PathsObject, ReferenceObject } from "openapi3-ts/oas30";
 import { inject, singleton } from "tsyringe";
@@ -8,7 +8,7 @@ import type { NotificationsConfig } from "@src/notifications/config/env.config";
 import { NOTIFICATIONS_CONFIG } from "@src/notifications/providers/notifications-config.provider";
 import type { OpenApiHonoHandler } from "../open-api-hono-handler/open-api-hono-handler";
 
-const logger = LoggerService.forContext("OpenApiDocsService");
+const logger = createOtelLogger({ context: "OpenApiDocsService" });
 
 @singleton()
 export class OpenApiDocsService {

--- a/apps/api/src/core/services/postgres-logger/postgres-logger.service.ts
+++ b/apps/api/src/core/services/postgres-logger/postgres-logger.service.ts
@@ -1,4 +1,5 @@
-import { LoggerService } from "@akashnetwork/logging";
+import type { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import type { LogWriter } from "drizzle-orm/logger";
 import { format } from "sql-formatter";
 
@@ -17,7 +18,7 @@ export class PostgresLoggerService implements LogWriter {
 
   constructor(options?: PostgresLoggerServiceOptions) {
     const orm = options?.orm || "drizzle";
-    this.logger = new LoggerService({ base: { context: "POSTGRES", orm, database: options?.database } });
+    this.logger = createOtelLogger({ base: { context: "POSTGRES", orm, database: options?.database } });
     this.isDrizzle = orm === "drizzle";
     this.useFormat = options?.useFormat || false;
   }

--- a/apps/api/src/dashboard/controllers/dashboard-data/dashboard-data.controller.ts
+++ b/apps/api/src/dashboard/controllers/dashboard-data/dashboard-data.controller.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { cloneDeep } from "lodash";
 import { singleton } from "tsyringe";
 
@@ -9,7 +9,7 @@ import { emptyProviderGraphData, ProviderGraphDataService } from "@src/provider/
 import { TransactionService } from "@src/transaction/services/transaction/transaction.service";
 import { createLoggingExecutor } from "@src/utils/logging";
 
-const logger = LoggerService.forContext("DashboardData");
+const logger = createOtelLogger({ context: "DashboardData" });
 const runOrLog = createLoggingExecutor(logger);
 
 const emptyStats = {

--- a/apps/api/src/dashboard/routes/graph-data/graph-data.router.ts
+++ b/apps/api/src/dashboard/routes/graph-data/graph-data.router.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { container } from "tsyringe";
 
 import { createRoute } from "@src/core/lib/create-route/create-route";
@@ -8,7 +8,7 @@ import { GraphDataController } from "@src/dashboard/controllers/graph-data/graph
 import { GraphDataParamsSchema, GraphDataResponseSchema } from "@src/dashboard/http-schemas/graph-data/graph-data.schema";
 import { isValidGraphDataName } from "@src/services/db/statsService";
 
-const logger = LoggerService.forContext("GraphDataRouter");
+const logger = createOtelLogger({ context: "GraphDataRouter" });
 
 export const graphDataRouter = new OpenApiHonoHandler();
 

--- a/apps/api/src/dashboard/services/stats/stats.service.ts
+++ b/apps/api/src/dashboard/services/stats/stats.service.ts
@@ -1,7 +1,7 @@
 import { AkashBlock as Block, Lease, Provider, ProviderSnapshot } from "@akashnetwork/database/dbSchemas/akash";
 import { Day } from "@akashnetwork/database/dbSchemas/base";
 import { CoinGeckoHttpService, CosmosHttpService } from "@akashnetwork/http-sdk";
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { differenceInSeconds, minutesToSeconds, sub, subHours } from "date-fns";
 import { cloneDeep } from "lodash";
 import uniqBy from "lodash/uniqBy";
@@ -20,7 +20,7 @@ import { createLoggingExecutor } from "@src/utils/logging";
 
 const numberOrZero: (x: number | undefined | null) => number = (x: number | undefined | null) => (typeof x === "number" ? x : 0);
 
-const logger = LoggerService.forContext("StatsService");
+const logger = createOtelLogger({ context: "StatsService" });
 const runOrLog = createLoggingExecutor(logger);
 
 type GpuUtilizationData = {

--- a/apps/api/src/db/dbConnection.ts
+++ b/apps/api/src/db/dbConnection.ts
@@ -1,5 +1,6 @@
 import { chainModels, userModels } from "@akashnetwork/database/dbSchemas";
 import { Template, TemplateFavorite, UserSetting } from "@akashnetwork/database/dbSchemas/user";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import pg from "pg";
 import { Transaction as DbTransaction } from "sequelize";
 import { Sequelize } from "sequelize-typescript";
@@ -74,7 +75,7 @@ container.register(APP_INITIALIZER, {
  * Create backups per version
  * Load from backup if exists for current version
  */
-export async function connectUsingSequelize(logger: LoggerService = LoggerService.forContext("DB")): Promise<void> {
+export async function connectUsingSequelize(logger = createOtelLogger({ context: "DB" })): Promise<void> {
   logger.debug(`Connecting to chain database (${chainDb.config.host}/${chainDb.config.database})...`);
   await chainDb.authenticate();
   logger.debug("Connection has been established successfully.");

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { ForbiddenError } from "@casl/ability";
 import { millisecondsInHour } from "date-fns/constants";
 import assert from "http-assert";
@@ -19,7 +19,7 @@ type DeploymentSettingWithEstimatedTopUpAmount = DeploymentSettingsOutput & { es
 
 @singleton()
 export class DeploymentSettingService {
-  private readonly logger = LoggerService.forContext(DeploymentSettingService.name);
+  private readonly logger = createOtelLogger({ context: DeploymentSettingService.name });
 
   private readonly topUpFrequencyMs = this.config.get("AUTO_TOP_UP_JOB_INTERVAL_IN_H") * millisecondsInHour;
   constructor(

--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
@@ -3,7 +3,7 @@ import { Source } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { MsgCloseDeployment, MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { TxRaw } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import { BidHttpService, BlockHttpService } from "@akashnetwork/http-sdk";
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { DirectSecp256k1HdWallet, EncodeObject, Registry } from "@cosmjs/proto-signing";
 import { calculateFee, SigningStargateClient } from "@cosmjs/stargate";
 import pick from "lodash/pick";
@@ -18,7 +18,7 @@ import { sdlTemplateWithRam, sdlTemplateWithRamAndInterface } from "./sdl-templa
 
 @singleton()
 export class GpuBidsCreatorService {
-  private readonly logger = LoggerService.forContext(GpuBidsCreatorService.name);
+  private readonly logger = createOtelLogger({ context: GpuBidsCreatorService.name });
   readonly #deploymentConfig: DeploymentConfig;
 
   constructor(

--- a/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
+++ b/apps/api/src/deployment/services/stale-managed-deployments-cleaner/stale-managed-deployments-cleaner.service.ts
@@ -1,4 +1,4 @@
-import { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { secondsInMinute } from "date-fns/constants";
 import { singleton } from "tsyringe";
 
@@ -14,7 +14,7 @@ import { averageBlockTime } from "@src/utils/constants";
 
 @singleton()
 export class StaleManagedDeploymentsCleanerService {
-  private readonly logger = LoggerService.forContext(StaleManagedDeploymentsCleanerService.name);
+  private readonly logger = createOtelLogger({ context: StaleManagedDeploymentsCleanerService.name });
 
   private readonly MAX_LIVE_BLOCKS = Math.floor((10 * secondsInMinute) / averageBlockTime);
 

--- a/apps/api/src/middlewares/clientInfoMiddleware.ts
+++ b/apps/api/src/middlewares/clientInfoMiddleware.ts
@@ -1,4 +1,5 @@
-import { LoggerService } from "@akashnetwork/logging";
+import type { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { getConnInfo } from "@hono/node-server/conninfo";
 import crypto from "crypto";
 import type { Context, Next } from "hono";
@@ -37,7 +38,7 @@ export const clientInfoMiddleware = createMiddleware<{
       fingerprint: fingerprint
     });
   } catch (error) {
-    logger ??= LoggerService.forContext("clientInfoMiddleware");
+    logger ??= createOtelLogger({ context: "clientInfoMiddleware" });
     logger.error({ error });
   } finally {
     await next();

--- a/apps/api/src/open-telemetry.ts
+++ b/apps/api/src/open-telemetry.ts
@@ -1,4 +1,0 @@
-import { LoggerService } from "@akashnetwork/logging";
-import { collectOtel } from "@akashnetwork/logging/otel";
-
-LoggerService.mixin = collectOtel;

--- a/apps/api/src/provider/services/provider-dashboard/provider-dashboard.service.spec.ts
+++ b/apps/api/src/provider/services/provider-dashboard/provider-dashboard.service.spec.ts
@@ -1,7 +1,7 @@
 import "@test/setup-functional-tests"; // eslint-disable-line simple-import-sort/imports
 
 import type { Provider } from "@akashnetwork/database/dbSchemas/akash";
-import type { Block } from "@akashnetwork/database/dbSchemas/base/block";
+import type { Block } from "@akashnetwork/database/dbSchemas/base";
 import { subDays } from "date-fns";
 
 import { createAkashBlock, createProvider } from "@test/seeders";

--- a/apps/api/src/rest-app.ts
+++ b/apps/api/src/rest-app.ts
@@ -1,7 +1,7 @@
 import "./app";
 
-import { LoggerService } from "@akashnetwork/logging";
 import { HttpLoggerInterceptor } from "@akashnetwork/logging/hono";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { otel } from "@hono/otel";
 import { swaggerUI } from "@hono/swagger-ui";
 import { Hono } from "hono";
@@ -185,7 +185,7 @@ appHono.onError(container.resolve(HonoErrorHandlerService).handle);
 export { appHono as app, connectUsingSequelize as initDb };
 
 export async function bootstrap(): Promise<void> {
-  await startServer(appHono, LoggerService.forContext("APP"), process, {
+  await startServer(appHono, createOtelLogger({ context: "APP" }), process, {
     port: container.resolve(CORE_CONFIG).PORT,
     beforeStart: migratePG
   });

--- a/apps/provider-proxy/src/services/HonoErrorHandlerService/HonoErrorHandlerService.ts
+++ b/apps/provider-proxy/src/services/HonoErrorHandlerService/HonoErrorHandlerService.ts
@@ -1,4 +1,5 @@
-import { LoggerService } from "@akashnetwork/logging";
+import type { LoggerService } from "@akashnetwork/logging";
+import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { ZodError } from "zod";
 
 import type { AppContext } from "../../types/AppContext";
@@ -6,7 +7,7 @@ import type { AppContext } from "../../types/AppContext";
 export class HonoErrorHandlerService {
   private readonly logger: LoggerService;
 
-  constructor(logger = LoggerService.forContext("ErrorHandler")) {
+  constructor(logger = createOtelLogger({ context: "ErrorHandler" })) {
     this.logger = logger;
     this.handle = this.handle.bind(this);
   }


### PR DESCRIPTION
## Why

This allows to get rid of open telemetry specific import order sensitive side effect in console api

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated internal logging to an OpenTelemetry-based logger and moved from a global mixin to per-instance/factory initialization across services.

* **Tests**
  * Updated tests to reflect injected logging dependencies and new logger initialization patterns.

* **Impact**
  * No user-facing behavior, API, or error-handling changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->