### PR TITLE
fix: ensure that tsbuild picks proper dependencies for internal packages

### DIFF
--- a/.github/workflows/all-ci.yml
+++ b/.github/workflows/all-ci.yml
@@ -13,6 +13,7 @@ concurrency:
 permissions:
   contents: read
   pull-requests: read
+  checks: read
 
 jobs:
   setup:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -101,6 +101,7 @@
     "pg-boss": "^11.0.4",
     "pg-hstore": "^2.3.4",
     "postgres": "^3.4.4",
+    "protobufjs": "^6.11.2",
     "reflect-metadata": "^0.2.2",
     "semver": "^7.3.8",
     "sequelize": "^6.21.3",

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -1,4 +1,4 @@
-import type { v2Sdl } from "@akashnetwork/akashjs/build/sdl/types";
+import type { v2Sdl } from "@akashnetwork/chain-sdk";
 import yaml from "js-yaml";
 
 import type { BillingConfig } from "@src/billing/providers";

--- a/apps/api/src/deployment/services/sdl/sdl.service.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.ts
@@ -1,4 +1,4 @@
-import type { v2Manifest, v2Sdl, v3Manifest } from "@akashnetwork/akashjs/build/sdl/types";
+import type { v2Manifest, v2Sdl, v3Manifest } from "@akashnetwork/chain-sdk";
 import type { NetworkId } from "@akashnetwork/chain-sdk";
 import { SDL } from "@akashnetwork/chain-sdk";
 import yaml from "js-yaml";

--- a/apps/api/src/provider/repositories/provider/provider.repository.ts
+++ b/apps/api/src/provider/repositories/provider/provider.repository.ts
@@ -1,5 +1,5 @@
 // TODO: replace this import with @akashnetwork/chain-sdk when it exports those types
-import type { Attribute, SignedBy } from "@akashnetwork/akashjs/build/sdl/types";
+import type { Attribute, SignedBy } from "@akashnetwork/chain-sdk";
 import {
   Provider,
   ProviderAttribute,

--- a/apps/api/test/mocks/template.ts
+++ b/apps/api/test/mocks/template.ts
@@ -1,4 +1,4 @@
-import type { v2Sdl } from "@akashnetwork/akashjs/build/sdl/types";
+import type { v2Sdl } from "@akashnetwork/chain-sdk";
 import dot from "dot-object";
 import update, { type CustomCommands, type Spec } from "immutability-helper";
 import { dump } from "js-yaml";

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,7 @@
         "pg-boss": "^11.0.4",
         "pg-hstore": "^2.3.4",
         "postgres": "^3.4.4",
+        "protobufjs": "^6.11.2",
         "reflect-metadata": "^0.2.2",
         "semver": "^7.3.8",
         "sequelize": "^6.21.3",
@@ -177,36 +178,36 @@
       }
     },
     "apps/api/node_modules/@cosmjs/amino": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.36.1.tgz",
-      "integrity": "sha512-JRAtBA0bcIlhYZ5AXMT8VYUaxqVfEDiQbcEg0FLEIFofssj3V4aXFO93lsPI3AeWwRSZhWA+guGd/iHFC05UbQ==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.36.2.tgz",
+      "integrity": "sha512-r4yV1bhl412gwHGlyaUaJHIJnmldtyGsAwyz3oHHVxduiECj06Rv6wqeyLZfQa9W6hU+MlZwy7LabSUkkyGwjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cosmjs/crypto": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1"
+        "@cosmjs/crypto": "^0.36.2",
+        "@cosmjs/encoding": "^0.36.2",
+        "@cosmjs/math": "^0.36.2",
+        "@cosmjs/utils": "^0.36.2"
       }
     },
     "apps/api/node_modules/@cosmjs/crypto": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.36.1.tgz",
-      "integrity": "sha512-7vx9rZAuboyMxs9zv3hZhNA0JAFMpaW+fFgRDQzZzfIVj0z4h8RW4dJu0xx5cv3KBQXmoRUzWklpnFuMQYiGdg==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.36.2.tgz",
+      "integrity": "sha512-QL4NHtcqR6DEKIN200aLeR8gKO433K0f5avKV0TVFP/g12UtnEGSk79PJq5Gv1PLc9GtATHgLLQI/3D8TEe+ig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
+        "@cosmjs/encoding": "^0.36.2",
+        "@cosmjs/math": "^0.36.2",
+        "@cosmjs/utils": "^0.36.2",
         "@noble/ciphers": "^1.3.0",
         "@noble/curves": "^1.9.2",
-        "@noble/hashes": "^1",
+        "@noble/hashes": "^1.8.0",
         "hash-wasm": "^4.12.0"
       }
     },
     "apps/api/node_modules/@cosmjs/encoding": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.36.1.tgz",
-      "integrity": "sha512-i5dTiOdSAfyU76lmOm0+VLEIDEtmINtpOeAuzzBJP1er5fDJvpBysgY9MefVwXNBY/P46W10Uta9zQc98ehBXg==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.36.2.tgz",
+      "integrity": "sha512-i3+P1EKYoLcONAsmpJPhDAc3Wh3ajZNRHt/hczi/JEQXmleTJLVzv2mXUyllM6Qa+B6ybbr3Z2lnEFa8L3yLqg==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -215,93 +216,63 @@
       }
     },
     "apps/api/node_modules/@cosmjs/json-rpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.36.1.tgz",
-      "integrity": "sha512-7vpTw3r3vVaiMY9L0hDh2QP5RnmSim00DhQuqtrPz/qd740Q2xtxhO7UxnWOzL85gG1Tyr9KshE46QIhZcTU/Q==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.36.2.tgz",
+      "integrity": "sha512-3IRamylHVCxBevXGlnIoWUdJCLsP5LwHbXYUsBnC9T8UttZ5oYRN5gDf6+2dQEPk+p9xOv2i8xrCwNWxo7675Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cosmjs/stream": "^0.36.1",
+        "@cosmjs/stream": "^0.36.2",
         "xstream": "^11.14.0"
       }
     },
     "apps/api/node_modules/@cosmjs/math": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.36.1.tgz",
-      "integrity": "sha512-ML5X5iupmTUV6bik+YEShrmK49ikB8jMQfgzdQV7qeBMN2Rc4ijd1/sFya5AiyJzxtBlYe7yv0i5NyNzZPqKpQ==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.36.2.tgz",
+      "integrity": "sha512-uJZRzxqnBk3MgxFgeyUwLgUzWkAIcmznWSB/tgGCjGCnUNebzI+44dA3ncEDCMqQysi/MZ+cSwAcDU7IY2PFeA==",
       "license": "Apache-2.0"
     },
-    "apps/api/node_modules/@cosmjs/proto-signing": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.36.1.tgz",
-      "integrity": "sha512-aWGJW4gwVEf/HaVe7Bf8K3Vc7J8vOMvChDhUr2FT8NG7REJ2CztJ0jcYgaJLRzoEj6rLJoN97eAf2hUjFQxWTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.1",
-        "@cosmjs/crypto": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
     "apps/api/node_modules/@cosmjs/socket": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.36.1.tgz",
-      "integrity": "sha512-p6KgnQmlz1MYJjWi66xyLLYk0NqXFQ/OE5LlC6+Pj6tv7sxjhqsQiQYwfgKJjSwTbduXv2vOHrqEnKZ892E5Xw==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.36.2.tgz",
+      "integrity": "sha512-Pb7JcTFWnq6yfY0IEejHrpSxNDJYcqjjAa1D29a6b/obk4qa4o3oIV5bIx6zAbdRq8uLoBfvWs0bHTNnVuBWJg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cosmjs/stream": "^0.36.1",
+        "@cosmjs/stream": "^0.36.2",
         "isomorphic-ws": "^4.0.1",
         "ws": "^7",
         "xstream": "^11.14.0"
       }
     },
-    "apps/api/node_modules/@cosmjs/stargate": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.36.1.tgz",
-      "integrity": "sha512-MCvZCginWI/2crnf7xYNsVNPzXLRgjuXUYF7t00JSOeif3MBM3YUHKQjjMsFNVys4eEDkfbptfn9bDghFy1nag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/proto-signing": "^0.36.1",
-        "@cosmjs/stream": "^0.36.1",
-        "@cosmjs/tendermint-rpc": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
     "apps/api/node_modules/@cosmjs/stream": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.36.1.tgz",
-      "integrity": "sha512-q8TrUt7iiWGf6N5x7vWGqWIhtgPzTMkZlM73vkE4F3rcWbybJHgNu7inOhwnuJpR+gFZd9JNq+jAtjsbptZGag==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.36.2.tgz",
+      "integrity": "sha512-FlZx2Buovem837LdTLPkPFcxzuQ7zierAqSXwMPr/MG3k+qMxHNfLFTTCXMNWQ4ZlbYedud8ZqCL3/HKdS5mig==",
       "license": "Apache-2.0",
       "dependencies": {
         "xstream": "^11.14.0"
       }
     },
     "apps/api/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.36.1.tgz",
-      "integrity": "sha512-9EN84YVqdgDLB97xFq+aqsolbMCyKwg6NcB/CR1s3DrquzJEx9/ZNEBJak/VVfb+croDFgvQd4X7CzqkW4N2ag==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.36.2.tgz",
+      "integrity": "sha512-76Z99C1NVf/Yv/1bWU0wul8MhRwVdqiZxqU5bcHqvJLoQ2nKUfGpSSYRdbMHfZ63J8ryRqQ95uPvPTfrBb+agw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cosmjs/crypto": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/json-rpc": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/socket": "^0.36.1",
-        "@cosmjs/stream": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
+        "@cosmjs/crypto": "^0.36.2",
+        "@cosmjs/encoding": "^0.36.2",
+        "@cosmjs/json-rpc": "^0.36.2",
+        "@cosmjs/math": "^0.36.2",
+        "@cosmjs/socket": "^0.36.2",
+        "@cosmjs/stream": "^0.36.2",
+        "@cosmjs/utils": "^0.36.2",
         "readonly-date": "^1.0.0",
         "xstream": "^11.14.0"
       }
     },
     "apps/api/node_modules/@cosmjs/utils": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.36.1.tgz",
-      "integrity": "sha512-kjdDD6t7dMLRUtbRCRskP7sNpyNf6cxVgaM2z7n64e6upXwE+bsoKfKrG+iY2ABT57oH6UxJYgcB+7ACmPxZCg==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.36.2.tgz",
+      "integrity": "sha512-OOr2HU/Ph+/GI1Fx2UCf3LOyX9YTCP51d2HitTOjjEJRYnkfKXP3lMBl1FZo5QaFWxnfuBc+Cj+cSoiQUJRyzQ==",
       "license": "Apache-2.0"
     },
     "apps/api/node_modules/@noble/ciphers": {
@@ -410,7 +381,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
       "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -1033,12 +1003,6 @@
         "node": ">=10"
       }
     },
-    "apps/api/node_modules/cosmjs-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.10.1.tgz",
-      "integrity": "sha512-CENXb4O5GN+VyB68HYXFT2SOhv126Z59631rZC56m8uMWa6/cSlFeai8BwZGT1NMepw0Ecf+U8XSOnBzZUWh9Q==",
-      "license": "Apache-2.0"
-    },
     "apps/api/node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -1347,89 +1311,11 @@
         "readonly-date": "^1.0.0"
       }
     },
