### PR TITLE
chore: adds support for github merge queue

### DIFF
--- a/.github/workflows/all-ci.yml
+++ b/.github/workflows/all-ci.yml
@@ -1,5 +1,6 @@
 name: CI
 on:
+  merge_group:
   pull_request:
     branches: ["main", "main-sdk-next"]
   push:

--- a/.github/workflows/local-packages-ci.yml
+++ b/.github/workflows/local-packages-ci.yml
@@ -1,14 +1,26 @@
-name: "Local Package CI"
+name: "Local Packages CI"
 
 on:
+  merge_group:
   pull_request:
     branches: ["main", "main-sdk-next"]
     paths:
       - "packages/**"
       - ".github/workflows/local-packages-validate.yml"
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
+  should-validate:
+    uses: ./.github/workflows/reusable-should-validate.yml
+    with:
+      path: packages
+
   validate:
+    needs: should-validate
+    if: needs.should-validate.outputs.has_changes == 'true'
     name: Validate local packages
     runs-on: ubuntu-latest
 
@@ -19,6 +31,7 @@ jobs:
       - uses: ./.github/actions/setup-app-deps
 
       - name: Static analysis
+        if: github.event_name != 'merge_group'
         run: npm run lint -w ./packages --if-present -- --quiet
 
       - name: Type checking

--- a/.github/workflows/reusable-should-validate.yml
+++ b/.github/workflows/reusable-should-validate.yml
@@ -27,31 +27,17 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       enabled: ${{ github.event_name == 'push' || steps.has_changes.outputs.value == 'true' }}
-      has_changes: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && steps.has_changes.outputs.value }}
+      has_changes: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || github.event_name == 'merge_group') && steps.has_changes.outputs.value }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - uses: ./.github/actions/local-dependencies
+        if: contains(inputs.path, 'apps/')
         id: local_deps
         with:
           path: ${{ inputs.path }}
-
-      - name: Get package name
-        id: package_name
-        env:
-          WORKSPACE_PATH: ${{ inputs.path }}
-        run: |
-          package_name=${WORKSPACE_PATH##*/}
-
-          if [[ "$package_name" == "deploy-web" ]]; then
-            package_name="console-web"
-          elif [[ "$package_name" == "api" ]]; then
-            package_name="console-api"
-          fi
-
-          echo "value=$package_name" >> "$GITHUB_OUTPUT"
 
       - name: Check for changes
         uses: dorny/paths-filter@v3.0.2
@@ -59,10 +45,9 @@ jobs:
         with:
           token: ${{ secrets.gh-token }}
           filters: |
-            local_deps: &local_deps ${{ steps.local_deps.outputs.deps_json }}
+            local_deps: &local_deps ${{ steps.local_deps.outputs.deps_json || '[]' }}
             app_workflows: &app_workflows
-              - ".github/workflows/${{ steps.package_name.outputs.value }}-validate-n-build.yml"
-              - ".github/workflows/${{ steps.package_name.outputs.value }}-docker-build.yml"
+              - ".github/workflows/all-ci.yml"
               - ".github/workflows/reusable-should-validate.yml"
               - ".github/workflows/reusable-validate-app.yml"
               - ".github/workflows/reusable-validate-app-unsafe.yml"

--- a/.github/workflows/reusable-validate-app.yml
+++ b/.github/workflows/reusable-validate-app.yml
@@ -25,6 +25,8 @@ jobs:
     needs: should-validate
     if: needs.should-validate.outputs.enabled == 'true'
     runs-on: ubuntu-latest
+    env:
+      TEST_SCRIPT_NAME: ${{ github.event_name == 'merge_group' && 'test' || 'test:cov' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,20 +35,22 @@ jobs:
         with:
           app: ${{ inputs.app }}
 
-      - name: Run static code analysis
-        if: github.event_name == 'pull_request'
-        run: |
-          npm list eslint --depth 0 || true
-          npm list eslint-plugin-import-x --depth 0 || true
-          npm run lint -w apps/${{ inputs.app }} -- --quiet
-
       - name: Check whether app has tests
         id: tests_details
+        env:
+          PACKAGE_PATH: "./apps/${{ inputs.app }}/package.json"
         run: |
-          has_tests=$(node -p "require('./apps/${{ inputs.app }}/package.json').scripts['test:cov'] ? 'true' : 'false'")
-          requires_env_setup=$(node -p "require('./apps/${{ inputs.app }}/package.json').scripts['test:ci-setup'] ? 'true' : 'false'")
+          read -r has_tests requires_env_setup < <(jq -r '[
+            (if .scripts["${{ env.TEST_SCRIPT_NAME }}"] then "true" else "false" end),
+            (if .scripts["test:ci-setup"] then "true" else "false" end)
+          ] | @tsv' "$PACKAGE_PATH")
           echo "has_tests=$has_tests" >> "$GITHUB_OUTPUT"
           echo "requires_env_setup=$requires_env_setup" >> "$GITHUB_OUTPUT"
+
+      - name: Run static code analysis
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group' && steps.tests_details.outputs.has_tests != 'true'
+        run: |
+          npm run lint -w apps/${{ inputs.app }} -- --quiet
 
       - uses: docker/setup-buildx-action@v3
         if: ${{ steps.tests_details.outputs.requires_env_setup == 'true' }}
@@ -69,14 +73,14 @@ jobs:
 
       - name: Run tests
         if: ${{ steps.tests_details.outputs.has_tests == 'true' }}
-        run: npm run test:cov --workspace=apps/${{ inputs.app }}
+        run: npm run "$TEST_SCRIPT_NAME" --workspace=apps/${{ inputs.app }}
 
       - name: Teardown tests environment
         if: ${{ always() && steps.tests_details.outputs.requires_env_setup == 'true' }}
         run: npm run --if-present --workspace=apps/${{ inputs.app }} test:ci-teardown
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && steps.tests_details.outputs.has_tests == 'true' }}
+        if: ${{ !cancelled() && steps.tests_details.outputs.has_tests == 'true' && github.event_name != 'merge_group' }}
         uses: codecov/test-results-action@v1
         with:
           files: ./junit.xml
@@ -85,7 +89,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload Test Coverage
-        if: steps.tests_details.outputs.has_tests == 'true'
+        if: steps.tests_details.outputs.has_tests == 'true' && github.event_name != 'merge_group'
         uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -16,11 +16,10 @@
     "prod": "node ./dist/server.js",
     "release": "release-it",
     "start": "npm run build && node ./dist/server.js",
+    "test": "jest --selectProjects unit functional",
     "test:cov": "jest --selectProjects unit functional --coverage --reporters=default --reporters=jest-junit",
     "test:e2e": "jest --selectProjects e2e",
     "test:functional": "jest --selectProjects functional",
-    "test:functional:cov": "jest --selectProjects functional --coverage",
-    "test:functional:watch": "jest --selectProjects functional --watch",
     "test:unit": "jest --selectProjects unit"
   },
   "dependencies": {


### PR DESCRIPTION
## Why

After every merge we need to rebase and wait for checks to run. Merge queue can do it automatically, if PR fails it will be excluded from the queue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI adds a new merge_group event and routes it across workflows.
  * "Local Package CI" renamed and an initial should-validate check added; validation now runs conditionally.
  * Workflows gain read permissions and a new conditional job to validate changed paths.
  * Steps are path-gated, static analysis runs conditionally by event/test presence, and uploads skip merge_group events.
  * Provider package tests consolidated into a single combined test script.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->