### PR TITLE
docs: updates api docs menu item

### DIFF
--- a/apps/deploy-web/src/components/layout/Sidebar.tsx
+++ b/apps/deploy-web/src/components/layout/Sidebar.tsx
@@ -201,9 +201,9 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
                     target: "_blank"
                   },
                   {
-                    title: "Akash Console API",
+                    title: "Akash API Docs",
                     icon: props => <EvPlug {...props} />,
-                    url: "https://console-api.akash.network/v1/swagger",
+                    url: "https://akash.network/docs/api-documentation/getting-started/",
                     activeRoutes: [],
                     target: "_blank"
                   },


### PR DESCRIPTION
Part 3 of https://github.com/akash-network/website/issues/1028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the sidebar Resources entry to improve guidance: the item now appears as "Akash API Docs" and its link points to the official API documentation getting-started page (replacing the previous console API link), ensuring users are directed to the current API docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->