-    "apps/deploy-web/node_modules/@cosmjs/json-rpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.36.1.tgz",
-      "integrity": "sha512-7vpTw3r3vVaiMY9L0hDh2QP5RnmSim00DhQuqtrPz/qd740Q2xtxhO7UxnWOzL85gG1Tyr9KshE46QIhZcTU/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.36.1",
-        "xstream": "^11.14.0"
-      }
-    },
     "apps/deploy-web/node_modules/@cosmjs/math": {
       "version": "0.36.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.36.1.tgz",
       "integrity": "sha512-ML5X5iupmTUV6bik+YEShrmK49ikB8jMQfgzdQV7qeBMN2Rc4ijd1/sFya5AiyJzxtBlYe7yv0i5NyNzZPqKpQ==",
       "license": "Apache-2.0"
-    },
-    "apps/deploy-web/node_modules/@cosmjs/proto-signing": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.36.1.tgz",
-      "integrity": "sha512-aWGJW4gwVEf/HaVe7Bf8K3Vc7J8vOMvChDhUr2FT8NG7REJ2CztJ0jcYgaJLRzoEj6rLJoN97eAf2hUjFQxWTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.1",
-        "@cosmjs/crypto": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "apps/deploy-web/node_modules/@cosmjs/socket": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.36.1.tgz",
-      "integrity": "sha512-p6KgnQmlz1MYJjWi66xyLLYk0NqXFQ/OE5LlC6+Pj6tv7sxjhqsQiQYwfgKJjSwTbduXv2vOHrqEnKZ892E5Xw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.36.1",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "apps/deploy-web/node_modules/@cosmjs/stargate": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.36.1.tgz",
-      "integrity": "sha512-MCvZCginWI/2crnf7xYNsVNPzXLRgjuXUYF7t00JSOeif3MBM3YUHKQjjMsFNVys4eEDkfbptfn9bDghFy1nag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/proto-signing": "^0.36.1",
-        "@cosmjs/stream": "^0.36.1",
-        "@cosmjs/tendermint-rpc": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "apps/deploy-web/node_modules/@cosmjs/stream": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.36.1.tgz",
-      "integrity": "sha512-q8TrUt7iiWGf6N5x7vWGqWIhtgPzTMkZlM73vkE4F3rcWbybJHgNu7inOhwnuJpR+gFZd9JNq+jAtjsbptZGag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "apps/deploy-web/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.36.1.tgz",
-      "integrity": "sha512-9EN84YVqdgDLB97xFq+aqsolbMCyKwg6NcB/CR1s3DrquzJEx9/ZNEBJak/VVfb+croDFgvQd4X7CzqkW4N2ag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/json-rpc": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/socket": "^0.36.1",
-        "@cosmjs/stream": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
     },
     "apps/deploy-web/node_modules/@cosmjs/utils": {
       "version": "0.36.1",
@@ -2792,7 +2678,6 @@
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-8.3.0.tgz",
       "integrity": "sha512-hmC3u0anySPI+As+wFGrKG38pXnXAUqyiitnYeYknEOslcDM96AkBdMNxKYOopecuP/v1HMbclUEq8/DKKn+6w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.16"
       }
@@ -2998,12 +2883,6 @@
       "peerDependencies": {
         "webpack": "^5.1.0"
       }
-    },
-    "apps/deploy-web/node_modules/cosmjs-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.10.1.tgz",
-      "integrity": "sha512-CENXb4O5GN+VyB68HYXFT2SOhv126Z59631rZC56m8uMWa6/cSlFeai8BwZGT1NMepw0Ecf+U8XSOnBzZUWh9Q==",
-      "license": "Apache-2.0"
     },
     "apps/deploy-web/node_modules/cssstyle": {
       "version": "4.6.0",
@@ -4364,27 +4243,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "apps/deploy-web/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "apps/deploy-web/node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -4548,89 +4406,11 @@
         "readonly-date": "^1.0.0"
       }
     },
-    "apps/indexer/node_modules/@cosmjs/json-rpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.36.1.tgz",
-      "integrity": "sha512-7vpTw3r3vVaiMY9L0hDh2QP5RnmSim00DhQuqtrPz/qd740Q2xtxhO7UxnWOzL85gG1Tyr9KshE46QIhZcTU/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.36.1",
-        "xstream": "^11.14.0"
-      }
-    },
     "apps/indexer/node_modules/@cosmjs/math": {
       "version": "0.36.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.36.1.tgz",
       "integrity": "sha512-ML5X5iupmTUV6bik+YEShrmK49ikB8jMQfgzdQV7qeBMN2Rc4ijd1/sFya5AiyJzxtBlYe7yv0i5NyNzZPqKpQ==",
       "license": "Apache-2.0"
-    },
-    "apps/indexer/node_modules/@cosmjs/proto-signing": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.36.1.tgz",
-      "integrity": "sha512-aWGJW4gwVEf/HaVe7Bf8K3Vc7J8vOMvChDhUr2FT8NG7REJ2CztJ0jcYgaJLRzoEj6rLJoN97eAf2hUjFQxWTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.1",
-        "@cosmjs/crypto": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "apps/indexer/node_modules/@cosmjs/socket": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.36.1.tgz",
-      "integrity": "sha512-p6KgnQmlz1MYJjWi66xyLLYk0NqXFQ/OE5LlC6+Pj6tv7sxjhqsQiQYwfgKJjSwTbduXv2vOHrqEnKZ892E5Xw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.36.1",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "apps/indexer/node_modules/@cosmjs/stargate": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.36.1.tgz",
-      "integrity": "sha512-MCvZCginWI/2crnf7xYNsVNPzXLRgjuXUYF7t00JSOeif3MBM3YUHKQjjMsFNVys4eEDkfbptfn9bDghFy1nag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/proto-signing": "^0.36.1",
-        "@cosmjs/stream": "^0.36.1",
-        "@cosmjs/tendermint-rpc": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "apps/indexer/node_modules/@cosmjs/stream": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.36.1.tgz",
-      "integrity": "sha512-q8TrUt7iiWGf6N5x7vWGqWIhtgPzTMkZlM73vkE4F3rcWbybJHgNu7inOhwnuJpR+gFZd9JNq+jAtjsbptZGag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "apps/indexer/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.36.1.tgz",
-      "integrity": "sha512-9EN84YVqdgDLB97xFq+aqsolbMCyKwg6NcB/CR1s3DrquzJEx9/ZNEBJak/VVfb+croDFgvQd4X7CzqkW4N2ag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/json-rpc": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/socket": "^0.36.1",
-        "@cosmjs/stream": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
     },
     "apps/indexer/node_modules/@cosmjs/utils": {
       "version": "0.36.1",
@@ -5513,7 +5293,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.4.0.tgz",
       "integrity": "sha512-KtcyFHssTn5ZgDu6SXmUznS80OFs/wN7y6MyFRRcKU6TOw8hNcGxKvt8hsdaLJfhzUszNSjURetq5Qpkad14Gw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -6093,12 +5872,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "apps/indexer/node_modules/cosmjs-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.10.1.tgz",
-      "integrity": "sha512-CENXb4O5GN+VyB68HYXFT2SOhv126Z59631rZC56m8uMWa6/cSlFeai8BwZGT1NMepw0Ecf+U8XSOnBzZUWh9Q==",
-      "license": "Apache-2.0"
     },
     "apps/indexer/node_modules/debug": {
       "version": "3.2.7",
@@ -7047,27 +6820,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "apps/indexer/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "apps/log-collector": {
       "name": "@akashnetwork/log-collector",
       "version": "2.12.1",
@@ -7861,26 +7613,6 @@
       "integrity": "sha512-uJZRzxqnBk3MgxFgeyUwLgUzWkAIcmznWSB/tgGCjGCnUNebzI+44dA3ncEDCMqQysi/MZ+cSwAcDU7IY2PFeA==",
       "license": "Apache-2.0"
     },
-    "apps/notifications/node_modules/@cosmjs/proto-signing": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.36.1.tgz",
-      "integrity": "sha512-aWGJW4gwVEf/HaVe7Bf8K3Vc7J8vOMvChDhUr2FT8NG7REJ2CztJ0jcYgaJLRzoEj6rLJoN97eAf2hUjFQxWTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.1",
-        "@cosmjs/crypto": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "apps/notifications/node_modules/@cosmjs/proto-signing/node_modules/cosmjs-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.10.1.tgz",
-      "integrity": "sha512-CENXb4O5GN+VyB68HYXFT2SOhv126Z59631rZC56m8uMWa6/cSlFeai8BwZGT1NMepw0Ecf+U8XSOnBzZUWh9Q==",
-      "license": "Apache-2.0"
-    },
     "apps/notifications/node_modules/@cosmjs/socket": {
       "version": "0.36.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.36.1.tgz",
@@ -7892,28 +7624,6 @@
         "ws": "^7",
         "xstream": "^11.14.0"
       }
-    },
-    "apps/notifications/node_modules/@cosmjs/stargate": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.36.1.tgz",
-      "integrity": "sha512-MCvZCginWI/2crnf7xYNsVNPzXLRgjuXUYF7t00JSOeif3MBM3YUHKQjjMsFNVys4eEDkfbptfn9bDghFy1nag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/proto-signing": "^0.36.1",
-        "@cosmjs/stream": "^0.36.1",
-        "@cosmjs/tendermint-rpc": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "apps/notifications/node_modules/@cosmjs/stargate/node_modules/cosmjs-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.10.1.tgz",
-      "integrity": "sha512-CENXb4O5GN+VyB68HYXFT2SOhv126Z59631rZC56m8uMWa6/cSlFeai8BwZGT1NMepw0Ecf+U8XSOnBzZUWh9Q==",
-      "license": "Apache-2.0"
     },
     "apps/notifications/node_modules/@cosmjs/stream": {
       "version": "0.36.1",
@@ -8069,7 +7779,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.4.0.tgz",
       "integrity": "sha512-KtcyFHssTn5ZgDu6SXmUznS80OFs/wN7y6MyFRRcKU6TOw8hNcGxKvt8hsdaLJfhzUszNSjURetq5Qpkad14Gw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -9140,6 +8849,225 @@
         "whatwg-fetch": "^3.6.20"
       }
     },
