### PR TITLE
fix: fixes dispose of sequelize db connections

### DIFF
--- a/apps/api/src/chain/providers/sequelize.provider.ts
+++ b/apps/api/src/chain/providers/sequelize.provider.ts
@@ -65,17 +65,18 @@ async function syncUserSchema() {
 
 container.register(APP_INITIALIZER, {
   useFactory: instancePerContainerCachingFactory(
-    DisposableRegistry.registerFromFactory(
-      c =>
-        ({
-          async [ON_APP_START]() {
-            await connectUsingSequelize(c.resolve(LoggerService));
-          },
-          async dispose() {
-            await Promise.all([c.resolve(CHAIN_DB).close(), c.resolve(USER_DB).close()]);
-          }
-        }) satisfies AppInitializer & Disposable
-    )
+    DisposableRegistry.registerFromFactory(c => {
+      const chainDb = c.resolve(CHAIN_DB);
+      const userDb = c.resolve(USER_DB);
+      return {
+        async [ON_APP_START]() {
+          await connectUsingSequelize(c.resolve(LoggerService));
+        },
+        async dispose() {
+          await Promise.all([chainDb.close(), userDb.close()]);
+        }
+      } satisfies AppInitializer & Disposable;
+    })
   )
 });
 


### PR DESCRIPTION
## Why

It's not allowed to resolve any container symbols inside `.dispose` function. At this point, container throws an error that it has been disposed and cannot be used to resolve refs. That's why we need to resolve dbs earlier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database resource lifecycle management to improve application startup and shutdown efficiency, ensuring more reliable resource handling without changes to user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->