### PR TITLE
fix: ensure SDL is not reset on changes during redeploy

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
@@ -23,7 +23,7 @@ import { useWhen } from "@src/hooks/useWhen";
 import { useDeploymentDetail } from "@src/queries/useDeploymentQuery";
 import { useDeploymentLeaseList } from "@src/queries/useLeaseQuery";
 import { useProviderList } from "@src/queries/useProvidersQuery";
-import { extractRepositoryUrl, isCiCdImageInYaml } from "@src/services/remote-deploy/env-var-manager.service";
+import { extractRepositoryUrl } from "@src/services/remote-deploy/env-var-manager.service";
 import { RouteStep } from "@src/types/route-steps.type";
 import { UrlService } from "@src/utils/urlUtils";
 import Layout from "../layout/Layout";
@@ -43,7 +43,7 @@ export interface DeploymentDetailProps {
 type Tab = "ALERTS" | "EVENTS" | "LOGS" | "SHELL" | "EDIT" | "LEASES";
 
 export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq }) => {
-  const { analyticsService, deploymentLocalStorage } = useServices();
+  const { analyticsService, deploymentLocalStorage, sdlAnalyzer } = useServices();
   const router = useRouter();
 
   const [activeTab, setActiveTab] = useState<Tab>("LEASES");
@@ -53,7 +53,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq }) => {
   const { isSettingsInit } = useSettings();
   const [leaseRefs, setLeaseRefs] = useState<Array<any>>([]);
   const [deploymentManifest, setDeploymentManifest] = useState<string | null>(null);
-  const isRemoteDeploy: boolean = !!editedManifest && !!isCiCdImageInYaml(editedManifest);
+  const isRemoteDeploy = sdlAnalyzer.hasCiCdImage(editedManifest);
   const repo: string | null = isRemoteDeploy ? extractRepositoryUrl(editedManifest) : null;
   const { user } = useUser();
   const isAlertsEnabled = useFlag("alerts") && !!user?.userId && isManaged;

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
@@ -1,0 +1,385 @@
+import React from "react";
+import type { TemplateOutput } from "@akashnetwork/http-sdk";
+import { mock } from "jest-mock-extended";
+import { createStore, Provider as JotaiStoreProvider } from "jotai";
+import type { ReadonlyURLSearchParams } from "next/navigation";
+
+import { CI_CD_TEMPLATE_ID } from "@src/config/remote-deploy.config";
+import type { ContextType as LocalNotesContext } from "@src/context/LocalNoteProvider/LocalNoteContext";
+import type { SdlContextProps } from "@src/context/SdlBuilderProvider";
+import type { AppDIContainer } from "@src/context/ServicesProvider";
+import sdlStore from "@src/store/sdlStore";
+import type { TemplateCreation } from "@src/types";
+import { RouteStep } from "@src/types/route-steps.type";
+import { hardcodedTemplates } from "@src/utils/templates";
+import { UrlService } from "@src/utils/urlUtils";
+import { DEPENDENCIES, NewDeploymentContainer } from "./NewDeploymentContainer";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
+
+describe(NewDeploymentContainer.name, () => {
+  it("renders TemplateList when step is choose-template", async () => {
+    setup({ step: RouteStep.chooseTemplate });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("template-list")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("manifest-edit")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("create-lease")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("stepper")).not.toBeInTheDocument();
+  });
+
+  it("renders ManifestEdit and Stepper when step is edit-deployment", async () => {
+    const { ManifestEdit } = setup({ step: RouteStep.editDeployment });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("manifest-edit")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("stepper")).toBeInTheDocument();
+    expect(screen.queryByTestId("template-list")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("create-lease")).not.toBeInTheDocument();
+    expect(ManifestEdit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedTemplate: null,
+        editedManifest: "",
+        isGitProviderTemplate: false
+      }),
+      {}
+    );
+  });
+
+  it("renders CreateLease and Stepper when step is create-leases", async () => {
+    const { CreateLease } = setup({ step: RouteStep.createLeases, dseq: "12345" });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("create-lease")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("stepper")).toBeInTheDocument();
+    expect(screen.queryByTestId("template-list")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("manifest-edit")).not.toBeInTheDocument();
+    expect(CreateLease).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dseq: "12345"
+      }),
+      {}
+    );
+  });
+
+  it("sets isGitProviderTemplate to true when gitProvider is github", async () => {
+    const { ManifestEdit } = setup({
+      step: RouteStep.editDeployment,
+      gitProvider: "github"
+    });
+
+    await waitFor(() => {
+      expect(ManifestEdit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isGitProviderTemplate: true
+        }),
+        {}
+      );
+    });
+  });
+
+  it("sets isGitProviderTemplate to true when code param is present", async () => {
+    const { ManifestEdit } = setup({
+      step: RouteStep.editDeployment,
+      code: "auth-code-123"
+    });
+
+    await waitFor(() => {
+      expect(ManifestEdit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isGitProviderTemplate: true
+        }),
+        {}
+      );
+    });
+  });
+
+  it("sets isGitProviderTemplate to true when templateId is CI_CD_TEMPLATE_ID", async () => {
+    const { ManifestEdit } = setup({
+      step: RouteStep.editDeployment,
+      templateId: CI_CD_TEMPLATE_ID
+    });
+
+    await waitFor(() => {
+      expect(ManifestEdit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isGitProviderTemplate: true
+        }),
+        {}
+      );
+    });
+  });
+
+  it("redirects to gitlab with correct params when state is gitlab and code is present", async () => {
+    const { mockRouter } = setup({
+      state: "gitlab",
+      code: "gitlab-auth-code"
+    });
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalledWith(
+        UrlService.newDeployment({
+          step: RouteStep.editDeployment,
+          gitProvider: "github",
+          gitProviderCode: "gitlab-auth-code",
+          templateId: CI_CD_TEMPLATE_ID
+        })
+      );
+    });
+  });
+
+  it("does not redirect to gitlab when redeploy param is present", async () => {
+    const { mockRouter } = setup({
+      state: "gitlab",
+      code: "gitlab-auth-code",
+      redeploy: "123"
+    });
+
+    await waitFor(() => {
+      expect(mockRouter.replace).not.toHaveBeenCalled();
+    });
+  });
+
+  it("redirects to edit-deployment step when templateId matches hardcodedTemplates", async () => {
+    const hardcodedTemplate = hardcodedTemplates[0];
+    const { mockRouter } = setup({
+      step: RouteStep.chooseTemplate,
+      templateId: hardcodedTemplate?.code
+    });
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalledWith(expect.stringContaining(`step=${RouteStep.editDeployment}`));
+    });
+  });
+
+  it("redirects to edit-deployment step when requestedTemplate prop is provided", async () => {
+    const requestedTemplate: TemplateOutput = {
+      id: "template-123",
+      name: "Test Template",
+      deploy: "version: 2.0\nservices:\n  web:\n    image: nginx",
+      config: { ssh: false },
+      summary: "",
+      logoUrl: "",
+      readme: "",
+      path: "",
+      guide: "",
+      githubUrl: "",
+      persistentStorageEnabled: false
+    };
+
+    const { mockRouter } = setup({
+      step: RouteStep.chooseTemplate,
+      requestedTemplate
+    });
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalledWith(expect.stringContaining(`step=${RouteStep.editDeployment}`));
+    });
+  });
+
+  it("redirects to edit-deployment step when deploySdl atom is available", async () => {
+    const deploySdl: TemplateCreation = {
+      code: "custom-sdl",
+      name: "Custom Template",
+      title: "Custom Template",
+      category: "General",
+      description: "Custom SDL template",
+      content: "custom sdl content"
+    };
+
+    const { mockRouter } = setup({
+      step: RouteStep.chooseTemplate,
+      deploySdl
+    });
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalledWith(expect.stringContaining(`step=${RouteStep.editDeployment}`));
+    });
+  });
+
+  it("redirects to edit-deployment step when redeploy param is present", async () => {
+    const redeployData = {
+      name: "Redeployed App",
+      manifest: "redeploy manifest content"
+    };
+
+    const { mockRouter } = setup({
+      step: RouteStep.chooseTemplate,
+      redeploy: "123",
+      redeployData
+    });
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalledWith(expect.stringContaining(`step=${RouteStep.editDeployment}`));
+    });
+  });
+
+  it("toggles ssh component when template has ssh config", async () => {
+    const { sdlBuilder } = setup({
+      step: RouteStep.chooseTemplate,
+      requestedTemplate: {
+        id: "ssh-template",
+        name: "SSH Template",
+        deploy: "ssh deploy content",
+        config: { ssh: true },
+        summary: "",
+        logoUrl: "",
+        readme: "",
+        path: "",
+        guide: "",
+        githubUrl: "",
+        persistentStorageEnabled: false
+      }
+    });
+
+    await waitFor(() => {
+      expect(sdlBuilder.toggleCmp).toHaveBeenCalledWith("ssh");
+    });
+  });
+
+  it("sets isGitProviderTemplate and redirects when CI/CD image is in yaml", async () => {
+    const deploySdl: TemplateCreation = {
+      code: "ci-cd",
+      name: "CI/CD Template",
+      title: "CI/CD Template",
+      category: "CI/CD",
+      description: "CI/CD template",
+      content: "ci-cd-image"
+    };
+
+    const { mockRouter } = setup({
+      step: RouteStep.chooseTemplate,
+      deploySdl,
+      hasCiCdImageInSDL: true
+    });
+
+    await waitFor(() => {
+      expect(mockRouter.replace).toHaveBeenCalledWith(expect.stringContaining("gitProvider"));
+    });
+  });
+
+  it("shows loading state when templates are loading", () => {
+    const { Layout } = setup({
+      step: RouteStep.chooseTemplate,
+      isLoadingTemplates: true
+    });
+
+    expect(Layout).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isLoading: true
+      }),
+      {}
+    );
+  });
+
+  it("renders with default step 0 when no step param is provided", async () => {
+    setup({});
+
+    await waitFor(() => {
+      expect(screen.getByTestId("template-list")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("stepper")).not.toBeInTheDocument();
+  });
+
+  function setup(
+    input: {
+      step?: RouteStep;
+      dseq?: string;
+      templateId?: string;
+      gitProvider?: string;
+      code?: string;
+      state?: string;
+      redeploy?: string;
+      redeployData?: { name: string; manifest: string };
+      requestedTemplate?: TemplateOutput;
+      deploySdl?: TemplateCreation | null;
+      isLoadingTemplates?: boolean;
+      hasCiCdImageInSDL?: boolean;
+    } = {}
+  ) {
+    const searchParams = new Map<string, string>();
+    if (input.step) searchParams.set("step", input.step);
+    if (input.dseq) searchParams.set("dseq", input.dseq);
+    if (input.templateId) searchParams.set("templateId", input.templateId);
+    if (input.gitProvider) searchParams.set("gitProvider", input.gitProvider);
+    if (input.code) searchParams.set("code", input.code);
+    if (input.state) searchParams.set("state", input.state);
+    if (input.redeploy) searchParams.set("redeploy", input.redeploy);
+
+    const mockSearchParams = {
+      get: (key: string) => searchParams.get(key) ?? null,
+      entries: () => searchParams.entries()
+    } as unknown as ReadonlyURLSearchParams;
+
+    const mockRouter = {
+      replace: jest.fn(),
+      push: jest.fn()
+    };
+
+    const Layout = jest.fn(({ children }: { children: React.ReactNode }) => <div data-testid="layout">{children}</div>);
+    const TemplateList = jest.fn(() => <div data-testid="template-list">TemplateList</div>);
+    const ManifestEdit = jest.fn(() => <div data-testid="manifest-edit">ManifestEdit</div>);
+    const CreateLease = jest.fn(() => <div data-testid="create-lease">CreateLease</div>);
+    const CustomizedSteppers = jest.fn(() => <div data-testid="stepper">Stepper</div>);
+
+    // Create stable references for hook return values to prevent infinite re-renders
+    const sdlBuilder = mock<SdlContextProps>();
+    const localNotes = mock<LocalNotesContext>({
+      getDeploymentData: jest.fn().mockReturnValue(input.redeployData ?? null)
+    });
+    const templatesValue = {
+      isLoading: input.isLoadingTemplates ?? false,
+      templates: [] as never[],
+      categories: [] as never[]
+    };
+
+    const sdlAnalyzer = mock<AppDIContainer["sdlAnalyzer"]>({
+      hasCiCdImage: jest.fn(() => input.hasCiCdImageInSDL ?? false)
+    });
+
+    const dependencies = {
+      ...DEPENDENCIES,
+      Layout,
+      TemplateList,
+      ManifestEdit,
+      CreateLease,
+      CustomizedSteppers,
+      useRouter: () => mockRouter,
+      useSearchParams: () => mockSearchParams,
+      useSdlBuilder: () => sdlBuilder,
+      useLocalNotes: () => localNotes,
+      useTemplates: () => templatesValue
+    } as unknown as typeof DEPENDENCIES;
+    const store = createStore();
+
+    if (input.deploySdl !== undefined) {
+      store.set(sdlStore.deploySdl, input.deploySdl);
+    }
+
+    render(
+      <TestContainerProvider
+        services={{
+          sdlAnalyzer: () => sdlAnalyzer
+        }}
+      >
+        <JotaiStoreProvider store={store}>
+          <NewDeploymentContainer template={input.requestedTemplate} templateId={input.templateId} dependencies={dependencies} />
+        </JotaiStoreProvider>
+      </TestContainerProvider>
+    );
+
+    return {
+      mockRouter,
+      localNotes,
+      sdlBuilder,
+      Layout,
+      CreateLease,
+      ManifestEdit,
+      TemplateList
+    };
+  }
+});