+    "apps/provider-console/node_modules/@cosmjs/json-rpc": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.28.13.tgz",
+      "integrity": "sha512-fInSvg7x9P6p+GWqet+TMhrMTM3OWWdLJOGS5w2ryubMjgpR1rLiAx77MdTNkArW+/6sUwku0sN4veM4ENQu6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/stream": "0.28.13",
+        "xstream": "^11.14.0"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/proto-signing": {
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
+      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/amino": "^0.32.4",
+        "@cosmjs/crypto": "^0.32.4",
+        "@cosmjs/encoding": "^0.32.4",
+        "@cosmjs/math": "^0.32.4",
+        "@cosmjs/utils": "^0.32.4",
+        "cosmjs-types": "^0.9.0"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/socket": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.28.13.tgz",
+      "integrity": "sha512-lavwGxQ5VdeltyhpFtwCRVfxeWjH5D5mmN7jgx9nuCf3XSFbTcOYxrk2pQ4usenu1Q1KZdL4Yl5RCNrJuHD9Ug==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/stream": "0.28.13",
+        "isomorphic-ws": "^4.0.1",
+        "ws": "^7",
+        "xstream": "^11.14.0"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/stargate": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.28.13.tgz",
+      "integrity": "sha512-dVBMazDz8/eActHsRcZjDHHptOBMqvibj5CFgEtZBp22gP6ASzoAUXTlkSVk5FBf4sfuUHoff6st134/+PGMAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@confio/ics23": "^0.6.8",
+        "@cosmjs/amino": "0.28.13",
+        "@cosmjs/encoding": "0.28.13",
+        "@cosmjs/math": "0.28.13",
+        "@cosmjs/proto-signing": "0.28.13",
+        "@cosmjs/stream": "0.28.13",
+        "@cosmjs/tendermint-rpc": "0.28.13",
+        "@cosmjs/utils": "0.28.13",
+        "cosmjs-types": "^0.4.0",
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.3",
+        "xstream": "^11.14.0"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/stargate/node_modules/@cosmjs/amino": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.28.13.tgz",
+      "integrity": "sha512-IHnH2zGwaY69qT4mVAavr/pfzx6YE+ud1NHJbvVePlbGiz68CXTi5LHR+K0lrKB5mQ7E+ZErWz2mw5U/x+V1wQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/crypto": "0.28.13",
+        "@cosmjs/encoding": "0.28.13",
+        "@cosmjs/math": "0.28.13",
+        "@cosmjs/utils": "0.28.13"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/stargate/node_modules/@cosmjs/crypto": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
+      "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
+      "deprecated": "This uses elliptic for cryptographic operations, which contains several security-relevant bugs. To what degree this affects your application is something you need to carefully investigate. See https://github.com/cosmos/cosmjs/issues/1708 for further pointers. Starting with version 0.34.0 the cryptographic library has been replaced. However, private keys might still be at risk.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/encoding": "0.28.13",
+        "@cosmjs/math": "0.28.13",
+        "@cosmjs/utils": "0.28.13",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.3",
+        "libsodium-wrappers": "^0.7.6"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/stargate/node_modules/@cosmjs/encoding": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.28.13.tgz",
+      "integrity": "sha512-jtXbAYtV77rLHxoIrjGFsvgGjeTKttuHRv6cvuy3toCZzY7JzTclKH5O2g36IIE4lXwD9xwuhGJ2aa6A3dhNkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/stargate/node_modules/@cosmjs/math": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
+      "integrity": "sha512-PDpL8W/kbyeWi0mQ2OruyqE8ZUAdxPs1xCbDX3WXJwy2oU+X2UTbkuweJHVpS9CIqmZulBoWQAmlf6t6zr1N/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/stargate/node_modules/@cosmjs/proto-signing": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.28.13.tgz",
+      "integrity": "sha512-nSl/2ZLsUJYz3Ad0RY3ihZUgRHIow2OnYqKsESMu+3RA/jTi9bDYhiBu8mNMHI0xrEJry918B2CyI56pOUHdPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/amino": "0.28.13",
+        "@cosmjs/crypto": "0.28.13",
+        "@cosmjs/encoding": "0.28.13",
+        "@cosmjs/math": "0.28.13",
+        "@cosmjs/utils": "0.28.13",
+        "cosmjs-types": "^0.4.0",
+        "long": "^4.0.0"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/stargate/node_modules/@cosmjs/utils": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.28.13.tgz",
+      "integrity": "sha512-dVeMBiyg+46x7XBZEfJK8yTihphbCFpjVYmLJVqmTsHfJwymQ65cpyW/C+V/LgWARGK8hWQ/aX9HM5Ao8QmMSg==",
+      "license": "Apache-2.0"
+    },
+    "apps/provider-console/node_modules/@cosmjs/stargate/node_modules/cosmjs-types": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.4.1.tgz",
+      "integrity": "sha512-I7E/cHkIgoJzMNQdFF0YVqPlaTqrqKHrskuSTIqlEyxfB5Lf3WKCajSXVK2yHOfOFfSux/RxEdpMzw/eO4DIog==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "long": "^4.0.0",
+        "protobufjs": "~6.11.2"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/stream": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.28.13.tgz",
+      "integrity": "sha512-AnjtfwT8NwPPkd3lhZhjOlOzT0Kn9bgEu2IPOZjQ1nmG2bplsr6TJmnwn0dJxHT7UGtex17h6whKB5N4wU37Wg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xstream": "^11.14.0"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/tendermint-rpc": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.28.13.tgz",
+      "integrity": "sha512-GB+ZmfuJIGQm0hsRtLYjeR3lOxF7Z6XyCBR0cX5AAYOZzSEBJjevPgUHD6tLn8zIhvzxaW3/VKnMB+WmlxdH4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/crypto": "0.28.13",
+        "@cosmjs/encoding": "0.28.13",
+        "@cosmjs/json-rpc": "0.28.13",
+        "@cosmjs/math": "0.28.13",
+        "@cosmjs/socket": "0.28.13",
+        "@cosmjs/stream": "0.28.13",
+        "@cosmjs/utils": "0.28.13",
+        "axios": "^0.21.2",
+        "readonly-date": "^1.0.0",
+        "xstream": "^11.14.0"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/tendermint-rpc/node_modules/@cosmjs/crypto": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
+      "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
+      "deprecated": "This uses elliptic for cryptographic operations, which contains several security-relevant bugs. To what degree this affects your application is something you need to carefully investigate. See https://github.com/cosmos/cosmjs/issues/1708 for further pointers. Starting with version 0.34.0 the cryptographic library has been replaced. However, private keys might still be at risk.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/encoding": "0.28.13",
+        "@cosmjs/math": "0.28.13",
+        "@cosmjs/utils": "0.28.13",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.3",
+        "libsodium-wrappers": "^0.7.6"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/tendermint-rpc/node_modules/@cosmjs/encoding": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.28.13.tgz",
+      "integrity": "sha512-jtXbAYtV77rLHxoIrjGFsvgGjeTKttuHRv6cvuy3toCZzY7JzTclKH5O2g36IIE4lXwD9xwuhGJ2aa6A3dhNkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/tendermint-rpc/node_modules/@cosmjs/math": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
+      "integrity": "sha512-PDpL8W/kbyeWi0mQ2OruyqE8ZUAdxPs1xCbDX3WXJwy2oU+X2UTbkuweJHVpS9CIqmZulBoWQAmlf6t6zr1N/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      }
+    },
+    "apps/provider-console/node_modules/@cosmjs/tendermint-rpc/node_modules/@cosmjs/utils": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.28.13.tgz",
+      "integrity": "sha512-dVeMBiyg+46x7XBZEfJK8yTihphbCFpjVYmLJVqmTsHfJwymQ65cpyW/C+V/LgWARGK8hWQ/aX9HM5Ao8QmMSg==",
+      "license": "Apache-2.0"
+    },
+    "apps/provider-console/node_modules/@cosmjs/tendermint-rpc/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "apps/provider-console/node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
     "apps/provider-console/node_modules/lucide-react": {
       "version": "0.395.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.395.0.tgz",
@@ -9161,6 +9089,27 @@
       },
       "engines": {
         "node": ">= 10.13"
+      }
+    },
+    "apps/provider-console/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "apps/provider-proxy": {
@@ -9240,7 +9189,6 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -9296,89 +9244,11 @@
         "readonly-date": "^1.0.0"
       }
     },
-    "apps/provider-proxy/node_modules/@cosmjs/json-rpc": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.36.2.tgz",
-      "integrity": "sha512-3IRamylHVCxBevXGlnIoWUdJCLsP5LwHbXYUsBnC9T8UttZ5oYRN5gDf6+2dQEPk+p9xOv2i8xrCwNWxo7675Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.36.2",
-        "xstream": "^11.14.0"
-      }
-    },
     "apps/provider-proxy/node_modules/@cosmjs/math": {
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.36.2.tgz",
       "integrity": "sha512-uJZRzxqnBk3MgxFgeyUwLgUzWkAIcmznWSB/tgGCjGCnUNebzI+44dA3ncEDCMqQysi/MZ+cSwAcDU7IY2PFeA==",
       "license": "Apache-2.0"
-    },
-    "apps/provider-proxy/node_modules/@cosmjs/proto-signing": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.36.2.tgz",
-      "integrity": "sha512-dyZsgZBQgGkaE4cazHVX8GDwrRJVKUVDnrODkyFXVNbxMnm4t6nxpK1qwgY9GHlWUhck3Dh9NT3BoMbXiMYTZQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.2",
-        "@cosmjs/crypto": "^0.36.2",
-        "@cosmjs/encoding": "^0.36.2",
-        "@cosmjs/math": "^0.36.2",
-        "@cosmjs/utils": "^0.36.2",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "apps/provider-proxy/node_modules/@cosmjs/socket": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.36.2.tgz",
-      "integrity": "sha512-Pb7JcTFWnq6yfY0IEejHrpSxNDJYcqjjAa1D29a6b/obk4qa4o3oIV5bIx6zAbdRq8uLoBfvWs0bHTNnVuBWJg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.36.2",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "apps/provider-proxy/node_modules/@cosmjs/stargate": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.36.2.tgz",
-      "integrity": "sha512-vnNK4dXF+s2v1aKPfYxKVrvXPcnBQb8rPoBScnTpPWnRt3XXbLw7Oo6fTQQWwKYNKQzi6DOApeEB+bCYcaPAAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.2",
-        "@cosmjs/encoding": "^0.36.2",
-        "@cosmjs/math": "^0.36.2",
-        "@cosmjs/proto-signing": "^0.36.2",
-        "@cosmjs/stream": "^0.36.2",
-        "@cosmjs/tendermint-rpc": "^0.36.2",
-        "@cosmjs/utils": "^0.36.2",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "apps/provider-proxy/node_modules/@cosmjs/stream": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.36.2.tgz",
-      "integrity": "sha512-FlZx2Buovem837LdTLPkPFcxzuQ7zierAqSXwMPr/MG3k+qMxHNfLFTTCXMNWQ4ZlbYedud8ZqCL3/HKdS5mig==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "apps/provider-proxy/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.36.2.tgz",
-      "integrity": "sha512-76Z99C1NVf/Yv/1bWU0wul8MhRwVdqiZxqU5bcHqvJLoQ2nKUfGpSSYRdbMHfZ63J8ryRqQ95uPvPTfrBb+agw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.36.2",
-        "@cosmjs/encoding": "^0.36.2",
-        "@cosmjs/json-rpc": "^0.36.2",
-        "@cosmjs/math": "^0.36.2",
-        "@cosmjs/socket": "^0.36.2",
-        "@cosmjs/stream": "^0.36.2",
-        "@cosmjs/utils": "^0.36.2",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
     },
     "apps/provider-proxy/node_modules/@cosmjs/utils": {
       "version": "0.36.2",
@@ -9895,7 +9765,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
       "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -10315,12 +10184,6 @@
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true
     },
-    "apps/provider-proxy/node_modules/cosmjs-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.10.1.tgz",
-      "integrity": "sha512-CENXb4O5GN+VyB68HYXFT2SOhv126Z59631rZC56m8uMWa6/cSlFeai8BwZGT1NMepw0Ecf+U8XSOnBzZUWh9Q==",
-      "license": "Apache-2.0"
-    },
     "apps/provider-proxy/node_modules/esbuild": {
       "version": "0.24.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
@@ -10519,89 +10382,11 @@
         "readonly-date": "^1.0.0"
       }
     },
