### PR TITLE
chore(dx): add commit and PR conventions to Claude instructions

### DIFF
--- a/.claude/instructions/commit-and-pr-conventions.md
+++ b/.claude/instructions/commit-and-pr-conventions.md
@@ -1,0 +1,15 @@
+## Commit and PR Conventions
+
+## Commit Messages
+- Must comply with `.commitlintrc.json` (extends `@commitlint/config-conventional`)
+- Scope is required and must be from the allowed list in `.commitlintrc.json`
+- Always check `.commitlintrc.json` for the current list of allowed scopes before committing
+
+## Branch Names
+- Format: `(feature|fix)/<scope>`
+- Prefer using a scope from `.commitlintrc.json` when applicable
+- Use another reasonable short name if no commitlint scope fits
+
+## PR Descriptions
+- Must use the template from `.github/pull_request_template.md`
+- Always read the template before creating a PR to ensure the correct format is used

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,8 @@ See detailed guidelines:
 
 See detailed guidelines:
 @./.claude/instructions/use-logger-service-instead-of-console.md
+
+## Commit and PR Conventions
+
+See detailed guidelines:
+@./.claude/instructions/commit-and-pr-conventions.md


### PR DESCRIPTION
## Why

- Add commit message and PR description conventions to Claude AI instructions so the AI assistant follows project standards when creating commits and PRs.

## What

- Added `.claude/instructions/commit-and-pr-conventions.md` with guidelines for commit messages, branch names, and PR descriptions
- Updated `CLAUDE.md` to reference the new conventions file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established standardized commit message conventions with required scope prefixes following conventional format guidelines.
  * Defined branch naming conventions using feature/fix prefixes with aligned scopes.
  * Documented pull request template requirements for consistent PR descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->