### PR TITLE
fix: managed wallet deposit denom

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit.tsx
@@ -218,6 +218,10 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
 
       if (isManaged) {
         sdl = appendAuditorRequirement(sdl);
+        // Ensure managed wallet denom is used (synchronous replacement to avoid race condition with useWhen hook)
+        if (managedDenom && managedDenom !== "uakt") {
+          sdl = sdl.replace(/uakt/g, managedDenom);
+        }
       }
 
       const [dd, newCert] = await Promise.all([createAndValidateDeploymentData(sdl, null, deposit), genNewCertificateIfLocalIsInvalid()]);

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit.tsx
@@ -218,7 +218,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
 
       if (isManaged) {
         sdl = appendAuditorRequirement(sdl);
-        // Ensure managed wallet denom is used (synchronous replacement to avoid race condition with useWhen hook)
+
         if (managedDenom && managedDenom !== "uakt") {
           sdl = sdl.replace(/uakt/g, managedDenom);
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managed deployments now properly remap denominations in the deployment manifest when using custom configurations instead of the default denomination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->