### PR TITLE
feat(billing): add server-side transaction resolution to simplify client polling

### DIFF
--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -1,0 +1,196 @@
+import { faker } from "@faker-js/faker";
+import type Stripe from "stripe";
+import { container } from "tsyringe";
+import { mock } from "vitest-mock-extended";
+
+import { AuthService } from "@src/auth/services/auth.service";
+import type { UserWalletRepository } from "@src/billing/repositories";
+import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
+import type { StripeService } from "@src/billing/services/stripe/stripe.service";
+import type { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
+import { StripeController } from "./stripe.controller";
+
+import { generateDatabaseStripeTransaction } from "@test/seeders/database-stripe-transaction.seeder";
+import { UserSeeder } from "@test/seeders/user.seeder";
+
+describe(StripeController.name, () => {
+  describe("confirmPayment", () => {
+    it("returns transactionId and transactionStatus on successful payment", async () => {
+      const { controller, stripe, user } = setup();
+      const transactionId = faker.string.uuid();
+
+      stripe.hasPaymentMethod.mockResolvedValue(true);
+      stripe.createPaymentIntent.mockResolvedValue({
+        success: true,
+        paymentIntentId: faker.string.uuid(),
+        transactionId,
+        transactionStatus: "pending"
+      });
+
+      const result = await controller.confirmPayment({
+        userId: user.id,
+        paymentMethodId: faker.string.uuid(),
+        amount: 100,
+        currency: "usd"
+      });
+
+      expect(result).toEqual({
+        data: {
+          success: true,
+          transactionId,
+          transactionStatus: "pending"
+        }
+      });
+    });
+
+    it("resolves transaction when awaitResolved is true", async () => {
+      const { controller, stripe, user } = setup();
+      const transactionId = faker.string.uuid();
+      const resolvedTransaction = generateDatabaseStripeTransaction({ id: transactionId, status: "succeeded" });
+
+      stripe.hasPaymentMethod.mockResolvedValue(true);
+      stripe.createPaymentIntent.mockResolvedValue({
+        success: true,
+        paymentIntentId: faker.string.uuid(),
+        transactionId,
+        transactionStatus: "pending"
+      });
+      stripe.resolveTransaction.mockResolvedValue(resolvedTransaction);
+
+      const result = await controller.confirmPayment({
+        userId: user.id,
+        paymentMethodId: faker.string.uuid(),
+        amount: 100,
+        currency: "usd",
+        awaitResolved: true
+      });
+
+      expect(stripe.resolveTransaction).toHaveBeenCalledWith(transactionId);
+      expect(result).toEqual({
+        data: {
+          success: true,
+          transactionId,
+          transactionStatus: "succeeded"
+        }
+      });
+    });
+
+    it("returns 3DS data with transactionId and transactionStatus", async () => {
+      const { controller, stripe, user } = setup();
+      const transactionId = faker.string.uuid();
+      const paymentIntentId = faker.string.uuid();
+      const clientSecret = faker.string.alphanumeric(32);
+
+      stripe.hasPaymentMethod.mockResolvedValue(true);
+      stripe.createPaymentIntent.mockResolvedValue({
+        success: false,
+        requiresAction: true,
+        clientSecret,
+        paymentIntentId,
+        transactionId,
+        transactionStatus: "requires_action"
+      });
+
+      const result = await controller.confirmPayment({
+        userId: user.id,
+        paymentMethodId: faker.string.uuid(),
+        amount: 100,
+        currency: "usd"
+      });
+
+      expect(result).toEqual({
+        data: {
+          success: false,
+          requiresAction: true,
+          clientSecret,
+          paymentIntentId,
+          transactionId,
+          transactionStatus: "requires_action"
+        }
+      });
+    });
+  });
+
+  describe("applyCoupon", () => {
+    it("returns transactionId and transactionStatus on successful coupon", async () => {
+      const { controller, stripe, user } = setup();
+      const transactionId = faker.string.uuid();
+      const mockCoupon = mock<Stripe.Coupon>({ id: faker.string.uuid() });
+
+      stripe.applyCoupon.mockResolvedValue({
+        coupon: mockCoupon,
+        amountAdded: 10,
+        transactionId,
+        transactionStatus: "pending"
+      });
+
+      const result = await controller.applyCoupon({
+        couponId: faker.string.alphanumeric(10),
+        userId: user.id
+      });
+
+      expect(result).toEqual({
+        data: {
+          coupon: mockCoupon,
+          amountAdded: 10,
+          transactionId,
+          transactionStatus: "pending"
+        }
+      });
+    });
+
+    it("resolves transaction when awaitResolved is true", async () => {
+      const { controller, stripe, user } = setup();
+      const transactionId = faker.string.uuid();
+      const mockCoupon = mock<Stripe.Coupon>({ id: faker.string.uuid() });
+      const resolvedTransaction = generateDatabaseStripeTransaction({ id: transactionId, status: "succeeded" });
+
+      stripe.applyCoupon.mockResolvedValue({
+        coupon: mockCoupon,
+        amountAdded: 10,
+        transactionId,
+        transactionStatus: "pending"
+      });
+      stripe.resolveTransaction.mockResolvedValue(resolvedTransaction);
+
+      const result = await controller.applyCoupon({
+        couponId: faker.string.alphanumeric(10),
+        userId: user.id,
+        awaitResolved: true
+      });
+
+      expect(stripe.resolveTransaction).toHaveBeenCalledWith(transactionId);
+      expect(result).toEqual({
+        data: {
+          coupon: mockCoupon,
+          amountAdded: 10,
+          transactionId,
+          transactionStatus: "succeeded"
+        }
+      });
+    });
+  });
+
+  function setup() {
+    const user = UserSeeder.create();
+    const payingUser: PayingUser = { ...user, stripeCustomerId: user.stripeCustomerId! };
+    const stripe = mock<StripeService>();
+    const authService = mock<AuthService>({
+      currentUser: user
+    });
+    authService.getCurrentPayingUser.mockReturnValue(payingUser);
+    const stripeErrorService = mock<StripeErrorService>();
+    const userWalletRepository = mock<UserWalletRepository>();
+    const controller = new StripeController(stripe, authService, stripeErrorService, userWalletRepository);
+    container.register(AuthService, { useValue: authService });
+
+    return {
+      controller,
+      stripe,
+      authService,
+      stripeErrorService,
+      userWalletRepository,
+      user
+    };
+  }
+});

--- a/apps/api/src/billing/http-schemas/stripe.schema.ts
+++ b/apps/api/src/billing/http-schemas/stripe.schema.ts
@@ -68,15 +68,20 @@ export const ConfirmPaymentRequestSchema = z.object({
     userId: z.string(),
     paymentMethodId: z.string(),
     amount: z.number().gte(20, "Amount must be greater or equal to $20"),
-    currency: z.string()
+    currency: z.string(),
+    awaitResolved: z.boolean().optional()
   })
 });
