### PR TITLE
chore: accept neutral check for Socket Security: Pull Request Alerts

### DIFF
--- a/.github/actions/poll-check-status/action.yml
+++ b/.github/actions/poll-check-status/action.yml
@@ -8,6 +8,10 @@ inputs:
   sha:
     description: 'SHA to check the status on (defaults to the workflow run head SHA)'
     required: false
+  expected_conclusions:
+    description: 'Expected conclusions of the check (e.g., success, failure or "success;neutral"). If not provided, any completed status is accepted.'
+    required: false
+    default: "success"
   check_type:
     description: 'Type of check: "check_run" (Checks API) or "status" (Status API)'
     required: false
@@ -31,6 +35,7 @@ runs:
         CHECK_TYPE: ${{ inputs.check_type }}
         SLEEP_TIMEOUT: ${{ inputs.retry_delay }}
         MAX_RETRIES: ${{ inputs.max_retries }}
+        EXPECTED_CONCLUSIONS: ${{ inputs.expected_conclusions }}
       with:
         script: |
           const checkName = process.env.CHECK_NAME;
@@ -38,6 +43,7 @@ runs:
           const checkType = process.env.CHECK_TYPE;
           const maxRetries = Number(process.env.MAX_RETRIES);
           const sleepMs = Number(process.env.SLEEP_TIMEOUT);
+          const expectedConclusions = process.env.EXPECTED_CONCLUSIONS.split(";").map(s => s.trim());
 
           console.log(`Checking ${checkName} for SHA=${sha} (type: ${checkType})`);
 
@@ -62,7 +68,7 @@ runs:
               throw new Error(`${checkName} check did not complete after ${maxRetries} attempts (${statusMsg})`);
             }
 
-            if (check.conclusion !== 'success') {
+            if (!expectedConclusions.includes(check.conclusion)) {
               throw new Error(`${checkName} conclusion=${check.conclusion}`);
             }
 

--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -202,6 +202,7 @@ jobs:
         with:
           name: "Socket Security: Pull Request Alerts"
           sha: ${{ github.event.workflow_run.head_sha }}
+          expected_conclusions: "success;neutral"
 
   finalize:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Socket Security: Pull Request Alerts can report that we used all Free tier checks and stops deps validation. We need to bypass this and later will reconfigure CI to use gh action instead of gh app

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced CI workflow validation to accept multiple check conclusion statuses (e.g., success, neutral) instead of only success.
  * Added configurable acceptance criteria for pull request security checks with backward-compatible defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->