### PR TITLE
feat(log-collector): uses the latest log-collector image

### DIFF
--- a/apps/deploy-web/src/components/sdl/LogCollectorControl/LogCollectorControl.tsx
+++ b/apps/deploy-web/src/components/sdl/LogCollectorControl/LogCollectorControl.tsx
@@ -21,6 +21,7 @@ import { CpuFormControl } from "@src/components/sdl/CpuFormControl";
 import { DatadogEnvConfig } from "@src/components/sdl/DatadogEnvConfig/DatadogEnvConfig";
 import { EphemeralStorageFormControl } from "@src/components/sdl/EphemeralStorageFormControl";
 import { MemoryFormControl } from "@src/components/sdl/MemoryFormControl";
+import { LOG_COLLECTOR_IMAGE } from "@src/config/log-collector.config";
 import { useSdlEnv } from "@src/hooks/useSdlEnv/useSdlEnv";
 import { useThrottledEffect } from "@src/hooks/useThrottledEffect/useThrottledEffect";
 import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
@@ -179,10 +180,8 @@ export const LogCollectorControl: FC<Props> = ({ serviceIndex, dependencies: d =
   );
 };
 
-const IMAGE = "ghcr.io/akash-network/log-collector:1.7.0";
-
 export function isLogCollectorService(service: ServiceType): boolean {
-  return service.title.endsWith("-log-collector") && service.image === IMAGE;
+  return service.title.endsWith("-log-collector") && service.image === LOG_COLLECTOR_IMAGE;
 }
 
 export function findOwnLogCollectorServiceIndex(service: ServiceType, services: ServiceType[]): number {
@@ -193,7 +192,7 @@ function generateLogCollectorService<T extends ServiceType>(targetService: T): P
   return {
     id: toLogCollectorId(targetService),
     title: toLogCollectorTitle(targetService),
-    image: IMAGE,
+    image: LOG_COLLECTOR_IMAGE,
     placement: targetService.placement,
     env: [
       { key: "PROVIDER", value: "DATADOG" },

--- a/apps/deploy-web/src/config/log-collector.config.ts
+++ b/apps/deploy-web/src/config/log-collector.config.ts
@@ -1,0 +1,1 @@
+export const LOG_COLLECTOR_IMAGE = "ghcr.io/akash-network/log-collector:2.12.7";

--- a/apps/deploy-web/src/hooks/useSdlServiceManager/useSdlServiceManager.spec.tsx
+++ b/apps/deploy-web/src/hooks/useSdlServiceManager/useSdlServiceManager.spec.tsx
@@ -1,6 +1,7 @@
 import type { UseFormReturn } from "react-hook-form";
 import { FormProvider, useForm } from "react-hook-form";
 
+import { LOG_COLLECTOR_IMAGE } from "@src/config/log-collector.config";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { useSdlServiceManager } from "./useSdlServiceManager";
 
@@ -77,7 +78,7 @@ describe(useSdlServiceManager.name, () => {
         buildSDLService({ title: "service-1" }),
         buildSDLService({
           title: "service-1-log-collector",
-          image: "ghcr.io/akash-network/log-collector:1.7.0"
+          image: LOG_COLLECTOR_IMAGE
         }),
         buildSDLService({ title: "service-2" })
       ]
@@ -112,7 +113,7 @@ describe(useSdlServiceManager.name, () => {
         buildSDLService({ title: "service-1" }),
         buildSDLService({
           title: "service-1-log-collector",
-          image: "ghcr.io/akash-network/log-collector:1.7.0"
+          image: LOG_COLLECTOR_IMAGE
         }),
         buildSDLService({ title: "service-3" })
       ]

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -350,7 +350,14 @@ export const ServiceSchema = z
     env: z.array(EnvironmentVariableSchema).optional(),
     placement: PlacementSchema,
     count: z.number().min(1, { message: "Service count is required." }),
-    sshPubKey: z.string().optional()
+    sshPubKey: z.string().optional(),
+    params: z
+      .object({
+        permissions: z.object({
+          read: z.array(z.enum(["deployment", "logs"]))
+        })
+      })
+      .optional()
   })
   .superRefine((data, ctx) => {
     validateCpuAmount(data.profile.cpu, data.count, ctx);

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
@@ -1,5 +1,6 @@
 import yaml from "js-yaml";
 
+import { LOG_COLLECTOR_IMAGE } from "@src/config/log-collector.config";
 import type { ServiceType } from "@src/types";
 import { buildCommand, generateSdl } from "./sdlGenerator";
 
@@ -27,7 +28,7 @@ describe("sdlGenerator", () => {
       return {
         id: "web-log-collector",
         title: "web-log-collector",
-        image: "ghcr.io/akash-network/log-collector:1.7.0",
+        image: LOG_COLLECTOR_IMAGE,
         profile: {
           cpu: 0.1,
           ram: 256,


### PR DESCRIPTION
## Why

Uses the latest log-collector image with latest fixes.

## What

Enabling log collector adds following service to SDL:
```yaml
  web-log-collector:
    image: ghcr.io/akash-network/log-collector:2.12.7
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Services can now include optional permissions to grant read access for deployment and logs.

* **Bug Fixes & Updates**
  * Log collector image updated to ghcr.io/akash-network/log-collector:2.12.7.
  * Log collector image is now sourced from a centralized configuration for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->