+
+export const TransactionStatusSchema = z.enum(["created", "pending", "requires_action", "succeeded", "failed", "refunded", "canceled"]);
 
 export const PaymentIntentResultSchema = z.object({
   success: z.boolean(),
   requiresAction: z.boolean().optional(),
   clientSecret: z.string().optional(),
-  paymentIntentId: z.string().optional()
+  paymentIntentId: z.string().optional(),
+  transactionId: z.string(),
+  transactionStatus: TransactionStatusSchema.optional()
 });
 
 export const PaymentMethodValidationResultSchema = z.object({
@@ -94,7 +99,8 @@ export const ConfirmPaymentResponseSchema = z.object({
 export const ApplyCouponRequestSchema = z.object({
   data: z.object({
     couponId: z.string(),
-    userId: z.string()
+    userId: z.string(),
+    awaitResolved: z.boolean().optional()
   })
 });
 
@@ -111,6 +117,8 @@ export const ApplyCouponResponseSchema = z.object({
   data: z.object({
     coupon: CouponSchema.nullable().optional(),
     amountAdded: z.number().optional(),
+    transactionId: z.string().optional(),
+    transactionStatus: TransactionStatusSchema.optional(),
     error: z
       .object({
         message: z.string(),

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -12722,6 +12722,9 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                 "properties": {
                   "data": {
                     "properties": {
+                      "awaitResolved": {
+                        "type": "boolean",
+                      },
                       "couponId": {
                         "type": "string",
                       },
@@ -12803,6 +12806,21 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "message",
                           ],
                           "type": "object",
+                        },
+                        "transactionId": {
+                          "type": "string",
+                        },
+                        "transactionStatus": {
+                          "enum": [
+                            "created",
+                            "pending",
+                            "requires_action",
+                            "succeeded",
+                            "failed",
+                            "refunded",
+                            "canceled",
+                          ],
+                          "type": "string",
                         },
                       },
                       "type": "object",
@@ -13718,6 +13736,9 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "minimum": 20,
                         "type": "number",
                       },
+                      "awaitResolved": {
+                        "type": "boolean",
+                      },
                       "currency": {
                         "type": "string",
                       },
@@ -13765,9 +13786,25 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "success": {
                           "type": "boolean",
                         },
+                        "transactionId": {
+                          "type": "string",
+                        },
+                        "transactionStatus": {
+                          "enum": [
+                            "created",
+                            "pending",
+                            "requires_action",
+                            "succeeded",
+                            "failed",
+                            "refunded",
+                            "canceled",
+                          ],
+                          "type": "string",
+                        },
                       },
                       "required": [
                         "success",
+                        "transactionId",
                       ],
                       "type": "object",
                     },
@@ -13800,9 +13837,25 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "success": {
                           "type": "boolean",
                         },
+                        "transactionId": {
+                          "type": "string",
+                        },
+                        "transactionStatus": {
+                          "enum": [
+                            "created",
+                            "pending",
+                            "requires_action",
+                            "succeeded",
+                            "failed",
+                            "refunded",
+                            "canceled",
+                          ],
+                          "type": "string",
+                        },
                       },
                       "required": [
                         "success",
+                        "transactionId",
                       ],
                       "type": "object",
                     },

--- a/apps/api/test/seeders/database-stripe-transaction.seeder.ts
+++ b/apps/api/test/seeders/database-stripe-transaction.seeder.ts
@@ -1,0 +1,33 @@
+import { faker } from "@faker-js/faker";
+
+import type { StripeTransactionOutput } from "@src/billing/repositories";
+
+export function generateDatabaseStripeTransaction(overrides: Partial<StripeTransactionOutput> = {}) {
+  const baseTransaction: StripeTransactionOutput = {
+    id: faker.string.uuid(),
+    userId: faker.string.uuid(),
+    type: "payment_intent",
+    status: "created",
+    amount: faker.number.int({ min: 1000, max: 100000 }),
+    amountRefunded: 0,
+    currency: "usd",
+    stripePaymentIntentId: null,
+    stripeChargeId: null,
+    stripeCouponId: null,
+    stripePromotionCodeId: null,
+    stripeInvoiceId: null,
+    paymentMethodType: null,
+    cardBrand: null,
+    cardLast4: null,
+    receiptUrl: null,
+    description: null,
+    errorMessage: null,
+    createdAt: faker.date.recent(),
+    updatedAt: faker.date.recent()
+  };
+
+  return {
+    ...baseTransaction,
+    ...overrides
+  };
+}


### PR DESCRIPTION
## Why

Currently clients poll for balance changes to determine when a payment or coupon has been processed. Comparing balances is unreliable — concurrent transactions or timing issues can cause incorrect results. By exposing transaction status and allowing the server to poll for terminal state, the client can rely on a definitive status rather than balance diffs.

## What

- Add `awaitResolved` flag to payment and coupon request schemas
- Add `resolveTransaction` method using cockatiel retry + timeout to poll DB for terminal transaction status (4s initial delay, 500ms interval, 60s timeout)
- Expose `transactionId` and `transactionStatus` in payment and coupon responses
- On timeout, return last known transaction status instead of failing
- Throw 404 immediately if transaction not found (should never happen)
- Add unit tests for `resolveTransaction`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payment and coupon endpoints now return transactionId and transactionStatus for clearer transaction visibility.
  * Optional awaitResolved flag lets clients request resolved (real-time) transaction status before the response returns.
  * Transaction status enum expanded to represent intermediate and terminal states (e.g., created, pending, requires_action, succeeded, failed, refunded, canceled).

* **Tests**
  * Expanded tests for transaction creation, polling/resolution, terminal states, 3DS flows, and coupon application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->