### PR TITLE
fix(deployment): remove extra quotes from log collector label selector

### DIFF
--- a/apps/deploy-web/src/components/sdl/LogCollectorControl/LogCollectorControl.spec.tsx
+++ b/apps/deploy-web/src/components/sdl/LogCollectorControl/LogCollectorControl.spec.tsx
@@ -78,7 +78,7 @@ describe(LogCollectorControl.name, () => {
     await waitFor(
       async () => {
         const selector = form.getValues("services.1.env")?.find(env => env.key === "POD_LABEL_SELECTOR");
-        expect(selector?.value).toBe('"akash.network/manifest-service=new-title"');
+        expect(selector?.value).toBe("akash.network/manifest-service=new-title");
       },
       { timeout: 1000 }
     );

--- a/apps/deploy-web/src/components/sdl/LogCollectorControl/LogCollectorControl.tsx
+++ b/apps/deploy-web/src/components/sdl/LogCollectorControl/LogCollectorControl.tsx
@@ -84,7 +84,7 @@ export const LogCollectorControl: FC<Props> = ({ serviceIndex, dependencies: d =
   );
 
   useThrottledEffect(() => {
-    const nextTitle = `"akash.network/manifest-service=${targetService.title}"`;
+    const nextTitle = `akash.network/manifest-service=${targetService.title}`;
     if (env.values.POD_LABEL_SELECTOR !== nextTitle) {
       env.setValue("POD_LABEL_SELECTOR", nextTitle);
     }
@@ -197,7 +197,7 @@ function generateLogCollectorService<T extends ServiceType>(targetService: T): P
     placement: targetService.placement,
     env: [
       { key: "PROVIDER", value: "DATADOG" },
-      { key: "POD_LABEL_SELECTOR", value: `"akash.network/manifest-service=${targetService.title}"` },
+      { key: "POD_LABEL_SELECTOR", value: `akash.network/manifest-service=${targetService.title}` },
       { key: "DD_API_KEY", value: "" },
       { key: "DD_SITE", value: "" }
     ],


### PR DESCRIPTION
## Why                                                                                                                             
                                                        
  The log-collector pod was failing with a K8s API 400 error when listing pods:                                                      
                                                                                                                                     
  unable to parse requirement: Invalid value: ""akash.network/manifest-service=web""                                                 
                                                                                                                                     

  The `POD_LABEL_SELECTOR` env var was being set with surrounding double quotes (e.g. `"akash.network/manifest-service=web"` instead
  of `akash.network/manifest-service=web`), causing the Kubernetes API to reject it as an invalid label selector.

  ## What

  - Removed extra double quotes from `POD_LABEL_SELECTOR` value in `generateLogCollectorService` and in the `useThrottledEffect` that
   syncs it on title change
  - Updated the corresponding test expectation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed formatting of a log-collector environment variable so its value is emitted without extraneous quotes, improving configuration consistency and preventing mismatches in label comparisons.

* **Tests**
  * Updated unit test expectations to match the corrected environment variable formatting, ensuring tests reflect the emitted configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->