### PR TITLE
fix: update template retrieval and response handling

### DIFF
--- a/apps/api/src/routers/legacyRouter.ts
+++ b/apps/api/src/routers/legacyRouter.ts
@@ -191,14 +191,10 @@ legacyRouter.get("/v1/templates-list.json", async c => {
   return c.redirect("/v1/templates-list", redirectStatusCode);
 });
 
-legacyRouter.get("/v1/templates/:id", async (c, next) => {
+legacyRouter.get("/v1/templates/:id.json", async c => {
   const id = c.req.param("id");
-  if (!id?.endsWith(".json")) {
-    return next();
-  }
-  const templateId = id.slice(0, -5); // Remove ".json" suffix
   const queryString = new URL(c.req.url).search;
-  return c.redirect(`/v1/templates/${templateId}${queryString}`, redirectStatusCode);
+  return c.redirect(`/v1/templates/${id}${queryString}`, redirectStatusCode);
 });
 
 legacyRouter.post("/user/subscribeToNewsletter", proxyToV1);

--- a/apps/api/src/routers/legacyRouter.ts
+++ b/apps/api/src/routers/legacyRouter.ts
@@ -191,10 +191,11 @@ legacyRouter.get("/v1/templates-list.json", async c => {
   return c.redirect("/v1/templates-list", redirectStatusCode);
 });
 
-legacyRouter.get("/v1/templates/:id.json", async c => {
+legacyRouter.get("/v1/templates/:id{.+\\.json}", async c => {
   const id = c.req.param("id");
+  const templateId = id.slice(0, -5); // Remove ".json" suffix
   const queryString = new URL(c.req.url).search;
-  return c.redirect(`/v1/templates/${id}${queryString}`, redirectStatusCode);
+  return c.redirect(`/v1/templates/${templateId}${queryString}`, redirectStatusCode);
 });
 
 legacyRouter.post("/user/subscribeToNewsletter", proxyToV1);

--- a/apps/api/src/routers/legacyRouter.ts
+++ b/apps/api/src/routers/legacyRouter.ts
@@ -191,9 +191,13 @@ legacyRouter.get("/v1/templates-list.json", async c => {
   return c.redirect("/v1/templates-list", redirectStatusCode);
 });
 
-legacyRouter.get("/v1/templates/:id.json", async c => {
+legacyRouter.get("/v1/templates/:id", async (c, next) => {
   const id = c.req.param("id");
-  return c.redirect(`/v1/templates/${id}`, redirectStatusCode);
+  if (!id?.endsWith(".json")) {
+    return next();
+  }
+  const templateId = id.slice(0, -5); // Remove ".json" suffix
+  return c.redirect(`/v1/templates/${templateId}`, redirectStatusCode);
 });
 
 legacyRouter.post("/user/subscribeToNewsletter", proxyToV1);

--- a/apps/api/src/routers/legacyRouter.ts
+++ b/apps/api/src/routers/legacyRouter.ts
@@ -197,7 +197,8 @@ legacyRouter.get("/v1/templates/:id", async (c, next) => {
     return next();
   }
   const templateId = id.slice(0, -5); // Remove ".json" suffix
-  return c.redirect(`/v1/templates/${templateId}`, redirectStatusCode);
+  const queryString = new URL(c.req.url).search;
+  return c.redirect(`/v1/templates/${templateId}${queryString}`, redirectStatusCode);
 });
 
 legacyRouter.post("/user/subscribeToNewsletter", proxyToV1);

--- a/apps/api/src/template/controllers/template/template.controller.ts
+++ b/apps/api/src/template/controllers/template/template.controller.ts
@@ -13,10 +13,10 @@ export class TemplateController {
     return await this.templateGalleryService.getGallerySummaryBuffer();
   }
 
-  async getTemplateById(id: string): Promise<{ data: Template }> {
+  async getTemplateById(id: string): Promise<Template> {
     const template = await this.templateGalleryService.getTemplateById(id);
     assert(template, 404, "Template not found");
 
-    return { data: template };
+    return template;
   }
 }

--- a/apps/api/src/template/controllers/template/template.controller.ts
+++ b/apps/api/src/template/controllers/template/template.controller.ts
@@ -13,10 +13,10 @@ export class TemplateController {
     return await this.templateGalleryService.getGallerySummaryBuffer();
   }
 
-  async getTemplateById(id: string): Promise<Template> {
+  async getTemplateById(id: string): Promise<{ data: Template }> {
     const template = await this.templateGalleryService.getTemplateById(id);
     assert(template, 404, "Template not found");
 
-    return template;
+    return { data: template };
   }
 }

--- a/apps/api/src/template/http-schemas/template.schema.ts
+++ b/apps/api/src/template/http-schemas/template.schema.ts
@@ -41,7 +41,5 @@ export const GetTemplateByIdParamsSchema = z.object({
   })
 });
 
-export const GetTemplateByIdResponseSchema = z.object({
-  data: TemplateSchema
-});
+export const GetTemplateByIdResponseSchema = TemplateSchema;
 export type GetTemplateByIdResponse = z.infer<typeof GetTemplateByIdResponseSchema>;

--- a/apps/api/src/template/http-schemas/template.schema.ts
+++ b/apps/api/src/template/http-schemas/template.schema.ts
@@ -41,5 +41,5 @@ export const GetTemplateByIdParamsSchema = z.object({
   })
 });
 
-export const GetTemplateByIdResponseSchema = TemplateSchema;
+export const GetTemplateByIdResponseSchema = z.object({ data: TemplateSchema });
 export type GetTemplateByIdResponse = z.infer<typeof GetTemplateByIdResponseSchema>;

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.spec.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.spec.ts
@@ -195,8 +195,8 @@ describe(TemplateGalleryService.name, () => {
 
       await service.buildTemplateGalleryCache(categoriesSchema);
 
-      expect(fsMock.writeFile).toHaveBeenCalledWith("/data/templates/v1/templates/t1.json", JSON.stringify(template1));
-      expect(fsMock.writeFile).toHaveBeenCalledWith("/data/templates/v1/templates/t2.json", JSON.stringify(template2));
+      expect(fsMock.writeFile).toHaveBeenCalledWith("/data/templates/v1/templates/t1.json", JSON.stringify({ data: template1 }));
+      expect(fsMock.writeFile).toHaveBeenCalledWith("/data/templates/v1/templates/t2.json", JSON.stringify({ data: template2 }));
     });
   });
 
