### PR TITLE
fix: add custom Monaco language support for deployment logs

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
@@ -291,6 +291,7 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
               <ViewPanel stickToBottom style={{ overflow: "hidden" }}>
                 <MemoMonaco
                   value={logText}
+                  language="log"
                   onMount={handleEditorDidMount}
                   options={{
                     readOnly: true

--- a/apps/deploy-web/src/components/shared/DynamicMonacoEditor/DynamicMonacoEditor.tsx
+++ b/apps/deploy-web/src/components/shared/DynamicMonacoEditor/DynamicMonacoEditor.tsx
@@ -93,7 +93,7 @@ export type Props = {
   theme?: string;
   value: string;
   height?: string | number;
-  language?: "yaml" | "plaintext";
+  language?: "yaml" | "plaintext" | "log";
   onChange?: OnChange;
   onMount?: OnMount;
   onValidate?: OnValidate;

--- a/apps/deploy-web/src/components/shared/DynamicMonacoEditor/monaco-editor.ts
+++ b/apps/deploy-web/src/components/shared/DynamicMonacoEditor/monaco-editor.ts
@@ -133,6 +133,7 @@ import "monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShow
 // NOTE: Do NOT import from monaco-editor/esm/vs/basic-languages/yaml/yaml.contribution.js
 // Those files import ALL editor contributions, negating our selective imports.
 // Instead, we copied the YAML language definition here:
+import "./monaco-log-definitions";
 import "./monaco-yaml-definitions";
 
 import { editor, MarkerSeverity } from "monaco-editor/esm/vs/editor/editor.api.js";

--- a/apps/deploy-web/src/components/shared/DynamicMonacoEditor/monaco-log-definitions.ts
+++ b/apps/deploy-web/src/components/shared/DynamicMonacoEditor/monaco-log-definitions.ts
@@ -1,0 +1,25 @@
+/**
+ * Custom Monaco language definition for deployment logs/events.
+ *
+ * Log format (logs):   [serviceName]: message
+ * Event format:        [serviceName]: [type] [reason] [objectKind] note
+ */
+
+/* eslint-disable no-useless-escape */
+import { languages } from "monaco-editor/esm/vs/editor/editor.api.js";
+
+const logLanguage: languages.IMonarchLanguage = {
+  tokenPostfix: ".log",
+  tokenizer: {
+    root: [
+      [/^\[[\w.-]+\]:/, "namespace"],
+      [/\[Warning\]/, "keyword"],
+      [/\[Normal\]/, "string"],
+      [/\[[\w]+\]/, "type"],
+      [/[^\[]+/, "string"]
+    ]
+  }
+};
+
+languages.register({ id: "log" });
+languages.setMonarchTokensProvider("log", logLanguage);


### PR DESCRIPTION
<img width="1374" height="591" alt="image" src="https://github.com/user-attachments/assets/26099afa-202b-48ed-a1d6-c54385573710" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added custom syntax highlighting for deployment logs, improving readability by visually distinguishing log entries, service names, warnings, and event types in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->