### PR TITLE
fix(log-collector): allow HTTP k8s API connections by setting skipTLSVerify

### DIFF
--- a/apps/log-collector/src/providers/k8s-client.provider.ts
+++ b/apps/log-collector/src/providers/k8s-client.provider.ts
@@ -13,6 +13,13 @@ container.register(KubeConfig, {
   useFactory: () => {
     const kc = new KubeConfig();
     kc.loadFromDefault();
+
+    const cluster = kc.getCurrentCluster();
+    if (cluster?.server?.startsWith("http:")) {
+      const idx = kc.clusters.indexOf(cluster);
+      kc.clusters[idx] = { ...cluster, skipTLSVerify: true };
+    }
+
     return kc;
   }
 });


### PR DESCRIPTION
  ## Why                                                                                           
                                  
  The log-collector crashes on startup with:                                                       
  `HTTP protocol is not allowed when skipTLSVerify is not set or false`                            

  The `@kubernetes/client-node` library's `loadFromCluster()` sets the scheme to `http://` for
  ports 80/8080/8001 but defaults `skipTLSVerify` to `false`. Its own `createAgent()` then rejects
  that combination, making in-cluster HTTP connections impossible.

  ## What

  After loading the KubeConfig, detects if the current cluster uses HTTP and replaces the cluster
  entry with `skipTLSVerify: true`. This is safe because HTTP doesn't use TLS regardless.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS verification handling for HTTP Kubernetes server endpoints to ensure proper connectivity when using unsecured HTTP connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->