### PR TITLE
fix(observability): redact sensitive data from logs

### DIFF
--- a/apps/api/src/auth/services/auth.interceptor.ts
+++ b/apps/api/src/auth/services/auth.interceptor.ts
@@ -72,7 +72,7 @@ export class AuthInterceptor implements HonoInterceptor {
 
             return await next();
           } catch (error) {
-            this.logger.error(error);
+            this.logger.warn({ event: "API_KEY_VALIDATION_FAILED", message: error instanceof Error ? error.message : "Unknown error" });
             throw new Unauthorized("Invalid API key");
           }
         }

--- a/apps/deploy-web/src/components/billing-usage/TrendIndicator/TrendIndicator.tsx
+++ b/apps/deploy-web/src/components/billing-usage/TrendIndicator/TrendIndicator.tsx
@@ -41,7 +41,7 @@ export const TrendIndicator = <Field extends string & Keys<Data>, Data extends H
     if (firstValue === 0) return null;
 
     const percentageChange = ((lastValue - firstValue) / firstValue) * 100;
-    const isCurrentDay = isToday(new Date(lastItem.date));
+    const isCurrentDay = isToday(new Date(`${lastItem.date}T00:00:00`));
 
     return {
       change: Math.round(percentageChange * 100) / 100,

--- a/apps/deploy-web/src/pages/api/auth/password-login.ts
+++ b/apps/deploy-web/src/pages/api/auth/password-login.ts
@@ -34,7 +34,8 @@ export default defineApiHandler({
     const { cause, ...errorDetails } = result.val;
     services.logger.warn({
       event: "PASSWORD_LOGIN_ERROR",
-      cause: result.val
+      code: errorDetails.code,
+      message: errorDetails.message
     });
     return res.status(400).json(errorDetails);
   }

--- a/apps/deploy-web/src/pages/api/auth/password-signup.ts
+++ b/apps/deploy-web/src/pages/api/auth/password-signup.ts
@@ -56,7 +56,8 @@ export default defineApiHandler({
     const { cause, ...errorDetails } = result.val;
     services.logger.warn({
       event: "PASSWORD_SIGNUP_ERROR",
-      cause: result.val
+      code: errorDetails.code,
+      message: errorDetails.message
     });
 
     if (result.val.code === "user_exists") {

--- a/apps/deploy-web/src/pages/api/auth/send-password-reset-email.ts
+++ b/apps/deploy-web/src/pages/api/auth/send-password-reset-email.ts
@@ -33,7 +33,8 @@ export default defineApiHandler({
       const { cause, ...errorDetails } = result.val;
       services.logger.warn({
         event: "SEND_PASSWORD_RESET_EMAIL_ERROR",
-        cause: result.val
+        code: errorDetails.code,
+        message: errorDetails.message
       });
       return res.status(400).json(errorDetails);
     } catch (error) {

--- a/apps/deploy-web/src/services/error-handler/error-handler.service.ts
+++ b/apps/deploy-web/src/services/error-handler/error-handler.service.ts
@@ -31,7 +31,7 @@ export class ErrorHandlerService {
       finalTags.status = error.response.status.toString();
       finalTags.method = error.response.config.method?.toUpperCase() || "UNKNOWN";
       finalTags.url = error.response.config.url || "UNKNOWN";
-      extra.headers = error.response.headers;
+      extra.headers = pickSafeHeaders(error.response.headers);
     }
 
     this.logger.error({ ...extra, ...finalTags, error });
@@ -79,6 +79,18 @@ export interface TraceData {
   traceId?: string;
   traceIdW3C?: string;
   baggage?: string;
+}
+
+const SAFE_HEADERS = new Set(["content-type", "content-length", "x-request-id", "x-correlation-id", "retry-after", "server"]);
+
+function pickSafeHeaders(headers: Record<string, unknown>): Record<string, unknown> {
+  const safe: Record<string, unknown> = {};
+  for (const key of Object.keys(headers)) {
+    if (SAFE_HEADERS.has(key.toLowerCase())) {
+      safe[key] = headers[key];
+    }
+  }
+  return safe;
 }
 
 /**

--- a/apps/deploy-web/src/services/session/session.service.ts
+++ b/apps/deploy-web/src/services/session/session.service.ts
@@ -244,7 +244,6 @@ function extractResponseDetails(response: AxiosResponse) {
     url: response.config?.url,
     method: response.config?.method,
     status: response.status,
-    data: response.data,
     headers: {
       "Content-Type": response.headers["content-type"],
       server: response.headers["server"]

--- a/packages/logging/src/hono/http-logger/http-logger.service.ts
+++ b/packages/logging/src/hono/http-logger/http-logger.service.ts
@@ -18,6 +18,11 @@ type HttpRequestLog = {
   userId?: string;
 };
 
+function stripQueryParams(url: string): string {
+  const index = url.indexOf("?");
+  return index === -1 ? url : url.slice(0, index);
+}
+
 export class HttpLoggerInterceptor {
   constructor(private readonly logger?: LoggerService) {}
 
@@ -34,7 +39,7 @@ export class HttpLoggerInterceptor {
         const log: HttpRequestLog = {
           httpRequest: {
             requestMethod: c.req.method,
-            requestUrl: c.req.url,
+            requestUrl: stripQueryParams(c.req.url),
             status: c.res.status,
             referrer: c.req.raw.referrer,
             protocol: c.req.header("x-forwarded-proto"),

--- a/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.ts
+++ b/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.ts
@@ -24,13 +24,11 @@ export function collectFullErrorStack(error: string | Error | AggregateError | E
     const requestedPath = currentError.response.config?.url
       ? `${currentError.response.config.method?.toUpperCase() || "(HTTP method not specified)"} ${currentError.response.config?.url}`
       : "Unknown request";
-    const body = currentError.response.data ? JSON.stringify(currentError.response.data) : "No body";
     stack.push(
       "\nResponse:",
       `\nRequest: ${requestedPath}`,
       `\nStatus: ${currentError.response.status}`,
-      `\nError: ${sanitizeString(currentError.response.data?.message) || "Not specified"} (code: ${currentError.response.data?.code || "Not specified"})`,
-      `\nBody: ${body.length > 200 ? `${body.slice(0, 200)}...` : body}`
+      `\nError: ${sanitizeString(currentError.response.data?.message) || "Not specified"} (code: ${currentError.response.data?.code || "Not specified"})`
     );
   }
 


### PR DESCRIPTION
## Why

Audit of log output revealed several locations where sensitive data (Auth0 response bodies, tokens, SQL parameters, HTTP headers) could leak into structured logs. This PR remediates all identified instances to improve application security.

## What

### Phase 1: Fix critical/high call sites
- **Auth handler logging** — Stop logging full `result.val` (contains Auth0 response bodies with tokens). Now only logs `code` and `message`.
- **`extractResponseDetails`** — Remove `data: response.data` from the return value. Status, URL, method, and safe headers are sufficient for debugging.
- **Error handler headers** — Replace `extra.headers = error.response.headers` with `pickSafeHeaders()` allowlist (`content-type`, `content-length`, `x-request-id`, `x-correlation-id`, `retry-after`, `server`).
- **SQL parameter redaction** — Add `redactSqlLiterals()` that replaces string literals and large numeric literals in logged SQL.
- **API key auth error** — Replace `this.logger.error(error)` (logs raw error) with structured `logger.warn({ event, message })`.

### Phase 2: Centralized Pino redaction layer
- Add Pino's built-in `redact` option covering passwords, tokens, secrets, authorization headers, cookies, and API keys as a defense-in-depth safety net.

### Phase 3: Tighten error serializers
- **Response body** — Remove `Body:` line from `collectFullErrorStack` (response bodies can contain tokens/user data).
- **`error.data` filtering** — Only keep `errorCode` and `errorType` in the HTTP error serializer (the structured fields used by `HonoErrorHandlerService`).
- **Query parameter stripping** — Strip query strings from logged HTTP request URLs (can contain tokens, API keys, PII).

### Bonus: TrendIndicator timezone fix
- Date-only strings (`"2026-02-20"`) parsed as UTC midnight by `new Date()`, causing `isToday()` to return false in timezones behind UTC. Fixed by appending `T00:00:00` to force local-time parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date determination in trend indicator for edge case handling
  * Removed sensitive data (headers, credentials, SQL literals) from error logs
  * Removed response body data from error stack traces

* **New Features**
  * Structured warning logging for authentication validation failures
  * Automatic redaction of sensitive fields in logs (passwords, tokens, cookies)
  * Query parameter stripping from logged request URLs
  * Safe header filtering in HTTP error responses

* **Tests**
  * Added sensitive header filtering verification tests
  * Expanded redaction coverage for credentials and SQL data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->