### PR TITLE
fix: properly proxy body-less requests

### DIFF
--- a/apps/deploy-web/src/lib/nextjs/pageGuards/pageGuards.ts
+++ b/apps/deploy-web/src/lib/nextjs/pageGuards/pageGuards.ts
@@ -9,7 +9,12 @@ export async function isFeatureEnabled(featureName: string, context: AppTypedCon
 
 export async function isAuthenticated(context: AppTypedContext): Promise<boolean> {
   const session = await context.getCurrentSession();
-  return !!session?.user;
+  if (!session?.user) return false;
+
+  const accessTokenExpiry = new Date((session.accessTokenExpiresAt || 0) * 1_000);
+  if (accessTokenExpiry <= new Date()) return false;
+
+  return true;
 }
 
 export async function redirectIfAccessTokenExpired(context: AppTypedContext): Promise<{ redirect: Redirect } | true> {

--- a/apps/deploy-web/src/lib/nextjs/proxyRequest/proxyRequest.spec.ts
+++ b/apps/deploy-web/src/lib/nextjs/proxyRequest/proxyRequest.spec.ts
@@ -55,6 +55,26 @@ describe(proxyRequest.name, () => {
       );
     });
 
+    it("forwards POST request without body", async () => {
+      const { mockFetch } = await setup({
+        method: "POST",
+        fetchResponse: {
+          status: 201,
+          headers: new Headers(),
+          body: createReadableStream("created")
+        }
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://target.com/api",
+        expect.objectContaining({
+          method: "POST",
+          body: undefined,
+          duplex: undefined
+        })
+      );
+    });
+
     it("does not include body for GET requests", async () => {
       const { mockFetch } = await setup({
         method: "GET",
@@ -404,9 +424,7 @@ describe(proxyRequest.name, () => {
 
     if (input.requestBody) {
       const readable = Readable.from([input.requestBody]);
-      Object.assign(req, readable);
-    } else {
-      const readable = Readable.from([]);
+      req.headers["content-length"] = input.requestBody.length.toString();
       Object.assign(req, readable);
     }
 

--- a/apps/deploy-web/src/lib/nextjs/proxyRequest/proxyRequest.ts
+++ b/apps/deploy-web/src/lib/nextjs/proxyRequest/proxyRequest.ts
@@ -72,7 +72,9 @@ async function forwardRequestStream(req: NextApiRequest, res: NextApiResponse, o
   });
 
   const method = req.method?.toUpperCase() || "GET";
-  const body = method === "GET" || method === "HEAD" ? undefined : Readable.toWeb(req);
+  const contentLength = Number(req.headers["content-length"]) || 0;
+  const hasBody = method !== "GET" && method !== "HEAD" && (contentLength > 0 || req.headers["transfer-encoding"]);
+  const body = hasBody ? Readable.toWeb(req) : undefined;
 
   const fetch = options.fetch ?? globalThis.fetch;
   const response = await fetch(options.target, {


### PR DESCRIPTION
## Why

Currently fetch proxy doesn't proxy POST requests without body. This PR fixes it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Explicitly validate access token expiry to prevent use of expired credentials.
  * Ensure proxying omits request bodies when none are present, avoiding unnecessary transmission.

* **Tests**
  * Added/updated tests to cover token-expiry behavior and forwarding of POST requests without a body.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->