### PR TITLE
fix(deployment): implement countByOwner method and corresponding tests

### DIFF
--- a/apps/api/src/deployment/repositories/deployment/deployment.repository.spec.ts
+++ b/apps/api/src/deployment/repositories/deployment/deployment.repository.spec.ts
@@ -1,0 +1,52 @@
+import { Deployment } from "@akashnetwork/database/dbSchemas/akash";
+import { Op } from "sequelize";
+
+import { DeploymentRepository } from "./deployment.repository";
+
+describe(DeploymentRepository.name, () => {
+  describe("countByOwner", () => {
+    it("counts all deployments for an owner when no status filter", async () => {
+      const owner = "akash1abc123";
+      const expectedCount = 42;
+      const { repository, countSpy } = setup({ count: expectedCount });
+
+      const result = await repository.countByOwner(owner);
+
+      expect(countSpy).toHaveBeenCalledWith({ where: { owner } });
+      expect(result).toBe(expectedCount);
+    });
+
+    it("counts only active deployments when status is 'active'", async () => {
+      const owner = "akash1abc123";
+      const expectedCount = 10;
+      const { repository, countSpy } = setup({ count: expectedCount });
+
+      const result = await repository.countByOwner(owner, "active");
+
+      expect(countSpy).toHaveBeenCalledWith({
+        where: { owner, closedHeight: null }
+      });
+      expect(result).toBe(expectedCount);
+    });
+
+    it("counts only closed deployments when status is 'closed'", async () => {
+      const owner = "akash1abc123";
+      const expectedCount = 32;
+      const { repository, countSpy } = setup({ count: expectedCount });
+
+      const result = await repository.countByOwner(owner, "closed");
+
+      expect(countSpy).toHaveBeenCalledWith({
+        where: { owner, closedHeight: { [Op.ne]: null } }
+      });
+      expect(result).toBe(expectedCount);
+    });
+  });
+
+  function setup(input: { count: number }) {
+    const countSpy = jest.spyOn(Deployment, "count").mockResolvedValue(input.count);
+    const repository = new DeploymentRepository();
+
+    return { repository, countSpy };
+  }
+});

--- a/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
@@ -56,6 +56,16 @@ export class DeploymentRepository {
     });
   }
 
