### PR TITLE
chore: enforce snyk deps check on PR only

### DIFF
--- a/.github/actions/poll-check-status/action.yml
+++ b/.github/actions/poll-check-status/action.yml
@@ -41,11 +41,35 @@ runs:
 
           console.log(`Checking ${checkName} for SHA=${sha} (type: ${checkType})`);
 
+          const getCheckStatus = checkType === 'status' ? getStatus : getCheckRun;
           const checksParams = {
             owner: context.repo.owner,
             repo: context.repo.repo,
             ref: sha,
           };
+
+          for (let attempt = 0; attempt < maxRetries; attempt++) {
+            const check = await getCheckStatus();
+
+            if (check?.status !== 'completed') {
+              if (attempt < maxRetries - 1) {
+                const logPrefix = check ? `Check ${checkName} status: ${check.status}` : `Check ${checkName} not found yet`;
+                console.log(`${logPrefix}. Retry ${attempt + 1}/${maxRetries} in ${sleepMs / 1000}s...`);
+                await new Promise(resolve => setTimeout(resolve, sleepMs));
+                continue;
+              }
+              const statusMsg = check ? `status: ${check.status}` : 'not found';
+              throw new Error(`${checkName} check did not complete after ${maxRetries} attempts (${statusMsg})`);
+            }
+
+            if (check.conclusion !== 'success') {
+              throw new Error(`${checkName} conclusion=${check.conclusion}`);
+            }
+
+            console.log(`${checkName} is success ✅`);
+            break;
+          }
+
           async function getCheckRun() {
             const { data } = await github.rest.checks.listForRef({
               ...checksParams,
@@ -72,28 +96,4 @@ runs:
               status: isCompleted ? 'completed' : 'in_progress',
               conclusion: status.state === 'success' ? 'success' : (isCompleted ? 'failure' : null)
             };
-          }
-
-          const getCheckStatus = checkType === 'status' ? getStatus : getCheckRun;
-
-          for (let attempt = 0; attempt < maxRetries; attempt++) {
-            const check = await getCheckStatus();
-
-            if (check?.status !== 'completed') {
-              if (attempt < maxRetries - 1) {
-                const logPrefix = check ? `Check ${checkName} status: ${check.status}` : `Check ${checkName} not found yet`;
-                console.log(`${logPrefix}. Retry ${attempt + 1}/${maxRetries} in ${sleepMs / 1000}s...`);
-                await new Promise(resolve => setTimeout(resolve, sleepMs));
-                continue;
-              }
-              const statusMsg = check ? `status: ${check.status}` : 'not found';
-              throw new Error(`${checkName} check did not complete after ${maxRetries} attempts (${statusMsg})`);
-            }
-
-            if (check.conclusion !== 'success') {
-              throw new Error(`${checkName} conclusion=${check.conclusion}`);
-            }
-
-            console.log(`${checkName} is success ✅`);
-            break;
           }

--- a/.github/actions/poll-check-status/action.yml
+++ b/.github/actions/poll-check-status/action.yml
@@ -1,0 +1,99 @@
+name: 'Poll check status'
+description: 'Polls the status of a check run with the given name and waits until it completes'
+
+inputs:
+  name:
+    description: 'Check name to check status for'
+    required: true
+  sha:
+    description: 'SHA to check the status on (defaults to the workflow run head SHA)'
+    required: false
+  check_type:
+    description: 'Type of check: "check_run" (Checks API) or "status" (Status API)'
+    required: false
+    default: "check_run"
+  retry_delay:
+    description: 'Delay between retries in milliseconds'
+    required: false
+    default: "30000"
+  max_retries:
+    description: 'Maximum number of retries before giving up'
+    required: false
+    default: "5"
+runs:
+  using: "composite"
+  steps:
+    - name: 'Poll check status'
+      uses: actions/github-script@v7
+      env:
+        CHECK_NAME: ${{ inputs.name }}
+        CHECK_SHA: ${{ inputs.sha || github.sha }}
+        CHECK_TYPE: ${{ inputs.check_type }}
+        SLEEP_TIMEOUT: ${{ inputs.retry_delay }}
+        MAX_RETRIES: ${{ inputs.max_retries }}
+      with:
+        script: |
+          const checkName = process.env.CHECK_NAME;
+          const sha = process.env.CHECK_SHA;
+          const checkType = process.env.CHECK_TYPE;
+          const maxRetries = Number(process.env.MAX_RETRIES);
+          const sleepMs = Number(process.env.SLEEP_TIMEOUT);
+
+          console.log(`Checking ${checkName} for SHA=${sha} (type: ${checkType})`);
+
+          const checksParams = {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            ref: sha,
+          };
+          async function getCheckRun() {
+            const { data } = await github.rest.checks.listForRef({
+              ...checksParams,
+              check_name: checkName
+            });
+
+            const check = data.check_runs[0];
+            if (!check) return null;
+
+            return {
+              status: check.status,
+              conclusion: check.conclusion
+            };
+          }
+
+          async function getStatus() {
+            const { data } = await github.rest.repos.getCombinedStatusForRef(checksParams);
+
+            const status = data.statuses.find(s => s.context === checkName);
+            if (!status) return null;
+
+            const isCompleted = ['success', 'failure', 'error'].includes(status.state);
+            return {
+              status: isCompleted ? 'completed' : 'in_progress',
+              conclusion: status.state === 'success' ? 'success' : (isCompleted ? 'failure' : null)
+            };
+          }
+
+          const getCheckStatus = checkType === 'status' ? getStatus : getCheckRun;
+
+          for (let attempt = 0; attempt < maxRetries; attempt++) {
+            const check = await getCheckStatus();
+
+            if (check?.status !== 'completed') {
+              if (attempt < maxRetries - 1) {
+                const logPrefix = check ? `Check ${checkName} status: ${check.status}` : `Check ${checkName} not found yet`;
+                console.log(`${logPrefix}. Retry ${attempt + 1}/${maxRetries} in ${sleepMs / 1000}s...`);
+                await new Promise(resolve => setTimeout(resolve, sleepMs));
+                continue;
+              }
+              const statusMsg = check ? `status: ${check.status}` : 'not found';
+              throw new Error(`${checkName} check did not complete after ${maxRetries} attempts (${statusMsg})`);
+            }
+
+            if (check.conclusion !== 'success') {
+              throw new Error(`${checkName} conclusion=${check.conclusion}`);
+            }
+
+            console.log(`${checkName} is success ✅`);
+            break;
+          }

--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Check snyk status
         uses: ./.github/actions/poll-check-status
         with:
-          name: security/snyk
+          name: "security/snyk (corysturtevant)"
           sha: ${{ github.event.workflow_run.head_sha }}
           check_type: status
 

--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -179,9 +179,33 @@ jobs:
       pr_head_repo: ${{ needs.setup.outputs.pr_head_repo }}
       skip_change_detection: true
 
+  apps-deps-scan:
+    needs: [setup]
+    if: ${{ needs.setup.outputs.should_run == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github
+
+      - name: Check snyk status
+        uses: ./.github/actions/poll-check-status
+        with:
+          name: security/snyk
+          sha: ${{ github.event.workflow_run.head_sha }}
+          check_type: status
+
+      - name: Check socketio status
+        uses: ./.github/actions/poll-check-status
+        with:
+          name: "Socket Security: Pull Request Alerts"
+          sha: ${{ github.event.workflow_run.head_sha }}
+
   finalize:
     runs-on: ubuntu-latest
-    needs: [create-check-run, setup, security-scan]
+    needs: [create-check-run, setup, security-scan, apps-deps-scan]
     if: ${{ always() && needs.create-check-run.outputs.run_scan == 'true' }}
     steps:
       - name: Decide final conclusion and summary
@@ -191,6 +215,7 @@ jobs:
           SETUP_SKIP_REASON: ${{ needs.setup.outputs.skip_reason }}
           MATRIX: ${{ needs.setup.outputs.matrix }}
           SCAN_RESULT: ${{ needs.security-scan.result }}
+          APPS_DEPS_SCAN_RESULT: ${{ needs.apps-deps-scan.result }}
         run: |
           conclusion="success"
           summary="Security scan passed."
@@ -204,6 +229,9 @@ jobs:
           elif [[ "$SCAN_RESULT" != "success" ]]; then
             conclusion="failure"
             summary="Security scan failed (result=$SCAN_RESULT)"
+          elif [[ "$APPS_DEPS_SCAN_RESULT" != "success" ]]; then
+            conclusion="failure"
+            summary="Apps dependencies scan failed (result=$APPS_DEPS_SCAN_RESULT)"
           fi
 
           echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/reusable-validate-app.yml
+++ b/.github/workflows/reusable-validate-app.yml
@@ -121,6 +121,11 @@ jobs:
       contents: read
       checks: read
     steps:
+      - name: Checkout gha
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github
       - name: Conditionally required codecov/patch check
         if: >-
           needs.validate.result == 'success' && github.event_name == 'pull_request' && (
@@ -129,45 +134,10 @@ jobs:
             inputs.app == 'notifications' ||
             inputs.app == 'provider-proxy'
           )
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ github.event.pull_request.head.sha }}
-          APP: ${{ inputs.app }}
-        run: |
-          RETRIES=5
-          SLEEP_TIMEOUT=30
-          RETRY_ATTEMPT=0
-          CHECK_NAME="codecov/patch/$APP"
-          echo "Checking $CHECK_NAME for SHA=$SHA"
-
-          while [ $RETRY_ATTEMPT -lt $RETRIES ]; do
-            result="$(gh api -H "Accept: application/vnd.github+json" \
-              "/repos/$REPO/commits/$SHA/check-runs?check_name=$CHECK_NAME" \
-              --jq '.check_runs[0] | "\(.status) \(.conclusion)"')"
-
-            status="${result%% *}"
-            conclusion="${result#* }"
-
-            if [[ "$status" != "completed" ]]; then
-              RETRY_ATTEMPT=$((RETRY_ATTEMPT + 1))
-              if [ $RETRY_ATTEMPT -lt $RETRIES ]; then
-                echo "Check not completed yet (status: $status). Retry $RETRY_ATTEMPT/$RETRIES in ${SLEEP_TIMEOUT}s..."
-                sleep $SLEEP_TIMEOUT
-                continue
-              fi
-              echo "$CHECK_NAME check did not complete after $RETRIES attempts (status: $status)"
-              exit 1
-            fi
-
-            if [ "$conclusion" != "success" ]; then
-              echo "$CHECK_NAME conclusion=$conclusion"
-              exit 1
-            fi
-
-            echo "$CHECK_NAME is success ✅"
-            break
-          done
+        uses: ./.github/actions/poll-check-status
+        with:
+          name: codecov/patch/${{ inputs.app }}
+          sha: ${{ github.event.pull_request.head.sha }}
 
       - name: Check statuses
         env:


### PR DESCRIPTION
## Why

Because we don't need it to be required during merge queue checks, only on PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a reusable polling action to monitor CI check statuses with configurable retry delay and max attempts, improving reliability.
  * Replaced inline polling across workflows with the reusable action to consolidate behavior and simplify jobs.
  * Added an apps dependency-scan job and incorporated its result into final decision logic and summary reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->