### PR TITLE
refactor: removes legacy stats from provider responses

### DIFF
--- a/apps/api/src/dashboard/controllers/dashboard-data/dashboard-data.controller.ts
+++ b/apps/api/src/dashboard/controllers/dashboard-data/dashboard-data.controller.ts
@@ -54,7 +54,7 @@ export class DashboardDataController {
         inflation: 0,
         stakingAPR: undefined
       }),
-      runOrLog(() => this.statsService.getNetworkCapacity(), cloneDeep(emptyNetworkCapacity)),
+      runOrLog(() => this.statsService.getLegacyNetworkCapacity(), cloneDeep(emptyNetworkCapacity)),
       runOrLog(() => this.providerGraphDataService.getProviderGraphData("count"), cloneDeep(emptyProviderGraphData)),
       runOrLog(() => this.akashBlockService.getBlocks(5), []),
       runOrLog(() => this.transactionService.getTransactions(5), [])

--- a/apps/api/src/dashboard/http-schemas/dashboard-data/dashboard-data.schema.ts
+++ b/apps/api/src/dashboard/http-schemas/dashboard-data/dashboard-data.schema.ts
@@ -1,6 +1,30 @@
 import { z } from "zod";
 
-import { NetworkCapacityResponseSchema } from "../network-capacity/network-capacity.schema";
+const LegacyNetworkCapacityResponseSchema = z.object({
+  activeProviderCount: z.number(),
+  activeCPU: z.number(),
+  activeGPU: z.number(),
+  activeMemory: z.number(),
+  activeStorage: z.number(),
+  pendingCPU: z.number(),
+  pendingGPU: z.number(),
+  pendingMemory: z.number(),
+  pendingStorage: z.number(),
+  availableCPU: z.number(),
+  availableGPU: z.number(),
+  availableMemory: z.number(),
+  availableStorage: z.number(),
+  totalCPU: z.number(),
+  totalGPU: z.number(),
+  totalMemory: z.number(),
+  totalStorage: z.number(),
+  activeEphemeralStorage: z.number(),
+  pendingEphemeralStorage: z.number(),
+  availableEphemeralStorage: z.number(),
+  activePersistentStorage: z.number(),
+  pendingPersistentStorage: z.number(),
+  availablePersistentStorage: z.number()
+});
 
 export const DashboardDataResponseSchema = z.object({
   chainStats: z.object({
@@ -46,7 +70,7 @@ export const DashboardDataResponseSchema = z.object({
     activeMemory: z.number(),
     activeStorage: z.number()
   }),
-  networkCapacity: NetworkCapacityResponseSchema,
+  networkCapacity: LegacyNetworkCapacityResponseSchema,
   networkCapacityStats: z.object({
     currentValue: z.number(),
     compareValue: z.number(),

--- a/apps/api/src/dashboard/http-schemas/dashboard-data/dashboard-data.schema.ts
+++ b/apps/api/src/dashboard/http-schemas/dashboard-data/dashboard-data.schema.ts
@@ -23,7 +23,9 @@ const LegacyNetworkCapacityResponseSchema = z.object({
   availableEphemeralStorage: z.number(),
   activePersistentStorage: z.number(),
   pendingPersistentStorage: z.number(),
-  availablePersistentStorage: z.number()
+  availablePersistentStorage: z.number(),
+  totalEphemeralStorage: z.number(),
+  totalPersistentStorage: z.number()
 });
 
 export const DashboardDataResponseSchema = z.object({

--- a/apps/api/src/dashboard/http-schemas/network-capacity/network-capacity.schema.ts
+++ b/apps/api/src/dashboard/http-schemas/network-capacity/network-capacity.schema.ts
@@ -1,29 +1,23 @@
 import z from "zod";
 
+const statItemSchema = z.object({
+  active: z.number(),
+  pending: z.number(),
+  available: z.number(),
+  total: z.number()
+});
 export const NetworkCapacityResponseSchema = z.object({
   activeProviderCount: z.number(),
-  activeCPU: z.number(),
-  activeGPU: z.number(),
-  activeMemory: z.number(),
-  activeStorage: z.number(),
-  pendingCPU: z.number(),
-  pendingGPU: z.number(),
-  pendingMemory: z.number(),
-  pendingStorage: z.number(),
-  availableCPU: z.number(),
-  availableGPU: z.number(),
-  availableMemory: z.number(),
-  availableStorage: z.number(),
-  totalCPU: z.number(),
-  totalGPU: z.number(),
-  totalMemory: z.number(),
-  totalStorage: z.number(),
-  activeEphemeralStorage: z.number(),
-  pendingEphemeralStorage: z.number(),
-  availableEphemeralStorage: z.number(),
-  activePersistentStorage: z.number(),
-  pendingPersistentStorage: z.number(),
-  availablePersistentStorage: z.number()
+  resources: z.object({
+    cpu: statItemSchema,
+    gpu: statItemSchema,
+    memory: statItemSchema,
+    storage: z.object({
+      ephemeral: statItemSchema,
+      persistent: statItemSchema,
+      total: statItemSchema
+    })
+  })
 });
 
 export type NetworkCapacityResponse = z.infer<typeof NetworkCapacityResponseSchema>;

--- a/apps/api/src/dashboard/services/stats/stats.service.spec.ts
+++ b/apps/api/src/dashboard/services/stats/stats.service.spec.ts
@@ -1,0 +1,378 @@
+import { Provider, ProviderSnapshot } from "@akashnetwork/database/dbSchemas/akash";
+import type { CoinGeckoHttpService, CosmosHttpService } from "@akashnetwork/http-sdk";
+import { mock } from "jest-mock-extended";
+
+import { cacheEngine } from "@src/caching/helpers";
+import type { DashboardConfig } from "../../providers/config.provider";
+import { StatsService } from "./stats.service";
+
+describe(StatsService.name, () => {
+  beforeEach(() => {
+    cacheEngine.clearAllKeyInCache();
+  });
+
+  describe("getNetworkCapacity", () => {
+    it("returns empty capacity when no providers found", async () => {
+      const { service } = setup();
+
+      jest.spyOn(Provider, "findAll").mockResolvedValue([]);
+
+      const result = await service.getNetworkCapacity();
+
+      expect(result).toEqual({
+        activeProviderCount: 0,
+        resources: {
+          cpu: { active: 0, pending: 0, available: 0, total: 0 },
+          gpu: { active: 0, pending: 0, available: 0, total: 0 },
+          memory: { active: 0, pending: 0, available: 0, total: 0 },
+          storage: {
+            ephemeral: { active: 0, pending: 0, available: 0, total: 0 },
+            persistent: { active: 0, pending: 0, available: 0, total: 0 },
+            total: { active: 0, pending: 0, available: 0, total: 0 }
+          }
+        }
+      });
+    });
+
+    it("aggregates resources from single provider", async () => {
+      const { service } = setup();
+
+      const mockSnapshot = {
+        activeCPU: 1000,
+        pendingCPU: 200,
+        availableCPU: 3000,
+        activeGPU: 2,
+        pendingGPU: 1,
+        availableGPU: 5,
+        activeMemory: 1073741824,
+        pendingMemory: 536870912,
+        availableMemory: 4294967296,
+        activeEphemeralStorage: 10737418240,
+        pendingEphemeralStorage: 5368709120,
+        availableEphemeralStorage: 53687091200,
+        activePersistentStorage: 21474836480,
+        pendingPersistentStorage: 10737418240,
+        availablePersistentStorage: 107374182400
+      };
+
+      const mockProvider = {
+        hostUri: "https://provider1.example.com",
+        lastSuccessfulSnapshot: mockSnapshot
+      };
+
+      jest.spyOn(Provider, "findAll").mockResolvedValue([mockProvider as unknown as Provider]);
+
+      const result = await service.getNetworkCapacity();
+
+      expect(result).toEqual({
+        activeProviderCount: 1,
+        resources: {
+          cpu: {
+            active: 1000,
+            pending: 200,
+            available: 3000,
+            total: 4200
+          },
+          gpu: {
+            active: 2,
+            pending: 1,
+            available: 5,
+            total: 8
+          },
+          memory: {
+            active: 1073741824,
+            pending: 536870912,
+            available: 4294967296,
+            total: 5905580032
+          },
+          storage: {
+            ephemeral: {
+              active: 10737418240,
+              pending: 5368709120,
+              available: 53687091200,
+              total: 69793218560
+            },
+            persistent: {
+              active: 21474836480,
+              pending: 10737418240,
+              available: 107374182400,
+              total: 139586437120
+            },
+            total: {
+              active: 32212254720,
+              pending: 16106127360,
+              available: 161061273600,
+              total: 209379655680
+            }
+          }
+        }
+      });
+    });
+
+    it("aggregates resources from multiple providers", async () => {
+      const { service } = setup();
+
+      const mockSnapshot1 = {
+        activeCPU: 1000,
+        pendingCPU: 100,
+        availableCPU: 2000,
+        activeGPU: 1,
+        pendingGPU: 0,
+        availableGPU: 3,
+        activeMemory: 1073741824,
+        pendingMemory: 0,
+        availableMemory: 2147483648,
+        activeEphemeralStorage: 10737418240,
+        pendingEphemeralStorage: 0,
+        availableEphemeralStorage: 21474836480,
+        activePersistentStorage: 5368709120,
+        pendingPersistentStorage: 0,
+        availablePersistentStorage: 10737418240
+      };
+
+      const mockSnapshot2 = {
+        activeCPU: 500,
+        pendingCPU: 50,
+        availableCPU: 1000,
+        activeGPU: 2,
+        pendingGPU: 1,
+        availableGPU: 5,
+        activeMemory: 536870912,
+        pendingMemory: 268435456,
+        availableMemory: 1073741824,
+        activeEphemeralStorage: 5368709120,
+        pendingEphemeralStorage: 2684354560,
+        availableEphemeralStorage: 10737418240,
+        activePersistentStorage: 2684354560,
+        pendingPersistentStorage: 1342177280,
+        availablePersistentStorage: 5368709120
+      };
+
+      const mockProviders = [
+        { hostUri: "https://provider1.example.com", lastSuccessfulSnapshot: mockSnapshot1 },
+        { hostUri: "https://provider2.example.com", lastSuccessfulSnapshot: mockSnapshot2 }
+      ];
+
+      jest.spyOn(Provider, "findAll").mockResolvedValue(mockProviders as unknown as Provider[]);
+
+      const result = await service.getNetworkCapacity();
+
+      expect(result).toEqual({
+        activeProviderCount: 2,
+        resources: {
+          cpu: {
+            active: 1500,
+            pending: 150,
+            available: 3000,
+            total: 4650
+          },
+          gpu: {
+            active: 3,
+            pending: 1,
+            available: 8,
+            total: 12
+          },
+          memory: {
+            active: 1610612736,
+            pending: 268435456,
+            available: 3221225472,
+            total: 5100273664
+          },
+          storage: {
+            ephemeral: {
+              active: 16106127360,
+              pending: 2684354560,
+              available: 32212254720,
+              total: 51002736640
+            },
+            persistent: {
+              active: 8053063680,
+              pending: 1342177280,
+              available: 16106127360,
+              total: 25501368320
+            },
+            total: {
+              active: 24159191040,
+              pending: 4026531840,
+              available: 48318382080,
+              total: 76504104960
+            }
+          }
+        }
+      });
+    });
+
+    it("deduplicates providers with the same hostUri", async () => {
+      const { service } = setup();
+
+      const mockSnapshot1 = {
+        activeCPU: 1000,
+        pendingCPU: 0,
+        availableCPU: 2000,
+        activeGPU: 1,
+        pendingGPU: 0,
+        availableGPU: 3,
+        activeMemory: 1073741824,
+        pendingMemory: 0,
+        availableMemory: 2147483648,
+        activeEphemeralStorage: 10737418240,
+        pendingEphemeralStorage: 0,
+        availableEphemeralStorage: 21474836480,
+        activePersistentStorage: 5368709120,
+        pendingPersistentStorage: 0,
+        availablePersistentStorage: 10737418240
+      };
+
+      const mockSnapshot2 = {
+        activeCPU: 500,
+        pendingCPU: 50,
+        availableCPU: 1000,
+        activeGPU: 2,
+        pendingGPU: 1,
+        availableGPU: 5,
+        activeMemory: 536870912,
+        pendingMemory: 268435456,
+        availableMemory: 1073741824,
+        activeEphemeralStorage: 5368709120,
+        pendingEphemeralStorage: 2684354560,
+        availableEphemeralStorage: 10737418240,
+        activePersistentStorage: 2684354560,
+        pendingPersistentStorage: 1342177280,
+        availablePersistentStorage: 5368709120
+      };
+
+      const mockProviders = [
+        { hostUri: "https://provider1.example.com", lastSuccessfulSnapshot: mockSnapshot1 },
+        { hostUri: "https://provider1.example.com", lastSuccessfulSnapshot: mockSnapshot2 }
+      ];
+
+      jest.spyOn(Provider, "findAll").mockResolvedValue(mockProviders as unknown as Provider[]);
+
+      const result = await service.getNetworkCapacity();
+
+      expect(result.activeProviderCount).toBe(1);
+      expect(result.resources.cpu).toEqual({
+        active: 1000,
+        pending: 0,
+        available: 2000,
+        total: 3000
+      });
+    });
+
+    it("handles null values in snapshot fields", async () => {
+      const { service } = setup();
+
+      const mockSnapshot = {
+        activeCPU: null,
+        pendingCPU: undefined,
+        availableCPU: 1000,
+        activeGPU: 0,
+        pendingGPU: null,
+        availableGPU: 2,
+        activeMemory: null,
+        pendingMemory: null,
+        availableMemory: 1073741824,
+        activeEphemeralStorage: null,
+        pendingEphemeralStorage: null,
+        availableEphemeralStorage: 10737418240,
+        activePersistentStorage: null,
+        pendingPersistentStorage: null,
+        availablePersistentStorage: 5368709120
+      };
+
+      const mockProvider = {
+        hostUri: "https://provider1.example.com",
+        lastSuccessfulSnapshot: mockSnapshot
+      };
+
+      jest.spyOn(Provider, "findAll").mockResolvedValue([mockProvider as unknown as Provider]);
+
+      const result = await service.getNetworkCapacity();
+
+      expect(result).toEqual({
+        activeProviderCount: 1,
+        resources: {
+          cpu: {
+            active: 0,
+            pending: 0,
+            available: 1000,
+            total: 1000
+          },
+          gpu: {
+            active: 0,
+            pending: 0,
+            available: 2,
+            total: 2
+          },
+          memory: {
+            active: 0,
+            pending: 0,
+            available: 1073741824,
+            total: 1073741824
+          },
+          storage: {
+            ephemeral: {
+              active: 0,
+              pending: 0,
+              available: 10737418240,
+              total: 10737418240
+            },
+            persistent: {
+              active: 0,
+              pending: 0,
+              available: 5368709120,
+              total: 5368709120
+            },
+            total: {
+              active: 0,
+              pending: 0,
+              available: 16106127360,
+              total: 16106127360
+            }
+          }
+        }
+      });
+    });
+
+    it("queries providers with correct filters", async () => {
+      const { service } = setup({ PROVIDER_UPTIME_GRACE_PERIOD_MINUTES: 10 });
+
+      const findAllSpy = jest.spyOn(Provider, "findAll").mockResolvedValue([]);
+
+      await service.getNetworkCapacity();
+
+      expect(findAllSpy).toHaveBeenCalledWith({
+        where: {
+          deletedHeight: null
+        },
+        include: [
+          {
+            required: true,
+            model: ProviderSnapshot,
+            as: "lastSuccessfulSnapshot",
+            where: expect.objectContaining({
+              checkDate: expect.any(Object)
+            })
+          }
+        ]
+      });
+    });
+  });
+
+  function setup(input?: { PROVIDER_UPTIME_GRACE_PERIOD_MINUTES?: number }) {
+    const cosmosHttpService = mock<CosmosHttpService>();
+    const coinGeckoHttpService = mock<CoinGeckoHttpService>();
+    const dashboardConfig: DashboardConfig = {
+      PROVIDER_UPTIME_GRACE_PERIOD_MINUTES: input?.PROVIDER_UPTIME_GRACE_PERIOD_MINUTES ?? 15
+    };
+
+    const service = new StatsService(dashboardConfig, cosmosHttpService, coinGeckoHttpService);
+
+    return {
+      service,
+      cosmosHttpService,
+      coinGeckoHttpService,
+      dashboardConfig
+    };
+  }
+});

--- a/apps/api/src/dashboard/services/stats/stats.service.ts
+++ b/apps/api/src/dashboard/services/stats/stats.service.ts
@@ -58,7 +58,9 @@ export const emptyNetworkCapacity = {
   availableEphemeralStorage: 0,
   activePersistentStorage: 0,
   pendingPersistentStorage: 0,
-  availablePersistentStorage: 0
+  availablePersistentStorage: 0,
+  totalEphemeralStorage: 0,
+  totalPersistentStorage: 0
 };
 
 @singleton()

--- a/apps/api/src/dashboard/services/stats/stats.service.ts
+++ b/apps/api/src/dashboard/services/stats/stats.service.ts
@@ -3,7 +3,6 @@ import { Day } from "@akashnetwork/database/dbSchemas/base";
 import { CoinGeckoHttpService, CosmosHttpService } from "@akashnetwork/http-sdk";
 import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { differenceInSeconds, minutesToSeconds, sub, subHours } from "date-fns";
-import { cloneDeep } from "lodash";
 import uniqBy from "lodash/uniqBy";
 import { Op, QueryTypes } from "sequelize";
 import { inject, singleton } from "tsyringe";
@@ -16,7 +15,9 @@ import type { DashboardConfig } from "@src/dashboard/providers/config.provider";
 import { DASHBOARD_CONFIG } from "@src/dashboard/providers/config.provider";
 import { chainDb } from "@src/db/dbConnection";
 import { AuthorizedGraphDataName } from "@src/services/db/statsService";
+import { ProviderCapacityStats, StatsItem } from "@src/types/provider";
 import { toUTC } from "@src/utils";
+import { forEachInChunks } from "@src/utils/array/array";
 import { createLoggingExecutor } from "@src/utils/logging";
 
 const numberOrZero: (x: number | undefined | null) => number = (x: number | undefined | null) => (typeof x === "number" ? x : 0);
@@ -276,29 +277,29 @@ export class StatsService {
 
   @Memoize({ ttlInSeconds: minutesToSeconds(5) })
   async getChainStats() {
-    const bondedTokensAsPromised = await runOrLog(async () => {
+    const bondedTokensAsPromised = runOrLog(async () => {
       const stakingPool = await this.cosmosHttpService.getStakingPool();
 
       return parseInt(stakingPool.bonded_tokens);
     }, 0);
 
-    const totalSupplyAsPromised = await runOrLog(async () => {
+    const totalSupplyAsPromised = runOrLog(async () => {
       const supply = await this.cosmosHttpService.getBankSupply();
 
       return parseInt(supply.find(x => x.denom === "uakt")?.amount || "0");
     }, 0);
 
-    const communityPoolAsPromised = await runOrLog(async () => {
+    const communityPoolAsPromised = runOrLog(async () => {
       const pool = await this.cosmosHttpService.getCommunityPool();
 
       return parseFloat(pool.find(x => x.denom === "uakt")?.amount || "0");
     }, 0);
 
-    const inflationAsPromised = await runOrLog(async () => {
+    const inflationAsPromised = runOrLog(async () => {
       return await this.cosmosHttpService.getInflation();
     }, 0);
 
-    const communityTaxAsPromised = await runOrLog(async () => {
+    const communityTaxAsPromised = runOrLog(async () => {
       const params = await this.cosmosHttpService.getDistributionParams();
 
       return parseFloat(params.community_tax || "0");
@@ -326,8 +327,45 @@ export class StatsService {
     };
   }
 
+  async getLegacyNetworkCapacity() {
+    const capacity = await this.getNetworkCapacity();
+
+    return {
+      activeProviderCount: capacity.activeProviderCount,
+      activeCPU: capacity.resources.cpu.active,
+      pendingCPU: capacity.resources.cpu.pending,
+      availableCPU: capacity.resources.cpu.available,
+      totalCPU: capacity.resources.cpu.total,
+
+      activeGPU: capacity.resources.gpu.active,
+      pendingGPU: capacity.resources.gpu.pending,
+      availableGPU: capacity.resources.gpu.available,
+      totalGPU: capacity.resources.gpu.total,
+
+      activeMemory: capacity.resources.memory.active,
+      pendingMemory: capacity.resources.memory.pending,
+      availableMemory: capacity.resources.memory.available,
+      totalMemory: capacity.resources.memory.total,
+
+      activeEphemeralStorage: capacity.resources.storage.ephemeral.active,
+      pendingEphemeralStorage: capacity.resources.storage.ephemeral.pending,
+      availableEphemeralStorage: capacity.resources.storage.ephemeral.available,
+      totalEphemeralStorage: capacity.resources.storage.ephemeral.total,
+
+      activePersistentStorage: capacity.resources.storage.persistent.active,
+      pendingPersistentStorage: capacity.resources.storage.persistent.pending,
+      availablePersistentStorage: capacity.resources.storage.persistent.available,
+      totalPersistentStorage: capacity.resources.storage.persistent.total,
+
+      activeStorage: capacity.resources.storage.total.active,
+      pendingStorage: capacity.resources.storage.total.pending,
+      availableStorage: capacity.resources.storage.total.available,
+      totalStorage: capacity.resources.storage.total.total
+    };
+  }
+
   @Memoize({ ttlInSeconds: 15 })
-  async getNetworkCapacity() {
+  async getNetworkCapacity(): Promise<{ resources: ProviderCapacityStats; activeProviderCount: number }> {
     const providers = await Provider.findAll({
       where: {
         deletedHeight: null
@@ -343,41 +381,56 @@ export class StatsService {
     });
 
     const filteredProviders = uniqBy(providers, provider => provider.hostUri);
-    const stats = filteredProviders.reduce((all, provider) => {
-      all.activeCPU += provider.lastSuccessfulSnapshot.activeCPU || 0;
-      all.pendingCPU += provider.lastSuccessfulSnapshot.pendingCPU || 0;
-      all.availableCPU += provider.lastSuccessfulSnapshot.availableCPU || 0;
+    const stats = {
+      cpu: buildStatItem(0, 0, 0),
+      gpu: buildStatItem(0, 0, 0),
+      memory: buildStatItem(0, 0, 0),
+      storage: {
+        ephemeral: buildStatItem(0, 0, 0),
+        persistent: buildStatItem(0, 0, 0),
+        total: buildStatItem(0, 0, 0)
+      }
+    };
 
-      all.activeGPU += provider.lastSuccessfulSnapshot.activeGPU || 0;
-      all.pendingGPU += provider.lastSuccessfulSnapshot.pendingGPU || 0;
-      all.availableGPU += provider.lastSuccessfulSnapshot.availableGPU || 0;
+    await forEachInChunks(
+      filteredProviders,
+      provider => {
+        stats.cpu.active += provider.lastSuccessfulSnapshot.activeCPU || 0;
+        stats.cpu.pending += provider.lastSuccessfulSnapshot.pendingCPU || 0;
+        stats.cpu.available += provider.lastSuccessfulSnapshot.availableCPU || 0;
+        stats.cpu.total = stats.cpu.active + stats.cpu.pending + stats.cpu.available;
 
-      all.activeMemory += provider.lastSuccessfulSnapshot.activeMemory || 0;
-      all.pendingMemory += provider.lastSuccessfulSnapshot.pendingMemory || 0;
-      all.availableMemory += provider.lastSuccessfulSnapshot.availableMemory || 0;
+        stats.gpu.active += provider.lastSuccessfulSnapshot.activeGPU || 0;
+        stats.gpu.pending += provider.lastSuccessfulSnapshot.pendingGPU || 0;
+        stats.gpu.available += provider.lastSuccessfulSnapshot.availableGPU || 0;
+        stats.gpu.total = stats.gpu.active + stats.gpu.pending + stats.gpu.available;
 
-      all.activeEphemeralStorage += provider.lastSuccessfulSnapshot.activeEphemeralStorage || 0;
-      all.pendingEphemeralStorage += provider.lastSuccessfulSnapshot.pendingEphemeralStorage || 0;
-      all.availableEphemeralStorage += provider.lastSuccessfulSnapshot.availableEphemeralStorage || 0;
+        stats.memory.active += provider.lastSuccessfulSnapshot.activeMemory || 0;
+        stats.memory.pending += provider.lastSuccessfulSnapshot.pendingMemory || 0;
+        stats.memory.available += provider.lastSuccessfulSnapshot.availableMemory || 0;
+        stats.memory.total = stats.memory.active + stats.memory.pending + stats.memory.available;
 
-      all.activePersistentStorage += provider.lastSuccessfulSnapshot.activePersistentStorage || 0;
-      all.pendingPersistentStorage += provider.lastSuccessfulSnapshot.pendingPersistentStorage || 0;
-      all.availablePersistentStorage += provider.lastSuccessfulSnapshot.availablePersistentStorage || 0;
+        stats.storage.ephemeral.active += provider.lastSuccessfulSnapshot.activeEphemeralStorage || 0;
+        stats.storage.ephemeral.pending += provider.lastSuccessfulSnapshot.pendingEphemeralStorage || 0;
+        stats.storage.ephemeral.available += provider.lastSuccessfulSnapshot.availableEphemeralStorage || 0;
+        stats.storage.ephemeral.total = stats.storage.ephemeral.active + stats.storage.ephemeral.pending + stats.storage.ephemeral.available;
 
-      return all;
-    }, cloneDeep(emptyNetworkCapacity));
+        stats.storage.persistent.active += provider.lastSuccessfulSnapshot.activePersistentStorage || 0;
+        stats.storage.persistent.pending += provider.lastSuccessfulSnapshot.pendingPersistentStorage || 0;
+        stats.storage.persistent.available += provider.lastSuccessfulSnapshot.availablePersistentStorage || 0;
+        stats.storage.persistent.total = stats.storage.persistent.active + stats.storage.persistent.pending + stats.storage.persistent.available;
+      },
+      { maxTimeSpentPerChunk: 15 }
+    );
 
-    stats.activeStorage = stats.activeEphemeralStorage + stats.activePersistentStorage;
-    stats.pendingStorage = stats.pendingEphemeralStorage + stats.pendingPersistentStorage;
-    stats.availableStorage = stats.availableEphemeralStorage + stats.availablePersistentStorage;
+    stats.storage.total.active = stats.storage.ephemeral.active + stats.storage.persistent.active;
+    stats.storage.total.pending = stats.storage.ephemeral.pending + stats.storage.persistent.pending;
+    stats.storage.total.available = stats.storage.ephemeral.available + stats.storage.persistent.available;
+    stats.storage.total.total = stats.storage.ephemeral.total + stats.storage.persistent.total;
 
     return {
-      ...stats,
-      activeProviderCount: filteredProviders.length,
-      totalCPU: stats.activeCPU + stats.pendingCPU + stats.availableCPU,
-      totalGPU: stats.activeGPU + stats.pendingGPU + stats.availableGPU,
-      totalMemory: stats.activeMemory + stats.pendingMemory + stats.availableMemory,
-      totalStorage: stats.activeStorage + stats.pendingStorage + stats.availableStorage
+      resources: stats,
+      activeProviderCount: filteredProviders.length
     };
   }
 
@@ -439,4 +492,13 @@ export class StatsService {
       leases
     };
   }
+}
+
+function buildStatItem(active: number, pending: number, available: number): StatsItem {
+  return {
+    active,
+    pending,
+    available,
+    total: active + pending + available
+  };
 }

--- a/apps/api/src/db/dbConnection.ts
+++ b/apps/api/src/db/dbConnection.ts
@@ -15,10 +15,7 @@ import { APP_INITIALIZER, ON_APP_START } from "@src/core/providers/app-initializ
 import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
 import { PostgresLoggerService } from "@src/core/services/postgres-logger/postgres-logger.service";
 
-const indexerDbUri = container
-  .resolve(ChainConfigService)
-  .get("CHAIN_INDEXER_POSTGRES_DB_URI")
-  .replace("%DB_PASSWORD", encodeURIComponent(process.env.DB_PASSWORD || ""));
+const indexerDbUri = container.resolve(ChainConfigService).get("CHAIN_INDEXER_POSTGRES_DB_URI");
 const coreConfig = container.resolve(CoreConfigService);
 const dbUri = coreConfig.get("POSTGRES_DB_URI");
 

--- a/apps/api/src/db/dbConnection.ts
+++ b/apps/api/src/db/dbConnection.ts
@@ -15,7 +15,10 @@ import { APP_INITIALIZER, ON_APP_START } from "@src/core/providers/app-initializ
 import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
 import { PostgresLoggerService } from "@src/core/services/postgres-logger/postgres-logger.service";
 
-const indexerDbUri = container.resolve(ChainConfigService).get("CHAIN_INDEXER_POSTGRES_DB_URI");
+const indexerDbUri = container
+  .resolve(ChainConfigService)
+  .get("CHAIN_INDEXER_POSTGRES_DB_URI")
+  .replace("%DB_PASSWORD", encodeURIComponent(process.env.DB_PASSWORD || ""));
 const coreConfig = container.resolve(CoreConfigService);
 const dbUri = coreConfig.get("POSTGRES_DB_URI");
 

--- a/apps/api/src/provider/http-schemas/provider.schema.ts
+++ b/apps/api/src/provider/http-schemas/provider.schema.ts
@@ -32,24 +32,6 @@ export const ProviderListResponseSchema = z.array(
     isOnline: z.boolean(),
     lastOnlineDate: z.string().nullable(),
     isAudited: z.boolean(),
-    activeStats: z.object({
-      cpu: z.number(),
-      gpu: z.number(),
-      memory: z.number(),
-      storage: z.number()
-    }),
-    pendingStats: z.object({
-      cpu: z.number(),
-      gpu: z.number(),
-      memory: z.number(),
-      storage: z.number()
-    }),
-    availableStats: z.object({
-      cpu: z.number(),
-      gpu: z.number(),
-      memory: z.number(),
-      storage: z.number()
-    }),
     gpuModels: z.array(
       z.object({
         vendor: z.string(),
@@ -108,7 +90,7 @@ export const ProviderParamsSchema = z.object({
 
 export const ProviderResponseSchema = z.object({
   owner: z.string(),
-  name: z.string(),
+  name: z.string().nullable(),
   hostUri: z.string(),
   createdHeight: z.number(),
   email: z.string().nullable(),
@@ -139,24 +121,6 @@ export const ProviderResponseSchema = z.object({
       ephemeral: statsItemSchema,
       persistent: statsItemSchema
     })
-  }),
-  activeStats: z.object({
-    cpu: z.number(),
-    gpu: z.number(),
-    memory: z.number(),
-    storage: z.number()
-  }),
-  pendingStats: z.object({
-    cpu: z.number(),
-    gpu: z.number(),
-    memory: z.number(),
-    storage: z.number()
-  }),
-  availableStats: z.object({
-    cpu: z.number(),
-    gpu: z.number(),
-    memory: z.number(),
-    storage: z.number()
   }),
   gpuModels: z.array(
     z.object({

--- a/apps/api/src/types/provider.ts
+++ b/apps/api/src/types/provider.ts
@@ -29,36 +29,7 @@ export interface ProviderList {
     ram: string;
     interface: string;
   }>;
-  stats: {
-    cpu: StatsItem;
-    gpu: StatsItem;
-    memory: StatsItem;
-    storage: {
-      ephemeral: StatsItem;
-      persistent: StatsItem;
-    };
-  };
-  /** @deprecated use `stats` instead */
-  activeStats: {
-    cpu: number;
-    gpu: number;
-    memory: number;
-    storage: number;
-  };
-  /** @deprecated use `stats` instead */
-  pendingStats: {
-    cpu: number;
-    gpu: number;
-    memory: number;
-    storage: number;
-  };
-  /** @deprecated use `stats` instead */
-  availableStats: {
-    cpu: number;
-    gpu: number;
-    memory: number;
-    storage: number;
-  };
+  stats: ProviderCapacityStats;
   attributes: Array<{
     key: string;
     value: string;
@@ -93,6 +64,17 @@ export interface ProviderList {
   featEndpointIp: boolean;
 }
 
+export interface ProviderCapacityStats {
+  cpu: StatsItem;
+  gpu: StatsItem;
+  memory: StatsItem;
+  storage: {
+    ephemeral: StatsItem;
+    persistent: StatsItem;
+    total: StatsItem;
+  };
+}
+
 export interface ProviderDetail extends ProviderList {
   uptime: {
     id: string;
@@ -105,4 +87,5 @@ export interface StatsItem {
   active: number;
   available: number;
   pending: number;
+  total: number;
 }

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -8502,100 +8502,172 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
               "application/json": {
                 "schema": {
                   "properties": {
-                    "activeCPU": {
-                      "type": "number",
-                    },
-                    "activeEphemeralStorage": {
-                      "type": "number",
-                    },
-                    "activeGPU": {
-                      "type": "number",
-                    },
-                    "activeMemory": {
-                      "type": "number",
-                    },
-                    "activePersistentStorage": {
-                      "type": "number",
-                    },
                     "activeProviderCount": {
                       "type": "number",
                     },
-                    "activeStorage": {
-                      "type": "number",
-                    },
-                    "availableCPU": {
-                      "type": "number",
-                    },
-                    "availableEphemeralStorage": {
-                      "type": "number",
-                    },
-                    "availableGPU": {
-                      "type": "number",
-                    },
-                    "availableMemory": {
-                      "type": "number",
-                    },
-                    "availablePersistentStorage": {
-                      "type": "number",
-                    },
-                    "availableStorage": {
-                      "type": "number",
-                    },
-                    "pendingCPU": {
-                      "type": "number",
-                    },
-                    "pendingEphemeralStorage": {
-                      "type": "number",
-                    },
-                    "pendingGPU": {
-                      "type": "number",
-                    },
-                    "pendingMemory": {
-                      "type": "number",
-                    },
-                    "pendingPersistentStorage": {
-                      "type": "number",
-                    },
-                    "pendingStorage": {
-                      "type": "number",
-                    },
-                    "totalCPU": {
-                      "type": "number",
-                    },
-                    "totalGPU": {
-                      "type": "number",
-                    },
-                    "totalMemory": {
-                      "type": "number",
-                    },
-                    "totalStorage": {
-                      "type": "number",
+                    "resources": {
+                      "properties": {
+                        "cpu": {
+                          "properties": {
+                            "active": {
+                              "type": "number",
+                            },
+                            "available": {
+                              "type": "number",
+                            },
+                            "pending": {
+                              "type": "number",
+                            },
+                            "total": {
+                              "type": "number",
+                            },
+                          },
+                          "required": [
+                            "active",
+                            "pending",
+                            "available",
+                            "total",
+                          ],
+                          "type": "object",
+                        },
+                        "gpu": {
+                          "properties": {
+                            "active": {
+                              "type": "number",
+                            },
+                            "available": {
+                              "type": "number",
+                            },
+                            "pending": {
+                              "type": "number",
+                            },
+                            "total": {
+                              "type": "number",
+                            },
+                          },
+                          "required": [
+                            "active",
+                            "pending",
+                            "available",
+                            "total",
+                          ],
+                          "type": "object",
+                        },
+                        "memory": {
+                          "properties": {
+                            "active": {
+                              "type": "number",
+                            },
+                            "available": {
+                              "type": "number",
+                            },
+                            "pending": {
+                              "type": "number",
+                            },
+                            "total": {
+                              "type": "number",
+                            },
+                          },
+                          "required": [
+                            "active",
+                            "pending",
+                            "available",
+                            "total",
+                          ],
+                          "type": "object",
+                        },
+                        "storage": {
+                          "properties": {
+                            "ephemeral": {
+                              "properties": {
+                                "active": {
+                                  "type": "number",
+                                },
+                                "available": {
+                                  "type": "number",
+                                },
+                                "pending": {
+                                  "type": "number",
+                                },
+                                "total": {
+                                  "type": "number",
+                                },
+                              },
+                              "required": [
+                                "active",
+                                "pending",
+                                "available",
+                                "total",
+                              ],
+                              "type": "object",
+                            },
+                            "persistent": {
+                              "properties": {
+                                "active": {
+                                  "type": "number",
+                                },
+                                "available": {
+                                  "type": "number",
+                                },
+                                "pending": {
+                                  "type": "number",
+                                },
+                                "total": {
+                                  "type": "number",
+                                },
+                              },
+                              "required": [
+                                "active",
+                                "pending",
+                                "available",
+                                "total",
+                              ],
+                              "type": "object",
+                            },
+                            "total": {
+                              "properties": {
+                                "active": {
+                                  "type": "number",
+                                },
+                                "available": {
+                                  "type": "number",
+                                },
+                                "pending": {
+                                  "type": "number",
+                                },
+                                "total": {
+                                  "type": "number",
+                                },
+                              },
+                              "required": [
+                                "active",
+                                "pending",
+                                "available",
+                                "total",
+                              ],
+                              "type": "object",
+                            },
+                          },
+                          "required": [
+                            "ephemeral",
+                            "persistent",
+                            "total",
+                          ],
+                          "type": "object",
+                        },
+                      },
+                      "required": [
+                        "cpu",
+                        "gpu",
+                        "memory",
+                        "storage",
+                      ],
+                      "type": "object",
                     },
                   },
                   "required": [
                     "activeProviderCount",
-                    "activeCPU",
-                    "activeGPU",
-                    "activeMemory",
-                    "activeStorage",
-                    "pendingCPU",
-                    "pendingGPU",
-                    "pendingMemory",
-                    "pendingStorage",
-                    "availableCPU",
-                    "availableGPU",
-                    "availableMemory",
-                    "availableStorage",
-                    "totalCPU",
-                    "totalGPU",
-                    "totalMemory",
-                    "totalStorage",
-                    "activeEphemeralStorage",
-                    "pendingEphemeralStorage",
-                    "availableEphemeralStorage",
-                    "activePersistentStorage",
-                    "pendingPersistentStorage",
-                    "availablePersistentStorage",
+                    "resources",
                   ],
                   "type": "object",
                 },
@@ -11164,29 +11236,6 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                 "schema": {
                   "items": {
                     "properties": {
-                      "activeStats": {
-                        "properties": {
-                          "cpu": {
-                            "type": "number",
-                          },
-                          "gpu": {
-                            "type": "number",
-                          },
-                          "memory": {
-                            "type": "number",
-                          },
-                          "storage": {
-                            "type": "number",
-                          },
-                        },
-                        "required": [
-                          "cpu",
-                          "gpu",
-                          "memory",
-                          "storage",
-                        ],
-                        "type": "object",
-                      },
                       "akashVersion": {
                         "type": "string",
                       },
@@ -11214,29 +11263,6 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                           "type": "object",
                         },
                         "type": "array",
-                      },
-                      "availableStats": {
-                        "properties": {
-                          "cpu": {
-                            "type": "number",
-                          },
-                          "gpu": {
-                            "type": "number",
-                          },
-                          "memory": {
-                            "type": "number",
-                          },
-                          "storage": {
-                            "type": "number",
-                          },
-                        },
-                        "required": [
-                          "cpu",
-                          "gpu",
-                          "memory",
-                          "storage",
-                        ],
-                        "type": "object",
                       },
                       "city": {
                         "nullable": true,
@@ -11417,29 +11443,6 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                       "owner": {
                         "type": "string",
                       },
-                      "pendingStats": {
-                        "properties": {
-                          "cpu": {
-                            "type": "number",
-                          },
-                          "gpu": {
-                            "type": "number",
-                          },
-                          "memory": {
-                            "type": "number",
-                          },
-                          "storage": {
-                            "type": "number",
-                          },
-                        },
-                        "required": [
-                          "cpu",
-                          "gpu",
-                          "memory",
-                          "storage",
-                        ],
-                        "type": "object",
-                      },
                       "statusPage": {
                         "nullable": true,
                         "type": "string",
@@ -11499,9 +11502,6 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                       "isOnline",
                       "lastOnlineDate",
                       "isAudited",
-                      "activeStats",
-                      "pendingStats",
-                      "availableStats",
                       "gpuModels",
                       "attributes",
                       "host",
@@ -11566,29 +11566,6 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
               "application/json": {
                 "schema": {
                   "properties": {
-                    "activeStats": {
-                      "properties": {
-                        "cpu": {
-                          "type": "number",
-                        },
-                        "gpu": {
-                          "type": "number",
-                        },
-                        "memory": {
-                          "type": "number",
-                        },
-                        "storage": {
-                          "type": "number",
-                        },
-                      },
-                      "required": [
-                        "cpu",
-                        "gpu",
-                        "memory",
-                        "storage",
-                      ],
-                      "type": "object",
-                    },
                     "akashVersion": {
                       "type": "string",
                     },
@@ -11616,29 +11593,6 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                         "type": "object",
                       },
                       "type": "array",
-                    },
-                    "availableStats": {
-                      "properties": {
-                        "cpu": {
-                          "type": "number",
-                        },
-                        "gpu": {
-                          "type": "number",
-                        },
-                        "memory": {
-                          "type": "number",
-                        },
-                        "storage": {
-                          "type": "number",
-                        },
-                      },
-                      "required": [
-                        "cpu",
-                        "gpu",
-                        "memory",
-                        "storage",
-                      ],
-                      "type": "object",
                     },
                     "city": {
                       "nullable": true,
@@ -11794,6 +11748,7 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                       "type": "string",
                     },
                     "name": {
+                      "nullable": true,
                       "type": "string",
                     },
                     "networkProvider": {
@@ -11812,29 +11767,6 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                     },
                     "owner": {
                       "type": "string",
-                    },
-                    "pendingStats": {
-                      "properties": {
-                        "cpu": {
-                          "type": "number",
-                        },
-                        "gpu": {
-                          "type": "number",
-                        },
-                        "memory": {
-                          "type": "number",
-                        },
-                        "storage": {
-                          "type": "number",
-                        },
-                      },
-                      "required": [
-                        "cpu",
-                        "gpu",
-                        "memory",
-                        "storage",
-                      ],
-                      "type": "object",
                     },
                     "stats": {
                       "properties": {
@@ -12034,9 +11966,6 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                     "lastOnlineDate",
                     "isAudited",
                     "stats",
-                    "activeStats",
-                    "pendingStats",
-                    "availableStats",
                     "gpuModels",
                     "attributes",
                     "host",

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -4247,10 +4247,16 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                         "totalCPU": {
                           "type": "number",
                         },
+                        "totalEphemeralStorage": {
+                          "type": "number",
+                        },
                         "totalGPU": {
                           "type": "number",
                         },
                         "totalMemory": {
+                          "type": "number",
+                        },
+                        "totalPersistentStorage": {
                           "type": "number",
                         },
                         "totalStorage": {
@@ -4281,6 +4287,8 @@ exports[`API Docs GET /v1/doc returns docs with all routes expected 1`] = `
                         "activePersistentStorage",
                         "pendingPersistentStorage",
                         "availablePersistentStorage",
+                        "totalEphemeralStorage",
+                        "totalPersistentStorage",
                       ],
                       "type": "object",
                     },

--- a/apps/api/test/functional/network-capacity.spec.ts
+++ b/apps/api/test/functional/network-capacity.spec.ts
@@ -205,28 +205,16 @@ describe("Network Capacity", () => {
       expect(response.status).toBe(200);
       expect(data).toEqual({
         activeProviderCount: 2,
-        activeCPU: 902,
-        pendingCPU: 912,
-        availableCPU: 922,
-        activeGPU: 904,
-        pendingGPU: 914,
-        availableGPU: 924,
-        activeMemory: 906,
-        pendingMemory: 916,
-        availableMemory: 926,
-        activeStorage: 1818,
-        pendingStorage: 1838,
-        availableStorage: 1858,
-        activeEphemeralStorage: 910,
-        pendingEphemeralStorage: 920,
-        availableEphemeralStorage: 930,
-        activePersistentStorage: 908,
-        pendingPersistentStorage: 918,
-        availablePersistentStorage: 928,
-        totalCPU: 2736,
-        totalGPU: 2742,
-        totalMemory: 2748,
-        totalStorage: 5514
+        resources: {
+          cpu: { active: 902, pending: 912, available: 922, total: 2736 },
+          gpu: { active: 904, pending: 914, available: 924, total: 2742 },
+          memory: { active: 906, pending: 916, available: 926, total: 2748 },
+          storage: {
+            ephemeral: { active: 910, pending: 920, available: 930, total: 2760 },
+            persistent: { active: 908, pending: 918, available: 928, total: 2754 },
+            total: { active: 1818, pending: 1838, available: 1858, total: 5514 }
+          }
+        }
       });
     });
   });

--- a/apps/deploy-web/next.config.js
+++ b/apps/deploy-web/next.config.js
@@ -27,7 +27,37 @@ const CopyPlugin = require("copy-webpack-plugin");
 const transpilePackages = ["geist", "@akashnetwork/ui", "@auth0/nextjs-auth0"];
 
 if (process.env.NODE_ENV === "test") {
-  transpilePackages.push("nanoid", "uint8arrays", "multiformats", "@marsidev/react-turnstile", "@panva/hkdf", "jose", "@nivo/pie", "@nivo/tooltip");
+  transpilePackages.push(
+    "nanoid",
+    "uint8arrays",
+    "multiformats",
+    "@marsidev/react-turnstile",
+    "@panva/hkdf",
+    "jose",
+    "@nivo/pie",
+    "@nivo/tooltip",
+    "d3-interpolate",
+    "d3-color",
+    "d3-scale",
+    "d3-array",
+    "internmap",
+    "d3-time",
+    "d3-scale-chromatic",
+    "d3-delaunay",
+    "d3-dispatch",
+    "d3-drag",
+    "d3-ease",
+    "d3-format",
+    "d3-geo",
+    "d3-path",
+    "d3-selection",
+    "d3-shape",
+    "d3-time",
+    "d3-time-format",
+    "d3-timer",
+    "d3-transition",
+    "d3-zoom"
+  );
 }
 
 /**

--- a/apps/deploy-web/next.config.js
+++ b/apps/deploy-web/next.config.js
@@ -27,7 +27,7 @@ const CopyPlugin = require("copy-webpack-plugin");
 const transpilePackages = ["geist", "@akashnetwork/ui", "@auth0/nextjs-auth0"];
 
 if (process.env.NODE_ENV === "test") {
-  transpilePackages.push("nanoid", "uint8arrays", "multiformats", "@marsidev/react-turnstile", "@panva/hkdf", "jose");
+  transpilePackages.push("nanoid", "uint8arrays", "multiformats", "@marsidev/react-turnstile", "@panva/hkdf", "jose", "@nivo/pie", "@nivo/tooltip");
 }
 
 /**

--- a/apps/deploy-web/src/components/providers/NetworkCapacity/NetworkCapacity.spec.tsx
+++ b/apps/deploy-web/src/components/providers/NetworkCapacity/NetworkCapacity.spec.tsx
@@ -1,0 +1,280 @@
+import { IntlProvider } from "react-intl";
+import { ThemeProvider } from "next-themes";
+
+import type { NetworkCapacityStats } from "@src/queries/useProvidersQuery";
+import type { DEPENDENCIES, Props } from "./NetworkCapacity";
+import NetworkCapacity from "./NetworkCapacity";
+
+import { render, screen } from "@testing-library/react";
+
+describe(NetworkCapacity.name, () => {
+  describe("CPU section", () => {
+    it("renders CPU label", () => {
+      setup();
+      expect(screen.queryByText("CPU")).toBeInTheDocument();
+    });
+
+    it("displays CPU values in CPU units (divides by 1000)", () => {
+      const stats = createStats({ cpu: { active: 50000, available: 100000, pending: 0, total: 150000 } });
+      setup({ stats });
+
+      expect(screen.queryByText(/50\s*CPU\s*\/\s*150\s*CPU/)).toBeInTheDocument();
+    });
+
+    it("rounds CPU values to integers for display", () => {
+      const stats = createStats({ cpu: { active: 50500, available: 100000, pending: 0, total: 150500 } });
+      setup({ stats });
+
+      expect(screen.queryByText(/51\s*CPU\s*\/\s*151\s*CPU/)).toBeInTheDocument();
+    });
+
+    it("passes correct CPU data to ResponsivePie", () => {
+      const stats = createStats({ cpu: { active: 50000, available: 100000, pending: 0, total: 150000 } });
+      const { pieProps } = setup({ stats });
+
+      const cpuPieData = pieProps[0].data;
+      expect(cpuPieData).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "active", label: "Active", value: 50 }),
+          expect.objectContaining({ id: "available", label: "Available", value: 100 })
+        ])
+      );
+    });
+  });
+
+  describe("GPU section", () => {
+    it("renders GPU label", () => {
+      setup();
+      expect(screen.queryByText("GPU")).toBeInTheDocument();
+    });
+
+    it("displays GPU values directly without division", () => {
+      const stats = createStats({ gpu: { active: 25, available: 75, pending: 0, total: 100 } });
+      setup({ stats });
+
+      expect(screen.queryByText(/25\s*GPU\s*\/\s*100\s*GPU/)).toBeInTheDocument();
+    });
+
+    it("passes correct GPU data to ResponsivePie", () => {
+      const stats = createStats({ gpu: { active: 25, available: 75, pending: 0, total: 100 } });
+      const { pieProps } = setup({ stats });
+
+      const gpuPieData = pieProps[1].data;
+      expect(gpuPieData).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "active", label: "Active", value: 25 }),
+          expect.objectContaining({ id: "available", label: "Available", value: 75 })
+        ])
+      );
+    });
+  });
+
+  describe("Memory section", () => {
+    it("renders Memory label", () => {
+      setup();
+      expect(screen.queryByText("Memory")).toBeInTheDocument();
+    });
+
+    it("displays memory in human-readable units", () => {
+      const oneGB = 1000 * 1000 * 1000;
+      const stats = createStats({ memory: { active: oneGB, available: oneGB, pending: 0, total: 2 * oneGB } });
+      setup({ stats });
+
+      expect(screen.queryByText(/1\s*GB/)).toBeInTheDocument();
+      expect(screen.queryByText(/2\s*GB/)).toBeInTheDocument();
+    });
+
+    it("passes memory data in bytes to ResponsivePie", () => {
+      const oneGB = 1000 * 1000 * 1000;
+      const stats = createStats({ memory: { active: oneGB, available: oneGB, pending: 0, total: 2 * oneGB } });
+      const { pieProps } = setup({ stats });
+
+      const memoryPieData = pieProps[2].data;
+      expect(memoryPieData).toEqual(
+        expect.arrayContaining([expect.objectContaining({ id: "active", value: oneGB }), expect.objectContaining({ id: "available", value: oneGB })])
+      );
+    });
+  });
+
+  describe("Storage section", () => {
+    it("renders Storage label", () => {
+      setup();
+      expect(screen.queryByText("Storage")).toBeInTheDocument();
+    });
+
+    it("displays combined ephemeral and persistent storage", () => {
+      const oneTB = 1000 * 1000 * 1000 * 1000;
+      const stats = createStats({
+        storage: {
+          ephemeral: { active: oneTB, available: oneTB, pending: 0, total: 2 * oneTB },
+          persistent: { active: oneTB, available: oneTB, pending: 0, total: 2 * oneTB },
+          total: { active: 2 * oneTB, available: 2 * oneTB, pending: 0, total: 4 * oneTB }
+        }
+      });
+      setup({ stats });
+
+      expect(screen.queryByText(/2\s*TB/)).toBeInTheDocument();
+      expect(screen.queryByText(/4\s*TB/)).toBeInTheDocument();
+    });
+
+    it("passes storage breakdown data to ResponsivePie", () => {
+      const oneTB = 1000 * 1000 * 1000 * 1000;
+      const oneGB = 1000 * 1000 * 1000;
+      const stats = createStats({
+        storage: {
+          ephemeral: { active: oneTB, available: 500 * oneGB, pending: 100 * oneGB, total: 2 * oneTB },
+          persistent: { active: 2 * oneTB, available: oneTB, pending: 200 * oneGB, total: 4 * oneTB },
+          total: { active: 3 * oneTB, available: 1.5 * oneTB, pending: 0, total: 6 * oneTB }
+        }
+      });
+      const { pieProps } = setup({ stats });
+
+      const storagePieData = pieProps[3].data;
+      expect(storagePieData).toHaveLength(4);
+      expect(storagePieData).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "active-ephemeral", label: "Active emphemeral" }),
+          expect.objectContaining({ id: "active-persistent", label: "Active persistent" }),
+          expect.objectContaining({ id: "available-emphemeral", label: "Available emphemeral" }),
+          expect.objectContaining({ id: "available-persistent", label: "Available persistent" })
+        ])
+      );
+    });
+
+    it("calculates available storage as available + pending", () => {
+      const oneTB = 1000 * 1000 * 1000 * 1000;
+      const oneGB = 1000 * 1000 * 1000;
+      const stats = createStats({
+        storage: {
+          ephemeral: { active: oneTB, available: 500 * oneGB, pending: 100 * oneGB, total: 2 * oneTB },
+          persistent: { active: 2 * oneTB, available: oneTB, pending: 200 * oneGB, total: 4 * oneTB },
+          total: { active: 3 * oneTB, available: 1.5 * oneTB, pending: 0, total: 6 * oneTB }
+        }
+      });
+      const { pieProps } = setup({ stats });
+
+      const storagePieData = pieProps[3].data;
+      const availableEphemeral = storagePieData.find(d => d.id === "available-emphemeral");
+      const availablePersistent = storagePieData.find(d => d.id === "available-persistent");
+
+      expect(availableEphemeral?.value).toBe(500 * oneGB + 100 * oneGB);
+      expect(availablePersistent?.value).toBe(oneTB + 200 * oneGB);
+    });
+  });
+
+  describe("pie chart rendering", () => {
+    it("renders 4 ResponsivePie components per render", () => {
+      const { pieProps } = setup();
+      expect(pieProps).toHaveLength(4 * 2); // 2 renderings
+    });
+
+    it("passes TooltipLabel as tooltip prop to all pie charts", () => {
+      const { pieProps, mockTooltipLabel } = setup();
+
+      pieProps.forEach(props => {
+        expect(props.tooltip).toBe(mockTooltipLabel);
+      });
+    });
+
+    it("applies consistent pie chart configuration", () => {
+      const { pieProps } = setup();
+
+      pieProps.forEach(props => {
+        expect(props.innerRadius).toBe(0.3);
+        expect(props.padAngle).toBe(2);
+        expect(props.cornerRadius).toBe(4);
+        expect(props.activeOuterRadiusOffset).toBe(8);
+        expect(props.borderWidth).toBe(0);
+        expect(props.enableArcLinkLabels).toBe(false);
+        expect(props.arcLabelsSkipAngle).toBe(30);
+      });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles zero values", () => {
+      const stats = createStats({
+        cpu: { active: 0, available: 0, pending: 0, total: 0 },
+        gpu: { active: 0, available: 0, pending: 0, total: 0 }
+      });
+      setup({ stats });
+
+      expect(screen.queryByText(/0\s*CPU\s*\/\s*0\s*CPU/)).toBeInTheDocument();
+      expect(screen.queryByText(/0\s*GPU\s*\/\s*0\s*GPU/)).toBeInTheDocument();
+    });
+
+    it("handles large values", () => {
+      const stats = createStats({
+        cpu: { active: 1000000000, available: 2000000000, pending: 0, total: 3000000000 }
+      });
+      setup({ stats });
+
+      expect(screen.queryByText(/1000000\s*CPU\s*\/\s*3000000\s*CPU/)).toBeInTheDocument();
+    });
+  });
+
+  function setup(input?: TestInput) {
+    type PieData = { id: string; label: string; value: number; color: string };
+    type PieProps = {
+      data: PieData[];
+      tooltip: unknown;
+      innerRadius: number;
+      padAngle: number;
+      cornerRadius: number;
+      activeOuterRadiusOffset: number;
+      borderWidth: number;
+      enableArcLinkLabels: boolean;
+      arcLabelsSkipAngle: number;
+    };
+    const mockPieProps: PieProps[] = [];
+    const mockTooltipLabel = jest.fn();
+
+    const MockResponsivePie = jest.fn((props: PieProps) => {
+      mockPieProps.push(props);
+      return null;
+    });
+
+    const dependencies: typeof DEPENDENCIES = {
+      ResponsivePie: MockResponsivePie as unknown as typeof DEPENDENCIES.ResponsivePie,
+      TooltipLabel: mockTooltipLabel as unknown as typeof DEPENDENCIES.TooltipLabel
+    };
+
+    const stats = input?.stats ?? createStats();
+    const theme = input?.theme ?? "light";
+
+    const result = render(
+      <ThemeProvider defaultTheme={theme} attribute="class">
+        <IntlProvider locale="en-US" defaultLocale="en-US">
+          <NetworkCapacity stats={stats} dependencies={dependencies} />
+        </IntlProvider>
+      </ThemeProvider>
+    );
+
+    return {
+      ...result,
+      pieProps: mockPieProps,
+      mockTooltipLabel,
+      MockResponsivePie
+    };
+  }
+
+  interface TestInput {
+    stats?: Props["stats"];
+    theme?: "light" | "dark";
+  }
+});
+
+function createStats(overrides?: Partial<NetworkCapacityStats["resources"]>): NetworkCapacityStats["resources"] {
+  const oneGB = 1000 * 1000 * 1000;
+  return {
+    cpu: { active: 10000, available: 90000, pending: 0, total: 100000 },
+    gpu: { active: 10, available: 90, pending: 0, total: 100 },
+    memory: { active: oneGB, available: 9 * oneGB, pending: 0, total: 10 * oneGB },
+    storage: {
+      ephemeral: { active: 100 * oneGB, available: 400 * oneGB, pending: 0, total: 500 * oneGB },
+      persistent: { active: 200 * oneGB, available: 300 * oneGB, pending: 0, total: 500 * oneGB },
+      total: { active: 300 * oneGB, available: 700 * oneGB, pending: 0, total: 1000 * oneGB }
+    },
+    ...overrides
+  };
+}

--- a/apps/deploy-web/src/components/providers/NetworkCapacity/NetworkCapacity.spec.tsx
+++ b/apps/deploy-web/src/components/providers/NetworkCapacity/NetworkCapacity.spec.tsx
@@ -133,9 +133,9 @@ describe(NetworkCapacity.name, () => {
       expect(storagePieData).toHaveLength(4);
       expect(storagePieData).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ id: "active-ephemeral", label: "Active emphemeral" }),
+          expect.objectContaining({ id: "active-ephemeral", label: "Active ephemeral" }),
           expect.objectContaining({ id: "active-persistent", label: "Active persistent" }),
-          expect.objectContaining({ id: "available-emphemeral", label: "Available emphemeral" }),
+          expect.objectContaining({ id: "available-ephemeral", label: "Available ephemeral" }),
           expect.objectContaining({ id: "available-persistent", label: "Available persistent" })
         ])
       );
@@ -154,7 +154,7 @@ describe(NetworkCapacity.name, () => {
       const { pieProps } = setup({ stats });
 
       const storagePieData = pieProps[3].data;
-      const availableEphemeral = storagePieData.find(d => d.id === "available-emphemeral");
+      const availableEphemeral = storagePieData.find(d => d.id === "available-ephemeral");
       const availablePersistent = storagePieData.find(d => d.id === "available-persistent");
 
       expect(availableEphemeral?.value).toBe(500 * oneGB + 100 * oneGB);

--- a/apps/deploy-web/src/components/providers/NetworkCapacity/NetworkCapacity.tsx
+++ b/apps/deploy-web/src/components/providers/NetworkCapacity/NetworkCapacity.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useMemo } from "react";
 import { useIntl } from "react-intl";
 import type { PieSvgProps, PieTooltipProps } from "@nivo/pie";
 import { ResponsivePie } from "@nivo/pie";
@@ -6,6 +7,7 @@ import { BasicTooltip } from "@nivo/tooltip";
 import { useTheme } from "next-themes";
 
 import useTailwind from "@src/hooks/useTailwind";
+import type { NetworkCapacityStats } from "@src/queries/useProvidersQuery";
 import { roundDecimal } from "@src/utils/mathHelpers";
 import { bytesToShrink } from "@src/utils/unitUtils";
 
@@ -18,28 +20,40 @@ type NetworkCapacityDatum = {
 };
 
 export interface Props {
-  activeCPU: number;
-  pendingCPU: number;
-  totalCPU: number;
-  activeGPU: number;
-  pendingGPU: number;
-  totalGPU: number;
-  activeMemory: number;
-  pendingMemory: number;
-  totalMemory: number;
-  activeStorage: number;
-  pendingStorage: number;
-  totalStorage: number;
-  activeEphemeralStorage: number;
-  pendingEphemeralStorage: number;
-  availableEphemeralStorage: number;
-  activePersistentStorage: number;
-  pendingPersistentStorage: number;
-  availablePersistentStorage: number;
+  stats: NetworkCapacityStats["resources"];
+  dependencies?: typeof DEPENDENCIES;
 }
 
-const NetworkCapacity: React.FunctionComponent<Props> = props => {
-  const { activeCPU, totalCPU, activeGPU, totalGPU, activeMemory, totalMemory, activeStorage, totalStorage } = props;
+export const DEPENDENCIES = {
+  ResponsivePie,
+  TooltipLabel
+};
+
+const NetworkCapacity: React.FunctionComponent<Props> = ({ stats, dependencies: d = DEPENDENCIES }) => {
+  const networkCapacity = useMemo(() => {
+    return {
+      activeCPU: stats.cpu.active / 1000,
+      pendingCPU: stats.cpu.pending / 1000,
+      totalCPU: stats.cpu.total / 1000,
+      activeGPU: stats.gpu.active,
+      pendingGPU: stats.gpu.pending,
+      totalGPU: stats.gpu.total,
+      activeMemory: stats.memory.active,
+      pendingMemory: stats.memory.pending,
+      totalMemory: stats.memory.total,
+      activeStorage: stats.storage.ephemeral.active + stats.storage.persistent.active,
+      pendingStorage: stats.storage.ephemeral.pending + stats.storage.persistent.pending,
+      totalStorage: stats.storage.total.total,
+      activeEphemeralStorage: stats.storage.ephemeral.active,
+      pendingEphemeralStorage: stats.storage.ephemeral.pending,
+      availableEphemeralStorage: stats.storage.ephemeral.available,
+      activePersistentStorage: stats.storage.persistent.active,
+      pendingPersistentStorage: stats.storage.persistent.pending,
+      availablePersistentStorage: stats.storage.persistent.available
+    };
+  }, [stats]);
+  const { activeCPU, totalCPU, activeGPU, totalGPU, activeMemory, totalMemory, activeStorage, totalStorage } = networkCapacity;
+
   const activeMemoryBytes = activeMemory;
   const availableMemoryBytes = totalMemory - activeMemory;
   const activeStorageBytes = activeStorage;
@@ -51,7 +65,7 @@ const NetworkCapacity: React.FunctionComponent<Props> = props => {
   const cpuData = useData(activeCPU, totalCPU - activeCPU);
   const gpuData = useData(activeGPU, totalGPU - activeGPU);
   const memoryData = useData(activeMemoryBytes, availableMemoryBytes);
-  const storageData = useStorageData(props);
+  const storageData = useStorageData(stats.storage);
   const pieTheme = usePieTheme();
   const intl = useIntl();
 
@@ -63,7 +77,7 @@ const NetworkCapacity: React.FunctionComponent<Props> = props => {
           {Math.round(activeCPU)}&nbsp;CPU&nbsp;/&nbsp;{Math.round(totalCPU)}&nbsp;CPU
         </p>
         <div className="flex h-[200px] w-[200px] items-center justify-center">
-          <ResponsivePie
+          <d.ResponsivePie
             data={cpuData}
             margin={{ top: 15, right: 15, bottom: 15, left: 0 }}
             innerRadius={0.3}
@@ -86,7 +100,7 @@ const NetworkCapacity: React.FunctionComponent<Props> = props => {
             enableArcLinkLabels={false}
             arcLabelsSkipAngle={30}
             theme={pieTheme}
-            tooltip={TooltipLabel}
+            tooltip={d.TooltipLabel}
           />
         </div>
       </div>
@@ -97,7 +111,7 @@ const NetworkCapacity: React.FunctionComponent<Props> = props => {
           {Math.round(activeGPU)}&nbsp;GPU&nbsp;/&nbsp;{Math.round(totalGPU)}&nbsp;GPU
         </p>
         <div className="flex h-[200px] w-[200px] items-center justify-center">
-          <ResponsivePie
+          <d.ResponsivePie
             data={gpuData}
             margin={{ top: 15, right: 15, bottom: 15, left: 0 }}
             innerRadius={0.3}
@@ -119,7 +133,7 @@ const NetworkCapacity: React.FunctionComponent<Props> = props => {
             enableArcLinkLabels={false}
             arcLabelsSkipAngle={30}
             theme={pieTheme}
-            tooltip={TooltipLabel}
+            tooltip={d.TooltipLabel}
           />
         </div>
       </div>
@@ -130,7 +144,7 @@ const NetworkCapacity: React.FunctionComponent<Props> = props => {
           {`${roundDecimal(_activeMemory.value, 2)} ${_activeMemory.unit}`}&nbsp;/&nbsp;{`${roundDecimal(_totalMemory.value, 2)} ${_totalMemory.unit}`}
         </p>
         <div className="flex h-[200px] w-[200px] items-center justify-center">
-          <ResponsivePie
+          <d.ResponsivePie
             data={memoryData}
             margin={{ top: 15, right: 15, bottom: 15, left: 15 }}
             innerRadius={0.3}
@@ -151,7 +165,7 @@ const NetworkCapacity: React.FunctionComponent<Props> = props => {
             enableArcLinkLabels={false}
             arcLabelsSkipAngle={30}
             theme={pieTheme}
-            tooltip={TooltipLabel}
+            tooltip={d.TooltipLabel}
           />
         </div>
       </div>
@@ -162,7 +176,7 @@ const NetworkCapacity: React.FunctionComponent<Props> = props => {
           {`${roundDecimal(_activeStorage.value, 2)} ${_activeStorage.unit}`}&nbsp;/&nbsp;{`${roundDecimal(_totalStorage.value, 2)} ${_totalStorage.unit}`}
         </p>
         <div className="flex h-[200px] w-[200px] items-center justify-center">
-          <ResponsivePie
+          <d.ResponsivePie
             data={storageData}
             margin={{ top: 15, right: 15, bottom: 15, left: 15 }}
             innerRadius={0.3}
@@ -182,7 +196,7 @@ const NetworkCapacity: React.FunctionComponent<Props> = props => {
             enableArcLinkLabels={false}
             arcLabelsSkipAngle={30}
             theme={pieTheme}
-            tooltip={TooltipLabel}
+            tooltip={d.TooltipLabel}
           />
         </div>
       </div>
@@ -210,7 +224,7 @@ const useData = (active: number, available: number): NetworkCapacityDatum[] => {
   ];
 };
 
-function useStorageData(props: Props): NetworkCapacityDatum[] {
+function useStorageData(storageStats: NetworkCapacityStats["resources"]["storage"]): NetworkCapacityDatum[] {
   const { resolvedTheme } = useTheme();
   const tw = useTailwind();
 
@@ -219,25 +233,25 @@ function useStorageData(props: Props): NetworkCapacityDatum[] {
       id: "active-ephemeral",
       label: "Active emphemeral",
       color: tw.theme.colors["primary"].DEFAULT,
-      value: props.activeEphemeralStorage
+      value: storageStats.ephemeral.active
     },
     {
       id: "active-persistent",
       label: "Active persistent",
       color: tw.theme.colors["primary"].visited,
-      value: props.activePersistentStorage
+      value: storageStats.persistent.active
     },
     {
       id: "available-emphemeral",
       label: "Available emphemeral",
       color: resolvedTheme === "dark" ? tw.theme.colors.neutral[400] : tw.theme.colors.neutral[500],
-      value: props.availableEphemeralStorage + props.pendingEphemeralStorage
+      value: storageStats.ephemeral.available + storageStats.ephemeral.pending
     },
     {
       id: "available-persistent",
       label: "Available persistent",
       color: resolvedTheme === "dark" ? tw.theme.colors.neutral[600] : tw.theme.colors.neutral[300],
-      value: props.availablePersistentStorage + props.pendingPersistentStorage
+      value: storageStats.persistent.available + storageStats.persistent.pending
     }
   ];
 }
@@ -261,8 +275,8 @@ const usePieTheme = () => {
   };
 };
 
-const TooltipLabel = <R,>({ datum }: PieTooltipProps<R>) => (
-  <BasicTooltip id={datum.label} value={datum.formattedValue} enableChip={true} color={datum.color} />
-);
+function TooltipLabel<R>({ datum }: PieTooltipProps<R>) {
+  return <BasicTooltip id={datum.label} value={datum.formattedValue} enableChip={true} color={datum.color} />;
+}
 
 export default NetworkCapacity;

--- a/apps/deploy-web/src/components/providers/NetworkCapacity/NetworkCapacity.tsx
+++ b/apps/deploy-web/src/components/providers/NetworkCapacity/NetworkCapacity.tsx
@@ -231,7 +231,7 @@ function useStorageData(storageStats: NetworkCapacityStats["resources"]["storage
   return [
     {
       id: "active-ephemeral",
-      label: "Active emphemeral",
+      label: "Active ephemeral",
       color: tw.theme.colors["primary"].DEFAULT,
       value: storageStats.ephemeral.active
     },
@@ -242,8 +242,8 @@ function useStorageData(storageStats: NetworkCapacityStats["resources"]["storage
       value: storageStats.persistent.active
     },
     {
-      id: "available-emphemeral",
-      label: "Available emphemeral",
+      id: "available-ephemeral",
+      label: "Available ephemeral",
       color: resolvedTheme === "dark" ? tw.theme.colors.neutral[400] : tw.theme.colors.neutral[500],
       value: storageStats.ephemeral.available + storageStats.ephemeral.pending
     },

--- a/apps/deploy-web/src/components/providers/ProviderList.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderList.tsx
@@ -33,7 +33,7 @@ import { Title } from "../shared/Title";
 import { ProviderMap } from "./ProviderMap";
 import { ProviderTable } from "./ProviderTable";
 
-const NetworkCapacity = dynamic(() => import("./NetworkCapacity"), {
+const NetworkCapacity = dynamic(() => import("./NetworkCapacity/NetworkCapacity"), {
   ssr: false
 });
 
@@ -125,8 +125,8 @@ export const ProviderList: React.FunctionComponent = () => {
         } else if (sort === "my-active-leases-desc") {
           return b.userActiveLeases - a.userActiveLeases;
         } else if (sort === "gpu-available-desc") {
-          const totalGpuB = b.availableStats.gpu + b.pendingStats.gpu + b.activeStats.gpu;
-          const totalGpuA = a.availableStats.gpu + a.pendingStats.gpu + a.activeStats.gpu;
+          const totalGpuB = b.stats.gpu.available + b.stats.gpu.pending + b.stats.gpu.active;
+          const totalGpuA = a.stats.gpu.available + a.stats.gpu.pending + a.stats.gpu.active;
           return totalGpuB - totalGpuA;
         } else {
           return 1;
@@ -201,7 +201,7 @@ export const ProviderList: React.FunctionComponent = () => {
 
       {providers && networkCapacity && (
         <div className="mb-8">
-          <NetworkCapacity {...networkCapacity} />
+          <NetworkCapacity stats={networkCapacity.resources} />
         </div>
       )}
 

--- a/apps/deploy-web/src/components/providers/ProviderTableRow.tsx
+++ b/apps/deploy-web/src/components/providers/ProviderTableRow.tsx
@@ -27,17 +27,24 @@ export const ProviderListRow: React.FunctionComponent<Props> = ({ provider }) =>
   const router = useRouter();
   const { favoriteProviders, updateFavoriteProviders } = useLocalNotes();
   const isFavorite = favoriteProviders.some(x => provider.owner === x);
-  const activeCPU = provider.isOnline ? provider.activeStats.cpu / 1000 : 0;
-  const pendingCPU = provider.isOnline ? provider.pendingStats.cpu / 1000 : 0;
-  const totalCPU = provider.isOnline ? (provider.availableStats.cpu + provider.pendingStats.cpu + provider.activeStats.cpu) / 1000 : 0;
-  const activeGPU = provider.isOnline ? provider.activeStats.gpu : 0;
-  const pendingGPU = provider.isOnline ? provider.pendingStats.gpu : 0;
-  const totalGPU = provider.isOnline ? provider.availableStats.gpu + provider.pendingStats.gpu + provider.activeStats.gpu : 0;
-  const _activeMemory = provider.isOnline ? bytesToShrink(provider.activeStats.memory + provider.pendingStats.memory) : null;
-  const _totalMemory = provider.isOnline ? bytesToShrink(provider.availableStats.memory + provider.pendingStats.memory + provider.activeStats.memory) : null;
-  const _activeStorage = provider.isOnline ? bytesToShrink(provider.activeStats.storage + provider.pendingStats.storage) : null;
+  const activeCPU = provider.isOnline ? provider.stats.cpu.active / 1000 : 0;
+  const pendingCPU = provider.isOnline ? provider.stats.cpu.pending / 1000 : 0;
+  const totalCPU = provider.isOnline ? (provider.stats.cpu.available + provider.stats.cpu.pending + provider.stats.cpu.active) / 1000 : 0;
+  const activeGPU = provider.isOnline ? provider.stats.gpu.active : 0;
+  const pendingGPU = provider.isOnline ? provider.stats.gpu.pending : 0;
+  const totalGPU = provider.isOnline ? provider.stats.gpu.available + provider.stats.gpu.pending + provider.stats.gpu.active : 0;
+  const _activeMemory = provider.isOnline ? bytesToShrink(provider.stats.memory.active) : null;
+  const _totalMemory = provider.isOnline ? bytesToShrink(provider.stats.memory.available + provider.stats.memory.pending + provider.stats.memory.active) : null;
+  const _activeStorage = provider.isOnline ? bytesToShrink(provider.stats.storage.ephemeral.active + provider.stats.storage.persistent.active) : null;
   const _totalStorage = provider.isOnline
-    ? bytesToShrink(provider.availableStats.storage + provider.pendingStats.storage + provider.activeStats.storage)
+    ? bytesToShrink(
+        provider.stats.storage.ephemeral.available +
+          provider.stats.storage.ephemeral.pending +
+          provider.stats.storage.ephemeral.active +
+          provider.stats.storage.persistent.available +
+          provider.stats.storage.persistent.pending +
+          provider.stats.storage.persistent.active
+      )
     : null;
   const gpuModels = provider.gpuModels.map(x => x.model).filter(createFilterUnique());
 
@@ -167,8 +174,8 @@ export const ProviderListRow: React.FunctionComponent<Props> = ({ provider }) =>
           <div className="flex items-center">
             <CapacityIcon
               value={
-                (provider.activeStats.memory + provider.pendingStats.memory) /
-                (provider.availableStats.memory + provider.pendingStats.memory + provider.activeStats.memory)
+                (provider.stats.memory.active + provider.stats.memory.pending) /
+                (provider.stats.memory.available + provider.stats.memory.pending + provider.stats.memory.active)
               }
               fontSize="small"
             />
@@ -185,8 +192,16 @@ export const ProviderListRow: React.FunctionComponent<Props> = ({ provider }) =>
           <div className="flex items-center">
             <CapacityIcon
               value={
-                (provider.activeStats.storage + provider.pendingStats.storage) /
-                (provider.availableStats.storage + provider.pendingStats.storage + provider.activeStats.storage)
+                (provider.stats.storage.ephemeral.active +
+                  provider.stats.storage.ephemeral.pending +
+                  provider.stats.storage.persistent.active +
+                  provider.stats.storage.persistent.pending) /
+                (provider.stats.storage.ephemeral.available +
+                  provider.stats.storage.ephemeral.pending +
+                  provider.stats.storage.ephemeral.active +
+                  provider.stats.storage.persistent.available +
+                  provider.stats.storage.persistent.pending +
+                  provider.stats.storage.persistent.active)
               }
               fontSize="small"
             />

--- a/apps/deploy-web/src/queries/useProvidersQuery.ts
+++ b/apps/deploy-web/src/queries/useProvidersQuery.ts
@@ -3,10 +3,19 @@ import { useQuery } from "@tanstack/react-query";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useScopedFetchProviderUrl } from "@src/hooks/useScopedFetchProviderUrl";
-import type { ApiProviderDetail, ApiProviderList, ApiProviderRegion, Auditor, ProviderStatus, ProviderStatusDto, ProviderVersion } from "@src/types/provider";
+import type {
+  ApiProviderDetail,
+  ApiProviderList,
+  ApiProviderRegion,
+  Auditor,
+  ProviderStatus,
+  ProviderStatusDto,
+  ProviderVersion,
+  StatsItem
+} from "@src/types/provider";
 import type { ProviderAttributesSchema } from "@src/types/providerAttributes";
 import { ApiUrlService } from "@src/utils/apiUtils";
-import { getNetworkCapacityDto, providerStatusToDto } from "@src/utils/providerUtils";
+import { providerStatusToDto } from "@src/utils/providerUtils";
 import { QueryKeys } from "./queryKeys";
 
 export function useProviderDetail(
@@ -52,9 +61,23 @@ export function useNetworkCapacity(options = {}) {
   const { publicConsoleApiHttpClient } = useServices();
   return useQuery({
     queryKey: QueryKeys.getNetworkCapacity(),
-    queryFn: () => publicConsoleApiHttpClient.get(ApiUrlService.networkCapacity()).then(response => getNetworkCapacityDto(response.data)),
+    queryFn: () => publicConsoleApiHttpClient.get<NetworkCapacityStats>(ApiUrlService.networkCapacity()).then(response => response.data),
     ...options
   });
+}
+
+export interface NetworkCapacityStats {
+  activeProviderCount: number;
+  resources: {
+    cpu: StatsItem;
+    gpu: StatsItem;
+    memory: StatsItem;
+    storage: {
+      ephemeral: StatsItem;
+      persistent: StatsItem;
+      total: StatsItem;
+    };
+  };
 }
 
 export function useAuditors(options = {}) {

--- a/apps/deploy-web/src/types/provider.ts
+++ b/apps/deploy-web/src/types/provider.ts
@@ -197,6 +197,7 @@ export interface ApiProviderList {
     storage: {
       ephemeral: StatsItem;
       persistent: StatsItem;
+      total: StatsItem;
     };
   };
   attributes: Array<{

--- a/apps/deploy-web/src/types/provider.ts
+++ b/apps/deploy-web/src/types/provider.ts
@@ -57,24 +57,6 @@ export interface ApiProvider {
     value: string;
     auditedBy: Array<string>;
   }>;
-  activeStats: {
-    cpu: number;
-    gpu: number;
-    memory: number;
-    storage: number;
-  };
-  pendingStats: {
-    cpu: number;
-    gpu: number;
-    memory: number;
-    storage: number;
-  };
-  availableStats: {
-    cpu: number;
-    gpu: number;
-    memory: number;
-    storage: number;
-  };
   isValidVersion: boolean;
 }
 
@@ -208,27 +190,6 @@ export interface ApiProviderList {
   lastOnlineDate: string;
   isAudited: boolean;
   gpuModels: { vendor: string; model: string; ram: string; interface: string }[];
-  /** @deprecated use `stats` instead */
-  activeStats: {
-    cpu: number;
-    gpu: number;
-    memory: number;
-    storage: number;
-  };
-  /** @deprecated use `stats` instead */
-  pendingStats: {
-    cpu: number;
-    gpu: number;
-    memory: number;
-    storage: number;
-  };
-  /** @deprecated use `stats` instead */
-  availableStats: {
-    cpu: number;
-    gpu: number;
-    memory: number;
-    storage: number;
-  };
   stats: {
     cpu: StatsItem;
     gpu: StatsItem;
@@ -309,4 +270,5 @@ export interface StatsItem {
   active: number;
   available: number;
   pending: number;
+  total: number;
 }

--- a/apps/deploy-web/src/utils/providerUtils.ts
+++ b/apps/deploy-web/src/utils/providerUtils.ts
@@ -23,16 +23,6 @@ export function providerStatusToDto(providerStatus: ProviderStatus, providerVers
   };
 }
 
-export function getNetworkCapacityDto(networkCapacity: any) {
-  return {
-    ...networkCapacity,
-    activeCPU: networkCapacity.activeCPU / 1000,
-    pendingCPU: networkCapacity.pendingCPU / 1000,
-    availableCPU: networkCapacity.availableCPU / 1000,
-    totalCPU: networkCapacity.totalCPU / 1000
-  };
-}
-
 export function getProviderLocalData(): LocalProviderData {
   const dataStr = localStorage.getItem(`${networkStore.selectedNetworkId}/provider.data`);
   if (!dataStr) {


### PR DESCRIPTION
## Why

To reduce payload and resolve tech debt. Ref https://github.com/akash-network/console/issues/665

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network capacity now shows hierarchical metrics (cpu, gpu, memory, storage) with storage split into ephemeral, persistent, plus a total aggregate.

* **Refactor**
  * Provider statistics consolidated into a single nested stats structure; UI components updated to consume the new shape and accept injected charting dependencies.
  * Legacy-shaped network-capacity output preserved for compatibility.

* **Tests**
  * Comprehensive service and UI tests added for aggregation, multi-provider scenarios, edge cases, and chart rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->