### PR TITLE
fix(auth): remove deployment-specific return-to handling from AuthPage

### DIFF
--- a/apps/deploy-web/src/components/auth/AuthPage/AuthPage.tsx
+++ b/apps/deploy-web/src/components/auth/AuthPage/AuthPage.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useRef, useState } from "react";
 import { Button, Separator, Tabs, TabsContent, TabsList, TabsTrigger } from "@akashnetwork/ui/components";
 import { useMutation } from "@tanstack/react-query";
-import { DollarSignIcon, RocketIcon, Undo2, ZapIcon } from "lucide-react";
+import { DollarSignIcon, RocketIcon, ZapIcon } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
@@ -61,7 +61,7 @@ export function AuthPage({ dependencies: d = DEPENDENCIES }: Props = {}) {
   const { checkSession } = d.useUser();
   const [email, setEmail] = useState("");
   const turnstileRef = useRef<TurnstileRef | null>(null);
-  const { returnTo, navigateBack, isDeploymentReturnTo } = d.useReturnTo({ defaultReturnTo: "/" });
+  const { returnTo, navigateBack } = d.useReturnTo({ defaultReturnTo: "/" });
 
   const redirectToSocialLogin = useCallback(
     async (provider: "github" | "google-oauth2") => {
@@ -185,74 +185,63 @@ export function AuthPage({ dependencies: d = DEPENDENCIES }: Props = {}) {
                   onGoBack={() => setActiveView("login")}
                 />
               </>
-            )) ||
-              (isDeploymentReturnTo && (
-                <>
-                  <d.SocialAuth onSocialLogin={redirectToSocialLogin} />
-                  <div className="mt-4 flex">
-                    <d.Button type="button" onClick={navigateBack} variant="outline" className="h-9 flex-1 border-neutral-200 dark:border-neutral-800">
-                      <Undo2 className="mr-2 h-4 w-4" />
-                      Go Back
-                    </d.Button>
+            )) || (
+              <d.Tabs value={activeView} onValueChange={setActiveView} className="w-full">
+                <div className="mb-5 w-full">
+                  <d.TabsList className="m-0 flex h-auto max-w-[1304px] flex-1 items-center justify-start rounded-none border-0 border-l-0 border-r-0 border-t-0 bg-transparent p-0">
+                    <d.TabsTrigger
+                      value="login"
+                      className="flex-1 cursor-pointer rounded-none border-0 border-b-2 border-l-0 border-r-0 border-t-0 border-b-transparent bg-transparent py-1.5 shadow-none transition-colors data-[state=active]:border-b-neutral-900 data-[state=active]:bg-transparent data-[state=active]:shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:data-[state=active]:border-b-neutral-100"
+                    >
+                      <div className="flex items-center justify-center gap-2 px-2.5 py-2">
+                        <span
+                          className={`text-sm font-normal leading-5 transition-colors ${activeView === "login" ? "text-neutral-950 dark:text-[var(--text-light)]" : "text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300"}`}
+                        >
+                          Log in
+                        </span>
+                      </div>
+                    </d.TabsTrigger>
+                    <d.TabsTrigger
+                      value="signup"
+                      className="flex-1 cursor-pointer rounded-none border-0 border-b-2 border-l-0 border-r-0 border-t-0 border-b-transparent bg-transparent py-1.5 shadow-none transition-colors data-[state=active]:border-b-neutral-900 data-[state=active]:bg-transparent data-[state=active]:shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:data-[state=active]:border-b-neutral-100"
+                    >
+                      <div className="flex items-center justify-center gap-2 px-2.5 py-2">
+                        <span
+                          className={`text-sm font-normal leading-5 transition-colors ${activeView === "signup" ? "text-neutral-950 dark:text-[var(--text-light)]" : "text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300"}`}
+                        >
+                          Sign up
+                        </span>
+                      </div>
+                    </d.TabsTrigger>
+                  </d.TabsList>
+                </div>
+
+                <d.SocialAuth onSocialLogin={redirectToSocialLogin} />
+
+                <div className="relative flex items-center justify-center self-stretch py-2.5">
+                  <d.Separator className="absolute inset-0 top-1/2" />
+                  <div className="current relative top-[-1px] z-10 px-2" style={{ backgroundColor: "hsl(var(--background))" }}>
+                    <span className="relative top-1/2 text-xs font-normal text-neutral-500 dark:text-neutral-400">Or continue with</span>
                   </div>
-                </>
-              )) || (
-                <d.Tabs value={activeView} onValueChange={setActiveView} className="w-full">
-                  <div className="mb-5 w-full">
-                    <d.TabsList className="m-0 flex h-auto max-w-[1304px] flex-1 items-center justify-start rounded-none border-0 border-l-0 border-r-0 border-t-0 bg-transparent p-0">
-                      <d.TabsTrigger
-                        value="login"
-                        className="flex-1 cursor-pointer rounded-none border-0 border-b-2 border-l-0 border-r-0 border-t-0 border-b-transparent bg-transparent py-1.5 shadow-none transition-colors data-[state=active]:border-b-neutral-900 data-[state=active]:bg-transparent data-[state=active]:shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:data-[state=active]:border-b-neutral-100"
-                      >
-                        <div className="flex items-center justify-center gap-2 px-2.5 py-2">
-                          <span
-                            className={`text-sm font-normal leading-5 transition-colors ${activeView === "login" ? "text-neutral-950 dark:text-[var(--text-light)]" : "text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300"}`}
-                          >
-                            Log in
-                          </span>
-                        </div>
-                      </d.TabsTrigger>
-                      <d.TabsTrigger
-                        value="signup"
-                        className="flex-1 cursor-pointer rounded-none border-0 border-b-2 border-l-0 border-r-0 border-t-0 border-b-transparent bg-transparent py-1.5 shadow-none transition-colors data-[state=active]:border-b-neutral-900 data-[state=active]:bg-transparent data-[state=active]:shadow-none hover:bg-transparent focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:data-[state=active]:border-b-neutral-100"
-                      >
-                        <div className="flex items-center justify-center gap-2 px-2.5 py-2">
-                          <span
-                            className={`text-sm font-normal leading-5 transition-colors ${activeView === "signup" ? "text-neutral-950 dark:text-[var(--text-light)]" : "text-neutral-500 hover:text-neutral-700 dark:text-neutral-400 dark:hover:text-neutral-300"}`}
-                          >
-                            Sign up
-                          </span>
-                        </div>
-                      </d.TabsTrigger>
-                    </d.TabsList>
-                  </div>
+                </div>
 
-                  <d.SocialAuth onSocialLogin={redirectToSocialLogin} />
+                <d.RemoteApiError className="mb-5" error={signInOrSignUp.error} />
 
-                  <div className="relative flex items-center justify-center self-stretch py-2.5">
-                    <d.Separator className="absolute inset-0 top-1/2" />
-                    <div className="current relative top-[-1px] z-10 px-2" style={{ backgroundColor: "hsl(var(--background))" }}>
-                      <span className="relative top-1/2 text-xs font-normal text-neutral-500 dark:text-neutral-400">Or continue with</span>
-                    </div>
-                  </div>
+                <d.TabsContent value="login" className="mt-0">
+                  <d.SignInForm
+                    isLoading={signInOrSignUp.isPending}
+                    defaultEmail={email}
+                    onEmailChange={setEmail}
+                    onSubmit={value => signInOrSignUp.mutate({ type: "signin", value })}
+                    onForgotPasswordClick={() => setActiveView("forgot-password")}
+                  />
+                </d.TabsContent>
 
-                  <d.RemoteApiError className="mb-5" error={signInOrSignUp.error} />
-
-                  <d.TabsContent value="login" className="mt-0">
-                    <d.SignInForm
-                      isLoading={signInOrSignUp.isPending}
-                      defaultEmail={email}
-                      onEmailChange={setEmail}
-                      onSubmit={value => signInOrSignUp.mutate({ type: "signin", value })}
-                      onForgotPasswordClick={() => setActiveView("forgot-password")}
-                    />
-                  </d.TabsContent>
-
-                  <d.TabsContent value="signup" className="mt-0">
-                    <d.SignUpForm isLoading={signInOrSignUp.isPending} onSubmit={value => signInOrSignUp.mutate({ type: "signup", value })} />
-                  </d.TabsContent>
-                </d.Tabs>
-              )}
+                <d.TabsContent value="signup" className="mt-0">
+                  <d.SignUpForm isLoading={signInOrSignUp.isPending} onSubmit={value => signInOrSignUp.mutate({ type: "signup", value })} />
+                </d.TabsContent>
+              </d.Tabs>
+            )}
             <d.Turnstile
               turnstileRef={turnstileRef}
               enabled={publicConfig.NEXT_PUBLIC_TURNSTILE_ENABLED}


### PR DESCRIPTION
## Why

Simplify the auth page by removing the unused deployment-specific return-to conditional block. This special case showed social auth with a "Go Back" button when navigating from a deployment flow, adding unnecessary complexity to the auth page rendering logic.

## What

- Removed the `isDeploymentReturnTo` conditional block from `AuthPage`
- Removed unused `Undo2` icon import from `lucide-react`
- Removed unused `isDeploymentReturnTo` destructuring from `useReturnTo` hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication page now displays a consistent login/signup experience in all scenarios (Tabs-based UI always shown, including social sign-in and "Or continue with" separator).

* **Refactor**
  * Streamlined authentication flow and component behavior for improved stability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->