### PR TITLE
fix: sets default monaco lang to plaintext

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.spec.tsx
@@ -1,0 +1,319 @@
+import type { ForwardRefExoticComponent } from "react";
+import { mock } from "jest-mock-extended";
+import { createStore, Provider as JotaiStoreProvider } from "jotai";
+
+import type { AppDIContainer } from "@src/context/ServicesProvider";
+import sdlStore from "@src/store/sdlStore";
+import { DEPENDENCIES, ManifestEdit } from "./ManifestEdit";
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ComponentMock, createRefComponentMock } from "@tests/unit/mocks";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
+
+type Dependencies = typeof DEPENDENCIES;
+
+describe(ManifestEdit.name, () => {
+  it("renders deployment name input and Create Deployment button", () => {
+    setup();
+
+    expect(screen.getByLabelText(/Name your deployment/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Create Deployment/i })).toBeInTheDocument();
+  });
+
+  it("disables Create Deployment button when editedManifest is empty", () => {
+    setup({ editedManifest: null });
+
+    expect(screen.getByRole("button", { name: /Create Deployment/i })).toBeDisabled();
+  });
+
+  it("disables Create Deployment button when blockchain is down", () => {
+    setup({ editedManifest: "some-manifest", isBlockchainDown: true });
+
+    expect(screen.getByRole("button", { name: /Create Deployment/i })).toBeDisabled();
+  });
+
+  it("sets deployment name from selected template", async () => {
+    setup({ selectedTemplate: { title: "My Template", code: "my-template", category: "General", description: "A template", name: "Template Name" } });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Name your deployment/i)).toHaveValue("Template Name");
+    });
+  });
+
+  it("shows parsing error when create deployment is clicked with invalid SDL", async () => {
+    setup({ editedManifest: "some-manifest" });
+
+    await userEvent.click(screen.getByRole("button", { name: /Create Deployment/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Error while parsing SDL/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows Builder and YAML buttons when yml-editor component is available", () => {
+    setup({ hasComponents: ["yml-editor"] });
+
+    expect(screen.getByRole("button", { name: /Builder/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /YAML/i })).toBeInTheDocument();
+  });
+
+  it("hides Builder and YAML buttons when yml-editor component is not available", () => {
+    setup({ hasComponents: [] });
+
+    expect(screen.queryByRole("button", { name: /Builder/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /YAML/i })).not.toBeInTheDocument();
+  });
+
+  it("hides mode toggle buttons for git provider templates", () => {
+    setup({ isGitProviderTemplate: true, hasComponents: ["yml-editor"] });
+
+    expect(screen.queryByRole("button", { name: /Builder/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /YAML/i })).not.toBeInTheDocument();
+  });
+
+  it("shows upload button when yml-uploader is available and no templateId", () => {
+    setup({ hasComponents: ["yml-uploader"], templateId: null });
+
+    expect(screen.getByText(/Upload your SDL/i)).toBeInTheDocument();
+  });
+
+  it("hides upload button when templateId is set", () => {
+    setup({ hasComponents: ["yml-uploader"], templateId: "some-template" });
+
+    expect(screen.queryByText(/Upload your SDL/i)).not.toBeInTheDocument();
+  });
+
+  it("renders SDLEditor when in yaml mode and yml-editor is available", () => {
+    const SDLEditor = jest.fn(ComponentMock);
+    const SdlBuilder = createRefComponentMock();
+    setup({ hasComponents: ["yml-editor"], editedManifest: "some-yaml", SDLEditor, SdlBuilder, selectedSdlEditMode: "yaml" });
+
+    expect(SdlBuilder.renderFn).not.toHaveBeenCalled();
+    expect(SDLEditor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        value: "some-yaml"
+      }),
+      expect.anything()
+    );
+  });
+
+  it("renders SdlBuilder when in builder mode", () => {
+    const SdlBuilder = createRefComponentMock();
+    const SDLEditor = jest.fn(ComponentMock);
+    setup({ SdlBuilder, SDLEditor, selectedSdlEditMode: "builder" });
+
+    expect(SdlBuilder.renderFn).toHaveBeenCalled();
+    expect(SDLEditor).not.toHaveBeenCalled();
+  });
+
+  it("shows PrerequisiteList when create deployment is clicked for non-managed wallet", async () => {
+    const PrerequisiteList = jest.fn(ComponentMock);
+    const SDLEditor = jest.fn(ComponentMock);
+
+    setup({
+      editedManifest: "some-manifest",
+      isManaged: false,
+      PrerequisiteList,
+      SDLEditor,
+      hasComponents: ["yml-editor"],
+      selectedSdlEditMode: "yaml"
+    });
+
+    act(() => {
+      triggerSdlValidation(SDLEditor, true);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Create Deployment/i })).not.toBeDisabled();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Create Deployment/i }));
+
+    await waitFor(() => {
+      expect(PrerequisiteList).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onClose: expect.any(Function),
+          onContinue: expect.any(Function)
+        }),
+        expect.anything()
+      );
+    });
+  });
+
+  it("shows DeploymentDepositModal when create deployment is clicked for managed wallet", async () => {
+    const DeploymentDepositModal = jest.fn(ComponentMock);
+    const SDLEditor = jest.fn(ComponentMock);
+
+    setup({
+      editedManifest: "some-manifest",
+      isManaged: true,
+      DeploymentDepositModal,
+      SDLEditor,
+      hasComponents: ["yml-editor"],
+      selectedSdlEditMode: "yaml"
+    });
+
+    act(() => {
+      triggerSdlValidation(SDLEditor, true);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Create Deployment/i })).not.toBeDisabled();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Create Deployment/i }));
+
+    await waitFor(() => {
+      expect(DeploymentDepositModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          handleCancel: expect.any(Function),
+          onDeploymentDeposit: expect.any(Function),
+          denom: "uakt",
+          title: "Confirm deployment creation?"
+        }),
+        expect.anything()
+      );
+    });
+  });
+
+  it("tracks create_deployment_btn_clk event when Create Deployment is clicked", async () => {
+    const analyticsService = mock<AppDIContainer["analyticsService"]>();
+    setup({ editedManifest: "some-manifest", analyticsService });
+
+    await userEvent.click(screen.getByRole("button", { name: /Create Deployment/i }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("create_deployment_btn_clk", "Amplitude");
+  });
+
+  it("updates deployment name input when user types", async () => {
+    setup();
+
+    const input = screen.getByLabelText(/Name your deployment/i);
+    await userEvent.clear(input);
+    await userEvent.type(input, "My Deployment");
+
+    expect(input).toHaveValue("My Deployment");
+  });
+
+  function triggerSdlValidation(SDLEditor: jest.Mock, isValid: boolean) {
+    const lastCall = SDLEditor.mock.calls[SDLEditor.mock.calls.length - 1];
+    if (lastCall) {
+      const props = lastCall[0];
+      props.onValidate({ isValid });
+    }
+  }
+
+  function setup(input?: {
+    editedManifest?: string | null;
+    selectedTemplate?: { title: string; code: string; category: string; description: string; name?: string };
+    isGitProviderTemplate?: boolean;
+    isBlockchainDown?: boolean;
+    isManaged?: boolean;
+    hasComponents?: string[];
+    templateId?: string | null;
+    SDLEditor?: jest.Mock;
+    SdlBuilder?: jest.Mock | ForwardRefExoticComponent<any>;
+    PrerequisiteList?: jest.Mock;
+    DeploymentDepositModal?: jest.Mock;
+    analyticsService?: AppDIContainer["analyticsService"];
+    selectedSdlEditMode?: "yaml" | "builder";
+  }) {
+    const hasComponents = new Set(input?.hasComponents ?? []);
+    const analyticsService = input?.analyticsService ?? mock<AppDIContainer["analyticsService"]>();
+    const store = createStore();
+
+    if (input?.selectedSdlEditMode) {
+      store.set(sdlStore.selectedSdlEditMode, input.selectedSdlEditMode);
+    }
+
+    const dependencies = {
+      ...DEPENDENCIES,
+      Alert: ComponentMock,
+      CustomTooltip: ComponentMock,
+      FileButton: ComponentMock,
+      SDLEditor: input?.SDLEditor ?? ComponentMock,
+      SdlBuilder: input?.SdlBuilder ?? createRefComponentMock(),
+      ShareDeployButton: ComponentMock,
+      DeploymentDepositModal: input?.DeploymentDepositModal ?? ComponentMock,
+      DeploymentMinimumEscrowAlertText: ComponentMock,
+      TrialDeploymentBadge: ComponentMock,
+      CustomNextSeo: ComponentMock,
+      LinkTo: ComponentMock,
+      PrerequisiteList: input?.PrerequisiteList ?? ComponentMock,
+      ViewPanel: ComponentMock,
+      useSettings: () => ({
+        settings: {
+          apiEndpoint: "https://api.example.com",
+          rpcEndpoint: "https://rpc.example.com",
+          isCustomNode: false,
+          nodes: [],
+          selectedNode: null,
+          customNode: null,
+          isBlockchainDown: input?.isBlockchainDown ?? false
+        },
+        setSettings: jest.fn(),
+        isLoadingSettings: false,
+        isSettingsInit: true,
+        refreshNodeStatuses: jest.fn(),
+        isRefreshingNodeStatus: false
+      }),
+      useWallet: (() => ({
+        address: "akash123",
+        walletName: "test",
+        isWalletConnected: true,
+        isWalletLoaded: true,
+        isManaged: input?.isManaged ?? false,
+        isTrialing: false,
+        signAndBroadcastTx: jest.fn().mockResolvedValue({})
+      })) as unknown as Dependencies["useWallet"],
+      useCertificate: () =>
+        mock({
+          updateSelectedCertificate: jest.fn(),
+          genNewCertificateIfLocalIsInvalid: jest.fn().mockResolvedValue(null)
+        }),
+      useSdlBuilder: (() => ({
+        hasComponent: (name: string) => hasComponents.has(name),
+        toggleCmp: jest.fn()
+      })) as unknown as Dependencies["useSdlBuilder"],
+      useImportSimpleSdl: () => [],
+      useManagedWalletDenom: () => "uakt",
+      useDepositParams: (() => ({ data: 5000000 })) as unknown as Dependencies["useDepositParams"],
+      useMuiTheme: () => ({
+        breakpoints: {
+          down: () => "(max-width: 900px)"
+        }
+      }),
+      useMediaQuery: () => false,
+      useSnackbar: () => ({
+        enqueueSnackbar: jest.fn(),
+        closeSnackbar: jest.fn()
+      }),
+      useRouter: () => mock(),
+      useSearchParams: (() => ({
+        get: (key: string) => (key === "templateId" ? input?.templateId ?? null : null)
+      })) as unknown as Dependencies["useSearchParams"]
+    } as unknown as Dependencies;
+
+    return render(
+      <TestContainerProvider
+        services={{
+          analyticsService: () => analyticsService,
+          chainApiHttpClient: () => mock<AppDIContainer["chainApiHttpClient"]>(),
+          deploymentLocalStorage: () => mock<AppDIContainer["deploymentLocalStorage"]>()
+        }}
+      >
+        <JotaiStoreProvider store={store}>
+          <ManifestEdit
+            editedManifest={input?.editedManifest !== undefined ? input.editedManifest : "some-manifest"}
+            setEditedManifest={jest.fn()}
+            onTemplateSelected={jest.fn()}
+            selectedTemplate={(input?.selectedTemplate as any) ?? null}
+            isGitProviderTemplate={input?.isGitProviderTemplate}
+            dependencies={dependencies}
+          />
+        </JotaiStoreProvider>
+      </TestContainerProvider>
+    );
+  }
+});

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
@@ -41,12 +41,46 @@ import type { SdlBuilderRefType } from "../SdlBuilder";
 import { SdlBuilder } from "../SdlBuilder";
 import { ShareDeployButton } from "../ShareDeployButton/ShareDeployButton";
 
