### PR TITLE
feat: adds more db configuration options in api

### DIFF
--- a/apps/api/src/chain/providers/sequelize.provider.ts
+++ b/apps/api/src/chain/providers/sequelize.provider.ts
@@ -31,6 +31,10 @@ container.register(CHAIN_DB, {
     const dbUri = c.resolve(ChainConfigService).get("CHAIN_INDEXER_POSTGRES_DB_URI");
     return new Sequelize(dbUri, {
       dialectModule: pg,
+      dialectOptions: {
+        connectionTimeoutMillis: config.get("SEQUELIZE_CONNECTION_TIMEOUT"),
+        keepAlive: config.get("SEQUELIZE_KEEP_ALIVE")
+      },
       logging: msg => logger.write(msg),
       logQueryParameters: true,
       transactionType: DbTransaction.TYPES.IMMEDIATE,

--- a/apps/api/src/core/config/env.config.ts
+++ b/apps/api/src/core/config/env.config.ts
@@ -21,6 +21,11 @@ export const envSchema = z
     SEQUELIZE_POOL_IDLE: z.number({ coerce: true }).optional().default(30000),
     SEQUELIZE_POOL_ACQUIRE: z.number({ coerce: true }).optional().default(10000),
     SEQUELIZE_POOL_EVICT: z.number({ coerce: true }).optional().default(60000),
+    SEQUELIZE_CONNECTION_TIMEOUT: z.number({ coerce: true }).optional().default(3000),
+    SEQUELIZE_KEEP_ALIVE: z
+      .enum(["true", "false"])
+      .default("true")
+      .transform(value => value === "true"),
     DRIZZLE_MIGRATIONS_FOLDER: z.string().optional().default("./drizzle"),
     DEPLOYMENT_ENV: z.string().optional().default("production"),
     NETWORK: z.enum(["mainnet", "testnet", "sandbox"]).default("mainnet"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added configurable database connection settings via environment variables: connection timeout (default 3000 ms) and keep-alive behavior (enabled by default), allowing operators to tune DB connectivity for improved reliability across deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->