-    "apps/stats-web/node_modules/@cosmjs/json-rpc": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.36.2.tgz",
-      "integrity": "sha512-3IRamylHVCxBevXGlnIoWUdJCLsP5LwHbXYUsBnC9T8UttZ5oYRN5gDf6+2dQEPk+p9xOv2i8xrCwNWxo7675Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.36.2",
-        "xstream": "^11.14.0"
-      }
-    },
     "apps/stats-web/node_modules/@cosmjs/math": {
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.36.2.tgz",
       "integrity": "sha512-uJZRzxqnBk3MgxFgeyUwLgUzWkAIcmznWSB/tgGCjGCnUNebzI+44dA3ncEDCMqQysi/MZ+cSwAcDU7IY2PFeA==",
       "license": "Apache-2.0"
-    },
-    "apps/stats-web/node_modules/@cosmjs/proto-signing": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.36.2.tgz",
-      "integrity": "sha512-dyZsgZBQgGkaE4cazHVX8GDwrRJVKUVDnrODkyFXVNbxMnm4t6nxpK1qwgY9GHlWUhck3Dh9NT3BoMbXiMYTZQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.2",
-        "@cosmjs/crypto": "^0.36.2",
-        "@cosmjs/encoding": "^0.36.2",
-        "@cosmjs/math": "^0.36.2",
-        "@cosmjs/utils": "^0.36.2",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "apps/stats-web/node_modules/@cosmjs/socket": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.36.2.tgz",
-      "integrity": "sha512-Pb7JcTFWnq6yfY0IEejHrpSxNDJYcqjjAa1D29a6b/obk4qa4o3oIV5bIx6zAbdRq8uLoBfvWs0bHTNnVuBWJg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.36.2",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "apps/stats-web/node_modules/@cosmjs/stargate": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.36.2.tgz",
-      "integrity": "sha512-vnNK4dXF+s2v1aKPfYxKVrvXPcnBQb8rPoBScnTpPWnRt3XXbLw7Oo6fTQQWwKYNKQzi6DOApeEB+bCYcaPAAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.2",
-        "@cosmjs/encoding": "^0.36.2",
-        "@cosmjs/math": "^0.36.2",
-        "@cosmjs/proto-signing": "^0.36.2",
-        "@cosmjs/stream": "^0.36.2",
-        "@cosmjs/tendermint-rpc": "^0.36.2",
-        "@cosmjs/utils": "^0.36.2",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "apps/stats-web/node_modules/@cosmjs/stream": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.36.2.tgz",
-      "integrity": "sha512-FlZx2Buovem837LdTLPkPFcxzuQ7zierAqSXwMPr/MG3k+qMxHNfLFTTCXMNWQ4ZlbYedud8ZqCL3/HKdS5mig==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "apps/stats-web/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.36.2.tgz",
-      "integrity": "sha512-76Z99C1NVf/Yv/1bWU0wul8MhRwVdqiZxqU5bcHqvJLoQ2nKUfGpSSYRdbMHfZ63J8ryRqQ95uPvPTfrBb+agw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.36.2",
-        "@cosmjs/encoding": "^0.36.2",
-        "@cosmjs/json-rpc": "^0.36.2",
-        "@cosmjs/math": "^0.36.2",
-        "@cosmjs/socket": "^0.36.2",
-        "@cosmjs/stream": "^0.36.2",
-        "@cosmjs/utils": "^0.36.2",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
     },
     "apps/stats-web/node_modules/@cosmjs/utils": {
       "version": "0.36.2",
@@ -11676,12 +11461,6 @@
         "node": ">=8"
       }
     },
-    "apps/stats-web/node_modules/cosmjs-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.10.1.tgz",
-      "integrity": "sha512-CENXb4O5GN+VyB68HYXFT2SOhv126Z59631rZC56m8uMWa6/cSlFeai8BwZGT1NMepw0Ecf+U8XSOnBzZUWh9Q==",
-      "license": "Apache-2.0"
-    },
     "apps/stats-web/node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -11823,27 +11602,6 @@
         "node": ">=8"
       }
     },
-    "apps/stats-web/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@adobe/css-tools": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.1.tgz",
@@ -11902,24 +11660,18 @@
         "node": ">18.0.0"
       }
     },
-    "node_modules/@akashnetwork/akashjs/node_modules/@cosmjs/encoding": {
+    "node_modules/@akashnetwork/akashjs/node_modules/@cosmjs/proto-signing": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
-      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
+      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@akashnetwork/akashjs/node_modules/@cosmjs/math": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
-      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0"
+        "@cosmjs/amino": "^0.32.4",
+        "@cosmjs/crypto": "^0.32.4",
+        "@cosmjs/encoding": "^0.32.4",
+        "@cosmjs/math": "^0.32.4",
+        "@cosmjs/utils": "^0.32.4",
+        "cosmjs-types": "^0.9.0"
       }
     },
     "node_modules/@akashnetwork/akashjs/node_modules/@cosmjs/stargate": {
@@ -11941,9 +11693,9 @@
       }
     },
     "node_modules/@akashnetwork/akashjs/node_modules/dotenv": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.0.tgz",
-      "integrity": "sha512-Omf1L8paOy2VJhILjyhrhqwLIdstqm1BvcDPKg4NGAlkwEu9ODyrFbvk8UymUOMCT+HXo31jg1lArIrVAAhuGA==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -12013,89 +11765,11 @@
         "readonly-date": "^1.0.0"
       }
     },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/json-rpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.36.1.tgz",
-      "integrity": "sha512-7vpTw3r3vVaiMY9L0hDh2QP5RnmSim00DhQuqtrPz/qd740Q2xtxhO7UxnWOzL85gG1Tyr9KshE46QIhZcTU/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.36.1",
-        "xstream": "^11.14.0"
-      }
-    },
     "node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/math": {
       "version": "0.36.1",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.36.1.tgz",
       "integrity": "sha512-ML5X5iupmTUV6bik+YEShrmK49ikB8jMQfgzdQV7qeBMN2Rc4ijd1/sFya5AiyJzxtBlYe7yv0i5NyNzZPqKpQ==",
       "license": "Apache-2.0"
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/proto-signing": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.36.1.tgz",
-      "integrity": "sha512-aWGJW4gwVEf/HaVe7Bf8K3Vc7J8vOMvChDhUr2FT8NG7REJ2CztJ0jcYgaJLRzoEj6rLJoN97eAf2hUjFQxWTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.1",
-        "@cosmjs/crypto": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/socket": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.36.1.tgz",
-      "integrity": "sha512-p6KgnQmlz1MYJjWi66xyLLYk0NqXFQ/OE5LlC6+Pj6tv7sxjhqsQiQYwfgKJjSwTbduXv2vOHrqEnKZ892E5Xw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.36.1",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/stargate": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.36.1.tgz",
-      "integrity": "sha512-MCvZCginWI/2crnf7xYNsVNPzXLRgjuXUYF7t00JSOeif3MBM3YUHKQjjMsFNVys4eEDkfbptfn9bDghFy1nag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/proto-signing": "^0.36.1",
-        "@cosmjs/stream": "^0.36.1",
-        "@cosmjs/tendermint-rpc": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/stream": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.36.1.tgz",
-      "integrity": "sha512-q8TrUt7iiWGf6N5x7vWGqWIhtgPzTMkZlM73vkE4F3rcWbybJHgNu7inOhwnuJpR+gFZd9JNq+jAtjsbptZGag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.36.1.tgz",
-      "integrity": "sha512-9EN84YVqdgDLB97xFq+aqsolbMCyKwg6NcB/CR1s3DrquzJEx9/ZNEBJak/VVfb+croDFgvQd4X7CzqkW4N2ag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/json-rpc": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/socket": "^0.36.1",
-        "@cosmjs/stream": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
     },
     "node_modules/@akashnetwork/chain-sdk/node_modules/@cosmjs/utils": {
       "version": "0.36.1",
@@ -12128,33 +11802,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/cosmjs-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.10.1.tgz",
-      "integrity": "sha512-CENXb4O5GN+VyB68HYXFT2SOhv126Z59631rZC56m8uMWa6/cSlFeai8BwZGT1NMepw0Ecf+U8XSOnBzZUWh9Q==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@akashnetwork/chain-sdk/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@akashnetwork/console-api": {
@@ -12693,7 +12340,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -14178,7 +13824,6 @@
     "node_modules/@babel/preset-env": {
       "version": "7.24.7",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.24.7",
         "@babel/helper-compilation-targets": "^7.24.7",
@@ -14481,15 +14126,13 @@
       "resolved": "https://registry.npmjs.org/@biomejs/wasm-nodejs/-/wasm-nodejs-1.9.4.tgz",
       "integrity": "sha512-ZqNlhKcZW6MW1LxWIOfh9YVrBykvzyFad3bOh6JJFraDnNa3NXboRDiaI8dmrbb0ZHXCU1Tsq6WQsKV2Vpp5dw==",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.9.0.tgz",
       "integrity": "sha512-rnJenoStJ8nvmt9Gzye8nkYd6V22xUAnu4086ER7h1zJ508vStko4pMvDeQ446ilDTFpV5wnoc5YS7XvMwwMqA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@casl/ability": {
       "version": "6.7.2",
@@ -14767,7 +14410,6 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -15028,7 +14670,6 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.0.tgz",
       "integrity": "sha512-xhiwnYlJNHzmFsRw+iSPIwXR/xweTvTw8x5HiwWp10sbVtd4OpOXbRgE7V58xs1EC17fzusF1f5uOAy24OkBuA==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -15051,41 +14692,11 @@
       "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
       "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
         "@cosmjs/math": "^0.32.4",
         "@cosmjs/utils": "^0.32.4"
-      }
-    },
-    "node_modules/@cosmjs/amino/node_modules/@cosmjs/crypto": {
-      "version": "0.32.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers-sumo": "^0.7.11"
-      }
-    },
-    "node_modules/@cosmjs/amino/node_modules/@cosmjs/encoding": {
-      "version": "0.32.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@cosmjs/amino/node_modules/@cosmjs/math": {
-      "version": "0.32.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0"
       }
     },
     "node_modules/@cosmjs/cosmwasm-stargate": {
@@ -15105,36 +14716,18 @@
         "pako": "^2.0.2"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/crypto": {
+    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/proto-signing": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
-      "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
+      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
+      "license": "Apache-2.0",
       "dependencies": {
+        "@cosmjs/amino": "^0.32.4",
+        "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
         "@cosmjs/math": "^0.32.4",
         "@cosmjs/utils": "^0.32.4",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers-sumo": "^0.7.11"
-      }
-    },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/encoding": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
-      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/math": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
-      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
+        "cosmjs-types": "^0.9.0"
       }
     },
     "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/stargate": {
@@ -15155,24 +14748,25 @@
       }
     },
     "node_modules/@cosmjs/crypto": {
-      "version": "0.28.13",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.32.4.tgz",
+      "integrity": "sha512-zicjGU051LF1V9v7bp8p7ovq+VyC91xlaHdsFOTo2oVry3KQikp8L/81RkXmUIT8FxMwdx1T7DmFwVQikcSDIw==",
+      "deprecated": "This uses elliptic for cryptographic operations, which contains several security-relevant bugs. To what degree this affects your application is something you need to carefully investigate. See https://github.com/cosmos/cosmjs/issues/1708 for further pointers. Starting with version 0.34.0 the cryptographic library has been replaced. However, private keys might still be at risk.",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cosmjs/encoding": "0.28.13",
-        "@cosmjs/math": "0.28.13",
-        "@cosmjs/utils": "0.28.13",
+        "@cosmjs/encoding": "^0.32.4",
+        "@cosmjs/math": "^0.32.4",
+        "@cosmjs/utils": "^0.32.4",
         "@noble/hashes": "^1",
         "bn.js": "^5.2.0",
-        "elliptic": "^6.5.3",
-        "libsodium-wrappers": "^0.7.6"
+        "elliptic": "^6.5.4",
+        "libsodium-wrappers-sumo": "^0.7.11"
       }
     },
