### PR TITLE
chore: fixes releases flow failure mode and handles non-existing deployment flow

### DIFF
--- a/.github/workflows/all-release.yml
+++ b/.github/workflows/all-release.yml
@@ -72,6 +72,7 @@ jobs:
     if: fromJson(needs.setup.outputs.backends).include[0]
     strategy:
       matrix: ${{ fromJson(needs.setup.outputs.backends) }}
+      fail-fast: false
     uses: ./.github/workflows/reusable-release-app.yml
     secrets: inherit
     permissions:
@@ -88,6 +89,7 @@ jobs:
     if: fromJson(needs.setup.outputs.nextjs).include[0]
     strategy:
       matrix: ${{ fromJson(needs.setup.outputs.nextjs) }}
+      fail-fast: false
     uses: ./.github/workflows/reusable-release-nextjs-app.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/reusable-release-app.yml
+++ b/.github/workflows/reusable-release-app.yml
@@ -53,10 +53,17 @@ jobs:
     permissions:
       actions: write
     steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github
       - name: Trigger deployment
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          if [ ! -f ".github/workflows/${{ inputs.deploy_workflow }}" ]; then
+            echo "Deployment workflow .github/workflows/${{ inputs.deploy_workflow }} not found! Deployment trigger skipped."
+            exit 0
+          fi
           gh workflow run ${{ inputs.deploy_workflow }} \
             --repo ${{ github.repository }} \
             -f image_tag=${{ needs.release.outputs.git_tag }} \

--- a/.github/workflows/reusable-release-nextjs-app.yml
+++ b/.github/workflows/reusable-release-nextjs-app.yml
@@ -70,10 +70,17 @@ jobs:
     permissions:
       actions: write
     steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github
       - name: Trigger deployment
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          if [ ! -f ".github/workflows/${{ inputs.deploy_workflow }}" ]; then
+            echo "Deployment workflow .github/workflows/${{ inputs.deploy_workflow }} not found! Deployment trigger skipped."
+            exit 0
+          fi
           gh workflow run ${{ inputs.deploy_workflow }} \
             --repo ${{ github.repository }} \
             -f image_tag=${{ needs.release.outputs.git_tag }} \


### PR DESCRIPTION
## Why

Found a bug: https://github.com/akash-network/console/actions/runs/22358963456/job/64706658194
1. failure in one app release should not cancel others
2. if there is no deployment workflow for the app, it should not be triggered 

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Made batch releases more resilient so other jobs continue when one job in a matrix fails.
  * Added pre-deploy validation to skip deployment if the expected workflow is missing, avoiding failed runs.
  * Optimized checkout during deploy to only fetch needed workflow metadata, reducing CI overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->