### PR TITLE
fix: adds E2E_TESTING_CLIENT_TOKEN to userAgent to disable rate limiting

### DIFF
--- a/apps/deploy-web/playwright.config.ts
+++ b/apps/deploy-web/playwright.config.ts
@@ -2,6 +2,8 @@ import { defineConfig, devices } from "@playwright/test";
 import dotenv from "dotenv";
 import path from "path";
 
+import { getUserAgent } from "./tests/ui/fixture/base-test"; // for process.env types
+
 dotenv.config({ path: path.resolve(__dirname, "env/.env.test") });
 
 /**
@@ -35,7 +37,8 @@ export default defineConfig({
       name: "chromium",
       use: {
         ...devices["Desktop Chrome"],
-        channel: "chromium" // https://github.com/microsoft/playwright/issues/33566
+        channel: "chromium", // https://github.com/microsoft/playwright/issues/33566
+        userAgent: getUserAgent()
       }
     }
 

--- a/apps/deploy-web/tests/ui/fixture/base-test.ts
+++ b/apps/deploy-web/tests/ui/fixture/base-test.ts
@@ -1,5 +1,5 @@
 import type { Page } from "@playwright/test";
-import { test as baseTest } from "@playwright/test";
+import { devices, test as baseTest } from "@playwright/test";
 
 export * from "@playwright/test";
 
@@ -19,4 +19,8 @@ export async function injectUIConfig(page: Page) {
       NEXT_PUBLIC_TURNSTILE_SITE_KEY: "1x00000000000000000000AA"
     });
   });
+}
+
+export function getUserAgent() {
+  return `${devices["Desktop Chrome"].userAgent} UIT/${process.env.E2E_TESTING_CLIENT_TOKEN}.`;
 }

--- a/apps/deploy-web/tests/ui/fixture/context-with-extension.ts
+++ b/apps/deploy-web/tests/ui/fixture/context-with-extension.ts
@@ -4,7 +4,7 @@ import os from "os";
 import path from "path";
 
 import { selectChainNetwork } from "../actions/selectChainNetwork";
-import { injectUIConfig, test as baseTest } from "./base-test";
+import { getUserAgent, injectUIConfig, test as baseTest } from "./base-test";
 import { testEnvConfig } from "./test-env.config";
 import { awaitWalletAndApprove, connectWalletViaLeap, getExtensionPage, setupWallet } from "./wallet-setup";
 
@@ -13,7 +13,7 @@ export const PATH_TO_EXTENSION = path.join(os.tmpdir(), "console-deploy-web-e2e-
 // @see https://playwright.dev/docs/chrome-extensions
 export const test = baseTest.extend<ExtensionContext>({
   // eslint-disable-next-line no-empty-pattern
-  context: async ({}, use) => {
+  context: async ({ contextOptions }, use) => {
     const args = [
       // keep new line
       `--disable-extensions-except=${PATH_TO_EXTENSION}`,
@@ -22,9 +22,11 @@ export const test = baseTest.extend<ExtensionContext>({
 
     const userDataDirForTest = `${testEnvConfig.USER_DATA_DIR}-${crypto.randomUUID()}`;
     const context = await chromium.launchPersistentContext(userDataDirForTest, {
+      ...contextOptions,
+      userAgent: getUserAgent(),
       channel: "chromium",
       args,
-      permissions: ["clipboard-read", "clipboard-write"]
+      permissions: (contextOptions.permissions ?? []).concat(["clipboard-read", "clipboard-write"])
     });
 
     try {

--- a/apps/deploy-web/tests/ui/fixture/wallet-setup.ts
+++ b/apps/deploy-web/tests/ui/fixture/wallet-setup.ts
@@ -177,8 +177,8 @@ export async function topUpWallet(address: string, attempt = 0) {
   try {
     const balance = await getBalance(address);
 
-    if (balance > 100 * 1_000_000) {
-      // 100 AKT should be enough
+    if (balance > 50 * 1_000_000) {
+      // 50 AKT should be enough
       return;
     }
 

--- a/apps/deploy-web/tests/ui/globalSetup/setup-wallet.ts
+++ b/apps/deploy-web/tests/ui/globalSetup/setup-wallet.ts
@@ -7,6 +7,7 @@ import { pipeline } from "node:stream/promises";
 import path from "path";
 
 import { selectChainNetwork } from "../actions/selectChainNetwork";
+import { getUserAgent } from "../fixture/base-test";
 import { PATH_TO_EXTENSION } from "../fixture/context-with-extension";
 import { testEnvConfig } from "../fixture/test-env.config";
 import { connectWalletViaLeap, getExtensionPage, importWalletToLeap, topUpWallet } from "../fixture/wallet-setup";
@@ -52,7 +53,8 @@ export default async () => {
     channel: "chromium",
     args,
     headless: !!process.env.CI,
-    permissions: ["clipboard-read", "clipboard-write"]
+    permissions: ["clipboard-read", "clipboard-write"],
+    userAgent: getUserAgent()
   });
 
   const extPage = await context.waitForEvent("page", { timeout: 5_000 }).catch(() => getExtensionPage(context));


### PR DESCRIPTION
## Why

Cloudflare blocks our e2e tests by displaying captcha and they fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved test environment setup to consistently apply a custom user agent across UI tests and persistent browser contexts.
* **Tests**
  * Updated test context handling to accept and merge runtime options (including permissions) for more flexible test scenarios.
  * Reduced wallet simulation top-up threshold from 100 AKT to 50 AKT.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->