### PR TITLE
chore: removes leading slashes to ensure slack does not break cmd

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,8 @@
 coverage:
   ignore:
     - "apps/api/src/*/routes/**/*.ts"
+    - "apps/api/src/routes/**/*.ts"
+    - "apps/api/src/routers/**/*.ts"
     - "apps/api/src/server.ts"
     - "apps/api/src/console.ts"
     - "apps/api/src/background-jobs-app.ts"

--- a/.github/actions/slack-pending-deployment-approval/action.yml
+++ b/.github/actions/slack-pending-deployment-approval/action.yml
@@ -64,8 +64,8 @@ runs:
                   Alternatively, use gh cli to run workflow:
                   ```
                   gh workflow run reusable-deploy-k8s.yml \
-                    -f app=${{ inputs.app }} \
-                    -f appVersion=${{ inputs.new-version }} \
-                    -f approve=true ${{ inputs.linked-workflow-run-id && format('-f linked-workflow-run-id={0}', inputs.linked-workflow-run-id) || '' }} \
-                    -f environment=${{ inputs.environment }} ${{ inputs.chain && format('-f chain={0}', inputs.chain) || '' }}
+                  -f app=${{ inputs.app }} \
+                  -f appVersion=${{ inputs.new-version }} \
+                  -f approve=true ${{ inputs.linked-workflow-run-id && format('-f linked-workflow-run-id={0}', inputs.linked-workflow-run-id) || '' }} \
+                  -f environment=${{ inputs.environment }} ${{ inputs.chain && format('-f chain={0}', inputs.chain) || '' }}
                   ```

--- a/.github/workflows/all-ci.yml
+++ b/.github/workflows/all-ci.yml
@@ -31,6 +31,7 @@ jobs:
     needs: setup
     strategy:
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+      fail-fast: false
     uses: ./.github/workflows/reusable-validate-app.yml
     secrets: inherit
     with:

--- a/apps/api/src/rest-app.ts
+++ b/apps/api/src/rest-app.ts
@@ -172,7 +172,7 @@ appHono.get("/status", c => {
 
 appHono.get("/v1/doc", async c => {
   const scope = c.req.query("scope") || "full";
-  assert(["full", "console"].includes(scope), 403, '"scope" query is invalid. Valid options: "full", "api"');
+  assert(["full", "console"].includes(scope), 403, '"scope" query is invalid. Valid options: "full", "console"');
   return c.json(await container.resolve(OpenApiDocsService).generateDocs(openApiHonoHandlers, { scope }));
 });
 appHono.get("/v1/swagger", swaggerUI({ url: "/v1/doc" }));


### PR DESCRIPTION
## Why

1. To fix api coverage
2. To fix broken deploy command by slack (it inserts non-breaking spaces)
3. To disable fail-fast matrix behavior on ci checks to see the all errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Excluded additional API route paths from code coverage reporting.
  * CI updated to run all matrix jobs independently (no fail-fast).
  * Minor workflow formatting adjustments (no behavioral change).

* **Bug Fixes**
  * Corrected validation error message for the /v1/doc endpoint to list the proper allowed options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->