### PR TITLE
fix: adds amplitude proxy request to otel ignore

### DIFF
--- a/apps/deploy-web/sentry.client.config.ts
+++ b/apps/deploy-web/sentry.client.config.ts
@@ -15,7 +15,7 @@ initSentry({
   ],
   // propagate sentry-trace and baggage headers to internal API only
   // everything else will be done with custom interceptor
-  tracePropagationTargets: [/^\/api\//, /^\/_next\//],
+  tracePropagationTargets: [/^\/api\/(?!collect)/, /^\/_next\//],
   integrations: [
     // Filter out errors originating from browser extensions
     // Note: uses inboundFiltersIntegration (not eventFiltersIntegration) to override defaultIntegrations


### PR DESCRIPTION
## Why

Because sentry sends to it Sentry-Trace and Baggage which are too big and amplitude rejects request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted trace propagation configuration to exclude specific internal API endpoints from header tracing. This optimization reduces monitoring overhead and improves application performance by preventing unnecessary tracing operations on collection-related paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->