### PR TITLE
fix: hides deployment stepper on the first step and fixes wallet btn spacing

### DIFF
--- a/apps/deploy-web/src/components/layout/WalletStatus.tsx
+++ b/apps/deploy-web/src/components/layout/WalletStatus.tsx
@@ -89,7 +89,7 @@ export function WalletStatus() {
             </div>
           </div>
         ) : (
-          <div className="w-full">
+          <div>
             {!isSignedInWithTrial && <ConnectManagedWalletButton className="mb-2 mr-2 w-full md:mb-0 md:w-auto" />}
             <ConnectWalletButton className="w-full md:w-auto" />
           </div>

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer.tsx
@@ -150,9 +150,11 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
     }
   }
 
+  const isFirstStepCompleted = activeStep !== null && activeStep >= 1;
+
   return (
     <Layout isLoading={isLoadingTemplates} isUsingSettings isUsingWallet containerClassName="pb-0 h-full">
-      {activeStep !== null && (
+      {isFirstStepCompleted && (
         <div className="flex w-full items-center">
           <CustomizedSteppers activeStep={activeStep} />
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment flow stepper now appears only after the first step is completed, preventing premature navigation hints and reducing confusion during initial setup.

* **Style**
  * Adjusted wallet status layout in the disconnected state to improve spacing and visual consistency across screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->