### PR TITLE
fix(deployment): optimizes provider deployment query

### DIFF
--- a/apps/api/src/provider/services/provider-deployments/provider-deployments.service.integration.ts
+++ b/apps/api/src/provider/services/provider-deployments/provider-deployments.service.integration.ts
@@ -1,0 +1,352 @@
+import type { Lease } from "@akashnetwork/database/dbSchemas/akash";
+import type { Block } from "@akashnetwork/database/dbSchemas/base";
+import { faker } from "@faker-js/faker";
+import type { CreationAttributes } from "sequelize";
+import { container } from "tsyringe";
+
+import { CHAIN_DB } from "@src/chain";
+import { ProviderDeploymentsService } from "./provider-deployments.service";
+
+import { createAkashAddress, createAkashBlock, createDeployment, createDeploymentGroup, createLease, createProvider } from "@test/seeders";
+
+function uniqueHeight() {
+  return faker.number.int({ min: 20_000_000, max: 2_000_000_000 });
+}
+
+describe(ProviderDeploymentsService.name, () => {
+  describe("getProviderDeployments", () => {
+    it("returns deployments with lease details for a provider", async () => {
+      const createdHeight = uniqueHeight();
+      const closedHeight = createdHeight + 1000;
+      const { service, providerAddress, owner, blocks } = await setup({
+        blocks: [
+          { height: createdHeight, datetime: new Date("2024-01-01") },
+          { height: closedHeight, datetime: new Date("2024-01-15") }
+        ],
+        deployments: [
+          {
+            createdHeight,
+            denom: "uakt",
+            balance: 500,
+            withdrawnAmount: 100,
+            lastWithdrawHeight: createdHeight + 500,
+            leaseOverrides: {
+              createdHeight,
+              closedHeight,
+              price: 0.5,
+              cpuUnits: 1000,
+              gpuUnits: 1,
+              memoryQuantity: 1073741824,
+              ephemeralStorageQuantity: 5368709120,
+              persistentStorageQuantity: 10737418240,
+              gseq: 1,
+              oseq: 1
+            }
+          }
+        ]
+      });
+
+      const result = await service.getProviderDeployments(providerAddress, 0, 10);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        owner,
+        denom: "uakt",
+        createdHeight,
+        createdDate: blocks[0].datetime,
+        status: "active",
+        balance: 500,
+        transferred: 100,
+        settledAt: createdHeight + 500,
+        resources: {
+          cpu: 1000,
+          gpu: 1,
+          memory: 1073741824,
+          ephemeralStorage: 5368709120,
+          persistentStorage: 10737418240
+        }
+      });
+      expect(result[0].leases).toHaveLength(1);
+      expect(result[0].leases[0]).toMatchObject({
+        provider: providerAddress,
+        gseq: 1,
+        oseq: 1,
+        price: 0.5,
+        createdHeight,
+        createdDate: blocks[0].datetime,
+        closedHeight,
+        closedDate: blocks[1].datetime,
+        status: "closed"
+      });
+    });
+
+    it("filters by active status", async () => {
+      const height1 = uniqueHeight();
+      const height2 = uniqueHeight();
+      const { service, providerAddress } = await setup({
+        blocks: [{ height: height1 }, { height: height2 }],
+        deployments: [
+          { createdHeight: height1, leaseOverrides: { createdHeight: height1, closedHeight: undefined } },
+          { createdHeight: height2, closedHeight: height2, leaseOverrides: { createdHeight: height2, closedHeight: height2 } }
+        ]
+      });
+
+      const activeResult = await service.getProviderDeployments(providerAddress, 0, 10, "active");
+      expect(activeResult).toHaveLength(1);
+      expect(activeResult[0].status).toBe("active");
+
+      const closedResult = await service.getProviderDeployments(providerAddress, 0, 10, "closed");
+      expect(closedResult).toHaveLength(1);
+      expect(closedResult[0].status).toBe("closed");
+    });
+
+    it("paginates results ordered by createdHeight DESC", async () => {
+      const baseHeight = uniqueHeight();
+      const { service, providerAddress } = await setup({
+        blocks: [{ height: baseHeight }, { height: baseHeight + 100 }, { height: baseHeight + 200 }],
+        deployments: [
+          { createdHeight: baseHeight, leaseOverrides: { createdHeight: baseHeight } },
+          { createdHeight: baseHeight + 100, leaseOverrides: { createdHeight: baseHeight + 100 } },
+          { createdHeight: baseHeight + 200, leaseOverrides: { createdHeight: baseHeight + 200 } }
+        ]
+      });
+
+      const firstPage = await service.getProviderDeployments(providerAddress, 0, 2);
+      expect(firstPage).toHaveLength(2);
+      expect(firstPage[0].createdHeight).toBe(baseHeight + 200);
+      expect(firstPage[1].createdHeight).toBe(baseHeight + 100);
+
+      const secondPage = await service.getProviderDeployments(providerAddress, 2, 2);
+      expect(secondPage).toHaveLength(1);
+      expect(secondPage[0].createdHeight).toBe(baseHeight);
+    });
+
+    it("excludes deployments from other providers", async () => {
+      const height = uniqueHeight();
+      const otherProvider = createAkashAddress();
+      const { service, providerAddress, owner } = await setup({
+        blocks: [{ height }],
+        deployments: [{ createdHeight: height, leaseOverrides: { createdHeight: height } }]
+      });
+
+      await createProvider({ owner: otherProvider });
+      await seedLeaseWithDeployment({ owner, providerAddress: otherProvider, createdHeight: height, leaseOverrides: { createdHeight: height } });
+
+      const result = await service.getProviderDeployments(providerAddress, 0, 10);
+      expect(result).toHaveLength(1);
+      expect(result[0].leases[0].provider).toBe(providerAddress);
+    });
+
+    it("aggregates resources from multiple leases", async () => {
+      const height = uniqueHeight();
+      const { service, providerAddress } = await setup({
+        blocks: [{ height }],
+        deployments: []
+      });
+
+      const owner = createAkashAddress();
+      const deployment = await createDeployment({ owner, createdHeight: height });
+      const deploymentGroup1 = await createDeploymentGroup({ deploymentId: deployment.id, owner, dseq: deployment.dseq });
+      const deploymentGroup2 = await createDeploymentGroup({ deploymentId: deployment.id, owner, dseq: deployment.dseq, gseq: 2 });
+
+      await createLease({
+        deploymentId: deployment.id,
+        deploymentGroupId: deploymentGroup1.id,
+        owner,
+        dseq: deployment.dseq,
+        providerAddress,
+        createdHeight: height,
+        cpuUnits: 1000,
+        gpuUnits: 1,
+        memoryQuantity: 1073741824,
+        ephemeralStorageQuantity: 5368709120,
+        persistentStorageQuantity: 10737418240,
+        gseq: 1,
+        oseq: 1
+      });
+
+      await createLease({
+        deploymentId: deployment.id,
+        deploymentGroupId: deploymentGroup2.id,
+        owner,
+        dseq: deployment.dseq,
+        providerAddress,
+        createdHeight: height,
+        cpuUnits: 2000,
+        gpuUnits: 2,
+        memoryQuantity: 2147483648,
+        ephemeralStorageQuantity: 10737418240,
+        persistentStorageQuantity: 21474836480,
+        gseq: 2,
+        oseq: 1
+      });
+
+      const result = await service.getProviderDeployments(providerAddress, 0, 10);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].resources).toEqual({
+        cpu: 3000,
+        gpu: 3,
+        memory: 1073741824 + 2147483648,
+        ephemeralStorage: 5368709120 + 10737418240,
+        persistentStorage: 10737418240 + 21474836480
+      });
+      expect(result[0].leases).toHaveLength(2);
+    });
+
+    it("does not count multiple leases per deployment as separate pagination entries", async () => {
+      const baseHeight = uniqueHeight();
+      const { service, providerAddress } = await setup({
+        blocks: [{ height: baseHeight }, { height: baseHeight + 100 }],
+        deployments: []
+      });
+
+      const owner = createAkashAddress();
+
+      const deployment1 = await createDeployment({ owner, createdHeight: baseHeight });
+      const dg1a = await createDeploymentGroup({ deploymentId: deployment1.id, owner, dseq: deployment1.dseq, gseq: 1 });
+      const dg1b = await createDeploymentGroup({ deploymentId: deployment1.id, owner, dseq: deployment1.dseq, gseq: 2 });
+      await createLease({
+        deploymentId: deployment1.id,
+        deploymentGroupId: dg1a.id,
+        owner,
+        dseq: deployment1.dseq,
+        providerAddress,
+        createdHeight: baseHeight,
+        gseq: 1,
+        oseq: 1
+      });
+      await createLease({
+        deploymentId: deployment1.id,
+        deploymentGroupId: dg1b.id,
+        owner,
+        dseq: deployment1.dseq,
+        providerAddress,
+        createdHeight: baseHeight,
+        gseq: 2,
+        oseq: 1
+      });
+
+      const deployment2 = await createDeployment({ owner, createdHeight: baseHeight + 100 });
+      const dg2 = await createDeploymentGroup({ deploymentId: deployment2.id, owner, dseq: deployment2.dseq, gseq: 1 });
+      await createLease({
+        deploymentId: deployment2.id,
+        deploymentGroupId: dg2.id,
+        owner,
+        dseq: deployment2.dseq,
+        providerAddress,
+        createdHeight: baseHeight + 100,
+        gseq: 1,
+        oseq: 1
+      });
+
+      const firstPage = await service.getProviderDeployments(providerAddress, 0, 1);
+      expect(firstPage).toHaveLength(1);
+      expect(firstPage[0].dseq).toBe(deployment2.dseq);
+
+      const secondPage = await service.getProviderDeployments(providerAddress, 1, 1);
+      expect(secondPage).toHaveLength(1);
+      expect(secondPage[0].dseq).toBe(deployment1.dseq);
+      expect(secondPage[0].leases).toHaveLength(2);
+    });
+  });
+
+  describe("getProviderDeploymentsCount", () => {
+    it("returns total count of deployments for a provider", async () => {
+      const height1 = uniqueHeight();
+      const height2 = uniqueHeight();
+      const { service, providerAddress } = await setup({
+        blocks: [{ height: height1 }, { height: height2 }],
+        deployments: [
+          { createdHeight: height1, leaseOverrides: { createdHeight: height1 } },
+          { createdHeight: height2, leaseOverrides: { createdHeight: height2 } }
+        ]
+      });
+
+      const count = await service.getProviderDeploymentsCount(providerAddress);
+      expect(count).toBe(2);
+    });
+
+    it("filters count by status", async () => {
+      const height1 = uniqueHeight();
+      const height2 = uniqueHeight();
+      const { service, providerAddress } = await setup({
+        blocks: [{ height: height1 }, { height: height2 }],
+        deployments: [
+          { createdHeight: height1, leaseOverrides: { createdHeight: height1, closedHeight: undefined } },
+          { createdHeight: height2, closedHeight: height2, leaseOverrides: { createdHeight: height2, closedHeight: height2 } }
+        ]
+      });
+
+      const activeCount = await service.getProviderDeploymentsCount(providerAddress, "active");
+      expect(activeCount).toBe(1);
+
+      const closedCount = await service.getProviderDeploymentsCount(providerAddress, "closed");
+      expect(closedCount).toBe(1);
+    });
+  });
+
+  async function setup(input: {
+    blocks: Partial<CreationAttributes<Block>>[];
+    deployments: (Omit<SeedLeaseWithDeploymentInput, "owner" | "providerAddress"> & { closedHeight?: number })[];
+  }) {
+    container.resolve(CHAIN_DB);
+
+    const providerAddress = createAkashAddress();
+    const owner = createAkashAddress();
+
+    const blocks = await Promise.all(input.blocks.map(b => createAkashBlock(b)));
+    await createProvider({ owner: providerAddress });
+
+    for (const dep of input.deployments) {
+      await seedLeaseWithDeployment({ owner, providerAddress, ...dep });
+    }
+
+    return {
+      service: new ProviderDeploymentsService(),
+      providerAddress,
+      owner,
+      blocks
+    };
+  }
+});
+
+interface SeedLeaseWithDeploymentInput {
+  owner: string;
+  providerAddress: string;
+  createdHeight: number;
+  closedHeight?: number;
+  denom?: string;
+  balance?: number;
+  withdrawnAmount?: number;
+  lastWithdrawHeight?: number;
+  leaseOverrides?: Partial<CreationAttributes<Lease>>;
+}
+
+async function seedLeaseWithDeployment(input: SeedLeaseWithDeploymentInput) {
+  const deployment = await createDeployment({
+    owner: input.owner,
+    createdHeight: input.createdHeight,
+    closedHeight: input.closedHeight,
+    denom: input.denom || "uakt",
+    balance: input.balance ?? 1000,
+    withdrawnAmount: input.withdrawnAmount ?? 0,
+    lastWithdrawHeight: input.lastWithdrawHeight
+  });
+  const deploymentGroup = await createDeploymentGroup({
+    deploymentId: deployment.id,
+    owner: input.owner,
+    dseq: deployment.dseq
+  });
+
+  const lease = await createLease({
+    deploymentId: deployment.id,
+    deploymentGroupId: deploymentGroup.id,
+    owner: input.owner,
+    dseq: deployment.dseq,
+    providerAddress: input.providerAddress,
+    ...input.leaseOverrides
+  });
+
+  return { deployment, deploymentGroup, lease };
+}


