### PR TITLE
chore: refactor functional api tests to rely on fs lock

### DIFF
--- a/apps/api/test/functional/api-key.spec.ts
+++ b/apps/api/test/functional/api-key.spec.ts
@@ -11,6 +11,7 @@ import { UserRepository } from "@src/user/repositories/user/user.repository";
 
 import { ApiKeySeeder } from "@test/seeders/api-key.seeder";
 import { stub } from "@test/services/stub";
+import { topUpWallet } from "@test/services/topUpWallet";
 import { WalletTestingService } from "@test/services/wallet-testing.service";
 
 const OBFUSCATED_API_KEY_PATTERN = /^ac\.sk\.test\.[A-Za-z0-9]{6}\*{3}[A-Za-z0-9]{6}$/;
@@ -54,6 +55,10 @@ describe("API Keys", () => {
 
     return { user: userWithId, token };
   }
+
+  beforeAll(async () => {
+    await topUpWallet();
+  });
 
   beforeEach(async () => {
     config = stub<CoreConfigService>({ get: jest.fn() });

--- a/apps/api/test/functional/balances.spec.ts
+++ b/apps/api/test/functional/balances.spec.ts
@@ -15,6 +15,7 @@ import { DeploymentGrantResponseSeeder } from "@test/seeders/deployment-grant-re
 import { DeploymentListResponseSeeder } from "@test/seeders/deployment-list-response.seeder";
 import { FeeAllowanceResponseSeeder } from "@test/seeders/fee-allowance-response.seeder";
 import { stub } from "@test/services/stub";
+import { topUpWallet } from "@test/services/topUpWallet";
 import { WalletTestingService } from "@test/services/wallet-testing.service";
 
 jest.setTimeout(20000);
@@ -22,6 +23,10 @@ jest.setTimeout(20000);
 describe("Balances", () => {
   const mockMasterWalletAddress = "akash1testmasterwalletaddress";
   const mockDeploymentGrantDenom = "uakt";
+
+  beforeAll(async () => {
+    await topUpWallet();
+  });
 
   afterEach(() => {
     jest.restoreAllMocks();

--- a/apps/api/test/functional/bids.spec.ts
+++ b/apps/api/test/functional/bids.spec.ts
@@ -8,11 +8,16 @@ import { marketVersion } from "@src/utils/constants";
 
 import { createAkashAddress, createProvider } from "@test/seeders";
 import { BidSeeder } from "@test/seeders/bid.seeder";
+import { topUpWallet } from "@test/services/topUpWallet";
 import { WalletTestingService } from "@test/services/wallet-testing.service";
 
 jest.setTimeout(20000);
 
 describe("Bids API", () => {
+  beforeAll(async () => {
+    await topUpWallet();
+  });
+
   describe.each(["/v1/bids/:dseq", "/v1/bids?dseq=:dseq"])("GET %s", path => {
     it("should respond with bids list", async () => {
       const { dseq, user, providers } = await setup();

--- a/apps/api/test/functional/create-deployment.spec.ts
+++ b/apps/api/test/functional/create-deployment.spec.ts
@@ -14,6 +14,7 @@ import { CORE_CONFIG } from "@src/core";
 import { app } from "@src/rest-app";
 import { certVersion, deploymentVersion } from "@src/utils/constants";
 
+import { topUpWallet } from "@test/services/topUpWallet";
 import { WalletTestingService } from "@test/services/wallet-testing.service";
 
 jest.setTimeout(30000);
@@ -24,6 +25,10 @@ const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.ym
 describe("Tx Sign", () => {
   const registry = container.resolve<Registry>(TYPE_REGISTRY);
   const walletService = new WalletTestingService(app);
+
+  beforeAll(async () => {
+    await topUpWallet({ minAmount: 5_100_000 });
+  });
 
   afterEach(async () => {
     nock.cleanAll();

--- a/apps/api/test/functional/deployment-setting.spec.ts
+++ b/apps/api/test/functional/deployment-setting.spec.ts
@@ -6,6 +6,7 @@ import { LeaseRepository } from "@src/deployment/repositories/lease/lease.reposi
 import { app } from "@src/rest-app";
 
 import { DrainingDeploymentSeeder } from "@test/seeders/draining-deployment.seeder";
+import { topUpWallet } from "@test/services/topUpWallet";
 import { WalletTestingService } from "@test/services/wallet-testing.service";
 
 jest.setTimeout(30000);
@@ -14,6 +15,10 @@ describe("Deployment Settings", () => {
   const walletService = new WalletTestingService(app);
   const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
   const leaseRepository = container.resolve(LeaseRepository);
+
+  beforeAll(async () => {
+    await topUpWallet();
+  });
 
   beforeEach(() => {
     jest.spyOn(leaseRepository, "findOneByDseqAndOwner").mockResolvedValue(DrainingDeploymentSeeder.create());

--- a/apps/api/test/functional/managed-api-deployment-flow.spec.ts
+++ b/apps/api/test/functional/managed-api-deployment-flow.spec.ts
@@ -25,6 +25,7 @@ import { app } from "@src/rest-app";
 
 import { createDeployment as createDeploymentSeed, createDeploymentGroup, createLease as createLeaseSeed, createProvider } from "@test/seeders";
 import { AppHttpService } from "@test/services/app-http.service";
+import { topUpWallet } from "@test/services/topUpWallet";
 import { WalletTestingService } from "@test/services/wallet-testing.service";
 
 jest.setTimeout(120_000);
@@ -34,6 +35,10 @@ type AuthType = "mTLS" | "JWT";
 
 describe("Managed Wallet API Deployment Flow", () => {
   const http = new AppHttpService(app);
+
+  beforeAll(async () => {
+    await topUpWallet({ minAmount: 6_100_000 });
+  });
 
   /**
    * Authentication types supported by the test.

--- a/apps/api/test/functional/sign-and-broadcast-tx.spec.ts
+++ b/apps/api/test/functional/sign-and-broadcast-tx.spec.ts
@@ -8,6 +8,7 @@ import { TYPE_REGISTRY } from "@src/billing/providers/type-registry.provider";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { app } from "@src/rest-app";
 
+import { topUpWallet } from "@test/services/topUpWallet";
 import { WalletTestingService } from "@test/services/wallet-testing.service";
 
 jest.setTimeout(30000);
@@ -15,6 +16,10 @@ jest.setTimeout(30000);
 describe("Tx Sign", () => {
   const registry = container.resolve<Registry>(TYPE_REGISTRY);
   const walletService = new WalletTestingService(app);
+
+  beforeAll(async () => {
+    await topUpWallet();
+  });
 
   describe("POST /v1/tx", () => {
     it("should create a wallet for a user", async () => {

--- a/apps/api/test/functional/start-trial.spec.ts
+++ b/apps/api/test/functional/start-trial.spec.ts
@@ -11,6 +11,7 @@ import type { ApiPgDatabase } from "@src/core";
 import { POSTGRES_DB, resolveTable } from "@src/core";
 import { app } from "@src/rest-app";
 
+import { topUpWallet } from "@test/services/topUpWallet";
 import { WalletTestingService } from "@test/services/wallet-testing.service";
 
 jest.setTimeout(20000);
@@ -22,6 +23,10 @@ describe("start trial", () => {
   const userWalletsQuery = db.query.UserWallets;
   const authzHttpService = container.resolve(AuthzHttpService);
   const walletTestingService = new WalletTestingService(app);
+
+  beforeAll(async () => {
+    await topUpWallet();
+  });
 
   afterEach(() => {
     jest.restoreAllMocks();

--- a/apps/api/test/functional/stripe-webhook.spec.ts
+++ b/apps/api/test/functional/stripe-webhook.spec.ts
@@ -11,6 +11,7 @@ import { POSTGRES_DB, resolveTable } from "@src/core";
 import { app } from "@src/rest-app";
 import { Users } from "@src/user/model-schemas/user/user.schema";
 
+import { topUpWallet } from "@test/services/topUpWallet";
 import { WalletTestingService } from "@test/services/wallet-testing.service";
 
 jest.setTimeout(30000);
@@ -55,6 +56,10 @@ describe("Stripe webhook", () => {
       })
     });
   };
+
+  beforeAll(async () => {
+    await topUpWallet();
+  });
 
   describe("POST /v1/stripe-webhook", () => {
     describe("payment_intent.succeeded", () => {

--- a/apps/api/test/functional/wallets-refill.spec.ts
+++ b/apps/api/test/functional/wallets-refill.spec.ts
@@ -7,11 +7,16 @@ import { UserWalletRepository } from "@src/billing/repositories";
 import { ManagedSignerService, ManagedUserWalletService } from "@src/billing/services";
 import { app } from "@src/rest-app";
 
+import { topUpWallet } from "@test/services/topUpWallet";
 import { WalletTestingService } from "@test/services/wallet-testing.service";
 
 jest.setTimeout(240000);
 
 describe("Wallets Refill", () => {
+  beforeAll(async () => {
+    await topUpWallet();
+  });
+
   describe("console refill-wallets", () => {
     it("should refill wallets low on fee allowance", async () => {
       const { managedUserWalletService, config, walletController, walletService, userWalletRepository } = setup();

--- a/apps/api/test/services/fs-lock.ts
+++ b/apps/api/test/services/fs-lock.ts
@@ -1,0 +1,243 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { setTimeout as delay } from "timers/promises";
+
+export interface FsLockOptions {
+  /**
+   * Maximum time in milliseconds to wait for the lock.
+   * @default 5 minutes - faucet operations can be slow
+   */
+  timeout?: number;
+  /**
+   * Time in milliseconds after which a lock file is considered stale and can be deleted.
+   * This handles cases where a worker may have crashed without releasing the lock.
+   * @default 1 minute - short enough to recover from crashes quickly
+   */
+  staleLockThreshold?: number;
+  /**
+   * Base delay in milliseconds between lock acquisition retries.
+   * Actual delay includes jitter: baseRetryDelay + random(0, baseRetryDelay).
+   * @default 100ms
+   */
+  baseRetryDelay?: number;
+}
+
+const DEFAULT_OPTIONS: Required<FsLockOptions> = {
+  timeout: 5 * 60 * 1000,
+  staleLockThreshold: 60 * 1000,
+  baseRetryDelay: 100
+};
+
+/**
+ * Resolves a lock path. If the input is a simple name (no path separators),
+ * it creates the lock file in os.tmpdir(). Otherwise, uses the path as-is.
+ */
+function resolveLockPath(lockPathOrName: string): string {
+  if (!lockPathOrName.includes(path.sep) && !lockPathOrName.includes("/")) {
+    return path.join(os.tmpdir(), lockPathOrName);
+  }
+  return lockPathOrName;
+}
+
+/**
+ * Checks if a lock file is stale based on its mtime.
+ */
+async function isLockStale(lockPath: string, staleLockThreshold: number): Promise<boolean> {
+  try {
+    const stats = await fs.promises.stat(lockPath);
+    const ageMs = Date.now() - stats.mtimeMs;
+    return ageMs > staleLockThreshold;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Attempts to delete a stale lock file.
+ * Returns true if the lock was successfully deleted or didn't exist.
+ */
+async function tryDeleteStaleLock(lockPath: string): Promise<boolean> {
+  try {
+    await fs.promises.unlink(lockPath);
+    debugLog(`Deleted stale lock file: ${lockPath}`);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return true;
+    }
+    debugLog(`Failed to delete stale lock: ${lockPath}`, err);
+    return false;
+  }
+}
+
+/**
+ * Logs debug messages when DEBUG_FAUCET=1 is set.
+ */
+function debugLog(message: string, ...args: unknown[]): void {
+  if (process.env.DEBUG_FAUCET === "1") {
+    console.log(`[fs-lock] ${message}`, ...args);
+  }
+}
+
+/**
+ * Calculates retry delay with jitter.
+ */
+function getRetryDelay(baseDelay: number): number {
+  return baseDelay + Math.random() * baseDelay;
+}
+
+/**
+ * Executes a function while holding a cross-process filesystem lock.
+ *
+ * Lock behavior:
+ * - Acquires lock via atomic file creation (O_CREAT | O_EXCL).
+ * - If lock exists, retries with jitter until acquired or timeout.
+ * - If lock file is older than staleLockThreshold, deletes it and retries (handles crashed workers).
+ * - Releases lock in finally block: closes handle and unlinks file.
+ *
+ * @param lockPathOrName - Either a simple name (will be placed in os.tmpdir())
+ *                         or a full path to the lock file.
+ * @param fn - The async function to execute while holding the lock.
+ * @param opts - Optional configuration for timeouts and retry behavior.
+ * @returns The return value of fn.
+ * @throws Error if lock cannot be acquired within timeout.
+ *
+ * @example
+ * // Global faucet lock
+ * await withFsLock("cosmos-faucet.lock", async () => {
+ *   await faucet.topup(address, amount);
+ * });
+ *
+ * @example
+ * // Custom lock path
+ * await withFsLock("/tmp/my-custom.lock", async () => {
+ *   // critical section
+ * });
+ */
+export async function withFsLock<T>(lockPathOrName: string, fn: () => Promise<T>, opts?: FsLockOptions): Promise<T> {
+  const options = { ...DEFAULT_OPTIONS, ...opts };
+
+  if (options.staleLockThreshold < options.timeout) {
+    options.staleLockThreshold = options.timeout;
+  }
+
+  const lockPath = resolveLockPath(lockPathOrName);
+  const startTime = Date.now();
+
+  debugLog(`Attempting to acquire lock: ${lockPath}`);
+
+  let fileHandle: fs.promises.FileHandle | undefined;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const elapsed = Date.now() - startTime;
+    if (elapsed >= options.timeout) {
+      throw new Error(`Failed to acquire lock within ${options.timeout}ms: ${lockPath}`);
+    }
+
+    try {
+      // Attempt atomic lock acquisition using O_CREAT | O_EXCL (wx flag)
+      fileHandle = await fs.promises.open(lockPath, "wx");
+      debugLog(`Lock acquired: ${lockPath}`);
+      break;
+    } catch (err) {
+      const nodeErr = err as NodeJS.ErrnoException;
+
+      if (nodeErr.code === "EEXIST") {
+        // Lock file exists - check if it's stale
+        if (await isLockStale(lockPath, options.staleLockThreshold)) {
+          debugLog(`Lock file is stale, attempting to delete: ${lockPath}`);
+          if (await tryDeleteStaleLock(lockPath)) {
+            // Retry immediately after deleting stale lock
+            continue;
+          }
+        }
+
+        // Wait with jitter before retrying
+        const retryDelay = getRetryDelay(options.baseRetryDelay);
+        debugLog(`Lock busy, retrying in ${Math.round(retryDelay)}ms`);
+        await delay(retryDelay);
+        continue;
+      }
+
+      // Unexpected error
+      throw err;
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    // Release lock: close handle and delete file
+    try {
+      if (fileHandle) {
+        await fileHandle.close();
+      }
+      await fs.promises.unlink(lockPath);
+      debugLog(`Lock released: ${lockPath}`);
+    } catch (err) {
+      debugLog(`Error releasing lock: ${lockPath}`, err);
+    }
+  }
+}
+
+/**
+ * Global faucet lock path.
+ * Use this constant with withFsLock for faucet operations.
+ */
+export const FAUCET_LOCK_PATH = `${os.tmpdir()}/cosmos-faucet.lock`;
+
+/**
+ * Convenience function for acquiring the global faucet lock.
+ *
+ * @param fn - The async function to execute while holding the faucet lock.
+ * @param opts - Optional configuration for timeouts and retry behavior.
+ * @returns The return value of fn.
+ *
+ * @example
+ * await withFaucetLock(async () => {
+ *   await faucet.topup(address, amount);
+ * });
+ */
+export async function withFaucetLock<T>(fn: () => Promise<T>, opts?: FsLockOptions): Promise<T> {
+  return withFsLock(FAUCET_LOCK_PATH, fn, opts);
+}
+
+/**
+ * Forcefully removes a lock file if it exists.
+ * Use this to clean up stale locks from crashed test runs.
+ *
+ * @param lockPathOrName - Either a simple name or a full path to the lock file.
+ *
+ * @example
+ * // Clean up the global faucet lock
+ * await forceUnlock(FAUCET_LOCK_PATH);
+ *
+ * // Or using the convenience function
+ * await forceUnlockFaucet();
+ */
+export async function forceUnlock(lockPathOrName: string): Promise<void> {
+  const lockPath = resolveLockPath(lockPathOrName);
+  try {
+    await fs.promises.unlink(lockPath);
+    debugLog(`Force unlocked: ${lockPath}`);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw err;
+    }
+    // Lock file doesn't exist, that's fine
+  }
+}
+
+/**
+ * Forcefully removes the global faucet lock file.
+ * Use this to clean up stale locks from crashed test runs.
+ *
+ * @example
+ * // In a cleanup script or before running tests
+ * await forceUnlockFaucet();
+ */
+export async function forceUnlockFaucet(): Promise<void> {
+  return forceUnlock(FAUCET_LOCK_PATH);
+}

--- a/apps/api/test/services/retry-policies.ts
+++ b/apps/api/test/services/retry-policies.ts
@@ -1,0 +1,210 @@
+import { ExponentialBackoff, handleWhen, retry } from "cockatiel";
+
+/**
+ * Logs debug messages when DEBUG_FAUCET=1 is set.
+ */
+function debugLog(message: string, ...args: unknown[]): void {
+  if (process.env.DEBUG_FAUCET === "1") {
+    console.log(`[retry-policies] ${message}`, ...args);
+  }
+}
+
+/**
+ * Extracts error message from various error types.
+ */
+function getErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}
+
+/**
+ * Pattern matchers for account sequence mismatch errors.
+ * These occur when multiple transactions are sent from the same account
+ * before the previous one is confirmed.
+ */
+const SEQUENCE_MISMATCH_PATTERNS = [/account sequence mismatch/i, /incorrect account sequence/i, /expected sequence/i];
+
+/**
+ * Checks if an error is an account sequence mismatch error.
+ * These errors occur when broadcasting transactions from shared signers
+ * and the account sequence is out of sync.
+ *
+ * @param err - The error to check.
+ * @returns true if the error is an account sequence mismatch.
+ *
+ * @example
+ * try {
+ *   await signingClient.sendTokens(...);
+ * } catch (err) {
+ *   if (isAccountSequenceMismatch(err)) {
+ *     // Can retry with updated sequence
+ *   }
+ * }
+ */
+export function isAccountSequenceMismatch(err: unknown): boolean {
+  const message = getErrorMessage(err);
+  const isMatch = SEQUENCE_MISMATCH_PATTERNS.some(pattern => pattern.test(message));
+
+  if (isMatch) {
+    debugLog("Detected account sequence mismatch:", message);
+  }
+
+  return isMatch;
+}
+
+/**
+ * Pattern matchers for transient faucet errors that should be retried.
+ * Includes rate limiting, timeouts, and network errors.
+ */
+const FAUCET_TRANSIENT_PATTERNS = [
+  // HTTP rate limiting
+  /429/,
+  /rate limit/i,
+  /too many requests/i,
+
+  // Timeouts
+  /timeout/i,
+  /ETIMEDOUT/,
+  /timed out/i,
+
+  // Connection errors
+  /ECONNRESET/,
+  /ECONNREFUSED/,
+  /ENOTFOUND/,
+  /EAI_AGAIN/,
+  /socket hang up/i,
+
+  // Temporary/transient errors
+  /tempor/i, // temporary, temporarily
+  /unavailable/i,
+  /service unavailable/i,
+  /try again/i,
+
+  // Network errors
+  /network/i,
+  /fetch failed/i,
+  /EPIPE/,
+  /ECONNABORTED/
+];
+
+/**
+ * Checks if an error is a transient faucet error that should be retried.
+ * Includes rate limiting (429), timeouts, and network errors.
+ *
+ * @param err - The error to check.
+ * @returns true if the error is transient and should be retried.
+ *
+ * @example
+ * try {
+ *   await fetch(faucetUrl, { ... });
+ * } catch (err) {
+ *   if (isFaucetTransient(err)) {
+ *     // Safe to retry
+ *   }
+ * }
+ */
+export function isFaucetTransient(err: unknown): boolean {
+  const message = getErrorMessage(err);
+  const isMatch = FAUCET_TRANSIENT_PATTERNS.some(pattern => pattern.test(message));
+
+  if (isMatch) {
+    debugLog("Detected transient faucet error:", message);
+  }
+
+  return isMatch;
+}
+
+/**
+ * Retry policy for faucet operations.
+ *
+ * Configuration:
+ * - Max attempts: 8
+ * - Initial delay: 250ms
+ * - Max delay: 3000ms (3 seconds)
+ * - Backoff: Exponential with randomization
+ *
+ * Handles:
+ * - Rate limiting (429)
+ * - Timeouts
+ * - Connection errors (ECONNRESET, ECONNREFUSED, etc.)
+ * - Temporary unavailability
+ *
+ * @example
+ * const result = await faucetRetryPolicy.execute(async () => {
+ *   const response = await fetch(faucetUrl, {
+ *     method: "POST",
+ *     body: `address=${encodeURIComponent(address)}`
+ *   });
+ *   if (!response.ok) {
+ *     throw new Error(`Faucet error: ${response.status}`);
+ *   }
+ *   return response;
+ * });
+ */
+export const faucetRetryPolicy = retry(handleWhen(isFaucetTransient), {
+  maxAttempts: 8,
+  backoff: new ExponentialBackoff({
+    initialDelay: 250,
+    maxDelay: 3000
+  })
+});
+
+/**
+ * Retry policy for account sequence mismatch errors.
+ *
+ * Configuration:
+ * - Max attempts: 5
+ * - Initial delay: 150ms
+ * - Max delay: 2000ms (2 seconds)
+ * - Backoff: Exponential with randomization
+ *
+ * Use this when broadcasting transactions from shared signers.
+ *
+ * @example
+ * const result = await sequenceRetryPolicy.execute(async () => {
+ *   return await signingClient.sendTokens(
+ *     fromAddress,
+ *     toAddress,
+ *     coins(amount, denom),
+ *     fee
+ *   );
+ * });
+ */
+export const sequenceRetryPolicy = retry(handleWhen(isAccountSequenceMismatch), {
+  maxAttempts: 5,
+  backoff: new ExponentialBackoff({
+    initialDelay: 150,
+    maxDelay: 2000
+  })
+});
+
+/**
+ * Retry policy for waiting for balance updates after faucet topup.
+ * Uses shorter delays and more attempts since we're just polling.
+ *
+ * Configuration:
+ * - Max attempts: 15
+ * - Initial delay: 500ms
+ * - Max delay: 2000ms (2 seconds)
+ *
+ * @example
+ * await balanceWaitPolicy.execute(async () => {
+ *   const balance = await getBalance(address, denom);
+ *   if (BigInt(balance.amount) < BigInt(minAmount)) {
+ *     throw new Error("Balance not yet updated");
+ *   }
+ *   return balance;
+ * });
+ */
+export const balanceWaitPolicy = retry(
+  handleWhen(() => true),
+  {
+    maxAttempts: 15,
+    backoff: new ExponentialBackoff({
+      initialDelay: 500,
+      maxDelay: 2000
+    })
+  }
+);

--- a/apps/api/test/services/test-wallet.service.ts
+++ b/apps/api/test/services/test-wallet.service.ts
@@ -2,15 +2,15 @@ import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import * as fs from "fs";
 import { sep as FOLDER_SEP } from "path";
 
-import { reusePendingPromise } from "@src/caching/helpers";
 import { WALLET_ADDRESS_PREFIX } from "../../src/billing/lib/wallet/wallet";
+import { reusePendingPromise } from "../../src/caching/helpers";
 
 export class TestWalletService {
   private mnemonics: Record<string, string> = {};
 
   constructor() {
     this.restoreCache();
-    this.getStoredMnemonic = reusePendingPromise(this.getStoredMnemonic, {
+    this.getStoredMnemonic = reusePendingPromise(this.getStoredMnemonic.bind(this), {
       getKey: (path: string) => `test-wallet-mnemonic-${this.getFileName(path)}`
     });
   }

--- a/apps/api/test/services/topUpWallet.ts
+++ b/apps/api/test/services/topUpWallet.ts
@@ -1,0 +1,85 @@
+import type { Balance, Denom } from "@akashnetwork/http-sdk";
+import { BalanceHttpService } from "@akashnetwork/http-sdk";
+import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
+import dotenv from "dotenv";
+import dotenvExpand from "dotenv-expand";
+
+import { WALLET_ADDRESS_PREFIX } from "@src/billing/services";
+import { withFaucetLock } from "./fs-lock";
+import { balanceWaitPolicy, faucetRetryPolicy } from "./retry-policies";
+
+const { parsed: config } = dotenvExpand.expand(dotenv.config({ path: "env/.env.functional.test" }));
+
+export interface TopUpWalletOptions {
+  /** @default process.env.FUNDING_WALLET_ADDRESS */
+  address?: string;
+  denom?: Denom;
+  minAmount?: string | bigint | number;
+}
+
+const balanceHttpService = new BalanceHttpService({
+  baseURL: config!.REST_API_NODE_URL
+});
+
+export async function topUpWallet(options: TopUpWalletOptions = {}): Promise<Balance> {
+  const { denom = "uakt", minAmount = 1_000_000 } = options;
+  const minAmountBigInt = BigInt(minAmount);
+  const address = options.address ?? (await getFundingWalletAddress());
+
+  const currentBalance = await balanceHttpService.getBalance(address, denom);
+  const currentAmount = BigInt(currentBalance?.amount ?? "0");
+
+  if (currentAmount >= minAmountBigInt) {
+    return currentBalance ?? { denom: denom as Denom, amount: 0 };
+  }
+
+  return withFaucetLock(async () => {
+    // Re-check balance after acquiring lock (another worker might have topped up)
+    const balanceAfterLock = await balanceHttpService.getBalance(address, denom);
+    const amountAfterLock = BigInt(balanceAfterLock?.amount ?? "0");
+
+    if (amountAfterLock >= minAmountBigInt) {
+      return balanceAfterLock ?? { denom: denom as Denom, amount: 0 };
+    }
+
+    await faucetRetryPolicy.execute(async () => {
+      await topUpViaFaucet(config!.FAUCET_URL, address);
+    });
+
+    const finalBalance = await balanceWaitPolicy.execute(async () => {
+      const balance = await balanceHttpService.getBalance(address, denom);
+      const amount = BigInt(balance?.amount ?? "0");
+
+      if (amount < minAmountBigInt) {
+        throw new Error(`Balance not yet updated: ${amount} < ${minAmountBigInt}`);
+      }
+
+      return balance ?? { denom: denom as Denom, amount: 0 };
+    });
+
+    return finalBalance;
+  });
+}
+
+let fundingWalletAddressPromise: Promise<string> | undefined;
+function getFundingWalletAddress(): Promise<string> {
+  fundingWalletAddressPromise ??= DirectSecp256k1HdWallet.fromMnemonic(process.env.FUNDING_WALLET_MNEMONIC!, { prefix: WALLET_ADDRESS_PREFIX })
+    .then(wallet => wallet.getAccounts())
+    .then(accounts => accounts[0].address);
+  return fundingWalletAddressPromise;
+}
+
+async function topUpViaFaucet(faucetUrl: string, address: string): Promise<void> {
+  const response = await fetch(faucetUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded"
+    },
+    body: `address=${encodeURIComponent(address)}`
+  });
+
+  if (response.status >= 300 || response.status < 200) {
+    const errorBody = await response.text().catch(() => "Unknown error");
+    throw new Error(`Faucet request failed with status ${response.status}: ${errorBody}`);
+  }
+}

--- a/apps/api/test/setup-global-functional.ts
+++ b/apps/api/test/setup-global-functional.ts
@@ -1,8 +1,13 @@
-import { localConfig } from "./services/local.config";
-import { TestWalletService } from "./services/test-wallet.service";
+import { forceUnlockFaucet } from "./services/fs-lock";
 
+/**
+ * Jest global setup for functional tests.
+ *
+ * This setup cleans up any stale faucet locks from previous crashed runs
+ * to ensure tests can acquire the lock properly.
+ */
 export default async () => {
-  if (!localConfig.FUNDING_WALLET_MNEMONIC) {
-    await new TestWalletService().init();
-  }
+  // Clean up any stale faucet lock from previous crashed test runs
+  await forceUnlockFaucet();
+  console.log("[global-setup] Cleaned up any stale faucet locks.");
 };


### PR DESCRIPTION
## Why

We currently pre-topup test wallets in Jest global setup / custom environment. While this avoids faucet contention, it significantly hurts developer experience:
- setup logic creates a new wallet per spec file, and tops up it. Very often we don't need this (only 10 test files require wallet topup and 22 doesn't require it)
- functional tests startup is very long, doesn't allow to do tests filtering until it finishes topup logic. This makes feedback loops slow and frustrating during local development. Every change in files -> waiting for wallets topup

## What

This PR replaces eager, global topups with a lazy funding model:
- wallets are funded only when a test actually needs it
- faucet access is safely serialized across Jest workers via fs lock
- transient faucet failures and account sequence mismatches are retried

This approach does not aim to make faucet-dependent tests faster, but it greatly improves DX and test isolation by removing unnecessary global side effects and allowing developers to quickly run or filter tests without paying the faucet cost upfront. However it potentially can speed up functional tests execution because we don't need to wait for redundant wallet creation and topups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added pre-test wallet top-ups across functional suites and a beforeAll funding step for more reliable tests.
  * Simplified and concurrentized test wallet initialization with memoized mnemonic retrieval for faster setup.
* **Reliability**
  * Introduced cross-process locking and centralized retry policies to reduce transient failures.
  * Added persistent mnemonic caching and startup cleanup to prevent stale-lock and wallet flakiness.
* **New Features**
  * Added a faucet-backed wallet top-up utility to ensure minimum balances during tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->