### PR TITLE
fix(billing): preserve trial status for coupon claim invoice top-ups

### DIFF
--- a/apps/api/src/billing/services/refill/refill.service.spec.ts
+++ b/apps/api/src/billing/services/refill/refill.service.spec.ts
@@ -37,6 +37,19 @@ describe(RefillService.name, () => {
       expect(analyticsService.track).toHaveBeenCalledWith(userId, "balance_top_up");
     });
 
+    it("does not end trial when endTrial option is false", async () => {
+      const { service, userWalletRepository, managedUserWalletService, balancesService } = setup();
+      const existingWallet = UserWalletSeeder.create({ userId });
+      userWalletRepository.findOneBy.mockResolvedValue(existingWallet);
+      managedUserWalletService.authorizeSpending.mockResolvedValue();
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(5000);
+      balancesService.refreshUserWalletLimits.mockResolvedValue();
+
+      await service.topUpWallet(amountUsd, userId, { endTrial: false });
+
+      expect(balancesService.refreshUserWalletLimits).toHaveBeenCalledWith(existingWallet, { endTrial: false });
+    });
+
     it("should create new wallet when none exists", async () => {
       const { service, userWalletRepository, walletInitializerService, balancesService, managedUserWalletService, managedSignerService, analyticsService } =
         setup();

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -64,7 +64,7 @@ export class RefillService {
    * @param amountUsd - The amount in USD *cents* to top up the wallet with (e.g. 10000 = $100)
    * @param userId - The ID of the user to top up the wallet for
    */
-  async topUpWallet(amountUsd: number, userId: UserWalletOutput["userId"]) {
+  async topUpWallet(amountUsd: number, userId: UserWalletOutput["userId"], options: { endTrial?: boolean } = {}) {
     const userWallet = await this.getOrCreateUserWallet(userId);
     const currentLimit = await this.balancesService.retrieveDeploymentLimit(userWallet);
 
@@ -75,7 +75,7 @@ export class RefillService {
       limits
     });
 
-    await this.balancesService.refreshUserWalletLimits(userWallet, { endTrial: true });
+    await this.balancesService.refreshUserWalletLimits(userWallet, { endTrial: options.endTrial ?? true });
     this.analyticsService.track(userId, "balance_top_up");
     this.logger.debug({ event: "WALLET_TOP_UP", userWallet, limits });
   }

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
@@ -56,7 +56,7 @@ describe(StripeWebhookService.name, () => {
         receiptUrl: "https://receipt.url",
         stripePaymentIntentId: paymentIntentId
       });
-      expect(refillService.topUpWallet).toHaveBeenCalledWith(amount, mockUser.id);
+      expect(refillService.topUpWallet).toHaveBeenCalledWith(amount, mockUser.id, { endTrial: undefined });
     });
 
     it("returns early when customer ID is missing", async () => {
@@ -147,7 +147,7 @@ describe(StripeWebhookService.name, () => {
       await service.tryToTopUpWalletFromPaymentIntent(event);
 
       expect(stripeTransactionRepository.findById).toHaveBeenCalledWith(internalTransaction.id);
-      expect(refillService.topUpWallet).toHaveBeenCalledWith(amount, mockUser.id);
+      expect(refillService.topUpWallet).toHaveBeenCalledWith(amount, mockUser.id, { endTrial: undefined });
       expect(stripeTransactionRepository.updateById).toHaveBeenCalledWith(
         "tx-123",
         expect.objectContaining({
@@ -219,7 +219,7 @@ describe(StripeWebhookService.name, () => {
         receiptUrl: "https://receipt.stripe.com/inv",
         stripePaymentIntentId: paymentIntentId
       });
-      expect(refillService.topUpWallet).toHaveBeenCalledWith(transactionAmount, mockUser.id);
+      expect(refillService.topUpWallet).toHaveBeenCalledWith(transactionAmount, mockUser.id, { endTrial: false });
     });
 
     it("returns early when customer ID is missing", async () => {
@@ -327,7 +327,7 @@ describe(StripeWebhookService.name, () => {
         receiptUrl: undefined,
         stripePaymentIntentId: undefined
       });
-      expect(refillService.topUpWallet).toHaveBeenCalledWith(transactionAmount, mockUser.id);
+      expect(refillService.topUpWallet).toHaveBeenCalledWith(transactionAmount, mockUser.id, { endTrial: false });
     });
   });
 

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
@@ -88,6 +88,7 @@ export class StripeWebhookService {
         ? payment.payment_intent
         : payment.payment_intent.id
       : undefined;
+    const endTrial = transaction.type !== "coupon_claim";
 
     await this.topUpWalletFromTransaction({
       customerId,
@@ -96,7 +97,8 @@ export class StripeWebhookService {
       paymentMethodType: undefined,
       paymentAmount: transaction.amount,
       stripePaymentIntentId,
-      eventDescription: `invoice ${invoice.id}`
+      eventDescription: `invoice ${invoice.id}`,
+      endTrial
     });
   }
 
@@ -148,6 +150,7 @@ export class StripeWebhookService {
     paymentAmount: number;
     stripePaymentIntentId: string | undefined;
     eventDescription: string;
+    endTrial?: boolean;
   }): Promise<void> {
     if (!params.customerId) {
       this.logger.error({
@@ -196,7 +199,8 @@ export class StripeWebhookService {
       stripePaymentIntentId: params.stripePaymentIntentId,
       paymentAmount: params.paymentAmount,
       userId: user.id,
-      eventDescription: params.eventDescription
+      eventDescription: params.eventDescription,
+      endTrial: params.endTrial
     });
   }
 
@@ -212,6 +216,7 @@ export class StripeWebhookService {
     paymentAmount: number;
     userId: string;
     eventDescription: string;
+    endTrial?: boolean;
   }): Promise<void> {
     const transaction = await this.stripeTransactionRepository.findOneByAndLock({ id: params.transactionId });
 
@@ -243,7 +248,7 @@ export class StripeWebhookService {
       stripePaymentIntentId: params.stripePaymentIntentId
     });
 
-    await this.refillService.topUpWallet(params.paymentAmount, params.userId);
+    await this.refillService.topUpWallet(params.paymentAmount, params.userId, { endTrial: params.endTrial });
   }
 
   @WithTransaction()


### PR DESCRIPTION
## Why

Coupon claim invoices should not end the user trial period. Previously, all invoice-based wallet top-ups would unconditionally end the trial, which incorrectly affected users redeeming coupons.

## What

- Added endTrial option to RefillService.topUpWallet (defaults to true for backward compatibility)
- StripeWebhookService.tryToTopUpWalletFromInvoice now sets endTrial=false for coupon_claim transactions
- Plumbed endTrial through topUpWalletFromTransaction and updateTransactionAndTopUp
- Updated existing test assertions and added a new test for endTrial: false in RefillService

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Top-ups now respect an explicit "end trial" flag: coupon redemptions won’t end trials, other top-ups end trials by default.

* **Behavior**
  * Invoice-based top-ups derive and propagate the trial-ending flag through the top-up flow and event payloads.
  * Top-up flow accepts an optional options object to control trial-ending behavior.

* **Tests**
  * Added/updated tests to verify explicit false and default-true end-trial behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->