### PR TITLE
refactor: replace per-file GitHub API calls with ZIP archive downloads

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -135,6 +135,7 @@
     "@types/semver": "^7.5.2",
     "@types/uuid": "^8.3.1",
     "@types/yauzl": "^2.10.3",
+    "@types/yazl": "^3.3.0",
     "@typescript-eslint/eslint-plugin": "^7.12.0",
     "dot-object": "^2.1.5",
     "drizzle-kit": "^0.22.7",
@@ -153,6 +154,7 @@
     "ts-jest": "^29.1.4",
     "tsup": "^8.5.1",
     "type-fest": "^4.26.1",
-    "typescript": "~5.8.2"
+    "typescript": "~5.8.2",
+    "yazl": "^3.3.1"
   }
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -92,6 +92,7 @@
     "human-interval": "^2.0.1",
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.2",
+    "jszip": "^3.10.1",
     "lodash": "^4.17.21",
     "lru-cache": "^11.1.0",
     "markdown-to-txt": "^2.0.1",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -92,7 +92,6 @@
     "human-interval": "^2.0.1",
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.2",
-    "jszip": "^3.10.1",
     "lodash": "^4.17.21",
     "lru-cache": "^11.1.0",
     "markdown-to-txt": "^2.0.1",
@@ -113,6 +112,7 @@
     "tsyringe": "^4.10.0",
     "unleash-client": "^6.6.0",
     "uuid": "^9.0.1",
