### PR TITLE
chore: ensures that associate-pr action fetches it from proper ref

### DIFF
--- a/.github/actions/associated-pr/action.yml
+++ b/.github/actions/associated-pr/action.yml
@@ -2,8 +2,8 @@ name: Get Associated PR
 description: Gets the associated PR for a commit (takes commit from github context or sha input)
 
 inputs:
-  sha:
-    description: Commit SHA to look up (defaults to github.sha)
+  ref:
+    description: Git ref or commit SHA to look up (defaults to github.sha)
     required: false
     default: ""
   gh-user-to-slack-user:
@@ -40,22 +40,50 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Get commit SHA
+      id: get-sha
+      env:
+        INPUT_REF: ${{ inputs.ref }}
+      uses: actions/github-script@v7
+      with:
+        script: | # js
+          if (!process.env.INPUT_REF) {
+            core.info(`No ref input provided, using context.sha: ${context.sha}`);
+            core.setOutput('sha', context.sha);
+            return;
+          }
+
+          // handles console-web/v1.2.3 tags and inputs with typos console-web/vv1.2.3
+          if (/^[\w-]+\/v{1,2}[\d.]+(-\w+\.\d+)?$/.test(process.env.INPUT_REF)) {
+            core.info(`Ref input looks like app version tag, trying to resolve its sha: ${process.env.INPUT_REF}`);
+            const { data } = await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `tags/${process.env.INPUT_REF.replace(/\/v{2,}/, '/v')}`,
+            });
+            core.setOutput('sha', data.object.sha);
+            return;
+          }
+
+          core.info(`Using provided ref as sha: ${process.env.INPUT_REF}`);
+          core.setOutput('sha', process.env.INPUT_REF);
+
     - uses: actions/github-script@v7
       id: associated-pr
       env:
         GH_USER_TO_SLACK_USER: ${{ inputs.gh-user-to-slack-user }}
-        INPUT_SHA: ${{ inputs.sha }}
+        INPUT_SHA: ${{ steps.get-sha.outputs.sha }}
       with:
-        script: |
+        script: | # js
           const commitSha = process.env.INPUT_SHA || context.sha;
           let pr = context.payload.pull_request;
 
-          // Retry logic to handle timing issues with GitHub API
-          // Sometimes the commit-PR association isn't immediately available after merge
-          if (!pr) {
+          if (!pr || pr.head?.sha !== commitSha) {
             const maxRetries = 5;
-            const baseDelay = 2000; // 2 seconds
+            const baseDelay = 2000;
 
+            // Retry logic to handle timing issues with GitHub API
+            // Sometimes the commit-PR association isn't immediately available after merge
             for (let attempt = 0; attempt < maxRetries; attempt++) {
               if (attempt > 0) {
                 // Exponential backoff: 2s, 4s, 8s, 16s, 32s
@@ -64,13 +92,11 @@ runs:
                 await new Promise(resolve => setTimeout(resolve, delay));
               }
 
-              const response = (
-                await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                  commit_sha: commitSha,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                })
-              );
+              const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                commit_sha: commitSha,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
 
               if (response.data && response.data.length > 0) {
                 pr = response.data[0];
@@ -80,7 +106,12 @@ runs:
             }
           }
 