@@ -205,7 +205,7 @@ describe(TemplateGalleryService.name, () => {
       const { service, fsMock } = setup();
       const template = { id: "t1", name: "Template 1" };
 
-      fsMock.readFile.mockResolvedValue(JSON.stringify(template));
+      fsMock.readFile.mockResolvedValue(JSON.stringify({ data: template }));
 
       const result = await service.getTemplateById("t1");
 
@@ -233,7 +233,7 @@ describe(TemplateGalleryService.name, () => {
       const { service, fsMock } = setup();
       const template = { id: "t1", name: "Template 1" };
 
-      fsMock.readFile.mockResolvedValue(JSON.stringify(template));
+      fsMock.readFile.mockResolvedValue(JSON.stringify({ data: template }));
 
       const firstResult = await service.getTemplateById("t1");
       const secondResult = await service.getTemplateById("t1");

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.ts
@@ -78,7 +78,7 @@ export class TemplateGalleryService {
     const { errors } = await PromisePool.for(allTemplates)
       .withConcurrency(100)
       .process(async template => {
-        await this.#fs.writeFile(this.#templateCachePath(template.id), JSON.stringify(template));
+        await this.#fs.writeFile(this.#templateCachePath(template.id), JSON.stringify({ data: template }));
       });
 
     if (errors.length > 0) {
@@ -143,7 +143,7 @@ export class TemplateGalleryService {
 
     try {
       const templateContent = await this.#fs.readFile(this.#templateCachePath(id), "utf8");
-      const template = JSON.parse(templateContent);
+      const template = JSON.parse(templateContent).data;
       this.#parsedTemplates.set(id, template);
       return template;
     } catch (error) {

--- a/apps/deploy-web/src/pages/templates/[templateId]/index.tsx
+++ b/apps/deploy-web/src/pages/templates/[templateId]/index.tsx
@@ -38,14 +38,16 @@ export const getServerSideProps = defineServerSideProps({
             title,
             description,
             url,
-            images: [
-              {
-                url: template.logoUrl,
-                width: 1200,
-                height: 630,
-                alt: "Template image"
-              }
-            ]
+            ...(template.logoUrl && {
+              images: [
+                {
+                  url: template.logoUrl,
+                  width: 1200,
+                  height: 630,
+                  alt: "Template image"
+                }
+              ]
+            })
           }
         }
       }

--- a/packages/http-sdk/src/template/template-http.service.ts
+++ b/packages/http-sdk/src/template/template-http.service.ts
@@ -39,7 +39,8 @@ export class TemplateHttpService {
   }
 
   async findById(id: string): Promise<TemplateOutput> {
-    return extractData(await this.#httpClient.get<TemplateOutput>(`/v1/templates/${id}.json`));
+    const response = extractData(await this.#httpClient.get<{ data: TemplateOutput }>(`/v1/templates/${id}.json`));
+    return response.data;
   }
 
   async findGroupedByCategory(): Promise<ApiOutput<TemplateCategory[]>> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Template page metadata now only includes preview images when a logo is present.
  * Legacy template redirects now preserve original query parameters when forwarding requests.

* **Chores**
  * API template responses standardized to a consistent { data: ... } envelope across services and client SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->