### PR DESCRIPTION
## Why

The `GET /v1/providers/{provider}/deployments/{skip}/{limit}` endpoint is the top query by total execution time in `pg_stat_statements` — 817 calls with **11.2 seconds mean execution time** (9.1M ms total). This is caused by Sequelize generating a correlated subquery when combining `include` (JOIN) with `LIMIT/OFFSET` pagination. For every row in the `deployment` table, Postgres runs a subquery against `lease`, resulting in a full table scan.

## What

- Replace the Sequelize `findAll` with `include` + pagination in `ProviderDeploymentsService.getProviderDeployments` with a raw SQL query using `JOIN + GROUP BY` for the initial paginated dseq lookup. This eliminates the correlated subquery and allows Postgres to use the existing `(providerAddress, closedHeight, createdHeight)` index on the `lease` table.
- The second query (fetching full deployment/lease details by dseq list) remains unchanged as it operates on a small bounded set.
- Add integration tests covering: full response shape, active/closed status filtering, pagination ordering, provider isolation, and resource aggregation across multiple leases.

### Before (Sequelize-generated SQL)
```sql
SELECT "deployment".* FROM (
  SELECT ... FROM "deployment"
  WHERE (
    SELECT "deploymentId" FROM "lease"
    WHERE "leases"."providerAddress" = $1
      AND "leases"."deploymentId" = "deployment"."id"
    LIMIT 1
  ) IS NOT NULL
  ORDER BY ... LIMIT $2 OFFSET $3
) AS "deployment" INNER JOIN "lease" ...
```

