### PR TITLE
feat(observability): adds tracing withing POST /v1/certificates endpoint

### DIFF
--- a/apps/api/src/auth/services/api-key/api-key-auth.service.ts
+++ b/apps/api/src/auth/services/api-key/api-key-auth.service.ts
@@ -6,6 +6,7 @@ import { singleton } from "tsyringe";
 
 import { ApiKeyOutput, ApiKeyRepository } from "@src/auth/repositories/api-key/api-key.repository";
 import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
+import { Trace } from "@src/core/services/tracing/tracing.service";
 import { ApiKeyGeneratorService } from "./api-key-generator.service";
 
 @singleton()
@@ -25,6 +26,7 @@ export class ApiKeyAuthService {
     return apiKeys[comparisons.findIndex(result => result)];
   }
 
+  @Trace()
   async getAndValidateApiKeyFromHeader(apiKey: string | undefined): Promise<ApiKeyOutput> {
     assert(apiKey, 401, "Invalid API key");
 

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -5,6 +5,7 @@ import { singleton } from "tsyringe";
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
 import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
+import { Trace } from "@src/core/services/tracing/tracing.service";
 
 export type DbCreateUserWalletInput = ApiPgTables["UserWallets"]["$inferInsert"];
 export type DbUserWalletInput = Partial<DbCreateUserWalletInput>;
@@ -96,6 +97,7 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
     );
   }
 
+  @Trace()
   async findOneByUserId(userId: UserWalletOutput["userId"]) {
     if (!userId) return undefined;
 

--- a/apps/api/src/user/repositories/user/user.repository.ts
+++ b/apps/api/src/user/repositories/user/user.repository.ts
@@ -6,6 +6,7 @@ import { UserWallets } from "@src/billing/model-schemas";
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
 import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
+import { Trace } from "@src/core/services/tracing/tracing.service";
 import { userAgentMaxLength } from "@src/user/model-schemas/user/user.schema";
 
 export type UserOutput = ApiPgTables["Users"]["$inferSelect"] & {
@@ -32,14 +33,17 @@ export class UserRepository extends BaseRepository<ApiPgTables["Users"], UserInp
     return this.toOutput(item);
   }
 
+  @Trace()
   async findById(id: UserOutput["id"]): Promise<UserOutput | undefined> {
     return this.findUserWithWallet(eq(this.table.id, id));
   }
 
+  @Trace()
   async findByUserId(userId: UserOutput["userId"]): Promise<UserOutput | undefined> {
     return this.findUserWithWallet(eq(this.table.userId, userId!));
   }
 
+  @Trace()
   async markAsActive(
     id: UserOutput["id"],
     options: {


### PR DESCRIPTION
## Why

The `POST /v1/certificates` endpoint takes ~20s (up to 1,5min), with ~12s being completely untraced between `AuthInterceptor.intercept` and `ManagedSignerService.executeDerivedDecodedTxByUserId`. This makes it impossible to identify the bottleneck (JWT/JWKS validation, DB lookups, or PEM certificate generation).

## What

Adds `@Trace()` decorators to key methods in the certificate creation flow to break down the untraced gap:
- `UserRepository.findById`, `findByUserId`, `markAsActive`
- `UserWalletRepository.findOneByUserId`
- `ApiKeyAuthService.getAndValidateApiKeyFromHeader`
- `CertificateService.create`
- `CertificateService.generatePEM` via `withSpan` (external package, can't use decorator)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added distributed tracing instrumentation to API key validation, user wallet lookups, certificate generation, and user repository operations to enhance system observability and monitoring capabilities.

* **Refactor**
  * Optimized certificate generation flow with improved address handling and enhanced tracing for better performance visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->