### PR TITLE
chore: adds permission to create deployment

### DIFF
--- a/.github/workflows/console-api-release.yml
+++ b/.github/workflows/console-api-release.yml
@@ -26,6 +26,10 @@ jobs:
       cancel-if-stale: ${{ inputs.cancel-if-stale == 'true' }}
 
   deploy-beta-mainnet:
+    permissions:
+      contents: read
+      pull-requests: read
+      deployments: write
     needs: setup
     if: ${{ !needs.setup.outputs.skip }}
     name: Deploy to beta mainnet
@@ -38,6 +42,10 @@ jobs:
       chain: mainnet
 
   deploy-beta-sandbox:
+    permissions:
+      contents: read
+      pull-requests: read
+      deployments: write
     needs: setup
     if: ${{ !needs.setup.outputs.skip }}
     name: Deploy to beta sandbox
@@ -82,6 +90,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      deployments: write
     needs:
       - setup
       - deploy-beta-mainnet
@@ -99,6 +108,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      deployments: write
     needs:
       - setup
       - test-beta-sandbox

--- a/.github/workflows/console-web-release.yml
+++ b/.github/workflows/console-web-release.yml
@@ -26,6 +26,10 @@ jobs:
       cancel-if-stale: ${{ inputs.cancel-if-stale == 'true' }}
 
   deploy-beta:
+    permissions:
+      contents: read
+      pull-requests: read
+      deployments: write
     needs: setup
     if: ${{ !needs.setup.outputs.skip }}
     name: Deploy to beta
@@ -53,6 +57,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      deployments: write
     needs: [setup, test-beta]
     name: Deploy to prod
     uses: ./.github/workflows/reusable-deploy-k8s.yml

--- a/.github/workflows/indexer-release.yml
+++ b/.github/workflows/indexer-release.yml
@@ -29,6 +29,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      deployments: write
     needs: setup
     if: ${{ !needs.setup.outputs.skip }}
     name: Deploy to prod mainnet
@@ -44,6 +45,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      deployments: write
     needs: setup
     if: ${{ !needs.setup.outputs.skip }}
     name: Deploy to prod sandbox

--- a/.github/workflows/notifications-release.yml
+++ b/.github/workflows/notifications-release.yml
@@ -26,6 +26,10 @@ jobs:
       cancel-if-stale: ${{ inputs.cancel-if-stale == 'true' }}
 
   deploy-beta:
+    permissions:
+      contents: read
+      pull-requests: read
+      deployments: write
     needs: setup
     if: ${{ !needs.setup.outputs.skip }}
     name: Deploy to beta
@@ -40,6 +44,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      deployments: write
     needs: [setup, deploy-beta]
     name: Deploy to prod
     uses: ./.github/workflows/reusable-deploy-k8s.yml

--- a/.github/workflows/provider-proxy-release.yml
+++ b/.github/workflows/provider-proxy-release.yml
@@ -26,6 +26,10 @@ jobs:
       cancel-if-stale: ${{ inputs.cancel-if-stale == 'true' }}
 
   deploy-beta-mainnet:
+    permissions:
+      contents: read
+      pull-requests: read
+      deployments: write
     needs: setup
     if: ${{ !needs.setup.outputs.skip }}
     name: Deploy to beta mainnet
@@ -38,6 +42,10 @@ jobs:
       chain: mainnet
 
   deploy-beta-sandbox:
+    permissions:
+      contents: read
+      pull-requests: read
+      deployments: write
     needs: setup
     if: ${{ !needs.setup.outputs.skip }}
     name: Deploy to beta sandbox
@@ -90,6 +98,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      deployments: write
     needs:
       - setup
       - test-beta-mainnet
@@ -106,6 +115,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      deployments: write
     needs:
       - setup
       - test-beta-sandbox

--- a/.github/workflows/reusable-deploy-k8s.yml
+++ b/.github/workflows/reusable-deploy-k8s.yml
@@ -145,13 +145,16 @@ jobs:
           linked-workflow-run-id: ${{ github.run_id }}
 
   deploy:
+    permissions:
+      contents: read
+      deployments: write
     runs-on: ubuntu-latest
     needs: deployment-prerequisites
     if: >-
       needs.deployment-prerequisites.outputs.require_approval != 'true' || inputs.approve == 'true' || inputs.approve == true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Load kubeconfig
         id: op-load-secret

--- a/.github/workflows/stats-web-release.yml
+++ b/.github/workflows/stats-web-release.yml
@@ -26,6 +26,10 @@ jobs:
       cancel-if-stale: ${{ inputs.cancel-if-stale == 'true' }}
 
   deploy-beta:
+    permissions:
+      contents: read
+      pull-requests: read
+      deployments: write
     needs: setup
     if: ${{ !needs.setup.outputs.skip }}
     name: Deploy to beta
@@ -40,6 +44,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      deployments: write
     needs: [setup, deploy-beta]
     name: Deploy to prod
     uses: ./.github/workflows/reusable-deploy-k8s.yml

--- a/.github/workflows/tx-signer-release.yml
+++ b/.github/workflows/tx-signer-release.yml
@@ -26,6 +26,10 @@ jobs:
       cancel-if-stale: ${{ inputs.cancel-if-stale == 'true' }}
 
   deploy-beta-mainnet:
+    permissions:
+      contents: read
+      pull-requests: read
+      deployments: write
     needs: setup
     if: ${{ !needs.setup.outputs.skip }}
     name: Deploy to beta mainnet
@@ -38,6 +42,10 @@ jobs:
       chain: mainnet
 
   deploy-beta-sandbox:
+    permissions:
+      contents: read
+      pull-requests: read
+      deployments: write
     needs: setup
     if: ${{ !needs.setup.outputs.skip }}
     name: Deploy to beta sandbox
@@ -53,6 +61,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      deployments: write
     needs:
       - setup
       - deploy-beta-mainnet
@@ -70,6 +79,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      deployments: write
     needs:
       - setup
       - deploy-beta-sandbox


### PR DESCRIPTION
## Why

Right the last deploy step cannot create deployment dynamically because GH_TOKEN doesn't contain such permission - https://github.com/akash-network/console/actions/runs/22183804324/job/64152963909

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment permissions in GitHub Actions workflows across multiple services (console API, console web, indexer, notifications, provider proxy, transaction signer, and stats) to enable proper deployment tracking and management in beta and production environments.
  * Updated checkout action to a newer version in deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->