### PR TITLE
chore: fixes notifications about deployments waiting approval

### DIFF
--- a/.github/workflows/all-deploy-testnet.yml
+++ b/.github/workflows/all-deploy-testnet.yml
@@ -91,7 +91,6 @@ jobs:
       appVersion: sdk53
       environment: staging
       chain: sandbox
-      skip_beta_deployment_check: true
       force-rollout: true
 
   deploy-notifications:
@@ -113,5 +112,4 @@ jobs:
       app: console-web
       appVersion: sdk53-sandbox
       environment: staging
-      skip_beta_deployment_check: true
       force-rollout: true

--- a/.github/workflows/console-api-deploy-testnet.yml
+++ b/.github/workflows/console-api-deploy-testnet.yml
@@ -37,5 +37,4 @@ jobs:
       appVersion: ${{ needs.build.outputs.image_tag }}
       environment: staging
       chain: testnet
-      skip_beta_deployment_check: true
       force-rollout: true

--- a/.github/workflows/console-web-deploy-testnet.yml
+++ b/.github/workflows/console-web-deploy-testnet.yml
@@ -55,5 +55,4 @@ jobs:
       app: console-web-testnet
       appVersion: ${{ needs.build-beta-testnet.outputs.base_image_tag }}
       environment: staging
-      skip_beta_deployment_check: true
       force-rollout: true

--- a/.github/workflows/indexer-deploy-testnet.yml
+++ b/.github/workflows/indexer-deploy-testnet.yml
@@ -37,5 +37,4 @@ jobs:
       appVersion: ${{ needs.build.outputs.image_tag }}
       environment: staging
       chain: testnet
-      skip_beta_deployment_check: true
       force-rollout: true

--- a/.github/workflows/reusable-deploy-k8s.yml
+++ b/.github/workflows/reusable-deploy-k8s.yml
@@ -40,14 +40,6 @@ on:
           - mainnet
           - sandbox
           - testnet
-      skip_beta_deployment_check:
-        type: boolean
-        required: false
-        default: false
-        description: >-
-          Bypass beta deployment check.
-          Use with caution — this will deploy directly to production without verifying the beta environment.
-          Skipping this check may result in deploying an unstable version with potential bugs.
       force-rollout:
         type: boolean
         required: false
@@ -74,14 +66,6 @@ on:
         required: false
         type: string
         default: NA
-      skip_beta_deployment_check:
-        type: boolean
-        required: false
-        default: false
-        description: >-
-          Bypass beta deployment check.
-          Use with caution — this will deploy directly to production without verifying the beta environment.
-          Skipping this check may result in deploying an unstable version with potential bugs.
       force-rollout:
         type: boolean
         required: false
@@ -97,31 +81,13 @@ jobs:
   deployment-prerequisites:
     runs-on: ubuntu-latest
     outputs:
-      require_approval: ${{ steps.approval-status.outputs.require_approval }}
       environment: ${{ steps.determine-environment.outputs.environment }}
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Notify in Slack if beta deployment check was skipped
-        if: github.event_name == 'workflow_dispatch' && (inputs.skip_beta_deployment_check == 'true' || inputs.skip_beta_deployment_check == true)
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook-type: incoming-webhook
-          webhook: ${{ secrets.FAILED_E2E_TESTS_SLACK_WEBHOOK_URL }}
-          payload: |
-            blocks:
-              - type: "header"
-                text:
-                  type: "plain_text"
-                  text: "Deployment to production without beta deployment check"
-              - type: "section"
-                text:
-                  type: "mrkdwn"
-                  text: |
-                    *App:* ${{ inputs.app }}@${{ inputs.appVersion }}
-                    *Workflow:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-                    *Author:* ${{ github.actor }}
+        uses: actions/checkout@v6
 
       - name: Determine environment
         id: determine-environment
@@ -145,27 +111,15 @@ jobs:
           require_approval=$(gh api "repos/$GITHUB_REPOSITORY/environments/$DEPLOYMENT_ENVIRONMENT" \
             --jq '.protection_rules | map(.type) | contains(["required_reviewers"])')
           echo "require_approval=$require_approval" >> "$GITHUB_OUTPUT"
-
-  notify-about-pending-deployment:
-    permissions:
-      contents: read
-      pull-requests: read
-    runs-on: ubuntu-latest
-    needs: deployment-prerequisites
-    if: >-
-      github.event_name != 'workflow_dispatch' &&
-      needs.deployment-prerequisites.outputs.require_approval == 'true'
-
-    steps:
-      - uses: actions/checkout@v6
       - name: Notify in Slack about pending deployment
+        if: steps.approval-status.outputs.require_approval == 'true'
         uses: ./.github/actions/slack-pending-deployment-approval
         with:
           url: ${{ vars.CONSOLE_WEB_BETA_URL }}
           slack-webhook-url: ${{ secrets.FAILED_E2E_TESTS_SLACK_WEBHOOK_URL }}
           gh-user-to-slack-user: ${{ vars.GH_USER_TO_SLACK_USER }}
           new-app-version: "${{ inputs.app }}@${{ inputs.appVersion }}"
-          environment: ${{ needs.deployment-prerequisites.outputs.environment }}
+          environment: ${{ steps.determine-environment.outputs.environment }}
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Right now, this workflow is always triggered via workflow_dispatch, either manually by a human or automatically by the system after a release. As a result, this check prevents us from receiving Slack notifications about pending deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed explicit beta-skip options from several deployment workflows so the beta check now runs consistently.
  * Updated deployment prerequisites and checkout steps for more reliable execution.
* **Bug Fixes**
  * Consolidated and simplified deployment notifications so a single inline alert triggers when approval is required and reports the correct environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->