### PR TITLE
fix(deployment): detect closed deployments in auto-top-up cycle

### DIFF
--- a/apps/api/src/deployment/repositories/lease/lease.repository.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.ts
@@ -63,7 +63,8 @@ export class LeaseRepository implements DrainingDeploymentLeaseSource {
       where: {
         predictedClosedHeight: { [Op.lte]: closureHeight },
         owner,
-        dseq: { [Op.in]: dseqs }
+        dseq: { [Op.in]: dseqs },
+        closedHeight: null
       },
       attributes: [
         "dseq",

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -57,18 +57,15 @@ export class DrainingDeploymentService {
             const deployment = byDseqOwner[Number(deploymentSetting.dseq)];
 
             if (!deployment) {
+              acc[1].push(deploymentSetting.id);
               return acc;
             }
 
-            if (deployment.closedHeight) {
-              acc[1].push(deploymentSetting.id);
-            } else {
-              acc[0].push({
-                ...deploymentSetting,
-                predictedClosedHeight: deployment.predictedClosedHeight,
-                blockRate: deployment.blockRate
-              });
-            }
+            acc[0].push({
+              ...deploymentSetting,
+              predictedClosedHeight: deployment.predictedClosedHeight,
+              blockRate: deployment.blockRate
+            });
             return acc;
           },
           [[], []]


### PR DESCRIPTION
## Why

When the auto-top-up lease lookup was migrated from indexer-only to RPC-first with indexer fallback, a bug was introduced: closed deployments became invisible to the sync logic.

The RPC service filters leases by `state === "active"`, so closed deployments are excluded from results. Previously, the indexer DB path could detect them via `closedHeight`, but:
1. On the RPC path (primary), closed deployments were silently skipped every cycle without ever being marked as `closed` in the local `DeploymentSettings` table
2. On the DB fallback path, the `predictedClosedHeight <= closureHeight` filter could also miss manually-closed deployments that still had a high predicted closure height

This caused stale deployment settings to accumulate and be re-queried on every auto-top-up cycle.

## What

- **`draining-deployment.service.ts`**: Deployment settings with no matching active lease are now marked as `closed: true` instead of being silently skipped. Removed the `closedHeight` branch since data sources now only return active leases.
- **`lease.repository.ts`**: Added `closedHeight: null` filter to the DB query so it only returns active (non-closed) leases, consistent with the RPC service behavior.
- **`draining-deployment.service.spec.ts`**: Updated test to exercise the new "missing from lease results = closed" logic using an owner with multiple deployment settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking and filtering of closed deployments to ensure accurate status updates.
  * Enhanced logic for marking missing deployments as closed during the draining process.

* **Tests**
  * Updated test scenarios to reflect refined deployment closure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->