-    "node_modules/@cosmjs/crypto/node_modules/@cosmjs/utils": {
-      "version": "0.28.13",
-      "license": "Apache-2.0"
-    },
     "node_modules/@cosmjs/encoding": {
-      "version": "0.28.13",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
+      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -15190,6 +14784,8 @@
     },
     "node_modules/@cosmjs/launchpad": {
       "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/launchpad/-/launchpad-0.27.1.tgz",
+      "integrity": "sha512-DcFwGD/z5PK8CzO2sojDxa+Be9EIEtRZb2YawgVnw2Ht/p5FlNv+OVo8qlishpBdalXEN7FvQ1dVeDFEe9TuJw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/amino": "0.27.1",
@@ -15203,6 +14799,8 @@
     },
     "node_modules/@cosmjs/launchpad/node_modules/@cosmjs/amino": {
       "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.27.1.tgz",
+      "integrity": "sha512-w56ar/nK9+qlvWDpBPRmD0Blk2wfkkLqRi1COs1x7Ll1LF0AtkIBUjbRKplENLbNovK0T3h+w8bHiFm+GBGQOA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/crypto": "0.27.1",
@@ -15213,6 +14811,9 @@
     },
     "node_modules/@cosmjs/launchpad/node_modules/@cosmjs/crypto": {
       "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.27.1.tgz",
+      "integrity": "sha512-vbcxwSt99tIYJg8Spp00wc3zx72qx+pY3ozGuBN8gAvySnagK9dQ/jHwtWQWdammmdD6oW+75WfIHZ+gNa+Ybg==",
+      "deprecated": "This uses elliptic for cryptographic operations, which contains several security-relevant bugs. To what degree this affects your application is something you need to carefully investigate. See https://github.com/cosmos/cosmjs/issues/1708 for further pointers. Starting with version 0.34.0 the cryptographic library has been replaced. However, private keys might still be at risk.",
       "license": "Apache-2.0",
       "dependencies": {
         "@cosmjs/encoding": "0.27.1",
@@ -15229,6 +14830,8 @@
     },
     "node_modules/@cosmjs/launchpad/node_modules/@cosmjs/encoding": {
       "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.27.1.tgz",
+      "integrity": "sha512-rayLsA0ojHeniaRfWWcqSsrE/T1rl1gl0OXVNtXlPwLJifKBeLEefGbOUiAQaT0wgJ8VNGBazVtAZBpJidfDhw==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -15238,6 +14841,8 @@
     },
     "node_modules/@cosmjs/launchpad/node_modules/@cosmjs/math": {
       "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.27.1.tgz",
+      "integrity": "sha512-cHWVjmfIjtRc7f80n7x+J5k8pe+vTVTQ0lA82tIxUgqUvgS6rogPP/TmGtTiZ4+NxWxd11DUISY6gVpr18/VNQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bn.js": "^5.2.0"
@@ -15245,52 +14850,73 @@
     },
     "node_modules/@cosmjs/launchpad/node_modules/@cosmjs/utils": {
       "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.27.1.tgz",
+      "integrity": "sha512-VG7QPDiMUzVPxRdJahDV8PXxVdnuAHiIuG56hldV4yPnOz/si/DLNd7VAUUA5923b6jS1Hhev0Hr6AhEkcxBMg==",
       "license": "Apache-2.0"
     },
     "node_modules/@cosmjs/launchpad/node_modules/axios": {
       "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/@cosmjs/math": {
-      "version": "0.28.13",
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
+      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "bn.js": "^5.2.0"
       }
     },
     "node_modules/@cosmjs/proto-signing": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
-      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.36.2.tgz",
+      "integrity": "sha512-dyZsgZBQgGkaE4cazHVX8GDwrRJVKUVDnrODkyFXVNbxMnm4t6nxpK1qwgY9GHlWUhck3Dh9NT3BoMbXiMYTZQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
-        "@cosmjs/amino": "^0.32.4",
-        "@cosmjs/crypto": "^0.32.4",
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "cosmjs-types": "^0.9.0"
+        "@cosmjs/amino": "^0.36.2",
+        "@cosmjs/crypto": "^0.36.2",
+        "@cosmjs/encoding": "^0.36.2",
+        "@cosmjs/math": "^0.36.2",
+        "@cosmjs/utils": "^0.36.2",
+        "cosmjs-types": "^0.10.1"
+      }
+    },
+    "node_modules/@cosmjs/proto-signing/node_modules/@cosmjs/amino": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.36.2.tgz",
+      "integrity": "sha512-r4yV1bhl412gwHGlyaUaJHIJnmldtyGsAwyz3oHHVxduiECj06Rv6wqeyLZfQa9W6hU+MlZwy7LabSUkkyGwjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/crypto": "^0.36.2",
+        "@cosmjs/encoding": "^0.36.2",
+        "@cosmjs/math": "^0.36.2",
+        "@cosmjs/utils": "^0.36.2"
       }
     },
     "node_modules/@cosmjs/proto-signing/node_modules/@cosmjs/crypto": {
-      "version": "0.32.4",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.36.2.tgz",
+      "integrity": "sha512-QL4NHtcqR6DEKIN200aLeR8gKO433K0f5avKV0TVFP/g12UtnEGSk79PJq5Gv1PLc9GtATHgLLQI/3D8TEe+ig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers-sumo": "^0.7.11"
+        "@cosmjs/encoding": "^0.36.2",
+        "@cosmjs/math": "^0.36.2",
+        "@cosmjs/utils": "^0.36.2",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.2",
+        "@noble/hashes": "^1.8.0",
+        "hash-wasm": "^4.12.0"
       }
     },
     "node_modules/@cosmjs/proto-signing/node_modules/@cosmjs/encoding": {
-      "version": "0.32.4",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.36.2.tgz",
+      "integrity": "sha512-i3+P1EKYoLcONAsmpJPhDAc3Wh3ajZNRHt/hczi/JEQXmleTJLVzv2mXUyllM6Qa+B6ybbr3Z2lnEFa8L3yLqg==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -15299,11 +14925,49 @@
       }
     },
     "node_modules/@cosmjs/proto-signing/node_modules/@cosmjs/math": {
-      "version": "0.32.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0"
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.36.2.tgz",
+      "integrity": "sha512-uJZRzxqnBk3MgxFgeyUwLgUzWkAIcmznWSB/tgGCjGCnUNebzI+44dA3ncEDCMqQysi/MZ+cSwAcDU7IY2PFeA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@cosmjs/proto-signing/node_modules/@cosmjs/utils": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.36.2.tgz",
+      "integrity": "sha512-OOr2HU/Ph+/GI1Fx2UCf3LOyX9YTCP51d2HitTOjjEJRYnkfKXP3lMBl1FZo5QaFWxnfuBc+Cj+cSoiQUJRyzQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@cosmjs/proto-signing/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@cosmjs/proto-signing/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@cosmjs/proto-signing/node_modules/cosmjs-types": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.10.1.tgz",
+      "integrity": "sha512-CENXb4O5GN+VyB68HYXFT2SOhv126Z59631rZC56m8uMWa6/cSlFeai8BwZGT1NMepw0Ecf+U8XSOnBzZUWh9Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/@cosmjs/socket": {
       "version": "0.32.4",
@@ -15336,114 +15000,157 @@
       }
     },
     "node_modules/@cosmjs/stargate": {
-      "version": "0.28.13",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.36.2.tgz",
+      "integrity": "sha512-vnNK4dXF+s2v1aKPfYxKVrvXPcnBQb8rPoBScnTpPWnRt3XXbLw7Oo6fTQQWwKYNKQzi6DOApeEB+bCYcaPAAw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@confio/ics23": "^0.6.8",
-        "@cosmjs/amino": "0.28.13",
-        "@cosmjs/encoding": "0.28.13",
-        "@cosmjs/math": "0.28.13",
-        "@cosmjs/proto-signing": "0.28.13",
-        "@cosmjs/stream": "0.28.13",
-        "@cosmjs/tendermint-rpc": "0.28.13",
-        "@cosmjs/utils": "0.28.13",
-        "cosmjs-types": "^0.4.0",
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.3",
-        "xstream": "^11.14.0"
+        "@cosmjs/amino": "^0.36.2",
+        "@cosmjs/encoding": "^0.36.2",
+        "@cosmjs/math": "^0.36.2",
+        "@cosmjs/proto-signing": "^0.36.2",
+        "@cosmjs/stream": "^0.36.2",
+        "@cosmjs/tendermint-rpc": "^0.36.2",
+        "@cosmjs/utils": "^0.36.2",
+        "cosmjs-types": "^0.10.1"
       }
     },
     "node_modules/@cosmjs/stargate/node_modules/@cosmjs/amino": {
-      "version": "0.28.13",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.36.2.tgz",
+      "integrity": "sha512-r4yV1bhl412gwHGlyaUaJHIJnmldtyGsAwyz3oHHVxduiECj06Rv6wqeyLZfQa9W6hU+MlZwy7LabSUkkyGwjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cosmjs/crypto": "0.28.13",
-        "@cosmjs/encoding": "0.28.13",
-        "@cosmjs/math": "0.28.13",
-        "@cosmjs/utils": "0.28.13"
+        "@cosmjs/crypto": "^0.36.2",
+        "@cosmjs/encoding": "^0.36.2",
+        "@cosmjs/math": "^0.36.2",
+        "@cosmjs/utils": "^0.36.2"
+      }
+    },
+    "node_modules/@cosmjs/stargate/node_modules/@cosmjs/crypto": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.36.2.tgz",
+      "integrity": "sha512-QL4NHtcqR6DEKIN200aLeR8gKO433K0f5avKV0TVFP/g12UtnEGSk79PJq5Gv1PLc9GtATHgLLQI/3D8TEe+ig==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.36.2",
+        "@cosmjs/math": "^0.36.2",
+        "@cosmjs/utils": "^0.36.2",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "^1.9.2",
+        "@noble/hashes": "^1.8.0",
+        "hash-wasm": "^4.12.0"
+      }
+    },
+    "node_modules/@cosmjs/stargate/node_modules/@cosmjs/encoding": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.36.2.tgz",
+      "integrity": "sha512-i3+P1EKYoLcONAsmpJPhDAc3Wh3ajZNRHt/hczi/JEQXmleTJLVzv2mXUyllM6Qa+B6ybbr3Z2lnEFa8L3yLqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
       }
     },
     "node_modules/@cosmjs/stargate/node_modules/@cosmjs/json-rpc": {
-      "version": "0.28.13",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.36.2.tgz",
+      "integrity": "sha512-3IRamylHVCxBevXGlnIoWUdJCLsP5LwHbXYUsBnC9T8UttZ5oYRN5gDf6+2dQEPk+p9xOv2i8xrCwNWxo7675Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cosmjs/stream": "0.28.13",
+        "@cosmjs/stream": "^0.36.2",
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/stargate/node_modules/@cosmjs/proto-signing": {
-      "version": "0.28.13",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/amino": "0.28.13",
-        "@cosmjs/crypto": "0.28.13",
-        "@cosmjs/encoding": "0.28.13",
-        "@cosmjs/math": "0.28.13",
-        "@cosmjs/utils": "0.28.13",
-        "cosmjs-types": "^0.4.0",
-        "long": "^4.0.0"
-      }
+    "node_modules/@cosmjs/stargate/node_modules/@cosmjs/math": {
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.36.2.tgz",
+      "integrity": "sha512-uJZRzxqnBk3MgxFgeyUwLgUzWkAIcmznWSB/tgGCjGCnUNebzI+44dA3ncEDCMqQysi/MZ+cSwAcDU7IY2PFeA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@cosmjs/stargate/node_modules/@cosmjs/socket": {
-      "version": "0.28.13",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.36.2.tgz",
+      "integrity": "sha512-Pb7JcTFWnq6yfY0IEejHrpSxNDJYcqjjAa1D29a6b/obk4qa4o3oIV5bIx6zAbdRq8uLoBfvWs0bHTNnVuBWJg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cosmjs/stream": "0.28.13",
+        "@cosmjs/stream": "^0.36.2",
         "isomorphic-ws": "^4.0.1",
         "ws": "^7",
         "xstream": "^11.14.0"
       }
     },
     "node_modules/@cosmjs/stargate/node_modules/@cosmjs/stream": {
-      "version": "0.28.13",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.36.2.tgz",
+      "integrity": "sha512-FlZx2Buovem837LdTLPkPFcxzuQ7zierAqSXwMPr/MG3k+qMxHNfLFTTCXMNWQ4ZlbYedud8ZqCL3/HKdS5mig==",
       "license": "Apache-2.0",
       "dependencies": {
         "xstream": "^11.14.0"
       }
     },
     "node_modules/@cosmjs/stargate/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.28.13",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.36.2.tgz",