### After (raw SQL)
```sql
SELECT d."dseq"
FROM "deployment" d
INNER JOIN "lease" l ON l."deploymentId" = d."id"
  AND l."providerAddress" = $1
GROUP BY d."id"
ORDER BY d."createdHeight" DESC, d."dseq" DESC
LIMIT $2 OFFSET $3
```

Some more detailed explanation: the correlated subquery has no independent filter on deployment. The only         
  condition is:                                                                                 
          
```sql                                                                                      
WHERE (                                                                                       
  SELECT "deploymentId" FROM "lease"                      
  WHERE "leases"."providerAddress" = $1                                                       
    AND "leases"."deploymentId" = "deployment"."id"  -- references outer row                  
  LIMIT 1
) IS NOT NULL
```

Postgres has to evaluate this for every row in deployment because it can't know which
deployments have matching leases without checking each one. The subquery is correlated — it
depends on "deployment"."id" from the outer query — so Postgres can't optimize it into a join.

With the raw query fix, we flip the approach: start from lease (which has the index on
providerAddress), find the matching rows, then join to deployment. Postgres scans only the
relevant lease rows for that provider, then looks up the corresponding deployments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration tests for provider deployment listing, filtering, pagination, and multi-lease resource aggregation to improve reliability.

* **Performance**
  * Improved provider deployment retrieval for faster, more consistent listing and pagination, including more accurate status filtering and resource summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->