### PR TITLE
chore: restore junit reporter on coverage

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,7 +27,7 @@
     "test:ci-setup": "dc up -d --wait --wait-timeout 60 db mock-oauth2-server provider-proxy",
     "test:ci-teardown": "dc down",
     "test:component": "vitest run --project=unit --project=integration",
-    "test:cov": "vitest run --project=unit --project=functional --project=integration --coverage",
+    "test:cov": "vitest run --project=unit --project=functional --project=integration --coverage --reporter=default --reporter=junit",
     "test:e2e": "vitest run --project=e2e",
     "test:functional": "vitest run --project=functional",
     "test:functional:cov": "vitest run --project=functional --coverage",

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -32,6 +32,9 @@ export default defineConfig({
   test: {
     environment: "node",
     globals: true,
+    outputFile: {
+      junit: "junit.xml"
+    },
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],


### PR DESCRIPTION
## Why

restore junit reporter on coverage

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured test infrastructure to generate JUnit format test reports, enabling improved integration with continuous integration systems and enhanced test result tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->