+      "integrity": "sha512-76Z99C1NVf/Yv/1bWU0wul8MhRwVdqiZxqU5bcHqvJLoQ2nKUfGpSSYRdbMHfZ63J8ryRqQ95uPvPTfrBb+agw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@cosmjs/crypto": "0.28.13",
-        "@cosmjs/encoding": "0.28.13",
-        "@cosmjs/json-rpc": "0.28.13",
-        "@cosmjs/math": "0.28.13",
-        "@cosmjs/socket": "0.28.13",
-        "@cosmjs/stream": "0.28.13",
-        "@cosmjs/utils": "0.28.13",
-        "axios": "^0.21.2",
+        "@cosmjs/crypto": "^0.36.2",
+        "@cosmjs/encoding": "^0.36.2",
+        "@cosmjs/json-rpc": "^0.36.2",
+        "@cosmjs/math": "^0.36.2",
+        "@cosmjs/socket": "^0.36.2",
+        "@cosmjs/stream": "^0.36.2",
+        "@cosmjs/utils": "^0.36.2",
         "readonly-date": "^1.0.0",
         "xstream": "^11.14.0"
       }
     },
     "node_modules/@cosmjs/stargate/node_modules/@cosmjs/utils": {
-      "version": "0.28.13",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.36.2.tgz",
+      "integrity": "sha512-OOr2HU/Ph+/GI1Fx2UCf3LOyX9YTCP51d2HitTOjjEJRYnkfKXP3lMBl1FZo5QaFWxnfuBc+Cj+cSoiQUJRyzQ==",
       "license": "Apache-2.0"
     },
-    "node_modules/@cosmjs/stargate/node_modules/axios": {
-      "version": "0.21.4",
+    "node_modules/@cosmjs/stargate/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@cosmjs/stargate/node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@cosmjs/stargate/node_modules/cosmjs-types": {
-      "version": "0.4.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "long": "^4.0.0",
-        "protobufjs": "~6.11.2"
-      }
-    },
-    "node_modules/@cosmjs/stargate/node_modules/long": {
-      "version": "4.0.0",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.10.1.tgz",
+      "integrity": "sha512-CENXb4O5GN+VyB68HYXFT2SOhv126Z59631rZC56m8uMWa6/cSlFeai8BwZGT1NMepw0Ecf+U8XSOnBzZUWh9Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@cosmjs/stargate/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -15483,35 +15190,6 @@
         "xstream": "^11.14.0"
       }
     },
-    "node_modules/@cosmjs/tendermint-rpc/node_modules/@cosmjs/crypto": {
-      "version": "0.32.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.32.4",
-        "@cosmjs/math": "^0.32.4",
-        "@cosmjs/utils": "^0.32.4",
-        "@noble/hashes": "^1",
-        "bn.js": "^5.2.0",
-        "elliptic": "^6.5.4",
-        "libsodium-wrappers-sumo": "^0.7.11"
-      }
-    },
-    "node_modules/@cosmjs/tendermint-rpc/node_modules/@cosmjs/encoding": {
-      "version": "0.32.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@cosmjs/tendermint-rpc/node_modules/@cosmjs/math": {
-      "version": "0.32.4",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
     "node_modules/@cosmjs/utils": {
       "version": "0.32.4",
       "license": "Apache-2.0"
@@ -15544,22 +15222,18 @@
       "integrity": "sha512-gzf+pkAbEZ7fKuTuwmrEAEcx1K/BNrKuCnB9s+WwSo9Ad/3s+GV5LOXcOOxjjHh9Mrs9kvnxKvzKjOwWu8gDJw==",
       "license": "SEE LICENSE IN LICENSE"
     },
-    "node_modules/@cosmos-kit/core/node_modules/@cosmjs/encoding": {
+    "node_modules/@cosmos-kit/core/node_modules/@cosmjs/proto-signing": {
       "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.32.4.tgz",
-      "integrity": "sha512-tjvaEy6ZGxJchiizzTn7HVRiyTg1i4CObRRaTRPknm5EalE13SV+TCHq38gIDfyUeden4fCuaBVEdBR5+ti7Hw==",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
+      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "node_modules/@cosmos-kit/core/node_modules/@cosmjs/math": {
-      "version": "0.32.4",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.32.4.tgz",
-      "integrity": "sha512-++dqq2TJkoB8zsPVYCvrt88oJWsy1vMOuSOKcdlnXuOA/ASheTJuYy4+oZlTQ3Fr8eALDLGGPhJI02W2HyAQaw==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
+        "@cosmjs/amino": "^0.32.4",
+        "@cosmjs/crypto": "^0.32.4",
+        "@cosmjs/encoding": "^0.32.4",
+        "@cosmjs/math": "^0.32.4",
+        "@cosmjs/utils": "^0.32.4",
+        "cosmjs-types": "^0.9.0"
       }
     },
     "node_modules/@cosmos-kit/core/node_modules/@cosmjs/stargate": {
@@ -15794,6 +15468,34 @@
       "integrity": "sha512-gzf+pkAbEZ7fKuTuwmrEAEcx1K/BNrKuCnB9s+WwSo9Ad/3s+GV5LOXcOOxjjHh9Mrs9kvnxKvzKjOwWu8gDJw==",
       "license": "SEE LICENSE IN LICENSE"
     },
+    "node_modules/@cosmos-kit/react-lite/node_modules/@cosmjs/proto-signing": {
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
+      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@cosmjs/amino": "^0.32.4",
+        "@cosmjs/crypto": "^0.32.4",
+        "@cosmjs/encoding": "^0.32.4",
+        "@cosmjs/math": "^0.32.4",
+        "@cosmjs/utils": "^0.32.4",
+        "cosmjs-types": "^0.9.0"
+      }
+    },
+    "node_modules/@cosmos-kit/react-lite/node_modules/@dao-dao/cosmiframe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@dao-dao/cosmiframe/-/cosmiframe-0.1.0.tgz",
+      "integrity": "sha512-NW4pGt1ctqDfhn/A6RU2vwnFEu3O4aBNnBMrGnw31n+L35drYNEsA9ZB7KZsHmRRlkNx+jSuJSv2Fv0BFBDDJQ==",
+      "license": "BSD-3-Clause-Clear",
+      "dependencies": {
+        "uuid": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@cosmjs/amino": ">= ^0.32",
+        "@cosmjs/proto-signing": ">= ^0.32"
+      }
+    },
     "node_modules/@cosmos-kit/react/node_modules/@chain-registry/types": {
       "version": "0.46.15",
       "resolved": "https://registry.npmjs.org/@chain-registry/types/-/types-0.46.15.tgz",
@@ -15815,6 +15517,20 @@
       "peerDependencies": {
         "@cosmjs/amino": ">=0.32.3",
         "@walletconnect/types": "2.11.0"
+      }
+    },
+    "node_modules/@cosmos-kit/walletconnect/node_modules/@cosmjs/proto-signing": {
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
+      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/amino": "^0.32.4",
+        "@cosmjs/crypto": "^0.32.4",
+        "@cosmjs/encoding": "^0.32.4",
+        "@cosmjs/math": "^0.32.4",
+        "@cosmjs/utils": "^0.32.4",
+        "cosmjs-types": "^0.9.0"
       }
     },
     "node_modules/@cosmostation/extension-client": {
@@ -16015,7 +15731,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -16038,21 +15753,8 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@dao-dao/cosmiframe": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@dao-dao/cosmiframe/-/cosmiframe-0.1.0.tgz",
-      "integrity": "sha512-NW4pGt1ctqDfhn/A6RU2vwnFEu3O4aBNnBMrGnw31n+L35drYNEsA9ZB7KZsHmRRlkNx+jSuJSv2Fv0BFBDDJQ==",
-      "dependencies": {
-        "uuid": "^9.0.1"
-      },
-      "peerDependencies": {
-        "@cosmjs/amino": ">= ^0.32",
-        "@cosmjs/proto-signing": ">= ^0.32"
       }
     },
     "node_modules/@date-fns/tz": {
@@ -16137,7 +15839,6 @@
     "node_modules/@dotenvx/dotenvx/node_modules/picomatch": {
       "version": "4.0.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16254,7 +15955,6 @@
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -16268,7 +15968,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
       "integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -16307,7 +16006,6 @@
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.11.0.tgz",
       "integrity": "sha512-6q89fj2z8VBTx9w93kJ5n51hsmtYuFPtZgnc1L8VzRx9ti4EU6EyvF6Nn1H1x3vcCQCF7u2dB2lY4AYJwUW4PA==",
-      "peer": true,
       "dependencies": {
         "@emotion/utils": "^1.2.1",
         "html-tokenize": "^2.0.0",
@@ -16332,7 +16030,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
       "integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -17391,7 +17088,6 @@
           "url": "https://opencollective.com/fakerjs"
         }
       ],
-      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=6.14.13"
@@ -17554,7 +17250,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.11.tgz",
       "integrity": "sha512-3RaoxOqkHHN2c05bwtBNVJmOf/UwMam0rZYtdl7dsRpsvDwcNpv6LkGgzltQ7xVf822LzBoKEPRvf4D7+xeIDw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -18561,7 +18256,6 @@
       "version": "1.23.31",
       "resolved": "https://registry.npmjs.org/@interchain-ui/react/-/react-1.23.31.tgz",
       "integrity": "sha512-7vyp0PaWr0VJzcC26D71Fr9OgOQLG5amV8zSV0XQSmBg3fRIwDSs4Mtn5ThASA2/2yWY3kqtZsNYNIMCQ8xjYg==",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.6.4",
         "@floating-ui/dom": "^1.6.7",
@@ -19261,7 +18955,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -19490,7 +19183,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -19992,6 +19684,20 @@
         "long": "^5.2.3"
       }
     },
+    "node_modules/@leapwallet/cosmos-snap-provider/node_modules/@cosmjs/proto-signing": {
+      "version": "0.32.4",
+      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
+      "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cosmjs/amino": "^0.32.4",
+        "@cosmjs/crypto": "^0.32.4",
+        "@cosmjs/encoding": "^0.32.4",
+        "@cosmjs/math": "^0.32.4",
+        "@cosmjs/utils": "^0.32.4",
+        "cosmjs-types": "^0.9.0"
+      }
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -20391,7 +20097,6 @@
     "node_modules/@mui/material": {
       "version": "5.15.20",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/base": "5.0.0-beta.40",
@@ -21183,7 +20888,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.3.tgz",
       "integrity": "sha512-ogEK+GriWodIwCw6buQ1rpcH4Kx+G7YQ9EwuPySI3rS05pSdtQ++UhucjusSI9apNidv+QURBztJkRecwwJQXg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.0.0",
         "iterare": "1.2.1",
@@ -21288,7 +20992,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.0.11.tgz",
       "integrity": "sha512-jMH3jrjrPiaGrkQ5hANNcgDWN+j+hcM5GMQ3jSs4vOWNs3lmKHTVR11wJ9y5tTNnwKydzMogeju0VTUdfXDI5Q==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -21356,7 +21059,6 @@
       "version": "11.0.11",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.0.11.tgz",
       "integrity": "sha512-iv6nH66i/RuRQufg5UUboQ4jQX4NuuePrYQpHB3ueiEIhJm2yLhhNYM6Y2l/76y9woW2eckbiqbzmW/JajAgeQ==",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.0.1",
@@ -22513,7 +22215,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -22772,7 +22473,6 @@
       "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -23018,7 +22718,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -23040,7 +22739,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -23053,7 +22751,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -23775,7 +23472,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
       "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -25636,7 +25332,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
       "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -25853,7 +25548,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -25957,7 +25651,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
       "integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -29689,7 +29382,6 @@
       "integrity": "sha512-3arRdUp1fNx55itnjKiUhO6t4Mf91TsrTIYINDNLAZPS0TPd5YpiXRctwjel0qqWoOOhjA34cZ3m4dksLDFUYg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redocly/ajv": "^8.11.2",
         "@redocly/config": "^0.22.0",
@@ -29860,7 +29552,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -30402,6 +30093,7 @@
       "resolved": "https://registry.npmjs.org/@scure/starknet/-/starknet-1.1.0.tgz",
       "integrity": "sha512-83g3M6Ix2qRsPN4wqLDqiRZ2GBNbjVWfboJE/9UjfG+MHr6oDSu/CWgy8hsBSJejr09DkkL+l0Ze4KVrlCIdtQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "~1.7.0",
         "@noble/hashes": "~1.6.0"
@@ -30415,6 +30107,7 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
       "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.6.0"
       },
