### PR TITLE
refactor: skips parsing JSON cache when serving templates

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,9 @@
 coverage:
+  ignore:
+    - "apps/api/src/*/routers/**/*.ts"
   status:
     project:
-      default: off
+      default: false
       api:
         target: 80%
         flags:

--- a/apps/api/scripts/buildAkashTemplatesCache.ts
+++ b/apps/api/scripts/buildAkashTemplatesCache.ts
@@ -4,6 +4,7 @@ import "@akashnetwork/env-loader";
 import { LoggerService } from "@akashnetwork/logging";
 import { promises as fsp } from "node:fs";
 
+import { GetTemplatesListResponseSchema } from "../src/template/http-schemas/template.schema";
 import { TemplateGalleryService } from "../src/template/services/template-gallery/template-gallery.service";
 import { dataFolderPath } from "../src/utils/constants";
 
@@ -21,7 +22,7 @@ const templateGalleryService = new TemplateGalleryService(LoggerService.forConte
   templateSourceProcessingConcurrency: 30
 });
 
-templateGalleryService.getTemplateGallery().catch(err => {
+templateGalleryService.buildTemplateGalleryCache(GetTemplatesListResponseSchema.shape.data).catch(err => {
   console.error("Encountered an error trying to warm up Akash templates cache");
   console.error(err);
   process.exit(1);

--- a/apps/api/src/template/http-schemas/template.schema.ts
+++ b/apps/api/src/template/http-schemas/template.schema.ts
@@ -16,17 +16,22 @@ export const TemplateSchema = z.object({
   })
 });
 
-export const TemplateCategorySchema = z.object({
-  title: z.string(),
-  templates: z.array(TemplateSchema)
+export const TemplateSummarySchema = TemplateSchema.pick({
+  id: true,
+  name: true,
+  logoUrl: true,
+  summary: true
 });
 
-export const GetTemplatesFullResponseSchema = z.array(TemplateCategorySchema);
-export type GetTemplatesFullResponse = z.infer<typeof GetTemplatesFullResponseSchema>;
+export const TemplateCategorySchema = z.object({
+  title: z.string(),
+  templates: z.array(TemplateSummarySchema)
+});
 
 export const GetTemplatesListResponseSchema = z.object({
   data: z.array(TemplateCategorySchema)
 });
+
 export type GetTemplatesListResponse = z.infer<typeof GetTemplatesListResponseSchema>;
 
 export const GetTemplateByIdParamsSchema = z.object({

--- a/apps/api/src/template/routes/templates/templates.router.ts
+++ b/apps/api/src/template/routes/templates/templates.router.ts
@@ -1,40 +1,14 @@
+import type { TypedResponse } from "hono";
 import { container } from "tsyringe";
 
 import { createRoute } from "@src/core/lib/create-route/create-route";
 import { OpenApiHonoHandler } from "@src/core/services/open-api-hono-handler/open-api-hono-handler";
 import { SECURITY_NONE } from "@src/core/services/openapi-docs/openapi-security";
 import { TemplateController } from "@src/template/controllers/template/template.controller";
-import {
-  GetTemplateByIdParamsSchema,
-  GetTemplateByIdResponseSchema,
-  GetTemplatesFullResponseSchema,
-  GetTemplatesListResponseSchema
-} from "@src/template/http-schemas/template.schema";
+import type { GetTemplatesListResponse } from "@src/template/http-schemas/template.schema";
+import { GetTemplateByIdParamsSchema, GetTemplateByIdResponseSchema, GetTemplatesListResponseSchema } from "@src/template/http-schemas/template.schema";
 
 export const templatesRouter = new OpenApiHonoHandler();
-
-const getTemplatesFullRoute = createRoute({
-  method: "get",
-  path: "/v1/templates",
-  tags: ["Other"],
-  security: SECURITY_NONE,
-  cache: { maxAge: 300, staleWhileRevalidate: 600 },
-  responses: {
-    200: {
-      description: "Returns a list of deployment templates grouped by categories",
-      content: {
-        "application/json": {
-          schema: GetTemplatesFullResponseSchema
-        }
-      }
-    }
-  }
-});
-templatesRouter.openapi(getTemplatesFullRoute, async function routeGetTemplatesFullList(c) {
-  const result = await container.resolve(TemplateController).getTemplatesFull();
-
-  return c.json(result, 200);
-});
 
 const getTemplatesListRoute = createRoute({
   method: "get",
@@ -56,7 +30,8 @@ const getTemplatesListRoute = createRoute({
 templatesRouter.openapi(getTemplatesListRoute, async function routeGetTemplatesList(c) {
   const result = await container.resolve(TemplateController).getTemplatesList();
 
-  return c.json(result, 200);
+  c.header("Content-Type", "application/json");
+  return c.body(result, 200) as unknown as TypedResponse<GetTemplatesListResponse, 200, "json">;
 });
 
 const getTemplateByIdRoute = createRoute({

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.ts
@@ -48,7 +48,7 @@ export class TemplateGalleryService {
   async getCachedTemplateGallery(): Promise<GalleriesCache> {
     if (this.#galleriesCache) return this.#galleriesCache;
 
-    const cacheFileExists = await this.#fs.access(this.#galleriesCachePath, fsConstants.W_OK | fsConstants.R_OK).then(
+    const cacheFileExists = await this.#fs.access(this.#galleriesCachePath, fsConstants.R_OK).then(
       () => true,
       () => false
     );
@@ -102,6 +102,7 @@ export class TemplateGalleryService {
     const serializeTemplatesContent = serializedTemplates.join("\n");
     const content = `${JSON.stringify(metadata)}\n${serializedCategoriesContent}\n${serializeTemplatesContent}`;
 
+    await this.#fs.mkdir(path.dirname(this.#galleriesCachePath), { recursive: true });
     await this.#fs.writeFile(this.#galleriesCachePath, content);
 
     return {

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.ts
@@ -1,12 +1,13 @@
 import { Octokit } from "@octokit/rest";
-import { constants as fsConstants, promises as fsp } from "node:fs";
+import type { promises as fsp } from "node:fs";
+import { constants as fsConstants } from "node:fs";
 import path from "node:path";
+import type z from "zod";
 
-import { Memoize, reusePendingPromise } from "@src/caching/helpers";
-import { LoggerService } from "@src/core";
+import { reusePendingPromise } from "@src/caching/helpers";
+import type { LoggerService } from "@src/core";
 import type { Category, FinalCategory, Template } from "@src/template/types/template";
 import { REPOSITORIES, TemplateFetcherService } from "../template-fetcher/template-fetcher.service";
-import type { MergedTemplateCategoriesResult } from "../template-processor/template-processor.service";
 import { TemplateProcessorService } from "../template-processor/template-processor.service";
 
 type Options = {
@@ -17,32 +18,107 @@ type Options = {
 };
 
 export class TemplateGalleryService {
-  private lastGalleryData: {
-    categories: FinalCategory[];
-    templatesIds: MergedTemplateCategoriesResult["templatesIds"];
-  } | null = null;
+  #galleriesCache: GalleriesCache | null = null;
+  #parsedTemplates: Record<string, Template> = {};
 
-  private readonly templateFetcher: TemplateFetcherService;
+  private readonly templateFetcher: TemplateFetcherService | null;
   private readonly templateProcessor: TemplateProcessorService;
   readonly #logger: LoggerService;
   readonly #fs: FileSystemApi;
   readonly #options: Options;
+  readonly #galleriesCachePath: string;
 
   constructor(logger: LoggerService, fs: FileSystemApi, options: Options) {
     this.#logger = logger;
     this.#fs = fs;
     this.templateProcessor = new TemplateProcessorService();
-    this.templateFetcher = new TemplateFetcherService(this.templateProcessor, this.#logger, fetch, getOctokit(options.githubPAT), {
-      categoryProcessingConcurrency: options.categoryProcessingConcurrency,
-      templateSourceProcessingConcurrency: options.templateSourceProcessingConcurrency
-    });
+    this.templateFetcher = options.githubPAT
+      ? new TemplateFetcherService(this.templateProcessor, this.#logger, fetch, getOctokit(options.githubPAT), {
+          categoryProcessingConcurrency: options.categoryProcessingConcurrency,
+          templateSourceProcessingConcurrency: options.templateSourceProcessingConcurrency
+        })
+      : null;
     this.#options = options;
-    this.getTemplatesFromRepo = reusePendingPromise(this.getTemplatesFromRepo.bind(this), { getKey: options => options.repository });
-    this.getTemplateById = reusePendingPromise(this.getTemplateById.bind(this), { getKey: id => id });
+    this.#galleriesCachePath = `${options.dataFolderPath}/templates/templates-gallery.json`;
+    this.getTemplatesFromRepo = reusePendingPromise(this.getTemplatesFromRepo.bind(this), { getKey: options => `templates-from-repo-${options.repository}` });
+    this.getTemplateById = reusePendingPromise(this.getTemplateById.bind(this), { getKey: id => `template-by-id-${id}` });
+    this.getCachedTemplateGallery = reusePendingPromise(this.getCachedTemplateGallery.bind(this), { getKey: () => "cached-template-gallery" });
   }
 
-  @Memoize({ ttlInSeconds: Infinity })
-  async getTemplateGallery() {
+  async getCachedTemplateGallery(): Promise<GalleriesCache> {
+    if (this.#galleriesCache) return this.#galleriesCache;
+
+    const cacheFileExists = await this.#fs.access(this.#galleriesCachePath, fsConstants.W_OK | fsConstants.R_OK).then(
+      () => true,
+      () => false
+    );
+
+    if (!cacheFileExists) {
+      throw new Error(`Template gallery cache file not found: ${this.#galleriesCachePath}`);
+    }
+
+    const cacheContent = await this.#fs.readFile(this.#galleriesCachePath, "utf8");
+    const metadataString = cacheContent.slice(0, cacheContent.indexOf("\n"));
+    const content = cacheContent.slice(metadataString.length + 1);
+    const metadata = JSON.parse(metadataString);
+    const categories = content.slice(0, metadata.templatesOffset).trim();
+    const templates = content.slice(metadata.templatesOffset).trim();
+
+    this.#galleriesCache = Object.freeze({
+      metadata,
+      categories,
+      templates
+    });
+    return this.#galleriesCache;
+  }
+
+  async buildTemplateGalleryCache(categoriesSchema: z.ZodSchema): Promise<GalleriesCache> {
+    const gallery = await this.getTemplateGallery();
+    const result = gallery.reduce<{ templates: Template[]; categories: FinalCategory[] }>(
+      (acc, category) => {
+        acc.templates.push(...category.templates);
+        acc.categories.push(category);
+        return acc;
+      },
+      { templates: [], categories: [] }
+    );
+
+    result.categories = categoriesSchema.parse(result.categories);
+    const serializedTemplates = result.templates.map(template => JSON.stringify(template));
+    const templatesRangesByIndex = buildContentRanges(serializedTemplates);
+    const templatesRangesById = result.templates.reduce(
+      (acc, template, index) => {
+        acc[template.id] = templatesRangesByIndex[index];
+        return acc;
+      },
+      {} as Record<string, [start: number, end: number]>
+    );
+    const serializedCategoriesContent = JSON.stringify(result.categories);
+
+    const metadata: GalleriesCache["metadata"] = {
+      templatesRanges: templatesRangesById,
+      templatesOffset: serializedCategoriesContent.length + 1 // +1 for the newline character
+    };
+    const serializeTemplatesContent = serializedTemplates.join("\n");
+    const content = `${JSON.stringify(metadata)}\n${serializedCategoriesContent}\n${serializeTemplatesContent}`;
+
+    await this.#fs.writeFile(this.#galleriesCachePath, content);
+
+    return {
+      metadata,
+      categories: serializedCategoriesContent,
+      templates: serializeTemplatesContent
+    };
+  }
+
+  /**
+   * !!! WARNING !!!
+   * DO NOT USE THIS METHOD to serve requests, it's event loop blocking because works with big JSON objects.
+   * Use getTemplateGallerySerialized instead.
+   */
+  async getTemplateGallery(): Promise<FinalCategory[]> {
+    if (!this.templateFetcher) return [];
+
     try {
       this.#logger.debug({
         event: "GET_TEMPLATE_GALLERY_START",
@@ -64,43 +140,49 @@ export class TemplateGalleryService {
       ]);
 
       const templateGallery = this.templateProcessor.mergeTemplateCategories(omnibusTemplates, awesomeAkashTemplates, linuxServerTemplates);
-      const categories = templateGallery.categories.map(({ templateSources, ...category }) => category);
-      this.lastGalleryData = { categories, templatesIds: templateGallery.templatesIds };
+      const categories = templateGallery.map(({ templateSources, ...category }) => category);
 
       this.#logger.debug({
         event: "GET_TEMPLATE_GALLERY_END",
         githubRequestsRemaining: this.templateFetcher.githubRequestsRemaining,
-        categoriesCount: templateGallery.categories.length
+        categoriesCount: categories.length
       });
 
-      return this.lastGalleryData;
+      return categories;
     } catch (error) {
-      if (this.lastGalleryData) {
-        this.#logger.error({
-          event: "GET_TEMPLATE_GALLERY_ERROR",
-          message: "Serving template gallery from last working version",
-          error
-        });
-        return this.lastGalleryData;
-      } else {
-        this.#logger.error({
-          event: "GET_TEMPLATE_GALLERY_ERROR",
-          message: "no fallback available",
-          error
-        });
-        throw error;
-      }
+      this.#logger.error({
+        event: "GET_TEMPLATE_GALLERY_ERROR",
+        message: "no fallback available",
+        error
+      });
+      throw error;
     }
   }
 
   async getTemplateById(id: Required<Template>["id"]): Promise<Template | null> {
-    const { templatesIds, categories } = await this.getTemplateGallery();
-    if (!templatesIds[id]) return null;
+    if (Object.hasOwn(this.#parsedTemplates, id)) return this.#parsedTemplates[id];
 
-    const { categoryIndex, templateIndex } = templatesIds[id];
-    const template = categories[categoryIndex].templates?.[templateIndex];
-    if (!template) return null;
-    return template;
+    const { templates, metadata } = await this.getCachedTemplateGallery();
+    if (!Object.hasOwn(metadata.templatesRanges, id)) return null;
+
+    const [start, end] = metadata.templatesRanges[id];
+
+    const templateContent = templates.slice(start, end).trim();
+
+    try {
+      this.#parsedTemplates[id] = JSON.parse(templateContent);
+      return this.#parsedTemplates[id];
+    } catch (error) {
+      this.#logger.error({
+        event: "GET_TEMPLATE_BY_ID_ERROR",
+        message: "Error parsing template content",
+        error,
+        templateId: id,
+        templateRange: metadata.templatesRanges[id],
+        templatesSize: templates.length
+      });
+      return null;
+    }
   }
 
   private async getTemplatesFromRepo({
@@ -110,6 +192,8 @@ export class TemplateGalleryService {
     repository: keyof typeof REPOSITORIES;
     fetchTemplates: (version: string) => Promise<Category[]>;
   }): Promise<Category[]> {
+    if (!this.templateFetcher) return [];
+
     const { repoName, repoOwner } = REPOSITORIES[repository];
     const cachePathPrefix = `${this.#options.dataFolderPath}/templates/${repoOwner}-${repoName}`;
     const latestCommitSha = await this.templateFetcher.fetchLatestCommitSha(repository).catch(async error => {
@@ -182,4 +266,25 @@ export interface FileSystemApi {
   readFile: typeof fsp.readFile;
   writeFile: typeof fsp.writeFile;
   mkdir: typeof fsp.mkdir;
+}
+
+export interface GalleriesCache {
+  metadata: {
+    templatesRanges: Record<string, [start: number, end: number]>;
+    templatesOffset: number;
+  };
+  categories: string;
+  templates: string;
+}
+
+function buildContentRanges(content: string[]): Record<number, [start: number, end: number]> {
+  let offset = 0;
+  return content.reduce(
+    (acc, chunk, index) => {
+      acc[index] = [offset, offset + chunk.length];
+      offset += chunk.length + 1; // +1 for the newline character
+      return acc;
+    },
+    {} as Record<number, [start: number, end: number]>
+  );
 }

--- a/apps/api/src/template/services/template-processor/template-processor.service.spec.ts
+++ b/apps/api/src/template/services/template-processor/template-processor.service.spec.ts
@@ -8,8 +8,7 @@ describe(TemplateProcessorService.name, () => {
 
       const result = service.mergeTemplateCategories();
 
-      expect(result.categories).toHaveLength(0);
-      expect(Object.keys(result.templatesIds)).toHaveLength(0);
+      expect(result).toHaveLength(0);
     });
 
     it("returns categories unchanged when no duplicates exist", () => {
@@ -19,7 +18,7 @@ describe(TemplateProcessorService.name, () => {
 
       const result = service.mergeTemplateCategories(categoriesGroup, anotherCategoriesGroup);
 
-      expect(result.categories).toEqual([
+      expect(result).toEqual([
         expect.objectContaining({ title: categoriesGroup[0].title }),
         expect.objectContaining({ title: anotherCategoriesGroup[0].title })
       ]);
@@ -32,8 +31,8 @@ describe(TemplateProcessorService.name, () => {
 
       const result = service.mergeTemplateCategories(categoriesGroup, anotherCategoriesGroup);
 
-      expect(result.categories).toEqual([expect.objectContaining({ title: categoriesGroup[0].title })]);
-      expect(result.categories[0].templates).toEqual([expect.objectContaining({ id: "t1" }), expect.objectContaining({ id: "t2" })]);
+      expect(result).toEqual([expect.objectContaining({ title: categoriesGroup[0].title })]);
+      expect(result[0].templates).toEqual([expect.objectContaining({ id: "t1" }), expect.objectContaining({ id: "t2" })]);
     });
 
     it("merges categories case-insensitively", () => {
@@ -43,8 +42,8 @@ describe(TemplateProcessorService.name, () => {
 
       const result = service.mergeTemplateCategories(categoriesGroup, anotherCategoriesGroup);
 
-      expect(result.categories).toEqual([expect.objectContaining({ title: categoriesGroup[0].title })]);
-      expect(result.categories[0].templates).toEqual([expect.objectContaining({ id: "t1" }), expect.objectContaining({ id: "t2" })]);
+      expect(result).toEqual([expect.objectContaining({ title: categoriesGroup[0].title })]);
+      expect(result[0].templates).toEqual([expect.objectContaining({ id: "t1" }), expect.objectContaining({ id: "t2" })]);
     });
 
     it("handles categories with undefined templates", () => {
@@ -54,8 +53,8 @@ describe(TemplateProcessorService.name, () => {
 
       const result = service.mergeTemplateCategories(categoriesGroup, anotherCategoriesGroup);
 
-      expect(result.categories).toHaveLength(1);
-      expect(result.categories[0].templates).toHaveLength(1);
+      expect(result).toHaveLength(1);
+      expect(result[0].templates).toHaveLength(1);
     });
 
     it("creates deep copy of categories to avoid mutation", () => {
@@ -65,61 +64,8 @@ describe(TemplateProcessorService.name, () => {
 
       const result = service.mergeTemplateCategories(categories);
 
-      result.categories[0].title = "Modified";
+      result[0].title = "Modified";
       expect(originalCategory.title).toBe("AI");
-    });
-
-    it("returns templatesIds with correct indices for multiple categories", () => {
-      const { service } = setup();
-      const categoriesGroup: Category[] = [{ title: "AI", templateSources: [], templates: [{ id: "t1" }] as Category["templates"] }];
-      const anotherCategoriesGroup: Category[] = [{ title: "Gaming", templateSources: [], templates: [{ id: "t2" }, { id: "t3" }] as Category["templates"] }];
-
-      const result = service.mergeTemplateCategories(categoriesGroup, anotherCategoriesGroup);
-
-      expect(result.templatesIds).toEqual({
-        t1: { categoryIndex: 0, templateIndex: 0 },
-        t2: { categoryIndex: 1, templateIndex: 0 },
-        t3: { categoryIndex: 1, templateIndex: 1 }
-      });
-    });
-
-    it("returns templatesIds with offset indices when merging categories with same title", () => {
-      const { service } = setup();
-      const categoriesGroup: Category[] = [{ title: "AI", templateSources: [], templates: [{ id: "t1" }, { id: "t2" }] as Category["templates"] }];
-      const anotherCategoriesGroup: Category[] = [{ title: "AI", templateSources: [], templates: [{ id: "t3" }, { id: "t4" }] as Category["templates"] }];
-
-      const result = service.mergeTemplateCategories(categoriesGroup, anotherCategoriesGroup);
-
-      expect(result.templatesIds).toEqual({
-        t1: { categoryIndex: 0, templateIndex: 0 },
-        t2: { categoryIndex: 0, templateIndex: 1 },
-        t3: { categoryIndex: 0, templateIndex: 2 },
-        t4: { categoryIndex: 0, templateIndex: 3 }
-      });
-    });
-
-    it("returns templatesIds with correct indices for mixed merge scenario", () => {
-      const { service } = setup();
-      const categoriesGroup: Category[] = [
-        { title: "AI", templateSources: [], templates: [{ id: "ai-1" }] as Category["templates"] },
-        { title: "Gaming", templateSources: [], templates: [{ id: "game-1" }] as Category["templates"] }
-      ];
-      const anotherCategoriesGroup: Category[] = [
-        { title: "AI", templateSources: [], templates: [{ id: "ai-2" }] as Category["templates"] },
-        { title: "Tools", templateSources: [], templates: [{ id: "tool-1" }] as Category["templates"] },
-        { title: "ai", templateSources: [], templates: [{ id: "ai-3" }] as Category["templates"] },
-        { title: "ai", templateSources: [] }
-      ];
-
-      const result = service.mergeTemplateCategories(categoriesGroup, anotherCategoriesGroup);
-
-      expect(result.templatesIds).toEqual({
-        "ai-1": { categoryIndex: 0, templateIndex: 0 },
-        "game-1": { categoryIndex: 1, templateIndex: 0 },
-        "ai-2": { categoryIndex: 0, templateIndex: 1 },
-        "tool-1": { categoryIndex: 2, templateIndex: 0 },
-        "ai-3": { categoryIndex: 0, templateIndex: 2 }
-      });
     });
   });
 

--- a/apps/api/src/template/services/template-processor/template-processor.service.ts
+++ b/apps/api/src/template/services/template-processor/template-processor.service.ts
@@ -6,15 +6,12 @@ import { isUrlAbsolute } from "@src/utils/urls";
 import type { Category, Template, TemplateConfig, TemplateSource } from "../../types/template";
 
 export class TemplateProcessorService {
-  mergeTemplateCategories(...categories: Category[][]): MergedTemplateCategoriesResult {
-    const mergedCategories: MergedTemplateCategoriesResult["categories"] = [];
-    const templatesIds: MergedTemplateCategoriesResult["templatesIds"] = {};
+  mergeTemplateCategories(...categories: Category[][]): MergedCategory[] {
+    const mergedCategories: MergedCategory[] = [];
     for (const category of categories.flat()) {
       let categoryIndex = mergedCategories.findIndex(c => c.title.toLowerCase() === category.title.toLowerCase());
-      let templatesIndexOffset = 0;
       if (categoryIndex !== -1) {
         const existingCategory = mergedCategories[categoryIndex];
-        templatesIndexOffset = existingCategory.templates?.length || 0;
         existingCategory.templates = (existingCategory.templates || []).concat(category.templates || []);
       } else {
         categoryIndex = mergedCategories.length;
@@ -22,13 +19,9 @@ export class TemplateProcessorService {
         categoryClone.templates ??= [];
         mergedCategories.push(categoryClone);
       }
-
-      for (let index = 0; index < (category.templates?.length || 0); index++) {
-        const template = category.templates![index];
-        templatesIds[template.id] = { categoryIndex, templateIndex: index + templatesIndexOffset };
-      }
     }
-    return { categories: mergedCategories, templatesIds };
+
+    return mergedCategories;
   }
 
   getTemplateSummary(readme: string): string | null {
@@ -126,7 +119,4 @@ export class TemplateProcessorService {
   }
 }
 
-export interface MergedTemplateCategoriesResult {
-  categories: Array<Omit<Category, "templates"> & { templates: Template[] }>;
-  templatesIds: Record<string, { categoryIndex: number; templateIndex: number }>;
-}
+export type MergedCategory = Omit<Category, "templates"> & { templates: Template[] };

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -13955,97 +13955,6 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
         ],
       },
     },
-    "/v1/templates": {
-      "get": {
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "items": {
-                    "properties": {
-                      "templates": {
-                        "items": {
-                          "properties": {
-                            "config": {
-                              "properties": {
-                                "ssh": {
-                                  "type": "boolean",
-                                },
-                              },
-                              "type": "object",
-                            },
-                            "deploy": {
-                              "type": "string",
-                            },
-                            "githubUrl": {
-                              "type": "string",
-                            },
-                            "guide": {
-                              "type": "string",
-                            },
-                            "id": {
-                              "type": "string",
-                            },
-                            "logoUrl": {
-                              "nullable": true,
-                              "type": "string",
-                            },
-                            "name": {
-                              "type": "string",
-                            },
-                            "path": {
-                              "type": "string",
-                            },
-                            "persistentStorageEnabled": {
-                              "type": "boolean",
-                            },
-                            "readme": {
-                              "type": "string",
-                            },
-                            "summary": {
-                              "type": "string",
-                            },
-                          },
-                          "required": [
-                            "id",
-                            "name",
-                            "path",
-                            "logoUrl",
-                            "summary",
-                            "readme",
-                            "deploy",
-                            "persistentStorageEnabled",
-                            "githubUrl",
-                            "config",
-                          ],
-                          "type": "object",
-                        },
-                        "type": "array",
-                      },
-                      "title": {
-                        "type": "string",
-                      },
-                    },
-                    "required": [
-                      "title",
-                      "templates",
-                    ],
-                    "type": "object",
-                  },
-                  "type": "array",
-                },
-              },
-            },
-            "description": "Returns a list of deployment templates grouped by categories",
-          },
-        },
-        "security": [],
-        "tags": [
-          "Other",
-        ],
-      },
-    },
     "/v1/templates-list": {
       "get": {
         "responses": {
@@ -14060,23 +13969,6 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                           "templates": {
                             "items": {
                               "properties": {
-                                "config": {
-                                  "properties": {
-                                    "ssh": {
-                                      "type": "boolean",
-                                    },
-                                  },
-                                  "type": "object",
-                                },
-                                "deploy": {
-                                  "type": "string",
-                                },
-                                "githubUrl": {
-                                  "type": "string",
-                                },
-                                "guide": {
-                                  "type": "string",
-                                },
                                 "id": {
                                   "type": "string",
                                 },
@@ -14087,15 +13979,6 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                                 "name": {
                                   "type": "string",
                                 },
-                                "path": {
-                                  "type": "string",
-                                },
-                                "persistentStorageEnabled": {
-                                  "type": "boolean",
-                                },
-                                "readme": {
-                                  "type": "string",
-                                },
                                 "summary": {
                                   "type": "string",
                                 },
@@ -14103,14 +13986,8 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                               "required": [
                                 "id",
                                 "name",
-                                "path",
                                 "logoUrl",
                                 "summary",
-                                "readme",
-                                "deploy",
-                                "persistentStorageEnabled",
-                                "githubUrl",
-                                "config",
                               ],
                               "type": "object",
                             },


### PR DESCRIPTION
## Why

Currently combined templates cache size is 4.7Mb. `JSON.parse` is a sync operation and it may block event loop. Because of this liveness helthcheck fails and container is marked as unhealthy


## What

1. Removed obsolete /templates endpoint. It was replaced with /templates-list -> https://github.com/akash-network/console/issues/102
2. Restored templates-list shape. It supposed to return only basic information about templates but unexpectedly for me it serves the whole template data right now (including big readme and other information which we don't need on the list)
3. saves templates cache in kind of [nd-json](https://docs.mulesoft.com/dataweave/latest/dataweave-formats-ndjson) format. To have possibility to selectively parse only parts of the cache file, to reduce blocking time by `JSON.parse`
4. prebuilt serialized response for /templates-list. So, whenever somebody requests templates, API will just serve a string from RAM. Super fast response (50ms). At the moment, it takes 1-3 seconds on production to serve templates from cache. 

<img width="670" height="55" alt="Screenshot 2026-01-26 at 08 22 34" src="https://github.com/user-attachments/assets/fd163a0c-02fd-4cff-adf0-046cbed78e3e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent on-disk template gallery cache and cache-builder to speed listings and detail retrieval.
  * Per-template in-memory caching for faster repeated loads.
* **Refactor**
  * Template list now returns streamlined summaries (id, name, logo, summary); full-templates endpoint removed.
  * Template detail responses standardized as JSON-wrapped data.
  * Internal merging now returns a flat array of categories instead of a wrapped result.
* **Tests**
  * Updated tests to align with array-based gallery and cache behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->