### PR TITLE
fix: restore auditors.json

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -4,6 +4,8 @@ This project consists of essential config files for Akash Console.
 
 Here's a short description of the purpose of each files.
 
+- [Auditors](https://github.com/akash-network/console/blob/main/config/auditors.json)
+  - The list of provider auditors that are listed on Akash Console.
 - [Mainnet Nodes](https://github.com/akash-network/console/blob/main/config/mainnet-nodes.json)
   - The list of api/rpc nodes for the Mainnet.
 - [Testnet Nodes](https://github.com/akash-network/console/blob/main/config/testnet-nodes.json)

--- a/config/auditors.json
+++ b/config/auditors.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "akash-network",
+    "name": "Akash Network",
+    "address": "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63",
+    "website": "https://akash.network"
+  }
+]


### PR DESCRIPTION
## Why

because prod uses it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to document auditor configuration setup.

* **New Features**
  * Added provider auditor configuration enabling auditor listings on Akash Console. Initial entry includes Akash Network auditor information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->