@@ -30430,6 +30123,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
       "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -30442,6 +30136,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
       "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -31397,14 +31092,16 @@
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
       "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@starknet-io/starknet-types-08": {
       "name": "@starknet-io/types-js",
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.8.4.tgz",
       "integrity": "sha512-0RZ3TZHcLsUTQaq1JhDSCM8chnzO4/XNsSCozwDET64JK5bjFDIf2ZUkta+tl5Nlbf4usoU7uZiDI/Q57kt2SQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@streamparser/json": {
       "version": "0.0.20",
@@ -31443,7 +31140,6 @@
       "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.6.0.tgz",
       "integrity": "sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@xhmikosr/bin-wrapper": "^13.0.5",
@@ -31497,7 +31193,6 @@
       "integrity": "sha512-Si27CiYwqJSF3K0HgxugQnjHNfH7YqqD89V+fLpyRHr81uTmCQpF0bnVdRMQ2SGAkCFJACYETRiBSrZOQ660+Q==",
       "devOptional": true,
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.19"
@@ -31541,6 +31236,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31556,6 +31252,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31571,6 +31268,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31586,6 +31284,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31601,6 +31300,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31616,6 +31316,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31631,6 +31332,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31646,6 +31348,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31661,6 +31364,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31676,6 +31380,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31689,7 +31394,6 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
       "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
@@ -31735,7 +31439,6 @@
       "version": "5.67.2",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.67.2.tgz",
       "integrity": "sha512-+iaFJ/pt8TaApCk6LuZ0WHS/ECVfTzrxDOEL9HH9Dayyb5OVuomLzDXeSaI2GlGT/8HN7bDGiRXDts3LV+u6ww==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -31745,7 +31448,6 @@
       "version": "5.67.2",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.67.2.tgz",
       "integrity": "sha512-6Sa+BVNJWhAV4QHvIqM73norNeGRWGC3ftN0Ix87cmMvI215I1wyJ44KUTt/9a0V9YimfGcg25AITaYVel71Og==",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.67.2"
       },
@@ -31821,7 +31523,6 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -32097,7 +31798,6 @@
       "version": "7.20.5",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -32606,7 +32306,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
       "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -32701,7 +32400,6 @@
     "node_modules/@types/react": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -32711,7 +32409,6 @@
     "node_modules/@types/react-dom": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -32899,8 +32596,7 @@
     },
     "node_modules/@types/validator": {
       "version": "13.11.10",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/webpack-node-externals": {
       "version": "3.0.4",
@@ -33519,7 +33215,6 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.17.1.tgz",
       "integrity": "sha512-tOHQXHm10FrJeXKFeWE09JfDGN/tvV6mbjwoNB9k03u930Vg021vTnbrCwVLkECj9Zvh/SHLBHJ4r2flGqfovw==",
-      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@vanilla-extract/private": "^1.0.6",
@@ -33544,7 +33239,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@vanilla-extract/dynamic/-/dynamic-2.1.2.tgz",
       "integrity": "sha512-9BGMciD8rO1hdSPIAh1ntsG4LPD3IYKhywR7VOmmz9OO4Lx1hlwkSg3E6X07ujFx7YuBfx0GDQnApG9ESHvB2A==",
-      "peer": true,
       "dependencies": {
         "@vanilla-extract/private": "^1.0.6"
       }
@@ -34070,7 +33764,6 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.11.0.tgz",
       "integrity": "sha512-AB5b1lrEbCGHxqS2vqfCkIoODieH+ZAUp9rA1O2ftrhnqDJiJK983Df87JhYhECsQUBHHfALphA8ydER0q+9sw==",
-      "peer": true,
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -34716,6 +34409,7 @@
       "resolved": "https://registry.npmjs.org/abi-wan-kanabi/-/abi-wan-kanabi-2.2.4.tgz",
       "integrity": "sha512-0aA81FScmJCPX+8UvkXLki3X1+yPQuWxEkqXBVKltgPAK79J+NB+Lp5DouMXa7L6f+zcRlIA/6XO7BN/q9fnvg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ansicolors": "^0.3.2",
         "cardinal": "^2.1.1",
@@ -34731,6 +34425,7 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -34806,7 +34501,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -34902,7 +34596,6 @@
     "node_modules/ajv": {
       "version": "6.12.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -35054,7 +34747,6 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -35097,7 +34789,8 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansis": {
       "version": "3.16.0",
@@ -35431,6 +35124,8 @@
     },
     "node_modules/asn1js": {
       "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.4.0.tgz",
+      "integrity": "sha512-PvZC0FMyMut8aOnR2jAEGSkmRtHIUYPe9amUEnGjr9TdnUmsfoOkjrvUkOEU9mzpYBR1HyO9bF+8U1cLTMMHhQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "pvutils": "^1.1.3"
@@ -35634,7 +35329,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -36423,7 +36117,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -36575,6 +36268,8 @@
     },
     "node_modules/bytestreamjs": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=6.0.0"
@@ -36870,7 +36565,6 @@
     "node_modules/camelcase": {
       "version": "5.3.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -36906,6 +36600,7 @@
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
       "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
@@ -37036,6 +36731,8 @@
     },
     "node_modules/chownr": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
     "node_modules/chrome-trace-event": {
@@ -37612,7 +37309,6 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37770,7 +37466,9 @@
       }
     },
     "node_modules/console-browserify": {
-      "version": "1.2.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+      "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -38121,8 +37819,7 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
       "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
@@ -38391,8 +38088,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/csv-stringify": {
       "version": "6.6.0",
@@ -38535,8 +38231,7 @@
     "node_modules/d3-selection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
-      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
-      "peer": true
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
@@ -38749,7 +38444,6 @@
     "node_modules/date-fns": {
       "version": "2.30.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -39198,6 +38892,8 @@
     },
     "node_modules/detect-indent": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+      "integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -39556,7 +39252,6 @@
       "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.31.2.tgz",
       "integrity": "sha512-QnenevbnnAzmbNzQwbhklvIYrDE8YER8K7kSrAWQSV1YvFCdSQPzj+jzqRdTSsV2cDqSpQ0NXGyL1G9I43LDLg==",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=3",
@@ -40191,7 +39886,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -40468,7 +40162,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -40502,7 +40195,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.10.0.tgz",
       "integrity": "sha512-5ej+0WILhX3D6wkcdsyYmPp10SUIK6fmuZ6KS8nf9MD8CJ6/S/3Dl7m21g+MLeaTMsvcEXo3JunNAbgHwXxs/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pkgr/core": "^0.2.0",
         "@types/doctrine": "^0.0.9",
@@ -41155,6 +40847,8 @@
     },
     "node_modules/expand-template": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "license": "(MIT OR WTFPL)",
       "engines": {
         "node": ">=6"
@@ -42572,6 +42266,8 @@
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
     },
     "node_modules/fs-extra": {
@@ -42718,7 +42414,6 @@
       "resolved": "https://registry.npmjs.org/gel/-/gel-2.0.2.tgz",
       "integrity": "sha512-XTKpfNR9HZOw+k0Bl04nETZjuP5pypVAXsZADSdwr3EtyygTTe1RqvftU2FjGu7Tp9e576a9b/iIOxWrRBxMiQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@petamoriken/float16": "^3.8.7",
         "debug": "^4.3.4",
@@ -43016,6 +42711,34 @@
         }
       }
     },