+    "yauzl": "^3.2.0",
     "zod": "3.*"
   },
   "devDependencies": {
@@ -134,6 +134,7 @@
     "@types/pg": "^8.11.6",
     "@types/semver": "^7.5.2",
     "@types/uuid": "^8.3.1",
+    "@types/yauzl": "^2.10.3",
     "@typescript-eslint/eslint-plugin": "^7.12.0",
     "dot-object": "^2.1.5",
     "drizzle-kit": "^0.22.7",

--- a/apps/api/src/template/config/env.config.ts
+++ b/apps/api/src/template/config/env.config.ts
@@ -2,7 +2,7 @@ import z from "zod";
 
 export const envSchema = z.object({
   GITHUB_PAT: z.string().optional(),
-  TEMPLATE_REFRESH_INTERVAL_SECONDS: z
+  TEMPLATE_REFRESH_INTERVAL_SECONDS: z.coerce
     .number()
     .optional()
     .default(15 * 60)

--- a/apps/api/src/template/config/env.config.ts
+++ b/apps/api/src/template/config/env.config.ts
@@ -5,7 +5,8 @@ export const envSchema = z.object({
   TEMPLATE_REFRESH_INTERVAL_SECONDS: z.coerce
     .number()
     .optional()
-    .default(15 * 60)
+    .default(15 * 60),
+  TEMPLATE_REFRESH_ENABLED: z.coerce.boolean().optional().default(true)
 });
 
 export type TemplateConfig = z.infer<typeof envSchema>;

--- a/apps/api/src/template/config/env.config.ts
+++ b/apps/api/src/template/config/env.config.ts
@@ -6,7 +6,10 @@ export const envSchema = z.object({
     .number()
     .optional()
     .default(15 * 60),
-  TEMPLATE_REFRESH_ENABLED: z.coerce.boolean().optional().default(false)
+  TEMPLATE_REFRESH_ENABLED: z
+    .string()
+    .default("false")
+    .transform(value => value === "true")
 });
 
 export type TemplateConfig = z.infer<typeof envSchema>;

--- a/apps/api/src/template/config/env.config.ts
+++ b/apps/api/src/template/config/env.config.ts
@@ -6,7 +6,7 @@ export const envSchema = z.object({
     .number()
     .optional()
     .default(15 * 60),
-  TEMPLATE_REFRESH_ENABLED: z.coerce.boolean().optional().default(true)
+  TEMPLATE_REFRESH_ENABLED: z.coerce.boolean().optional().default(false)
 });
 
 export type TemplateConfig = z.infer<typeof envSchema>;

--- a/apps/api/src/template/config/env.config.ts
+++ b/apps/api/src/template/config/env.config.ts
@@ -1,7 +1,11 @@
 import z from "zod";
 
 export const envSchema = z.object({
-  GITHUB_PAT: z.string().optional()
+  GITHUB_PAT: z.string().optional(),
+  TEMPLATE_REFRESH_INTERVAL_SECONDS: z
+    .number()
+    .optional()
+    .default(15 * 60)
 });
 
 export type TemplateConfig = z.infer<typeof envSchema>;

--- a/apps/api/src/template/controllers/template/template.controller.ts
+++ b/apps/api/src/template/controllers/template/template.controller.ts
@@ -1,24 +1,13 @@
 import assert from "http-assert";
-import { promises as fsp } from "node:fs";
 import { inject, singleton } from "tsyringe";
 
-import { LoggerService } from "@src/core";
-import { TEMPLATE_CONFIG, type TemplateConfig } from "@src/template/providers/config.provider";
 import { Template } from "@src/template/types/template";
-import { dataFolderPath } from "@src/utils/constants";
+import { TEMPLATE_GALLERY_SERVICE } from "../../providers/template-gallery.provider";
 import { TemplateGalleryService } from "../../services/template-gallery/template-gallery.service";
 
 @singleton()
 export class TemplateController {
-  private readonly templateGalleryService: TemplateGalleryService;
-
-  constructor(@inject(TEMPLATE_CONFIG) templateConfig: TemplateConfig, logger: LoggerService) {
-    logger.setContext(TemplateGalleryService.name);
-    this.templateGalleryService = new TemplateGalleryService(logger, fsp, {
-      githubPAT: templateConfig.GITHUB_PAT,
-      dataFolderPath
-    });
-  }
+  constructor(@inject(TEMPLATE_GALLERY_SERVICE) private readonly templateGalleryService: TemplateGalleryService) {}
 
   async getTemplatesList(): Promise<string> {
     const { categories } = await this.templateGalleryService.getCachedTemplateGallery();

--- a/apps/api/src/template/index.ts
+++ b/apps/api/src/template/index.ts
@@ -1,1 +1,4 @@
+import "./providers/template-gallery.provider";
+import "./providers/template-refresh.provider";
+
 export * from "./routes";

--- a/apps/api/src/template/providers/template-gallery.provider.ts
+++ b/apps/api/src/template/providers/template-gallery.provider.ts
@@ -1,0 +1,22 @@
+import { promises as fsp } from "node:fs";
+import type { InjectionToken } from "tsyringe";
+import { container, instancePerContainerCachingFactory } from "tsyringe";
+
+import { LoggerService } from "@src/core";
+import { dataFolderPath } from "@src/utils/constants";
+import { TemplateGalleryService } from "../services/template-gallery/template-gallery.service";
+import { TEMPLATE_CONFIG } from "./config.provider";
+
+export const TEMPLATE_GALLERY_SERVICE: InjectionToken<TemplateGalleryService> = Symbol("TEMPLATE_GALLERY_SERVICE");
+
+container.register(TEMPLATE_GALLERY_SERVICE, {
+  useFactory: instancePerContainerCachingFactory(c => {
+    const config = c.resolve(TEMPLATE_CONFIG);
+    const logger = c.resolve(LoggerService);
+    logger.setContext(TemplateGalleryService.name);
+    return new TemplateGalleryService(logger, fsp, {
+      githubPAT: config.GITHUB_PAT,
+      dataFolderPath
+    });
+  })
+});

--- a/apps/api/src/template/providers/template-refresh.provider.ts
+++ b/apps/api/src/template/providers/template-refresh.provider.ts
@@ -1,0 +1,20 @@
+import { container, instancePerContainerCachingFactory } from "tsyringe";
+
+import { LoggerService } from "@src/core";
+import { DisposableRegistry } from "@src/core/lib/disposable-registry/disposable-registry";
+import { APP_INITIALIZER } from "@src/core/providers/app-initializer";
+import { TemplateRefreshService } from "../services/template-refresh/template-refresh.service";
+import { TEMPLATE_CONFIG } from "./config.provider";
+import { TEMPLATE_GALLERY_SERVICE } from "./template-gallery.provider";
+
+container.register(APP_INITIALIZER, {
+  useFactory: instancePerContainerCachingFactory(
+    DisposableRegistry.registerFromFactory(c => {
+      const templateGalleryService = c.resolve(TEMPLATE_GALLERY_SERVICE);
+      const logger = c.resolve(LoggerService);
+      logger.setContext(TemplateRefreshService.name);
+      const config = c.resolve(TEMPLATE_CONFIG);
+      return new TemplateRefreshService(templateGalleryService, logger, config);
+    })
+  )
+});

--- a/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
@@ -1,0 +1,129 @@
+import { mock } from "jest-mock-extended";
+import yazl from "yazl";
+
+import type { LoggerService } from "@src/core";
+import { GitHubArchiveService } from "./github-archive.service";
+
+describe(GitHubArchiveService.name, () => {
+  describe("getArchive with fileFilter", () => {
+    it("only stores content for files matching the filter", async () => {
+      const { service, installArchive } = setup();
+      await installArchive({
+        "root/readme.md": "# Hello",
+        "root/deploy.yaml": "deploy content",
+        "root/large-binary.bin": "should be skipped",
+        "root/src/index.ts": "should also be skipped"
+      });
+
+      const filter = (relativePath: string) => {
+        const name = relativePath.split("/").pop()?.toLowerCase() ?? "";
+        return name === "readme.md" || name === "deploy.yaml";
+      };
+
+      const reader = await service.getArchive("owner", "repo", "ref", filter);
+
+      expect(await reader.readFile("readme.md")).toBe("# Hello");
+      expect(await reader.readFile("deploy.yaml")).toBe("deploy content");
+      expect(await reader.readFile("large-binary.bin")).toBeNull();
+      expect(await reader.readFile("src/index.ts")).toBeNull();
+    });
+
+    it("preserves directory listings regardless of filter", async () => {
+      const { service, installArchive } = setup();
+      await installArchive({
+        "root/sub/readme.md": "content",
+        "root/sub/image.png": "binary data",
+        "root/sub/nested/file.txt": "text"
+      });
+
+      const filter = (relativePath: string) => relativePath.endsWith("readme.md");
+
+      const reader = await service.getArchive("owner", "repo", "ref", filter);
+
+      const subEntries = reader.listDirectory("sub");
+      const entryNames = subEntries.map(e => e.name);
+      expect(entryNames).toContain("readme.md");
+      expect(entryNames).toContain("image.png");
+      expect(entryNames).toContain("nested");
+    });
+
+    it("returns null for readFile on filtered-out files", async () => {
+      const { service, installArchive } = setup();
+      await installArchive({
+        "root/keep.md": "kept",
+        "root/skip.txt": "skipped"
+      });
+
+      const filter = (relativePath: string) => relativePath.endsWith(".md");
+
+      const reader = await service.getArchive("owner", "repo", "ref", filter);
+
+      expect(await reader.readFile("keep.md")).toBe("kept");
+      expect(await reader.readFile("skip.txt")).toBeNull();
+    });
+  });
+
+  describe("getArchive without fileFilter", () => {
+    it("extracts all files when no filter is provided", async () => {
+      const { service, installArchive } = setup();
+      await installArchive({
+        "root/readme.md": "# Hello",
+        "root/image.png": "binary data",
+        "root/src/index.ts": "code"
+      });
+
+      const reader = await service.getArchive("owner", "repo", "ref");
+
+      expect(await reader.readFile("readme.md")).toBe("# Hello");
+      expect(await reader.readFile("image.png")).toBe("binary data");
+      expect(await reader.readFile("src/index.ts")).toBe("code");
+    });
+  });
+
+  function setup() {
+    const logger = mock<LoggerService>();
+    const service = new GitHubArchiveService(logger);
+
+    async function installArchive(files: Record<string, string>) {
+      const zipBuffer = await createZipBuffer(files);
+
+      jest.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(new Uint8Array(zipBuffer), {
+          status: 200,
+          headers: { "Content-Type": "application/zip" }
+        })
+      );
+    }
+
+    return { service, logger, installArchive };
+  }
+
+  function createZipBuffer(files: Record<string, string>): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+      const zipfile = new yazl.ZipFile();
+
+      const dirs = new Set<string>();
+      for (const filePath of Object.keys(files)) {
+        const parts = filePath.split("/");
+        for (let i = 1; i < parts.length; i++) {
+          const dirPath = parts.slice(0, i).join("/") + "/";
+          if (!dirs.has(dirPath)) {
+            dirs.add(dirPath);
+            zipfile.addEmptyDirectory(dirPath);
+          }
+        }
+      }
+
+      for (const [filePath, content] of Object.entries(files)) {
+        zipfile.addBuffer(Buffer.from(content), filePath);
+      }
+
+      zipfile.end();
+
+      const chunks: Buffer[] = [];
+      zipfile.outputStream.on("data", (chunk: Buffer) => chunks.push(chunk));
+      zipfile.outputStream.on("end", () => resolve(Buffer.concat(chunks)));
+      zipfile.outputStream.on("error", reject);
+    });
+  }
+});

--- a/apps/api/src/template/services/github-archive/github-archive.service.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.ts
@@ -28,7 +28,8 @@ export class GitHubArchiveService {
   }
 
   async getArchive(owner: string, repo: string, ref: string, fileFilter?: (relativePath: string) => boolean): Promise<ArchiveReader> {
-    const cacheKey = `${owner}/${repo}/${ref}`;
+    const filterKey = fileFilter ? fileFilter.name || "filtered" : "unfiltered";
+    const cacheKey = `${owner}/${repo}/${ref}:${filterKey}`;
 
     const cached = this.#cache.get(cacheKey);
     if (cached) return cached;

--- a/apps/api/src/template/services/github-archive/github-archive.service.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.ts
@@ -1,0 +1,101 @@
+import JSZip from "jszip";
+
+export interface DirectoryEntry {
+  name: string;
+  path: string;
+  type: "file" | "dir";
+}
+
+export interface ArchiveReader {
+  readFile(path: string): Promise<string | null>;
+  listDirectory(path: string): DirectoryEntry[];
+}
+
+export class GitHubArchiveService {
+  readonly #cache = new Map<string, Promise<ArchiveReader>>();
+
+  async getArchive(owner: string, repo: string, ref: string): Promise<ArchiveReader> {
+    const cacheKey = `${owner}/${repo}/${ref}`;
+
+    const cached = this.#cache.get(cacheKey);
+    if (cached) return cached;
+
+    const promise = this.#downloadAndParse(owner, repo, ref);
+    this.#cache.set(cacheKey, promise);
+
+    try {
+      return await promise;
+    } catch (error) {
+      this.#cache.delete(cacheKey);
+      throw error;
+    }
+  }
+
+  async #downloadAndParse(owner: string, repo: string, ref: string): Promise<ArchiveReader> {
+    const url = `https://github.com/${owner}/${repo}/archive/${ref}.zip`;
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`Failed to download archive from ${url}: ${response.status} ${response.statusText}`);
+    }
+
+    const buffer = await response.arrayBuffer();
+    const zip = await JSZip.loadAsync(buffer);
+
+    const rootPrefix = this.#detectRootPrefix(zip);
+
+    return this.#createArchiveReader(zip, rootPrefix);
+  }
+
+  #detectRootPrefix(zip: JSZip): string {
+    const firstEntry = Object.keys(zip.files)[0];
+    if (!firstEntry) return "";
+
+    const slashIndex = firstEntry.indexOf("/");
+    if (slashIndex === -1) return "";
+
+    return firstEntry.slice(0, slashIndex + 1);
+  }
+
+  #createArchiveReader(zip: JSZip, rootPrefix: string): ArchiveReader {
+    return {
+      async readFile(path: string): Promise<string | null> {
+        const fullPath = rootPrefix + path;
+        const file = zip.file(fullPath);
+        if (!file) return null;
+        return file.async("string");
+      },
+
+      listDirectory(path: string): DirectoryEntry[] {
+        const dirPath = rootPrefix + (path ? path + "/" : "");
+        const entries: DirectoryEntry[] = [];
+        const seen = new Set<string>();
+
+        zip.forEach((relativePath, entry) => {
+          if (!relativePath.startsWith(dirPath)) return;
+
+          const remainder = relativePath.slice(dirPath.length);
+          if (!remainder) return;
+
+          const slashIndex = remainder.indexOf("/");
+          const isDirectChild = slashIndex === -1 || slashIndex === remainder.length - 1;
+          if (!isDirectChild) return;
+
+          const name = slashIndex === -1 ? remainder : remainder.slice(0, slashIndex);
+          if (seen.has(name)) return;
+          seen.add(name);
+
+          const entryPath = path ? `${path}/${name}` : name;
+
+          entries.push({
+            name,
+            path: entryPath,
+            type: entry.dir ? "dir" : "file"
+          });
+        });
+
+        return entries;
+      }
+    };
+  }
+}

