### PR TITLE
chore: refactor gh env approval to manual workflow run

### DIFF
--- a/.github/actions/slack-pending-deployment-approval/action.yml
+++ b/.github/actions/slack-pending-deployment-approval/action.yml
@@ -5,7 +5,10 @@ inputs:
   url:
     description: Base URL to Console API or UI
     required: true
-  new-app-version:
+  app:
+    description: Application name
+    required: true
+  new-version:
     description: New app version
     required: true
   slack-webhook-url:
@@ -22,7 +25,15 @@ inputs:
   environment:
     description: Environment name
     required: false
-    default: "production"
+    default: "staging" # or prod
+  chain:
+    description: Blockchain name (if applicable)
+    required: false
+    default: ""
+  linked-workflow-run-id:
+    description: The ID of the workflow run that called this action
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -46,6 +57,15 @@ runs:
 
                   Hey ${{ steps.associated-pr.outputs.slack-user != '' && format('<@{0}>', steps.associated-pr.outputs.slack-user) || steps.associated-pr.outputs.author }},
 
-                  A new version of *${{inputs.new-app-version}}* is ready to be deployed to *${{ inputs.environment }}*. Please test your changes on <${{ inputs.url }}|beta> and <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Confirm> the deployment.
+                  A new version of *${{inputs.app}}* `${{ inputs.new-version }}` is ready to be deployed to *${{ inputs.environment }}${{ inputs.chain != '' && format('-{0}', inputs.chain) || '' }}*. Please test your changes on <${{ inputs.url }}|beta> and <${{ github.server_url }}/${{ github.repository }}/actions/workflows/reusable-deploy-k8s.yml|Confirm> the deployment.
                   This was triggered by the following PR:
                   <${{ github.server_url }}/${{ github.repository }}/pull/${{ steps.associated-pr.outputs.number }}|${{ steps.associated-pr.outputs.title }}>
+
+                  Alternatively, use gh cli to run workflow:
+                  ```
+                  gh workflow run reusable-deploy-k8s.yml \
+                    -f app=${{ inputs.app }} \
+                    -f appVersion=${{ inputs.new-version }}
+                    -f approve=true ${{ inputs.linked-workflow-run-id && format('-f linked-workflow-run-id={0}', inputs.linked-workflow-run-id) || '' }} \
+                    -f environment=${{ inputs.environment }} ${{ inputs.chain && format('-f chain={0}', inputs.chain) || '' }}
+                  ```

--- a/.github/workflows/reusable-deploy-k8s.yml
+++ b/.github/workflows/reusable-deploy-k8s.yml
@@ -127,11 +127,8 @@ jobs:
         id: approval-status
         env:
           DEPLOYMENT_ENVIRONMENT: ${{ steps.determine-environment.outputs.environment }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          env="${{ inputs.environment }}-${{ inputs.chain }}"
-          require_approval=$([[ "$env" == "prod-NA" || "$env" == "prod" ]] && echo "true" || echo "false")
+          require_approval=$([[ "$DEPLOYMENT_ENVIRONMENT" == "production" || "$DEPLOYMENT_ENVIRONMENT" == "production-mainnet" ]] && echo "true" || echo "false")
           echo "require_approval=$require_approval" >> "$GITHUB_OUTPUT"
       - name: Notify in Slack about pending deployment
         if: steps.approval-status.outputs.require_approval == 'true'
@@ -253,11 +250,14 @@ jobs:
         run: |
           DEPLOYMENT_ID=$(
             gh api -X POST "repos/$REPOSITORY/deployments" \
-              -f ref="$GH_REF" \
-              -f environment="$APP_ENV" \
-              -f auto_merge=false \
-              -f required_contexts='[]' \
-              --jq '.id'
+              --input - --jq '.id' <<EOF
+          {
+            "ref": "$GH_REF",
+            "environment": "$APP_ENV",
+            "auto_merge": false,
+            "required_contexts": []
+          }
+          EOF
           )
           echo "Deployment: $DEPLOYMENT_ID"
 

--- a/.github/workflows/reusable-deploy-k8s.yml
+++ b/.github/workflows/reusable-deploy-k8s.yml
@@ -125,13 +125,14 @@ jobs:
 
       - name: Check if approval is required
         id: approval-status
+        if: inputs.approve == 'false' || inputs.approve == false
         env:
           DEPLOYMENT_ENVIRONMENT: ${{ steps.determine-environment.outputs.environment }}
         run: |
           require_approval=$([[ "$DEPLOYMENT_ENVIRONMENT" == "production" || "$DEPLOYMENT_ENVIRONMENT" == "production-mainnet" ]] && echo "true" || echo "false")
           echo "require_approval=$require_approval" >> "$GITHUB_OUTPUT"
       - name: Notify in Slack about pending deployment
-        if: steps.approval-status.outputs.require_approval == 'true'
+        if: steps.approval-status.outputs.require_approval == 'true' && (inputs.approve == 'false' || inputs.approve == false)
         uses: ./.github/actions/slack-pending-deployment-approval
         with:
           url: ${{ vars.CONSOLE_WEB_BETA_URL }}
@@ -260,6 +261,11 @@ jobs:
           EOF
           )
           echo "Deployment: $DEPLOYMENT_ID"
+
+          if [ -z "$DEPLOYMENT_ID" ]; then
+            echo "Failed to create deployment"
+            exit 1
+          fi
 
           gh api -X POST "repos/$REPOSITORY/deployments/$DEPLOYMENT_ID/statuses" \
             -f state="success" \

