### PR TITLE
chore: adds link to security scan workflow

### DIFF
--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -237,7 +237,7 @@ jobs:
           fi
 
           echo "conclusion=$conclusion" >> "$GITHUB_OUTPUT"
-          echo "summary=$summary" >> "$GITHUB_OUTPUT"
+          echo "summary=$summary. Managed in [this workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})" >> "$GITHUB_OUTPUT"
 
       - name: Complete check run
         uses: actions/github-script@v7


### PR DESCRIPTION
## Why

To let devs see the actual workflow and have an ability to re-run it

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow summary output to include a link to the current workflow run for improved accessibility to build details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->