### PR TITLE
fix(deployment): include closed deployments in RPC response for auto-top-up

### DIFF
--- a/apps/api/src/deployment/config/env.config.ts
+++ b/apps/api/src/deployment/config/env.config.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 
 export const envSchema = z.object({
-  AUTO_TOP_UP_JOB_INTERVAL_IN_H: z.number({ coerce: true }).optional().default(1),
-  AUTO_TOP_UP_DEPLOYMENT_INTERVAL_IN_H: z.number({ coerce: true }).optional().default(3),
+  AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: z.number({ coerce: true }).optional().default(24),
+  AUTO_TOP_UP_AMOUNT_IN_H: z.number({ coerce: true }).optional().default(48),
   PROVIDER_PROXY_URL: z.string().url(),
   GPU_BOT_WALLET_MNEMONIC: z.string().optional()
 });

--- a/apps/api/src/deployment/repositories/lease/lease.repository.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.ts
@@ -63,8 +63,7 @@ export class LeaseRepository implements DrainingDeploymentLeaseSource {
       where: {
         predictedClosedHeight: { [Op.lte]: closureHeight },
         owner,
-        dseq: { [Op.in]: dseqs },
-        closedHeight: null
+        dseq: { [Op.in]: dseqs }
       },
       attributes: [
         "dseq",

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
@@ -104,7 +104,7 @@ describe(DeploymentSettingService.name, () => {
     const userWalletRepository = mock<UserWalletRepository>();
 
     const config = mockConfigService<DeploymentConfigService>({
-      AUTO_TOP_UP_JOB_INTERVAL_IN_H: 1
+      AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 24
     });
 
     const service = new DeploymentSettingService(

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
@@ -10,6 +10,7 @@ import type { WalletReloadJobService } from "@src/billing/services/wallet-reload
 import type { DeploymentSettingRepository, DeploymentSettingsOutput } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import type { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import type { DrainingDeploymentService } from "../draining-deployment/draining-deployment.service";
+import type { TopUpManagedDeploymentsInstrumentationService } from "../top-up-managed-deployments/top-up-managed-deployments-instrumentation.service";
 import { DeploymentSettingService } from "./deployment-setting.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
@@ -102,6 +103,7 @@ describe(DeploymentSettingService.name, () => {
     const drainingDeploymentService = mock<DrainingDeploymentService>();
     const walletReloadJobService = mock<WalletReloadJobService>();
     const userWalletRepository = mock<UserWalletRepository>();
+    const instrumentation = mock<TopUpManagedDeploymentsInstrumentationService>();
 
     const config = mockConfigService<DeploymentConfigService>({
       AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 24
@@ -113,7 +115,8 @@ describe(DeploymentSettingService.name, () => {
       drainingDeploymentService,
       walletReloadJobService,
       config,
-      userWalletRepository
+      userWalletRepository,
+      instrumentation
     );
 
     return {
@@ -123,7 +126,8 @@ describe(DeploymentSettingService.name, () => {
       drainingDeploymentService,
       walletReloadJobService,
       config,
-      userWalletRepository
+      userWalletRepository,
+      instrumentation
     };
   }
 });

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
@@ -22,7 +22,8 @@ type DeploymentSettingWithEstimatedTopUpAmount = DeploymentSettingsOutput & { es
 export class DeploymentSettingService {
   private readonly logger = createOtelLogger({ context: DeploymentSettingService.name });
 
-  private readonly topUpFrequencyMs = this.config.get("AUTO_TOP_UP_JOB_INTERVAL_IN_H") * millisecondsInHour;
+  private readonly topUpFrequencyMs = this.config.get("AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H") * millisecondsInHour;
+
   constructor(
     private readonly deploymentSettingRepository: DeploymentSettingRepository,
     private readonly authService: AuthService,

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
@@ -59,7 +59,7 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
         pagination: { limit: 1000, key: nextKey || undefined }
       });
 
-      const filteredItems = response.leases.filter(lease => lease.lease.state === "active" && dseqSet.has(lease.lease.id.dseq));
+      const filteredItems = response.leases.filter(lease => dseqSet.has(lease.lease.id.dseq));
       allItems.push(...filteredItems);
       nextKey = response.pagination.next_key;
     } while (nextKey);
@@ -86,7 +86,7 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
       });
 
       const filteredItems = response.deployments
-        .filter(deployment => deployment.deployment.state === "active" && dseqSet.has(deployment.deployment.id.dseq))
+        .filter(deployment => dseqSet.has(deployment.deployment.id.dseq))
         .map(deployment => ({
           dseq: deployment.deployment.id.dseq,
           createdHeight: Number(deployment.deployment.created_at),
@@ -130,17 +130,21 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
 
       const denom = rpcLease.escrow_payment.state.rate.denom;
       const rateAmount = Number(rpcLease.escrow_payment.state.rate.amount);
+      const closedHeight = rpcLease.lease.closed_on && rpcLease.lease.closed_on !== "0" ? Number(rpcLease.lease.closed_on) : undefined;
 
       const existing = leaseMap.get(dseq);
       if (existing) {
         existing.blockRate += rateAmount;
+        if (!closedHeight) {
+          existing.closedHeight = undefined;
+        }
       } else {
         leaseMap.set(dseq, {
           dseq: Number(dseq),
           owner,
           denom,
           blockRate: rateAmount,
-          closedHeight: rpcLease.lease.closed_on && rpcLease.lease.closed_on !== "0" ? Number(rpcLease.lease.closed_on) : undefined
+          closedHeight
         });
       }
     }

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -171,13 +171,13 @@ describe(DrainingDeploymentService.name, () => {
     it("calculates amount for integer block rate", async () => {
       const { service } = setup();
       const result = await service.calculateTopUpAmount({ blockRate: 50 });
-      expect(result).toBe(90000);
+      expect(result).toBe(1440000);
     });
 
     it("floors decimal block rate", async () => {
       const { service } = setup();
       const result = await service.calculateTopUpAmount({ blockRate: 10.7 });
-      expect(result).toBe(19260);
+      expect(result).toBe(308160);
     });
   });
 
@@ -535,8 +535,8 @@ describe(DrainingDeploymentService.name, () => {
     rpcService.findManyByDseqAndOwner.mockResolvedValue([]);
 
     const config = mockConfigService<DeploymentConfigService>({
-      AUTO_TOP_UP_JOB_INTERVAL_IN_H: 1,
-      AUTO_TOP_UP_DEPLOYMENT_INTERVAL_IN_H: 3
+      AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H: 24,
+      AUTO_TOP_UP_AMOUNT_IN_H: 48
     });
 
     const service = new DrainingDeploymentService(

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -3,6 +3,7 @@ import "@test/mocks/logger-service.mock";
 import type { AnyAbility } from "@casl/ability";
 import { faker } from "@faker-js/faker";
 import { addWeeks } from "date-fns";
+import { groupBy } from "lodash";
 import { mock } from "vitest-mock-extended";
 
 import type { UserWalletRepository } from "@src/billing/repositories";
@@ -24,44 +25,57 @@ import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
 describe(DrainingDeploymentService.name, () => {
   describe("findDrainingDeploymentsByOwner", () => {
-    it("paginates draining deployments by owner and marks missing ones as closed", async () => {
-      const { service, deploymentSettingRepository, leaseRepository, loggerService } = setup();
+    it("paginates draining deployments by owner and marks closed ones as such", async () => {
+      const { service, deploymentSettingRepository, leaseRepository, loggerService, currentHeight } = setup();
+      const deploymentSettings = AutoTopUpDeploymentSeeder.createMany(4);
+      const addresses = deploymentSettings.map(s => s.address);
+      const dseqs = deploymentSettings.map(s => Number(s.dseq));
 
-      const address1 = createAkashAddress();
-      const address2 = createAkashAddress();
-      const address3 = createAkashAddress();
+      const activeBatches: DrainingDeploymentOutput[][] = [
+        [
+          {
+            dseq: dseqs[0],
+            owner: addresses[0],
+            denom: "uakt",
+            blockRate: faker.number.int({ min: 50, max: 100 }),
+            predictedClosedHeight: faker.number.int({ min: 900000, max: 1000000 })
+          }
+        ],
+        [
+          {
+            dseq: dseqs[3],
+            owner: addresses[3],
+            denom: "uakt",
+            blockRate: faker.number.int({ min: 50, max: 100 }),
+            predictedClosedHeight: faker.number.int({ min: 900000, max: 1000000 })
+          }
+        ]
+      ];
 
-      const settings1 = AutoTopUpDeploymentSeeder.createMany(2, { address: address1 });
-      const settings2 = AutoTopUpDeploymentSeeder.createMany(1, { address: address2 });
-      const settings3 = AutoTopUpDeploymentSeeder.createMany(1, { address: address3 });
-
-      const activeLeases1: DrainingDeploymentOutput[] = [
+      const closedBatch: DrainingDeploymentOutput[] = [
         {
-          dseq: Number(settings1[0].dseq),
-          owner: address1,
+          dseq: dseqs[1],
+          owner: addresses[1],
           denom: "uakt",
           blockRate: faker.number.int({ min: 50, max: 100 }),
-          predictedClosedHeight: faker.number.int({ min: 900000, max: 1000000 })
+          predictedClosedHeight: currentHeight + 1000,
+          closedHeight: currentHeight - 100
         }
       ];
 
-      const activeLeases2: DrainingDeploymentOutput[] = [
-        {
-          dseq: Number(settings2[0].dseq),
-          owner: address2,
-          denom: "uakt",
-          blockRate: faker.number.int({ min: 50, max: 100 }),
-          predictedClosedHeight: faker.number.int({ min: 900000, max: 1000000 })
-        }
-      ];
+      jest
+        .spyOn(service, "findLeases")
+        .mockResolvedValueOnce(activeBatches[0])
+        .mockResolvedValueOnce(closedBatch)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(activeBatches[1]);
 
-      jest.spyOn(service, "findLeases").mockResolvedValueOnce(activeLeases1).mockResolvedValueOnce(activeLeases2).mockResolvedValueOnce([]);
-
+      const deploymentSettingsByAddress = groupBy(deploymentSettings, "address");
       deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
         (async function* () {
-          yield { address: address1, deploymentSettings: settings1 };
-          yield { address: address2, deploymentSettings: settings2 };
-          yield { address: address3, deploymentSettings: settings3 };
+          for (const [address, settings] of Object.entries(deploymentSettingsByAddress)) {
+            yield { address, deploymentSettings: settings };
+          }
         })()
       );
 
@@ -72,33 +86,24 @@ describe(DrainingDeploymentService.name, () => {
 
       expect(leaseRepository.findManyByDseqAndOwner).not.toHaveBeenCalled();
       expect(loggerService.error).not.toHaveBeenCalled();
-      expect(deploymentSettingRepository.updateManyById).toHaveBeenCalledWith([settings1[1].id], { closed: true });
+      expect(deploymentSettingRepository.updateManyById).toHaveBeenCalledWith(expect.arrayContaining([expect.any(String)]), { closed: true });
 
-      expect(callback).toHaveBeenCalledTimes(2);
-      expect(callback).toHaveBeenNthCalledWith(
-        1,
-        expect.objectContaining({
-          address: address1,
-          deployments: expect.arrayContaining([
-            expect.objectContaining({
-              dseq: settings1[0].dseq,
-              address: address1
-            })
-          ])
-        })
-      );
-      expect(callback).toHaveBeenNthCalledWith(
-        2,
-        expect.objectContaining({
-          address: address2,
-          deployments: expect.arrayContaining([
-            expect.objectContaining({
-              dseq: settings2[0].dseq,
-              address: address2
-            })
-          ])
-        })
-      );
+      expect(callback).toHaveBeenCalledTimes(activeBatches.length);
+      activeBatches.forEach((batch, index) => {
+        const deployment = batch[0];
+        expect(callback).toHaveBeenNthCalledWith(
+          index + 1,
+          expect.objectContaining({
+            address: deployment.owner,
+            deployments: expect.arrayContaining([
+              expect.objectContaining({
+                dseq: deployment.dseq.toString(),
+                address: deployment.owner
+              })
+            ])
+          })
+        );
+      });
     });
   });
 

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -15,6 +15,7 @@ import type { DrainingDeploymentOutput, LeaseRepository } from "@src/deployment/
 import { averageBlockCountInAnHour } from "@src/utils/constants";
 import type { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import type { DrainingDeploymentRpcService } from "../draining-deployment-rpc/draining-deployment-rpc.service";
+import type { TopUpManagedDeploymentsInstrumentationService } from "../top-up-managed-deployments/top-up-managed-deployments-instrumentation.service";
 import { DrainingDeploymentService } from "./draining-deployment.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
@@ -539,6 +540,8 @@ describe(DrainingDeploymentService.name, () => {
       AUTO_TOP_UP_AMOUNT_IN_H: 48
     });
 
+    const instrumentation = mock<TopUpManagedDeploymentsInstrumentationService>();
+
     const service = new DrainingDeploymentService(
       blockHttpService,
       leaseRepository,
@@ -547,7 +550,8 @@ describe(DrainingDeploymentService.name, () => {
       config,
       loggerService,
       rpcService,
-      balancesService
+      balancesService,
+      instrumentation
     );
 
     return {

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -57,15 +57,18 @@ export class DrainingDeploymentService {
             const deployment = byDseqOwner[Number(deploymentSetting.dseq)];
 
             if (!deployment) {
-              acc[1].push(deploymentSetting.id);
               return acc;
             }
 
-            acc[0].push({
-              ...deploymentSetting,
-              predictedClosedHeight: deployment.predictedClosedHeight,
-              blockRate: deployment.blockRate
-            });
+            if (deployment.closedHeight) {
+              acc[1].push(deploymentSetting.id);
+            } else {
+              acc[0].push({
+                ...deploymentSetting,
+                predictedClosedHeight: deployment.predictedClosedHeight,
+                blockRate: deployment.blockRate
+              });
+            }
             return acc;
           },
           [[], []]

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -12,6 +12,7 @@ import { DrainingDeployment } from "@src/deployment/types/draining-deployment";
 import { averageBlockCountInAnHour } from "@src/utils/constants";
 import { DeploymentConfigService } from "../deployment-config/deployment-config.service";
 import { DrainingDeploymentRpcService } from "../draining-deployment-rpc/draining-deployment-rpc.service";
+import { TopUpManagedDeploymentsInstrumentationService } from "../top-up-managed-deployments/top-up-managed-deployments-instrumentation.service";
 
 export type { DrainingDeployment } from "@src/deployment/types/draining-deployment";
 
@@ -25,7 +26,8 @@ export class DrainingDeploymentService {
     private readonly config: DeploymentConfigService,
     private readonly loggerService: LoggerService,
     private readonly rpcService: DrainingDeploymentRpcService,
-    private readonly balancesService: BalancesService
+    private readonly balancesService: BalancesService,
+    private readonly instrumentation: TopUpManagedDeploymentsInstrumentationService
   ) {
     loggerService.setContext(DrainingDeploymentService.name);
   }
@@ -76,6 +78,7 @@ export class DrainingDeploymentService {
 
         if (missingIds.length) {
           await this.deploymentSettingRepository.updateManyById(missingIds, { closed: true });
+          this.instrumentation.recordDeploymentsMarkedClosed(missingIds.length);
         }
 
         if (active.length) {

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -40,7 +40,7 @@ export class DrainingDeploymentService {
    */
   async *findDrainingDeploymentsByOwner(): AsyncGenerator<{ address: string; deployments: DrainingDeployment[] }> {
     const currentHeight = await this.blockHttpService.getCurrentHeight();
-    const expectedClosureHeight = Math.floor(currentHeight + averageBlockCountInAnHour * 2 * this.config.get("AUTO_TOP_UP_JOB_INTERVAL_IN_H"));
+    const expectedClosureHeight = Math.floor(currentHeight + averageBlockCountInAnHour * this.config.get("AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H"));
 
     for await (const { address, deploymentSettings } of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
       if (deploymentSettings.length === 0) {
@@ -119,7 +119,7 @@ export class DrainingDeploymentService {
    * @returns Top-up amount in credits
    */
   async calculateTopUpAmount(deployment: Pick<DrainingDeploymentOutput, "blockRate">): Promise<number> {
-    return Math.floor(deployment.blockRate * (averageBlockCountInAnHour * this.config.get("AUTO_TOP_UP_DEPLOYMENT_INTERVAL_IN_H")));
+    return Math.floor(deployment.blockRate * (averageBlockCountInAnHour * this.config.get("AUTO_TOP_UP_AMOUNT_IN_H")));
   }
 
   /**

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
@@ -1,0 +1,84 @@
+import type { Counter, Histogram, Meter } from "@opentelemetry/api";
+import { singleton } from "tsyringe";
+
+import { MetricsService } from "@src/core";
+
+@singleton()
+export class TopUpManagedDeploymentsInstrumentationService {
+  private readonly meter: Meter;
+  private readonly jobExecutions: Counter;
+  private readonly jobDuration: Histogram;
+  private readonly depositsTotal: Counter;
+  private readonly depositErrors: Counter;
+  private readonly deploymentsMarkedClosed: Counter;
+  private readonly depositAmount: Histogram;
+  private readonly predictedCloseBlocks: Histogram;
+  private readonly settingToggles: Counter;
+
+  constructor(private readonly metricsService: MetricsService) {
+    this.meter = this.metricsService.getMeter("auto-top-up", "1.0.0");
+
+    this.jobExecutions = this.metricsService.createCounter(this.meter, "auto_top_up_job_executions_total", {
+      description: "Total number of auto top-up job executions"
+    });
+
+    this.jobDuration = this.metricsService.createHistogram(this.meter, "auto_top_up_job_duration_ms", {
+      description: "Duration of auto top-up job execution in milliseconds",
+      unit: "ms"
+    });
+
+    this.depositsTotal = this.metricsService.createCounter(this.meter, "auto_top_up_deposits_total", {
+      description: "Total number of successful deposit transactions"
+    });
+
+    this.depositErrors = this.metricsService.createCounter(this.meter, "auto_top_up_deposit_errors_total", {
+      description: "Total number of failed deposit attempts"
+    });
+
+    this.deploymentsMarkedClosed = this.metricsService.createCounter(this.meter, "auto_top_up_deployments_marked_closed_total", {
+      description: "Total number of deployments marked as closed by the auto top-up job"
+    });
+
+    this.depositAmount = this.metricsService.createHistogram(this.meter, "auto_top_up_deposit_amount", {
+      description: "Deposit amounts per transaction",
+      unit: "uakt"
+    });
+
+    this.predictedCloseBlocks = this.metricsService.createHistogram(this.meter, "auto_top_up_predicted_close_blocks", {
+      description: "Number of blocks until predicted closure at detection time"
+    });
+
+    this.settingToggles = this.metricsService.createCounter(this.meter, "auto_top_up_setting_toggles_total", {
+      description: "Total number of auto top-up setting enable/disable toggles"
+    });
+  }
+
+  recordJobExecution(durationMs: number, status: "success" | "failure"): void {
+    this.jobExecutions.add(1, { status });
+    this.jobDuration.record(durationMs, { status });
+  }
+
+  recordDeposit(amount: number): void {
+    this.depositsTotal.add(1);
+    this.depositAmount.record(amount);
+  }
+
+  recordDepositError(errorType: string): void {
+    this.depositErrors.add(1, { error_type: errorType });
+  }
+
+  recordDeploymentsMarkedClosed(count: number): void {
+    this.deploymentsMarkedClosed.add(count);
+  }
+
+  recordPredictedCloseBlocks(currentHeight: number, predictedClosedHeight: number): void {
+    const blocksUntilClose = predictedClosedHeight - currentHeight;
+    if (blocksUntilClose > 0) {
+      this.predictedCloseBlocks.record(blocksUntilClose);
+    }
+  }
+
+  recordSettingToggle(enabled: boolean): void {
+    this.settingToggles.add(1, { enabled: String(enabled) });
+  }
+}

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -1,0 +1,340 @@
+import { and, eq } from "drizzle-orm";
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { UserWalletRepository } from "@src/billing/repositories";
+import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import type { ApiPgDatabase } from "@src/core";
+import { CORE_CONFIG, POSTGRES_DB, resolveTable } from "@src/core";
+import { UserRepository } from "@src/user/repositories";
+import { TopUpManagedDeploymentsService } from "./top-up-managed-deployments.service";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { DeploymentInfoSeeder } from "@test/seeders/deployment-info.seeder";
+import { LeaseApiResponseSeeder } from "@test/seeders/lease-api-response.seeder";
+
+const CURRENT_HEIGHT = 1000000;
+const CLOSED_HEIGHT = String(CURRENT_HEIGHT - 500);
+const DENOM = "uakt";
+const BLOCK_RATE = 50;
+const ESCROW_AMOUNT = "50000";
+
+/**
+ * This test defines the business rules for the auto top-up job.
+ * Internal implementation changes (RPC queries, DB fallback, caching, etc.)
+ * should conform to these tests passing. Only update these tests
+ * when the business rules themselves change.
+ */
+describe(TopUpManagedDeploymentsService.name, () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  describe("topUpDeployments", () => {
+    // Owner has two deployment settings with auto top-up enabled.
+    // One deployment is active and draining, the other is closed on chain.
+    // The draining deployment should receive a deposit transaction.
+    // The closed deployment should be marked as closed in the DB to disable future top-ups.
+    it("tops up draining deployment and marks closed-on-chain deployment as closed", async () => {
+      const {
+        topUpService,
+        executeDerivedTx,
+        createUserWithWallet,
+        createDeploymentSetting,
+        findSetting,
+        mockLeasesForOwner,
+        mockDeploymentsForOwner,
+        stubGetFreshLimits
+      } = await setup();
+      const { user, wallet, address } = await createUserWithWallet();
+      const drainingDseq = "100001";
+      const closedOnChainDseq = "100002";
+
+      await createDeploymentSetting(user.id, drainingDseq);
+      await createDeploymentSetting(user.id, closedOnChainDseq);
+
+      mockLeasesForOwner(address, [createActiveLease(address, drainingDseq), createClosedLease(address, closedOnChainDseq)]);
+      mockDeploymentsForOwner(address, [createActiveDeployment(address, drainingDseq), createClosedDeployment(address, closedOnChainDseq)]);
+      stubGetFreshLimits({ [address]: 10000000 });
+
+      await topUpService.topUpDeployments({ dryRun: false });
+
+      expect(executeDerivedTx).toHaveBeenCalledOnce();
+      expect(executeDerivedTx).toHaveBeenCalledWith(
+        wallet.id,
+        expect.arrayContaining([
+          expect.objectContaining({
+            value: expect.objectContaining({ id: expect.objectContaining({ xid: expect.stringContaining(`/${drainingDseq}`) }) })
+          })
+        ])
+      );
+
+      const closedSetting = await findSetting(address, closedOnChainDseq);
+      expect(closedSetting?.closed).toBe(true);
+    });
+
+    // Owner has two active deployments on chain. One has low escrow and is predicted
+    // to close within the job's look-ahead window (draining). The other has a large escrow
+    // and won't close any time soon (not yet draining).
+    // Only the draining deployment should receive a deposit transaction.
+    it("tops up draining deployments and skips not-yet-draining ones", async () => {
+      const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
+        await setup();
+      const { user, wallet, address } = await createUserWithWallet();
+      const drainingDseq = "300001";
+      const notYetDrainingDseq = "300002";
+
+      await createDeploymentSetting(user.id, drainingDseq);
+      await createDeploymentSetting(user.id, notYetDrainingDseq);
+
+      mockLeasesForOwner(address, [createActiveLease(address, drainingDseq), createActiveLease(address, notYetDrainingDseq)]);
+      mockDeploymentsForOwner(address, [
+        createActiveDeployment(address, drainingDseq),
+        DeploymentInfoSeeder.create({
+          owner: address,
+          dseq: notYetDrainingDseq,
+          state: "active",
+          amount: "500000000",
+          denom: DENOM,
+          createdAt: String(CURRENT_HEIGHT - 100)
+        })
+      ]);
+      stubGetFreshLimits({ [address]: 10000000 });
+
+      await topUpService.topUpDeployments({ dryRun: false });
+
+      expect(executeDerivedTx).toHaveBeenCalledOnce();
+      expect(executeDerivedTx).toHaveBeenCalledWith(
+        wallet.id,
+        expect.arrayContaining([
+          expect.objectContaining({
+            value: expect.objectContaining({ id: expect.objectContaining({ xid: expect.stringContaining(`/${drainingDseq}`) }) })
+          })
+        ])
+      );
+      expect(executeDerivedTx).not.toHaveBeenCalledWith(
+        wallet.id,
+        expect.arrayContaining([
+          expect.objectContaining({
+            value: expect.objectContaining({ id: expect.objectContaining({ xid: expect.stringContaining(`/${notYetDrainingDseq}`) }) })
+          })
+        ])
+      );
+    });
+
+    // Owner has two deployment settings with auto top-up enabled, but both deployments
+    // are closed on chain. No transactions should be submitted.
+    // Both deployment settings should be marked as closed in the DB.
+    it("marks all deployment settings as closed when all deployments are closed on chain", async () => {
+      const {
+        topUpService,
+        executeDerivedTx,
+        createUserWithWallet,
+        createDeploymentSetting,
+        findSetting,
+        mockLeasesForOwner,
+        mockDeploymentsForOwner,
+        stubGetFreshLimits
+      } = await setup();
+      const { user, address } = await createUserWithWallet();
+      const closedOnChainDseq1 = "400001";
+      const closedOnChainDseq2 = "400002";
+
+      await createDeploymentSetting(user.id, closedOnChainDseq1);
+      await createDeploymentSetting(user.id, closedOnChainDseq2);
+
+      mockLeasesForOwner(address, [createClosedLease(address, closedOnChainDseq1), createClosedLease(address, closedOnChainDseq2)]);
+      mockDeploymentsForOwner(address, [createClosedDeployment(address, closedOnChainDseq1), createClosedDeployment(address, closedOnChainDseq2)]);
+      stubGetFreshLimits({ [address]: 10000000 });
+
+      await topUpService.topUpDeployments({ dryRun: false });
+
+      expect(executeDerivedTx).not.toHaveBeenCalled();
+
+      const setting1 = await findSetting(address, closedOnChainDseq1);
+      expect(setting1?.closed).toBe(true);
+      const setting2 = await findSetting(address, closedOnChainDseq2);
+      expect(setting2?.closed).toBe(true);
+    });
+
+    // Owner has two deployment settings: one with auto top-up explicitly disabled,
+    // and one already marked as closed in the DB from a previous run.
+    // Neither should be picked up by the job. No transactions should be submitted.
+    it("skips deployments with auto top-up disabled or already marked closed", async () => {
+      const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting } = await setup();
+      const { user } = await createUserWithWallet();
+      const disabledAutoTopUpDseq = "600001";
+      const alreadyMarkedClosedDseq = "600002";
+
+      await createDeploymentSetting(user.id, disabledAutoTopUpDseq, { autoTopUpEnabled: false });
+      await createDeploymentSetting(user.id, alreadyMarkedClosedDseq, { closed: true });
+
+      await topUpService.topUpDeployments({ dryRun: false });
+
+      expect(executeDerivedTx).not.toHaveBeenCalled();
+    });
+
+    // Owner has a draining deployment but their wallet's deployment allowance is zero.
+    // The CachedBalance.reserveSufficientAmount call throws "Insufficient balance",
+    // which the job catches and counts but does not propagate.
+    // No transactions should be submitted, and the job should still return Ok.
+    it("handles insufficient user balance by skipping the deployment", async () => {
+      const { topUpService, executeDerivedTx, createUserWithWallet, createDeploymentSetting, mockLeasesForOwner, mockDeploymentsForOwner, stubGetFreshLimits } =
+        await setup();
+      const { user, address } = await createUserWithWallet();
+      const drainingDseq = "700001";
+
+      await createDeploymentSetting(user.id, drainingDseq);
+
+      mockLeasesForOwner(address, [createActiveLease(address, drainingDseq)]);
+      mockDeploymentsForOwner(address, [createActiveDeployment(address, drainingDseq)]);
+      stubGetFreshLimits({ [address]: 0 });
+
+      const result = await topUpService.topUpDeployments({ dryRun: false });
+
+      expect(result.ok).toBe(true);
+      expect(executeDerivedTx).not.toHaveBeenCalled();
+    });
+  });
+
+  function createActiveLease(owner: string, dseq: string) {
+    return LeaseApiResponseSeeder.create({
+      owner,
+      dseq,
+      state: "active",
+      price: { denom: DENOM, amount: String(BLOCK_RATE) }
+    });
+  }
+
+  function createClosedLease(owner: string, dseq: string) {
+    return LeaseApiResponseSeeder.create({
+      owner,
+      dseq,
+      state: "closed",
+      price: { denom: DENOM, amount: String(BLOCK_RATE) },
+      closed_on: CLOSED_HEIGHT
+    });
+  }
+
+  function createActiveDeployment(owner: string, dseq: string) {
+    return DeploymentInfoSeeder.create({
+      owner,
+      dseq,
+      state: "active",
+      amount: ESCROW_AMOUNT,
+      denom: DENOM,
+      createdAt: String(CURRENT_HEIGHT - 1000)
+    });
+  }
+
+  function createClosedDeployment(owner: string, dseq: string) {
+    return DeploymentInfoSeeder.create({
+      owner,
+      dseq,
+      state: "closed",
+      amount: ESCROW_AMOUNT,
+      denom: DENOM,
+      createdAt: String(CURRENT_HEIGHT - 1000)
+    });
+  }
+
+  async function setup() {
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const userWalletsTable = resolveTable("UserWallets");
+    const deploymentSettingsTable = resolveTable("DeploymentSettings");
+    const userRepository = container.resolve(UserRepository);
+    const apiNodeUrl = container.resolve(CORE_CONFIG).REST_API_NODE_URL;
+    const topUpService = container.resolve(TopUpManagedDeploymentsService);
+    const signerService = container.resolve(ManagedSignerService);
+    const balances = container.resolve(BalancesService);
+
+    nock(apiNodeUrl)
+      .get("/cosmos/base/tendermint/v1beta1/blocks/latest")
+      .reply(200, { block: { header: { height: String(CURRENT_HEIGHT) } } })
+      .persist();
+
+    const executeDerivedTx = vi.spyOn(signerService, "executeDerivedTx").mockResolvedValue({
+      code: 0,
+      hash: "TESTHASH",
+      rawLog: "[]"
+    });
+
+    async function createUserWithWallet(input?: { address?: string; deploymentAllowance?: string }) {
+      const address = input?.address ?? createAkashAddress();
+      const user = await userRepository.create({});
+      const [wallet] = await db
+        .insert(userWalletsTable)
+        .values({
+          userId: user.id,
+          address,
+          deploymentAllowance: input?.deploymentAllowance ?? "10000000",
+          feeAllowance: "5000000",
+          isTrialing: false
+        })
+        .returning();
+
+      return { user, wallet, address };
+    }
+
+    async function createDeploymentSetting(userId: string, dseq: string, overrides?: { autoTopUpEnabled?: boolean; closed?: boolean }) {
+      const [setting] = await db
+        .insert(deploymentSettingsTable)
+        .values({
+          userId,
+          dseq,
+          autoTopUpEnabled: overrides?.autoTopUpEnabled ?? true,
+          closed: overrides?.closed ?? false
+        })
+        .returning();
+
+      return setting;
+    }
+
+    async function findSetting(address: string, dseq: string) {
+      const wallet = await container.resolve(UserWalletRepository).findOneBy({ address });
+      if (!wallet) return undefined;
+
+      const results = await db
+        .select()
+        .from(deploymentSettingsTable)
+        .where(and(eq(deploymentSettingsTable.dseq, dseq), eq(deploymentSettingsTable.userId, wallet.userId)));
+
+      return results[0];
+    }
+
+    function mockLeasesForOwner(owner: string, leases: ReturnType<typeof LeaseApiResponseSeeder.create>[]) {
+      nock(apiNodeUrl)
+        .get("/akash/market/v1beta5/leases/list")
+        .query(query => query["filters.owner"] === owner)
+        .reply(200, { leases, pagination: { next_key: null, total: String(leases.length) } });
+    }
+
+    function mockDeploymentsForOwner(owner: string, deployments: ReturnType<typeof DeploymentInfoSeeder.create>[]) {
+      nock(apiNodeUrl)
+        .get("/akash/deployment/v1beta4/deployments/list")
+        .query(query => String(query["filters.owner"]) === owner)
+        .reply(200, { deployments, pagination: { next_key: null, total: String(deployments.length) } });
+    }
+
+    function stubGetFreshLimits(balanceByAddress: Record<string, number>) {
+      vi.spyOn(balances, "getFreshLimits").mockImplementation(async (wallet: { address: string | null }) => ({
+        fee: 5000000,
+        deployment: balanceByAddress[wallet.address!] ?? 0
+      }));
+    }
+
+    return {
+      topUpService,
+      executeDerivedTx,
+      createUserWithWallet,
+      createDeploymentSetting,
+      findSetting,
+      mockLeasesForOwner,
+      mockDeploymentsForOwner,
+      stubGetFreshLimits
+    };
+  }
+});

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -15,6 +15,7 @@ import { mockConfigService } from "../../../../test/mocks/config-service.mock";
 import type { LoggerService } from "../../../core";
 import type { CachedBalance, CachedBalanceService } from "../cached-balance/cached-balance.service";
 import { TopUpManagedDeploymentsService } from "./top-up-managed-deployments.service";
+import type { TopUpManagedDeploymentsInstrumentationService } from "./top-up-managed-deployments-instrumentation.service";
 
 import { createAkashAddress } from "@test/seeders";
 import { AutoTopUpDeploymentSeeder } from "@test/seeders/auto-top-up-deployment.seeder";
@@ -545,6 +546,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     const chainErrorService = mock<ChainErrorService>();
     chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(false);
     const logger = mock<LoggerService>();
+    const instrumentation = mock<TopUpManagedDeploymentsInstrumentationService>();
 
     const service = new TopUpManagedDeploymentsService(
       managedSignerService,
@@ -554,7 +556,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
       cachedBalanceService,
       blockHttpService,
       chainErrorService,
-      logger
+      logger,
+      instrumentation
     );
 
     return {
@@ -566,7 +569,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
       cachedBalanceService,
       blockHttpService,
       chainErrorService,
-      logger
+      logger,
+      instrumentation
     };
   }
 });


### PR DESCRIPTION
## Why

The auto top-up job silently failed to mark closed-on-chain deployments because the RPC service filtered results to `state === "active"` only. Deployments that closed on-chain never appeared in the RPC response, so the job never detected them as closed — leaving stale `autoTopUpEnabled` settings and unnecessary future processing.

This reverts the previous fix (#2835) which had a bug where active-but-not-draining deployments were incorrectly marked as closed, and replaces it with a correct approach.

## What

- **RPC fix**: Removed `state === "active"` filters from `#fetchLeases` and `#fetchDeployments` in `DrainingDeploymentRpcService`, so closed leases/deployments flow through with their real `closedHeight`. The existing consumer logic in `DrainingDeploymentService` already handles `closedHeight` correctly.
- **Config tuning**: Increased auto top-up look-ahead window from 2h to 24h and top-up amount from 3h to 48h of escrow. Deployments are now topped up ~once per 24h with 2 days of runway, providing more time to react to failures.
- **Config rename**: `AUTO_TOP_UP_JOB_INTERVAL_IN_H` → `AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H`, `AUTO_TOP_UP_DEPLOYMENT_INTERVAL_IN_H` → `AUTO_TOP_UP_AMOUNT_IN_H`. Removed misleading `2×` multipliers.
- **Prometheus metrics**: Added `TopUpManagedDeploymentsInstrumentationService` with OpenTelemetry metrics for monitoring the auto top-up job:
  - `auto_top_up_job_executions_total` — job run count with success/failure status
  - `auto_top_up_job_duration_ms` — job execution duration
  - `auto_top_up_deposits_total` / `auto_top_up_deposit_amount` — successful deposit count and amounts
  - `auto_top_up_deposit_errors_total` — failed deposits by error type (insufficient_balance, message_preparation, tx_error)
  - `auto_top_up_deployments_marked_closed_total` — key metric for detecting silent closure spikes
  - `auto_top_up_predicted_close_blocks` — blocks until predicted closure at detection time
- **Integration tests**: Added 5 business-rule-level integration tests for `TopUpManagedDeploymentsService` covering: draining + closed mix, draining + not-yet-draining, all closed, disabled/already-closed settings, and insufficient balance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New auto top-up settings: Look-Ahead Window (default 24h) and Top-Up Amount (default 48h).
  * Enhanced observability: metrics for job runs, durations, deposits, errors, predicted closes, and setting toggles.

* **Bug Fixes**
  * Broader lease/deployment inclusion and improved closed-deployment detection to avoid missed or duplicate top-ups.
  * Top-up calculations adjusted to use the new settings.

* **Tests**
  * New integration suite and updated unit tests covering top-up workflows and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->