### PR TITLE
test: makes more resillient provider-proxy e2e test

### DIFF
--- a/apps/provider-proxy/test/e2e/public-endpoints.spec.ts
+++ b/apps/provider-proxy/test/e2e/public-endpoints.spec.ts
@@ -1,49 +1,36 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { fetchAvailableProviders, fetchProvider, type Provider } from "./setup/fetchProvider";
 
 describe("Provider Proxy API", () => {
+  beforeAll(() => {
+    // ensure that tests can run against providers with self-signed certificates
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+  });
+
+  afterAll(() => {
+    delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+  });
+
   it("can fetch provider /version", async () => {
     const [provider] = await getProviders();
-    const response = await fetchProvider(provider, "/version");
-    expect(response.ok).toBe(true);
+    const [proxyResponse, providerResponse] = await Promise.all([fetchProvider(provider, "/version"), fetch(`${provider.hostUri}/version`)]);
+    expect(proxyResponse.ok).toBe(true);
 
-    const data = await response.json();
-    expect(data).toEqual(
-      expect.objectContaining({
-        akash: expect.objectContaining({
-          name: "provider-services",
-          version: expect.any(String),
-          commit: expect.any(String),
-          cosmos_sdk_version: expect.any(String)
-        }),
-        kube: expect.objectContaining({
-          major: expect.any(String),
-          minor: expect.any(String),
-          gitCommit: expect.any(String),
-          buildDate: expect.any(String)
-        })
-      })
-    );
+    const [proxyData, providerData] = await Promise.all([proxyResponse.json(), providerResponse.json()]);
+    expect(proxyData).toBeTruthy();
+    expect(proxyData).toEqual(providerData);
   });
 
   it("can fetch provider /status", async () => {
     const [provider] = await getProviders();
-    const response = await fetchProvider(provider, "/status");
-    expect(response.ok).toBe(true);
+    const [proxyResponse, providerResponse] = await Promise.all([fetchProvider(provider, "/status"), fetch(`${provider.hostUri}/status`)]);
+    expect(proxyResponse.ok).toBe(true);
+    expect(providerResponse.ok).toBe(true);
 
-    const data = await response.json();
-    expect(data).toEqual(
-      expect.objectContaining({
-        address: provider.owner,
-        cluster_public_hostname: new URL(provider.hostUri).hostname,
-        bidengine: expect.any(Object),
-        cluster: expect.objectContaining({
-          leases: expect.any(Number),
-          inventory: expect.any(Object)
-        })
-      })
-    );
+    const [proxyData, providerData] = await Promise.all([proxyResponse.json(), providerResponse.json()]);
+    expect(proxyData).toBeTruthy();
+    expect(proxyData).toEqual(providerData);
   });
 
   let providersPromise: Promise<Provider[]> | undefined;


### PR DESCRIPTION
## Why

My expectations about what the provider API returns from the /status endpoint were incorrect, and as a result, the provider-proxy e2e tests fail during deployment

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability by optimizing endpoint verification logic and establishing proper test environment configuration for secure connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->