### PR TITLE
fix: fixes timeout for communication with provider-proxy

### DIFF
--- a/apps/api/src/provider/services/provider/provider-proxy.service.spec.ts
+++ b/apps/api/src/provider/services/provider/provider-proxy.service.spec.ts
@@ -7,8 +7,6 @@ import type { ProviderProxyPayload } from "./provider-proxy.service";
 import { ProviderProxyService } from "./provider-proxy.service";
 
 describe(ProviderProxyService.name, () => {
-  const MAX_TIMEOUT = 30_000;
-
   describe("request", () => {
     it("sends POST request to / with mapped payload and returns response data", async () => {
       const { httpClient, service, url, options } = setup();
@@ -58,17 +56,7 @@ describe(ProviderProxyService.name, () => {
 
       await service.request(url, options);
 
-      expect(httpClient.post).toHaveBeenCalledWith("/", expect.objectContaining({ timeout }), { timeout });
-    });
-
-    it("caps timeout to max when it exceeds the limit", async () => {
-      const timeout = MAX_TIMEOUT + 10_000;
-      const { httpClient, service, url, options } = setup({ timeout });
-      httpClient.post.mockResolvedValue({ data: {} });
-
-      await service.request(url, options);
-
-      expect(httpClient.post).toHaveBeenCalledWith("/", expect.objectContaining({ timeout: MAX_TIMEOUT }), { timeout: MAX_TIMEOUT });
+      expect(httpClient.post).toHaveBeenCalledWith("/", expect.objectContaining({ timeout }), { timeout: 5 * timeout });
     });
 
     it("does not include timeout when not provided", async () => {
@@ -78,7 +66,7 @@ describe(ProviderProxyService.name, () => {
       await service.request(url, options);
 
       const [, payload, config] = httpClient.post.mock.calls[0];
-      expect(payload).not.toHaveProperty("timeout");
+      expect(payload).toHaveProperty("timeout", undefined);
       expect(config).toEqual({});
     });
   });

--- a/apps/api/src/provider/services/provider/provider.service.ts
+++ b/apps/api/src/provider/services/provider/provider.service.ts
@@ -6,7 +6,6 @@ import { add } from "date-fns";
 import assert from "http-assert";
 import createError from "http-errors";
 import { Op } from "sequelize";
-import { setTimeout as delay } from "timers/promises";
 import { singleton } from "tsyringe";
 
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
@@ -21,6 +20,8 @@ import { forEachInChunks } from "@src/utils/array/array";
 import { mapProviderToList } from "@src/utils/map/provider";
 import { AuditorService } from "../auditors/auditors.service";
 import { ProviderAttributesSchemaService } from "../provider-attributes-schema/provider-attributes-schema.service";
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
 @singleton()
 export class ProviderService {
@@ -87,7 +88,7 @@ export class ProviderService {
           auth: options.auth,
           chainNetwork: this.chainNetwork,
           providerIdentity: options.providerIdentity,
-          timeout: 30_000
+          timeout: 15_000
         });
 
         if (result) return result;
@@ -136,7 +137,7 @@ export class ProviderService {
       auth,
       chainNetwork: this.chainNetwork,
       providerIdentity,
-      timeout: 30000
+      timeout: 15000
     });
   }
 


### PR DESCRIPTION
## Why

The same timeout was passed to provider-proxy (which is per attempt timeout in case provider API doesn't respond) and to actual request timeout. This resulted in provider-proxy retries being ignored, in case of provider API timing out on the 1st attempt.

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted timeout configuration for provider operations, reducing timeout values from 30 to 15 seconds for manifest and lease operations.
  * Improved timeout scaling logic to better manage per-attempt and total timeout handling.

* **Tests**
  * Updated test suite to validate new timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->