--- a/apps/api/src/template/services/template-fetcher/template-fetcher.service.spec.ts
+++ b/apps/api/src/template/services/template-fetcher/template-fetcher.service.spec.ts
@@ -261,38 +261,39 @@ describe(TemplateFetcherService.name, () => {
         logo_URIs: { svg: "https://osmosis.zone/logo.svg" }
       };
 
-      mockArchive(archiveService, async () =>
-        createMockArchiveReader({
-          files: {
-            "cosmos/README.md": "# README content",
-            "cosmos/deploy.yaml": "deploy: content",
-            "osmosis/README.md": "# README content",
-            "osmosis/deploy.yaml": "deploy: content"
-          },
-          directories: {
-            "": [
-              { name: "cosmos", path: "cosmos", type: "dir" },
-              { name: "osmosis", path: "osmosis", type: "dir" },
-              { name: ".github", path: ".github", type: "dir" },
-              { name: "_scripts", path: "_scripts", type: "dir" },
-              { name: "README.md", path: "README.md", type: "file" }
-            ],
-            cosmos: [
-              { name: "README.md", path: "cosmos/README.md", type: "file" },
-              { name: "deploy.yaml", path: "cosmos/deploy.yaml", type: "file" }
-            ],
-            osmosis: [
-              { name: "README.md", path: "osmosis/README.md", type: "file" },
-              { name: "deploy.yaml", path: "osmosis/deploy.yaml", type: "file" }
-            ]
-          }
-        })
+      mockArchiveWithChainRegistry(
+        archiveService,
+        async () =>
+          createMockArchiveReader({
+            files: {
+              "cosmos/README.md": "# README content",
+              "cosmos/deploy.yaml": "deploy: content",
+              "osmosis/README.md": "# README content",
+              "osmosis/deploy.yaml": "deploy: content"
+            },
+            directories: {
+              "": [
+                { name: "cosmos", path: "cosmos", type: "dir" },
+                { name: "osmosis", path: "osmosis", type: "dir" },
+                { name: ".github", path: ".github", type: "dir" },
+                { name: "_scripts", path: "_scripts", type: "dir" },
+                { name: "README.md", path: "README.md", type: "file" }
+              ],
+              cosmos: [
+                { name: "README.md", path: "cosmos/README.md", type: "file" },
+                { name: "deploy.yaml", path: "cosmos/deploy.yaml", type: "file" }
+              ],
+              osmosis: [
+                { name: "README.md", path: "osmosis/README.md", type: "file" },
+                { name: "deploy.yaml", path: "osmosis/deploy.yaml", type: "file" }
+              ]
+            }
+          }),
+        {
+          cosmos: cosmosChainData,
+          osmosis: osmosisChainData
+        }
       );
-
-      mockFetchChainRegistry({
-        cosmos: cosmosChainData,
-        osmosis: osmosisChainData
-      });
 
       templateProcessor.processTemplate.mockReturnValue(createTemplate({ id: "processed" }));
 
@@ -311,29 +312,30 @@ describe(TemplateFetcherService.name, () => {
         logo_URIs: {}
       };
 
-      mockArchive(archiveService, async () =>
-        createMockArchiveReader({
-          files: {
-            "cosmos/README.md": "content",
-            "cosmos/deploy.yaml": "content"
-          },
-          directories: {
-            "": [
-              { name: "cosmos", path: "cosmos", type: "dir" },
-              { name: ".hidden", path: ".hidden", type: "dir" },
-              { name: "_internal", path: "_internal", type: "dir" }
-            ],
-            cosmos: [
-              { name: "README.md", path: "cosmos/README.md", type: "file" },
-              { name: "deploy.yaml", path: "cosmos/deploy.yaml", type: "file" }
-            ]
-          }
-        })
+      mockArchiveWithChainRegistry(
+        archiveService,
+        async () =>
+          createMockArchiveReader({
+            files: {
+              "cosmos/README.md": "content",
+              "cosmos/deploy.yaml": "content"
+            },
+            directories: {
+              "": [
+                { name: "cosmos", path: "cosmos", type: "dir" },
+                { name: ".hidden", path: ".hidden", type: "dir" },
+                { name: "_internal", path: "_internal", type: "dir" }
+              ],
+              cosmos: [
+                { name: "README.md", path: "cosmos/README.md", type: "file" },
+                { name: "deploy.yaml", path: "cosmos/deploy.yaml", type: "file" }
+              ]
+            }
+          }),
+        {
+          cosmos: cosmosChainData
+        }
       );
-
-      mockFetchChainRegistry({
-        cosmos: cosmosChainData
-      });
 
       templateProcessor.processTemplate.mockReturnValue(createTemplate({ id: "t1" }));
 
@@ -346,23 +348,24 @@ describe(TemplateFetcherService.name, () => {
     it("uses default summary when chain registry fetch fails", async () => {
       const { service, archiveService, templateProcessor, logger } = setup();
 
-      mockArchive(archiveService, async () =>
-        createMockArchiveReader({
-          files: {
-            "unknown-chain/README.md": "content",
-            "unknown-chain/deploy.yaml": "content"
-          },
-          directories: {
-            "": [{ name: "unknown-chain", path: "unknown-chain", type: "dir" }],
-            "unknown-chain": [
-              { name: "README.md", path: "unknown-chain/README.md", type: "file" },
-              { name: "deploy.yaml", path: "unknown-chain/deploy.yaml", type: "file" }
-            ]
-          }
-        })
+      mockArchiveWithChainRegistry(
+        archiveService,
+        async () =>
+          createMockArchiveReader({
+            files: {
+              "unknown-chain/README.md": "content",
+              "unknown-chain/deploy.yaml": "content"
+            },
+            directories: {
+              "": [{ name: "unknown-chain", path: "unknown-chain", type: "dir" }],
+              "unknown-chain": [
+                { name: "README.md", path: "unknown-chain/README.md", type: "file" },
+                { name: "deploy.yaml", path: "unknown-chain/deploy.yaml", type: "file" }
+              ]
+            }
+          }),
+        {}
       );
-
-      mockFetchChainRegistry({});
 
       templateProcessor.processTemplate.mockReturnValue(createTemplate({ id: "t1" }));
 
@@ -382,31 +385,67 @@ describe(TemplateFetcherService.name, () => {
         logo_URIs: { png: "https://first.png", svg: "https://second.svg" }
       };
 
-      mockArchive(archiveService, async () =>
-        createMockArchiveReader({
-          files: {
-            "cosmos/README.md": "content",
-            "cosmos/deploy.yaml": "content"
-          },
-          directories: {
-            "": [{ name: "cosmos", path: "cosmos", type: "dir" }],
-            cosmos: [
-              { name: "README.md", path: "cosmos/README.md", type: "file" },
-              { name: "deploy.yaml", path: "cosmos/deploy.yaml", type: "file" }
-            ]
-          }
-        })
+      mockArchiveWithChainRegistry(
+        archiveService,
+        async () =>
+          createMockArchiveReader({
+            files: {
+              "cosmos/README.md": "content",
+              "cosmos/deploy.yaml": "content"
+            },
+            directories: {
+              "": [{ name: "cosmos", path: "cosmos", type: "dir" }],
+              cosmos: [
+                { name: "README.md", path: "cosmos/README.md", type: "file" },
+                { name: "deploy.yaml", path: "cosmos/deploy.yaml", type: "file" }
+              ]
+            }
+          }),
+        {
+          cosmos: cosmosChainData
+        }
       );
-
-      mockFetchChainRegistry({
-        cosmos: cosmosChainData
-      });
 
       templateProcessor.processTemplate.mockReturnValue(createTemplate({ id: "t1" }));
 
       const result = await service.fetchOmnibusTemplates("v1");
 
       expect(result[0].templateSources[0].logoUrl).toBe("https://first.png");
+    });
+  });
+
+  describe("when archive download fails", () => {
+    it("returns empty array and logs warning instead of throwing", async () => {
+      const { service, archiveService, logger } = setup();
+      archiveService.getArchive.mockRejectedValue(new Error("Failed to download archive"));
+
+      const result = await service.fetchAwesomeAkashTemplates("v1");
+
+      expect(result).toEqual([]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "FETCH_TEMPLATES_FROM_README_FAILED",
+          repoOwner: "akash-network",
+          repoName: "awesome-akash",
+          repoVersion: "v1"
+        })
+      );
+    });
+
+    it("returns empty array for linux server templates when archive fails", async () => {
+      const { service, archiveService, logger } = setup();
+      archiveService.getArchive.mockRejectedValue(new Error("Network error"));
+
+      const result = await service.fetchLinuxServerTemplates("v1");
+
+      expect(result).toEqual([]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "FETCH_TEMPLATES_FROM_README_FAILED",
+          repoOwner: "cryptoandcoffee",
+          repoName: "akash-linuxserver"
+        })
+      );
     });
   });
 
@@ -565,21 +604,26 @@ describe(TemplateFetcherService.name, () => {
     archiveService.getArchive.mockImplementation(factory);
   }
 
-  function mockFetchChainRegistry(chains: Record<string, Partial<GithubChainRegistryChainResponse>>) {
-    const originalFetch = globalThis.fetch;
-    jest.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-      if (url.startsWith("https://raw.githubusercontent.com/cosmos/chain-registry/master/")) {
-        const chainPath = url.replace("https://raw.githubusercontent.com/cosmos/chain-registry/master/", "").replace("/chain.json", "");
-        if (Object.hasOwn(chains, chainPath)) {
-          return new Response(JSON.stringify(chains[chainPath]), {
-            status: 200,
-            headers: { "Content-Type": "application/json" }
-          });
-        }
-        return new Response("Not Found", { status: 404 });
+  function mockArchiveWithChainRegistry(
+    archiveService: ReturnType<typeof mock<GitHubArchiveService>>,
+    templateFactory: () => Promise<ArchiveReader>,
+    chains: Record<string, Partial<GithubChainRegistryChainResponse>>
+  ) {
+    const chainRegistryFiles: Record<string, string> = {};
+    for (const [chainPath, data] of Object.entries(chains)) {
+      chainRegistryFiles[`${chainPath}/chain.json`] = JSON.stringify(data);
+    }
+
+    const chainRegistryReader = createMockArchiveReader({
+      files: chainRegistryFiles,
+      directories: {}
+    });
+
+    archiveService.getArchive.mockImplementation(async (owner, repo) => {
+      if (owner === "cosmos" && repo === "chain-registry") {
+        return chainRegistryReader;
       }
-      return originalFetch(input, init);
+      return templateFactory();
     });
   }
 

--- a/apps/api/src/template/services/template-fetcher/template-fetcher.service.ts
+++ b/apps/api/src/template/services/template-fetcher/template-fetcher.service.ts
@@ -63,6 +63,10 @@ export class TemplateFetcherService {
     return this.#githubRequestsRemaining;
   }
 
+  clearArchiveCache(): void {
+    this.#archiveService.clearCache();
+  }
+
   async fetchLatestCommitSha(repository: keyof typeof REPOSITORIES) {
     const { repoOwner, repoName, mainBranch } = REPOSITORIES[repository];
     const response = await this.#octokit.rest.repos.getBranch({

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.spec.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.spec.ts
@@ -18,16 +18,14 @@ describe(TemplateGalleryService.name, () => {
       const { service, templateFetcher } = setup();
       const awesomeAkashTemplates = [createCategory({ title: "AI", templates: [{ id: "ai-1" }] })];
       const omnibusTemplates = [createCategory({ title: "Blockchain", templates: [{ id: "blockchain-1" }] })];
-      const linuxServerTemplates = [createCategory({ title: "Media", templates: [{ id: "media-1" }] })];
 
       templateFetcher.fetchAwesomeAkashTemplates.mockResolvedValue(awesomeAkashTemplates);
       templateFetcher.fetchOmnibusTemplates.mockResolvedValue(omnibusTemplates);
-      templateFetcher.fetchLinuxServerTemplates.mockResolvedValue(linuxServerTemplates);
 
       const result = await service.getTemplateGallery();
 
-      expect(result).toHaveLength(3);
-      expect(result.map(c => c.title)).toEqual(["Blockchain", "AI", "Media"]);
+      expect(result).toHaveLength(2);
+      expect(result.map(c => c.title)).toEqual(["Blockchain", "AI"]);
     });
 
     it("throws error when fetch fails", async () => {
@@ -57,7 +55,6 @@ describe(TemplateGalleryService.name, () => {
       expect(result[0].title).toBe("Cached");
       expect(templateFetcher.fetchAwesomeAkashTemplates).not.toHaveBeenCalled();
       expect(templateFetcher.fetchOmnibusTemplates).not.toHaveBeenCalled();
-      expect(templateFetcher.fetchLinuxServerTemplates).not.toHaveBeenCalled();
     });
 
     it("handles concurrent calls by sharing the same promise", async () => {
@@ -72,7 +69,6 @@ describe(TemplateGalleryService.name, () => {
       expect(result2).toEqual(result3);
       expect(templateFetcher.fetchAwesomeAkashTemplates).toHaveBeenCalledTimes(1);
       expect(templateFetcher.fetchOmnibusTemplates).toHaveBeenCalledTimes(1);
-      expect(templateFetcher.fetchLinuxServerTemplates).toHaveBeenCalledTimes(1);
     });
 
     it("returns cached gallery on filesystem if github request for latest commit sha fails", async () => {
@@ -262,8 +258,7 @@ describe(TemplateGalleryService.name, () => {
     const templateFetcher = mock<TemplateFetcherService>({
       fetchLatestCommitSha: jest.fn(() => Promise.resolve("abc123")),
       fetchAwesomeAkashTemplates: jest.fn(() => Promise.resolve([])),
-      fetchOmnibusTemplates: jest.fn(() => Promise.resolve([])),
-      fetchLinuxServerTemplates: jest.fn(() => Promise.resolve([]))
+      fetchOmnibusTemplates: jest.fn(() => Promise.resolve([]))
     });
 
     // HACK: assigning private properties to the service object. will refactor later

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.ts
@@ -134,7 +134,7 @@ export class TemplateGalleryService {
         event: "GET_TEMPLATE_GALLERY_START",
         msg: "Getting template gallery"
       });
-      const [awesomeAkashTemplates, omnibusTemplates, linuxServerTemplates] = await Promise.all([
+      const [awesomeAkashTemplates, omnibusTemplates] = await Promise.all([
         this.getTemplatesFromRepo({
           repository: "awesome-akash",
           fetchTemplates: this.templateFetcher.fetchAwesomeAkashTemplates.bind(this.templateFetcher)
@@ -142,14 +142,10 @@ export class TemplateGalleryService {
         this.getTemplatesFromRepo({
           repository: "cosmos-omnibus",
           fetchTemplates: this.templateFetcher.fetchOmnibusTemplates.bind(this.templateFetcher)
-        }),
-        this.getTemplatesFromRepo({
-          repository: "akash-linuxserver",
-          fetchTemplates: this.templateFetcher.fetchLinuxServerTemplates.bind(this.templateFetcher)
         })
       ]);
 
-      const templateGallery = this.templateProcessor.mergeTemplateCategories(omnibusTemplates, awesomeAkashTemplates, linuxServerTemplates);
+      const templateGallery = this.templateProcessor.mergeTemplateCategories(omnibusTemplates, awesomeAkashTemplates);
       const categories = templateGallery.map(({ templateSources, ...category }) => category);
 
       this.#logger.debug({

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.ts
@@ -34,7 +34,7 @@ export class TemplateGalleryService {
     this.#fs = fs;
     this.templateProcessor = new TemplateProcessorService();
     this.templateFetcher = options.githubPAT
-      ? new TemplateFetcherService(this.templateProcessor, this.#logger, getOctokit, new GitHubArchiveService(), {
+      ? new TemplateFetcherService(this.templateProcessor, this.#logger, getOctokit, new GitHubArchiveService(this.#logger), {
           githubPAT: options.githubPAT,
           categoryProcessingConcurrency: options.categoryProcessingConcurrency,
           templateSourceProcessingConcurrency: options.templateSourceProcessingConcurrency

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.ts
@@ -74,6 +74,13 @@ export class TemplateGalleryService {
     return this.#galleriesCache;
   }
 
+  async refreshCache(categoriesSchema: z.ZodSchema): Promise<void> {
+    await this.buildTemplateGalleryCache(categoriesSchema);
+    this.#galleriesCache = null;
+    this.#parsedTemplates = {};
+    this.templateFetcher?.clearArchiveCache();
+  }
+
   async buildTemplateGalleryCache(categoriesSchema: z.ZodSchema): Promise<GalleriesCache> {
     const gallery = await this.getTemplateGallery();
     const result = gallery.reduce<{ templates: Template[]; categories: FinalCategory[] }>(

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.ts
@@ -7,6 +7,7 @@ import type z from "zod";
 import type { LoggerService } from "@src/core";
 import type { Category, FinalCategory, Template } from "@src/template/types/template";
 import { reusePendingPromise } from "../../../caching/helpers.ts";
+import { GitHubArchiveService } from "../github-archive/github-archive.service.ts";
 import { REPOSITORIES, TemplateFetcherService } from "../template-fetcher/template-fetcher.service.ts";
 import { TemplateProcessorService } from "../template-processor/template-processor.service.ts";
 
@@ -33,7 +34,7 @@ export class TemplateGalleryService {
     this.#fs = fs;
     this.templateProcessor = new TemplateProcessorService();
     this.templateFetcher = options.githubPAT
-      ? new TemplateFetcherService(this.templateProcessor, this.#logger, getOctokit, {
+      ? new TemplateFetcherService(this.templateProcessor, this.#logger, getOctokit, new GitHubArchiveService(), {
           githubPAT: options.githubPAT,
           categoryProcessingConcurrency: options.categoryProcessingConcurrency,
           templateSourceProcessingConcurrency: options.templateSourceProcessingConcurrency

--- a/apps/api/src/template/services/template-refresh/template-refresh.service.ts
+++ b/apps/api/src/template/services/template-refresh/template-refresh.service.ts
@@ -1,0 +1,59 @@
+import type { Disposable } from "tsyringe";
+
+import type { LoggerService } from "@src/core";
+import type { AppInitializer } from "@src/core/providers/app-initializer";
+import { ON_APP_START } from "@src/core/providers/app-initializer";
+import { GetTemplatesListResponseSchema } from "@src/template/http-schemas/template.schema";
+import type { TemplateConfig } from "../../config/env.config";
+import type { TemplateGalleryService } from "../template-gallery/template-gallery.service";
+
+const categoriesSchema = GetTemplatesListResponseSchema.shape.data;
+
+export class TemplateRefreshService implements AppInitializer, Disposable {
+  #timeout: ReturnType<typeof setTimeout> | null = null;
+  #disposed = false;
+
+  constructor(
+    private readonly templateGalleryService: TemplateGalleryService,
+    private readonly logger: LoggerService,
+    private readonly config: TemplateConfig
+  ) {}
+
+  async [ON_APP_START](): Promise<void> {
+    if (!this.config.GITHUB_PAT) {
+      this.logger.info({ event: "TEMPLATE_REFRESH_DISABLED", message: "GITHUB_PAT not configured, template refresh disabled" });
+      return;
+    }
+
+    this.logger.info({
+      event: "TEMPLATE_REFRESH_REGISTERED",
+      message: `Template refresh scheduled every ${this.config.TEMPLATE_REFRESH_INTERVAL_SECONDS}s`
+    });
+
+    this.#scheduleNext();
+  }
+
+  dispose(): void {
+    this.#disposed = true;
+    if (this.#timeout) {
+      clearTimeout(this.#timeout);
+      this.#timeout = null;
+    }
+  }
+
+  #scheduleNext(): void {
+    if (this.#disposed) return;
+
+    this.#timeout = setTimeout(async () => {
+      try {
+        this.logger.info({ event: "TEMPLATE_REFRESH_START" });
+        await this.templateGalleryService.refreshCache(categoriesSchema);
+        this.logger.info({ event: "TEMPLATE_REFRESH_COMPLETE" });
+      } catch (error) {
+        this.logger.error({ event: "TEMPLATE_REFRESH_ERROR", error });
+      } finally {
+        this.#scheduleNext();
+      }
+    }, this.config.TEMPLATE_REFRESH_INTERVAL_SECONDS * 1000);
+  }
+}

--- a/apps/api/src/template/services/template-refresh/template-refresh.service.ts
+++ b/apps/api/src/template/services/template-refresh/template-refresh.service.ts
@@ -20,6 +20,11 @@ export class TemplateRefreshService implements AppInitializer, Disposable {
   ) {}
 
   async [ON_APP_START](): Promise<void> {
+    if (!this.config.TEMPLATE_REFRESH_ENABLED) {
+      this.logger.info({ event: "TEMPLATE_REFRESH_DISABLED", message: "Template refresh disabled via TEMPLATE_REFRESH_ENABLED" });
+      return;
+    }
+
     if (!this.config.GITHUB_PAT) {
       this.logger.info({ event: "TEMPLATE_REFRESH_DISABLED", message: "GITHUB_PAT not configured, template refresh disabled" });
       return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
         "human-interval": "^2.0.1",
         "js-yaml": "^4.1.1",
         "jsonwebtoken": "^9.0.2",
+        "jszip": "^3.10.1",
         "lodash": "^4.17.21",
         "lru-cache": "^11.1.0",
         "markdown-to-txt": "^2.0.1",
@@ -381,6 +382,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.0.tgz",
       "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -2678,6 +2680,7 @@
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-8.3.0.tgz",
       "integrity": "sha512-hmC3u0anySPI+As+wFGrKG38pXnXAUqyiitnYeYknEOslcDM96AkBdMNxKYOopecuP/v1HMbclUEq8/DKKn+6w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.16"
       }
@@ -5293,6 +5296,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.4.0.tgz",
       "integrity": "sha512-KtcyFHssTn5ZgDu6SXmUznS80OFs/wN7y6MyFRRcKU6TOw8hNcGxKvt8hsdaLJfhzUszNSjURetq5Qpkad14Gw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -7779,6 +7783,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.4.0.tgz",
       "integrity": "sha512-KtcyFHssTn5ZgDu6SXmUznS80OFs/wN7y6MyFRRcKU6TOw8hNcGxKvt8hsdaLJfhzUszNSjURetq5Qpkad14Gw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -9189,6 +9194,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.1.tgz",
       "integrity": "sha512-JzhkaTvM73m2K1URT6tv53k2RwngSmCXLZJgK580qNQOXRzZRR/BCMfZw3h+90JpnG6XksP5bYT+cz0rpUzUWQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -9765,6 +9771,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.0.1.tgz",
       "integrity": "sha512-MaZk9SJIDgo1peKevlbhP6+IwIiNPNmswNL4AF0WaQJLbHXjr9SrZMgS12+iqr9ToV4ZVosCcc0f8Rg67LXjxw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -12340,6 +12347,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -13824,6 +13832,7 @@
     "node_modules/@babel/preset-env": {
       "version": "7.24.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.24.7",
         "@babel/helper-compilation-targets": "^7.24.7",
@@ -14126,13 +14135,15 @@
       "resolved": "https://registry.npmjs.org/@biomejs/wasm-nodejs/-/wasm-nodejs-1.9.4.tgz",
       "integrity": "sha512-ZqNlhKcZW6MW1LxWIOfh9YVrBykvzyFad3bOh6JJFraDnNa3NXboRDiaI8dmrbb0ZHXCU1Tsq6WQsKV2Vpp5dw==",
       "dev": true,
-      "license": "MIT OR Apache-2.0"
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.9.0.tgz",
       "integrity": "sha512-rnJenoStJ8nvmt9Gzye8nkYd6V22xUAnu4086ER7h1zJ508vStko4pMvDeQ446ilDTFpV5wnoc5YS7XvMwwMqA==",
-      "license": "(Apache-2.0 AND BSD-3-Clause)"
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@casl/ability": {
       "version": "6.7.2",
@@ -14410,6 +14421,7 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -14670,6 +14682,7 @@
       "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.0.tgz",
       "integrity": "sha512-xhiwnYlJNHzmFsRw+iSPIwXR/xweTvTw8x5HiwWp10sbVtd4OpOXbRgE7V58xs1EC17fzusF1f5uOAy24OkBuA==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -14692,6 +14705,7 @@
       "resolved": "https://registry.npmjs.org/@cosmjs/amino/-/amino-0.32.4.tgz",
       "integrity": "sha512-zKYOt6hPy8obIFtLie/xtygCkH9ZROiQ12UHfKsOkWaZfPQUvVbtgmu6R4Kn1tFLI/SRkw7eqhaogmW/3NYu/Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
@@ -14877,6 +14891,7 @@
       "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.36.2.tgz",
       "integrity": "sha512-dyZsgZBQgGkaE4cazHVX8GDwrRJVKUVDnrODkyFXVNbxMnm4t6nxpK1qwgY9GHlWUhck3Dh9NT3BoMbXiMYTZQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.36.2",
         "@cosmjs/crypto": "^0.36.2",
@@ -15004,6 +15019,7 @@
       "resolved": "https://registry.npmjs.org/@cosmjs/stargate/-/stargate-0.36.2.tgz",
       "integrity": "sha512-vnNK4dXF+s2v1aKPfYxKVrvXPcnBQb8rPoBScnTpPWnRt3XXbLw7Oo6fTQQWwKYNKQzi6DOApeEB+bCYcaPAAw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.36.2",
         "@cosmjs/encoding": "^0.36.2",
@@ -15227,6 +15243,7 @@
       "resolved": "https://registry.npmjs.org/@cosmjs/proto-signing/-/proto-signing-0.32.4.tgz",
       "integrity": "sha512-QdyQDbezvdRI4xxSlyM1rSVBO2st5sqtbEIl3IX03uJ7YiZIQHyv6vaHVf1V4mapusCqguiHJzm4N4gsFdLBbQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -15731,6 +15748,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -15753,6 +15771,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15839,6 +15858,7 @@
     "node_modules/@dotenvx/dotenvx/node_modules/picomatch": {
       "version": "4.0.2",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15955,6 +15975,7 @@
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -15968,6 +15989,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.4.tgz",
       "integrity": "sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -16006,6 +16028,7 @@
       "version": "11.11.0",
       "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.11.0.tgz",
       "integrity": "sha512-6q89fj2z8VBTx9w93kJ5n51hsmtYuFPtZgnc1L8VzRx9ti4EU6EyvF6Nn1H1x3vcCQCF7u2dB2lY4AYJwUW4PA==",
+      "peer": true,
       "dependencies": {
         "@emotion/utils": "^1.2.1",
         "html-tokenize": "^2.0.0",
@@ -16030,6 +16053,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.5.tgz",
       "integrity": "sha512-/ZjjnaNKvuMPxcIiUkf/9SHoG4Q196DRl1w82hQ3WCsjo1IUR8uaGWrC6a87CrYAW0Kb/pK7hk8BnLgLRi9KoQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -17088,6 +17112,7 @@
           "url": "https://opencollective.com/fakerjs"
         }
       ],
+      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=6.14.13"
@@ -17250,6 +17275,7 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.10.11.tgz",
       "integrity": "sha512-3RaoxOqkHHN2c05bwtBNVJmOf/UwMam0rZYtdl7dsRpsvDwcNpv6LkGgzltQ7xVf822LzBoKEPRvf4D7+xeIDw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -18256,6 +18282,7 @@
       "version": "1.23.31",
       "resolved": "https://registry.npmjs.org/@interchain-ui/react/-/react-1.23.31.tgz",
       "integrity": "sha512-7vyp0PaWr0VJzcC26D71Fr9OgOQLG5amV8zSV0XQSmBg3fRIwDSs4Mtn5ThASA2/2yWY3kqtZsNYNIMCQ8xjYg==",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.6.4",
         "@floating-ui/dom": "^1.6.7",
@@ -18955,6 +18982,7 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -19183,6 +19211,7 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
         "@jest/types": "^29.6.3",
@@ -20097,6 +20126,7 @@
     "node_modules/@mui/material": {
       "version": "5.15.20",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/base": "5.0.0-beta.40",
@@ -20888,6 +20918,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.3.tgz",
       "integrity": "sha512-ogEK+GriWodIwCw6buQ1rpcH4Kx+G7YQ9EwuPySI3rS05pSdtQ++UhucjusSI9apNidv+QURBztJkRecwwJQXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.0.0",
         "iterare": "1.2.1",
@@ -20992,6 +21023,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.0.11.tgz",
       "integrity": "sha512-jMH3jrjrPiaGrkQ5hANNcgDWN+j+hcM5GMQ3jSs4vOWNs3lmKHTVR11wJ9y5tTNnwKydzMogeju0VTUdfXDI5Q==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -21059,6 +21091,7 @@
       "version": "11.0.11",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.0.11.tgz",
       "integrity": "sha512-iv6nH66i/RuRQufg5UUboQ4jQX4NuuePrYQpHB3ueiEIhJm2yLhhNYM6Y2l/76y9woW2eckbiqbzmW/JajAgeQ==",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.0.1",
@@ -22215,6 +22248,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -22473,6 +22507,7 @@
       "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -22718,6 +22753,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -22739,6 +22775,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -22751,6 +22788,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -23472,6 +23510,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
       "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -25332,6 +25371,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
       "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -25548,6 +25588,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -25651,6 +25692,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
       "integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -29382,6 +29424,7 @@
       "integrity": "sha512-3arRdUp1fNx55itnjKiUhO6t4Mf91TsrTIYINDNLAZPS0TPd5YpiXRctwjel0qqWoOOhjA34cZ3m4dksLDFUYg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@redocly/ajv": "^8.11.2",
         "@redocly/config": "^0.22.0",
@@ -29552,6 +29595,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -30093,7 +30137,6 @@
       "resolved": "https://registry.npmjs.org/@scure/starknet/-/starknet-1.1.0.tgz",
       "integrity": "sha512-83g3M6Ix2qRsPN4wqLDqiRZ2GBNbjVWfboJE/9UjfG+MHr6oDSu/CWgy8hsBSJejr09DkkL+l0Ze4KVrlCIdtQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/curves": "~1.7.0",
         "@noble/hashes": "~1.6.0"
@@ -30107,7 +30150,6 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
       "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.6.0"
       },
@@ -30123,7 +30165,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
       "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -30136,7 +30177,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
       "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -31092,16 +31132,14 @@
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
       "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-08": {
       "name": "@starknet-io/types-js",
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.8.4.tgz",
       "integrity": "sha512-0RZ3TZHcLsUTQaq1JhDSCM8chnzO4/XNsSCozwDET64JK5bjFDIf2ZUkta+tl5Nlbf4usoU7uZiDI/Q57kt2SQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@streamparser/json": {
       "version": "0.0.20",
@@ -31140,6 +31178,7 @@
       "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.6.0.tgz",
       "integrity": "sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@xhmikosr/bin-wrapper": "^13.0.5",
@@ -31193,6 +31232,7 @@
       "integrity": "sha512-Si27CiYwqJSF3K0HgxugQnjHNfH7YqqD89V+fLpyRHr81uTmCQpF0bnVdRMQ2SGAkCFJACYETRiBSrZOQ660+Q==",
       "devOptional": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.19"
@@ -31236,7 +31276,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31252,7 +31291,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31268,7 +31306,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31284,7 +31321,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31300,7 +31336,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31316,7 +31351,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31332,7 +31366,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31348,7 +31381,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31364,7 +31396,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31380,7 +31411,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -31394,6 +31424,7 @@
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
       "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
@@ -31439,6 +31470,7 @@
       "version": "5.67.2",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.67.2.tgz",
       "integrity": "sha512-+iaFJ/pt8TaApCk6LuZ0WHS/ECVfTzrxDOEL9HH9Dayyb5OVuomLzDXeSaI2GlGT/8HN7bDGiRXDts3LV+u6ww==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -31448,6 +31480,7 @@
       "version": "5.67.2",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.67.2.tgz",
       "integrity": "sha512-6Sa+BVNJWhAV4QHvIqM73norNeGRWGC3ftN0Ix87cmMvI215I1wyJ44KUTt/9a0V9YimfGcg25AITaYVel71Og==",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.67.2"
       },
@@ -31523,6 +31556,7 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -31798,6 +31832,7 @@
       "version": "7.20.5",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -32306,6 +32341,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
       "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -32400,6 +32436,7 @@
     "node_modules/@types/react": {
       "version": "18.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -32409,6 +32446,7 @@
     "node_modules/@types/react-dom": {
       "version": "18.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -32596,7 +32634,8 @@
     },
     "node_modules/@types/validator": {
       "version": "13.11.10",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/webpack-node-externals": {
       "version": "3.0.4",
@@ -33215,6 +33254,7 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@vanilla-extract/css/-/css-1.17.1.tgz",
       "integrity": "sha512-tOHQXHm10FrJeXKFeWE09JfDGN/tvV6mbjwoNB9k03u930Vg021vTnbrCwVLkECj9Zvh/SHLBHJ4r2flGqfovw==",
+      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@vanilla-extract/private": "^1.0.6",
@@ -33239,6 +33279,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@vanilla-extract/dynamic/-/dynamic-2.1.2.tgz",
       "integrity": "sha512-9BGMciD8rO1hdSPIAh1ntsG4LPD3IYKhywR7VOmmz9OO4Lx1hlwkSg3E6X07ujFx7YuBfx0GDQnApG9ESHvB2A==",
+      "peer": true,
       "dependencies": {
         "@vanilla-extract/private": "^1.0.6"
       }
@@ -33764,6 +33805,7 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.11.0.tgz",
       "integrity": "sha512-AB5b1lrEbCGHxqS2vqfCkIoODieH+ZAUp9rA1O2ftrhnqDJiJK983Df87JhYhECsQUBHHfALphA8ydER0q+9sw==",
+      "peer": true,
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -34409,7 +34451,6 @@
       "resolved": "https://registry.npmjs.org/abi-wan-kanabi/-/abi-wan-kanabi-2.2.4.tgz",
       "integrity": "sha512-0aA81FScmJCPX+8UvkXLki3X1+yPQuWxEkqXBVKltgPAK79J+NB+Lp5DouMXa7L6f+zcRlIA/6XO7BN/q9fnvg==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "ansicolors": "^0.3.2",
         "cardinal": "^2.1.1",
@@ -34425,7 +34466,6 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -34501,6 +34541,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -34596,6 +34637,7 @@
     "node_modules/ajv": {
       "version": "6.12.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -34747,6 +34789,7 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -34789,8 +34832,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ansis": {
       "version": "3.16.0",
@@ -35329,6 +35371,7 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/transform": "^29.7.0",
         "@types/babel__core": "^7.1.14",
@@ -36117,6 +36160,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -36565,6 +36609,7 @@
     "node_modules/camelcase": {
       "version": "5.3.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -36600,7 +36645,6 @@
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
       "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
@@ -37309,6 +37353,7 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -37819,7 +37864,8 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/cosmjs-types/-/cosmjs-types-0.9.0.tgz",
       "integrity": "sha512-MN/yUe6mkJwHnCFfsNPeCfXVhyxHYW6c/xDUzrSbBycYzw++XvWDMJArXp2pLdgD6FQ8DW79vkPjeNKVrXaHeQ==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
@@ -38088,7 +38134,8 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/csv-stringify": {
       "version": "6.6.0",
@@ -38231,7 +38278,8 @@
     "node_modules/d3-selection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
-      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA=="
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+      "peer": true
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
@@ -38444,6 +38492,7 @@
     "node_modules/date-fns": {
       "version": "2.30.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -39252,6 +39301,7 @@
       "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.31.2.tgz",
       "integrity": "sha512-QnenevbnnAzmbNzQwbhklvIYrDE8YER8K7kSrAWQSV1YvFCdSQPzj+jzqRdTSsV2cDqSpQ0NXGyL1G9I43LDLg==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=3",
@@ -39886,6 +39936,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -40162,6 +40213,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -40195,6 +40247,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.10.0.tgz",
       "integrity": "sha512-5ej+0WILhX3D6wkcdsyYmPp10SUIK6fmuZ6KS8nf9MD8CJ6/S/3Dl7m21g+MLeaTMsvcEXo3JunNAbgHwXxs/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pkgr/core": "^0.2.0",
         "@types/doctrine": "^0.0.9",
@@ -42414,6 +42467,7 @@
       "resolved": "https://registry.npmjs.org/gel/-/gel-2.0.2.tgz",
       "integrity": "sha512-XTKpfNR9HZOw+k0Bl04nETZjuP5pypVAXsZADSdwr3EtyygTTe1RqvftU2FjGu7Tp9e576a9b/iIOxWrRBxMiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@petamoriken/float16": "^3.8.7",
         "debug": "^4.3.4",
@@ -42709,34 +42763,6 @@
         "conventional-commits-parser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/conventional-commits-filter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/git-semver-tags/node_modules/conventional-commits-parser": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.2.1.tgz",
-      "integrity": "sha512-20pyHgnO40rvfI0NGF/xiEoFMkXDtkF8FwHvk5BokoFoCuTQRI8vrNCNFWUOfuolKJMm1tPCHc8GgYEtr1XRNA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "meow": "^13.0.0"
-      },
-      "bin": {
-        "conventional-commits-parser": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/git-semver-tags/node_modules/meow": {
@@ -43548,6 +43574,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.6.12.tgz",
       "integrity": "sha512-eHtf4kSDNw6VVrdbd5IQi16r22m3s7mWPLd7xOMhg1a/Yyb1A0qpUFq8xYMX4FMuDe1nTKeMX5rTx7Nmw+a+Ag==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -43923,6 +43950,7 @@
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
       "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -45138,6 +45166,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -45836,6 +45865,7 @@
     "node_modules/jiti": {
       "version": "1.21.3",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -46150,6 +46180,7 @@
       "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "acorn": "^8.8.1",
@@ -46252,6 +46283,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -46482,6 +46514,7 @@
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
       "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
       "dependencies": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -47367,8 +47400,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.3.0.tgz",
       "integrity": "sha512-ToxOC+SsduRmdSuoLZLYAr5zy1Qu7l5XhmPWM3zefCZ5IcrzW/h108qbJUKfOlDlhvhjUK84+8PSVX0kxnit0g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lowercase-keys": {
       "version": "3.0.0",
@@ -49946,6 +49978,7 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
       "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -50371,6 +50404,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
       "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
@@ -51522,6 +51556,7 @@
       "resolved": "https://registry.npmjs.org/ora/-/ora-8.1.1.tgz",
       "integrity": "sha512-YWielGi1XzG1UTvOaCFaNgEnuhZVMSHYkW/FQ7UX8O26PtlpdM84c0f7wLPlkvx2RfiQmnzd61d/MGxmpQeJPw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "cli-cursor": "^5.0.0",
@@ -52051,6 +52086,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -52494,7 +52530,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -52549,6 +52584,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -52690,6 +52726,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -52809,6 +52846,7 @@
     "node_modules/prettier": {
       "version": "3.3.1",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -53007,6 +53045,7 @@
     "node_modules/prop-types": {
       "version": "15.8.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -53505,6 +53544,7 @@
     "node_modules/react": {
       "version": "18.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -53620,6 +53660,7 @@
     "node_modules/react-dom": {
       "version": "18.2.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -53663,6 +53704,7 @@
       "version": "7.52.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.2.tgz",
       "integrity": "sha512-pqfPEbERnxxiNMPd0bzmt1tuaPcVccywFDpyk2uV5xCIBphHV5T8SVnX9/o3kplPE1zzKt77+YIoq+EMwJp56A==",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -54266,14 +54308,14 @@
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
       "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esprima": "~4.0.0"
       }
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
@@ -54518,6 +54560,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@iarna/toml": "2.2.5",
         "@octokit/rest": "20.1.1",
@@ -54563,6 +54606,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
       "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -55572,6 +55616,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -55730,6 +55775,7 @@
     "node_modules/rxjs": {
       "version": "7.8.1",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -55870,6 +55916,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -57290,7 +57337,6 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
       "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.6.0"
       },
@@ -57306,7 +57352,6 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
       "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -57319,7 +57364,6 @@
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.1.tgz",
       "integrity": "sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -57996,6 +58040,7 @@
     "node_modules/tailwindcss": {
       "version": "3.4.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -58652,6 +58697,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -59010,8 +59056,7 @@
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
       "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -59019,6 +59064,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -60583,6 +60629,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -61021,6 +61068,7 @@
       "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-3.7.6.tgz",
       "integrity": "sha512-ft3KpFySRL7kY07DL9INh9q0E1hZj+ORR69ZCKpdeag0byn6gR7TMZenS1yF3Lh4zSNpTnprSjb8mmr3Nx3deg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tiny-emitter": "^2.1.0",
         "uuid": "^9.0.1"
@@ -61845,6 +61893,7 @@
       "version": "5.98.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -61948,6 +61997,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",
@@ -62402,6 +62452,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -62693,6 +62744,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
       "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -62772,7 +62824,8 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
       "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
-      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead."
+      "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
+      "peer": true
     },
     "node_modules/xterm-addon-fit": {
       "version": "0.7.0",
@@ -62798,6 +62851,7 @@
       "version": "1.10.2",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -62879,6 +62933,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
       "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -134,6 +134,7 @@
         "@types/semver": "^7.5.2",
         "@types/uuid": "^8.3.1",
         "@types/yauzl": "^2.10.3",
+        "@types/yazl": "^3.3.0",
         "@typescript-eslint/eslint-plugin": "^7.12.0",
         "dot-object": "^2.1.5",
         "drizzle-kit": "^0.22.7",
@@ -152,7 +153,8 @@
         "ts-jest": "^29.1.4",
         "tsup": "^8.5.1",
         "type-fest": "^4.26.1",
-        "typescript": "~5.8.2"
+        "typescript": "~5.8.2",
+        "yazl": "^3.3.1"
       }
     },
     "apps/api/node_modules/@akashnetwork/chain-sdk": {
@@ -32690,6 +32692,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/yazl": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@types/yazl/-/yazl-3.3.0.tgz",
+      "integrity": "sha512-mFL6lGkk2N5u5nIxpNV/K5LW3qVSbxhJrMxYGOOxZndWxMgCamr/iCsq/1t9kd8pEwhuNP91LC5qZm/qS9pOEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.12.0",
       "license": "MIT",
@@ -62905,6 +62917,26 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
+      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "^1.0.0"
+      }
+    },
+    "node_modules/yazl/node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/yn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,6 @@
         "human-interval": "^2.0.1",
         "js-yaml": "^4.1.1",
         "jsonwebtoken": "^9.0.2",
-        "jszip": "^3.10.1",
         "lodash": "^4.17.21",
         "lru-cache": "^11.1.0",
         "markdown-to-txt": "^2.0.1",
@@ -112,6 +111,7 @@
         "tsyringe": "^4.10.0",
         "unleash-client": "^6.6.0",
         "uuid": "^9.0.1",
+        "yauzl": "^3.2.0",
         "zod": "3.*"
       },
       "devDependencies": {
@@ -133,6 +133,7 @@
         "@types/pg": "^8.11.6",
         "@types/semver": "^7.5.2",
         "@types/uuid": "^8.3.1",
+        "@types/yauzl": "^2.10.3",
         "@typescript-eslint/eslint-plugin": "^7.12.0",
         "dot-object": "^2.1.5",
         "drizzle-kit": "^0.22.7",
@@ -32679,6 +32680,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.12.0",
       "license": "MIT",
@@ -36235,7 +36246,6 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -52071,8 +52081,7 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
@@ -62890,7 +62899,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
       "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
-      "dev": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "pend": "~1.2.0"


### PR DESCRIPTION
## Summary
- Replaces hundreds of individual Octokit `repos.getContent` API calls per refresh cycle with 3 ZIP archive downloads from GitHub's CDN (not rate-limited)
- Adds `GitHubArchiveService` that downloads and parses repo archives using `yauzl`, providing `readFile()` and `listDirectory()` via an `ArchiveReader` interface
- Chain registry metadata now fetched from `raw.githubusercontent.com` instead of the GitHub API
- Adds periodic template gallery refresh (default 15-minute TTL) via `TemplateRefreshService`, so new templates appear without redeploying the API
- Extracts `TemplateGalleryService` into a shared DI singleton so the controller and refresh service operate on the same in-memory cache
- Uses a `setTimeout` chain (not `setInterval`) to guarantee no overlapping refreshes and clean disposal on shutdown
- Refresh is a no-op if `GITHUB_PAT` is not configured

### How the refresh works
1. Every 15 minutes (configurable via `TEMPLATE_REFRESH_INTERVAL_SECONDS`), the refresh service calls `TemplateGalleryService.refreshCache()`
2. `refreshCache()` rebuilds the cache file (SHA-based — skips ZIP download if nothing changed), then resets in-memory caches (`#galleriesCache`, `#parsedTemplates`) and clears the `GitHubArchiveService` archive cache to free old entries
3. The next request reads the fresh cache file; requests during refresh continue serving the old in-memory data

### New files
| File | Purpose |
|------|---------|
| `providers/template-gallery.provider.ts` | Shared singleton `TemplateGalleryService` via DI |
| `providers/template-refresh.provider.ts` | Registers `TemplateRefreshService` as `APP_INITIALIZER` with `DisposableRegistry` |
| `services/template-refresh/template-refresh.service.ts` | `setTimeout`-chain periodic refresh with error logging and dispose cleanup |

## Test plan
- [x] TypeScript type checking passes (`npx tsc --noEmit`)
- [x] All 73 template unit tests pass
- [ ] Manual test: start API with `GITHUB_PAT` set, verify "TEMPLATE_REFRESH_REGISTERED" log appears, temporarily set `TEMPLATE_REFRESH_INTERVAL_SECONDS=30` and confirm refresh logs appear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Archive-based repository retrieval for template content (new archive service)
  * Automatic periodic template cache refresh (configurable via env)

* **Improvements**
  * Template fetching now uses archive reads for more reliable listings and file access
  * Service wiring updated to support cache/refresh lifecycle and simplified gallery sources (legacy linux-server removed)

* **Tests**
  * Tests migrated to archive-based mocks and expanded for archive error scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->