### PR TITLE
fix: switch container build target to production

### DIFF
--- a/apps/deploy-web/nginx.conf
+++ b/apps/deploy-web/nginx.conf
@@ -35,35 +35,5 @@ http {
             proxy_buffer_size 16k;
             proxy_cookie_path / "/; HTTPOnly; Secure";
         }
-
-        # slash is important at the end of the location!
-        # See: https://nginx.org/en/docs/http/ngx_http_proxy_module.html?utm_source=chatgpt.com#proxy_pass
-        # To test this endpoint, uncomment commented proxy_pass directive and comment out the amplitude's one.
-        # Also update the Host header. Then use `wget -S -O - --no-check-certificate https://127.0.0.1/api/collect/qdqweqweqwe` inside container to test.
-        location /api/collect/ {
-            proxy_pass https://api2.amplitude.com/2/httpapi/;
-            # proxy_pass https://httpbin.org/anything/; # uncomment this for proxy testing
-
-            # remove cookies
-            proxy_set_header Cookie "";
-
-            # Preserve method/body; typical headers
-            proxy_http_version 1.1;
-            proxy_set_header Host api2.amplitude.com;
-            # proxy_set_header Host httpbin.org; # uncomment this for proxy testing
-
-            # Forward client IP info (useful for logs/debug; Amplitude may use IP in some contexts)
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-
-            # Streaming-ish behavior: avoid nginx buffering the whole request/response
-            proxy_request_buffering off;
-            proxy_buffering off;
-
-            # Timeouts (tune for your traffic)
-            proxy_connect_timeout 5s;
-            proxy_send_timeout 30s;
-            proxy_read_timeout 30s;
-        }
     }
 }

--- a/packages/docker/docker-compose.build.yml
+++ b/packages/docker/docker-compose.build.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../..
       dockerfile: packages/docker/Dockerfile.node
-      target: production-nginx
+      target: production
       args:
         WORKSPACE: apps/api
         GITHUB_PAT: ${GITHUB_PAT}
@@ -41,7 +41,7 @@ services:
     build:
       context: ../..
       dockerfile: packages/docker/Dockerfile.node
-      target: production-nginx
+      target: production
       args:
         WORKSPACE: apps/provider-proxy
 
@@ -50,7 +50,7 @@ services:
     build:
       context: ../..
       dockerfile: packages/docker/Dockerfile.nextjs
-      target: production-nginx
+      target: production
       args:
         WORKSPACE: apps/deploy-web
         DEPLOYMENT_ENV: ${DEPLOYMENT_ENV}


### PR DESCRIPTION
## Why

Since we don't use nginx inside container in production (ports are mapped directly to our backend services), we should not build container which includes nginx. This will make them smaller, CI faster and resource utilization better

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration for api, provider-proxy, and deploy-web services to use production build targets
  * Removed analytics collection endpoint configuration from reverse proxy setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->