### PR TITLE
feat(billing): add support for Link payment methods

### DIFF
--- a/apps/api/src/billing/http-schemas/stripe.schema.spec.ts
+++ b/apps/api/src/billing/http-schemas/stripe.schema.spec.ts
@@ -1,8 +1,32 @@
 import { secondsInDay } from "date-fns/constants";
 
-import { CustomerTransactionsCsvExportQuerySchema, CustomerTransactionsQuerySchema } from "./stripe.schema";
+import { CustomerTransactionsCsvExportQuerySchema, CustomerTransactionsQuerySchema, PaymentMethodSchema } from "./stripe.schema";
 
 describe("Stripe Schema", () => {
+  describe("PaymentMethodSchema", () => {
+    it("accepts payment method with card", () => {
+      const result = PaymentMethodSchema.parse({
+        type: "card",
+        card: { brand: "visa", last4: "4242", exp_month: 12, exp_year: 2025 }
+      });
+      expect(result.type).toBe("card");
+      expect(result.card?.brand).toBe("visa");
+    });
+
+    it("accepts payment method with link", () => {
+      const result = PaymentMethodSchema.parse({
+        type: "link",
+        link: { email: "user@test.com" }
+      });
+      expect(result.type).toBe("link");
+      expect(result.link?.email).toBe("user@test.com");
+    });
+
+    it("rejects payment method without card or link", () => {
+      expect(() => PaymentMethodSchema.parse({ type: "unknown" })).toThrow("At least one of card or link must be provided");
+    });
+  });
+
   describe("CustomerTransactionsQuerySchema", () => {
     it("accepts no dates", () => {
       const out = CustomerTransactionsQuerySchema.parse({});

--- a/apps/api/src/billing/http-schemas/stripe.schema.ts
+++ b/apps/api/src/billing/http-schemas/stripe.schema.ts
@@ -35,6 +35,12 @@ export const PaymentMethodSchema = z.object({
     })
     .nullable()
     .optional(),
+  link: z
+    .object({
+      email: z.string().nullable().optional()
+    })
+    .nullable()
+    .optional(),
   billing_details: z
     .object({
       address: z

--- a/apps/api/src/billing/http-schemas/stripe.schema.ts
+++ b/apps/api/src/billing/http-schemas/stripe.schema.ts
@@ -13,53 +13,57 @@ export const PaymentMethodMarkAsDefaultInputSchema = z.object({
   })
 });
 
-export const PaymentMethodSchema = z.object({
-  type: z.string(),
-  validated: z.boolean().optional(),
-  isDefault: z.boolean().optional(),
-  card: z
-    .object({
-      brand: z.string().nullable(),
-      last4: z.string().nullable(),
-      exp_month: z.number(),
-      exp_year: z.number(),
-      funding: z.string().nullable().optional(),
-      country: z.string().nullable().optional(),
-      network: z.string().nullable().optional(),
-      three_d_secure_usage: z
-        .object({
-          supported: z.boolean().nullable().optional()
-        })
-        .nullable()
-        .optional()
-    })
-    .nullable()
-    .optional(),
-  link: z
-    .object({
-      email: z.string().nullable().optional()
-    })
-    .nullable()
-    .optional(),
-  billing_details: z
-    .object({
-      address: z
-        .object({
-          city: z.string().nullable(),
-          country: z.string().nullable(),
-          line1: z.string().nullable(),
-          line2: z.string().nullable(),
-          postal_code: z.string().nullable(),
-          state: z.string().nullable()
-        })
-        .nullable()
-        .optional(),
-      email: z.string().nullable().optional(),
-      name: z.string().nullable().optional(),
-      phone: z.string().nullable().optional()
-    })
-    .optional()
-});
+export const PaymentMethodSchema = z
+  .object({
+    type: z.string(),
+    validated: z.boolean().optional(),
+    isDefault: z.boolean().optional(),
+    card: z
+      .object({
+        brand: z.string().nullable(),
+        last4: z.string().nullable(),
+        exp_month: z.number(),
+        exp_year: z.number(),
+        funding: z.string().nullable().optional(),
+        country: z.string().nullable().optional(),
+        network: z.string().nullable().optional(),
+        three_d_secure_usage: z
+          .object({
+            supported: z.boolean().nullable().optional()
+          })
+          .nullable()
+          .optional()
+      })
+      .nullable()
+      .optional(),
+    link: z
+      .object({
+        email: z.string().nullable().optional()
+      })
+      .nullable()
+      .optional(),
+    billing_details: z
+      .object({
+        address: z
+          .object({
+            city: z.string().nullable(),
+            country: z.string().nullable(),
+            line1: z.string().nullable(),
+            line2: z.string().nullable(),
+            postal_code: z.string().nullable(),
+            state: z.string().nullable()
+          })
+          .nullable()
+          .optional(),
+        email: z.string().nullable().optional(),
+        name: z.string().nullable().optional(),
+        phone: z.string().nullable().optional()
+      })
+      .optional()
+  })
+  .refine(data => !!(data.card || data.link), {
+    message: "At least one of card or link must be provided"
+  });
 
 export const PaymentMethodsResponseSchema = z.object({
   data: z.array(PaymentMethodSchema)

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -993,7 +993,7 @@ export class StripeService extends Stripe {
     }
   }
 
-  private extractFingerprint(paymentMethod: Stripe.PaymentMethod): string | undefined {
+  extractFingerprint(paymentMethod: Stripe.PaymentMethod): string | undefined {
     if (paymentMethod.card?.fingerprint) {
       return paymentMethod.card.fingerprint;
     }

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -157,7 +157,7 @@ export class StripeService extends Stripe {
       return { ...remote, validated: local.isValidated, isDefault: local.isDefault };
     }
 
-    const fingerprint = StripeService.extractFingerprint(remote);
+    const fingerprint = this.extractFingerprint(remote);
 
     assert(fingerprint, 403, "Payment method cannot be set as default. No identifiable fingerprint found.");
 
@@ -754,7 +754,7 @@ export class StripeService extends Stripe {
       currentUserId
     });
 
-    const fingerprints = paymentMethods.map(paymentMethod => StripeService.extractFingerprint(paymentMethod)).filter(Boolean) as string[];
+    const fingerprints = paymentMethods.map(paymentMethod => this.extractFingerprint(paymentMethod)).filter(Boolean) as string[];
 
     if (!fingerprints.length) {
       return false;
@@ -993,7 +993,7 @@ export class StripeService extends Stripe {
     }
   }
 
-  private static extractFingerprint(paymentMethod: Stripe.PaymentMethod): string | undefined {
+  private extractFingerprint(paymentMethod: Stripe.PaymentMethod): string | undefined {
     if (paymentMethod.card?.fingerprint) {
       return paymentMethod.card.fingerprint;
     }

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -1,5 +1,6 @@
 import type { AnyAbility } from "@casl/ability";
 import { ConstantBackoff, handleWhenResult, retry, TaskCancelledError, timeout, TimeoutStrategy, wrap } from "cockatiel";
+import crypto from "crypto";
 import { stringify } from "csv-stringify";
 import assert from "http-assert";
 import difference from "lodash/difference";
@@ -156,9 +157,9 @@ export class StripeService extends Stripe {
       return { ...remote, validated: local.isValidated, isDefault: local.isDefault };
     }
 
-    const fingerprint = remote.card?.fingerprint;
+    const fingerprint = StripeService.extractFingerprint(remote);
 
-    assert(fingerprint, 403, "Payment method fingerprint is missing");
+    assert(fingerprint, 403, "Payment method cannot be set as default. No identifiable fingerprint found.");
 
     const newLocal = await this.paymentMethodRepository.accessibleBy(ability, "create").createAsDefault({
       userId: user.id,
@@ -555,7 +556,12 @@ export class StripeService extends Stripe {
       currency: charge.currency,
       status: charge.status,
       created: charge.created,
-      paymentMethod: charge.payment_method_details,
+      paymentMethod: charge.payment_method_details
+        ? {
+            ...charge.payment_method_details,
+            link: charge.payment_method_details.link ? { email: undefined } : undefined
+          }
+        : null,
       receiptUrl: charge.receipt_url,
       description: charge.description,
       metadata: charge.metadata
@@ -748,7 +754,7 @@ export class StripeService extends Stripe {
       currentUserId
     });
 
-    const fingerprints = paymentMethods.map(paymentMethod => paymentMethod.card?.fingerprint).filter(Boolean) as string[];
+    const fingerprints = paymentMethods.map(paymentMethod => StripeService.extractFingerprint(paymentMethod)).filter(Boolean) as string[];
 
     if (!fingerprints.length) {
       return false;
@@ -984,6 +990,16 @@ export class StripeService extends Stripe {
         error: validationError
       });
       // Don't fail the test charge if validation update fails - the card is still valid
+    }
+  }
+
+  private static extractFingerprint(paymentMethod: Stripe.PaymentMethod): string | undefined {
+    if (paymentMethod.card?.fingerprint) {
+      return paymentMethod.card.fingerprint;
+    }
+
+    if (paymentMethod.type === "link" && paymentMethod.link?.email) {
+      return `link_${crypto.createHash("sha256").update(paymentMethod.link.email.toLowerCase()).digest("hex")}`;
     }
   }
 }

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
@@ -83,7 +83,8 @@ describe(WalletSettingService.name, () => {
         expect.objectContaining({
           id: newSetting.id,
           userId: user.id
-        })
+        }),
+        { withCleanup: true }
       );
     });
 
@@ -139,7 +140,8 @@ describe(WalletSettingService.name, () => {
         expect.objectContaining({
           id: updatedSetting.id,
           userId: user.id
-        })
+        }),
+        { withCleanup: true }
       );
     });
 

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.ts
@@ -113,7 +113,7 @@ export class WalletSettingService {
 
   async #arrangeSchedule(prev?: WalletSettingOutput, next?: WalletSettingOutput) {
     if (!prev?.autoReloadEnabled && next?.autoReloadEnabled) {
-      await this.walletReloadJobService.scheduleForWalletSetting(next);
+      await this.walletReloadJobService.scheduleForWalletSetting(next, { withCleanup: true });
     }
   }
 

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -12890,6 +12890,16 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "isDefault": {
                             "type": "boolean",
                           },
+                          "link": {
+                            "nullable": true,
+                            "properties": {
+                              "email": {
+                                "nullable": true,
+                                "type": "string",
+                              },
+                            },
+                            "type": "object",
+                          },
                           "type": {
                             "type": "string",
                           },
@@ -13045,6 +13055,16 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         },
                         "isDefault": {
                           "type": "boolean",
+                        },
+                        "link": {
+                          "nullable": true,
+                          "properties": {
+                            "email": {
+                              "nullable": true,
+                              "type": "string",
+                            },
+                          },
+                          "type": "object",
                         },
                         "type": {
                           "type": "string",
@@ -13540,6 +13560,16 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                   },
                                   "isDefault": {
                                     "type": "boolean",
+                                  },
+                                  "link": {
+                                    "nullable": true,
+                                    "properties": {
+                                      "email": {
+                                        "nullable": true,
+                                        "type": "string",
+                                      },
+                                    },
+                                    "type": "object",
                                   },
                                   "type": {
                                     "type": "string",

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.spec.tsx
@@ -6,7 +6,7 @@ import { PaymentMethodsRow } from "./PaymentMethodsRow";
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createMockPaymentMethod } from "@tests/seeders/payment";
+import { createMockLinkPaymentMethod, createMockPaymentMethod } from "@tests/seeders/payment";
 
 // Mock implementations for dependencies
 const MockTableRow = ({ children, className }: any) => <tr className={className}>{children}</tr>;
@@ -327,7 +327,8 @@ describe(PaymentMethodsRow.name, () => {
       setup({ paymentMethod });
 
       // Component should still render without crashing
-      expect(screen.getByText(/Valid until/)).toBeInTheDocument();
+      expect(screen.getByText("Card")).toBeInTheDocument();
+      expect(screen.queryByText(/Valid until/)).not.toBeInTheDocument();
     });
 
     it("handles two-digit month without padding", () => {
@@ -344,6 +345,24 @@ describe(PaymentMethodsRow.name, () => {
       });
 
       expect(screen.getByText(/12\/2025/)).toBeInTheDocument();
+    });
+
+    it("renders Link payment method without card details", () => {
+      setup({
+        paymentMethod: createMockLinkPaymentMethod({ link: undefined })
+      });
+
+      expect(screen.getByText("Link")).toBeInTheDocument();
+      expect(screen.queryByText(/Valid until/)).not.toBeInTheDocument();
+    });
+
+    it("renders Link payment method with email", () => {
+      setup({
+        paymentMethod: createMockLinkPaymentMethod({ link: { email: "email@example.com" } })
+      });
+
+      expect(screen.getByText(/Link \(email@example\.com\)/)).toBeInTheDocument();
+      expect(screen.queryByText(/Valid until/)).not.toBeInTheDocument();
     });
   });
 

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.tsx
@@ -43,7 +43,7 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
     setOpen(false);
   };
 
