### PR TITLE
fix: adds body limit to all openapi routes

### DIFF
--- a/apps/api/src/pricing/routes/pricing/pricing.router.ts
+++ b/apps/api/src/pricing/routes/pricing/pricing.router.ts
@@ -14,6 +14,9 @@ const postPricingRoute = createRoute({
   tags: ["Other"],
   security: SECURITY_NONE,
   summary: "Estimate the price of a deployment on akash and other cloud providers.",
+  bodyLimit: {
+    maxSize: 512 // 512 bytes
+  },
   request: {
     body: {
       description:

--- a/apps/api/src/rest-app.ts
+++ b/apps/api/src/rest-app.ts
@@ -3,7 +3,6 @@ import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { otel } from "@hono/otel";
 import { swaggerUI } from "@hono/swagger-ui";
 import { Hono } from "hono";
-import { compress } from "hono/compress";
 import { cors } from "hono/cors";
 import assert from "http-assert";
 import { container } from "tsyringe";
@@ -88,7 +87,6 @@ appHono.use(
     exposeHeaders: ["cf-mitigated"]
   })
 );
-appHono.use("*", compress());
 
 appHono.use(container.resolve(HttpLoggerInterceptor).intercept());
 appHono.use(container.resolve(RequestContextInterceptor).intercept());


### PR DESCRIPTION
## Why

ref #2582 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API endpoints now enforce request body size limits by default (512 KB) and a stricter 512-byte limit for pricing requests.

* **Changes**
  * Removed response compression from the API.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->