--- a/.github/workflows/reusable-deploy-k8s.yml
+++ b/.github/workflows/reusable-deploy-k8s.yml
@@ -46,6 +46,16 @@ on:
         default: false
         description: >-
           Force a Kubernetes rollout restart even if the Deployment spec is unchanged.
+      approve:
+        type: boolean
+        required: false
+        default: false
+        description: >-
+          Whether to require manual approval before proceeding with the deployment.
+      linked-workflow-run-id:
+        description: "The ID of the workflow run that triggered this deployment"
+        required: false
+        type: string
 
   workflow_call:
     inputs:
@@ -72,6 +82,12 @@ on:
         default: false
         description: >-
           Force a Kubernetes rollout restart even if the Deployment spec is unchanged.
+      approve:
+        type: boolean
+        required: false
+        default: false
+        description: >-
+          Whether to require manual approval before proceeding with the deployment.
 
 # 1 pending + 1 in-progress workflows
 concurrency:
@@ -82,12 +98,18 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       environment: ${{ steps.determine-environment.outputs.environment }}
+      require_approval: ${{ steps.approval-status.outputs.require_approval }}
     permissions:
       contents: read
       pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Display linked workflow run ID
+        if: ${{ inputs.linked-workflow-run-id }}
+        run: |
+          echo "Linked workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Determine environment
         id: determine-environment
@@ -108,8 +130,8 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          require_approval=$(gh api "repos/$GITHUB_REPOSITORY/environments/$DEPLOYMENT_ENVIRONMENT" \
-            --jq '.protection_rules | map(.type) | contains(["required_reviewers"])')
+          env="${{ inputs.environment }}-${{ inputs.chain }}"
+          require_approval=$([[ "$env" == "prod-NA" || "$env" == "prod" ]] && echo "true" || echo "false")
           echo "require_approval=$require_approval" >> "$GITHUB_OUTPUT"
       - name: Notify in Slack about pending deployment
         if: steps.approval-status.outputs.require_approval == 'true'
@@ -118,13 +140,17 @@ jobs:
           url: ${{ vars.CONSOLE_WEB_BETA_URL }}
           slack-webhook-url: ${{ secrets.FAILED_E2E_TESTS_SLACK_WEBHOOK_URL }}
           gh-user-to-slack-user: ${{ vars.GH_USER_TO_SLACK_USER }}
-          new-app-version: "${{ inputs.app }}@${{ inputs.appVersion }}"
-          environment: ${{ steps.determine-environment.outputs.environment }}
+          app: ${{ inputs.app }}
+          new-version: ${{ inputs.appVersion }}
+          environment: ${{ inputs.environment }}
+          chain: ${{ inputs.chain != 'NA' && inputs.chain || '' }}
+          linked-workflow-run-id: ${{ github.run_id }}
 
   deploy:
     runs-on: ubuntu-latest
     needs: deployment-prerequisites
-    environment: ${{ needs.deployment-prerequisites.outputs.environment }}
+    if: >-
+      needs.deployment-prerequisites.outputs.require_approval != 'true' || inputs.approve == 'true' || inputs.approve == true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -217,3 +243,24 @@ jobs:
         if: success() && inputs.force-rollout
         run: |
           kubectl --kubeconfig kubeconfig -n "${{ inputs.environment }}" rollout restart deploy "${{ env.release_name }}"
+
+      - name: Create deployment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          APP_ENV: ${{ needs.deployment-prerequisites.outputs.environment }}
+          GH_REF: ${{ inputs.app }}/v${{ inputs.appVersion }}
+        run: |
+          DEPLOYMENT_ID=$(
+            gh api -X POST "repos/$REPOSITORY/deployments" \
+              -f ref="$GH_REF" \
+              -f environment="$APP_ENV" \
+              -f auto_merge=false \
+              -f required_contexts='[]' \
+              --jq '.id'
+          )
+          echo "Deployment: $DEPLOYMENT_ID"
+
+          gh api -X POST "repos/$REPOSITORY/deployments/$DEPLOYMENT_ID/statuses" \
+            -f state="success" \
+            -f description="Deploy finished"

--- a/.github/workflows/reusable-deploy-setup.yml
+++ b/.github/workflows/reusable-deploy-setup.yml
@@ -27,9 +27,14 @@ jobs:
     steps:
       - id: extract
         env:
+          GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ inputs.image_tag }}
           APP: ${{ inputs.app }}
         run: |
+          if [[ "$TAG_NAME" == "latest" ]]; then
+            TAG_NAME=$(gh api "repos/${{ github.repository }}/releases/latest" --jq '.tag_name')
+          fi
+
           package_name="${TAG_NAME%%/*}"
           version="${TAG_NAME#*/}"
 
@@ -38,7 +43,7 @@ jobs:
           else
             echo "❌ This deployment workflow (app=$APP) can be started from $APP/v* tags or from specific version (e.g., v1.2.3, 1.2.3)."
             echo "You started it from: $TAG_NAME"
-            # exit 1
+            exit 1
           fi
 
           # Remove 'v' prefix if present


### PR DESCRIPTION
## Why

Github env approval is not available for private repos. So, changing the flow, so it works in private repository as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notifications show application and version separately, include optional chain and linked workflow-run ID, and include a CLI example to trigger the reusable deployment.
  * Workflows accept an explicit approve flag and an optional linked workflow-run ID.
  * Deployments are now created programmatically for clearer tracking.

* **Improvements**
  * Default deployment environment changed to staging.
  * Deployment gating simplified using environment/approve rules; linked run ID surfaces in notifications.
  * CLI tag resolution added and failure on invalid tags reinstated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->