--- a/apps/deploy-web/src/context/LocalNoteProvider/LocalNoteContext.tsx
+++ b/apps/deploy-web/src/context/LocalNoteProvider/LocalNoteContext.tsx
@@ -8,7 +8,7 @@ import { useServices } from "../ServicesProvider";
 import { settingsIdAtom } from "../SettingsProvider/settingsStore";
 import { DeploymentNameModal } from "./DeploymentNameModal";
 
-type ContextType = {
+export type ContextType = {
   getDeploymentName: (dseq: string | number) => string | null | undefined;
   changeDeploymentName: (dseq: string | number) => void;
   getDeploymentData: (dseq: string | number) => Partial<LocalDeploymentData> | null;
@@ -59,6 +59,6 @@ export const LocalNoteProvider: React.FC<{ children: React.ReactNode }> = ({ chi
   );
 };
 
-export const useLocalNotes = () => {
+export const useLocalNotes = (): ContextType => {
   return { ...React.useContext(LocalNoteProviderContext) };
 };

--- a/apps/deploy-web/src/context/SdlBuilderProvider/SdlBuilderProvider.tsx
+++ b/apps/deploy-web/src/context/SdlBuilderProvider/SdlBuilderProvider.tsx
@@ -5,7 +5,7 @@ import type { FCWithChildren } from "@src/types/component";
 import { sshVmDistros } from "@src/utils/sdl/data";
 
 type ComponentNames = "command" | "service-count" | "ssh" | "ssh-toggle" | "yml-editor" | "yml-uploader";
-interface SdlContextProps {
+export interface SdlContextProps {
   hasComponent: (component: ComponentNames) => boolean;
   toggleCmp: (component: ComponentNames) => void;
   imageList?: string[];

--- a/apps/deploy-web/src/pages/deploy-linux/index.tsx
+++ b/apps/deploy-web/src/pages/deploy-linux/index.tsx
@@ -1,4 +1,4 @@
-import { NewDeploymentContainer } from "@src/components/new-deployment/NewDeploymentContainer";
+import { NewDeploymentContainer } from "@src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer";
 import { createServerSideProps } from "@src/components/new-deployment/NewDeploymentPage/createServerSideProps";
 import { withSdlBuilder } from "@src/context/SdlBuilderProvider/SdlBuilderProvider";
 

--- a/apps/deploy-web/src/pages/new-deployment/index.tsx
+++ b/apps/deploy-web/src/pages/new-deployment/index.tsx
@@ -1,4 +1,4 @@
-import { NewDeploymentContainer } from "@src/components/new-deployment/NewDeploymentContainer";
+import { NewDeploymentContainer } from "@src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer";
 import { createServerSideProps } from "@src/components/new-deployment/NewDeploymentPage/createServerSideProps";
 import OnboardingRedirect from "@src/components/onboarding/OnboardingRedirect/OnboardingRedirect";
 import { withSdlBuilder } from "@src/context/SdlBuilderProvider/SdlBuilderProvider";

--- a/apps/deploy-web/src/services/app-di-container/browser-di-container.ts
+++ b/apps/deploy-web/src/services/app-di-container/browser-di-container.ts
@@ -11,6 +11,7 @@ import { DeploymentStorageService } from "../deployment-storage/deployment-stora
 import { BitbucketService } from "../remote-deploy/bitbucket-http.service";
 import { GitHubService } from "../remote-deploy/github-http.service";
 import { GitLabService } from "../remote-deploy/gitlab-http.service";
+import { SDLAnalyzer } from "../sdl-analyzer/sdl-analyzer";
 import { createAppRootContainer } from "./app-di-container";
 
 const rootContainer = createAppRootContainer({
@@ -56,5 +57,6 @@ export const services = createChildContainer(rootContainer, {
   storedWalletsService: () => walletUtils,
   deploymentLocalStorage: () => new DeploymentStorageService(localStorage, services.networkStore),
   windowLocation: () => window.location,
-  windowHistory: () => window.history
+  windowHistory: () => window.history,
+  sdlAnalyzer: () => new SDLAnalyzer({ ciCdImageName: services.publicConfig.NEXT_PUBLIC_CI_CD_IMAGE_NAME })
 });

--- a/apps/deploy-web/src/services/remote-deploy/env-var-manager.service.ts
+++ b/apps/deploy-web/src/services/remote-deploy/env-var-manager.service.ts
@@ -1,6 +1,5 @@
 import { nanoid } from "nanoid";
 
-import { browserEnvConfig } from "@src/config/browser-env.config";
 import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
 
 export class EnvVarManagerService {
@@ -58,10 +57,6 @@ export class EnvVarManagerService {
 
 export function formatUrlWithoutInitialPath(url?: string): string | undefined {
   return url?.split("/").slice(-2).join("/");
-}
-
-export function isCiCdImageInYaml(yml: string): boolean | undefined {
-  return yml.includes(browserEnvConfig.NEXT_PUBLIC_CI_CD_IMAGE_NAME);
 }
 
 export function extractRepositoryUrl(yml?: string | null): string | null {

--- a/apps/deploy-web/src/services/sdl-analyzer/sdl-analyzer.ts
+++ b/apps/deploy-web/src/services/sdl-analyzer/sdl-analyzer.ts
@@ -1,0 +1,16 @@
+export class SDLAnalyzer {
+  readonly #config: SDLAnalyzerConfig;
+
+  constructor(config: SDLAnalyzerConfig) {
+    this.#config = config;
+  }
+
+  hasCiCdImage(yml: string | null | undefined): boolean {
+    if (!yml) return false;
+    return yml.includes(this.#config.ciCdImageName);
+  }
+}
+
+export interface SDLAnalyzerConfig {
+  ciCdImageName: string;
+}

--- a/packages/net/tsconfig.build.json
+++ b/packages/net/tsconfig.build.json
@@ -6,7 +6,5 @@
     "strict": true
   },
   "include": ["src/**/*"],
-  "exclude": [
-    "vitest.config.ts"
-  ]
+  "exclude": ["vitest.config.ts"]
 }

--- a/packages/net/tsconfig.json
+++ b/packages/net/tsconfig.json
@@ -1,4 +1,4 @@
 {
   "exclude": ["node_modules"],
-  "extends": "./tsconfig.build.json",
+  "extends": "./tsconfig.build.json"
 }


### PR DESCRIPTION
## Why

reported  bug:

After clicking redeploy, it's not possible to edit SDL in editor




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the new deployment creation workflow, including multiple rendering scenarios and navigation paths.

* **Refactor**
  * Improved internal code organization and dependency management for enhanced maintainability and testability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->