### PR TITLE
fix(deployment): prevent auto-top-up from falsely marking active deployments as closed

### DIFF
--- a/apps/api/src/deployment/repositories/lease/lease.repository.spec.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.spec.ts
@@ -1,0 +1,90 @@
+import { Lease } from "@akashnetwork/database/dbSchemas/akash";
+import { describe, expect, it, vi } from "vitest";
+
+import { LeaseRepository } from "./lease.repository";
+
+vi.mock("@akashnetwork/database/dbSchemas/akash", () => ({
+  Lease: {
+    findAll: vi.fn(),
+    findAndCountAll: vi.fn()
+  }
+}));
+
+describe(LeaseRepository.name, () => {
+  describe("findActiveDseqsByOwner", () => {
+    it("returns empty set when dseqs is empty", async () => {
+      const { repo } = setup();
+      const result = await repo.findActiveDseqsByOwner("owner1", []);
+      expect(result).toEqual(new Set());
+      expect(Lease.findAll).not.toHaveBeenCalled();
+    });
+
+    it("returns set of active dseqs", async () => {
+      const { repo } = setup();
+      vi.mocked(Lease.findAll).mockResolvedValue([{ dseq: "100" }, { dseq: "200" }] as never);
+
+      const result = await repo.findActiveDseqsByOwner("owner1", ["100", "200", "300"]);
+
+      expect(result).toEqual(new Set(["100", "200"]));
+      expect(Lease.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ owner: "owner1", closedHeight: null }),
+          raw: true
+        })
+      );
+    });
+  });
+
+  describe("findManyByDseqAndOwner", () => {
+    it("returns empty result when dseqs is empty", async () => {
+      const { repo } = setup();
+      const result = await repo.findManyByDseqAndOwner(1000000, "owner1", []);
+      expect(result).toEqual({ drainingDeployments: [], activeDseqs: new Set() });
+      expect(Lease.findAll).not.toHaveBeenCalled();
+    });
+
+    it("returns draining deployments and active dseqs", async () => {
+      const { repo } = setup();
+      const drainingLease = { dseq: 100, owner: "owner1", denom: "uakt", predictedClosedHeight: 999000, closedHeight: null, blockRate: 50 };
+
+      vi.mocked(Lease.findAll)
+        .mockResolvedValueOnce([drainingLease] as never)
+        .mockResolvedValueOnce([{ dseq: "100" }, { dseq: "200" }] as never);
+
+      const result = await repo.findManyByDseqAndOwner(1000000, "owner1", ["100", "200"]);
+
+      expect(result.drainingDeployments).toEqual([drainingLease]);
+      expect(result.activeDseqs).toEqual(new Set(["100", "200"]));
+    });
+
+    it("handles single object result from findAll", async () => {
+      const { repo } = setup();
+      const singleLease = { dseq: 100, owner: "owner1", denom: "uakt", predictedClosedHeight: 999000, closedHeight: null, blockRate: 50 };
+
+      vi.mocked(Lease.findAll)
+        .mockResolvedValueOnce(singleLease as never)
+        .mockResolvedValueOnce([{ dseq: "100" }] as never);
+
+      const result = await repo.findManyByDseqAndOwner(1000000, "owner1", ["100"]);
+
+      expect(result.drainingDeployments).toEqual([singleLease]);
+    });
+
+    it("handles null/undefined result from findAll", async () => {
+      const { repo } = setup();
+      vi.mocked(Lease.findAll)
+        .mockResolvedValueOnce(null as never)
+        .mockResolvedValueOnce([] as never);
+
+      const result = await repo.findManyByDseqAndOwner(1000000, "owner1", ["100"]);
+
+      expect(result.drainingDeployments).toEqual([]);
+    });
+  });
+
+  function setup() {
+    vi.clearAllMocks();
+    const repo = new LeaseRepository();
+    return { repo };
+  }
+});

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -90,7 +90,9 @@ describe(DrainingDeploymentService.name, () => {
 
       expect(leaseRepository.findManyByDseqAndOwner).not.toHaveBeenCalled();
       expect(loggerService.error).not.toHaveBeenCalled();
-      expect(deploymentSettingRepository.updateManyById).toHaveBeenCalledWith([settings1[1].id], { closed: true });
+      expect(deploymentSettingRepository.updateManyById).toHaveBeenCalledTimes(2);
+      expect(deploymentSettingRepository.updateManyById).toHaveBeenNthCalledWith(1, [settings1[1].id], { closed: true });
+      expect(deploymentSettingRepository.updateManyById).toHaveBeenNthCalledWith(2, [settings3[0].id], { closed: true });
 
       expect(callback).toHaveBeenCalledTimes(2);
       expect(callback).toHaveBeenNthCalledWith(

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -33,8 +33,14 @@ describe(DrainingDeploymentService.name, () => {
       const address3 = createAkashAddress();
 
       const settings1 = AutoTopUpDeploymentSeeder.createMany(2, { address: address1 });
+      settings1[0].dseq = "200001";
+      settings1[1].dseq = "200002";
       const settings2 = AutoTopUpDeploymentSeeder.createMany(1, { address: address2 });
+      settings2[0].dseq = "200003";
       const settings3 = AutoTopUpDeploymentSeeder.createMany(1, { address: address3 });
+      settings3[0].dseq = "200004";
+
+      const normalizeDseq = (dseq: string) => String(Number(dseq));
 
       const result1: LeaseQueryResult = {
         drainingDeployments: [
@@ -46,7 +52,7 @@ describe(DrainingDeploymentService.name, () => {
             predictedClosedHeight: faker.number.int({ min: 900000, max: 1000000 })
           }
         ],
-        activeDseqs: new Set([settings1[0].dseq])
+        activeDseqs: new Set([normalizeDseq(settings1[0].dseq)])
       };
 
       const result2: LeaseQueryResult = {
@@ -59,7 +65,7 @@ describe(DrainingDeploymentService.name, () => {
             predictedClosedHeight: faker.number.int({ min: 900000, max: 1000000 })
           }
         ],
-        activeDseqs: new Set([settings2[0].dseq])
+        activeDseqs: new Set([normalizeDseq(settings2[0].dseq)])
       };
 
       const result3: LeaseQueryResult = {
@@ -118,6 +124,8 @@ describe(DrainingDeploymentService.name, () => {
 
       const address = createAkashAddress();
       const settings = AutoTopUpDeploymentSeeder.createMany(2, { address });
+      settings[0].dseq = "300001";
+      settings[1].dseq = "300002";
 
       const normalizeDseq = (dseq: string) => String(Number(dseq));
 
@@ -156,6 +164,8 @@ describe(DrainingDeploymentService.name, () => {
 
       const address = createAkashAddress();
       const settings = AutoTopUpDeploymentSeeder.createMany(2, { address });
+      settings[0].dseq = "400001";
+      settings[1].dseq = "400002";
 
       const result: LeaseQueryResult = {
         drainingDeployments: [],
@@ -184,6 +194,9 @@ describe(DrainingDeploymentService.name, () => {
 
       const address = createAkashAddress();
       const settings = AutoTopUpDeploymentSeeder.createMany(3, { address });
+      settings[0].dseq = "100001";
+      settings[1].dseq = "100002";
+      settings[2].dseq = "100003";
 
       const normalizeDseq = (dseq: string) => String(Number(dseq));
 

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -53,7 +53,8 @@ export class DrainingDeploymentService {
       const byDseq = keyBy(drainingDeployments, "dseq");
       const [active, closedIds] = deploymentSettings.reduce<[DrainingDeployment[], string[]]>(
         (acc, deploymentSetting) => {
-          const deployment = byDseq[Number(deploymentSetting.dseq)];
+          const normalizedDseq = String(Number(deploymentSetting.dseq));
+          const deployment = byDseq[normalizedDseq];
 
           if (deployment) {
             acc[0].push({
@@ -61,7 +62,7 @@ export class DrainingDeploymentService {
               predictedClosedHeight: deployment.predictedClosedHeight,
               blockRate: deployment.blockRate
             });
-          } else if (!activeDseqs.has(deploymentSetting.dseq)) {
+          } else if (!activeDseqs.has(normalizedDseq)) {
             acc[1].push(deploymentSetting.id);
           }
 

--- a/apps/api/src/deployment/types/draining-deployment.ts
+++ b/apps/api/src/deployment/types/draining-deployment.ts
@@ -12,6 +12,11 @@ export type RpcDeploymentInfo = {
   createdHeight: number;
 };
 
+export interface LeaseQueryResult {
+  drainingDeployments: DrainingDeploymentOutput[];
+  activeDseqs: Set<string>;
+}
+
 export interface DrainingDeploymentLeaseSource {
-  findManyByDseqAndOwner(closureHeight: number, owner: string, dseqs: string[]): Promise<DrainingDeploymentOutput[]>;
+  findManyByDseqAndOwner(closureHeight: number, owner: string, dseqs: string[]): Promise<LeaseQueryResult>;
 }


### PR DESCRIPTION
## Why

PR #2835 introduced a regression where active deployments with sufficient escrow get incorrectly marked as `closed: true` in `deployment_settings`. This happens because `findLeases()` filters by `predictedClosedHeight <= closureHeight`, excluding healthy deployments. The reduce logic in `findDrainingDeploymentsByOwner()` then treats "absent from draining results" as "closed on-chain," permanently removing those deployments from future auto-top-up cycles.

## What

Returns the set of **all active dseqs** alongside the filtered draining results from both the RPC and DB paths. The caller now uses a three-way branch:

- **In draining results** → top up
- **In active dseqs but not draining** → skip (leave `closed = false`)
- **Not in active dseqs** → mark `closed: true` (truly closed on-chain)

### Changes

- Added `LeaseQueryResult` type (`{ drainingDeployments, activeDseqs }`) to `draining-deployment.ts`
- **RPC service**: extracts `activeDseqs` from existing `leaseMap` keys (zero extra RPC calls)
- **DB fallback**: added `findActiveDseqsByOwner()` — lightweight `SELECT DISTINCT dseq WHERE closedHeight IS NULL`
- **`findDrainingDeploymentsByOwner()`**: three-way reduce logic replaces the old two-way (draining vs closed) assumption
- **`#findDrainingDeployments`**: destructures only `.drainingDeployments` (cost calculations unaffected)

### Tests added

- "returns active dseqs for deployments not in draining window"
- "does not mark active but non-draining deployments as closed"
- "marks all deployments as closed when none are active on-chain"
- "handles mix of draining, healthy, and closed deployments correctly"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Deployment queries now return a unified result that includes draining deployments and a set of active deployment sequence identifiers, with consistent empty-result behavior and parallelized retrieval for faster, more reliable closure detection.

* **Tests**
  * Test suites updated to validate the new result shape and to distinguish draining vs. active deployments in various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->