-type Props = {
+export type Props = {
   onTemplateSelected: Dispatch<TemplateCreation | null>;
   selectedTemplate: TemplateCreation | null;
   editedManifest: string | null;
   setEditedManifest: Dispatch<SetStateAction<string>>;
   isGitProviderTemplate?: boolean;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+export const DEPENDENCIES = {
+  Alert,
+  Button,
+  CustomTooltip,
+  FileButton,
+  Input,
+  Snackbar,
+  Spinner,
+  SDLEditor,
+  SdlBuilder,
+  ShareDeployButton,
+  DeploymentDepositModal,
+  DeploymentMinimumEscrowAlertText,
+  TrialDeploymentBadge,
+  CustomNextSeo,
+  LinkTo,
+  PrerequisiteList,
+  ViewPanel,
+  useServices,
+  useSettings,
+  useWallet,
+  useCertificate,
+  useSdlBuilder,
+  useImportSimpleSdl,
+  useManagedWalletDenom,
+  useDepositParams,
+  useMuiTheme,
+  useMediaQuery,
+  useSnackbar,
+  useRouter,
+  useSearchParams
 };
 
 export const ManifestEdit: React.FunctionComponent<Props> = ({
@@ -54,7 +88,8 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
   setEditedManifest,
   onTemplateSelected,
   selectedTemplate,
-  isGitProviderTemplate
+  isGitProviderTemplate,
+  dependencies: d = DEPENDENCIES
 }) => {
   const [parsingError, setParsingError] = useState<string | null>(null);
   const [isValidSdl, setIsValidSdl] = useState(false);
@@ -66,24 +101,24 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
   const [isRepoInputValid, setIsRepoInputValid] = useState(false);
   const [sdlDenom, setSdlDenom] = useState("uakt");
 
-  const { analyticsService, chainApiHttpClient, publicConfig: appConfig, deploymentLocalStorage } = useServices();
-  const { settings } = useSettings();
-  const { address, signAndBroadcastTx, isManaged, isTrialing } = useWallet();
-  const router = useRouter();
-  const { updateSelectedCertificate, genNewCertificateIfLocalIsInvalid } = useCertificate();
+  const { analyticsService, chainApiHttpClient, publicConfig: appConfig, deploymentLocalStorage } = d.useServices();
+  const { settings } = d.useSettings();
+  const { address, signAndBroadcastTx, isManaged, isTrialing } = d.useWallet();
+  const router = d.useRouter();
+  const { updateSelectedCertificate, genNewCertificateIfLocalIsInvalid } = d.useCertificate();
   const [, setDeploySdl] = useAtom(sdlStore.deploySdl);
-  const muiTheme = useMuiTheme();
-  const smallScreen = useMediaQuery(muiTheme.breakpoints.down("md"));
+  const muiTheme = d.useMuiTheme();
+  const smallScreen = d.useMediaQuery(muiTheme.breakpoints.down("md"));
   const sdlBuilderRef = useRef<SdlBuilderRefType>(null);
-  const { hasComponent } = useSdlBuilder();
-  const searchParams = useSearchParams();
+  const { hasComponent } = d.useSdlBuilder();
+  const searchParams = d.useSearchParams();
   const templateId = searchParams.get("templateId");
-  const { data: depositParams } = useDepositParams();
+  const { data: depositParams } = d.useDepositParams();
   const defaultDeposit = depositParams || appConfig.NEXT_PUBLIC_DEFAULT_INITIAL_DEPOSIT;
-  const wallet = useWallet();
-  const managedDenom = useManagedWalletDenom();
-  const { enqueueSnackbar } = useSnackbar();
-  const services = useImportSimpleSdl(isValidSdl ? editedManifest : null);
+  const wallet = d.useWallet();
+  const managedDenom = d.useManagedWalletDenom();
+  const { enqueueSnackbar } = d.useSnackbar();
+  const services = d.useImportSimpleSdl(isValidSdl ? editedManifest : null);
 
   useWhen(
     wallet.isManaged && sdlDenom === "uakt" && editedManifest,
@@ -160,7 +195,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
     analyticsService.track("create_deployment_btn_clk", "Amplitude");
 
     if (isGitProviderTemplate && !isRepoInputValid) {
-      enqueueSnackbar(<Snackbar title={"Please Fill All Required Fields"} subTitle="You need fill repo url and branch to deploy" iconVariant="error" />, {
+      enqueueSnackbar(<d.Snackbar title={"Please Fill All Required Fields"} subTitle="You need fill repo url and branch to deploy" iconVariant="error" />, {
         variant: "error"
       });
       return;
@@ -277,33 +312,33 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
 
   return (
     <>
-      <CustomNextSeo title="Create Deployment - Manifest Edit" url={`${domainName}${UrlService.newDeployment({ step: RouteStep.editDeployment })}`} />
+      <d.CustomNextSeo title="Create Deployment - Manifest Edit" url={`${domainName}${UrlService.newDeployment({ step: RouteStep.editDeployment })}`} />
 
       <div className="mb-2 pt-4">
         <div className="mb-2 flex flex-col items-end justify-between md:flex-row">
           <div className="w-full flex-grow">
-            <Input value={deploymentName} onChange={ev => setDeploymentName(ev.target.value)} label="Name your deployment (optional)" />
+            <d.Input value={deploymentName} onChange={ev => setDeploymentName(ev.target.value)} label="Name your deployment (optional)" />
           </div>
 
           <div className="flex w-full min-w-0 flex-shrink-0 items-center pt-2 md:w-auto md:pt-0">
-            <CustomTooltip
+            <d.CustomTooltip
               title={
                 <p>
                   You may use the sample deployment file as-is or modify it for your own needs as described in the{" "}
-                  <LinkTo onClick={ev => handleDocClick(ev, "https://akash.network/docs/getting-started/stack-definition-language/")}>
+                  <d.LinkTo onClick={ev => handleDocClick(ev, "https://akash.network/docs/getting-started/stack-definition-language/")}>
                     SDL (Stack Definition Language)
-                  </LinkTo>{" "}
+                  </d.LinkTo>{" "}
                   documentation. A typical modification would be to reference your own image instead of the demo app image.
                 </p>
               }
             >
               <InfoCircle className="mr-4 text-sm text-muted-foreground md:ml-4" />
-            </CustomTooltip>
+            </d.CustomTooltip>
 
             <div className="flex flex-grow items-center gap-2">
-              <ShareDeployButton services={services} />
+              <d.ShareDeployButton services={services} />
               <div className="flex-grow">
-                <Button
+                <d.Button
                   variant="default"
                   disabled={settings.isBlockchainDown || isCreatingDeployment || !!parsingError || !editedManifest}
                   onClick={() => handleCreateDeployment()}
@@ -311,7 +346,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
                   data-testid="create-deployment-btn"
                 >
                   {isCreatingDeployment ? (
-                    <Spinner size="small" />
+                    <d.Spinner size="small" />
                   ) : (
                     <>
                       Create Deployment{" "}
@@ -320,7 +355,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
                       </span>
                     </>
                   )}
-                </Button>
+                </d.Button>
               </div>
             </div>
           </div>
@@ -331,7 +366,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
         <div className="mb-2 flex gap-2">
           {hasComponent("yml-editor") && (
             <div className="flex items-center">
-              <Button
+              <d.Button
                 variant={selectedSdlEditMode === "builder" ? "default" : "outline"}
                 onClick={() => {
                   changeMode("builder");
@@ -342,8 +377,8 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
                 disabled={!!parsingError && selectedSdlEditMode === "yaml"}
               >
                 Builder
-              </Button>
-              <Button
+              </d.Button>
+              <d.Button
                 variant={selectedSdlEditMode === "yaml" ? "default" : "outline"}
                 color={selectedSdlEditMode === "yaml" ? "secondary" : "primary"}
                 onClick={() => {
@@ -354,12 +389,12 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
                 className="flex-grow rounded-s-none sm:flex-grow-0"
               >
                 YAML
-              </Button>
+              </d.Button>
             </div>
           )}
           {hasComponent("yml-uploader") && !templateId && (
             <>
-              <FileButton
+              <d.FileButton
                 onFileSelect={onFileSelect}
                 accept=".yml,.yaml,.txt"
                 size="sm"
@@ -368,21 +403,21 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
               >
                 <Upload className="text-xs" />
                 <span className="text-xs">Upload your SDL</span>
-              </FileButton>
+              </d.FileButton>
             </>
           )}
         </div>
       )}
 
-      {parsingError && <Alert variant="warning">{parsingError}</Alert>}
+      {parsingError && <d.Alert variant="warning">{parsingError}</d.Alert>}
 
       {hasComponent("yml-editor") && selectedSdlEditMode === "yaml" && (
-        <ViewPanel stickToBottom className={cn({ ["-mx-4"]: smallScreen })}>
-          <SDLEditor value={editedManifest || ""} onChange={handleTextChange} onValidate={syncSDLValidity} />
-        </ViewPanel>
+        <d.ViewPanel stickToBottom className={cn({ ["-mx-4"]: smallScreen })}>
+          <d.SDLEditor value={editedManifest || ""} onChange={handleTextChange} onValidate={syncSDLValidity} />
+        </d.ViewPanel>
       )}
       {(hasComponent("ssh") || selectedSdlEditMode === "builder") && (
-        <SdlBuilder
+        <d.SdlBuilder
           sdlString={editedManifest}
           onValidate={syncSDLValidity}
           ref={sdlBuilderRef}
@@ -395,29 +430,29 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
       )}
 
       {isDepositingDeployment && (
-        <DeploymentDepositModal
+        <d.DeploymentDepositModal
           handleCancel={() => setIsDepositingDeployment(false)}
           onDeploymentDeposit={onDeploymentDeposit}
           denom={sdlDenom}
           title="Confirm deployment creation?"
           infoText={
-            <Alert className="mb-6 text-xs" variant="default">
-              <DeploymentMinimumEscrowAlertText />
-              <LinkTo onClick={ev => handleDocClick(ev, "https://akash.network/docs/getting-started/intro-to-akash/payments/#escrow-accounts")}>
+            <d.Alert className="mb-6 text-xs" variant="default">
+              <d.DeploymentMinimumEscrowAlertText />
+              <d.LinkTo onClick={ev => handleDocClick(ev, "https://akash.network/docs/getting-started/intro-to-akash/payments/#escrow-accounts")}>
                 <strong>Learn more.</strong>
-              </LinkTo>
+              </d.LinkTo>
 
               {isTrialing && (
                 <div className="mt-2">
-                  <TrialDeploymentBadge />
+                  <d.TrialDeploymentBadge />
                 </div>
               )}
-            </Alert>
+            </d.Alert>
           }
           services={services}
         />
       )}
-      {isCheckingPrerequisites && <PrerequisiteList onClose={() => setIsCheckingPrerequisites(false)} onContinue={onPrerequisiteContinue} />}
+      {isCheckingPrerequisites && <d.PrerequisiteList onClose={() => setIsCheckingPrerequisites(false)} onContinue={onPrerequisiteContinue} />}
     </>
   );
 };

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
@@ -17,7 +17,7 @@ import { RouteStep } from "@src/types/route-steps.type";
 import { hardcodedTemplates } from "@src/utils/templates";
 import Layout from "../../layout/Layout";
 import { CreateLease } from "../CreateLease/CreateLease";
-import { ManifestEdit } from "../ManifestEdit";
+import { ManifestEdit } from "../ManifestEdit/ManifestEdit";
 import { CustomizedSteppers } from "../Stepper";
 import { TemplateList } from "../TemplateList";
 

--- a/apps/deploy-web/src/components/new-deployment/SdlBuilder.tsx
+++ b/apps/deploy-web/src/components/new-deployment/SdlBuilder.tsx
@@ -28,6 +28,7 @@ interface Props {
   setDeploymentName: Dispatch<string>;
   deploymentName: string;
   setIsRepoInputValid?: Dispatch<boolean>;
+  onValidate?: (event: { isValid: boolean }) => void;
 }
 
 export type SdlBuilderRefType = {
@@ -36,7 +37,7 @@ export type SdlBuilderRefType = {
 };
 
 export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
-  ({ sdlString, setEditedManifest, isGitProviderTemplate, setDeploymentName, deploymentName, setIsRepoInputValid }, ref) => {
+  ({ sdlString, setEditedManifest, isGitProviderTemplate, setDeploymentName, deploymentName, setIsRepoInputValid, onValidate }, ref) => {
     const [error, setError] = useState<string | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
     const [isInit, setIsInit] = useState(false);
@@ -49,7 +50,7 @@ export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
       },
       resolver: zodResolver(SdlBuilderFormValuesSchema)
     });
-    const { control, trigger, watch, setValue } = form;
+    const { control, trigger, watch, setValue, formState } = form;
     const serviceManager = useSdlServiceManager({ control });
 
     const { services: formServices = [] } = watch();
@@ -101,6 +102,10 @@ export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
         unsubscribe();
       };
     }, [watch]);
+
+    useEffect(() => {
+      onValidate?.({ isValid: formState.isValid });
+    }, [formState.isValid]);
 
     const getSdl = () => {
       try {

--- a/apps/deploy-web/src/components/sdl/SDLEditor/SDLEditor.tsx
+++ b/apps/deploy-web/src/components/sdl/SDLEditor/SDLEditor.tsx
@@ -5,6 +5,7 @@ import { forwardRef, useCallback, useImperativeHandle, useRef } from "react";
 import type { SDLInput } from "@akashnetwork/chain-sdk/web";
 import { validateSDL } from "@akashnetwork/chain-sdk/web";
 import type * as monacoModule from "monaco-editor";
+import type { Document } from "yaml";
 
 import type { IStandaloneCodeEditor } from "@src/components/shared/DynamicMonacoEditor/DynamicMonacoEditor";
 import { MemoMonaco } from "@src/components/shared/MemoMonaco";
@@ -46,9 +47,15 @@ export const SDLEditor = forwardRef<SdlEditorRefType, Props>(({ onChange, onVali
       const model = editor?.getModel();
       if (!model) return false;
 
-      const { parseDocument } = await import("yaml");
+      let doc: Document.Parsed;
+      try {
+        const { parseDocument } = await import("yaml");
+        doc = parseDocument(value, { keepSourceTokens: true });
+      } catch (error) {
+        onValidate?.({ isValid: false });
+        return false;
+      }
 
-      const doc = parseDocument(value, { keepSourceTokens: true });
       if (doc.errors.length) {
         onValidate?.({ isValid: false });
         // if there are errors, yaml is invalid and builtin monaco editor yaml service will show errors

--- a/apps/deploy-web/src/components/shared/DynamicMonacoEditor/DynamicMonacoEditor.tsx
+++ b/apps/deploy-web/src/components/shared/DynamicMonacoEditor/DynamicMonacoEditor.tsx
@@ -36,15 +36,21 @@ export const MONACO_OPTIONS = {
 
 const LazyMonacoEditor = dynamic(
   async () => {
+    const quiet = (worker: Worker) => {
+      // ignore worker errors since they are 3rd party and we cannot not do much
+      // user will in UX but everything still should work
+      worker.onerror = event => event.preventDefault();
+      return worker;
+    };
     // Set up Monaco environment for workers - must be done before importing monaco
     // This is inside dynamic() to ensure it's not included in server bundle
     globalThis.MonacoEnvironment = {
       getWorker(_moduleId: string, label: string) {
         switch (label) {
           case "editorWorkerService":
-            return new Worker(new URL("./monaco.worker.ts", import.meta.url), { type: "module" });
+            return quiet(new Worker(new URL("./monaco.worker.ts", import.meta.url), { type: "module" }));
           case "yaml":
-            return new Worker(new URL("./yaml.worker.ts", import.meta.url), { type: "module" });
+            return quiet(new Worker(new URL("./yaml.worker.ts", import.meta.url), { type: "module" }));
           default:
             throw new Error(`Unknown label ${label}`);
         }

--- a/apps/deploy-web/src/components/shared/DynamicMonacoEditor/DynamicMonacoEditor.tsx
+++ b/apps/deploy-web/src/components/shared/DynamicMonacoEditor/DynamicMonacoEditor.tsx
@@ -36,21 +36,15 @@ export const MONACO_OPTIONS = {
 
 const LazyMonacoEditor = dynamic(
   async () => {
-    const quiet = (worker: Worker) => {
-      // ignore worker errors since they are 3rd party and we cannot not do much
-      // user will in UX but everything still should work
-      worker.onerror = event => event.preventDefault();
-      return worker;
-    };
     // Set up Monaco environment for workers - must be done before importing monaco
     // This is inside dynamic() to ensure it's not included in server bundle
     globalThis.MonacoEnvironment = {
       getWorker(_moduleId: string, label: string) {
         switch (label) {
           case "editorWorkerService":
-            return quiet(new Worker(new URL("./monaco.worker.ts", import.meta.url), { type: "module" }));
+            return new Worker(new URL("./monaco.worker.ts", import.meta.url), { type: "module" });
           case "yaml":
-            return quiet(new Worker(new URL("./yaml.worker.ts", import.meta.url), { type: "module" }));
+            return new Worker(new URL("./yaml.worker.ts", import.meta.url), { type: "module" });
           default:
             throw new Error(`Unknown label ${label}`);
         }
@@ -99,7 +93,7 @@ export type Props = {
   theme?: string;
   value: string;
   height?: string | number;
-  language?: string;
+  language?: "yaml" | "plaintext";
   onChange?: OnChange;
   onMount?: OnMount;
   onValidate?: OnValidate;
@@ -115,7 +109,7 @@ export const DynamicMonacoEditor: React.FunctionComponent<Props> = ({
   onChange,
   onMount,
   onValidate,
-  language = "yaml",
+  language = "plaintext",
   options = {}
 }) => {
   const { resolvedTheme } = useTheme();

--- a/apps/deploy-web/src/hooks/useImportSimpleSdl.ts
+++ b/apps/deploy-web/src/hooks/useImportSimpleSdl.ts
@@ -8,8 +8,7 @@ export function useImportSimpleSdl(sdl: string | null | undefined) {
 
     try {
       return importSimpleSdl(sdl);
-    } catch (error) {
-      console.error("Failed to parse SDL:", error);
+    } catch {
       return [];
     }
   }, [sdl]);

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -159,7 +159,7 @@ export const importSimpleSdl = (yamlStr: string) => {
 
     return services;
   } catch (error) {
-    console.log(error);
+    console.error(error);
     throw error;
   }
 };

--- a/apps/deploy-web/tests/unit/mocks.tsx
+++ b/apps/deploy-web/tests/unit/mocks.tsx
@@ -1,4 +1,4 @@
-import type { FC } from "react";
+import { type FC, forwardRef } from "react";
 
 /**
  * Dump component that just renders children in React.Fragment
@@ -6,6 +6,14 @@ import type { FC } from "react";
 export function ComponentMock(props: Record<string, any>) {
   return <>{props.children}</>;
 }
+
+export const createRefComponentMock = () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const renderFn = jest.fn((props: Record<string, any>, _ref: unknown) => {
+    return <>{props.children}</>;
+  });
+  return Object.assign(forwardRef(renderFn), { renderFn });
+};
 
 export function MockComponents<T extends Record<string, any>>(components: T, overrides?: Partial<T>): Mocked<T> {
   return Object.keys(components).reduce((all, name: keyof T) => {


### PR DESCRIPTION
## Why

Because we have many `Maximum call stack size exceeded` error in sentry due to logs and events being parsed as yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manifest editor now accepts an injectable dependencies map to customize UI pieces and validation flow.
  * Editor language option narrowed for more predictable editing modes.

* **Bug Fixes**
  * Improved SDL/YAML parsing with clearer parsing-error handling and synchronized validation gating.
  * Reduced spurious editor error messages for a smoother editing experience.

* **Refactor**
  * Validation and editor/builder interactions rewired to ensure consistent UI feedback.

* **Tests**
  * Added comprehensive unit tests covering manifest editor behaviors and validation flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->