### PR TITLE
refactor: centralizes returnTo stack navigation

### DIFF
--- a/apps/deploy-web/src/components/auth/AuthPage/AuthPage.spec.tsx
+++ b/apps/deploy-web/src/components/auth/AuthPage/AuthPage.spec.tsx
@@ -94,7 +94,7 @@ describe(AuthPage.name, () => {
   describe("when SignIn tab is open", () => {
     it("runs sign-in flow and redirects to return url", async () => {
       const SignInFormMock = jest.fn(ComponentMock as typeof SignInForm);
-      const { authService, router, checkSession } = setup({
+      const { authService, checkSession, navigateBack } = setup({
         searchParams: {
           returnTo: "/dashboard"
         },
@@ -122,14 +122,14 @@ describe(AuthPage.name, () => {
         expect(checkSession).toHaveBeenCalled();
       });
       await waitFor(() => {
-        expect(router.push).toHaveBeenCalledWith("/dashboard");
+        expect(navigateBack).toHaveBeenCalled();
       });
     });
 
     it("shows alert when sign-in fails", async () => {
       const SignInFormMock = jest.fn(ComponentMock as typeof SignInForm);
       const RemoteApiErrorMock = jest.fn(({ error }) => error && <div>Unexpected error</div>);
-      const { authService, router } = setup({
+      const { authService, router, navigateBack } = setup({
         dependencies: {
           SignInForm: SignInFormMock,
           RemoteApiError: RemoteApiErrorMock
@@ -148,13 +148,14 @@ describe(AuthPage.name, () => {
         expect(screen.getByText(/unexpected error/i)).toBeInTheDocument();
       });
       expect(router.push).not.toHaveBeenCalled();
+      expect(navigateBack).not.toHaveBeenCalled();
     });
   });
 
   describe("when SignUp tab is open", () => {
     it("runs sign-up flow and redirects to return url", async () => {
       const SignUpFormMock = jest.fn(ComponentMock as typeof SignUpForm);
-      const { authService, router, checkSession } = setup({
+      const { authService, checkSession, navigateBack } = setup({
         searchParams: {
           returnTo: "/dashboard"
         },
@@ -183,14 +184,14 @@ describe(AuthPage.name, () => {
         expect(checkSession).toHaveBeenCalled();
       });
       await waitFor(() => {
-        expect(router.push).toHaveBeenCalledWith("/dashboard");
+        expect(navigateBack).toHaveBeenCalled();
       });
     });
 
     it("shows alert when sign-up fails", async () => {
       const SignUpFormMock = jest.fn(ComponentMock as typeof SignUpForm);
       const RemoteApiErrorMock = jest.fn(({ error }) => error && <div>Unexpected error</div>);
-      const { authService, router } = setup({
+      const { authService, router, navigateBack } = setup({
         dependencies: {
           SignUpForm: SignUpFormMock,
           RemoteApiError: RemoteApiErrorMock
@@ -210,6 +211,7 @@ describe(AuthPage.name, () => {
         expect(screen.getByText(/unexpected error/i)).toBeInTheDocument();
       });
       expect(router.push).not.toHaveBeenCalled();
+      expect(navigateBack).not.toHaveBeenCalled();
     });
   });
 
@@ -255,127 +257,6 @@ describe(AuthPage.name, () => {
     });
   });
 
-  describe("when deploy button flow is active", () => {
-    it("renders ConnectWalletButton when deploy button flow is active", () => {
-      const ConnectWalletButtonMock = jest.fn(() => <button data-testid="connect-wallet-btn">Connect Wallet</button>);
-      setup({
-        searchParams: {
-          tab: "login",
-          from: "/new-deployment?repoUrl=https://github.com/test/repo.git"
-        },
-        dependencies: {
-          useDeployButtonFlow: () => ({
-            isDeployButtonFlow: true,
-            params: {
-              repoUrl: "https://github.com/test/repo.git",
-              branch: null,
-              buildCommand: null,
-              startCommand: null,
-              installCommand: null,
-              buildDirectory: null,
-              nodeVersion: null,
-              templateId: null
-            },
-            buildReturnUrl: () => "/new-deployment",
-            buildUrlParams: () => ({ repoUrl: "https://github.com/test/repo.git" })
-          }),
-          ConnectWalletButton: ConnectWalletButtonMock
-        }
-      });
-
-      expect(screen.queryByTestId("connect-wallet-btn")).toBeInTheDocument();
-    });
-
-    it("does not render ConnectWalletButton when deploy button flow is inactive", () => {
-      setup({
-        searchParams: {
-          tab: "login"
-        }
-      });
-
-      expect(screen.queryByTestId("connect-wallet-btn")).not.toBeInTheDocument();
-    });
-
-    it("redirects to returnUrl when wallet connects during deploy button flow", async () => {
-      const { router } = setup({
-        searchParams: {
-          tab: "login",
-          from: "/new-deployment?repoUrl=https://github.com/test/repo.git"
-        },
-        dependencies: {
-          useDeployButtonFlow: () => ({
-            isDeployButtonFlow: true,
-            params: {
-              repoUrl: "https://github.com/test/repo.git",
-              branch: null,
-              buildCommand: null,
-              startCommand: null,
-              installCommand: null,
-              buildDirectory: null,
-              nodeVersion: null,
-              templateId: null
-            },
-            buildReturnUrl: () => "/new-deployment?repoUrl=https://github.com/test/repo.git",
-            buildUrlParams: () => ({ repoUrl: "https://github.com/test/repo.git" })
-          }),
-          useWallet: () => ({
-            address: "akash1test",
-            walletName: "test",
-            isWalletConnected: true,
-            isWalletLoaded: true,
-            connectManagedWallet: jest.fn(),
-            logout: jest.fn(),
-            signAndBroadcastTx: jest.fn(),
-            isManaged: false,
-            isCustodial: false,
-            isWalletLoading: false,
-            isTrialing: false,
-            isOnboarding: false,
-            switchWalletType: jest.fn(),
-            hasManagedWallet: false
-          })
-        }
-      });
-
-      await waitFor(() => {
-        expect(router.push).toHaveBeenCalledWith("/new-deployment?repoUrl=https://github.com/test/repo.git");
-      });
-    });
-
-    it("renders SocialAuth instead of Tabs when deploy button flow is active", () => {
-      const SocialAuthMock = jest.fn(ComponentMock);
-      const TabsMock = jest.fn(ComponentMock as typeof Tabs);
-      setup({
-        searchParams: {
-          tab: "login",
-          from: "/new-deployment?repoUrl=https://github.com/test/repo.git"
-        },
-        dependencies: {
-          useDeployButtonFlow: () => ({
-            isDeployButtonFlow: true,
-            params: {
-              repoUrl: "https://github.com/test/repo.git",
-              branch: null,
-              buildCommand: null,
-              startCommand: null,
-              installCommand: null,
-              buildDirectory: null,
-              nodeVersion: null,
-              templateId: null
-            },
-            buildReturnUrl: () => "/new-deployment",
-            buildUrlParams: () => ({ repoUrl: "https://github.com/test/repo.git" })
-          }),
-          SocialAuth: SocialAuthMock,
-          Tabs: TabsMock as unknown as typeof Tabs
-        }
-      });
-
-      expect(SocialAuthMock).toHaveBeenCalled();
-      expect(TabsMock).not.toHaveBeenCalled();
-    });
-  });
-
   function setup(input: {
     searchParams?: {
       tab?: "login" | "signup" | "forgot-password";
@@ -401,20 +282,13 @@ describe(AuthPage.name, () => {
       user: {}
     });
 
-    const useDeployButtonFlow: typeof DEPENDENCIES.useDeployButtonFlow = () => ({
-      isDeployButtonFlow: false,
-      params: {
-        repoUrl: null,
-        branch: null,
-        buildCommand: null,
-        startCommand: null,
-        installCommand: null,
-        buildDirectory: null,
-        nodeVersion: null,
-        templateId: null
-      },
-      buildReturnUrl: () => "/",
-      buildUrlParams: () => ({})
+    const navigateBack = jest.fn();
+    const useReturnTo: typeof DEPENDENCIES.useReturnTo = () => ({
+      returnTo: input.searchParams?.returnTo || input.searchParams?.from || "/",
+      navigateWithReturnTo: jest.fn(),
+      navigateBack,
+      hasReturnTo: true,
+      isDeploymentReturnTo: false
     });
 
     const useWallet: typeof DEPENDENCIES.useWallet = () => ({
@@ -465,7 +339,7 @@ describe(AuthPage.name, () => {
             useUser,
             useSearchParams,
             useRouter: () => router,
-            useDeployButtonFlow: input.dependencies?.useDeployButtonFlow || useDeployButtonFlow,
+            useReturnTo: input.dependencies?.useReturnTo || useReturnTo,
             useWallet: input.dependencies?.useWallet || useWallet,
             Turnstile,
             ...input.dependencies
@@ -477,7 +351,8 @@ describe(AuthPage.name, () => {
     return {
       authService,
       router,
-      checkSession
+      checkSession,
+      navigateBack
     };
   }
 });

--- a/apps/deploy-web/src/components/auth/SignUpButton/SignUpButton.spec.tsx
+++ b/apps/deploy-web/src/components/auth/SignUpButton/SignUpButton.spec.tsx
@@ -31,7 +31,7 @@ describe(SignUpButton.name, () => {
     expect(linkElement).toHaveClass("custom-class");
     expect(linkElement).toHaveAttribute("data-testid", "signup-link");
     expect(linkElement).toHaveAttribute("id", "signup-btn");
-    expect(linkElement).toHaveAttribute("href", `/login?from=${encodeURIComponent("/")}&tab=signup`);
+    expect(linkElement).toHaveAttribute("href", `/login?tab=signup&returnTo=${encodeURIComponent("/")}`);
   });
 
   it("renders as a button when specified", () => {
@@ -53,7 +53,7 @@ describe(SignUpButton.name, () => {
     fireEvent.click(buttonElement);
 
     await waitFor(() => {
-      expect(navigate).toHaveBeenCalledWith(`/login?from=${encodeURIComponent("/")}&tab=signup`);
+      expect(navigate).toHaveBeenCalledWith(`/login?tab=signup&returnTo=${encodeURIComponent("/")}`);
     });
   });
 

--- a/apps/deploy-web/src/components/onboarding/OnboardingPage.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingPage.tsx
@@ -6,14 +6,14 @@ import Link from "next/link";
 
 import { CustomNextSeo } from "@src/components/shared/CustomNextSeo";
 import { useServices } from "@src/context/ServicesProvider";
-import { useDeployButtonFlow } from "@src/hooks/useDeployButtonFlow/useDeployButtonFlow";
+import { useReturnTo } from "@src/hooks/useReturnTo";
 import { domainName, UrlService } from "@src/utils/urlUtils";
 import { OnboardingContainer } from "./OnboardingContainer/OnboardingContainer";
 import { OnboardingView } from "./OnboardingView/OnboardingView";
 
 export const OnboardingPage: FC = () => {
   const { analyticsService } = useServices();
-  const { isDeployButtonFlow } = useDeployButtonFlow();
+  const { isDeploymentReturnTo } = useReturnTo();
 
   const handleBackToConsole = () => {
     analyticsService.track("onboarding_back_to_console", {
@@ -27,7 +27,7 @@ export const OnboardingPage: FC = () => {
       <div className="container mx-auto px-4 py-12">
         <OnboardingContainer>{props => <OnboardingView {...props} />}</OnboardingContainer>
 
-        {!isDeployButtonFlow && (
+        {!isDeploymentReturnTo && (
           <div className="py-8 text-center">
             <Link href={UrlService.home()} className={cn(buttonVariants({ variant: "ghost" }), "inline-flex items-center gap-2")} onClick={handleBackToConsole}>
               <NavArrowLeft className="h-4 w-4" />

--- a/apps/deploy-web/src/components/onboarding/steps/WelcomeStep/WelcomeStep.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/WelcomeStep/WelcomeStep.tsx
@@ -4,7 +4,7 @@ import { Button, Spinner } from "@akashnetwork/ui/components";
 import Image from "next/image";
 
 import { useServices } from "@src/context/ServicesProvider";
-import { useDeployButtonFlow } from "@src/hooks/useDeployButtonFlow/useDeployButtonFlow";
+import { useReturnTo } from "@src/hooks/useReturnTo";
 import { TemplateCard } from "./TemplateCard";
 import { TrialStatusBar } from "./TrialStatusBar";
 
@@ -14,7 +14,7 @@ interface WelcomeStepProps {
 
 export const WelcomeStep: React.FunctionComponent<WelcomeStepProps> = ({ onComplete }) => {
   const { analyticsService } = useServices();
-  const { isDeployButtonFlow } = useDeployButtonFlow();
+  const { isDeploymentReturnTo } = useReturnTo();
   const [isDeploying, setIsDeploying] = useState(false);
   const [deployingTemplate, setDeployingTemplate] = useState<string | null>(null);
 
@@ -57,14 +57,14 @@ export const WelcomeStep: React.FunctionComponent<WelcomeStepProps> = ({ onCompl
 
       <div className="space-y-3">
         <h1 className="text-3xl font-semibold tracking-tight">Welcome to Akash Console</h1>
-        {isDeployButtonFlow ? (
+        {isDeploymentReturnTo ? (
           <p className="text-base text-muted-foreground">You&apos;re all set! Continue to complete your deployment.</p>
         ) : (
           <p className="text-base text-muted-foreground">Choose a template below to launch your first app in seconds.</p>
         )}
       </div>
 
-      {isDeployButtonFlow ? (
+      {isDeploymentReturnTo ? (
         <div className="flex justify-center">
           <Button onClick={goToDeployment} disabled={isDeploying} className="bg-primary px-8 py-6 text-lg text-primary-foreground hover:bg-primary/90">
             {isDeploying ? <Spinner size="small" /> : "Go to Deployment"}

--- a/apps/deploy-web/src/hooks/useDeployButtonFlow/useDeployButtonFlow.spec.ts
+++ b/apps/deploy-web/src/hooks/useDeployButtonFlow/useDeployButtonFlow.spec.ts
@@ -1,7 +1,5 @@
 import type { ReadonlyURLSearchParams } from "next/navigation";
 
-import { CI_CD_TEMPLATE_ID } from "@src/config/remote-deploy.config";
-import { RouteStep } from "@src/types/route-steps.type";
 import { useDeployButtonFlow } from "./useDeployButtonFlow";
 
 import { renderHook } from "@testing-library/react";
@@ -9,7 +7,9 @@ import { renderHook } from "@testing-library/react";
 describe(useDeployButtonFlow.name, () => {
   describe("deploy button flow detection", () => {
     it("detects deploy button flow when repoUrl is present in searchParams", () => {
-      const { result } = setup({}, "http://localhost:3000/new-deployment?repoUrl=https://github.com/test/repo.git");
+      const { result } = setup({
+        repoUrl: "https://github.com/test/repo.git"
+      });
 
       expect(result.current.isDeployButtonFlow).toBe(true);
       expect(result.current.params.repoUrl).toBe("https://github.com/test/repo.git");
@@ -21,42 +21,20 @@ describe(useDeployButtonFlow.name, () => {
       expect(result.current.isDeployButtonFlow).toBe(false);
       expect(result.current.params.repoUrl).toBeNull();
     });
-
-    it("detects deploy button flow when repoUrl is in returnTo parameter", () => {
-      const { result } = setup({
-        returnTo: "/new-deployment?repoUrl=https://github.com/test/repo.git&branch=main"
-      });
-
-      expect(result.current.isDeployButtonFlow).toBe(true);
-      expect(result.current.params.repoUrl).toBe("https://github.com/test/repo.git");
-      expect(result.current.params.branch).toBe("main");
-    });
-
-    it("detects deploy button flow when repoUrl is in from parameter", () => {
-      const { result } = setup({
-        from: "/new-deployment?repoUrl=https://github.com/test/repo.git&buildCommand=npm%20run%20build"
-      });
-
-      expect(result.current.isDeployButtonFlow).toBe(true);
-      expect(result.current.params.repoUrl).toBe("https://github.com/test/repo.git");
-      expect(result.current.params.buildCommand).toBe("npm run build");
-    });
-
-    it("falls back to window.location.href when returnTo and from are absent", () => {
-      const { result } = setup({}, "http://localhost:3000/new-deployment?repoUrl=https://github.com/test/repo.git&branch=main");
-
-      expect(result.current.isDeployButtonFlow).toBe(true);
-      expect(result.current.params.repoUrl).toBe("https://github.com/test/repo.git");
-      expect(result.current.params.branch).toBe("main");
-    });
   });
 
   describe("parameter extraction", () => {
     it("extracts all deploy button parameters", () => {
-      const { result } = setup(
-        {},
-        "http://localhost:3000/new-deployment?repoUrl=https://github.com/test/repo.git&branch=main&buildCommand=npm%20run%20build&startCommand=npm%20start&installCommand=npm%20install&buildDirectory=dist&nodeVersion=18&templateId=custom-template"
-      );
+      const { result } = setup({
+        repoUrl: "https://github.com/test/repo.git",
+        branch: "main",
+        buildCommand: "npm run build",
+        startCommand: "npm start",
+        installCommand: "npm install",
+        buildDirectory: "dist",
+        nodeVersion: "18",
+        templateId: "custom-template"
+      });
 
       expect(result.current.params).toEqual({
         repoUrl: "https://github.com/test/repo.git",
@@ -71,7 +49,7 @@ describe(useDeployButtonFlow.name, () => {
     });
 
     it("returns null for missing parameters", () => {
-      const { result } = setup({}, "http://localhost:3000/new-deployment?repoUrl=https://github.com/test/repo.git");
+      const { result } = setup({ repoUrl: "https://github.com/test/repo.git" });
 
       expect(result.current.params.branch).toBeNull();
       expect(result.current.params.buildCommand).toBeNull();
@@ -82,139 +60,44 @@ describe(useDeployButtonFlow.name, () => {
       expect(result.current.params.templateId).toBeNull();
     });
 
-    it("handles URL-encoded parameters in returnTo", () => {
-      const { result } = setup({
-        returnTo: "/new-deployment?repoUrl=https%3A%2F%2Fgithub.com%2Ftest%2Frepo.git&branch=main"
-      });
-
-      expect(result.current.params.repoUrl).toBe("https://github.com/test/repo.git");
-      expect(result.current.params.branch).toBe("main");
-    });
-
-    it("handles URL-encoded parameters in from", () => {
-      const { result } = setup({
-        from: "/new-deployment?repoUrl=https%3A%2F%2Fgithub.com%2Ftest%2Frepo.git&buildCommand=npm%20run%20build"
-      });
+    it("handles URL-encoded parameters", () => {
+      const { result } = setupWithQueryString("repoUrl=https%3A%2F%2Fgithub.com%2Ftest%2Frepo.git&buildCommand=npm%20run%20build");
 
       expect(result.current.params.repoUrl).toBe("https://github.com/test/repo.git");
       expect(result.current.params.buildCommand).toBe("npm run build");
     });
   });
 
-  describe("buildUrlParams", () => {
-    it("returns only defined parameters", () => {
-      const { result } = setup({}, "http://localhost:3000/new-deployment?repoUrl=https://github.com/test/repo.git&branch=main&buildCommand=npm%20run%20build");
-
-      const urlParams = result.current.buildUrlParams();
-
-      expect(urlParams).toEqual({
-        repoUrl: "https://github.com/test/repo.git",
-        branch: "main",
-        buildCommand: "npm run build"
-      });
-    });
-
-    it("excludes null parameters", () => {
-      const { result } = setup({}, "http://localhost:3000/new-deployment?repoUrl=https://github.com/test/repo.git");
-
-      const urlParams = result.current.buildUrlParams();
-
-      expect(urlParams).toEqual({
-        repoUrl: "https://github.com/test/repo.git"
-      });
-      expect(urlParams.branch).toBeUndefined();
-      expect(urlParams.buildCommand).toBeUndefined();
-    });
-
-    it("returns empty object when not a deploy button flow", () => {
-      const { result } = setup({});
-
-      const urlParams = result.current.buildUrlParams();
-
-      expect(urlParams).toEqual({});
-    });
-  });
-
-  describe("buildReturnUrl", () => {
-    it("builds return URL with default step and gitProvider for deploy button flow", () => {
-      const { result } = setup({}, "http://localhost:3000/new-deployment?repoUrl=https://github.com/test/repo.git&branch=main");
-
-      const returnUrl = result.current.buildReturnUrl();
-
-      expect(returnUrl).toContain(`templateId=${CI_CD_TEMPLATE_ID}`);
-      expect(returnUrl).toContain("repoUrl=https%3A%2F%2Fgithub.com%2Ftest%2Frepo.git");
-      expect(returnUrl).toContain("branch=main");
-      expect(returnUrl).toContain(`step=${RouteStep.editDeployment}`);
-      expect(returnUrl).toContain("gitProvider=github");
-    });
-
-    it("builds return URL with custom step", () => {
-      const { result } = setup({}, "http://localhost:3000/new-deployment?repoUrl=https://github.com/test/repo.git");
-
-      const returnUrl = result.current.buildReturnUrl({
-        step: RouteStep.createLeases
-      });
-
-      expect(returnUrl).toContain(`step=${RouteStep.createLeases}`);
-    });
-
-    it("builds return URL with custom gitProvider", () => {
-      const { result } = setup({}, "http://localhost:3000/new-deployment?repoUrl=https://github.com/test/repo.git");
-
-      const returnUrl = result.current.buildReturnUrl({
-        gitProvider: "gitlab"
-      });
-
-      expect(returnUrl).toContain("gitProvider=gitlab");
-    });
-
-    it("includes all deploy button parameters in return URL", () => {
-      const { result } = setup(
-        {},
-        "http://localhost:3000/new-deployment?repoUrl=https://github.com/test/repo.git&branch=main&buildCommand=npm%20run%20build&startCommand=npm%20start&installCommand=npm%20install&buildDirectory=dist&nodeVersion=18"
-      );
-
-      const returnUrl = result.current.buildReturnUrl();
-
-      expect(returnUrl).toContain("repoUrl=");
-      expect(returnUrl).toContain("branch=main");
-      expect(returnUrl).toContain("buildCommand=npm");
-      expect(returnUrl).toContain("run");
-      expect(returnUrl).toContain("build");
-      expect(returnUrl).toContain("startCommand=npm");
-      expect(returnUrl).toContain("start");
-      expect(returnUrl).toContain("installCommand=npm");
-      expect(returnUrl).toContain("install");
-      expect(returnUrl).toContain("buildDirectory=dist");
-      expect(returnUrl).toContain("nodeVersion=18");
-    });
-
-    it("returns root path when not a deploy button flow", () => {
-      const { result } = setup({});
-
-      const returnUrl = result.current.buildReturnUrl();
-
-      expect(returnUrl).toBe("/");
-    });
-
-    it("returns root path when repoUrl is null", () => {
-      const { result } = setup({}, "http://localhost:3000/new-deployment?branch=main");
-
-      const returnUrl = result.current.buildReturnUrl();
-
-      expect(returnUrl).toBe("/");
-    });
-  });
-
-  function setup(searchParams: Record<string, string | null>, windowHref?: string) {
+  function setup(searchParams: Record<string, string | null>) {
     const mockWindow = {
       location: {
-        href: windowHref || "http://localhost:3000/new-deployment",
-        origin: windowHref ? new URL(windowHref).origin : "http://localhost:3000"
+        href: "http://localhost:3000/new-deployment",
+        origin: "http://localhost:3000"
       }
     } as Window & typeof globalThis;
 
     const params = createSearchParams(searchParams);
+    const useSearchParams = () => params as ReadonlyURLSearchParams;
+
+    return renderHook(() =>
+      useDeployButtonFlow({
+        dependencies: {
+          useSearchParams,
+          window: mockWindow
+        }
+      })
+    );
+  }
+
+  function setupWithQueryString(queryString: string) {
+    const mockWindow = {
+      location: {
+        href: `http://localhost:3000/new-deployment?${queryString}`,
+        origin: "http://localhost:3000"
+      }
+    } as Window & typeof globalThis;
+
+    const params = new URLSearchParams(queryString);
     const useSearchParams = () => params as ReadonlyURLSearchParams;
 
     return renderHook(() =>

--- a/apps/deploy-web/src/hooks/useDeployButtonFlow/useDeployButtonFlow.ts
+++ b/apps/deploy-web/src/hooks/useDeployButtonFlow/useDeployButtonFlow.ts
@@ -1,10 +1,6 @@
 import { useCallback, useMemo } from "react";
 import { useSearchParams as useSearchParamsOriginal } from "next/navigation";
 
-import { CI_CD_TEMPLATE_ID } from "@src/config/remote-deploy.config";
-import { RouteStep } from "@src/types/route-steps.type";
-import { UrlService } from "@src/utils/urlUtils";
-
 export const DEPENDENCIES = {
   useSearchParams: useSearchParamsOriginal,
   window: typeof window === "undefined" ? undefined : window
@@ -36,7 +32,7 @@ export interface DeployButtonUrlParams {
   templateId?: string;
 }
 
-export type DeployButtonFlowResult = (
+export type DeployButtonFlowResult =
   | {
       /** Whether this is a deploy button flow (has repoUrl) */
       isDeployButtonFlow: true;
@@ -48,13 +44,7 @@ export type DeployButtonFlowResult = (
       isDeployButtonFlow: false;
       /** All deploy button parameters */
       params: DeployButtonFlowParams<null>;
-    }
-) & {
-  /** Builds a returnUrl for redirects (e.g., for onboarding flow) */
-  buildReturnUrl: (options?: { step?: string; gitProvider?: string }) => string;
-  /** Builds URL parameters object with only defined (non-null) values */
-  buildUrlParams: () => DeployButtonUrlParams;
-};
+    };
 
 /**
  * Hook to manage deploy button flow state and parameters.
@@ -63,15 +53,7 @@ export type DeployButtonFlowResult = (
 export const useDeployButtonFlow = ({ dependencies: d = DEPENDENCIES }: UseDeployButtonFlowOptions = {}): DeployButtonFlowResult => {
   const searchParams = d.useSearchParams();
 
-  const targetUrl = useMemo(() => {
-    if (typeof d.window === "undefined") return null;
-
-    const raw = searchParams.get("returnTo") || searchParams.get("from") || d.window.location.href;
-
-    return new URL(raw, d.window.location.origin);
-  }, [searchParams, d?.window]);
-
-  const getParam = useCallback((key: string) => targetUrl?.searchParams.get(key) || null, [targetUrl]);
+  const getParam = useCallback((key: string) => searchParams.get(key) || null, [searchParams]);
   const params = useMemo<DeployButtonFlowParams>(
     () => ({
       repoUrl: getParam("repoUrl"),
@@ -87,57 +69,12 @@ export const useDeployButtonFlow = ({ dependencies: d = DEPENDENCIES }: UseDeplo
   );
 
   const { repoUrl } = params;
-  const isDeployButtonFlow = !!repoUrl;
-
-  const buildUrlParams = useMemo(
-    () => (): DeployButtonUrlParams => {
-      const urlParams: DeployButtonUrlParams = {};
-      if (params.repoUrl) urlParams.repoUrl = params.repoUrl;
-      if (params.branch) urlParams.branch = params.branch;
-      if (params.buildCommand) urlParams.buildCommand = params.buildCommand;
-      if (params.startCommand) urlParams.startCommand = params.startCommand;
-      if (params.installCommand) urlParams.installCommand = params.installCommand;
-      if (params.buildDirectory) urlParams.buildDirectory = params.buildDirectory;
-      if (params.nodeVersion) urlParams.nodeVersion = params.nodeVersion;
-      if (params.templateId) urlParams.templateId = params.templateId;
-      return urlParams;
-    },
-    [
-      params.repoUrl,
-      params.branch,
-      params.buildCommand,
-      params.startCommand,
-      params.installCommand,
-      params.buildDirectory,
-      params.nodeVersion,
-      params.templateId
-    ]
-  );
-
-  const buildReturnUrl = useCallback(
-    (options?: { step?: string; gitProvider?: string }): string =>
-      isDeployButtonFlow && repoUrl
-        ? UrlService.newDeployment({
-            templateId: CI_CD_TEMPLATE_ID,
-            ...buildUrlParams(),
-            step: (options?.step as RouteStep) || RouteStep.editDeployment,
-            gitProvider: options?.gitProvider || "github"
-          })
-        : "/",
-    [isDeployButtonFlow, repoUrl, buildUrlParams]
-  );
 
   return useMemo(() => {
-    const commonResult: Omit<DeployButtonFlowResult, "isDeployButtonFlow" | "params"> = {
-      buildReturnUrl,
-      buildUrlParams
-    };
-
     if (typeof repoUrl === "string") {
       return {
         isDeployButtonFlow: true,
-        params: { ...params, repoUrl },
-        ...commonResult
+        params: { ...params, repoUrl }
       };
     }
 
@@ -146,8 +83,7 @@ export const useDeployButtonFlow = ({ dependencies: d = DEPENDENCIES }: UseDeplo
       params: {
         ...params,
         repoUrl: null
-      },
-      ...commonResult
+      }
     };
-  }, [buildReturnUrl, buildUrlParams, repoUrl, params]);
+  }, [repoUrl, params]);
 };

--- a/apps/deploy-web/src/hooks/useReturnTo/UrlReturnToStack.spec.ts
+++ b/apps/deploy-web/src/hooks/useReturnTo/UrlReturnToStack.spec.ts
@@ -1,0 +1,19 @@
+import { UrlReturnToStack } from "./UrlReturnToStack";
+
+describe(UrlReturnToStack.name, () => {
+  it("stacks returnTo and can be popped like a stack", () => {
+    const origin = "http://localhost:3000";
+
+    const second = UrlReturnToStack.createReturnable(`${origin}/first?firstParam=firstValue`, "/second?secondParam=secondValue");
+
+    const third = UrlReturnToStack.createReturnable(`${origin}${second}`, "/third?thirdParam=thirdValue", {
+      extraQueryParams: { fromSecond: "true" }
+    });
+
+    const poppedFromThird = UrlReturnToStack.getReturnTo(`${origin}${third}`);
+    expect(poppedFromThird).toBe("/second?secondParam=secondValue&fromSecond=true&returnTo=%2Ffirst%3FfirstParam%3DfirstValue");
+
+    const poppedFromSecond = UrlReturnToStack.getReturnTo(`${origin}${poppedFromThird}`);
+    expect(poppedFromSecond).toBe("/first?firstParam=firstValue");
+  });
+});

--- a/apps/deploy-web/src/hooks/useReturnTo/UrlReturnToStack.ts
+++ b/apps/deploy-web/src/hooks/useReturnTo/UrlReturnToStack.ts
@@ -1,0 +1,158 @@
+import { getValidInternalReturnToUrl } from "@src/utils/getValidInternalReturnToUrl/getValidInternalReturnToUrl";
+
+/** Extra query params to merge into a pushed returnTo entry. */
+export type ExtraQueryParams = Record<string, string | number | boolean | null | undefined>;
+
+/**
+ * Utilities for building and consuming a multi-`returnTo` stack stored in URL query params.
+ *
+ * Stack representation:
+ * - The stack is encoded as multiple `returnTo` query params in order.
+ * - Legacy `from` is supported as a single-entry fallback when no `returnTo` params exist.
+ *
+ * Safety:
+ * - `getReturnTo()` always validates the popped destination via `getValidInternalReturnToUrl`.
+ * - Invalid values resolve to `"/"`.
+ */
+export class UrlReturnToStack {
+  /**
+   * Compute the next navigation URL by popping the top returnTo entry from `location`.
+   * The returned URL also carries the remaining stack forward as `returnTo` params.
+   *
+   * @param location - Absolute URL or path-like string representing the current location.
+   */
+  static getReturnTo(location: string) {
+    return new UrlReturnToStack(location).getReturnTo();
+  }
+
+  /**
+   * Build a URL for navigating to `targetPath` while pushing the current `location` onto the returnTo stack.
+   *
+   * @param location - Absolute URL or path-like string representing the current location.
+   * @param targetPath - Absolute URL or path-like string representing the navigation target.
+   * @param options - Optional options for the pushed returnTo entry.
+   */
+  static createReturnable(location: string, targetPath: string, options?: { extraQueryParams?: ExtraQueryParams }) {
+    return new UrlReturnToStack(location).createReturnable(targetPath, options);
+  }
+
+  readonly #current: { pathname: string; params: URLSearchParams } | null;
+
+  /**
+   * @param currentLocation - Absolute URL or path-like string; query params are supported; fragments are ignored.
+   */
+  private constructor(currentLocation: string) {
+    this.#current = currentLocation ? this.#parsePathLike(currentLocation) : null;
+  }
+
+  /**
+   * Builds a URL for navigating to `targetPath` while pushing the current location onto the returnTo stack.
+   *
+   * Stack rules:
+   * - Preserves all existing `returnTo` params (in order), or falls back to legacy `from`.
+   * - Pushes the current route (pathname + search), stripped of any returnTo/from params.
+   * - Optionally merges `extraQueryParams` into the pushed returnTo entry (not the target URL).
+   */
+  createReturnable(targetPath: string, options?: { extraQueryParams?: ExtraQueryParams }): string {
+    const target = this.#parsePathLike(targetPath);
+    const stack = this.#getExistingReturnToStack(this.#current?.params);
+    const pushed = this.#current ? this.#stripReturnToParams(this.#current) : null;
+
+    if (pushed) {
+      stack.push(this.#mergeExtraParamsIntoReturnTo(pushed, options?.extraQueryParams));
+    }
+
+    if (!stack.length) {
+      const qs = target.params.toString();
+      return `${target.pathname}${qs ? `?${qs}` : ""}`;
+    }
+
+    stack.forEach(item => target.params.append("returnTo", item));
+    const qs = target.params.toString();
+
+    return `${target.pathname}${qs ? `?${qs}` : ""}`;
+  }
+
+  /**
+   * Returns the URL to navigate to by popping the top returnTo entry.
+   * The returned URL also carries the remaining stack forward as `returnTo` params.
+   */
+  getReturnTo(): string {
+    if (!this.#current) return "/";
+
+    const stack = this.#getExistingReturnToStack(this.#current.params);
+    if (!stack.length) return "/";
+
+    const destination = stack[stack.length - 1];
+    const remaining = stack.slice(0, -1);
+
+    const validated = getValidInternalReturnToUrl(destination);
+    if (!validated || validated === "/") return "/";
+
+    const dest = this.#parsePathLike(validated);
+    dest.params.delete("returnTo");
+    dest.params.delete("from");
+    remaining.forEach(v => dest.params.append("returnTo", v));
+
+    const qs = dest.params.toString();
+    return `${dest.pathname}${qs ? `?${qs}` : ""}`;
+  }
+
+  #getExistingReturnToStack(params: URLSearchParams | undefined): string[] {
+    if (!params) return [];
+
+    const all = params.getAll("returnTo");
+    if (all.length > 0) return [...all];
+
+    const from = params.get("from");
+    return from ? [from] : [];
+  }
+
+  #normalizePath(p: string) {
+    if (!p) return "/";
+    return p.startsWith("/") ? p : `/${p}`;
+  }
+
+  #parsePathLike(input: string): { pathname: string; params: URLSearchParams } {
+    const withoutHash = input.split("#")[0] || "";
+
+    /**
+     * Absolute URL input.
+     *
+     * Note: the returned `pathname` is relative; origin is intentionally discarded.
+     */
+    if (withoutHash.startsWith("http://") || withoutHash.startsWith("https://")) {
+      const u = new URL(withoutHash);
+      return { pathname: u.pathname || "/", params: new URLSearchParams(u.searchParams) };
+    }
+
+    const normalized = this.#normalizePath(withoutHash);
+    const qIndex = normalized.indexOf("?");
+    const pathname = qIndex === -1 ? normalized : normalized.slice(0, qIndex);
+    const query = qIndex === -1 ? "" : normalized.slice(qIndex + 1);
+    return { pathname: pathname || "/", params: new URLSearchParams(query) };
+  }
+
+  #mergeExtraParamsIntoReturnTo(returnTo: string, extra?: ExtraQueryParams): string {
+    if (!extra || Object.keys(extra).length === 0) return returnTo;
+
+    const u = this.#parsePathLike(returnTo);
+
+    for (const [k, v] of Object.entries(extra)) {
+      if (v === undefined || v === null) continue;
+      u.params.set(k, String(v));
+    }
+
+    const qs = u.params.toString();
+    return `${u.pathname}${qs ? `?${qs}` : ""}`;
+  }
+
+  #stripReturnToParams(current: { pathname: string; params: URLSearchParams }): string {
+    const params = new URLSearchParams(current.params);
+    params.delete("returnTo");
+    params.delete("from");
+
+    const qs = params.toString();
+    return `${current.pathname}${qs ? `?${qs}` : ""}`;
+  }
+}

--- a/apps/deploy-web/src/hooks/useReturnTo/index.ts
+++ b/apps/deploy-web/src/hooks/useReturnTo/index.ts
@@ -1,0 +1,1 @@
+export * from "./useReturnTo";

--- a/apps/deploy-web/src/hooks/useReturnTo/useReturnTo.spec.tsx
+++ b/apps/deploy-web/src/hooks/useReturnTo/useReturnTo.spec.tsx
@@ -1,0 +1,131 @@
+import { mock } from "jest-mock-extended";
+import type { ReadonlyURLSearchParams } from "next/navigation";
+
+import type { UrlReturnToStack } from "./UrlReturnToStack";
+import { DEPENDENCIES, useReturnTo } from "./useReturnTo";
+
+import { act, renderHook } from "@testing-library/react";
+
+describe(useReturnTo.name, () => {
+  it("computes returnTo from stack and navigates back", () => {
+    const { result, routerPush, getReturnTo } = setup({
+      pathname: "/foo",
+      search: "a=1",
+      stackReturnTo: "/bar?x=1"
+    });
+
+    expect(getReturnTo).toHaveBeenCalledWith("/foo?a=1");
+    expect(result.current.returnTo).toBe("/bar?x=1");
+
+    act(() => {
+      result.current.navigateBack();
+    });
+
+    expect(routerPush).toHaveBeenCalledWith("/bar?x=1");
+  });
+
+  it("navigates with returnTo by pushing a returnable URL", () => {
+    const { result, routerPush, createReturnable } = setup({
+      pathname: "/current",
+      search: "q=1",
+      stackReturnTo: "/ignored"
+    });
+
+    createReturnable.mockReturnValue("/login?returnTo=%2Fcurrent%3Fq%3D1");
+
+    act(() => {
+      result.current.navigateWithReturnTo("/login", { fromSignup: "true" });
+    });
+
+    expect(createReturnable).toHaveBeenCalledWith("/current?q=1", "/login", { extraQueryParams: { fromSignup: "true" } });
+    expect(routerPush).toHaveBeenCalledWith("/login?returnTo=%2Fcurrent%3Fq%3D1");
+  });
+
+  it("detects deployment returnTo", () => {
+    const { result } = setup({
+      pathname: "/foo",
+      search: "",
+      stackReturnTo: "/deployments/123?tab=logs"
+    });
+
+    expect(result.current.isDeploymentReturnTo).toBe(true);
+  });
+
+  it("falls back to defaultReturnTo when window is unavailable", () => {
+    const { result, routerPush, getReturnTo } = setup({
+      windowAvailable: false,
+      defaultReturnTo: "/fallback",
+      stackReturnTo: "/should-not-be-used"
+    });
+
+    expect(result.current.returnTo).toBe("/fallback");
+    expect(getReturnTo).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.navigateWithReturnTo("/login", { fromSignup: "true" });
+    });
+
+    expect(routerPush).toHaveBeenCalledWith("/login");
+  });
+
+  it("throws on navigateBack when returnTo is falsy", () => {
+    const { result } = setup({
+      windowAvailable: false,
+      stackReturnTo: "/ignored"
+    });
+
+    expect(() => {
+      result.current.navigateBack();
+    }).toThrow("No returnTo found");
+  });
+
+  function setup(input?: { pathname?: string; search?: string; stackReturnTo?: string; defaultReturnTo?: string; windowAvailable?: boolean }) {
+    jest.clearAllMocks();
+
+    const pathname = input?.pathname ?? "/";
+    const search = input?.search ?? "";
+    const stackReturnTo = input?.stackReturnTo ?? "/";
+    const windowAvailable = input?.windowAvailable ?? true;
+
+    type Router = ReturnType<typeof DEPENDENCIES.useRouter>;
+    const routerPush = jest.fn<ReturnType<Router["push"]>, Parameters<Router["push"]>>();
+    const router = mock<Router>({ push: routerPush });
+    const useRouter = () => router;
+
+    const params = new URLSearchParams(search);
+    const useSearchParams = () => params as unknown as ReadonlyURLSearchParams;
+
+    const getReturnTo = jest.fn(() => stackReturnTo);
+    const createReturnable = jest.fn(() => "/target");
+    const urlReturnToStack = mock<UrlReturnToStack>({
+      getReturnTo,
+      createReturnable
+    });
+
+    const useServices = jest.fn(() => ({ urlReturnToStack })) as unknown as typeof DEPENDENCIES.useServices;
+
+    const mockWindow = windowAvailable
+      ? ({
+          location: {
+            pathname,
+            search: search ? `?${search}` : ""
+          }
+        } as Window & typeof globalThis)
+      : undefined;
+
+    const result = renderHook(() =>
+      useReturnTo({
+        defaultReturnTo: input?.defaultReturnTo,
+        dependencies: {
+          ...DEPENDENCIES,
+          useRouter,
+          useSearchParams,
+          useServices,
+          window: mockWindow
+        }
+      })
+    );
+
+    return { ...result, routerPush, getReturnTo, createReturnable };
+  }
+});

--- a/apps/deploy-web/src/hooks/useReturnTo/useReturnTo.ts
+++ b/apps/deploy-web/src/hooks/useReturnTo/useReturnTo.ts
@@ -1,0 +1,142 @@
+import { useCallback, useMemo } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+import { useServices } from "@src/context/ServicesProvider";
+
+export const DEPENDENCIES = {
+  useRouter,
+  useSearchParams,
+  useServices,
+  window: typeof window === "undefined" ? undefined : window
+};
+
+export interface UseReturnToOptions<TDefaultReturnTo extends string | null | undefined = undefined> {
+  dependencies?: typeof DEPENDENCIES;
+  /** Default returnTo URL to use when none is provided in query params */
+  defaultReturnTo?: TDefaultReturnTo;
+}
+
+export type ReturnToPageType = "deployment" | "onboarding" | "auth" | "other" | null;
+
+export interface UseReturnToResult<TDefaultReturnTo extends string | null | undefined = undefined> {
+  /** The current returnTo URL (validated and safe) */
+  returnTo: TDefaultReturnTo extends string ? string : string | null;
+  /**
+   * Navigate to `path` while pushing the current location onto the returnTo stack.
+   *
+   * `extraQueryParams` are merged into the pushed returnTo entry (not into the target URL).
+   */
+  navigateWithReturnTo: (path: string, extraQueryParams?: Record<string, string>) => void;
+  /** Navigate back to the returnTo URL */
+  navigateBack: () => void;
+  /** Check if there's a returnTo */
+  hasReturnTo: boolean;
+  /** Check if returnTo is a deployment page */
+  isDeploymentReturnTo: boolean;
+}
+
+/**
+ * Manage return-to navigation for auth/onboarding flows.
+ *
+ * This hook uses a multi-`returnTo` stack (multiple `returnTo` query params) with a legacy `from` fallback.
+ * The stack behavior is implemented by `UrlReturnToStack` (exposed via DI as `urlReturnToStack`).
+ *
+ * Semantics:
+ * - `returnTo`: computed by popping the top returnTo entry (validated) and carrying the remaining stack forward.
+ * - `navigateBack()`: navigates to `returnTo`.
+ * - `navigateWithReturnTo(path)`: pushes the current location (stripped of returnTo/from) onto the stack and navigates to `path`.
+ *
+ * SSR note: this is a client hook (depends on `window` and `useSearchParams`). When `window` is unavailable,
+ * `returnTo` falls back to `defaultReturnTo` and `navigateWithReturnTo` falls back to navigating to `path` as-is.
+ */
+export const useReturnTo = <TDefaultReturnTo extends string | null | undefined = undefined>(
+  { dependencies: d = DEPENDENCIES, defaultReturnTo }: UseReturnToOptions<TDefaultReturnTo> = {} as UseReturnToOptions<TDefaultReturnTo>
+): UseReturnToResult<TDefaultReturnTo> => {
+  const router = d.useRouter();
+  const searchParams = d.useSearchParams();
+  const { urlReturnToStack } = d.useServices();
+
+  const currentLocation = useMemo(() => {
+    if (typeof d.window === "undefined") return "/";
+    const qs = searchParams.toString();
+    return `${d.window.location.pathname}${qs ? `?${qs}` : ""}`;
+  }, [d.window, searchParams]);
+
+  const returnTo = useMemo(() => {
+    if (typeof d.window === "undefined") {
+      return defaultReturnTo;
+    }
+    const computed = urlReturnToStack.getReturnTo(currentLocation);
+    const hasDefault = defaultReturnTo !== undefined && defaultReturnTo !== null;
+
+    if ((!computed || computed === "/") && hasDefault) {
+      return defaultReturnTo;
+    }
+
+    return computed;
+  }, [currentLocation, d.window, defaultReturnTo, urlReturnToStack]);
+
+  /**
+   * Navigate to `path` while stacking the current location as a returnTo entry.
+   *
+   * This uses the current URL (pathname + search params) as the entry to push.
+   */
+  const navigateWithReturnTo = useCallback(
+    (path: string, extraQueryParams?: Record<string, string>) => {
+      if (typeof d.window === "undefined") {
+        router.push(path);
+        return;
+      }
+
+      router.push(urlReturnToStack.createReturnable(currentLocation, path, { extraQueryParams }));
+    },
+    [currentLocation, d.window, router, urlReturnToStack]
+  );
+
+  /** Navigate back using the popped returnTo URL (already includes remaining stack). */
+  const navigateBack = useCallback(() => {
+    if (!returnTo) {
+      throw new Error("No returnTo found");
+    }
+
+    router.push(returnTo);
+  }, [returnTo, router]);
+
+  /**
+   * Detect page type from the computed `returnTo` navigation URL.
+   *
+   * Note: `returnTo` is a navigation-ready URL (destination + remaining stack carried forward), not a raw "peek".
+   */
+  const getReturnToPageType = useCallback((): ReturnToPageType => {
+    if (!returnTo) return null;
+
+    const path = returnTo.split("?")[0];
+    const lowerPath = path.toLowerCase();
+
+    if (lowerPath.startsWith("/new-deployment") || lowerPath.startsWith("/deploy-linux") || lowerPath.startsWith("/deployments/")) {
+      return "deployment";
+    }
+    if (lowerPath.startsWith("/signup") || lowerPath.startsWith("/onboarding")) {
+      return "onboarding";
+    }
+    if (lowerPath.startsWith("/login")) {
+      return "auth";
+    }
+
+    return null;
+  }, [returnTo]);
+
+  const isDeploymentReturnTo = useMemo(() => getReturnToPageType() === "deployment", [getReturnToPageType]);
+
+  return useMemo(
+    () =>
+      ({
+        returnTo: returnTo as TDefaultReturnTo extends string ? string : string | null,
+        navigateWithReturnTo,
+        navigateBack,
+        hasReturnTo: !!returnTo,
+        isDeploymentReturnTo
+      }) as UseReturnToResult<TDefaultReturnTo>,
+    [returnTo, navigateWithReturnTo, navigateBack, isDeploymentReturnTo]
+  );
+};

--- a/apps/deploy-web/src/lib/nextjs/pageGuards/pageGuards.spec.ts
+++ b/apps/deploy-web/src/lib/nextjs/pageGuards/pageGuards.spec.ts
@@ -103,6 +103,7 @@ function setup(input?: { enabledFeatures?: string[]; session?: Partial<Session> 
       }),
       logger: mock<LoggerService>(),
       urlService: UrlService
-    }
+    },
+    resolvedUrl: faker.internet.url()
   });
 }

--- a/apps/deploy-web/src/lib/nextjs/pageGuards/pageGuards.ts
+++ b/apps/deploy-web/src/lib/nextjs/pageGuards/pageGuards.ts
@@ -25,7 +25,7 @@ export async function redirectIfAccessTokenExpired(context: AppTypedContext): Pr
     return {
       redirect: {
         permanent: false,
-        destination: context.services.urlService.newLogin({ from: context.resolvedUrl })
+        destination: context.services.urlService.newLogin({ returnTo: context.resolvedUrl })
       }
     };
   }

--- a/apps/deploy-web/src/services/app-di-container/app-di-container.ts
+++ b/apps/deploy-web/src/services/app-di-container/app-di-container.ts
@@ -18,6 +18,7 @@ import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
 import type { Axios, AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from "axios";
 
 import { browserEnvConfig } from "@src/config/browser-env.config";
+import { UrlReturnToStack } from "@src/hooks/useReturnTo/UrlReturnToStack";
 import { AnalyticsService } from "@src/services/analytics/analytics.service";
 import networkStore from "@src/store/networkStore";
 import { registry } from "@src/utils/customRegistry";
@@ -185,6 +186,7 @@ export const createAppRootContainer = (config: ServicesConfig) => {
         }
       }),
     urlService: () => UrlService,
+    urlReturnToStack: () => UrlReturnToStack,
     userTracker: () => new UserTracker()
   });
 

--- a/apps/deploy-web/src/utils/getValidInternalReturnToUrl/getValidInternalReturnToUrl.spec.ts
+++ b/apps/deploy-web/src/utils/getValidInternalReturnToUrl/getValidInternalReturnToUrl.spec.ts
@@ -35,10 +35,6 @@ describe("getValidInternalReturnToUrl", () => {
     it("handles encoded paths", () => {
       expect(getValidInternalReturnToUrl(encodeURIComponent("/user/profile"))).toBe("/user/profile");
     });
-
-    it("handles paths with encoded characters", () => {
-      expect(getValidInternalReturnToUrl("/user%20profile")).toBe("/user profile");
-    });
   });
 
   describe("invalid paths - protocol-relative", () => {


### PR DESCRIPTION
Introduces UrlReturnToStack + useReturnTo to preserve multi-step returnTo across onboarding/login/Auth0 (SSR + API routes), with legacy `from` fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-entry return-to navigation stack and hook for consistent back/return behavior across auth, onboarding, and deployment.

* **Refactor**
  * Unified navigation flow: sign-in/sign-up, onboarding, and deployment now use the same return/navigation API; some deployment-specific UI paths streamlined.

* **Bug Fixes**
  * More reliable redirects and edge-case handling for external auth and repo-driven flows.

* **Tests**
  * New/updated tests covering the return-to stack and navigation behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->