-  const card = useCallback((paymentMethod: PaymentMethod) => {
+  const paymentMethodLabel = useMemo(() => {
     if (paymentMethod.card) {
       return (
         <>
@@ -58,9 +58,9 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
     }
 
     return <>{capitalizeFirstLetter(paymentMethod.type)}</>;
-  }, []);
+  }, [paymentMethod]);
 
-  const validUntil = useCallback((paymentMethod: PaymentMethod) => {
+  const validUntilContent = useMemo(() => {
     if (!paymentMethod.card) {
       return null;
     }
@@ -71,9 +71,7 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
         {month}/{paymentMethod.card.exp_year}
       </>
     );
-  }, []);
-
-  const validUntilContent = validUntil(paymentMethod);
+  }, [paymentMethod]);
 
   const defaultBadge = useMemo(() => {
     if (!paymentMethod.isDefault) {
@@ -101,7 +99,7 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
   return (
     <d.TableRow className="flex border-0 py-2 hover:bg-transparent">
       <d.TableCell className="flex items-center">
-        {card(paymentMethod)} {defaultBadge}
+        {paymentMethodLabel} {defaultBadge}
       </d.TableCell>
       {validUntilContent && <d.TableCell className="flex flex-grow items-center justify-end">Valid until {validUntilContent}</d.TableCell>}
       {hasOtherPaymentMethods && (

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.tsx
@@ -44,21 +44,36 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
   };
 
   const card = useCallback((paymentMethod: PaymentMethod) => {
+    if (paymentMethod.card) {
+      return (
+        <>
+          {capitalizeFirstLetter(paymentMethod.card.brand || "")} {paymentMethod.card.funding} **** {paymentMethod.card.last4}
+        </>
+      );
+    }
+
+    if (paymentMethod.type === "link") {
+      const email = paymentMethod.link?.email;
+      return <>{email ? `Link (${email})` : "Link"}</>;
+    }
+
+    return <>{capitalizeFirstLetter(paymentMethod.type)}</>;
+  }, []);
+
+  const validUntil = useCallback((paymentMethod: PaymentMethod) => {
+    if (!paymentMethod.card) {
+      return null;
+    }
+
+    const month = paymentMethod.card.exp_month?.toString().padStart(2, "0");
     return (
       <>
-        {capitalizeFirstLetter(paymentMethod.card?.brand || "")} {paymentMethod.card?.funding} **** {paymentMethod.card?.last4}
+        {month}/{paymentMethod.card.exp_year}
       </>
     );
   }, []);
 
-  const validUntil = useCallback((paymentMethod: PaymentMethod) => {
-    const month = paymentMethod.card?.exp_month?.toString().padStart(2, "0");
-    return (
-      <>
-        {month}/{paymentMethod.card?.exp_year}
-      </>
-    );
-  }, []);
+  const validUntilContent = validUntil(paymentMethod);
 
   const defaultBadge = useMemo(() => {
     if (!paymentMethod.isDefault) {
@@ -88,7 +103,7 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
       <d.TableCell className="flex items-center">
         {card(paymentMethod)} {defaultBadge}
       </d.TableCell>
-      <d.TableCell className="flex flex-grow items-center justify-end">Valid until {validUntil(paymentMethod)}</d.TableCell>
+      {validUntilContent && <d.TableCell className="flex flex-grow items-center justify-end">Valid until {validUntilContent}</d.TableCell>}
       {hasOtherPaymentMethods && (
         <d.TableCell className="min-h-[72px] min-w-[72px]">
           {!paymentMethod.isDefault && (

--- a/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.spec.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.spec.tsx
@@ -10,7 +10,7 @@ import { createMockLinkPaymentMethod, createMockPaymentMethod } from "@tests/see
 import { MockComponents } from "@tests/unit/mocks";
 
 describe(PaymentMethodCard.name, () => {
-  describe("display mode (default)", () => {
+  describe("when in display mode (default)", () => {
     it("renders card payment method with brand and last4", () => {
       setup({
         method: createMockPaymentMethod({
@@ -74,7 +74,7 @@ describe(PaymentMethodCard.name, () => {
     });
   });
 
-  describe("selection mode", () => {
+  describe("when in selection mode", () => {
     it("renders RadioGroupItem with method id", () => {
       const { dependencies } = setup({
         isSelectable: true,

--- a/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.spec.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.spec.tsx
@@ -1,0 +1,160 @@
+import "@testing-library/jest-dom";
+
+import React from "react";
+import type { PaymentMethod } from "@akashnetwork/http-sdk";
+
+import { DEPENDENCIES, PaymentMethodCard } from "./PaymentMethodCard";
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { createMockLinkPaymentMethod, createMockPaymentMethod } from "@tests/seeders/payment";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe(PaymentMethodCard.name, () => {
+  describe("display mode (default)", () => {
+    it("renders card payment method with brand and last4", () => {
+      setup({
+        method: createMockPaymentMethod({
+          card: { brand: "visa", last4: "4242", funding: "credit", exp_month: 12, exp_year: 2025 }
+        })
+      });
+
+      expect(screen.getByText(/VISA •••• 4242/)).toBeInTheDocument();
+      expect(screen.getByText(/Expires 12\/2025/)).toBeInTheDocument();
+    });
+
+    it("renders link payment method with email", () => {
+      setup({
+        method: createMockLinkPaymentMethod({ link: { email: "user@example.com" } })
+      });
+
+      expect(screen.getByText(/Link \(user@example\.com\)/)).toBeInTheDocument();
+    });
+
+    it("renders link payment method without email", () => {
+      setup({
+        method: createMockLinkPaymentMethod({ link: undefined })
+      });
+
+      expect(screen.getByText("Link")).toBeInTheDocument();
+    });
+
+    it("renders unknown payment method type with capitalized name", () => {
+      const method: PaymentMethod = {
+        id: "pm_test",
+        type: "sepa_debit",
+        created: Date.now(),
+        validated: true
+      };
+
+      setup({ method });
+
+      expect(screen.getByText("Sepa_debit")).toBeInTheDocument();
+    });
+
+    it("passes onRemove handler to Button with correct method id", () => {
+      const onRemove = jest.fn();
+      const { dependencies } = setup({
+        method: createMockPaymentMethod({ id: "pm_abc" }),
+        onRemove
+      });
+
+      const buttonProps = (dependencies.Button as jest.Mock).mock.calls[0][0];
+      act(() => {
+        buttonProps.onClick({ stopPropagation: jest.fn() });
+      });
+
+      expect(onRemove).toHaveBeenCalledWith("pm_abc");
+    });
+
+    it("passes disabled state to Button when isRemoving is true", () => {
+      const { dependencies } = setup({ isRemoving: true });
+
+      const buttonProps = (dependencies.Button as jest.Mock).mock.calls[0][0];
+      expect(buttonProps.disabled).toBe(true);
+    });
+  });
+
+  describe("selection mode", () => {
+    it("renders RadioGroupItem with method id", () => {
+      const { dependencies } = setup({
+        isSelectable: true,
+        method: createMockPaymentMethod({ id: "pm_sel" })
+      });
+
+      const radioProps = (dependencies.RadioGroupItem as jest.Mock).mock.calls[0][0];
+      expect(radioProps.value).toBe("pm_sel");
+      expect(radioProps.id).toBe("pm_sel");
+    });
+
+    it("calls onSelect with method id when clicked", () => {
+      const onSelect = jest.fn();
+      setup({
+        isSelectable: true,
+        onSelect,
+        method: createMockPaymentMethod({ id: "pm_click" })
+      });
+
+      fireEvent.click(screen.getByText(/•••• /));
+
+      expect(onSelect).toHaveBeenCalledWith("pm_click");
+    });
+
+    it("renders Remove button when not trialing", () => {
+      const { dependencies } = setup({ isSelectable: true, isTrialing: false });
+
+      expect((dependencies.Button as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+    });
+
+    it("does not render Remove button when trialing", () => {
+      const { dependencies } = setup({ isSelectable: true, isTrialing: true });
+
+      expect((dependencies.Button as jest.Mock).mock.calls.length).toBe(0);
+    });
+
+    it("does not show expiry for link methods", () => {
+      setup({
+        isSelectable: true,
+        method: createMockLinkPaymentMethod()
+      });
+
+      expect(screen.queryByText(/Expires/)).not.toBeInTheDocument();
+    });
+
+    it("shows expiry for card methods", () => {
+      setup({
+        isSelectable: true,
+        method: createMockPaymentMethod({
+          card: { brand: "mastercard", last4: "1234", funding: "debit", exp_month: 3, exp_year: 2027 }
+        })
+      });
+
+      expect(screen.getByText(/Expires 3\/2027/)).toBeInTheDocument();
+    });
+  });
+
+  function setup(
+    input: {
+      method?: PaymentMethod;
+      isRemoving?: boolean;
+      onRemove?: jest.Mock;
+      isSelectable?: boolean;
+      isSelected?: boolean;
+      onSelect?: jest.Mock;
+      showValidationBadge?: boolean;
+      isTrialing?: boolean;
+    } = {}
+  ) {
+    const dependencies = MockComponents(DEPENDENCIES);
+    const props = {
+      method: createMockPaymentMethod(),
+      isRemoving: false,
+      onRemove: jest.fn(),
+      dependencies,
+      ...input
+    };
+
+    const result = render(<PaymentMethodCard {...props} />);
+
+    return { ...result, dependencies };
+  }
+});

--- a/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.spec.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.spec.tsx
@@ -1,7 +1,6 @@
-import "@testing-library/jest-dom";
-
 import React from "react";
 import type { PaymentMethod } from "@akashnetwork/http-sdk";
+import { describe, expect, it, type Mock, vi } from "vitest";
 
 import { DEPENDENCIES, PaymentMethodCard } from "./PaymentMethodCard";
 
@@ -52,15 +51,15 @@ describe(PaymentMethodCard.name, () => {
     });
 
     it("passes onRemove handler to Button with correct method id", () => {
-      const onRemove = jest.fn();
+      const onRemove = vi.fn();
       const { dependencies } = setup({
         method: createMockPaymentMethod({ id: "pm_abc" }),
         onRemove
       });
 
-      const buttonProps = (dependencies.Button as jest.Mock).mock.calls[0][0];
+      const buttonProps = (dependencies.Button as Mock).mock.calls[0][0];
       act(() => {
-        buttonProps.onClick({ stopPropagation: jest.fn() });
+        buttonProps.onClick({ stopPropagation: vi.fn() });
       });
 
       expect(onRemove).toHaveBeenCalledWith("pm_abc");
@@ -69,7 +68,7 @@ describe(PaymentMethodCard.name, () => {
     it("passes disabled state to Button when isRemoving is true", () => {
       const { dependencies } = setup({ isRemoving: true });
 
-      const buttonProps = (dependencies.Button as jest.Mock).mock.calls[0][0];
+      const buttonProps = (dependencies.Button as Mock).mock.calls[0][0];
       expect(buttonProps.disabled).toBe(true);
     });
   });
@@ -81,13 +80,13 @@ describe(PaymentMethodCard.name, () => {
         method: createMockPaymentMethod({ id: "pm_sel" })
       });
 
-      const radioProps = (dependencies.RadioGroupItem as jest.Mock).mock.calls[0][0];
+      const radioProps = (dependencies.RadioGroupItem as Mock).mock.calls[0][0];
       expect(radioProps.value).toBe("pm_sel");
       expect(radioProps.id).toBe("pm_sel");
     });
 
     it("calls onSelect with method id when clicked", () => {
-      const onSelect = jest.fn();
+      const onSelect = vi.fn();
       setup({
         isSelectable: true,
         onSelect,
@@ -102,13 +101,13 @@ describe(PaymentMethodCard.name, () => {
     it("renders Remove button when not trialing", () => {
       const { dependencies } = setup({ isSelectable: true, isTrialing: false });
 
-      expect((dependencies.Button as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+      expect((dependencies.Button as Mock).mock.calls.length).toBeGreaterThan(0);
     });
 
     it("does not render Remove button when trialing", () => {
       const { dependencies } = setup({ isSelectable: true, isTrialing: true });
 
-      expect((dependencies.Button as jest.Mock).mock.calls.length).toBe(0);
+      expect((dependencies.Button as Mock).mock.calls.length).toBe(0);
     });
 
     it("does not show expiry for link methods", () => {
@@ -136,10 +135,10 @@ describe(PaymentMethodCard.name, () => {
     input: {
       method?: PaymentMethod;
       isRemoving?: boolean;
-      onRemove?: jest.Mock;
+      onRemove?: Mock;
       isSelectable?: boolean;
       isSelected?: boolean;
-      onSelect?: jest.Mock;
+      onSelect?: Mock;
       showValidationBadge?: boolean;
       isTrialing?: boolean;
     } = {}
@@ -148,7 +147,7 @@ describe(PaymentMethodCard.name, () => {
     const props = {
       method: createMockPaymentMethod(),
       isRemoving: false,
-      onRemove: jest.fn(),
+      onRemove: vi.fn(),
       dependencies,
       ...input
     };

--- a/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { useMemo } from "react";
 import type { PaymentMethod } from "@akashnetwork/http-sdk";
 import { Badge, Button, Card, CardDescription, CardHeader, CardTitle, RadioGroupItem } from "@akashnetwork/ui/components";
 import { CheckCircle, CreditCard } from "iconoir-react";
@@ -62,7 +62,7 @@ export const PaymentMethodCard: React.FC<PaymentMethodCardProps> = ({
     onRemove(method.id);
   };
 
-  const display = getPaymentMethodDisplay(method);
+  const display = useMemo(() => getPaymentMethodDisplay(method), [method]);
 
   if (isSelectable) {
     // Selection mode - used in payment page

--- a/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.tsx
@@ -4,6 +4,30 @@ import type { PaymentMethod } from "@akashnetwork/http-sdk";
 import { Badge, Button, Card, CardDescription, CardHeader, CardTitle, RadioGroupItem } from "@akashnetwork/ui/components";
 import { CheckCircle, CreditCard } from "iconoir-react";
 
+import { capitalizeFirstLetter } from "@src/utils/stringUtils";
+
+function getPaymentMethodDisplay(method: PaymentMethod): { label: string; expiry: string | null } {
+  if (method.card) {
+    return {
+      label: `${method.card.brand?.toUpperCase() || ""} •••• ${method.card.last4 || ""}`,
+      expiry: `Expires ${method.card.exp_month}/${method.card.exp_year}`
+    };
+  }
+
+  if (method.type === "link") {
+    const email = method.link?.email;
+    return {
+      label: email ? `Link (${email})` : "Link",
+      expiry: null
+    };
+  }
+
+  return {
+    label: capitalizeFirstLetter(method.type),
+    expiry: null
+  };
+}
+
 interface PaymentMethodCardProps {
   method: PaymentMethod;
   isRemoving: boolean;
@@ -38,6 +62,8 @@ export const PaymentMethodCard: React.FC<PaymentMethodCardProps> = ({
     onRemove(method.id);
   };
 
+  const display = getPaymentMethodDisplay(method);
+
   if (isSelectable) {
     // Selection mode - used in payment page
     return (
@@ -51,12 +77,8 @@ export const PaymentMethodCard: React.FC<PaymentMethodCardProps> = ({
           <RadioGroupItem value={method.id} id={method.id} />
           <div className="flex items-center gap-4">
             <div>
-              <div className="text-base font-medium">
-                {method.card?.brand?.toUpperCase()} •••• {method.card?.last4}
-              </div>
-              <div className="text-sm text-muted-foreground">
-                Expires {method.card?.exp_month}/{method.card?.exp_year}
-              </div>
+              <div className="text-base font-medium">{display.label}</div>
+              {display.expiry && <div className="text-sm text-muted-foreground">{display.expiry}</div>}
             </div>
           </div>
         </div>
@@ -79,12 +101,8 @@ export const PaymentMethodCard: React.FC<PaymentMethodCardProps> = ({
               <CreditCard className="h-5 w-5 text-primary" />
             </div>
             <div>
-              <CardTitle className="text-left text-base">
-                {method.card?.brand?.toUpperCase()} •••• {method.card?.last4}
-              </CardTitle>
-              <CardDescription>
-                Expires {method.card?.exp_month}/{method.card?.exp_year}
-              </CardDescription>
+              <CardTitle className="text-left text-base">{display.label}</CardTitle>
+              {display.expiry && <CardDescription>{display.expiry}</CardDescription>}
             </div>
           </div>
           <div className="flex items-center gap-2">

--- a/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.tsx
@@ -6,6 +6,18 @@ import { CheckCircle, CreditCard } from "iconoir-react";
 
 import { capitalizeFirstLetter } from "@src/utils/stringUtils";
 
+export const DEPENDENCIES = {
+  Badge,
+  Button,
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  RadioGroupItem,
+  CheckCircle,
+  CreditCard
+};
+
 function getPaymentMethodDisplay(method: PaymentMethod): { label: string; expiry: string | null } {
   if (method.card) {
     return {
@@ -32,13 +44,12 @@ interface PaymentMethodCardProps {
   method: PaymentMethod;
   isRemoving: boolean;
   onRemove: (paymentMethodId: string) => void;
-  // Selection mode props
   isSelectable?: boolean;
   isSelected?: boolean;
   onSelect?: (paymentMethodId: string) => void;
-  // Display mode props
   showValidationBadge?: boolean;
   isTrialing?: boolean;
+  dependencies?: typeof DEPENDENCIES;
 }
 
 export const PaymentMethodCard: React.FC<PaymentMethodCardProps> = ({
@@ -49,7 +60,8 @@ export const PaymentMethodCard: React.FC<PaymentMethodCardProps> = ({
   isSelected = false,
   onSelect,
   showValidationBadge = true,
-  isTrialing = false
+  isTrialing = false,
+  dependencies: d = DEPENDENCIES
 }) => {
   const handleCardClick = () => {
     if (isSelectable && onSelect) {
@@ -74,7 +86,7 @@ export const PaymentMethodCard: React.FC<PaymentMethodCardProps> = ({
         onClick={handleCardClick}
       >
         <div className="flex items-center gap-4">
-          <RadioGroupItem value={method.id} id={method.id} />
+          <d.RadioGroupItem value={method.id} id={method.id} />
           <div className="flex items-center gap-4">
             <div>
               <div className="text-base font-medium">{display.label}</div>
@@ -83,9 +95,9 @@ export const PaymentMethodCard: React.FC<PaymentMethodCardProps> = ({
           </div>
         </div>
         {!isTrialing && (
-          <Button variant="ghost" size="sm" onClick={handleRemoveClick} disabled={isRemoving}>
+          <d.Button variant="ghost" size="sm" onClick={handleRemoveClick} disabled={isRemoving}>
             Remove
-          </Button>
+          </d.Button>
         )}
       </div>
     );
@@ -93,30 +105,30 @@ export const PaymentMethodCard: React.FC<PaymentMethodCardProps> = ({
 
   // Display mode - used in onboarding
   return (
-    <Card className="relative">
-      <CardHeader>
+    <d.Card className="relative">
+      <d.CardHeader>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <div className="rounded-full bg-primary/10 p-2">
-              <CreditCard className="h-5 w-5 text-primary" />
+              <d.CreditCard className="h-5 w-5 text-primary" />
             </div>
             <div>
-              <CardTitle className="text-left text-base">{display.label}</CardTitle>
-              {display.expiry && <CardDescription>{display.expiry}</CardDescription>}
+              <d.CardTitle className="text-left text-base">{display.label}</d.CardTitle>
+              {display.expiry && <d.CardDescription>{display.expiry}</d.CardDescription>}
             </div>
           </div>
           <div className="flex items-center gap-2">
             {showValidationBadge && method.validated && (
-              <Badge variant="success" className="flex items-center p-1">
-                <CheckCircle className="h-4 w-4" />
-              </Badge>
+              <d.Badge variant="success" className="flex items-center p-1">
+                <d.CheckCircle className="h-4 w-4" />
+              </d.Badge>
             )}
-            <Button onClick={handleRemoveClick} variant="ghost" size="sm" disabled={isRemoving} className="text-muted-foreground">
+            <d.Button onClick={handleRemoveClick} variant="ghost" size="sm" disabled={isRemoving} className="text-muted-foreground">
               Remove
-            </Button>
+            </d.Button>
           </div>
         </div>
-      </CardHeader>
-    </Card>
+      </d.CardHeader>
+    </d.Card>
   );
 };

--- a/apps/deploy-web/tests/seeders/payment.ts
+++ b/apps/deploy-web/tests/seeders/payment.ts
@@ -21,6 +21,22 @@ export const createMockPaymentMethod = (overrides = {}) => ({
   ...overrides
 });
 
+export const createMockLinkPaymentMethod = (overrides = {}) => ({
+  id: `pm_${faker.string.alphanumeric(24)}`,
+  type: "link",
+  link: {
+    email: faker.internet.email()
+  },
+  billing_details: {
+    name: faker.person.fullName(),
+    email: faker.internet.email()
+  },
+  created: new Date().getTime(),
+  validated: true,
+  isDefault: false,
+  ...overrides
+});
+
 export const createMockDiscount = (overrides = {}) => ({
   id: `di_${faker.string.alphanumeric(24)}`,
   coupon: {

--- a/packages/http-sdk/src/stripe/stripe.types.ts
+++ b/packages/http-sdk/src/stripe/stripe.types.ts
@@ -40,6 +40,9 @@ export interface PaymentMethod {
     exp_month: number;
     exp_year: number;
   };
+  link?: {
+    email?: string;
+  };
 }
 
 export interface Charge {

--- a/packages/http-sdk/src/stripe/stripe.types.ts
+++ b/packages/http-sdk/src/stripe/stripe.types.ts
@@ -41,8 +41,8 @@ export interface PaymentMethod {
     exp_year: number;
   };
   link?: {
-    email?: string;
-  };
+    email?: string | null;
+  } | null;
 }
 
 export interface Charge {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Stripe Link as an alternative payment method; UI displays "Link" or "Link (email)" and hides "Valid until" for Link methods.

* **Improvements**
  * More consistent payment-method identification across flows (improved fingerprint handling).
  * Improved privacy: Link emails are redacted in transaction/charge exports and records.

* **Tests**
  * Updated and added tests covering Link payment method rendering and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->