### PR TITLE
feat(observability): logs healthcheck timeouts

### DIFF
--- a/apps/api/src/healthz/config/env.config.ts
+++ b/apps/api/src/healthz/config/env.config.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const envSchema = z.object({
+  HEALTHZ_TIMEOUT_SECONDS: z.number({ coerce: true }).optional().default(10)
+});
+
+export type HealthzConfig = z.infer<typeof envSchema>;

--- a/apps/api/src/healthz/providers/config.provider.ts
+++ b/apps/api/src/healthz/providers/config.provider.ts
@@ -1,0 +1,14 @@
+import type { InjectionToken } from "tsyringe";
+import { container, instancePerContainerCachingFactory } from "tsyringe";
+
+import { RAW_APP_CONFIG } from "@src/core/providers/raw-app-config.provider";
+import type { HealthzConfig } from "../config/env.config";
+import { envSchema } from "../config/env.config";
+
+export const HEALTHZ_CONFIG: InjectionToken<HealthzConfig> = Symbol("HEALTHZ_CONFIG");
+
+container.register(HEALTHZ_CONFIG, {
+  useFactory: instancePerContainerCachingFactory(c => envSchema.parse(c.resolve(RAW_APP_CONFIG)))
+});
+
+export type { HealthzConfig };

--- a/apps/api/src/healthz/services/healthz-config/healthz-config.service.ts
+++ b/apps/api/src/healthz/services/healthz-config/healthz-config.service.ts
@@ -1,0 +1,13 @@
+import { inject, singleton } from "tsyringe";
+
+import { ConfigService } from "@src/core/services/config/config.service";
+import type { HealthzConfig } from "../../config/env.config";
+import { envSchema } from "../../config/env.config";
+import { HEALTHZ_CONFIG } from "../../providers/config.provider";
+
+@singleton()
+export class HealthzConfigService extends ConfigService<typeof envSchema> {
+  constructor(@inject(HEALTHZ_CONFIG) config: HealthzConfig) {
+    super({ config });
+  }
+}

--- a/apps/api/src/healthz/services/healthz/healthz.service.spec.ts
+++ b/apps/api/src/healthz/services/healthz/healthz.service.spec.ts
@@ -3,6 +3,7 @@ import { millisecondsInMinute } from "date-fns";
 import { mock } from "vitest-mock-extended";
 
 import type { DbHealthcheck, JobQueueHealthcheck } from "@src/core";
+import type { HealthzConfigService } from "@src/healthz/services/healthz-config/healthz-config.service";
 import { HealthzService } from "./healthz.service";
 
 describe(HealthzService.name, () => {
@@ -197,7 +198,9 @@ describe(HealthzService.name, () => {
     const logger = mock<LoggerService>();
     const dbHealthcheck = mock<DbHealthcheck>({ ping: jest.fn().mockResolvedValue(undefined) });
     const jobQueueHealthcheck = mock<JobQueueHealthcheck>({ ping: jest.fn().mockResolvedValue(undefined) });
-    const healthzService = new HealthzService(dbHealthcheck, jobQueueHealthcheck, logger);
+    const healthzConfigService = mock<HealthzConfigService>();
+    healthzConfigService.get.calledWith("HEALTHZ_TIMEOUT_SECONDS").mockReturnValue(10);
+    const healthzService = new HealthzService(dbHealthcheck, jobQueueHealthcheck, healthzConfigService, logger);
 
     return {
       logger,


### PR DESCRIPTION
## Why

We log http requests only on completion. Meaning if there is a timeout and a restart we would not see the log for it. We need to see if healthchecks are timeouting to better identify the root of the issue.

## What

Adds logging for a healthcheck if it timeouts based on the configurable timeout value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable timeout monitoring for health checks with automatic logging of slow-running checks.

* **Tests**
  * Updated health check tests to support new timeout configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->