### PR TITLE
fix: set timestamp setting in env-loader

### DIFF
--- a/packages/env-loader/src/index.js
+++ b/packages/env-loader/src/index.js
@@ -8,6 +8,7 @@ const CUSTOM_LEVELS = {
 
 const logger = pino(
   {
+    timestamp: () => `,"time":"${new Date().toISOString()}"`,
     formatters: {
       level(label) {
         return { level: CUSTOM_LEVELS[label] || label };


### PR DESCRIPTION
## Why

Right now timestamp is logged as unix timestamp and it's hard to understand its value without additional tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logs now include ISO-formatted timestamps in the output for better event visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->