### PR TITLE
chore: runs security scan only after main CI finishes successfully

### DIFF
--- a/.github/actions/associated-pr/action.yml
+++ b/.github/actions/associated-pr/action.yml
@@ -1,7 +1,11 @@
 name: Get Associated PR
-description: Gets the associated PR for a commit (takes commit from github context)
+description: Gets the associated PR for a commit (takes commit from github context or sha input)
 
 inputs:
+  sha:
+    description: Commit SHA to look up (defaults to github.sha)
+    required: false
+    default: ""
   gh-user-to-slack-user:
     description: GitHub user to Slack user mapping
     required: false
@@ -20,6 +24,15 @@ outputs:
   slack-user:
     description: The Slack user of the author
     value: ${{ steps.associated-pr.outputs.slack-user }}
+  head_ref:
+    description: The head branch ref of the PR
+    value: ${{ steps.associated-pr.outputs.head_ref }}
+  head_repo:
+    description: The head repository full name of the PR
+    value: ${{ steps.associated-pr.outputs.head_repo }}
+  labels:
+    description: Comma-separated list of PR labels
+    value: ${{ steps.associated-pr.outputs.labels }}
 
 runs:
   using: "composite"
@@ -28,8 +41,10 @@ runs:
       id: associated-pr
       env:
         GH_USER_TO_SLACK_USER: ${{ inputs.gh-user-to-slack-user }}
+        INPUT_SHA: ${{ inputs.sha }}
       with:
         script: |
+          const commitSha = process.env.INPUT_SHA || context.sha;
           let pr = context.payload.pull_request;
 
           // Retry logic to handle timing issues with GitHub API
@@ -48,7 +63,7 @@ runs:
 
               const response = (
                 await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                  commit_sha: context.sha,
+                  commit_sha: commitSha,
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                 })
@@ -72,16 +87,22 @@ runs:
           }
 
           if (!pr) {
-            core.warning(`No PR found for commit ${context.sha} after retries`);
+            core.warning(`No PR found for commit ${commitSha} after retries`);
             core.setOutput('number', '');
             core.setOutput('title', '');
             core.setOutput('author', '');
             core.setOutput('slack-user', '');
+            core.setOutput('head_ref', '');
+            core.setOutput('head_repo', '');
+            core.setOutput('labels', '');
             return;
           }
 
           core.setOutput('number', pr.number);
           core.setOutput('title', pr.title);
+          core.setOutput('head_ref', pr.head.ref);
+          core.setOutput('head_repo', pr.head.repo?.full_name || '');
+          core.setOutput('labels', (pr.labels || []).map(l => l.name).join(','));
 
           const author = pr.merged_by?.login || pr.user.login;
           core.setOutput('author', author);

--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -1,17 +1,17 @@
-# We need a separate workflow to get access to secrets because github doesn't share secrets on pull_request events.
-# https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target
+# Security scan workflow triggered after CI completes successfully.
+# Uses workflow_run to run in base repo context, giving access to secrets for fork PRs.
 #
 # !!!! PLEASE be extra careful here and treat forked repository as untrusted user input !!!!
 
-name: Unsafe CI
+name: Security Scan
 on:
-  pull_request_target:
-    branches:
-      - main
-      - main-sdk-next
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 permissions:
@@ -20,39 +20,122 @@ permissions:
 
 jobs:
   setup:
+    # Only run on successful CI for pull requests
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.value }}
+      should_run: ${{ steps.check_label.outputs.should_run }}
+      skip_reason: ${{ steps.check_label.outputs.skip_reason }}
+      pr_head_ref: ${{ steps.associated_pr.outputs.head_ref }}
+      pr_head_repo: ${{ steps.associated_pr.outputs.head_repo }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Get associated PR
+        id: associated_pr
+        uses: ./.github/actions/associated-pr
         with:
-          ref: ${{ github.event.pull_request.head.repo.full_name == github.repository &&
-            github.event.pull_request.head.ref ||
-            github.event.pull_request.base.ref }}
-      - id: matrix
+          sha: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Check for skip label
+        id: check_label
+        env:
+          PR_NUMBER: ${{ steps.associated_pr.outputs.number }}
+          PR_LABELS: ${{ steps.associated_pr.outputs.labels }}
         run: |
-          # validate packages all at once because they are shared and validate each app separately
-          results=("packages")
-          for pattern in $(jq -r '.workspaces[] | select(. | startswith("./packages/") | not)' package.json); do
-            for dir in $pattern; do
-              [[ -d "$dir" ]] && results+=("${dir#./}")
-            done
+          if [[ -z "$PR_NUMBER" ]]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=No PR found for commit" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if echo "$PR_LABELS" | grep -q "ignore-static-security-analysis"; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=Label 'ignore-static-security-analysis' is present" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build matrix from changed files
+        if: steps.check_label.outputs.should_run == 'true'
+        id: matrix
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.associated_pr.outputs.number }}
+        run: |
+          # Get changed files from PR
+          changed_files=$(gh api "/repos/${{ github.repository }}/pulls/$PR_NUMBER/files" \
+            --paginate --jq '.[].filename')
+
+          # Get all apps
+          all_apps=$(find apps/* -type d -print0 -maxdepth 0 | xargs -0 -n1 basename)
+
+          # Filter apps that have changes
+          changed_apps=()
+          for app in $all_apps; do
+            if echo "$changed_files" | grep -q "^apps/$app/"; then
+              changed_apps+=("$app")
+            fi
           done
 
-          workspaces=$(printf '"%s",' "${results[@]}")
-          workspaces="[${workspaces%,}]"
-          echo "workspaces=$workspaces"
+          if [ ${#changed_apps[@]} -eq 0 ]; then
+            echo "No apps have changes, skipping security scan"
+            echo "value=" >> "$GITHUB_OUTPUT"
+          else
+            workspaces=$(printf '"%s",' "${changed_apps[@]}")
+            workspaces="[${workspaces%,}]"
+            echo "Apps with changes: $workspaces"
+            echo 'value={"workspace":'"$workspaces"'}' >> "$GITHUB_OUTPUT"
+          fi
 
-          echo 'value={"workspace":'"$workspaces"'}' >> "$GITHUB_OUTPUT"
-
-  validate:
+  security-scan:
     needs: setup
+    if: needs.setup.outputs.should_run == 'true' && needs.setup.outputs.matrix != ''
     strategy:
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+      fail-fast: false
     uses: ./.github/workflows/reusable-validate-app-unsafe.yml
     secrets:
       gh-token: ${{ secrets.GITHUB_TOKEN }}
       snyk-token: ${{ secrets.SNYK_TOKEN }}
     with:
-      path: ${{ matrix.workspace }}
+      path: apps/${{ matrix.workspace }}
+      pr_head_ref: ${{ needs.setup.outputs.pr_head_ref }}
+      pr_head_repo: ${{ needs.setup.outputs.pr_head_repo }}
+      skip_change_detection: true
+
+  # Result job creates a single check that can be used as a required status check.
+  # This ensures a check is always created for PRs, even when security scan is skipped.
+  result:
+    runs-on: ubuntu-latest
+    needs: [setup, security-scan]
+    if: always() && needs.setup.result == 'success'
+    steps:
+      - name: Check result
+        env:
+          SHOULD_RUN: ${{ needs.setup.outputs.should_run }}
+          SKIP_REASON: ${{ needs.setup.outputs.skip_reason }}
+          MATRIX: ${{ needs.setup.outputs.matrix }}
+          SCAN_RESULT: ${{ needs.security-scan.result }}
+        run: |
+          if [[ "$SHOULD_RUN" != "true" ]]; then
+            echo "SKIPPED: $SKIP_REASON"
+            exit 0
+          fi
+
+          if [[ -z "$MATRIX" ]]; then
+            echo "SKIPPED: No apps have changes in this PR"
+            exit 0
+          fi
+
+          if [[ "$SCAN_RESULT" != "success" ]]; then
+            echo "Security scan failed with result: $SCAN_RESULT"
+            exit 1
+          fi
+
+          echo "Security scan completed successfully ✅"

--- a/.github/workflows/reusable-validate-app-unsafe.yml
+++ b/.github/workflows/reusable-validate-app-unsafe.yml
@@ -12,6 +12,19 @@ on:
         description: "The path to the workspace to validate"
         required: true
         type: string
+      pr_head_ref:
+        description: "PR head branch ref (optional, defaults to github.event.pull_request.head.ref)"
+        required: false
+        type: string
+      pr_head_repo:
+        description: "PR head repository full name (optional, defaults to github.event.pull_request.head.repo.full_name)"
+        required: false
+        type: string
+      skip_change_detection:
+        description: "Skip change detection and always run (useful when called from workflow_run context)"
+        required: false
+        type: boolean
+        default: false
     secrets:
       gh-token:
         description: "github token used to fetch changed files in PR"
@@ -22,6 +35,7 @@ on:
 
 jobs:
   should-validate-unsafe:
+    if: ${{ !inputs.skip_change_detection }}
     uses: ./.github/workflows/reusable-should-validate.yml
     secrets:
       gh-token: ${{ secrets.gh-token }}
@@ -31,13 +45,13 @@ jobs:
   validate-unsafe:
     needs: should-validate-unsafe
     runs-on: ubuntu-latest
-    if: needs.should-validate-unsafe.outputs.has_changes == 'true'
+    if: always() && (inputs.skip_change_detection || needs.should-validate-unsafe.outputs.has_changes == 'true')
     steps:
       - name: Checkout UNTRUSTED user's fork
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ inputs.pr_head_ref || github.event.pull_request.head.ref }}
+          repository: ${{ inputs.pr_head_repo || github.event.pull_request.head.repo.full_name }}
           path: ./untrusted-user-fork
       - name: Copy .dcignore
         shell: bash


### PR DESCRIPTION
## Why

1. Reduce noise in gh checks list
2. Reduce usage of snyk free scans
3. Reduce gh runner usage (especially in case of CI failures)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced PR metadata exposure including branch reference, repository name, and labels
  * Added ability to skip security scans using a label in CI/CD workflows
  * Improved security scanning workflow with efficient dynamic app detection for fork pull requests
  * Added optional commit SHA parameter for more precise PR lookup and association during builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->