### PR TITLE
fix(log-collector): fix Docker build for workspace dependencies and SWC

### DIFF
--- a/apps/deploy-web/src/config/log-collector.config.ts
+++ b/apps/deploy-web/src/config/log-collector.config.ts
@@ -1,1 +1,1 @@
-export const LOG_COLLECTOR_IMAGE = "ghcr.io/akash-network/log-collector:2.12.7";
+export const LOG_COLLECTOR_IMAGE = "ghcr.io/akash-network/log-collector:2.12.8";

--- a/apps/log-collector/Dockerfile
+++ b/apps/log-collector/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.20
 # ----------- BUILDER STAGE ----------
 # Multi-stage build to optimize final image size
 # This stage compiles TypeScript and installs all dependencies
@@ -12,6 +13,7 @@ WORKDIR /app
 # Copy package files first for better Docker layer caching
 COPY package*.json ./
 COPY apps/log-collector/package.json ./apps/log-collector/
+COPY --parents packages/*/package.json ./
 RUN npm ci
 
 # Copy source code and build the application
@@ -54,6 +56,7 @@ WORKDIR /app
 # Only production packages are installed to minimize image size
 COPY --from=builder --chown=appuser:appuser /app/package*.json ./
 COPY --from=builder --chown=appuser:appuser /app/apps/log-collector/package.json ./apps/log-collector/
+COPY --from=builder --chown=appuser:appuser /app/packages/env-loader ./packages/env-loader/
 RUN npm ci --omit=dev -w apps/log-collector
 
 # Copy compiled application from builder stage

--- a/apps/log-collector/package.json
+++ b/apps/log-collector/package.json
@@ -40,6 +40,7 @@
     "@akashnetwork/dev-config": "*",
     "@akashnetwork/releaser": "*",
     "@faker-js/faker": "^8.4.1",
+    "@swc/core": "^1.11.10",
     "@types/jest": "^29.5.12",
     "@types/node": "^22.13.11",
     "jest": "^29.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -329,7 +329,6 @@
     "apps/api/node_modules/@opentelemetry/core": {
       "version": "2.0.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -1227,7 +1226,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1249,7 +1247,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1267,6 +1264,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1284,6 +1282,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1301,6 +1300,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1318,6 +1318,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1333,6 +1334,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1350,6 +1352,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1367,6 +1370,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1384,6 +1388,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1401,6 +1406,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1418,6 +1424,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1435,6 +1442,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1452,6 +1460,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1469,6 +1478,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1486,6 +1496,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1503,6 +1514,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1520,6 +1532,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1537,6 +1550,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1554,6 +1568,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1571,6 +1586,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1588,6 +1604,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1605,6 +1622,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1622,6 +1640,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1639,6 +1658,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2130,7 +2150,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.57.1",
@@ -2144,7 +2165,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.57.1",
@@ -2158,7 +2180,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.57.1",
@@ -2172,7 +2195,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.35.0",
@@ -2199,7 +2223,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.35.0",
@@ -2252,7 +2277,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.57.1",
@@ -2266,7 +2292,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.35.0",
@@ -2306,7 +2333,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.35.0",
@@ -2593,7 +2621,6 @@
     "apps/deploy-web/node_modules/@stripe/stripe-js": {
       "version": "8.3.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.16"
       }
@@ -2719,6 +2746,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2758,6 +2786,7 @@
       "version": "6.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -3027,6 +3056,7 @@
       "version": "7.3.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3108,7 +3138,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-android-arm64": {
       "version": "4.57.1",
@@ -3122,7 +3153,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.57.1",
@@ -3134,7 +3166,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.57.1",
@@ -3148,7 +3181,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.57.1",
@@ -3162,7 +3196,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.57.1",
@@ -3176,7 +3211,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.57.1",
@@ -3190,7 +3226,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.57.1",
@@ -3204,7 +3241,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.57.1",
@@ -3218,7 +3256,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.57.1",
@@ -3232,7 +3271,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.57.1",
@@ -3246,7 +3286,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.57.1",
@@ -3260,7 +3301,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.57.1",
@@ -3274,7 +3316,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.57.1",
@@ -3288,7 +3331,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.57.1",
@@ -3302,7 +3346,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.57.1",
@@ -3316,7 +3361,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.57.1",
@@ -3330,17 +3376,20 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@types/estree": {
       "version": "1.0.8",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/rollup": {
       "version": "4.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -3431,7 +3480,6 @@
     "apps/deploy-web/node_modules/yaml": {
       "version": "2.8.2",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -4376,7 +4424,6 @@
     "apps/indexer/node_modules/@opentelemetry/core": {
       "version": "2.4.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -5885,6 +5932,7 @@
         "@akashnetwork/dev-config": "*",
         "@akashnetwork/releaser": "*",
         "@faker-js/faker": "^8.4.1",
+        "@swc/core": "^1.11.10",
         "@types/jest": "^29.5.12",
         "@types/node": "^22.13.11",
         "jest": "^29.7.0",
@@ -6205,7 +6253,6 @@
     "apps/notifications/node_modules/@opentelemetry/core": {
       "version": "2.4.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -9153,7 +9200,6 @@
     "apps/tx-signer/node_modules/@opentelemetry/core": {
       "version": "2.5.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -10259,7 +10305,6 @@
     "node_modules/@babel/core": {
       "version": "7.28.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -11824,8 +11869,7 @@
     "node_modules/@biomejs/wasm-nodejs": {
       "version": "1.9.4",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@borewit/text-codec": {
       "version": "0.2.1",
@@ -11848,8 +11892,7 @@
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.9.0",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@casl/ability": {
       "version": "6.7.2",
@@ -12098,7 +12141,6 @@
       "version": "9.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -12340,7 +12382,6 @@
     "node_modules/@connectrpc/connect": {
       "version": "2.1.0",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -12359,7 +12400,6 @@
     "node_modules/@cosmjs/amino": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
@@ -12451,7 +12491,6 @@
     "node_modules/@cosmjs/proto-signing": {
       "version": "0.36.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.36.2",
         "@cosmjs/crypto": "^0.36.2",
@@ -12560,7 +12599,6 @@
     "node_modules/@cosmjs/stargate": {
       "version": "0.36.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.36.2",
         "@cosmjs/encoding": "^0.36.2",
@@ -12752,7 +12790,6 @@
     "node_modules/@cosmos-kit/core/node_modules/@cosmjs/proto-signing": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -13186,7 +13223,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -13222,7 +13258,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13304,7 +13339,6 @@
     "node_modules/@dotenvx/dotenvx/node_modules/picomatch": {
       "version": "4.0.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13418,7 +13452,6 @@
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -13430,7 +13463,6 @@
     "node_modules/@emotion/react": {
       "version": "11.11.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -13468,7 +13500,6 @@
     "node_modules/@emotion/server": {
       "version": "11.11.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/utils": "^1.2.1",
         "html-tokenize": "^2.0.0",
@@ -13491,7 +13522,6 @@
     "node_modules/@emotion/styled": {
       "version": "11.11.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -14232,6 +14262,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -14265,6 +14296,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -14298,6 +14330,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -14593,7 +14626,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=6.14.13"
@@ -14740,7 +14772,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -15327,7 +15358,6 @@
     "node_modules/@interchain-ui/react": {
       "version": "1.23.31",
       "license": "SEE LICENSE IN LICENSE",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.6.4",
         "@floating-ui/dom": "^1.6.7",
@@ -15783,7 +15813,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -16791,7 +16820,6 @@
     "node_modules/@mui/material": {
       "version": "5.15.20",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/base": "5.0.0-beta.40",
@@ -17212,7 +17240,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -17426,7 +17453,6 @@
     "node_modules/@nestjs/common": {
       "version": "11.1.13",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -17537,7 +17563,6 @@
       "version": "11.1.13",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -17602,7 +17627,6 @@
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.13",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -18541,7 +18565,6 @@
     "node_modules/@octokit/core": {
       "version": "7.0.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -18756,7 +18779,6 @@
       "version": "11.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -18970,7 +18992,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -19034,7 +19055,6 @@
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -19045,7 +19065,6 @@
     "node_modules/@opentelemetry/core": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -19679,7 +19698,6 @@
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.57.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -21379,7 +21397,6 @@
     "node_modules/@opentelemetry/resources": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -21617,7 +21634,6 @@
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -21707,7 +21723,6 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.38.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -25033,7 +25048,6 @@
       "version": "1.34.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redocly/ajv": "^8.11.2",
         "@redocly/config": "^0.22.0",
@@ -25174,7 +25188,6 @@
     "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
       "version": "4.0.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -25713,6 +25726,7 @@
     "node_modules/@scure/starknet": {
       "version": "1.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "~1.7.0",
         "@noble/hashes": "~1.6.0"
@@ -25724,6 +25738,7 @@
     "node_modules/@scure/starknet/node_modules/@noble/curves": {
       "version": "1.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.6.0"
       },
@@ -25737,6 +25752,7 @@
     "node_modules/@scure/starknet/node_modules/@noble/curves/node_modules/@noble/hashes": {
       "version": "1.6.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -25747,6 +25763,7 @@
     "node_modules/@scure/starknet/node_modules/@noble/hashes": {
       "version": "1.6.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -26506,12 +26523,14 @@
     "node_modules/@starknet-io/starknet-types-07": {
       "name": "@starknet-io/types-js",
       "version": "0.7.10",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@starknet-io/starknet-types-08": {
       "name": "@starknet-io/types-js",
       "version": "0.8.4",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@streamparser/json": {
       "version": "0.0.20",
@@ -26545,7 +26564,6 @@
       "version": "0.6.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@xhmikosr/bin-wrapper": "^13.0.5",
@@ -26596,7 +26614,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.19"
@@ -26640,6 +26657,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -26657,6 +26675,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -26674,6 +26693,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -26691,6 +26711,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -26708,6 +26729,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -26725,6 +26747,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -26742,6 +26765,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -26759,6 +26783,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -26776,6 +26801,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -26793,6 +26819,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -26804,7 +26831,6 @@
     "node_modules/@swc/helpers": {
       "version": "0.5.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
@@ -26846,7 +26872,6 @@
     "node_modules/@tanstack/query-core": {
       "version": "5.67.2",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -26855,7 +26880,6 @@
     "node_modules/@tanstack/react-query": {
       "version": "5.67.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.67.2"
       },
@@ -26923,7 +26947,6 @@
       "version": "10.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -27156,7 +27179,6 @@
       "version": "7.20.5",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -27597,7 +27619,6 @@
     "node_modules/@types/node": {
       "version": "22.15.30",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -27668,7 +27689,6 @@
     "node_modules/@types/react": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -27678,7 +27698,6 @@
     "node_modules/@types/react-dom": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -27852,8 +27871,7 @@
     },
     "node_modules/@types/validator": {
       "version": "13.11.10",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.5.13",
@@ -28430,7 +28448,6 @@
     "node_modules/@vanilla-extract/css": {
       "version": "1.17.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@vanilla-extract/private": "^1.0.6",
@@ -28453,7 +28470,6 @@
     "node_modules/@vanilla-extract/dynamic": {
       "version": "2.1.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vanilla-extract/private": "^1.0.6"
       }
@@ -29070,7 +29086,6 @@
     "node_modules/@walletconnect/types": {
       "version": "2.11.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -29602,6 +29617,7 @@
     "node_modules/abi-wan-kanabi": {
       "version": "2.2.4",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ansicolors": "^0.3.2",
         "cardinal": "^2.1.1",
@@ -29615,6 +29631,7 @@
     "node_modules/abi-wan-kanabi/node_modules/fs-extra": {
       "version": "10.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -29684,7 +29701,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -29764,7 +29780,6 @@
     "node_modules/ajv": {
       "version": "6.12.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -29824,7 +29839,6 @@
       "version": "4.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -29865,7 +29879,8 @@
     },
     "node_modules/ansicolors": {
       "version": "0.3.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ansis": {
       "version": "4.2.0",
@@ -30901,7 +30916,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -31265,7 +31279,6 @@
     "node_modules/camelcase": {
       "version": "5.3.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -31298,6 +31311,7 @@
     "node_modules/cardinal": {
       "version": "2.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
@@ -31391,7 +31405,6 @@
     "node_modules/chokidar": {
       "version": "3.6.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -31854,7 +31867,6 @@
     "node_modules/commander": {
       "version": "12.1.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -32089,8 +32101,7 @@
     },
     "node_modules/cosmjs-types": {
       "version": "0.9.0",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
@@ -32352,8 +32363,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/csv-stringify": {
       "version": "6.6.0",
@@ -32478,8 +32488,7 @@
     },
     "node_modules/d3-selection": {
       "version": "2.0.0",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
@@ -32664,7 +32673,6 @@
     "node_modules/date-fns": {
       "version": "2.30.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -33297,7 +33305,6 @@
     "node_modules/drizzle-orm": {
       "version": "0.31.2",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=3",
@@ -33850,6 +33857,7 @@
       "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -33857,7 +33865,6 @@
     "node_modules/eslint": {
       "version": "8.57.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -34128,7 +34135,6 @@
     "node_modules/eslint-plugin-import": {
       "version": "2.31.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -34160,7 +34166,6 @@
     "node_modules/eslint-plugin-import-x": {
       "version": "4.10.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pkgr/core": "^0.2.0",
         "@types/doctrine": "^0.0.9",
@@ -35613,7 +35618,6 @@
     "node_modules/gel": {
       "version": "2.0.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@petamoriken/float16": "^3.8.7",
         "debug": "^4.3.4",
@@ -36459,7 +36463,6 @@
     "node_modules/hono": {
       "version": "4.6.12",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -36754,7 +36757,6 @@
     "node_modules/immer": {
       "version": "10.1.1",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -37668,7 +37670,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -38353,7 +38354,6 @@
     "node_modules/jiti": {
       "version": "1.21.3",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -38536,7 +38536,6 @@
     "node_modules/jsep": {
       "version": "1.4.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -39494,7 +39493,8 @@
     },
     "node_modules/lossless-json": {
       "version": "4.3.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lowercase-keys": {
       "version": "3.0.0",
@@ -41826,7 +41826,6 @@
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -42124,7 +42123,6 @@
     "node_modules/next": {
       "version": "14.2.35",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
@@ -42896,6 +42894,7 @@
       "version": "8.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "cli-cursor": "^5.0.0",
@@ -42918,6 +42917,7 @@
       "version": "6.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -42929,6 +42929,7 @@
       "version": "5.4.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -42940,6 +42941,7 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "restore-cursor": "^5.0.0"
       },
@@ -42953,12 +42955,14 @@
     "node_modules/ora/node_modules/emoji-regex": {
       "version": "10.4.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ora/node_modules/onetime": {
       "version": "7.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-function": "^5.0.0"
       },
@@ -42973,6 +42977,7 @@
       "version": "5.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "onetime": "^7.0.0",
         "signal-exit": "^4.1.0"
@@ -42988,6 +42993,7 @@
       "version": "4.1.0",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -42999,6 +43005,7 @@
       "version": "7.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -43015,6 +43022,7 @@
       "version": "7.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -43269,7 +43277,6 @@
     "node_modules/pg": {
       "version": "8.18.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -43671,6 +43678,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -43714,7 +43722,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -43852,7 +43859,6 @@
     "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -43936,7 +43942,6 @@
     "node_modules/prettier": {
       "version": "3.3.1",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -44116,7 +44121,6 @@
     "node_modules/prop-types": {
       "version": "15.8.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -44455,7 +44459,6 @@
     "node_modules/react": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -44564,7 +44567,6 @@
     "node_modules/react-dom": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -44604,7 +44606,6 @@
     "node_modules/react-hook-form": {
       "version": "7.52.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -44965,14 +44966,14 @@
     "node_modules/redeyed": {
       "version": "2.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esprima": "~4.0.0"
       }
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
@@ -45535,7 +45536,6 @@
     "node_modules/rollup": {
       "version": "2.79.2",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -45666,7 +45666,6 @@
     "node_modules/rxjs": {
       "version": "7.8.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -45790,7 +45789,6 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "8.17.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -46703,6 +46701,7 @@
     "node_modules/starknet/node_modules/@noble/curves": {
       "version": "1.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.6.0"
       },
@@ -46716,6 +46715,7 @@
     "node_modules/starknet/node_modules/@noble/hashes": {
       "version": "1.6.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -46726,6 +46726,7 @@
     "node_modules/starknet/node_modules/@scure/base": {
       "version": "1.2.1",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -47314,7 +47315,6 @@
     "node_modules/tailwindcss": {
       "version": "3.4.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -47832,7 +47832,6 @@
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -48109,13 +48108,13 @@
     },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -48937,6 +48936,23 @@
         "node": ">= 12"
       }
     },
+    "node_modules/tsup/node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/tsyringe": {
       "version": "4.10.0",
       "license": "MIT",
@@ -49165,7 +49181,6 @@
     "node_modules/typescript": {
       "version": "5.8.3",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -49540,7 +49555,6 @@
     "node_modules/unleash-proxy-client": {
       "version": "3.7.6",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tiny-emitter": "^2.1.0",
         "uuid": "^9.0.1"
@@ -50130,7 +50144,6 @@
       "version": "4.0.18",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -51114,7 +51127,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -51177,7 +51189,6 @@
       "version": "7.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -51245,6 +51256,23 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/vscode-jsonrpc": {
@@ -51331,7 +51359,6 @@
     "node_modules/webpack": {
       "version": "5.104.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -51724,7 +51751,6 @@
     "node_modules/workbox-build/node_modules/ajv": {
       "version": "8.17.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -51986,7 +52012,6 @@
     "node_modules/ws": {
       "version": "8.18.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -52043,8 +52068,7 @@
     },
     "node_modules/xterm": {
       "version": "5.3.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/xterm-addon-fit": {
       "version": "0.7.0",
@@ -52145,7 +52169,6 @@
     "node_modules/zod": {
       "version": "3.24.4",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -53234,7 +53257,6 @@
     "packages/releaser/node_modules/conventional-commits-filter": {
       "version": "5.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -53242,7 +53264,6 @@
     "packages/releaser/node_modules/conventional-commits-parser": {
       "version": "6.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "meow": "^13.0.0"
       },


### PR DESCRIPTION
## Why

The log-collector Docker build was broken due to missing workspace package resolution and the @swc/core dependency not being available in the container. Without SWC, tsup falls back to esbuild which does not emit decorator metadata required by tsyringe DI.

## What

- Add BuildKit syntax header for COPY --parents support
- Copy all workspace package.json files in builder stage for proper npm workspace resolution
- Copy packages/env-loader to production stage (runtime dependency)
- Add @swc/core as explicit devDependency (tsup peer dep needed for decorator metadata emission)
- Bump log-collector image version to 2.12.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated log collector component to v2.12.8.
  * Expanded image build to include additional packages required at runtime.
  * Added build tooling dependency to support improved compilation during development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->