### PR TITLE
fix: increases timeout on provider-proxy requests

### DIFF
--- a/apps/api/src/provider/providers/provider-proxy.provider.ts
+++ b/apps/api/src/provider/providers/provider-proxy.provider.ts
@@ -1,0 +1,16 @@
+import { createHttpClient, type HttpClient } from "@akashnetwork/http-sdk";
+import type { InjectionToken } from "tsyringe";
+import { container, instancePerContainerCachingFactory } from "tsyringe";
+
+import { DeploymentConfigService } from "@src/deployment/services/deployment-config/deployment-config.service";
+
+export const PROVIDER_PROXY_HTTP_CLIENT: InjectionToken<HttpClient> = Symbol("PROVIDER_PROXY_HTTP_CLIENT");
+
+container.register(PROVIDER_PROXY_HTTP_CLIENT, {
+  useFactory: instancePerContainerCachingFactory(c => {
+    const configService = c.resolve(DeploymentConfigService);
+    return createHttpClient({
+      baseURL: configService.get("PROVIDER_PROXY_URL")
+    });
+  })
+});

--- a/apps/api/src/provider/services/provider/provider-proxy.service.spec.ts
+++ b/apps/api/src/provider/services/provider/provider-proxy.service.spec.ts
@@ -1,0 +1,106 @@
+import type { HttpClient } from "@akashnetwork/http-sdk";
+import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ProviderProxyPayload } from "./provider-proxy.service";
+import { ProviderProxyService } from "./provider-proxy.service";
+
+describe(ProviderProxyService.name, () => {
+  const MAX_TIMEOUT = 30_000;
+
+  describe("request", () => {
+    it("should POST to / with mapped payload and return response data", async () => {
+      const { httpClient, service, url, options } = setup();
+      const data = { result: faker.string.uuid() };
+      httpClient.post.mockResolvedValue({ data });
+
+      const result = await service.request(url, options);
+
+      expect(result).toBe(data);
+      expect(httpClient.post).toHaveBeenCalledWith(
+        "/",
+        {
+          auth: options.auth,
+          method: "GET",
+          url: options.providerIdentity.hostUri + url,
+          providerAddress: options.providerIdentity.owner,
+          network: options.chainNetwork
+        },
+        {}
+      );
+    });
+
+    it("should use the provided method instead of default GET", async () => {
+      const { httpClient, service, url, options } = setup({ method: "POST" });
+      httpClient.post.mockResolvedValue({ data: {} });
+
+      await service.request(url, options);
+
+      expect(httpClient.post).toHaveBeenCalledWith("/", expect.objectContaining({ method: "POST" }), expect.any(Object));
+    });
+
+    it("should forward body and headers in the payload", async () => {
+      const body = faker.string.sample();
+      const headers = { "x-custom": faker.string.uuid() };
+      const { httpClient, service, url, options } = setup({ body, headers });
+      httpClient.post.mockResolvedValue({ data: {} });
+
+      await service.request(url, options);
+
+      expect(httpClient.post).toHaveBeenCalledWith("/", expect.objectContaining({ body, headers }), expect.any(Object));
+    });
+
+    it("should pass timeout in both payload and config when within max", async () => {
+      const timeout = 5_000;
+      const { httpClient, service, url, options } = setup({ timeout });
+      httpClient.post.mockResolvedValue({ data: {} });
+
+      await service.request(url, options);
+
+      expect(httpClient.post).toHaveBeenCalledWith("/", expect.objectContaining({ timeout }), { timeout });
+    });
+
+    it("should cap timeout to max when it exceeds the limit", async () => {
+      const timeout = MAX_TIMEOUT + 10_000;
+      const { httpClient, service, url, options } = setup({ timeout });
+      httpClient.post.mockResolvedValue({ data: {} });
+
+      await service.request(url, options);
+
+      expect(httpClient.post).toHaveBeenCalledWith("/", expect.objectContaining({ timeout: MAX_TIMEOUT }), { timeout: MAX_TIMEOUT });
+    });
+
+    it("should not include timeout when not provided", async () => {
+      const { httpClient, service, url, options } = setup({ timeout: undefined });
+      httpClient.post.mockResolvedValue({ data: {} });
+
+      await service.request(url, options);
+
+      const [, payload, config] = httpClient.post.mock.calls[0];
+      expect(payload).not.toHaveProperty("timeout");
+      expect(config).toEqual({});
+    });
+  });
+
+  function setup(overrides?: Partial<ProviderProxyPayload>) {
+    const httpClient = mock<HttpClient>();
+    const service = new ProviderProxyService(httpClient);
+    const url = `/${faker.word.noun()}`;
+    const options: ProviderProxyPayload = {
+      chainNetwork: faker.word.noun(),
+      providerIdentity: {
+        owner: faker.string.alphanumeric(44),
+        hostUri: faker.internet.url({ appendSlash: false })
+      },
+      auth: {
+        type: "mtls",
+        certPem: faker.string.sample(),
+        keyPem: faker.string.sample()
+      },
+      ...overrides
+    };
+
+    return { httpClient, service, url, options };
+  }
+});

