### PR TITLE
fix(deployment): only warns on negative top up amount

### DIFF
--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
@@ -93,9 +93,9 @@ export class DeploymentSettingService {
     }
 
     const estimatedTopUpAmount = await this.drainingDeploymentService.calculateTopUpAmountForDseqAndUserId(params.dseq, params.userId);
-    if (estimatedTopUpAmount <= 0) {
+    if (estimatedTopUpAmount < 0) {
       this.logger.warn({
-        event: "ESTIMATED_TOP_UP_AMOUNT_NON_POSITIVE",
+        event: "ESTIMATED_TOP_UP_AMOUNT_NEGATIVE",
         estimatedTopUpAmount,
         dseq: params.dseq,
         userId: params.userId


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted behavior so the top-up check and its logging now only trigger for negative estimated top-up amounts (zero no longer triggers). No changes to returned values or surrounding logic; only the logging condition and its label were updated to better reflect negative-only cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->