### PR TITLE
fix(billing): delegate coupon wallet top-up to Stripe webhook for reliable payment processing

### DIFF
--- a/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
+++ b/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
@@ -78,6 +78,14 @@ export class StripeTransactionRepository extends BaseRepository<Table, StripeTra
     return item ? this.toOutput(item) : undefined;
   }
 
+  async findByInvoiceId(invoiceId: string): Promise<StripeTransactionOutput | undefined> {
+    const item = await this.cursor.query.StripeTransactions.findFirst({
+      where: this.whereAccessibleBy(eq(this.table.stripeInvoiceId, invoiceId))
+    });
+
+    return item ? this.toOutput(item) : undefined;
+  }
+
   async updateByPaymentIntentId(paymentIntentId: string, update: Partial<StripeTransactionInput>): Promise<StripeTransactionOutput | undefined> {
     const existing = await this.findByPaymentIntentId(paymentIntentId);
     if (!existing) return undefined;


### PR DESCRIPTION
Move wallet crediting from the synchronous applyCoupon flow to the invoice.payment_succeeded webhook handler. This leverages Stripe's built-in retry mechanism to ensure users receive credits even if the initial top-up call fails transiently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet top-ups now process invoice.payment_succeeded events and centralize transaction update + top-up flows.
  * Coupon application now follows an invoice-first lifecycle with explicit invoice items and an audit transaction record.

* **Bug Fixes / Reliability**
  * Improved locking, idempotency, and error handling for invoice/payment processing; captures card and receipt details reliably.
  * Failed coupon/invoice flows are rolled back to prevent unintended credits.

* **Tests**
  * Added extensive tests for invoice flows, edge cases, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->