--- a/apps/api/src/provider/services/provider/provider-proxy.service.spec.ts
+++ b/apps/api/src/provider/services/provider/provider-proxy.service.spec.ts
@@ -10,7 +10,7 @@ describe(ProviderProxyService.name, () => {
   const MAX_TIMEOUT = 30_000;
 
   describe("request", () => {
-    it("should POST to / with mapped payload and return response data", async () => {
+    it("sends POST request to / with mapped payload and returns response data", async () => {
       const { httpClient, service, url, options } = setup();
       const data = { result: faker.string.uuid() };
       httpClient.post.mockResolvedValue({ data });
@@ -31,7 +31,7 @@ describe(ProviderProxyService.name, () => {
       );
     });
 
-    it("should use the provided method instead of default GET", async () => {
+    it("uses the provided method instead of default GET", async () => {
       const { httpClient, service, url, options } = setup({ method: "POST" });
       httpClient.post.mockResolvedValue({ data: {} });
 
@@ -40,7 +40,7 @@ describe(ProviderProxyService.name, () => {
       expect(httpClient.post).toHaveBeenCalledWith("/", expect.objectContaining({ method: "POST" }), expect.any(Object));
     });
 
-    it("should forward body and headers in the payload", async () => {
+    it("forwards body and headers in the payload", async () => {
       const body = faker.string.sample();
       const headers = { "x-custom": faker.string.uuid() };
       const { httpClient, service, url, options } = setup({ body, headers });
@@ -51,7 +51,7 @@ describe(ProviderProxyService.name, () => {
       expect(httpClient.post).toHaveBeenCalledWith("/", expect.objectContaining({ body, headers }), expect.any(Object));
     });
 
-    it("should pass timeout in both payload and config when within max", async () => {
+    it("passes timeout in both payload and config when within max", async () => {
       const timeout = 5_000;
       const { httpClient, service, url, options } = setup({ timeout });
       httpClient.post.mockResolvedValue({ data: {} });
@@ -61,7 +61,7 @@ describe(ProviderProxyService.name, () => {
       expect(httpClient.post).toHaveBeenCalledWith("/", expect.objectContaining({ timeout }), { timeout });
     });
 
-    it("should cap timeout to max when it exceeds the limit", async () => {
+    it("caps timeout to max when it exceeds the limit", async () => {
       const timeout = MAX_TIMEOUT + 10_000;
       const { httpClient, service, url, options } = setup({ timeout });
       httpClient.post.mockResolvedValue({ data: {} });
@@ -71,7 +71,7 @@ describe(ProviderProxyService.name, () => {
       expect(httpClient.post).toHaveBeenCalledWith("/", expect.objectContaining({ timeout: MAX_TIMEOUT }), { timeout: MAX_TIMEOUT });
     });
 
-    it("should not include timeout when not provided", async () => {
+    it("does not include timeout when not provided", async () => {
       const { httpClient, service, url, options } = setup({ timeout: undefined });
       httpClient.post.mockResolvedValue({ data: {} });
 

--- a/apps/api/src/provider/services/provider/provider.service.spec.ts
+++ b/apps/api/src/provider/services/provider/provider.service.spec.ts
@@ -60,7 +60,7 @@ describe(ProviderService.name, () => {
           owner: provider.owner,
           hostUri: provider.hostUri
         },
-        timeout: 60000
+        timeout: 30_000
       });
       expect(result).toEqual({ success: true });
     });

--- a/apps/api/src/provider/services/provider/provider.service.ts
+++ b/apps/api/src/provider/services/provider/provider.service.ts
@@ -35,7 +35,7 @@ export class ProviderService {
     private readonly auditorsService: AuditorService,
     private readonly jwtTokenService: ProviderJwtTokenService,
     private readonly config: BillingConfigService,
-    private readonly netConfig: NetConfig
+    netConfig: NetConfig
   ) {
     this.chainNetwork = netConfig.mapped(this.config.get("NETWORK"));
   }
@@ -87,7 +87,7 @@ export class ProviderService {
           auth: options.auth,
           chainNetwork: this.chainNetwork,
           providerIdentity: options.providerIdentity,
-          timeout: 60000
+          timeout: 30_000
         });
 
         if (result) return result;

--- a/apps/provider-proxy/src/routes/proxyProviderRequest.ts
+++ b/apps/provider-proxy/src/routes/proxyProviderRequest.ts
@@ -12,7 +12,7 @@ const RequestPayload = addProviderAuthValidation(
   providerRequestSchema.extend({
     method: z.enum(["GET", "POST", "PUT", "DELETE"]),
     body: z.string().optional(),
-    timeout: z.number().max(10_000).min(0).default(9_000).optional()
+    timeout: z.number().max(30_000).min(0).default(9_000).optional()
   })
 );
 


### PR DESCRIPTION
## Why

because we see timeouts on lease creation/manifest submission

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased provider proxy timeout limits from 10s to 30s.
  * Reduced manifest submission timeout to 30s for faster failover.
  * Introduced a centralized provider proxy HTTP client setup for more consistent request handling.

* **Tests**
  * Added comprehensive unit tests covering proxy requests, timeout behavior, headers/body forwarding, and method overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->