### PR TITLE
chore: removes npm script for test in indexer

### DIFF
--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -25,7 +25,6 @@
     "prod": "node --max-old-space-size=8192 dist/server.js",
     "release": "release-it",
     "start": "webpack --mode development --config webpack.dev.js --watch",
-    "test": "jest",
     "validate:types": "tsc -p tsconfig.strict.json --noEmit && echo"
   },
   "dependencies": {


### PR DESCRIPTION
## Why

We don't have tests for indexer and if we run `npm run test` it fails and breaks CI

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->
