### PR TITLE
chore: ignore drizzle snapshot changes when calc label size

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
+          script: | # js
             const pullRequest = context.payload.pull_request;
             if (!pullRequest) {
               return;
@@ -51,10 +51,15 @@ jobs:
               per_page: 100,
             });
 
-            const excludedLockfiles = new Set(["pnpm-lock.yaml", "package-lock.json", "yarn.lock", "bun.lockb"]);
+            const excludedLockfiles = new Set([
+              "pnpm-lock.yaml",
+              "package-lock.json",
+              "yarn.lock",
+              "bun.lockb",
+            ]);
             const totalChangedLines = files.reduce((total, file) => {
               const path = file.filename ?? "";
-              if (excludedLockfiles.has(path)) {
+              if (excludedLockfiles.has(path) || (path.includes("/drizzle/meta/") && path.endsWith('.json'))) {
                 return total;
               }
               return total + (file.additions ?? 0) + (file.deletions ?? 0);
@@ -101,7 +106,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
+          script: | # js
             const login = context.payload.pull_request?.user?.login;
             if (!login) {
               return;


### PR DESCRIPTION
## Why

Because those snapshots is kind of lock files for db state

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to optimize file processing and exclusion logic.
  * Simplified maintainer label management process in CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->