### PR TITLE
chore: fixes deployment workflows

### DIFF
--- a/.github/workflows/console-api-release.yml
+++ b/.github/workflows/console-api-release.yml
@@ -5,15 +5,15 @@ on:
     inputs:
       image_tag:
         description: "Image tag to deploy (e.g., latest, 1.0.0, v1.0.0)"
-        required: true
+        required: false
         type: string
-        default: latest
 
 jobs:
   setup:
     uses: ./.github/workflows/reusable-deploy-setup.yml
     with:
-      image_tag: console-api/${{ inputs.image_tag }}
+      app: console-api
+      image_tag: ${{ inputs.image_tag || github.ref_name }}
 
   deploy-beta-mainnet:
     needs: setup

--- a/.github/workflows/console-web-release.yml
+++ b/.github/workflows/console-web-release.yml
@@ -5,15 +5,14 @@ on:
     inputs:
       image_tag:
         description: "Image tag to deploy (e.g., latest, 1.0.0, v1.0.0)"
-        required: true
+        required: false
         type: string
-        default: latest
-
 jobs:
   setup:
     uses: ./.github/workflows/reusable-deploy-setup.yml
     with:
-      image_tag: console-web/${{ inputs.image_tag }}
+      app: console-web
+      image_tag: ${{ inputs.image_tag || github.ref_name }}
 
   deploy-beta:
     needs: setup

--- a/.github/workflows/indexer-release.yml
+++ b/.github/workflows/indexer-release.yml
@@ -5,15 +5,14 @@ on:
     inputs:
       image_tag:
         description: "Image tag to deploy (e.g., latest, 1.0.0, v1.0.0)"
-        required: true
+        required: false
         type: string
-        default: latest
-
 jobs:
   setup:
     uses: ./.github/workflows/reusable-deploy-setup.yml
     with:
-      image_tag: indexer/${{ inputs.image_tag }}
+      app: indexer
+      image_tag: ${{ inputs.image_tag || github.ref_name }}
 
   deploy-prod-mainnet:
     permissions:

--- a/.github/workflows/notifications-release.yml
+++ b/.github/workflows/notifications-release.yml
@@ -5,15 +5,14 @@ on:
     inputs:
       image_tag:
         description: "Image tag to deploy (e.g., latest, 1.0.0, v1.0.0)"
-        required: true
+        required: false
         type: string
-        default: latest
-
 jobs:
   setup:
     uses: ./.github/workflows/reusable-deploy-setup.yml
     with:
-      image_tag: notifications/${{ inputs.image_tag }}
+      app: notifications
+      image_tag: ${{ inputs.image_tag || github.ref_name }}
 
   deploy-beta:
     needs: setup

--- a/.github/workflows/provider-proxy-release.yml
+++ b/.github/workflows/provider-proxy-release.yml
@@ -5,15 +5,14 @@ on:
     inputs:
       image_tag:
         description: "Image tag to deploy (e.g., latest, 1.0.0, v1.0.0)"
-        required: true
+        required: false
         type: string
-        default: latest
-
 jobs:
   setup:
     uses: ./.github/workflows/reusable-deploy-setup.yml
     with:
-      image_tag: provider-proxy/${{ inputs.image_tag }}
+      app: provider-proxy
+      image_tag: ${{ inputs.image_tag || github.ref_name }}
 
   deploy-beta-mainnet:
     needs: setup

--- a/.github/workflows/reusable-deploy-setup.yml
+++ b/.github/workflows/reusable-deploy-setup.yml
@@ -7,6 +7,10 @@ on:
         description: "Full image tag (e.g., console-api/latest, console-api/1.0.0, console-api/v1.0.0)"
         required: true
         type: string
+      app:
+        description: "Application name (e.g., console-api, tx-signer)"
+        required: true
+        type: string
     outputs:
       image_tag:
         description: "Resolved image tag to deploy"
@@ -23,19 +27,22 @@ jobs:
     steps:
       - id: extract
         env:
-          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ inputs.image_tag }}
+          APP: ${{ inputs.app }}
         run: |
-          tag="${{ inputs.image_tag }}"
-          package_name="${tag%%/*}"
-          version="${tag#*/}"
+          package_name="${TAG_NAME%%/*}"
+          version="${TAG_NAME#*/}"
+
+          if [[ "$TAG_NAME" = v* ]] || [[ "$TAG_NAME" = [0-9]* ]] || [[ "$package_name" = "$APP" ]]; then
+            echo "✅ Deployment tag is valid."
+          else
+            echo "❌ This deployment workflow (app=$APP) can be started from $APP/v* tags or from specific version (e.g., v1.2.3, 1.2.3)."
+            echo "You started it from: $TAG_NAME"
+            # exit 1
+          fi
 
           # Remove 'v' prefix if present
           version="${version#v}"
-
-          if [[ "$version" == "latest" ]]; then
-            # Fetch latest from registry
-            version=$(gh api "/orgs/${{ github.repository_owner }}/packages/container/${package_name}/versions" --jq '.[0].metadata.container.tags[0]')
-          fi
 
           # Remove beta suffix if present
           version="${version%-beta}"

--- a/.github/workflows/reusable-release-app.yml
+++ b/.github/workflows/reusable-release-app.yml
@@ -55,4 +55,3 @@ jobs:
           gh workflow run ${{ inputs.deploy_workflow }} \
             --repo ${{ github.repository }} \
             --ref ${{ needs.release.outputs.git_tag }} \
-            -f image_tag=${{ needs.release.outputs.git_tag }}

--- a/.github/workflows/reusable-release-nextjs-app.yml
+++ b/.github/workflows/reusable-release-nextjs-app.yml
@@ -72,4 +72,3 @@ jobs:
           gh workflow run ${{ inputs.deploy_workflow }} \
             --repo ${{ github.repository }} \
             --ref ${{ needs.release.outputs.git_tag }} \
-            -f image_tag=${{ needs.release.outputs.git_tag }}

--- a/.github/workflows/stats-web-release.yml
+++ b/.github/workflows/stats-web-release.yml
@@ -5,15 +5,14 @@ on:
     inputs:
       image_tag:
         description: "Image tag to deploy (e.g., latest, 1.0.0, v1.0.0)"
-        required: true
+        required: false
         type: string
-        default: latest
-
 jobs:
   setup:
     uses: ./.github/workflows/reusable-deploy-setup.yml
     with:
-      image_tag: stats-web/${{ inputs.image_tag }}
+      app: stats-web
+      image_tag: ${{ inputs.image_tag || github.ref_name }}
 
   deploy-beta:
     needs: setup

--- a/.github/workflows/tx-signer-release.yml
+++ b/.github/workflows/tx-signer-release.yml
@@ -5,15 +5,14 @@ on:
     inputs:
       image_tag:
         description: "Image tag to deploy (e.g., latest, 1.0.0, v1.0.0)"
-        required: true
+        required: false
         type: string
-        default: latest
-
 jobs:
   setup:
     uses: ./.github/workflows/reusable-deploy-setup.yml
     with:
-      image_tag: tx-signer/${{ inputs.image_tag }}
+      app: tx-signer
+      image_tag: ${{ inputs.image_tag || github.ref_name }}
 
   deploy-beta-mainnet:
     needs: setup


### PR DESCRIPTION
## Why

because currently release trigger deployment with invalid app version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made release image tag optional across deployment workflows and added automatic fallback to the workflow ref when not provided
  * Standardized passing of the target app identifier into deployment setup
  * Stopped forwarding explicit image_tag in some deploy triggers to rely on centralized tag resolution
  * Added enhanced validation and parsing of deployment tags for safer releases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->