### PR TITLE
fix: replace Snackbar with Notificator for error handling

### DIFF
--- a/apps/deploy-web/src/components/deployments/CreateCredentialsButton/CreateCredentialsButton.tsx
+++ b/apps/deploy-web/src/components/deployments/CreateCredentialsButton/CreateCredentialsButton.tsx
@@ -53,9 +53,11 @@ export const CreateCredentialsButton: FC<Props> = ({ afterCreate, containerClass
 
   return (
     <div className={containerClassName}>
-      <d.Alert variant="warning" className={cn({ "py-2 text-sm": buttonProps?.size === "sm" }, "truncate")}>
-        {warningText}
-      </d.Alert>
+      {warningText && (
+        <d.Alert variant="warning" className={cn({ "py-2 text-sm": buttonProps?.size === "sm" }, "truncate")}>
+          {warningText}
+        </d.Alert>
+      )}
       <d.Button
         className={warningText ? "mt-4" : ""}
         {...buttonProps}

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
@@ -311,6 +311,8 @@ describe("OnboardingContainer", () => {
     const mockUseSnackbar = jest.fn().mockReturnValue({
       enqueueSnackbar: jest.fn()
     });
+    const mockNotificator = { success: jest.fn(), error: jest.fn() };
+    const mockUseNotificator = jest.fn().mockReturnValue(mockNotificator);
     const mockUseManagedWalletDenom = jest.fn().mockReturnValue("uakt");
 
     const mockNavigateBack = jest.fn();
@@ -392,6 +394,7 @@ describe("OnboardingContainer", () => {
       useWallet: mockUseWallet,
       useCertificate: mockUseCertificate,
       useSnackbar: mockUseSnackbar,
+      useNotificator: mockUseNotificator,
       useManagedWalletDenom: mockUseManagedWalletDenom,
       useReturnTo: mockUseReturnTo,
       localStorage: mockLocalStorage,

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from "react";
 import React, { useCallback, useEffect, useState } from "react";
 import type { EncodeObject } from "@cosmjs/proto-signing";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useSnackbar } from "notistack";
 
 import { SuccessAnimation } from "@src/components/shared";
 import { useCertificate } from "@src/context/CertificateProvider";
@@ -11,6 +10,7 @@ import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useChainParam } from "@src/hooks/useChainParam/useChainParam";
 import { useManagedWalletDenom } from "@src/hooks/useManagedWalletDenom";
+import { useNotificator } from "@src/hooks/useNotificator";
 import { useReturnTo } from "@src/hooks/useReturnTo";
 import { useUser } from "@src/hooks/useUser";
 import { usePaymentMethodsQuery } from "@src/queries/usePaymentQueries";
@@ -53,7 +53,7 @@ const DEPENDENCIES = {
   useRouter,
   useWallet,
   useCertificate,
-  useSnackbar,
+  useNotificator,
   useManagedWalletDenom,
   useReturnTo,
   localStorage: typeof window !== "undefined" ? window.localStorage : null,
@@ -88,7 +88,7 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
   } = d.useServices();
   const { hasManagedWallet, isWalletLoading, connectManagedWallet, address, signAndBroadcastTx } = d.useWallet();
   const { genNewCertificateIfLocalIsInvalid, updateSelectedCertificate } = d.useCertificate();
-  const { enqueueSnackbar } = d.useSnackbar();
+  const notificator = d.useNotificator();
   const managedDenom = d.useManagedWalletDenom();
   const { navigateBack } = d.useReturnTo({ defaultReturnTo: "/" });
 
@@ -235,7 +235,7 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
             severity: "warning",
             tags: { component: "onboarding", template: templateName }
           });
-          enqueueSnackbar(`Template "${templateName}" is no longer supported, please choose another one`, { variant: "error" });
+          notificator.error(`Template "${templateName}" is no longer supported, please choose another one`);
           return;
         }
 
@@ -250,7 +250,7 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
               severity: "warning",
               tags: { component: "onboarding", template: templateName, templateId: templateConfig.id }
             });
-            enqueueSnackbar(`Template "${templateConfig.name}" is no longer supported, please choose another one`, { variant: "error" });
+            notificator.error(`Template "${templateConfig.name}" is no longer supported, please choose another one`);
             return;
           }
           sdl = template.deploy;
