### PR TITLE
feat: separates logs and k8s events syntax highlighting

### DIFF
--- a/apps/deploy-web/jest.config.ts
+++ b/apps/deploy-web/jest.config.ts
@@ -40,7 +40,7 @@ const getConfig = createJestConfig({
 export default async (): Promise<Config.InitialOptions> => {
   return {
     rootDir: ".",
-    collectCoverageFrom: ["<rootDir>/src/**/*.{js,ts,tsx}"],
+    collectCoverageFrom: ["<rootDir>/src/**/*.{js,ts,tsx}", "!<rootDir>/src/**/Editor/monaco-*.ts", "!<rootDir>/src/**/Editor/*.worker.ts"],
     projects: [
       {
         coveragePathIgnorePatterns: ["/lib/nextjs/", "/tests/", "/lib/auth0/"],

--- a/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
@@ -291,7 +291,7 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
               <ViewPanel stickToBottom style={{ overflow: "hidden" }}>
                 <Editor
                   value={logText}
-                  language="log"
+                  language={selectedLogsMode === "logs" ? "log" : "k8s-events"}
                   onMount={handleEditorDidMount}
                   options={{
                     readOnly: true

--- a/apps/deploy-web/src/components/shared/Editor/Editor.spec.tsx
+++ b/apps/deploy-web/src/components/shared/Editor/Editor.spec.tsx
@@ -1,12 +1,55 @@
-import { Editor, EditorSkeleton } from "./Editor";
+import type { Props } from "./Editor";
+import { DEPENDENCIES, Editor, EditorSkeleton } from "./Editor";
 
 import { render } from "@testing-library/react";
 
 describe(Editor.name || "Editor", () => {
-  describe(EditorSkeleton.name, () => {
-    it("renders skeleton lines with varying widths", () => {
-      const result = render(<EditorSkeleton />);
-      expect(result.container).toMatchSnapshot();
+  it("renders monaco editor with default props", async () => {
+    const LazyMonacoEditor = jest.fn(() => <div data-testid="lazy-monaco-editor" />);
+    const props = {
+      height: "50%",
+      value: "test monaco editor",
+      theme: "light",
+      onChange: () => {},
+      onMount: () => {},
+      onValidate: () => {},
+      wrapperProps: { "data-testid": "monaco-editor" },
+      path: "test-path.yaml",
+      language: "yaml" as const
+    };
+    setup({
+      ...props,
+      dependencies: {
+        ...DEPENDENCIES,
+        LazyMonacoEditor
+      }
     });
+    expect(LazyMonacoEditor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ...props,
+        language: "yaml"
+      }),
+      expect.anything()
+    );
+  });
+
+  function setup(input?: Partial<Omit<Props, "dependencies">> & { dependencies?: Partial<typeof DEPENDENCIES> }) {
+    return render(
+      <Editor
+        {...input}
+        value={input?.value ?? "test"}
+        dependencies={{
+          ...DEPENDENCIES,
+          ...input?.dependencies
+        }}
+      />
+    );
+  }
+});
+
+describe(EditorSkeleton.name, () => {
+  it("renders skeleton lines with varying widths", () => {
+    const result = render(<EditorSkeleton />);
+    expect(result.container).toMatchSnapshot();
   });
 });

--- a/apps/deploy-web/src/components/shared/Editor/Editor.tsx
+++ b/apps/deploy-web/src/components/shared/Editor/Editor.tsx
@@ -94,7 +94,7 @@ export type Props = {
   theme?: string;
   value: string;
   height?: string | number;
-  language?: "yaml" | "plaintext" | "log";
+  language?: "yaml" | "plaintext" | "log" | "k8s-events";
   onChange?: OnChange;
   onMount?: OnMount;
   onValidate?: OnValidate;

--- a/apps/deploy-web/src/components/shared/Editor/Editor.tsx
+++ b/apps/deploy-web/src/components/shared/Editor/Editor.tsx
@@ -100,6 +100,7 @@ export type Props = {
   onValidate?: OnValidate;
   options?: monaco.editor.IStandaloneEditorConstructionOptions;
   path?: string;
+  dependencies?: typeof DEPENDENCIES;
 };
 
 const SKELETON_LINE_WIDTHS = [75, 60, 85, 45, 70, 55, 80, 40, 65, 50, 90, 35, 70, 60, 75];
@@ -122,6 +123,11 @@ export function EditorSkeleton() {
 }
 
 const LazyMonacoEditor = dynamic(loadMonacoEditor, { ssr: false, loading: () => <EditorSkeleton /> });
+export const DEPENDENCIES = {
+  LazyMonacoEditor,
+  useTheme
+};
+
 const DynamicMonacoEditor: React.FunctionComponent<Props> = ({
   path,
   theme,
@@ -131,12 +137,13 @@ const DynamicMonacoEditor: React.FunctionComponent<Props> = ({
   onMount,
   onValidate,
   language = "plaintext",
-  options = {}
+  options = {},
+  dependencies: d = DEPENDENCIES
 }) => {
-  const { resolvedTheme } = useTheme();
+  const { resolvedTheme } = d.useTheme();
 
   return (
-    <LazyMonacoEditor
+    <d.LazyMonacoEditor
       height={height}
       language={language}
       defaultLanguage={language}

--- a/apps/deploy-web/src/components/shared/Editor/__snapshots__/Editor.spec.tsx.snap
+++ b/apps/deploy-web/src/components/shared/Editor/__snapshots__/Editor.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`Editor EditorSkeleton renders skeleton lines with varying widths 1`] = `
+exports[`EditorSkeleton renders skeleton lines with varying widths 1`] = `
 <div>
   <div
     class="flex h-full w-full bg-white dark:bg-[#1e1e1e]"

--- a/apps/deploy-web/src/components/shared/Editor/monaco-editor.ts
+++ b/apps/deploy-web/src/components/shared/Editor/monaco-editor.ts
@@ -136,7 +136,12 @@ import "monaco-editor/esm/vs/editor/standalone/browser/iPadShowKeyboard/iPadShow
 // Instead, we copied the YAML language definition here:
 import "./monaco-yaml-definitions";
 import "./monaco-log-definitions";
+import "./monaco-k8s-events-definitions";
+import "./monaco-theme";
 
+// ============================================================================
+// 17) Monaco editor API re-exports (for convenience)
+// ============================================================================
 import { editor, MarkerSeverity } from "monaco-editor/esm/vs/editor/editor.api.js";
 
 // Workaround https://github.com/remcohaszing/monaco-yaml/issues/272.

--- a/apps/deploy-web/src/components/shared/Editor/monaco-k8s-events-definitions.ts
+++ b/apps/deploy-web/src/components/shared/Editor/monaco-k8s-events-definitions.ts
@@ -1,0 +1,48 @@
+/**
+ * Custom Monaco language definition for deployment logs/events.
+ *
+ * Log format (logs):   [serviceName]: message
+ * Event format:        [serviceName]: [severity] [reason] [objectKind] note
+ *
+ * Supported severity levels: [Normal], [Warning], [Error]
+ * Examples:
+ *   [web]: [Normal] [Scheduled] [Pod] Successfully assigned...
+ *   [web]: [Warning] [BackOff] [Pod] Back-off restarting failed container
+ *   [web]: [Error] [Failed] [Pod] Error: ImagePullBackOff
+ */
+
+/* eslint-disable no-useless-escape */
+import { languages } from "monaco-editor/esm/vs/editor/editor.api.js";
+
+const k8sEventsLanguage: languages.IMonarchLanguage = {
+  tokenPostfix: ".k8s-events",
+  tokenizer: {
+    root: [
+      // Component/namespace at the beginning (e.g., [web]:, [ingress.provider]:)
+      [/^\[[\w.-]+\]:/, "namespace"],
+
+      // Severity levels
+      [/\[Error\]/, "log.error"],
+      [/\[Warning\]/, "log.warning"],
+      [/\[Normal\]/, "log.info"],
+
+      // Kubernetes resource kinds - highlight as types
+      [
+        /\[(Pod|Deployment|ReplicaSet|Service|Ingress|StatefulSet|DaemonSet|Job|CronJob|ConfigMap|Secret|PersistentVolumeClaim|PersistentVolume|Namespace|Node|Event|HorizontalPodAutoscaler|NetworkPolicy)\]/,
+        "type"
+      ],
+
+      // Error/failure-related reasons - highlight as errors
+      [/\[(Failed|FailedScheduling|FailedCreate|FailedMount|BackOff|CrashLoopBackOff|Unhealthy|Killing|Evicted|FailedKillPod|FailedSync)\]/, "log.error"],
+
+      // Reasons/Actions (any other bracketed word like [Scheduled], [Pulled], [Created], etc.)
+      [/\[[\w]+\]/, "variable"],
+
+      // Message text (everything not in brackets)
+      [/[^\[]+/, "string"]
+    ]
+  }
+};
+
+languages.register({ id: "k8s-events" });
+languages.setMonarchTokensProvider("k8s-events", k8sEventsLanguage);

--- a/apps/deploy-web/src/components/shared/Editor/monaco-log-definitions.ts
+++ b/apps/deploy-web/src/components/shared/Editor/monaco-log-definitions.ts
@@ -1,8 +1,12 @@
 /**
- * Custom Monaco language definition for deployment logs/events.
- *
- * Log format (logs):   [serviceName]: message
- * Event format:        [serviceName]: [type] [reason] [objectKind] note
+ * Custom Monaco language definition for deployment logs.
+ * Enhanced with VS Code log syntax patterns for:
+ * - Log levels (TRACE, DEBUG, INFO, WARN, ERROR, FATAL, etc.)
+ * - Timestamps and dates (ISO 8601, various formats)
+ * - Constants (UUIDs, SHA hashes, MAC addresses, numbers, booleans)
+ * - Strings (quoted text)
+ * - Exceptions (Exception class names, stack traces)
+ * - URLs and network addresses
  */
 
 /* eslint-disable no-useless-escape */
@@ -10,13 +14,107 @@ import { languages } from "monaco-editor/esm/vs/editor/editor.api.js";
 
 const logLanguage: languages.IMonarchLanguage = {
   tokenPostfix: ".log",
+  ignoreCase: false,
   tokenizer: {
     root: [
+      // Component/namespace at the beginning (e.g., [web]:, [ingress.provider]:)
       [/^\[[\w.-]+\]:/, "namespace"],
-      [/\[Warning\]/, "keyword"],
-      [/\[Normal\]/, "string"],
-      [/\[[\w]+\]/, "type"],
-      [/[^\[]+/, "string"]
+
+      // Akash-specific severity levels (keep these before generic log levels for priority)
+      [/\[Error\]/, "log.error"],
+      [/\[Warning\]/, "log.warning"],
+      [/\[Normal\]/, "log.debug"],
+
+      // Kubernetes resource kinds - highlight as types
+      [
+        /\[(Pod|Deployment|ReplicaSet|Service|Ingress|StatefulSet|DaemonSet|Job|CronJob|ConfigMap|Secret|PersistentVolumeClaim|PersistentVolume|Namespace|Node|Event|HorizontalPodAutoscaler|NetworkPolicy)\]/,
+        "type"
+      ],
+
+      // Error/failure-related reasons - highlight as errors
+      [/\[(Failed|FailedScheduling|FailedCreate|FailedMount|BackOff|CrashLoopBackOff|Unhealthy|Killing|Evicted|FailedKillPod|FailedSync)\]/, "log.error"],
+
+      // Reasons/Actions (any other bracketed word like [Scheduled], [Pulled], [Created], etc.)
+      [/\[[\w]+\]/, "variable"],
+
+      // === VS Code Log Syntax Patterns ===
+
+      // Log levels - ERROR/FATAL/CRITICAL/ALERT (case-insensitive variations)
+      [
+        /\b(ALERT|Alert|alert|CRITICAL|Critical|critical|EMERGENCY|Emergency|emergency|ERROR|Error|error|FAILURE|Failure|failure|FAIL|Fail|fail|FATAL|Fatal|fatal|EE)\b/,
+        "log.error"
+      ],
+      [/\[(error|eror|err|er|e|fatal|fatl|ftl|fa|f|ERROR|EROR|ERR|ER|E|FATAL|FATL|FTL|FA|F)\]/, "log.error"],
+
+      // Log levels - WARNING/WARN (case-insensitive)
+      [/\b(WARNING|Warning|warning|WARN|Warn|warn|WW)\b/, "log.warning"],
+      [/\b(warning|WARNING)\s*:/, "log.warning"],
+      [/\[(warning|warn|wrn|wn|w|WARNING|WARN|WRN|WN|W)\]/, "log.warning"],
+
+      // Log levels - INFO/NOTICE/HINT (case-insensitive)
+      [/\b(HINT|Hint|hint|INFO|Info|info|INFORMATION|Information|information|NOTICE|Notice|notice|II)\b/, "log.info"],
+      [/\b(info|information|INFO|INFORMATION)\s*:/, "log.info"],
+      [/\[(information|info|inf|in|i|INFORMATION|INFO|INF|IN|I)\]/, "log.info"],
+
+      // Log levels - DEBUG (case-insensitive)
+      [/\b(DEBUG|Debug|debug)\b/, "log.debug"],
+      [/\b(debug|DEBUG)\s*:/, "log.debug"],
+      [/\[(debug|dbug|dbg|de|d|DEBUG|DBUG|DBG|DE|D)\]/, "log.debug"],
+
+      // Log levels - TRACE/VERBOSE (case-insensitive)
+      [/\b(Trace|TRACE|trace)\b:?/, "log.verbose"],
+      [/\[(verbose|verb|vrb|vb|v|VERBOSE|VERB|VRB|VB|V)\]/, "log.verbose"],
+
+      // Exception types (e.g., NullPointerException, IOException)
+      [/\b([a-zA-Z.]*Exception)\b/, "log.exception"],
+
+      // Stack trace lines (lines starting with "at ")
+      [/^[\t ]*at[\t ].*$/, "log.exception"],
+
+      // ISO 8601 dates (YYYY-MM-DD)
+      [/\b\d{4}-\d{2}-\d{2}(?=T|\b)/, "log.date"],
+
+      // Other date formats (DD/MM/YYYY, DD-MM-YYYY, etc.)
+      [/\d{2}[^\w\s]\d{2}[^\w\s]\d{4}\b/, "log.date"],
+
+      // Time formats with timezone (HH:MM:SS.mmm+TZ or THHMMSS)
+      [/T?\d{1,2}:\d{2}(:\d{2}([.,]\d{1,})?)?(Z| ?[+-]\d{1,2}:\d{2})?\b/, "log.date"],
+      [/T\d{2}\d{2}(\d{2}([.,]\d{1,})?)?(Z| ?[+-]\d{1,2}\d{2})?\b/, "log.date"],
+
+      // UUIDs (8-4-4-4-12 format)
+      [/\b[0-9a-fA-F]{8}-?([0-9a-fA-F]{4}-?){3}[0-9a-fA-F]{12}\b/, "constant.language"],
+
+      // SHA hashes (40, 10, or 7 characters)
+      [/\b[0-9a-fA-F]{40}\b/, "constant.language"],
+      [/\b[0-9a-fA-F]{10}\b/, "constant.language"],
+      [/\b[0-9a-fA-F]{7}\b/, "constant.language"],
+
+      // MAC addresses and hex sequences with colons/hyphens
+      [/\b([0-9a-fA-F]{2,}[:-])+[0-9a-fA-F]{2,}\b/, "constant.language"],
+
+      // Hexadecimal numbers (0x prefix)
+      [/\b0x[a-fA-F0-9]+\b/, "constant.language"],
+
+      // Numbers
+      [/\b\d+(\.\d+)?\b/, "constant.numeric"],
+
+      // Booleans and null
+      [/\b(true|false|null|TRUE|FALSE|NULL)\b/, "constant.language"],
+
+      // URLs (http://, https://, ftp://, etc.)
+      [/\b[a-z]+:\/\/\S+/, "constant.language"],
+
+      // Domain names (e.g., example.com, api.github.com)
+      [/\b([\w-]+\.)+[\w-]+\b/, "constant.language"],
+
+      // Double-quoted strings
+      [/"[^"]*"/, "string"],
+
+      // Single-quoted strings
+      [/'[^']*'/, "string"],
+
+      // Message text (everything else) - catch remaining content
+      [/.+?/, ""]
     ]
   }
 };

--- a/apps/deploy-web/src/components/shared/Editor/monaco-theme.ts
+++ b/apps/deploy-web/src/components/shared/Editor/monaco-theme.ts
@@ -1,0 +1,33 @@
+import { editor } from "monaco-editor/esm/vs/editor/editor.api.js";
+
+editor.defineTheme("vs-dark", {
+  base: "vs-dark",
+  inherit: true,
+  rules: [
+    { token: "log.error", foreground: "f48771", fontStyle: "bold" },
+    { token: "log.exception", foreground: "f48771" },
+    { token: "log.warning", foreground: "dcdcaa" },
+    { token: "log.info", foreground: "4fc1ff" },
+    { token: "log.debug", foreground: "608b4e" },
+    { token: "log.verbose", foreground: "608b4e" },
+    { token: "log.date", foreground: "808080" },
+    { token: "namespace", foreground: "4ec9b0" }
+  ],
+  colors: {}
+});
+
+editor.defineTheme("hc-light", {
+  base: "hc-light",
+  inherit: true,
+  rules: [
+    { token: "log.error", foreground: "cd3131", fontStyle: "bold" },
+    { token: "log.exception", foreground: "cd3131" },
+    { token: "log.warning", foreground: "bf8803" },
+    { token: "log.info", foreground: "0000ff" },
+    { token: "log.debug", foreground: "008000" },
+    { token: "log.verbose", foreground: "008000" },
+    { token: "log.date", foreground: "808080" },
+    { token: "namespace", foreground: "267f99" }
+  ],
+  colors: {}
+});


### PR DESCRIPTION
## Why

To be represent text

## What

Logs
<img width="948" height="378" alt="Screenshot 2026-02-14 at 05 57 54" src="https://github.com/user-attachments/assets/646578bf-de65-4494-8326-d75d7b53edc3" />


Events
<img width="945" height="369" alt="Screenshot 2026-02-14 at 05 57 59" src="https://github.com/user-attachments/assets/8710ea64-1d7c-4ada-b58e-ebea96d21236" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated syntax highlighting for Kubernetes events in deployment logs.
  * Introduced two editor themes (vs-dark and hc-light) with improved token coloring.
  * Enhanced log syntax highlighting with richer detection of timestamps, severities, identifiers, and error/stack patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->