+    "node_modules/git-semver-tags/node_modules/conventional-commits-filter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/git-semver-tags/node_modules/conventional-commits-parser": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
+      "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "meow": "^13.0.0"
+      },
+      "bin": {
+        "conventional-commits-parser": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-semver-tags/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
@@ -43051,6 +42774,8 @@
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "license": "MIT"
     },
     "node_modules/glob": {
@@ -43823,7 +43548,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.6.12.tgz",
       "integrity": "sha512-eHtf4kSDNw6VVrdbd5IQi16r22m3s7mWPLd7xOMhg1a/Yyb1A0qpUFq8xYMX4FMuDe1nTKeMX5rTx7Nmw+a+Ag==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -44199,7 +43923,6 @@
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
       "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -45415,7 +45138,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -46114,7 +45836,6 @@
     "node_modules/jiti": {
       "version": "1.21.3",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -46429,7 +46150,6 @@
       "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "acorn": "^8.8.1",
@@ -46532,7 +46252,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -46812,6 +46531,8 @@
     },
     "node_modules/keytar": {
       "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -47646,7 +47367,8 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.3.0.tgz",
       "integrity": "sha512-ToxOC+SsduRmdSuoLZLYAr5zy1Qu7l5XhmPWM3zefCZ5IcrzW/h108qbJUKfOlDlhvhjUK84+8PSVX0kxnit0g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lowercase-keys": {
       "version": "3.0.0",
@@ -50145,6 +49867,8 @@
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
     },
     "node_modules/mlly": {
@@ -50222,7 +49946,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -50513,7 +50236,9 @@
       }
     },
     "node_modules/napi-build-utils": {
-      "version": "1.0.2",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/napi-macros": {
@@ -50646,7 +50371,6 @@
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
       "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
@@ -50824,7 +50548,9 @@
       }
     },
     "node_modules/node-abi": {
-      "version": "3.63.0",
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
@@ -50841,6 +50567,8 @@
     },
     "node_modules/node-addon-api": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
       "license": "MIT"
     },
     "node_modules/node-appwrite": {
@@ -51794,7 +51522,6 @@
       "resolved": "https://registry.npmjs.org/ora/-/ora-8.1.1.tgz",
       "integrity": "sha512-YWielGi1XzG1UTvOaCFaNgEnuhZVMSHYkW/FQ7UX8O26PtlpdM84c0f7wLPlkvx2RfiQmnzd61d/MGxmpQeJPw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "cli-cursor": "^5.0.0",
@@ -52324,7 +52051,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -52684,26 +52410,43 @@
       "license": "MIT"
     },
     "node_modules/pkijs": {
-      "version": "3.1.0",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.3.3.tgz",
+      "integrity": "sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "asn1js": "^3.0.5",
-        "bytestreamjs": "^2.0.0",
-        "pvtsutils": "^1.3.2",
+        "@noble/hashes": "1.4.0",
+        "asn1js": "^3.0.6",
+        "bytestreamjs": "^2.0.1",
+        "pvtsutils": "^1.3.6",
         "pvutils": "^1.1.3",
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/pkijs/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/pkijs/node_modules/asn1js": {
-      "version": "3.0.5",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
+      "integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "pvtsutils": "^1.3.2",
+        "pvtsutils": "^1.3.6",
         "pvutils": "^1.1.3",
-        "tslib": "^2.4.0"
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -52751,6 +52494,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -52805,7 +52549,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -52947,7 +52690,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -53032,7 +52774,9 @@
       }
     },
     "node_modules/prebuild-install": {
-      "version": "7.1.2",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.0",
@@ -53040,7 +52784,7 @@
         "github-from-package": "0.0.0",
         "minimist": "^1.2.3",
         "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
+        "napi-build-utils": "^2.0.0",
         "node-abi": "^3.3.0",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
@@ -53065,7 +52809,6 @@
     "node_modules/prettier": {
       "version": "3.3.1",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -53264,7 +53007,6 @@
     "node_modules/prop-types": {
       "version": "15.8.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -53462,17 +53204,21 @@
       "license": "MIT"
     },
     "node_modules/pvtsutils": {
-      "version": "1.3.5",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
       "license": "MIT",
       "dependencies": {
-        "tslib": "^2.6.1"
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/pvutils": {
-      "version": "1.1.3",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
       "license": "MIT",
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/qrcode": {
@@ -53759,7 +53505,6 @@
     "node_modules/react": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -53875,7 +53620,6 @@
     "node_modules/react-dom": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -53919,7 +53663,6 @@
       "version": "7.52.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.2.tgz",
       "integrity": "sha512-pqfPEbERnxxiNMPd0bzmt1tuaPcVccywFDpyk2uV5xCIBphHV5T8SVnX9/o3kplPE1zzKt77+YIoq+EMwJp56A==",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -54523,14 +54266,14 @@
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
       "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esprima": "~4.0.0"
       }
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
@@ -54775,7 +54518,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@iarna/toml": "2.2.5",
         "@octokit/rest": "20.1.1",
@@ -54821,7 +54563,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
       "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -55831,7 +55572,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -55990,7 +55730,6 @@
     "node_modules/rxjs": {
       "version": "7.8.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -56131,7 +55870,6 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -56865,6 +56603,8 @@
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
       "funding": [
         {
           "type": "github",
@@ -56883,6 +56623,8 @@
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
       "funding": [
         {
           "type": "github",
@@ -56906,6 +56648,8 @@
     },
     "node_modules/simple-jsonrpc-js": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/simple-jsonrpc-js/-/simple-jsonrpc-js-1.2.0.tgz",
+      "integrity": "sha512-owkAmh7fjSYBUZVestTPCZMKYQvNiDejqZ/iGfVaKs1nrC1ZBDA3qGraf94+JNFJmu536Tb8oPe8PSPuq7GO6Q==",
       "license": "MIT"
     },
     "node_modules/simple-update-notifier": {
@@ -57200,6 +56944,8 @@
     },
     "node_modules/sort-json": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sort-json/-/sort-json-2.0.1.tgz",
+      "integrity": "sha512-s8cs2bcsQCzo/P2T/uoU6Js4dS/jnX8+4xunziNoq9qmSpZNCrRIAIvp4avsz0ST18HycV4z/7myJ7jsHWB2XQ==",
       "license": "MIT",
       "dependencies": {
         "detect-indent": "^5.0.0",
@@ -57212,6 +56958,8 @@
     },
     "node_modules/sort-json/node_modules/detect-newline": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha512-CwffZFvlJffUg9zZA0uqrjQayUTC8ob94pnr5sFwaVv3IOmkfUHcWH+jXaQK3askE51Cqe8/9Ql/0uXNwqZ8Zg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -57542,6 +57290,7 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
       "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.6.0"
       },
@@ -57557,6 +57306,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
       "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -57569,6 +57319,7 @@
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.1.tgz",
       "integrity": "sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -58245,7 +57996,6 @@
     "node_modules/tailwindcss": {
       "version": "3.4.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -58381,9 +58131,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -58394,6 +58144,8 @@
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
@@ -58408,6 +58160,8 @@
     },
     "node_modules/tar-stream/node_modules/readable-stream": {
       "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -58416,13 +58170,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/tar-stream/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/tar/node_modules/chownr": {
@@ -58905,7 +58652,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -59264,7 +59010,8 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
       "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -59272,7 +59019,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -60606,6 +60352,8 @@
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -60835,7 +60583,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -61274,7 +61021,6 @@
       "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-3.7.6.tgz",
       "integrity": "sha512-ft3KpFySRL7kY07DL9INh9q0E1hZj+ORR69ZCKpdeag0byn6gR7TMZenS1yF3Lh4zSNpTnprSjb8mmr3Nx3deg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tiny-emitter": "^2.1.0",
         "uuid": "^9.0.1"
@@ -62099,7 +61845,6 @@
       "version": "5.98.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -62203,7 +61948,6 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",
@@ -62658,7 +62402,6 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -62950,7 +62693,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
       "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -63030,8 +62772,7 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
       "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
-      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
-      "peer": true
+      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead."
     },
     "node_modules/xterm-addon-fit": {
       "version": "0.7.0",
@@ -63057,7 +62798,6 @@
       "version": "1.10.2",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -63139,7 +62879,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
       "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -63379,172 +63118,9 @@
         "ts-jest": "^29.4.0"
       },
       "peerDependencies": {
-        "@cosmjs/proto-signing": "^0.36.1",
-        "@cosmjs/stargate": "^0.36.1"
+        "@cosmjs/proto-signing": "^0.36.2",
+        "@cosmjs/stargate": "^0.36.2"
       }
-    },
-    "packages/http-sdk/node_modules/@cosmjs/amino": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.36.1.tgz",
-      "integrity": "sha512-JRAtBA0bcIlhYZ5AXMT8VYUaxqVfEDiQbcEg0FLEIFofssj3V4aXFO93lsPI3AeWwRSZhWA+guGd/iHFC05UbQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1"
-      }
-    },
-    "packages/http-sdk/node_modules/@cosmjs/crypto": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.36.1.tgz",
-      "integrity": "sha512-7vx9rZAuboyMxs9zv3hZhNA0JAFMpaW+fFgRDQzZzfIVj0z4h8RW4dJu0xx5cv3KBQXmoRUzWklpnFuMQYiGdg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "^1.9.2",
-        "@noble/hashes": "^1",
-        "hash-wasm": "^4.12.0"
-      }
-    },
-    "packages/http-sdk/node_modules/@cosmjs/encoding": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.36.1.tgz",
-      "integrity": "sha512-i5dTiOdSAfyU76lmOm0+VLEIDEtmINtpOeAuzzBJP1er5fDJvpBysgY9MefVwXNBY/P46W10Uta9zQc98ehBXg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "bech32": "^1.1.4",
-        "readonly-date": "^1.0.0"
-      }
-    },
-    "packages/http-sdk/node_modules/@cosmjs/json-rpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/json-rpc/-/json-rpc-0.36.1.tgz",
-      "integrity": "sha512-7vpTw3r3vVaiMY9L0hDh2QP5RnmSim00DhQuqtrPz/qd740Q2xtxhO7UxnWOzL85gG1Tyr9KshE46QIhZcTU/Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.36.1",
-        "xstream": "^11.14.0"
-      }
-    },
-    "packages/http-sdk/node_modules/@cosmjs/math": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.36.1.tgz",
-      "integrity": "sha512-ML5X5iupmTUV6bik+YEShrmK49ikB8jMQfgzdQV7qeBMN2Rc4ijd1/sFya5AiyJzxtBlYe7yv0i5NyNzZPqKpQ==",
-      "license": "Apache-2.0"
-    },
-    "packages/http-sdk/node_modules/@cosmjs/proto-signing": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.36.1.tgz",
-      "integrity": "sha512-aWGJW4gwVEf/HaVe7Bf8K3Vc7J8vOMvChDhUr2FT8NG7REJ2CztJ0jcYgaJLRzoEj6rLJoN97eAf2hUjFQxWTw==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.1",
-        "@cosmjs/crypto": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "packages/http-sdk/node_modules/@cosmjs/socket": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/socket/-/socket-0.36.1.tgz",
-      "integrity": "sha512-p6KgnQmlz1MYJjWi66xyLLYk0NqXFQ/OE5LlC6+Pj6tv7sxjhqsQiQYwfgKJjSwTbduXv2vOHrqEnKZ892E5Xw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/stream": "^0.36.1",
-        "isomorphic-ws": "^4.0.1",
-        "ws": "^7",
-        "xstream": "^11.14.0"
-      }
-    },
-    "packages/http-sdk/node_modules/@cosmjs/stargate": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.36.1.tgz",
-      "integrity": "sha512-MCvZCginWI/2crnf7xYNsVNPzXLRgjuXUYF7t00JSOeif3MBM3YUHKQjjMsFNVys4eEDkfbptfn9bDghFy1nag==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@cosmjs/amino": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/proto-signing": "^0.36.1",
-        "@cosmjs/stream": "^0.36.1",
-        "@cosmjs/tendermint-rpc": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "cosmjs-types": "^0.10.1"
-      }
-    },
-    "packages/http-sdk/node_modules/@cosmjs/stream": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/stream/-/stream-0.36.1.tgz",
-      "integrity": "sha512-q8TrUt7iiWGf6N5x7vWGqWIhtgPzTMkZlM73vkE4F3rcWbybJHgNu7inOhwnuJpR+gFZd9JNq+jAtjsbptZGag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "xstream": "^11.14.0"
-      }
-    },
-    "packages/http-sdk/node_modules/@cosmjs/tendermint-rpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/tendermint-rpc/-/tendermint-rpc-0.36.1.tgz",
-      "integrity": "sha512-9EN84YVqdgDLB97xFq+aqsolbMCyKwg6NcB/CR1s3DrquzJEx9/ZNEBJak/VVfb+croDFgvQd4X7CzqkW4N2ag==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@cosmjs/crypto": "^0.36.1",
-        "@cosmjs/encoding": "^0.36.1",
-        "@cosmjs/json-rpc": "^0.36.1",
-        "@cosmjs/math": "^0.36.1",
-        "@cosmjs/socket": "^0.36.1",
-        "@cosmjs/stream": "^0.36.1",
-        "@cosmjs/utils": "^0.36.1",
-        "readonly-date": "^1.0.0",
-        "xstream": "^11.14.0"
-      }
-    },
-    "packages/http-sdk/node_modules/@cosmjs/utils": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.36.1.tgz",
-      "integrity": "sha512-kjdDD6t7dMLRUtbRCRskP7sNpyNf6cxVgaM2z7n64e6upXwE+bsoKfKrG+iY2ABT57oH6UxJYgcB+7ACmPxZCg==",
-      "license": "Apache-2.0"
-    },
-    "packages/http-sdk/node_modules/@noble/ciphers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/http-sdk/node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/http-sdk/node_modules/cosmjs-types": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.10.1.tgz",
-      "integrity": "sha512-CENXb4O5GN+VyB68HYXFT2SOhv126Z59631rZC56m8uMWa6/cSlFeai8BwZGT1NMepw0Ecf+U8XSOnBzZUWh9Q==",
-      "license": "Apache-2.0"
     },
     "packages/http-sdk/node_modules/date-fns": {
       "version": "4.1.0",
@@ -63553,27 +63129,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "packages/http-sdk/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.3.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "packages/jwt": {

--- a/packages/http-sdk/package.json
+++ b/packages/http-sdk/package.json
@@ -32,7 +32,7 @@
     "ts-jest": "^29.4.0"
   },
   "peerDependencies": {
-    "@cosmjs/proto-signing": "^0.36.1",
-    "@cosmjs/stargate": "^0.36.1"
+    "@cosmjs/proto-signing": "^0.36.2",
+    "@cosmjs/stargate": "^0.36.2"
   }
 }

--- a/packages/http-sdk/src/tx-http/tx-http.service.ts
+++ b/packages/http-sdk/src/tx-http/tx-http.service.ts
@@ -1,5 +1,4 @@
-import type { Registry } from "@cosmjs/proto-signing";
-import type { EncodeObject } from "@cosmjs/proto-signing/build/registry";
+import type { EncodeObject, Registry } from "@cosmjs/proto-signing";
 import type { DeliverTxResponse } from "@cosmjs/stargate";
 import type { AxiosRequestConfig } from "axios";
 


### PR DESCRIPTION
## Why

Just optimization, I expected it to speed up bootstap but it didn't help. Though bundling packages this way is more correct and eventually doesn't require building internal packages separately, since anyway the result is the sameg 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CosmJS peer versions to 0.36.2 and added protobufjs to the API app
  * CI workflow permissions adjusted to allow reading check results
* **Refactor**
  * Build tooling improved to better detect internal packages and warn about bundling them
  * Copy step made asynchronous for more reliable builds
* **Build**
  * Cleaned and consolidated type/module imports (no runtime/API changes)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->