@@ -303,7 +303,7 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
           router.push(urlService.newDeployment({ step: RouteStep.createLeases, dseq: dd.deploymentId.dseq }));
         }
       } catch (error) {
-        enqueueSnackbar("Failed to deploy template. Please try again.", { variant: "error" });
+        notificator.error("Failed to deploy template. Please try again.");
       }
     },
     [
@@ -320,7 +320,7 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
       updateSelectedCertificate,
       deploymentLocalStorage,
       analyticsService,
-      enqueueSnackbar,
+      notificator,
       errorHandler,
       managedDenom,
       navigateBack

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationContainer/EmailVerificationContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationContainer/EmailVerificationContainer.spec.tsx
@@ -46,7 +46,7 @@ describe("EmailVerificationContainer", () => {
   });
 
   it("should handle resend email error", async () => {
-    const { child, mockSendVerificationEmail, mockEnqueueSnackbar } = setup();
+    const { child, mockSendVerificationEmail, mockNotificator } = setup();
     mockSendVerificationEmail.mockRejectedValue(new Error("Failed"));
 
     const { onResendEmail } = child.mock.calls[0][0];
@@ -55,16 +55,7 @@ describe("EmailVerificationContainer", () => {
     });
 
     expect(mockSendVerificationEmail).toHaveBeenCalledWith("test-user");
-    expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
-      expect.objectContaining({
-        props: expect.objectContaining({
-          title: "Failed to send verification email",
-          subTitle: "Please try again later or contact support",
-          iconVariant: "error"
-        })
-      }),
-      { variant: "error" }
-    );
+    expect(mockNotificator.error).toHaveBeenCalledWith("Failed to send verification email. Please try again later");
   });
 
   it("should handle check verification success", async () => {
@@ -90,7 +81,7 @@ describe("EmailVerificationContainer", () => {
   });
 
   it("should handle check verification error", async () => {
-    const { child, mockCheckSession, mockEnqueueSnackbar } = setup();
+    const { child, mockCheckSession, mockNotificator } = setup();
     mockCheckSession.mockRejectedValue(new Error("Failed"));
 
     const { onCheckVerification } = child.mock.calls[0][0];
@@ -99,16 +90,7 @@ describe("EmailVerificationContainer", () => {
     });
 
     expect(mockCheckSession).toHaveBeenCalled();
-    expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
-      expect.objectContaining({
-        props: expect.objectContaining({
-          title: "Failed to check verification",
-          subTitle: "Please try again or refresh the page",
-          iconVariant: "error"
-        })
-      }),
-      { variant: "error" }
-    );
+    expect(mockNotificator.error).toHaveBeenCalledWith("Failed to check verification. Please try again or refresh the page");
   });
 
   it("should call onComplete when email is verified", () => {
@@ -167,11 +149,15 @@ describe("EmailVerificationContainer", () => {
       <div data-testid="snackbar" data-title={title} data-subtitle={subTitle} data-icon-variant={iconVariant} />
     );
 
+    const mockNotificator = { success: jest.fn(), error: jest.fn() };
+    const mockUseNotificator = jest.fn().mockReturnValue(mockNotificator);
+
     const dependencies = {
       useCustomUser: mockUseCustomUser,
       useSnackbar: mockUseSnackbar,
       useServices: mockUseServices,
-      Snackbar: mockSnackbar
+      Snackbar: mockSnackbar,
+      useNotificator: mockUseNotificator
     };
 
     const mockChildren = jest.fn().mockReturnValue(<div>Test</div>);
@@ -188,6 +174,7 @@ describe("EmailVerificationContainer", () => {
       mockSendVerificationEmail,
       mockCheckSession,
       mockEnqueueSnackbar,
+      mockNotificator,
       mockAnalyticsService
     };
   }

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationContainer/EmailVerificationContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationContainer/EmailVerificationContainer.tsx
@@ -6,12 +6,14 @@ import { useSnackbar } from "notistack";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
+import { useNotificator } from "@src/hooks/useNotificator";
 
 const DEPENDENCIES = {
   useCustomUser,
   useSnackbar,
   useServices,
-  Snackbar
+  Snackbar,
+  useNotificator
 };
 
 export type EmailVerificationContainerProps = {
@@ -30,6 +32,7 @@ export type EmailVerificationContainerProps = {
 export const EmailVerificationContainer: FC<EmailVerificationContainerProps> = ({ children, onComplete, dependencies: d = DEPENDENCIES }) => {
   const { user, checkSession } = d.useCustomUser();
   const { enqueueSnackbar } = d.useSnackbar();
+  const notificator = d.useNotificator();
   const [isResending, setIsResending] = useState(false);
   const [isChecking, setIsChecking] = useState(false);
   const { analyticsService, auth } = d.useServices();
@@ -46,13 +49,11 @@ export const EmailVerificationContainer: FC<EmailVerificationContainerProps> = (
         variant: "success"
       });
     } catch (error) {
-      enqueueSnackbar(<d.Snackbar title="Failed to send verification email" subTitle="Please try again later or contact support" iconVariant="error" />, {
-        variant: "error"
-      });
+      notificator.error("Failed to send verification email. Please try again later");
     } finally {
       setIsResending(false);
     }
-  }, [user?.id, auth, enqueueSnackbar, d.Snackbar]);
+  }, [user?.id, auth, enqueueSnackbar, d.Snackbar, notificator]);
 
   const handleCheckVerification = useCallback(async () => {
     setIsChecking(true);
@@ -62,13 +63,11 @@ export const EmailVerificationContainer: FC<EmailVerificationContainerProps> = (
         variant: "success"
       });
     } catch (error) {
-      enqueueSnackbar(<d.Snackbar title="Failed to check verification" subTitle="Please try again or refresh the page" iconVariant="error" />, {
-        variant: "error"
-      });
+      notificator.error("Failed to check verification. Please try again or refresh the page");
     } finally {
       setIsChecking(false);
     }
-  }, [checkSession, enqueueSnackbar, d.Snackbar]);
+  }, [checkSession, enqueueSnackbar, d.Snackbar, notificator]);
 
   const handleContinue = useCallback(() => {
     if (isEmailVerified) {

--- a/apps/deploy-web/src/components/onboarding/steps/PaymentMethodContainer/PaymentMethodContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/PaymentMethodContainer/PaymentMethodContainer.tsx
@@ -2,11 +2,11 @@
 import React, { type FC, useCallback, useEffect, useState } from "react";
 import type { ApiWalletWithOptional3DS } from "@akashnetwork/http-sdk";
 import type { PaymentMethod, SetupIntentResponse } from "@akashnetwork/http-sdk";
-import { useSnackbar } from "notistack";
 
 import { useServices } from "@src/context/ServicesProvider/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { use3DSecure } from "@src/hooks/use3DSecure";
+import { useNotificator } from "@src/hooks/useNotificator";
 import { useUser } from "@src/hooks/useUser";
 import { useCreateManagedWalletMutation } from "@src/queries/useManagedWalletQuery";
 import { usePaymentMethodsQuery, usePaymentMutations, useSetupIntentMutation } from "@src/queries/usePaymentQueries";
@@ -62,7 +62,7 @@ export const PaymentMethodContainer: FC<PaymentMethodContainerProps> = ({ childr
   const { isWalletLoading, hasManagedWallet, managedWalletError } = d.useWallet();
   const { user } = d.useUser();
   const { stripe, errorHandler } = useServices();
-  const { enqueueSnackbar } = useSnackbar();
+  const notificator = useNotificator();
 
   const [showAddForm, setShowAddForm] = useState(false);
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
@@ -102,7 +102,7 @@ export const PaymentMethodContainer: FC<PaymentMethodContainerProps> = ({ childr
         console.error("Wallet creation failed after 3D Secure:", error);
         setIsConnectingWallet(false);
         const errorMessage = extractErrorMessage(error as AppError);
-        enqueueSnackbar(errorMessage, { variant: "error", autoHideDuration: 5000 });
+        notificator.error(errorMessage);
       }
     },
     onError: (error: string) => {
@@ -119,13 +119,13 @@ export const PaymentMethodContainer: FC<PaymentMethodContainerProps> = ({ childr
       // Validate required fields
       if (!clientSecret || clientSecret.trim() === "") {
         console.error("3D Secure validation failed: clientSecret is missing or empty");
-        enqueueSnackbar("Authentication data is incomplete. Please try again.", { variant: "error" });
+        notificator.error("Authentication data is incomplete. Please try again.");
         return false;
       }
 
       if ((!paymentIntentId || paymentIntentId.trim() === "") && (!paymentMethodId || paymentMethodId.trim() === "")) {
         console.error("3D Secure validation failed: both paymentIntentId and paymentMethodId are missing or empty");
-        enqueueSnackbar("Payment method information is incomplete. Please try again.", { variant: "error" });
+        notificator.error("Payment method information is incomplete. Please try again.");
         return false;
       }
 
@@ -136,7 +136,7 @@ export const PaymentMethodContainer: FC<PaymentMethodContainerProps> = ({ childr
       });
       return true;
     },
-    [threeDSecure, enqueueSnackbar]
+    [threeDSecure, notificator]
   );
 
   useEffect(() => {
@@ -195,10 +195,7 @@ export const PaymentMethodContainer: FC<PaymentMethodContainerProps> = ({ childr
       console.error("Failed to remove payment method:", error);
       const errorMessage = extractErrorMessage(error as AppError);
 
-      enqueueSnackbar(errorMessage, {
-        variant: "error",
-        autoHideDuration: 5000
-      });
+      notificator.error(errorMessage);
     }
   };
 
@@ -235,10 +232,7 @@ export const PaymentMethodContainer: FC<PaymentMethodContainerProps> = ({ childr
 
       const errorMessage = extractErrorMessage(error as AppError);
 
-      enqueueSnackbar(errorMessage, {
-        variant: "error",
-        autoHideDuration: 5000
-      });
+      notificator.error(errorMessage);
     }
   };
 

--- a/apps/deploy-web/src/components/onboarding/steps/PaymentVerificationCard/PaymentVerificationCard.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/PaymentVerificationCard/PaymentVerificationCard.tsx
@@ -1,8 +1,8 @@
 "use client";
 import React from "react";
 import type { SetupIntentResponse } from "@akashnetwork/http-sdk";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@akashnetwork/ui/components";
-import { CreditCard } from "iconoir-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@akashnetwork/ui/components";
+import { CreditCard, InfoCircle } from "iconoir-react";
 
 import { PaymentMethodForm } from "@src/components/shared";
 import { Title } from "@src/components/shared/Title";
@@ -43,19 +43,30 @@ export const PaymentVerificationCard: React.FunctionComponent<PaymentVerificatio
   return (
     <div className="space-y-6 text-center">
       <Card className="mx-auto max-w-md text-left">
-        <CardHeader className="mb-2">
+        <CardHeader className="mb-2 pb-0">
           <div className="mb-4 flex flex-row items-center gap-4">
             <div className="rounded-full bg-primary/10 p-3">
               <CreditCard className="h-8 w-8 text-primary" />
             </div>
             <CardTitle>Add Payment Method</CardTitle>
           </div>
-          <CardDescription className="space-y-2">
-            <div>We need to verify your identity to provide you with the best service.</div>
-            <div className="text-sm text-muted-foreground">Your payment method will be used for identity verification during the trial start process.</div>
-          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
+          <div className="mb-8 rounded-md border border-blue-500/40 bg-blue-500/10 p-4">
+            <div className="flex gap-3">
+              <InfoCircle className="mt-0.5 h-5 w-5 shrink-0 text-blue-400" />
+              <div className="space-y-2">
+                <p className="text-sm font-semibold text-blue-400">We need to verify your identity before starting your free trial.</p>
+                <ul className="list-disc space-y-1 pl-4 text-sm text-blue-300/80">
+                  <li>
+                    Your card will <strong className="text-blue-300">not</strong> be charged
+                  </li>
+                  <li>A temporary hold of ~$1 may appear for a few days to verify your identity</li>
+                  <li>Virtual and prepaid cards are not accepted</li>
+                </ul>
+              </div>
+            </div>
+          </div>
           <PaymentMethodForm onSuccess={handleCardAdded} buttonText="Add Payment Method" processingText="Processing..." />
         </CardContent>
       </Card>

--- a/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
@@ -316,7 +316,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     enqueueSnackbar(
       <Snackbar
         title={snackTitle}
-        subTitle={<TransactionSnackbarContent snackMessage={snackMessage} transactionHash={transactionHash} />}
+        subTitle={<TransactionSnackbarContent snackMessage={snackMessage} transactionHash={transactionHash} isError={snackVariant === "error"} />}
         iconVariant={snackVariant}
       />,
       {
@@ -365,7 +365,13 @@ export function useIsManagedWalletUser() {
   return { canVisit, isLoading };
 }
 
-const TransactionSnackbarContent: React.FC<{ snackMessage: string; transactionHash: string }> = ({ snackMessage, transactionHash }) => {
+const SUPPORT_EMAIL = "support@akash.network";
+
+const TransactionSnackbarContent: React.FC<{ snackMessage: string; transactionHash: string; isError?: boolean }> = ({
+  snackMessage,
+  transactionHash,
+  isError
+}) => {
   const { publicConfig: appConfig } = useServices();
   const selectedNetworkId = networkStore.useSelectedNetworkId();
   const txUrl = transactionHash && `${appConfig.NEXT_PUBLIC_STATS_APP_URL}/transactions/${transactionHash}?network=${selectedNetworkId}`;
@@ -379,6 +385,14 @@ const TransactionSnackbarContent: React.FC<{ snackMessage: string; transactionHa
           <span>View transaction</span>
           <OpenNewWindow className="text-xs" />
         </Link>
+      )}
+      {isError && (
+        <div className="mt-2 text-xs">
+          Need help?{" "}
+          <a href={`mailto:${SUPPORT_EMAIL}?subject=Transaction Error&body=${encodeURIComponent(snackMessage)}`} className="underline">
+            Contact {SUPPORT_EMAIL}
+          </a>
+        </div>
       )}
     </>
   );

--- a/apps/deploy-web/src/hooks/useNotificator.tsx
+++ b/apps/deploy-web/src/hooks/useNotificator.tsx
@@ -9,9 +9,9 @@ function errorMessageWithSupport(message: string) {
     <div>
       <div>{message}</div>
       <div className="mt-2 text-xs">
-        Need help?{" "}
+        Need help? Contact{" "}
         <a href={`mailto:${SUPPORT_EMAIL}?subject=Console Error&body=${encodeURIComponent(message)}`} className="underline">
-          Contact {SUPPORT_EMAIL}
+          {SUPPORT_EMAIL}
         </a>
       </div>
     </div>
@@ -26,8 +26,8 @@ export function useNotificator() {
       success: (message: string, options?: { dataTestId: string }) => {
         enqueueSnackbar(<Snackbar data-testid={options?.dataTestId} title="Success" subTitle={message} />, { variant: "success", autoHideDuration: 3000 });
       },
-      error: (message: string, options?: { dataTestId: string }) => {
-        enqueueSnackbar(<Snackbar data-testid={options?.dataTestId} title="Error" subTitle={errorMessageWithSupport(message)} />, {
+      error: (message: string, options?: { dataTestId?: string; title?: string }) => {
+        enqueueSnackbar(<Snackbar data-testid={options?.dataTestId} title={options?.title || "Error"} subTitle={errorMessageWithSupport(message)} />, {
           variant: "error",
           autoHideDuration: 10000
         });

--- a/apps/deploy-web/src/hooks/useNotificator.tsx
+++ b/apps/deploy-web/src/hooks/useNotificator.tsx
@@ -10,7 +10,7 @@ function errorMessageWithSupport(message: string) {
       <div>{message}</div>
       <div className="mt-2 text-xs">
         Need help? Contact{" "}
-        <a href={`mailto:${SUPPORT_EMAIL}?subject=Console Error&body=${encodeURIComponent(message)}`} className="underline">
+        <a href={`mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent("Console Error")}&body=${encodeURIComponent(message)}`} className="underline">
           {SUPPORT_EMAIL}
         </a>
       </div>

--- a/apps/deploy-web/src/hooks/useNotificator.tsx
+++ b/apps/deploy-web/src/hooks/useNotificator.tsx
@@ -2,6 +2,22 @@ import React, { useMemo } from "react";
 import { Snackbar } from "@akashnetwork/ui/components";
 import { useSnackbar } from "notistack";
 
+const SUPPORT_EMAIL = "support@akash.network";
+
+function errorMessageWithSupport(message: string) {
+  return (
+    <div>
+      <div>{message}</div>
+      <div className="mt-2 text-xs">
+        Need help?{" "}
+        <a href={`mailto:${SUPPORT_EMAIL}?subject=Console Error&body=${encodeURIComponent(message)}`} className="underline">
+          Contact {SUPPORT_EMAIL}
+        </a>
+      </div>
+    </div>
+  );
+}
+
 export function useNotificator() {
   const { enqueueSnackbar } = useSnackbar();
 
@@ -11,7 +27,10 @@ export function useNotificator() {
         enqueueSnackbar(<Snackbar data-testid={options?.dataTestId} title="Success" subTitle={message} />, { variant: "success", autoHideDuration: 3000 });
       },
       error: (message: string, options?: { dataTestId: string }) => {
-        enqueueSnackbar(<Snackbar data-testid={options?.dataTestId} title="Error" subTitle={message} />, { variant: "error", autoHideDuration: 3000 });
+        enqueueSnackbar(<Snackbar data-testid={options?.dataTestId} title="Error" subTitle={errorMessageWithSupport(message)} />, {
+          variant: "error",
+          autoHideDuration: 10000
+        });
       }
     }),
     [enqueueSnackbar]

--- a/apps/deploy-web/src/pages/payment.tsx
+++ b/apps/deploy-web/src/pages/payment.tsx
@@ -124,7 +124,7 @@ const PayPage: React.FunctionComponent = () => {
 
       setError(errorInfo.message);
       setErrorAction(errorInfo.userAction);
-      notificator.error(errorInfo.message);
+      notificator.error(errorInfo.message, { title: "Payment Failed" });
     }
   };
 
@@ -147,7 +147,7 @@ const PayPage: React.FunctionComponent = () => {
 
       if (response.error) {
         const errorInfo = handleCouponError(response);
-        notificator.error(errorInfo.message);
+        notificator.error(errorInfo.message, { title: "Payment Failed" });
         return;
       }
 
@@ -160,7 +160,7 @@ const PayPage: React.FunctionComponent = () => {
       setCoupon("");
     } catch (error: unknown) {
       const errorInfo = handleStripeError(error);
-      notificator.error(errorInfo.message);
+      notificator.error(errorInfo.message, { title: "Payment Failed" });
       console.error("Coupon application error:", error);
     }
   };
@@ -181,7 +181,7 @@ const PayPage: React.FunctionComponent = () => {
       console.error("Failed to remove payment method:", error);
 
       const errorInfo = handleStripeError(error);
-      notificator.error(errorInfo.message);
+      notificator.error(errorInfo.message, { title: "Payment Failed" });
     } finally {
       setShowDeleteConfirmation(false);
       setCardToDelete(undefined);
@@ -239,7 +239,6 @@ const PayPage: React.FunctionComponent = () => {
       <div className="py-12">
         <Title className="text-center">Payment Methods</Title>
         <p className="mt-4 text-center text-gray-600">Manage your payment methods and make payments.</p>
-
         <div className="mx-auto max-w-md py-6">
           <PaymentSuccessAnimation
             show={showPaymentSuccess.show}

--- a/apps/deploy-web/src/pages/payment.tsx
+++ b/apps/deploy-web/src/pages/payment.tsx
@@ -17,6 +17,7 @@ import { useWallet } from "@src/context/WalletProvider";
 import { Guard } from "@src/hoc/guard/guard.hoc";
 import { use3DSecure } from "@src/hooks/use3DSecure";
 import { useIsOnboarded } from "@src/hooks/useIsOnboarded";
+import { useNotificator } from "@src/hooks/useNotificator";
 import { useUser } from "@src/hooks/useUser";
 import { defineServerSideProps } from "@src/lib/nextjs/defineServerSideProps/defineServerSideProps";
 import { redirectIfAccessTokenExpired } from "@src/lib/nextjs/pageGuards/pageGuards";
@@ -40,6 +41,7 @@ const PayPage: React.FunctionComponent = () => {
   const submittedAmountRef = useRef<string>("");
   const isDarkMode = resolvedTheme === "dark";
   const { enqueueSnackbar } = useSnackbar();
+  const notificator = useNotificator();
   const { user } = useUser();
   const { data: paymentMethods = [], isLoading: isLoadingPaymentMethods, refetch: refetchPaymentMethods } = usePaymentMethodsQuery();
   const { data: setupIntent, mutate: createSetupIntent, reset: resetSetupIntent } = useSetupIntentMutation();
@@ -122,7 +124,7 @@ const PayPage: React.FunctionComponent = () => {
 
       setError(errorInfo.message);
       setErrorAction(errorInfo.userAction);
-      enqueueSnackbar(<Snackbar title={errorInfo.message} iconVariant="error" />, { variant: "error" });
+      notificator.error(errorInfo.message);
     }
   };
 
@@ -145,7 +147,7 @@ const PayPage: React.FunctionComponent = () => {
 
       if (response.error) {
         const errorInfo = handleCouponError(response);
-        enqueueSnackbar(<Snackbar title={errorInfo.message} iconVariant="error" />, { variant: "error" });
+        notificator.error(errorInfo.message);
         return;
       }
 
@@ -158,7 +160,7 @@ const PayPage: React.FunctionComponent = () => {
       setCoupon("");
     } catch (error: unknown) {
       const errorInfo = handleStripeError(error);
-      enqueueSnackbar(<Snackbar title={errorInfo.message} iconVariant="error" />, { variant: "error" });
+      notificator.error(errorInfo.message);
       console.error("Coupon application error:", error);
     }
   };
@@ -179,7 +181,7 @@ const PayPage: React.FunctionComponent = () => {
       console.error("Failed to remove payment method:", error);
 
       const errorInfo = handleStripeError(error);
-      enqueueSnackbar(<Snackbar title={errorInfo.message} iconVariant="error" />, { variant: "error" });
+      notificator.error(errorInfo.message);
     } finally {
       setShowDeleteConfirmation(false);
       setCardToDelete(undefined);

--- a/apps/deploy-web/src/pages/user/verify-email/index.tsx
+++ b/apps/deploy-web/src/pages/user/verify-email/index.tsx
@@ -7,8 +7,10 @@ import { useSearchParams } from "next/navigation";
 import { NextSeo } from "next-seo";
 
 import Layout, { Loading } from "@src/components/layout/Layout";
+import { OnboardingStepIndex } from "@src/components/onboarding/OnboardingContainer/OnboardingContainer";
 import { useWhen } from "@src/hooks/useWhen";
 import { useVerifyEmail } from "@src/queries/useVerifyEmailQuery";
+import { ONBOARDING_STEP_KEY } from "@src/services/storage/keys";
 import { UrlService } from "@src/utils/urlUtils";
 
 type VerificationResultProps = {
@@ -17,6 +19,7 @@ type VerificationResultProps = {
 
 function VerificationResult({ isVerified }: VerificationResultProps) {
   const gotoOnboarding = useCallback(() => {
+    window.localStorage?.setItem(ONBOARDING_STEP_KEY, OnboardingStepIndex.PAYMENT_METHOD.toString());
     window.location.href = UrlService.onboarding();
   }, []);
 


### PR DESCRIPTION
  - Fix email verification redirect loop — sets the correct onboarding step in localStorage before redirecting so users land on the payment step instead of restarting from step
  0
  - Add clear card verification messaging — blue info banner explaining no charges, temporary ~$1 hold, and no virtual/prepaid cards
  - Add "Contact support@akash.network" mailto link to all error toasts across onboarding, payment, and transaction flows via useNotificator
  - Fix empty certificate alert in deployment detail when credentials exist but aren't usable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Informational banner on payment verification explaining identity checks and accepted card types.
  * Onboarding now stores the next step in local storage when continuing from email verification.

* **Improvements**
  * Unified notification system across onboarding and payment flows; error notifications show optional titles, stay visible longer, and include a support contact link.
  * Transaction error snackbars suggest contacting support.

* **Bug Fixes**
  * Warning alert displays only when relevant content exists.

* **Tests**
  * Tests updated to use and assert the new notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->