### PR TITLE
fix(user): shows friendly auth0 message and skips username update

### DIFF
--- a/apps/api/src/user/repositories/user/user.repository.ts
+++ b/apps/api/src/user/repositories/user/user.repository.ts
@@ -66,13 +66,14 @@ export class UserRepository extends BaseRepository<ApiPgTables["Users"], UserInp
       );
   }
 
-  async upsertByUserId(data: UserInput): Promise<UserOutput> {
+  async upsertOnExternalIdConflict(data: UserInput): Promise<UserOutput> {
+    const { username, ...withoutUsername } = data;
     const [item] = await this.cursor
       .insert(this.table)
       .values(this.toInput(data))
       .onConflictDoUpdate({
         target: [this.table.userId],
-        set: data
+        set: withoutUsername
       })
       .returning();
     return this.toOutput(item);

--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -112,7 +112,6 @@ describe(UserService.name, () => {
       expect(newUser).toMatchObject({
         id: existingUser.id,
         userId: existingUser.userId!,
-        username: input.wantedUsername,
         email: input.email,
         emailVerified: input.emailVerified,
         subscribedToNewsletter: input.subscribedToNewsletter

--- a/apps/api/src/user/services/user/user.service.ts
+++ b/apps/api/src/user/services/user/user.service.ts
@@ -79,7 +79,7 @@ export class UserService {
 
   private async upsertUser(userDetails: UpdateUserInput, attempt = 0): Promise<UserOutput> {
     try {
-      return await this.userRepository.upsertByUserId(userDetails);
+      return await this.userRepository.upsertOnExternalIdConflict(userDetails);
     } catch (error) {
       if (userDetails.username && isUniqueViolation(error) && error.constraint_name?.includes("username") && attempt < 10) {
         return this.upsertUser(

--- a/apps/deploy-web/src/services/session/session.service.ts
+++ b/apps/deploy-web/src/services/session/session.service.ts
@@ -117,7 +117,7 @@ export class SessionService {
     const isUserExists = signupResponse.status === 409 || (signupResponse.status === 400 && signupResponse.data.code === "invalid_signup");
     if (signupResponse.status >= 400 && !isUserExists) {
       return Err({
-        message: signupResponse.data.message || signupResponse.data.description || "Signup failed",
+        message: signupResponse.data.friendly_message || signupResponse.data.message || signupResponse.data.description || "Signup failed",
         code: "signup_failed",
         cause: extractResponseDetails(signupResponse)
       });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended username changes when updating existing user records during registration/upsert flows.
  * Signup error messaging now surfaces the backend's friendliest message first, with previous fallbacks used only when needed.

* **Tests**
  * Updated/added tests to verify username preservation and that signup returns friendly backend messages on error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->