### PR TITLE
fix: handles more cases on manifest error to show user the actual issue

### DIFF
--- a/apps/deploy-web/src/components/shared/ManifestErrorSnackbar/ManifestErrorSnackbar.spec.tsx
+++ b/apps/deploy-web/src/components/shared/ManifestErrorSnackbar/ManifestErrorSnackbar.spec.tsx
@@ -12,11 +12,32 @@ describe(ManifestErrorSnackbar.name, () => {
     expect(screen.queryByText(/You don't have local certificate/)).toBeInTheDocument();
   });
 
-  it("renders default error message for 400 error without issues", () => {
-    const err = createAxiosError(400, { error: {} });
+  it("renders message from provider for 400 error with message", () => {
+    const err = createAxiosError(400, { message: "Bad Request" });
+    setup({ err });
+
+    expect(screen.queryByText(/Bad Request/)).toBeInTheDocument();
+  });
+
+  it("renders text response from provider for 400 error with message", () => {
+    const err = createAxiosError(400, "Bad manifest format");
+    setup({ err });
+
+    expect(screen.queryByText(/Bad manifest format/)).toBeInTheDocument();
+  });
+
+  it("renders default error message if provider returns nothing for 400 error", () => {
+    const err = createAxiosError(400, "");
     setup({ err });
 
     expect(screen.queryByText(/Something went wrong/)).toBeInTheDocument();
+  });
+
+  it("renders stringified response if provider returns non-string data for 400 error", () => {
+    const err = createAxiosError(400, { foo: "bar" });
+    setup({ err });
+
+    expect(screen.queryByText(/{"foo":"bar"}/)).toBeInTheDocument();
   });
 
   it("renders expired certificate error for 400 with expired cert issue", () => {
@@ -131,6 +152,13 @@ describe(ManifestErrorSnackbar.name, () => {
     setup({ err });
 
     expect(screen.queryByText(/Some raw error/)).toBeInTheDocument();
+  });
+
+  it("renders exception message for non-HTTP errors", () => {
+    const err = new Error("Some exception occurred");
+    setup({ err });
+
+    expect(screen.queryByText(/Some exception occurred/)).toBeInTheDocument();
   });
 
   it("renders error title", () => {

--- a/apps/deploy-web/src/components/shared/ManifestErrorSnackbar/ManifestErrorSnackbar.tsx
+++ b/apps/deploy-web/src/components/shared/ManifestErrorSnackbar/ManifestErrorSnackbar.tsx
@@ -10,14 +10,16 @@ export const ManifestErrorSnackbar = ({ err, messages }: ManifestErrorSnackbarPr
   return <Snackbar title="Error" subTitle={`Error while sending manifest to provider. ${generateErrorText(err, messages)}`} iconVariant="error" />;
 };
 
-function generateErrorText(err: unknown, customMessages?: Record<string, string>) {
-  if (isHttpError(err) && err.response?.status === 401) {
+function generateErrorText(err: unknown, customMessages?: Record<string, string>): string {
+  if (!isHttpError(err)) {
+    return err && err instanceof Error ? err.message : String(err);
+  }
+
+  if (err.response?.status === 401) {
     return `You don't have local certificate. Please create a new one.`;
   }
 
-  if (isHttpError(err) && err.response?.status === 400) {
-    if (!err.response.data?.error?.issues) return DEFAULT_ERROR_MESSAGE;
-
+  if (err.response?.status === 400 && err.response.data?.error?.issues) {
     const errors = new Set<string>();
     err.response.data.error.issues.forEach((issue: Record<string, any>) => {
       const key = `${issue.path.join(".")}.${issue.params?.reason}`;
@@ -31,12 +33,11 @@ function generateErrorText(err: unknown, customMessages?: Record<string, string>
     return Array.from(errors).join("\n ");
   }
 
-  if (isHttpError(err) && err.response?.status === 422) {
-    // raw error message from provider. It returns error in text/plain format.
-    return typeof err.response.data === "string" ? err.response.data : err.response.data.message || JSON.stringify(err.response.data);
-  }
+  // raw error message from provider. It returns error in text/plain format.
+  const message = getProviderResponseError(err.response?.data);
+  if (message) return message;
 
-  return err;
+  return err.response?.data ? JSON.stringify(err.response?.data) : DEFAULT_ERROR_MESSAGE;
 }
 
 const DEFAULT_ERROR_MESSAGE = "Something went wrong. Please try refreshing the page and try again.";
@@ -45,3 +46,10 @@ const ERRORS_MAPPING: Record<string, string> = {
   "certPem.missingCertPair": "Please provide both public and private key of your certificate.",
   "certPem.invalid": "Provider rejected your certificate. Please try to create a new one. If the problem persists, please contact support."
 };
+
+function getProviderResponseError(data: unknown): string | undefined {
+  if (!data) return;
+  if (typeof data === "string") return data;
+  if (typeof data === "object" && "message" in data && typeof data.message === "string") return data.message;
+  return;
+}


### PR DESCRIPTION
## Why

Because provider API potentially may return 400 status code with plain text or message JSON payload and we need to display that to the user, so there is at least some clarity about what is wrong on manifest upload stage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging: clearer, more consistent messages for various HTTP and provider error payloads, with sensible fallbacks for empty, non-string, or structured responses.

* **Tests**
  * Expanded test coverage for multiple error payload types and edge cases to ensure correct messages are shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->