### PR TITLE
fix: moves amplitude on a separate subdomain

### DIFF
--- a/apps/deploy-web/env/.env
+++ b/apps/deploy-web/env/.env
@@ -34,6 +34,6 @@ NEXT_PUBLIC_UNLEASH_APP_NAME=console-web
 SENTRY_ORG=cloudmos
 SENTRY_PROJECT=deploy-web
 
-NEXT_PUBLIC_AMPLITUDE_PROXY_URL="/api/collect"
+NEXT_PUBLIC_AMPLITUDE_PROXY_URL="https://console-proxy.akash.network/collect"
 
 NEXT_PUBLIC_AUTH0_LOGIN=/login


### PR DESCRIPTION
## Why

It's easier than fighting with nginx-ingress configs to not send some headers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated analytics proxy configuration to use an external HTTPS endpoint for data collection instead of a local-relative path.
  * No other configuration or application behavior changes included; analytics routing is now directed to the specified external service endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->