### PR TITLE
chore: adds otel enabling in helm

### DIFF
--- a/.helm/console-api-prod-mainnet-values.yaml
+++ b/.helm/console-api-prod-mainnet-values.yaml
@@ -1,4 +1,6 @@
 deploymentEnv: production
+nodeOptions:
+  enabledOTEL: true
 
 chain: mainnet
 hostNames:

--- a/.helm/console-api-prod-sandbox-values.yaml
+++ b/.helm/console-api-prod-sandbox-values.yaml
@@ -1,4 +1,6 @@
 deploymentEnv: production
+nodeOptions:
+  enabledOTEL: true
 
 chain: sandbox
 hostNames:

--- a/.helm/console-api-staging-mainnet-values.yaml
+++ b/.helm/console-api-staging-mainnet-values.yaml
@@ -1,4 +1,6 @@
 deploymentEnv: staging
+nodeOptions:
+  enabledOTEL: true
 
 chain: mainnet
 hostNames:

--- a/.helm/console-api-staging-sandbox-values.yaml
+++ b/.helm/console-api-staging-sandbox-values.yaml
@@ -1,4 +1,6 @@
 deploymentEnv: staging
+nodeOptions:
+  enabledOTEL: true
 
 chain: sandbox
 hostNames:

--- a/.helm/console-api-staging-testnet-values.yaml
+++ b/.helm/console-api-staging-testnet-values.yaml
@@ -1,4 +1,6 @@
 deploymentEnv: staging
+nodeOptions:
+  enabledOTEL: true
 
 chain: testnet
 hostNames:

--- a/.helm/indexer-prod-mainnet-values.yaml
+++ b/.helm/indexer-prod-mainnet-values.yaml
@@ -1,4 +1,6 @@
 deploymentEnv: production
+nodeOptions:
+  enabledOTEL: true
 
 chain: mainnet
 nodePort: 30001

--- a/.helm/indexer-prod-sandbox-values.yaml
+++ b/.helm/indexer-prod-sandbox-values.yaml
@@ -1,4 +1,6 @@
 deploymentEnv: production
+nodeOptions:
+  enabledOTEL: true
 
 chain: sandbox
 nodePort: 30000

--- a/.helm/provider-proxy-prod-mainnet-values.yaml
+++ b/.helm/provider-proxy-prod-mainnet-values.yaml
@@ -1,3 +1,5 @@
 deploymentEnv: production
+nodeOptions:
+  enabledOTEL: true
 
 chain: mainnet

--- a/.helm/provider-proxy-prod-sandbox-values.yaml
+++ b/.helm/provider-proxy-prod-sandbox-values.yaml
@@ -1,3 +1,5 @@
 deploymentEnv: production
+nodeOptions:
+  enabledOTEL: true
 
 chain: sandbox

--- a/.helm/provider-proxy-staging-mainnet-values.yaml
+++ b/.helm/provider-proxy-staging-mainnet-values.yaml
@@ -1,3 +1,5 @@
 deploymentEnv: staging
+nodeOptions:
+  enabledOTEL: true
 
 chain: mainnet

--- a/.helm/provider-proxy-staging-sandbox-values.yaml
+++ b/.helm/provider-proxy-staging-sandbox-values.yaml
@@ -1,3 +1,5 @@
 deploymentEnv: staging
+nodeOptions:
+  enabledOTEL: true
 
 chain: sandbox

--- a/.helm/provider-proxy-staging-testnet-values.yaml
+++ b/.helm/provider-proxy-staging-testnet-values.yaml
@@ -1,3 +1,5 @@
 deploymentEnv: staging
+nodeOptions:
+  enabledOTEL: true
 
 chain: testnet


### PR DESCRIPTION
## Why

Because we need a standard NODE_OPTIONS with possibility to adjust parts of it per service level. Related to https://github.com/akash-network/helm-charts/pull/511

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled OpenTelemetry instrumentation across all deployment environments (production, staging, and sandbox) for improved system observability and monitoring capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->