### PR TITLE
chore: skips auto approval if PR is approved or closed

### DIFF
--- a/.github/actions/associated-pr/action.yml
+++ b/.github/actions/associated-pr/action.yml
@@ -33,6 +33,9 @@ outputs:
   labels:
     description: Comma-separated list of PR labels
     value: ${{ steps.associated-pr.outputs.labels }}
+  closed:
+    description: Whether the PR is closed
+    value: ${{ steps.associated-pr.outputs.closed }}
 
 runs:
   using: "composite"
@@ -95,6 +98,7 @@ runs:
             core.setOutput('head_ref', '');
             core.setOutput('head_repo', '');
             core.setOutput('labels', '');
+            core.setOutput('closed', '');
             return;
           }
 
@@ -103,6 +107,7 @@ runs:
           core.setOutput('head_ref', pr.head.ref);
           core.setOutput('head_repo', pr.head.repo?.full_name || '');
           core.setOutput('labels', (pr.labels || []).map(l => l.name).join(','));
+          core.setOutput('closed', pr.closed);
 
           const author = pr.merged_by?.login || pr.user.login;
           core.setOutput('author', author);

--- a/.github/workflows/auto-approval.yml
+++ b/.github/workflows/auto-approval.yml
@@ -24,7 +24,7 @@ jobs:
           sha: ${{ github.event.workflow_run.head_sha }}
       - name: Evaluate auto-approval criteria
         id: evaluate
-        if: steps.associated-pr.outputs.number != ''
+        if: steps.associated-pr.outputs.number != '' && steps.associated-pr.outputs.closed != 'true'
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.associated-pr.outputs.number }}
@@ -33,7 +33,7 @@ jobs:
           PR_AUTHOR: ${{ steps.associated-pr.outputs.author }}
           PR_HEAD_REPO: ${{ steps.associated-pr.outputs.head_repo }}
         with:
-          script: |
+          script: | # js
             const prNumber = parseInt(process.env.PR_NUMBER || "");
             const baseRepo = `${context.repo.owner}/${context.repo.repo}`;
             const headRepo = process.env.PR_HEAD_REPO ?? "";
@@ -87,9 +87,9 @@ jobs:
                 core.info("Skipping test: PR changes non-test files");
                 return;
               }
-            }
 
-            if (isDocs) {
+              core.setOutput("approval-reason", "all changes are related to tests");
+            } else if (isDocs) {
               const imagePattern = /\.(png|jpg|jpeg|gif|svg|webp|ico|bmp)$/i;
               const docsFilePattern = f => f.endsWith(".md") || imagePattern.test(f);
               const onlyDocFiles = filenames.every(docsFilePattern);
@@ -97,9 +97,9 @@ jobs:
                 core.info("Skipping docs: PR changes non-documentation files");
                 return;
               }
-            }
 
-            if (isChore) {
+              core.setOutput("approval-reason", "all changes are related to documentation");
+            } else if (isChore) {
               const sourceCodeFile = /\.(ts|tsx|js|jsx)$/;
               const touchesCode = filenames.some(f => {
                 return sourceCodeFile.test(f) && (f.includes("/packages/") || f.includes("/apps/"));
@@ -108,15 +108,29 @@ jobs:
                 core.info("Skipping chore: PR touches code files in packages/ or apps/");
                 return;
               }
+
+              core.setOutput("approval-reason", "chore that does not touch source code files");
             }
 
-            core.setOutput("can-approve", "true");
-            core.info(`PR #${prNumber} meets auto-approval criteria`);
       - name: Approve PR
-        if: steps.evaluate.outputs.can-approve == 'true'
+        if: steps.evaluate.outputs.approval-reason != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.associated-pr.outputs.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          gh pr review "$PR_NUMBER" -R "$REPO" --approve --body "Auto-approved: meets auto-approval criteria."
+          APPROVAL_REASON: ${{ steps.evaluate.outputs.approval-reason }}
+        run: | # shell
+          should_skip=$(gh pr view "$PR_NUMBER" \
+            -R "$GITHUB_REPOSITORY" \
+            --json closed,reviews \
+            --jq '.closed or any(
+              .reviews[];
+              .state == "APPROVED"
+              and .author.login == "github-actions[bot]"
+            )'
+          );
+
+          if [ "$should_skip" = "true" ]; then
+            echo "PR #$PR_NUMBER is already closed or approved, skipping approval";
+          else
+            gh pr review "$PR_NUMBER" -R "$GITHUB_REPOSITORY" --approve --body "Auto-approved: $APPROVAL_REASON."
+          fi


### PR DESCRIPTION
## Why

To get rid of unnecessary/noisy approvals when PR has been approved or has been closed

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced automated PR validation to skip forks/bot authors, require an "experienced-contributor" label and a size label (XS/S/M), and classify PRs (test/docs/chore) for targeted handling.
  * Switched to per-PR approval reasons (test/docs/chore) and added runtime guards to avoid approving closed PRs or those already approved by bots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->