-          if (pr && !pr.merged_by) {
+          if (!pr) {
+            core.warning(`No PR found for commit ${commitSha} after retries`);
+            return;
+          }
+
+          if (pr.merged && !pr.merged_by) {
             const { data } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -89,25 +120,12 @@ runs:
             pr = data;
           }
 
-          if (!pr) {
-            core.warning(`No PR found for commit ${commitSha} after retries`);
-            core.setOutput('number', '');
-            core.setOutput('title', '');
-            core.setOutput('author', '');
-            core.setOutput('slack-user', '');
-            core.setOutput('head_ref', '');
-            core.setOutput('head_repo', '');
-            core.setOutput('labels', '');
-            core.setOutput('closed', '');
-            return;
-          }
-
           core.setOutput('number', pr.number);
           core.setOutput('title', pr.title);
           core.setOutput('head_ref', pr.head.ref);
           core.setOutput('head_repo', pr.head.repo?.full_name || '');
           core.setOutput('labels', (pr.labels || []).map(l => l.name).join(','));
-          core.setOutput('closed', pr.closed);
+          core.setOutput('closed', pr.closed_at ? 'true' : 'false');
 
           const author = pr.merged_by?.login || pr.user.login;
           core.setOutput('author', author);

--- a/.github/actions/console-web-ui-testing/action.yml
+++ b/.github/actions/console-web-ui-testing/action.yml
@@ -2,6 +2,9 @@ name: Console Web UI testing
 description: Runs UI tests for Console Web
 
 inputs:
+  ref:
+    description: Git ref related to the tests (e.g., console-web/v1.2.3)
+    required: true
   url:
     description: Base URL to Console Web
     required: true
@@ -61,6 +64,7 @@ runs:
     - uses: ./.github/actions/slack-tests-failed-notification
       if: ${{ !cancelled() && steps.e2e-tests.outcome == 'failure' }}
       with:
+        ref: ${{ inputs.ref }}
         url: ${{ inputs.url }}
         gh-user-to-slack-user: ${{ inputs.gh-user-to-slack-user }}
         slack-webhook-url: ${{ inputs.slack-webhook-url }}

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -5,6 +5,9 @@ inputs:
   app:
     description: "App name (dir in ./apps/*)"
     required: true
+  app-version:
+    description: "App version to test (e.g., 1.2.3)"
+    required: true
   app-url:
     description: "URL of the deployed app, used for test failure notifications"
     required: true
@@ -34,6 +37,7 @@ runs:
     - uses: ./.github/actions/slack-tests-failed-notification
       if: ${{ !cancelled() && steps.e2e-tests.outcome == 'failure' }}
       with:
+        ref: ${{ inputs.app }}/v${{ inputs.app-version }}
         url: ${{ inputs.app-url }}
         slack-webhook-url: ${{ inputs.slack-webhook-url }}
         gh-user-to-slack-user: ${{ vars.GH_USER_TO_SLACK_USER }}

--- a/.github/actions/slack-pending-deployment-approval/action.yml
+++ b/.github/actions/slack-pending-deployment-approval/action.yml
@@ -33,7 +33,6 @@ inputs:
   linked-workflow-run-id:
     description: The ID of the workflow run that called this action
     required: false
-    default: ""
 
 runs:
   using: "composite"
@@ -42,6 +41,7 @@ runs:
       id: associated-pr
       with:
         gh-user-to-slack-user: ${{ inputs.gh-user-to-slack-user }}
+        ref: ${{ inputs.app }}/v${{ inputs.new-version }}
     - name: Notify in Slack
       uses: slackapi/slack-github-action@v2.0.0
       with:
@@ -58,7 +58,7 @@ runs:
                   Hey ${{ steps.associated-pr.outputs.slack-user != '' && format('<@{0}>', steps.associated-pr.outputs.slack-user) || steps.associated-pr.outputs.author }},
 
                   A new version of *${{inputs.app}}* `${{ inputs.new-version }}` is ready to be deployed to *${{ inputs.environment }}${{ inputs.chain != '' && format('-{0}', inputs.chain) || '' }}*. Please test your changes on <${{ inputs.url }}|beta> and <${{ github.server_url }}/${{ github.repository }}/actions/workflows/reusable-deploy-k8s.yml|Confirm> the deployment.
-                  This was triggered by the following PR:
+                  Triggered by the following PR in run <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ inputs.linked-workflow-run-id }}|#${{ inputs.linked-workflow-run-id }}>:
                   <${{ github.server_url }}/${{ github.repository }}/pull/${{ steps.associated-pr.outputs.number }}|${{ steps.associated-pr.outputs.title }}>
 
                   Alternatively, use gh cli to run workflow:

--- a/.github/actions/slack-tests-failed-notification/action.yml
+++ b/.github/actions/slack-tests-failed-notification/action.yml
@@ -5,6 +5,9 @@ inputs:
   url:
     description: Base URL to Console API or UI
     required: true
+  ref:
+    description: Git ref related to the tests (e.g., console-web/v1.2.3)
+    required: true
   slack-webhook-url:
     description: Slack webhook URL
     required: false
@@ -24,6 +27,7 @@ runs:
       id: associated-pr
       with:
         gh-user-to-slack-user: ${{ inputs.gh-user-to-slack-user }}
+        ref: ${{ inputs.ref }}
     - name: Notify in Slack
       uses: slackapi/slack-github-action@v2.0.0
       with:

--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -114,7 +114,7 @@ jobs:
         id: associated_pr
         uses: ./.github/actions/associated-pr
         with:
-          sha: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Check for skip label
         id: check_label

