### PR TITLE
feat: enhance AuthInterceptor to handle invalid bearer tokens

### DIFF
--- a/apps/api/src/auth/services/auth.interceptor.ts
+++ b/apps/api/src/auth/services/auth.interceptor.ts
@@ -39,7 +39,14 @@ export class AuthInterceptor implements HonoInterceptor {
     return async (c: Context, next: Next) => {
       const bearer = c.req.header("authorization");
 
-      const userId = bearer && (await this.userAuthService.getValidUserId(bearer, c.env));
+      let userId: string | null | undefined;
+      if (bearer) {
+        try {
+          userId = await this.userAuthService.getValidUserId(bearer, c.env);
+        } catch (error) {
+          this.logger.warn({ event: "AUTH_TOKEN_VALIDATION_FAILED", error });
+        }
+      }
 
       if (userId) {
         const currentUser = await this.userRepository.findByUserId(userId);

--- a/apps/api/src/auth/services/user-auth-token/user-auth-token.service.ts
+++ b/apps/api/src/auth/services/user-auth-token/user-auth-token.service.ts
@@ -12,7 +12,7 @@ export class UserAuthTokenService {
     this.#authConfigService = authConfigService;
   }
 
-  async getValidUserId(bearer: string, options?: VerifyRsaJwtEnv) {
+  async getValidUserId(bearer: string, options?: VerifyRsaJwtEnv): Promise<string | null> {
     const token = bearer.replace(/^Bearer\s+/i, "");
     const jwksUri = this.#authConfigService.get("AUTH0_JWKS_URI") || options?.JWKS_URI;
 
@@ -22,6 +22,10 @@ export class UserAuthTokenService {
 
     const jwks = await getJwks(jwksUri, useKVStore(kvStore || options?.VERIFY_RSA_JWT), options?.VERIFY_RSA_JWT_JWKS_CACHE_KEY);
     const result = await verify(token, jwks);
+
+    if (!result.payload) {
+      return null;
+    }
 
     return (result.payload as { sub: string }).sub;
   }

--- a/apps/api/src/user/controllers/user/user.controller.ts
+++ b/apps/api/src/user/controllers/user/user.controller.ts
@@ -27,6 +27,7 @@ export class UserController {
   async registerUser(data: RegisterUserInput): Promise<RegisterUserResponse> {
     const { req, env, var: httpVars } = this.httpContext;
     const userId = await this.userAuthTokenService.getValidUserId(req.header("authorization") || "", env);
+    assert(userId, 401, "Invalid or expired token");
     const user = await this.userService.registerUser({
       userId,
       wantedUsername: data.wantedUsername,


### PR DESCRIPTION
closes https://github.com/akash-network/console/issues/2284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Reject requests that supply both bearer and API-key credentials with a 400.
  * Ensure invalid or expired bearer tokens produce 401 responses and no longer allow further user actions.
  * Improve authentication handling so token validation failures are handled more gracefully.

* **Tests**
  * Expanded test coverage for bearer token and header conflict scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->