### PR TITLE
fix(stats): prevent SSR crash loop caused by Sentry consoleIntegration

### DIFF
--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -10,7 +10,8 @@
     "dev:inspect": "cross-env NODE_OPTIONS=\"--inspect\" ../../node_modules/.bin/next start -p 3001",
     "format": "prettier --write ./*.{ts,js,json} **/*.{ts,tsx,js,json}",
     "lint": "eslint .",
-    "start": "next start"
+    "start": "next start",
+    "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
     "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
@@ -72,6 +73,7 @@
     "prettier": "^3.3.0",
     "prettier-plugin-tailwindcss": "^0.6.1",
     "tailwindcss": "^3.3.5",
-    "typescript": "~5.8.2"
+    "typescript": "~5.8.2",
+    "vitest": "^4.0.0"
   }
 }

--- a/apps/stats-web/src/app/addresses/[address]/page.tsx
+++ b/apps/stats-web/src/app/addresses/[address]/page.tsx
@@ -49,6 +49,7 @@ async function fetchAddressData(address: string, network: Network["id"]): Promis
   logger.debug({ event: "FETCHING_ADDRESS_DATA", address, network, status: response.status });
 
   if (!response.ok && response.status !== 404) {
+    logger.error({ event: "ADDRESS_FETCH_ERROR", address, network, status: response.status });
     throw new Error(`Error fetching address data: ${address}`);
   } else if (response.status === 404) {
     return null;

--- a/apps/stats-web/src/instrumentation.ts
+++ b/apps/stats-web/src/instrumentation.ts
@@ -12,7 +12,10 @@ export async function register() {
     dsn: process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
     // Adjust this value in production, or use tracesSampler for greater control
     tracesSampleRate: 0.1,
-    enabled: process.env.NEXT_PUBLIC_SENTRY_ENABLED === "true"
+    enabled: process.env.NEXT_PUBLIC_SENTRY_ENABLED === "true",
+    // Disable consoleIntegration on the server to prevent Sentry's console.error patch
+    // from crashing the process when Node's util.inspect fails on Next.js internal error objects
+    integrations: defaults => defaults.filter(i => i.name !== "Console")
   });
 
   if (process.env.NEXT_RUNTIME === "nodejs") {

--- a/apps/stats-web/src/lib/serverFetch.spec.ts
+++ b/apps/stats-web/src/lib/serverFetch.spec.ts
@@ -93,10 +93,11 @@ describe(serverFetch.name, () => {
     const mockFetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
     globalThis.fetch = mockFetch;
 
-    return serverFetch(input.url, input.signal ? { signal: input.signal } : undefined).then(response => {
-      globalThis.fetch = originalFetch;
-      currentHeaders.ref = {};
-      return { response, mockFetch };
-    });
+    return serverFetch(input.url, input.signal ? { signal: input.signal } : undefined)
+      .then(response => ({ response, mockFetch }))
+      .finally(() => {
+        globalThis.fetch = originalFetch;
+        currentHeaders.ref = {};
+      });
   }
 });

