### PR TITLE
test: refactor wallets-refill to be blockchain independent

### DIFF
--- a/apps/api/test/functional/wallets-refill.spec.ts
+++ b/apps/api/test/functional/wallets-refill.spec.ts
@@ -1,85 +1,80 @@
+import nock from "nock";
 import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { WalletController } from "@src/billing/controllers/wallet/wallet.controller";
 import type { BillingConfig } from "@src/billing/providers";
 import { BILLING_CONFIG } from "@src/billing/providers";
 import { UserWalletRepository } from "@src/billing/repositories";
-import { ManagedSignerService, ManagedUserWalletService } from "@src/billing/services";
-import { app } from "@src/rest-app";
+import { ManagedUserWalletService } from "@src/billing/services";
+import type { ApiPgDatabase } from "@src/core";
+import { CORE_CONFIG } from "@src/core";
+import { POSTGRES_DB, resolveTable } from "@src/core";
+import { UserRepository } from "@src/user/repositories";
 
-import { topUpWallet } from "@test/services/topUpWallet";
-import { WalletTestingService } from "@test/services/wallet-testing.service";
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { DeploymentGrantResponseSeeder } from "@test/seeders/deployment-grant-response.seeder";
+import { FeeAllowanceResponseSeeder } from "@test/seeders/fee-allowance-response.seeder";
 
 describe("Wallets Refill", () => {
-  beforeAll(async () => {
-    await topUpWallet();
+  const managedUserWalletService = container.resolve(ManagedUserWalletService);
+  const config = container.resolve<BillingConfig>(BILLING_CONFIG);
+  const walletController = container.resolve(WalletController);
+  const userWalletRepository = container.resolve(UserWalletRepository);
+  const userRepository = container.resolve(UserRepository);
+  const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+  const userWalletsTable = resolveTable("UserWallets");
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
   });
 
   describe("console refill-wallets", () => {
-    it("should refill wallets low on fee allowance", async () => {
-      const { managedUserWalletService, config, walletController, walletService, userWalletRepository } = setup();
-      const NUMBER_OF_WALLETS = 5;
-      const prepareRecords = Array.from({ length: NUMBER_OF_WALLETS }).map(async (_, index) => {
-        const records = await walletService.createUserAndWallet();
-        const { user, token } = records;
-        const { wallet } = records;
-        let walletRecord = await userWalletRepository.findById(wallet.id);
-
-        expect(wallet.creditAmount).toBe(config.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT);
-        expect(walletRecord?.feeAllowance).toBe(config.TRIAL_FEES_ALLOWANCE_AMOUNT);
-
-        const limits = {
-          fees: config.FEE_ALLOWANCE_REFILL_THRESHOLD
-        };
-        const managedSignerService = container.resolve(ManagedSignerService);
-        await managedUserWalletService.authorizeSpending(managedSignerService, {
-          address: wallet.address,
-          limits
-        });
-        walletRecord = await userWalletRepository.updateById(
-          wallet.id,
-          {
-            feeAllowance: limits.fees,
-            isTrialing: index === NUMBER_OF_WALLETS - 1
-          },
-          { returning: true }
-        );
-
-        expect(walletRecord.feeAllowance).toBe(config.FEE_ALLOWANCE_REFILL_THRESHOLD);
-        expect(wallet.isTrialing).toBe(true);
-
-        return { user, token, wallet };
-      });
-
-      const records = await Promise.all(prepareRecords);
+    it("refills wallets low on fee allowance", async () => {
+      const wallets = await setup();
 
       await walletController.refillWallets();
 
-      await new Promise(resolve => setTimeout(resolve, 1000));
-
       await Promise.all(
-        records.map(async ({ wallet }) => {
+        wallets.map(async wallet => {
           const walletRecord = await userWalletRepository.findById(wallet.id);
-
           expect(walletRecord?.feeAllowance).toBe(config.FEE_ALLOWANCE_REFILL_AMOUNT);
         })
       );
     });
   });
 
-  function setup() {
-    const managedUserWalletService = container.resolve(ManagedUserWalletService);
-    const config = container.resolve<BillingConfig>(BILLING_CONFIG);
-    const walletController = container.resolve(WalletController);
-    const walletService = new WalletTestingService(app);
-    const userWalletRepository = container.resolve(UserWalletRepository);
+  async function setup() {
+    vi.spyOn(managedUserWalletService, "authorizeSpending").mockResolvedValue(undefined);
 
-    return {
-      managedUserWalletService,
-      config,
-      walletController,
-      walletService,
-      userWalletRepository
-    };
+    nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
+      .persist()
+      .get(/\/cosmos\/feegrant\/v1beta1\/allowance\/.*\/.*/)
+      .reply(200, FeeAllowanceResponseSeeder.create({ amount: String(config.FEE_ALLOWANCE_REFILL_AMOUNT) }));
+
+    nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
+      .persist()
+      .get(/\/cosmos\/authz\/v1beta1\/grants\?.*/)
+      .reply(200, DeploymentGrantResponseSeeder.create({ amount: String(config.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT) }));
+
+    const NUMBER_OF_WALLETS = 5;
+    return Promise.all(
+      Array.from({ length: NUMBER_OF_WALLETS }).map(async (_, index) => {
+        const user = await userRepository.create({});
+        const address = createAkashAddress();
+        const [wallet] = await db
+          .insert(userWalletsTable)
+          .values({
+            userId: user.id,
+            address,
+            isTrialing: index === NUMBER_OF_WALLETS - 1,
+            deploymentAllowance: String(config.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT),
+            feeAllowance: String(config.FEE_ALLOWANCE_REFILL_THRESHOLD)
+          })
+          .returning();
+        return wallet;
+      })
+    );
   }
 });


### PR DESCRIPTION
## Why

The `wallets-refill.spec.ts` functional test required a live blockchain connection to run. It called `topUpWallet()` to fund the master wallet and used `WalletTestingService.createUserAndWallet()` which performs real blockchain transactions (fee grants, deployment grants). This made the test slow, unreliable in isolated environments, and dependent on external network availability.

## What

- Remove `topUpWallet()` call and `beforeAll` hook
- Remove `WalletTestingService` and `ManagedSignerService` dependencies
- Create user wallets directly in the database using Drizzle with `feeAllowance` set to the refill threshold, bypassing blockchain setup
- Mock `managedUserWalletService.authorizeSpending()` with `vi.spyOn` to skip blockchain transactions
- Use nock to intercept REST API calls made by `refreshUserWalletLimits()` (fee allowance and deployment grant endpoints), returning the expected refill amount
- Add `afterEach` cleanup with `vi.restoreAllMocks()` and `nock.cleanAll()`
- Import vitest utilities explicitly (`afterEach`, `describe`, `expect`, `it`, `vi`)
- Move `setup()` function to bottom of `describe` block following project conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored wallet refill functional tests for better maintainability and isolation.
  * Moved per-wallet creation into a dedicated setup that seeds multiple wallets.
  * Added API mocks for external endpoints and per-test cleanup to restore/clear mocks.
  * Simplified test flow to call a consolidated refill operation and assert resulting fee allowances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->