--- a/.github/workflows/auto-approval.yml
+++ b/.github/workflows/auto-approval.yml
@@ -21,7 +21,7 @@ jobs:
         id: associated-pr
         uses: ./.github/actions/associated-pr
         with:
-          sha: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Evaluate auto-approval criteria
         id: evaluate
         if: steps.associated-pr.outputs.number != '' && steps.associated-pr.outputs.closed != 'true'

--- a/.github/workflows/console-api-release.yml
+++ b/.github/workflows/console-api-release.yml
@@ -61,7 +61,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    needs: deploy-beta-sandbox
+    needs:
+      - setup
+      - deploy-beta-sandbox
     name: Test beta sandbox
     runs-on: ubuntu-latest
     steps:
@@ -72,6 +74,7 @@ jobs:
           CONSOLE_API_E2E_API_KEY: ${{ secrets.CONSOLE_API_E2E_BETA_SANDBOX_API_KEY }}
         with:
           app: api
+          app-version: ${{ needs.setup.outputs.image_tag }}
           app-url: ${{ vars.CONSOLE_WEB_BETA_URL }}/api-sandbox
           environment: staging
           chain: sandbox

--- a/.github/workflows/console-web-release.yml
+++ b/.github/workflows/console-web-release.yml
@@ -42,11 +42,14 @@ jobs:
 
   test-beta:
     runs-on: ubuntu-latest
-    needs: deploy-beta
+    needs:
+      - setup
+      - deploy-beta
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/console-web-ui-testing
         with:
+          ref: console-web/v${{ needs.setup.outputs.image_tag }}
           url: ${{ vars.CONSOLE_WEB_BETA_URL }}
           slack-webhook-url: ${{ secrets.FAILED_E2E_TESTS_SLACK_WEBHOOK_URL }}
           test-wallet-mnemonic: ${{ secrets.CONSOLE_WEB_E2E_TEST_WALLET_MNEMONIC }}

--- a/.github/workflows/provider-proxy-release.yml
+++ b/.github/workflows/provider-proxy-release.yml
@@ -61,7 +61,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    needs: deploy-beta-sandbox
+    needs:
+      - setup
+      - deploy-beta-sandbox
     name: Test beta sandbox
     runs-on: ubuntu-latest
     steps:
@@ -72,6 +74,7 @@ jobs:
           CONSOLE_API_BASE_URL: ${{ vars.CONSOLE_WEB_BETA_URL }}/api-sandbox
         with:
           app: provider-proxy
+          app-version: ${{ needs.setup.outputs.image_tag }}
           app-url: ${{ vars.CONSOLE_WEB_BETA_URL }}/provider-proxy-sandbox
           environment: staging
           chain: sandbox
@@ -81,7 +84,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    needs: deploy-beta-mainnet
+    needs:
+      - setup
+      - deploy-beta-mainnet
     name: Test beta mainnet
     runs-on: ubuntu-latest
     steps:
@@ -92,6 +97,7 @@ jobs:
           CONSOLE_API_BASE_URL: ${{ vars.CONSOLE_WEB_BETA_URL }}/api-mainnet
         with:
           app: provider-proxy
+          app-version: ${{ needs.setup.outputs.image_tag }}
           app-url: ${{ vars.CONSOLE_WEB_BETA_URL }}/provider-proxy-mainnet
           environment: staging
           chain: mainnet
@@ -135,7 +141,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-    needs: deploy-prod-sandbox
+    needs:
+      - setup
+      - deploy-prod-sandbox
     name: Test prod sandbox
     runs-on: ubuntu-latest
     steps:
@@ -146,6 +154,7 @@ jobs:
           CONSOLE_API_BASE_URL: ${{ vars.CONSOLE_WEB_URL }}/api-sandbox
         with:
           app: provider-proxy
+          app-version: ${{ needs.setup.outputs.image_tag }}
           app-url: ${{ vars.CONSOLE_WEB_URL }}/provider-proxy-sandbox
           environment: prod
           chain: sandbox


### PR DESCRIPTION
## Why

Right now, associated-pr always fetches PR from the main branch. This may cause incorrect identification when multiple PRs has been merged to main at about the same time

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI reliability by using a Git ref input, deriving commit SHAs when needed, adding retries with exponential backoff for PR lookups, and avoiding clearing outputs when no PR is found.
  * Test and release workflows now pass explicit app/version refs to test and notification steps.
  * Jobs reordered so setup completes before testing and deployment.

* **New Features**
  * Added Slack user mapping output for richer notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->