--- a/apps/stats-web/src/lib/serverFetch.spec.ts
+++ b/apps/stats-web/src/lib/serverFetch.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest";
+
+const headerValues = vi.hoisted(() => {
+  return { values: {} as Record<string, string | null> };
+});
+
+vi.mock("next/headers", () => ({
+  headers: () => ({
+    get: (name: string) => headerValues.values[name] ?? null
+  })
+}));
+
+vi.mock("@/services/di", () => ({
+  errorHandler: {
+    getTraceData: () => ({})
+  }
+}));
+
+import { serverFetch } from "./serverFetch";
+
+describe("serverFetch", () => {
+  it("forwards request to fetch with no-store cache", async () => {
+    const { response, mockFetch } = await setup({ url: "https://api.example.com/v1/test" });
+
+    expect(response.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledWith("https://api.example.com/v1/test", expect.objectContaining({ cache: "no-store" }));
+  });
+
+  it("aborts after 10 seconds when API does not respond", async () => {
+    const { fetchPromise, advanceTimers } = setup({ url: "https://api.example.com/v1/slow", hangForever: true });
+
+    advanceTimers(10_000);
+
+    await expect(fetchPromise).rejects.toThrow("The operation was aborted.");
+  });
+
+  it("clears timeout after successful fetch", async () => {
+    const clearTimeoutSpy = vi.fn(clearTimeout);
+    globalThis.clearTimeout = clearTimeoutSpy;
+
+    await setup({ url: "https://api.example.com/v1/test" });
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+  });
+
+  it("uses caller-provided signal instead of internal timeout", async () => {
+    const callerController = new AbortController();
+    const { mockFetch } = await setup({ url: "https://api.example.com/v1/test", signal: callerController.signal });
+
+    expect(mockFetch).toHaveBeenCalledWith("https://api.example.com/v1/test", expect.objectContaining({ signal: callerController.signal }));
+  });
+
+  it("merges IP forwarding headers into the request", async () => {
+    const { mockFetch } = await setup({
+      url: "https://api.example.com/v1/test",
+      headers: { "cf-connecting-ip": "1.2.3.4", "x-forwarded-for": "5.6.7.8" }
+    });
+
+    const passedHeaders = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(passedHeaders.get("cf-connecting-ip")).toBe("1.2.3.4");
+    expect(passedHeaders.get("x-forwarded-for")).toBe("5.6.7.8");
+  });
+
+  function setup(input: { url: string; signal?: AbortSignal; headers?: Record<string, string>; hangForever?: true }) {
+    const originalFetch = globalThis.fetch;
+    headerValues.values = input.headers ?? {};
+
+    if (input.hangForever) {
+      vi.useFakeTimers();
+
+      const mockFetch = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            reject(new DOMException("The operation was aborted.", "AbortError"));
+          });
+        });
+      });
+      globalThis.fetch = mockFetch;
+
+      const fetchPromise = serverFetch(input.url).finally(() => {
+        globalThis.fetch = originalFetch;
+        headerValues.values = {};
+        vi.useRealTimers();
+      });
+
+      return { fetchPromise, mockFetch, advanceTimers: (ms: number) => vi.advanceTimersByTime(ms) };
+    }
+
+    const mockFetch = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+    globalThis.fetch = mockFetch;
+
+    return serverFetch(input.url, input.signal ? { signal: input.signal } : undefined).then(response => {
+      globalThis.fetch = originalFetch;
+      headerValues.values = {};
+      return { response, mockFetch };
+    });
+  }
+});

--- a/apps/stats-web/src/lib/serverFetch.ts
+++ b/apps/stats-web/src/lib/serverFetch.ts
@@ -63,9 +63,17 @@ export async function serverFetch(url: string, init?: RequestInit): Promise<Resp
     mergedHeaders.set(key, value);
   });
 
-  return fetch(url, {
-    ...init,
-    cache: "no-store",
-    headers: mergedHeaders
-  });
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+
+  try {
+    return await fetch(url, {
+      ...init,
+      cache: "no-store",
+      headers: mergedHeaders,
+      signal: init?.signal ?? controller.signal
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
 }

--- a/apps/stats-web/vitest.config.ts
+++ b/apps/stats-web/vitest.config.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@/": path.resolve("./src") + "/"
+    }
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.spec.ts"]
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8274,7 +8274,8 @@
         "prettier": "^3.3.0",
         "prettier-plugin-tailwindcss": "^0.6.1",
         "tailwindcss": "^3.3.5",
-        "typescript": "~5.8.2"
+        "typescript": "~5.8.2",
+        "vitest": "^4.0.0"
       }
     },
     "apps/stats-web/node_modules/@cosmjs/encoding": {


### PR DESCRIPTION
## Why

The `stats-web` pod has **70 container restarts** due to a two-stage crash:

1. **SSR timeout:** `serverFetch()` has no timeout, so when the API is slow, Next.js's internal SSR timeout fires
2. **Fatal secondary crash:** Sentry's `consoleIntegration` patches `console.error`. When the SSR timeout calls `console.error`, Node's `util.inspect` crashes at `formatProperty` trying to access `.value` on an undefined property descriptor of Next.js's internal error object. This uncaught exception kills the process.

Without Sentry's patch, the SSR timeout would be handled gracefully by Next.js's error boundary.

## What

- **Disable Sentry `Console` integration on the server** — prevents Sentry from patching `console.error`, eliminating the fatal secondary crash. Sentry still captures errors via `captureException`.
- **Add 10s `AbortController` timeout to `serverFetch`** — defense in depth to abort slow API calls before Next.js's own SSR timeout fires.
- **Add 404 handling to deployment detail page** — matches the pattern used by blocks/address/transaction pages. Returns a "not found" message instead of throwing.
- **Add error logging to address page** — adds `logger.error()` before throwing on non-404 errors, matching other pages.
- **Add vitest setup + `serverFetch` unit tests** — 5 tests covering timeout behavior, signal forwarding, and header merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Show a “Deployment not found” message for missing deployments.
  * Improved logging for failed address and deployment fetches.
  * Added a 10s timeout to API requests.
  * Disabled a problematic console integration in error tracking.

* **Tests**
  * Added unit tests covering server-side fetch behavior, timeouts, header forwarding, and teardown.
  * Added Vitest configuration and a new test:unit script.

* **Chores**
  * Added Vitest as a dev dependency and updated scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->