### PR TITLE
chore: sets connection pool size in tests to 1

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,7 +25,7 @@
     "start": "tsup --watch",
     "start:dev": "tsup src/server.ts --watch",
     "test": "vitest run --project=unit --project=functional --project=integration",
-    "test:ci-setup": "dc up -d db mock-oauth2-server provider-proxy",
+    "test:ci-setup": "dc up -d --wait --wait-timeout 60 db mock-oauth2-server provider-proxy",
     "test:ci-teardown": "dc down",
     "test:component": "vitest run --project=unit --project=integration",
     "test:cov": "vitest run --project=unit --project=functional --project=integration --coverage",

--- a/apps/api/test/services/test-database.service.ts
+++ b/apps/api/test/services/test-database.service.ts
@@ -51,7 +51,7 @@ export class TestDatabaseService {
 
   async teardown(): Promise<void> {
     console.log(`Dropping test databases: ${this.dbName}, ${this.indexerDbName}`);
-    const sql = postgres(this.postgresUri);
+    const sql = postgres(this.postgresUri, { max: 1 });
 
     try {
       await Promise.all(
@@ -72,7 +72,7 @@ export class TestDatabaseService {
   }
 
   private async createDatabase(dbName: string): Promise<void> {
-    const sql = postgres(this.postgresUri);
+    const sql = postgres(this.postgresUri, { max: 1 });
 
     try {
       const [exists] = await sql`

--- a/apps/api/test/services/test-wallet.service.ts
+++ b/apps/api/test/services/test-wallet.service.ts
@@ -17,7 +17,12 @@ export class TestWalletService {
 
   private restoreCache() {
     if (fs.existsSync(".cache/test-wallets.json")) {
-      this.mnemonics = JSON.parse(fs.readFileSync(".cache/test-wallets.json", "utf8"));
+      try {
+        this.mnemonics = JSON.parse(fs.readFileSync(".cache/test-wallets.json", "utf8"));
+      } catch (error) {
+        console.warn("Error restoring test wallet cache:", error);
+        this.mnemonics = {};
+      }
     }
   }
 

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -27,7 +27,7 @@
     "start:dev": "nest start --watch",
     "start:prod": "node dist/main",
     "test": "vitest run --project=unit --project=functional",
-    "test:ci-setup": "dc up -d db",
+    "test:ci-setup": "dc up -d --wait --wait-timeout 60 db",
     "test:ci-teardown": "dc down",
     "test:cov": "vitest run --project=unit --project=functional --coverage",
     "test:functional": "vitest run --project=functional",


### PR DESCRIPTION
## Why

There is no need for more connections in pool. We just create and drop db, need only single query

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced test database client resource usage to improve stability and reduce intermittent failures.
  * CI test setup now waits (with a 60s timeout) for required services to be ready before running tests, improving reliability of test runs.

* **Bug Fixes**
  * Robustified test wallet cache loading: malformed cache files are now caught, logged as warnings, and reset instead of causing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->