+  async countByOwner(owner: string, status?: "active" | "closed"): Promise<number> {
+    const whereClause: WhereOptions = { owner };
+    if (status === "active") {
+      whereClause.closedHeight = null;
+    } else if (status === "closed") {
+      whereClause.closedHeight = { [Op.ne]: null };
+    }
+    return await Deployment.count({ where: whereClause });
+  }
+
   async findStaleDeployments(options: StaleDeploymentsOptions): Promise<StaleDeploymentsOutput[]> {
     const deployments = await Deployment.findAll({
       attributes: ["dseq"],

--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
@@ -1,0 +1,242 @@
+import type { DeploymentHttpService, DeploymentListResponse, LeaseHttpService, RestAkashLeaseListResponse } from "@akashnetwork/http-sdk";
+import { faker } from "@faker-js/faker";
+import { mock } from "vitest-mock-extended";
+
+import type { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
+import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
+import type { FallbackDeploymentReaderService } from "@src/deployment/services/fallback-deployment-reader/fallback-deployment-reader.service";
+import type { FallbackLeaseReaderService } from "@src/deployment/services/fallback-lease-reader/fallback-lease-reader.service";
+import type { MessageService } from "@src/deployment/services/message-service/message.service";
+import type { ProviderService } from "@src/provider/services/provider/provider.service";
+import type { ProviderList } from "@src/types/provider";
+import { DeploymentReaderService } from "./deployment-reader.service";
+
+describe(DeploymentReaderService.name, () => {
+  describe("listWithResources", () => {
+    it("returns count from database instead of Cosmos SDK pagination total", async () => {
+      const address = faker.string.alphanumeric(44);
+      const dbCount = 42;
+      const cosmosTotal = "10";
+
+      const { service, deploymentRepository } = setup({
+        deploymentsResponse: createDeploymentsResponse({ total: cosmosTotal }),
+        leaseResponse: createEmptyLeaseResponse(),
+        dbCount
+      });
+
+      const result = await service.listWithResources({ address });
+
+      expect(deploymentRepository.countByOwner).toHaveBeenCalledWith(address, undefined);
+      expect(result.count).toBe(dbCount);
+    });
+
+    it("passes status filter to countByOwner for active deployments", async () => {
+      const address = faker.string.alphanumeric(44);
+      const dbCount = 15;
+
+      const { service, deploymentRepository } = setup({
+        deploymentsResponse: createDeploymentsResponse(),
+        leaseResponse: createEmptyLeaseResponse(),
+        dbCount
+      });
+
+      const result = await service.listWithResources({ address, status: "active" });
+
+      expect(deploymentRepository.countByOwner).toHaveBeenCalledWith(address, "active");
+      expect(result.count).toBe(dbCount);
+    });
+
+    it("passes status filter to countByOwner for closed deployments", async () => {
+      const address = faker.string.alphanumeric(44);
+      const dbCount = 27;
+
+      const { service, deploymentRepository } = setup({
+        deploymentsResponse: createDeploymentsResponse(),
+        leaseResponse: createEmptyLeaseResponse(),
+        dbCount
+      });
+
+      const result = await service.listWithResources({ address, status: "closed" });
+
+      expect(deploymentRepository.countByOwner).toHaveBeenCalledWith(address, "closed");
+      expect(result.count).toBe(dbCount);
+    });
+
+    it("returns deployment results mapped with resource fields", async () => {
+      const address = faker.string.alphanumeric(44);
+      const dseq = faker.string.numeric(6);
+      const deploymentsResponse = createDeploymentsResponse({
+        deployments: [createDeploymentInfo({ owner: address, dseq })]
+      });
+
+      const { service } = setup({
+        deploymentsResponse,
+        leaseResponse: createEmptyLeaseResponse(),
+        dbCount: 1
+      });
+
+      const result = await service.listWithResources({ address });
+
+      expect(result.results).toHaveLength(1);
+      expect(result.results[0].owner).toBe(address);
+      expect(result.results[0].dseq).toBe(dseq);
+    });
+
+    it("fetches providers when deployments exist", async () => {
+      const address = faker.string.alphanumeric(44);
+      const deploymentsResponse = createDeploymentsResponse({
+        deployments: [createDeploymentInfo({ owner: address })]
+      });
+
+      const { service, providerService } = setup({
+        deploymentsResponse,
+        leaseResponse: createEmptyLeaseResponse(),
+        dbCount: 1
+      });
+
+      await service.listWithResources({ address });
+
+      expect(providerService.getProviderList).toHaveBeenCalled();
+    });
+
+    it("skips provider fetch when no deployments", async () => {
+      const address = faker.string.alphanumeric(44);
+
+      const { service, providerService } = setup({
+        deploymentsResponse: createDeploymentsResponse({ deployments: [] }),
+        leaseResponse: createEmptyLeaseResponse(),
+        dbCount: 0
+      });
+
+      await service.listWithResources({ address });
+
+      expect(providerService.getProviderList).not.toHaveBeenCalled();
+    });
+
+    it("passes pagination params to deployments list", async () => {
+      const address = faker.string.alphanumeric(44);
+
+      const { service, deploymentHttpService } = setup({
+        deploymentsResponse: createDeploymentsResponse(),
+        leaseResponse: createEmptyLeaseResponse(),
+        dbCount: 0
+      });
+
+      await service.listWithResources({ address, skip: 10, limit: 5, reverseSorting: true });
+
+      expect(deploymentHttpService.findAll).toHaveBeenCalledWith({
+        owner: address,
+        state: undefined,
+        pagination: {
+          offset: 10,
+          limit: 5,
+          reverse: true,
+          countTotal: false
+        }
+      });
+    });
+  });
+
+  function setup(input: { deploymentsResponse: DeploymentListResponse; leaseResponse: RestAkashLeaseListResponse; dbCount: number }) {
+    const providerService = mock<ProviderService>({
+      getProviderList: jest.fn().mockResolvedValue([] as ProviderList[])
+    });
+    const deploymentHttpService = mock<DeploymentHttpService>({
+      findAll: jest.fn().mockResolvedValue(input.deploymentsResponse)
+    });
+    const leaseHttpService = mock<LeaseHttpService>({
+      list: jest.fn().mockResolvedValue(input.leaseResponse)
+    });
+    const deploymentRepository = mock<DeploymentRepository>({
+      countByOwner: jest.fn().mockResolvedValue(input.dbCount)
+    });
+
+    const service = new DeploymentReaderService(
+      providerService,
+      deploymentHttpService,
+      mock<FallbackDeploymentReaderService>(),
+      leaseHttpService,
+      mock<FallbackLeaseReaderService>(),
+      mock<MessageService>(),
+      mock<WalletReaderService>(),
+      deploymentRepository,
+      mock<LoggerService>()
+    );
+
+    return { service, providerService, deploymentHttpService, leaseHttpService, deploymentRepository };
+  }
+});
+
+function createDeploymentsResponse(overrides?: { deployments?: DeploymentListResponse["deployments"]; total?: string }): DeploymentListResponse {
+  return {
+    deployments: overrides?.deployments ?? [],
+    pagination: {
+      next_key: null,
+      total: overrides?.total ?? "0"
+    }
+  };
+}
+
+function createEmptyLeaseResponse(): RestAkashLeaseListResponse {
+  return {
+    leases: [],
+    pagination: {
+      next_key: null,
+      total: "0"
+    }
+  };
+}
+
+function createDeploymentInfo(overrides?: { owner?: string; dseq?: string }): DeploymentListResponse["deployments"][number] {
+  const owner = overrides?.owner ?? faker.string.alphanumeric(44);
+  const dseq = overrides?.dseq ?? faker.string.numeric(6);
+
+  return {
+    deployment: {
+      id: { owner, dseq },
+      state: "active",
+      hash: faker.string.hexadecimal({ length: 64 }),
+      created_at: faker.string.numeric(7)
+    },
+    groups: [
+      {
+        id: { owner, dseq, gseq: 1 },
+        state: "open",
+        group_spec: {
+          name: "default",
+          requirements: {
+            signed_by: { all_of: [], any_of: [] },
+            attributes: []
+          },
+          resources: [
+            {
+              resource: {
+                id: 1,
+                cpu: { units: { val: "1000" }, attributes: [] },
+                memory: { quantity: { val: "536870912" }, attributes: [] },
+                storage: [{ name: "default", quantity: { val: "1073741824" }, attributes: [] }],
+                gpu: { units: { val: "0" }, attributes: [] },
+                endpoints: []
+              },
+              count: 1,
+              price: { denom: "uakt", amount: "1000" }
+            }
+          ]
+        },
+        created_at: faker.string.numeric(7)
+      }
+    ],
+    escrow_account: {
+      id: { scope: "deployment", xid: `${owner}/${dseq}` },
+      state: {
+        owner,
+        state: "open",
+        transferred: [{ denom: "uakt", amount: "0" }],
+        settled_at: faker.string.numeric(7),
+        funds: [{ denom: "uakt", amount: "5000000" }],
+        deposits: [{ owner, height: faker.string.numeric(7), source: "", balance: { denom: "uakt", amount: "5000000" } }]
+      }
+    }
+  };
+}


### PR DESCRIPTION


## Why                                                                                                                                                                                                              
                                                                                          
  The deployments table at stats.akash.network/addresses/{address}/deployments shows "Page 1 of 1" even when an address has many deployments. The Cosmos SDK node returns an incorrect pagination.total value equal
   to the page size (e.g. "10") instead of the true total count, resulting in pageCount = ceil(10/10) = 1 and making pagination navigation impossible.
   https://stats.akash.network/addresses/akash10lq8uyfl52d6t467qmd58e7jzl9ecmvet2m57p/deployments
                                                                                                                                                                                                                   
 ## What                                                                                                                                                                                                             
                                                                                                                                                                                                                   
  - Added countByOwner(owner, status?) method to DeploymentRepository that performs a fast COUNT query against the database, optionally filtering by active/closed status
  - Modified DeploymentReaderService.listWithResources to use the DB count instead of the unreliable Cosmos SDK pagination.total
  - Parallelized the lease fetch, provider list fetch, and DB count query with Promise.all for improved performance
  - Set countTotal: false in the Cosmos SDK request since we no longer rely on its total
  - Added unit tests for DeploymentRepository.countByOwner (3 tests) and DeploymentReaderService.listWithResources (7 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment listings now return counts sourced from the backend and include owner/dseq mapping in results.

* **Tests**
  * Added comprehensive tests for deployment counting and listing behavior across status filters and pagination.

* **Chores**
  * Improved listing performance by parallelizing backend requests and optimizing count retrieval for faster, more reliable responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->