### PR TITLE
fix(config): make pg-boss pool size configurable

### DIFF
--- a/apps/api/src/core/config/env.config.ts
+++ b/apps/api/src/core/config/env.config.ts
@@ -12,6 +12,7 @@ export const envSchema = z
     NODE_ENV: z.enum(["development", "production", "test"]).optional().default("development"),
     POSTGRES_DB_URI: z.string(),
     POSTGRES_BACKGROUND_JOBS_SCHEMA: z.string().optional().default("pgboss"),
+    POSTGRES_BACKGROUND_JOBS_POOL_SIZE: z.number({ coerce: true }).optional().default(20),
     POSTGRES_MAX_CONNECTIONS: z.number({ coerce: true }).optional().default(20),
     POSTGRES_CONNECT_TIMEOUT: z.number({ coerce: true }).optional().default(5),
     POSTGRES_IDLE_TIMEOUT: z.number({ coerce: true }).optional().default(120),

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -26,7 +26,8 @@ export class JobQueueService implements Disposable {
       new PgBoss({
         connectionString: this.coreConfig.get("POSTGRES_DB_URI"),
         schema: this.coreConfig.get("POSTGRES_BACKGROUND_JOBS_SCHEMA"),
-        schedule: false
+        schedule: false,
+        max: this.coreConfig.get("POSTGRES_BACKGROUND_JOBS_POOL_SIZE")
       });
   }
 


### PR DESCRIPTION
## Why

pg-boss uses a default pool size of 10 connections, but the API registers 28 job workers (6 handlers, some with concurrency of 10). This may cause pool starvation under load — workers queue up waiting for connections, potentially leading to latency spikes on health checks and job processing.

## What

- Added `POSTGRES_BACKGROUND_JOBS_POOL_SIZE` env var (default: 20) to control pg-boss connection pool size
- Passed the configured pool size to the PgBoss constructor via the `max` option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable background job pool size via a new environment variable, with a default value of 20 connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->