### PR TITLE
chore: fixes cache key for node deps

### DIFF
--- a/.github/actions/setup-app-deps/action.yml
+++ b/.github/actions/setup-app-deps/action.yml
@@ -28,7 +28,7 @@ runs:
           node_modules
           apps/${{ inputs.app }}/node_modules
           packages/*/node_modules
-        key: ${{ inputs.app }}-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+        key: ${{ inputs.app }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('package-lock.json') }}
 
     - name: Install dependencies
       if: inputs.setup-only-nodejs == 'false' && steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Why

We have unexpected failures in gha, like this:

```
Error: Cannot find module @rollup/rollup-linux-x64-gnu. npm has a bug related to optional dependencies (https://github.com/npm/cli/issues/4828). Please try `npm i` again after removing both package-lock.json and node_modules directory.
```

It happens because our cache key doesn't include `runner.arch` but we use some native deps for which this distinction is important

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized dependency cache handling in the build process to account for runner architecture, improving build consistency across different system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->