### PR TITLE
fix(alert): disable deployment alerts before intentional close

### DIFF
--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -1,5 +1,5 @@
 import { MsgAccountDeposit } from "@akashnetwork/chain-sdk/private-types/akash.v1";
-import { MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { MsgCloseDeployment, MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { MsgCreateLease } from "@akashnetwork/chain-sdk/private-types/akash.v1beta5";
 import type { LeaseHttpService } from "@akashnetwork/http-sdk";
 import type { MongoAbility } from "@casl/ability";
@@ -19,6 +19,7 @@ import type { TrialValidationService } from "@src/billing/services/trial-validat
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import type { FeatureFlagValue } from "@src/core/services/feature-flags/feature-flags";
+import type { NotificationService } from "@src/notifications/services/notification/notification.service";
 import type { UserOutput, UserRepository } from "@src/user/repositories";
 import { createAkashAddress } from "../../../../test/seeders";
 import type { TxManagerService } from "../tx-manager/tx-manager.service";
@@ -293,6 +294,124 @@ describe(ManagedSignerService.name, () => {
       expect(userRepository.findById).not.toHaveBeenCalled();
     });
 
+    it("disables deployment alerts for a single MsgCloseDeployment", async () => {
+      const wallet = UserWalletSeeder.create({
+        userId: "user-123",
+        feeAllowance: 100,
+        deploymentAllowance: 100
+      });
+      const user = UserSeeder.create({ userId: "user-123" });
+      const messages: EncodeObject[] = [
+        {
+          typeUrl: `/${MsgCloseDeployment.$type}`,
+          value: MsgCloseDeployment.fromPartial({ id: { owner: wallet.address, dseq: 456 } })
+        }
+      ];
+
+      const { service, notificationService } = setup({
+        findOneByUserId: jest.fn().mockResolvedValue(wallet),
+        findById: jest.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
+          code: 0,
+          hash: "tx-hash",
+          rawLog: "success"
+        }),
+        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined)
+      });
+
+      await service.executeDerivedDecodedTxByUserId("user-123", messages);
+
+      expect(notificationService.disableDeploymentAlerts).toHaveBeenCalledTimes(1);
+      expect(notificationService.disableDeploymentAlerts).toHaveBeenCalledWith({
+        userId: "user-123",
+        walletAddress: wallet.address,
+        dseq: "456"
+      });
+    });
+
+    it("disables deployment alerts for multiple MsgCloseDeployment messages", async () => {
+      const wallet = UserWalletSeeder.create({
+        userId: "user-123",
+        feeAllowance: 100,
+        deploymentAllowance: 100
+      });
+      const user = UserSeeder.create({ userId: "user-123" });
+      const messages: EncodeObject[] = [
+        {
+          typeUrl: `/${MsgCloseDeployment.$type}`,
+          value: MsgCloseDeployment.fromPartial({ id: { owner: wallet.address, dseq: 100 } })
+        },
+        {
+          typeUrl: `/${MsgCloseDeployment.$type}`,
+          value: MsgCloseDeployment.fromPartial({ id: { owner: wallet.address, dseq: 200 } })
+        },
+        {
+          typeUrl: `/${MsgCloseDeployment.$type}`,
+          value: MsgCloseDeployment.fromPartial({ id: { owner: wallet.address, dseq: 300 } })
+        }
+      ];
+
+      const { service, notificationService } = setup({
+        findOneByUserId: jest.fn().mockResolvedValue(wallet),
+        findById: jest.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
+          code: 0,
+          hash: "tx-hash",
+          rawLog: "success"
+        }),
+        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined)
+      });
+
+      await service.executeDerivedDecodedTxByUserId("user-123", messages);
+
+      expect(notificationService.disableDeploymentAlerts).toHaveBeenCalledTimes(3);
+      expect(notificationService.disableDeploymentAlerts).toHaveBeenCalledWith({
+        userId: "user-123",
+        walletAddress: wallet.address,
+        dseq: "100"
+      });
+      expect(notificationService.disableDeploymentAlerts).toHaveBeenCalledWith({
+        userId: "user-123",
+        walletAddress: wallet.address,
+        dseq: "200"
+      });
+      expect(notificationService.disableDeploymentAlerts).toHaveBeenCalledWith({
+        userId: "user-123",
+        walletAddress: wallet.address,
+        dseq: "300"
+      });
+    });
+
+    it("does not disable deployment alerts when no MsgCloseDeployment is present", async () => {
+      const wallet = UserWalletSeeder.create({
+        userId: "user-123",
+        feeAllowance: 100,
+        deploymentAllowance: 100
+      });
+      const user = UserSeeder.create({ userId: "user-123" });
+      const messages: EncodeObject[] = [
+        {
+          typeUrl: MsgCreateLease.$type,
+          value: MsgCreateLease.fromPartial({ bidId: { dseq: 123 } })
+        }
+      ];
+
+      const { service, notificationService } = setup({
+        findOneByUserId: jest.fn().mockResolvedValue(wallet),
+        findById: jest.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
+          code: 0,
+          hash: "tx-hash",
+          rawLog: "success"
+        }),
+        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined)
+      });
+
+      await service.executeDerivedDecodedTxByUserId("user-123", messages);
+
+      expect(notificationService.disableDeploymentAlerts).not.toHaveBeenCalled();
+    });
+
     it("validates lease provider for all leases regardless of trial status", async () => {
       const wallet = UserWalletSeeder.create({
         userId: "user-123",
@@ -525,6 +644,7 @@ describe(ManagedSignerService.name, () => {
     transformChainError?: ChainErrorService["toAppError"];
     hasLeases?: LeaseHttpService["hasLeases"];
     decode?: Registry["decode"];
+    disableDeploymentAlerts?: NotificationService["disableDeploymentAlerts"];
   }) {
     const mocks = {
       userWalletRepository: mock<UserWalletRepository>({
@@ -570,6 +690,9 @@ describe(ManagedSignerService.name, () => {
       }),
       managedUserWalletService: mock<ManagedUserWalletService>({
         refillWalletFees: jest.fn()
+      }),
+      notificationService: mock<NotificationService>({
+        disableDeploymentAlerts: input?.disableDeploymentAlerts ?? jest.fn()
       })
     };
 
@@ -590,7 +713,8 @@ describe(ManagedSignerService.name, () => {
       mocks.domainEvents,
       mocks.leaseHttpService,
       mocks.walletReloadJobService,
-      mocks.managedUserWalletService
+      mocks.managedUserWalletService,
+      mocks.notificationService
     );
 
     return { service, registry: registryMock, ...mocks };

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -1,5 +1,5 @@
 import { MsgAccountDeposit } from "@akashnetwork/chain-sdk/private-types/akash.v1";
-import { MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { MsgCloseDeployment, MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { MsgCreateLease } from "@akashnetwork/chain-sdk/private-types/akash.v1beta5";
 import { LeaseHttpService } from "@akashnetwork/http-sdk";
 import { EncodeObject, Registry } from "@cosmjs/proto-signing";
@@ -19,6 +19,7 @@ import { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.se
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { Trace, withSpan } from "@src/core/services/tracing/tracing.service";
+import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { UserRepository } from "@src/user/repositories";
 import { BalancesService } from "../balances/balances.service";
 import { BillingConfigService } from "../billing-config/billing-config.service";
@@ -44,7 +45,8 @@ export class ManagedSignerService {
     private readonly domainEvents: DomainEventsService,
     private readonly leaseHttpService: LeaseHttpService,
     private readonly walletReloadJobService: WalletReloadJobService,
-    private readonly managedUserWalletService: ManagedUserWalletService
+    private readonly managedUserWalletService: ManagedUserWalletService,
+    private readonly notificationService: NotificationService
   ) {}
 
   @Trace()
@@ -111,6 +113,18 @@ export class ManagedSignerService {
   }> {
     await this.#validateBalances(userWallet, messages);
     await this.anonymousValidateService.validateLeaseProvidersAuditors(messages, userWallet);
+
+    const closeDeploymentMessage: { typeUrl: string; value: MsgCloseDeployment } | undefined = messages.find(message =>
+      message.typeUrl.endsWith(".MsgCloseDeployment")
+    );
+
+    if (closeDeploymentMessage && userWallet.userId) {
+      await this.notificationService.disableDeploymentAlerts({
+        userId: userWallet.userId,
+        walletAddress: userWallet.address!,
+        dseq: closeDeploymentMessage.value.id!.dseq.toString()
+      });
+    }
 
     const createLeaseMessage: { typeUrl: string; value: MsgCreateLease } | undefined = messages.find(message => message.typeUrl.endsWith(".MsgCreateLease"));
     const hasCreateTrialLeaseMessage = userWallet.isTrialing && !!createLeaseMessage;

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -114,16 +114,18 @@ export class ManagedSignerService {
     await this.#validateBalances(userWallet, messages);
     await this.anonymousValidateService.validateLeaseProvidersAuditors(messages, userWallet);
 
-    const closeDeploymentMessage: { typeUrl: string; value: MsgCloseDeployment } | undefined = messages.find(message =>
-      message.typeUrl.endsWith(".MsgCloseDeployment")
-    );
+    if (userWallet.userId) {
+      const closeDeploymentMessages: { typeUrl: string; value: MsgCloseDeployment }[] = messages.filter(message =>
+        message.typeUrl.endsWith(".MsgCloseDeployment")
+      );
 
-    if (closeDeploymentMessage && userWallet.userId) {
-      await this.notificationService.disableDeploymentAlerts({
-        userId: userWallet.userId,
-        walletAddress: userWallet.address!,
-        dseq: closeDeploymentMessage.value.id!.dseq.toString()
-      });
+      for (const message of closeDeploymentMessages) {
+        await this.notificationService.disableDeploymentAlerts({
+          userId: userWallet.userId,
+          walletAddress: userWallet.address!,
+          dseq: message.value.id!.dseq.toString()
+        });
+      }
     }
 
     const createLeaseMessage: { typeUrl: string; value: MsgCreateLease } | undefined = messages.find(message => message.typeUrl.endsWith(".MsgCreateLease"));

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -119,11 +119,15 @@ export class ManagedSignerService {
         message.typeUrl.endsWith(".MsgCloseDeployment")
       );
 
-      for (const message of closeDeploymentMessages) {
+      const uniqueDseqs = [
+        ...new Set(closeDeploymentMessages.filter(message => message.value?.id?.dseq != null).map(message => message.value.id!.dseq.toString()))
+      ];
+
+      for (const dseq of uniqueDseqs) {
         await this.notificationService.disableDeploymentAlerts({
           userId: userWallet.userId,
           walletAddress: userWallet.address!,
-          dseq: message.value.id!.dseq.toString()
+          dseq
         });
       }
     }

--- a/apps/api/src/notifications/services/notification/notification.service.spec.ts
+++ b/apps/api/src/notifications/services/notification/notification.service.spec.ts
@@ -275,6 +275,147 @@ describe(NotificationService.name, () => {
     });
   });
 
+  describe("disableDeploymentAlerts", () => {
+    const input = { userId: "user-1", walletAddress: "akash1abc", dseq: "123" };
+
+    it("fetches alerts and disables when both alerts are enabled", async () => {
+      const { service, api } = setup();
+
+      api.v1.getDeploymentAlerts.mockResolvedValue({
+        data: {
+          data: {
+            dseq: "123",
+            alerts: {
+              deploymentBalance: { notificationChannelId: "ch-1", enabled: true, threshold: 300000, id: "alert-1", status: "active" },
+              deploymentClosed: { notificationChannelId: "ch-2", enabled: true, id: "alert-2", status: "active" }
+            }
+          }
+        }
+      } as never);
+      api.v1.upsertDeploymentAlert.mockResolvedValue({} as never);
+
+      await service.disableDeploymentAlerts(input);
+
+      expect(api.v1.getDeploymentAlerts).toHaveBeenCalledWith({
+        parameters: {
+          path: { dseq: "123" },
+          header: { "x-user-id": "user-1" }
+        }
+      });
+      expect(api.v1.upsertDeploymentAlert).toHaveBeenCalledWith({
+        parameters: {
+          path: { dseq: "123" },
+          header: { "x-owner-address": "akash1abc", "x-user-id": "user-1" }
+        },
+        body: {
+          data: {
+            alerts: {
+              deploymentBalance: { notificationChannelId: "ch-1", enabled: false, threshold: 300000 },
+              deploymentClosed: { notificationChannelId: "ch-2", enabled: false }
+            }
+          }
+        }
+      });
+    });
+
+    it("skips upsert when alerts are already disabled", async () => {
+      const { service, api } = setup();
+
+      api.v1.getDeploymentAlerts.mockResolvedValue({
+        data: {
+          data: {
+            dseq: "123",
+            alerts: {
+              deploymentBalance: { notificationChannelId: "ch-1", enabled: false, threshold: 300000, id: "alert-1", status: "active" },
+              deploymentClosed: { notificationChannelId: "ch-2", enabled: false, id: "alert-2", status: "active" }
+            }
+          }
+        }
+      } as never);
+
+      await service.disableDeploymentAlerts(input);
+
+      expect(api.v1.upsertDeploymentAlert).not.toHaveBeenCalled();
+    });
+
+    it("skips upsert when alerts are suppressed by system", async () => {
+      const { service, api } = setup();
+
+      api.v1.getDeploymentAlerts.mockResolvedValue({
+        data: {
+          data: {
+            dseq: "123",
+            alerts: {
+              deploymentBalance: { notificationChannelId: "ch-1", enabled: true, threshold: 300000, id: "alert-1", status: "active", suppressedBySystem: true },
+              deploymentClosed: { notificationChannelId: "ch-2", enabled: true, id: "alert-2", status: "active", suppressedBySystem: true }
+            }
+          }
+        }
+      } as never);
+
+      await service.disableDeploymentAlerts(input);
+
+      expect(api.v1.upsertDeploymentAlert).not.toHaveBeenCalled();
+    });
+
+    it("skips upsert when no alerts exist", async () => {
+      const { service, api } = setup();
+
+      api.v1.getDeploymentAlerts.mockResolvedValue({
+        data: { data: { dseq: "123", alerts: {} } }
+      } as never);
+
+      await service.disableDeploymentAlerts(input);
+
+      expect(api.v1.upsertDeploymentAlert).not.toHaveBeenCalled();
+    });
+
+    it("catches errors without throwing", async () => {
+      jest.useFakeTimers();
+      const { service, api, logger } = setup();
+
+      api.v1.getDeploymentAlerts.mockRejectedValue(new Error("Network error"));
+
+      await Promise.all([service.disableDeploymentAlerts(input), jest.runAllTimersAsync()]);
+
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "DISABLE_DEPLOYMENT_ALERTS_FAILED", dseq: "123" }));
+      jest.useRealTimers();
+    });
+
+    it("only disables the alert that is enabled", async () => {
+      const { service, api } = setup();
+
+      api.v1.getDeploymentAlerts.mockResolvedValue({
+        data: {
+          data: {
+            dseq: "123",
+            alerts: {
+              deploymentBalance: { notificationChannelId: "ch-1", enabled: false, threshold: 300000, id: "alert-1", status: "active" },
+              deploymentClosed: { notificationChannelId: "ch-2", enabled: true, id: "alert-2", status: "active" }
+            }
+          }
+        }
+      } as never);
+      api.v1.upsertDeploymentAlert.mockResolvedValue({} as never);
+
+      await service.disableDeploymentAlerts(input);
+
+      expect(api.v1.upsertDeploymentAlert).toHaveBeenCalledWith({
+        parameters: {
+          path: { dseq: "123" },
+          header: { "x-owner-address": "akash1abc", "x-user-id": "user-1" }
+        },
+        body: {
+          data: {
+            alerts: {
+              deploymentClosed: { notificationChannelId: "ch-2", enabled: false }
+            }
+          }
+        }
+      });
+    });
+  });
+
   function setup(overrides?: { api?: DeepMockProxy<NotificationsApiClient>; userRepository?: MockProxy<UserRepository>; logger?: MockProxy<LoggerService> }) {
     const api = overrides?.api ?? mockDeep<NotificationsApiClient>();
     const userRepository = overrides?.userRepository ?? mock<UserRepository>();

--- a/apps/api/src/notifications/services/notification/notification.service.ts
+++ b/apps/api/src/notifications/services/notification/notification.service.ts
@@ -130,6 +130,76 @@ export class NotificationService {
     return threshold;
   }
 
+  async disableDeploymentAlerts(input: { userId: string; walletAddress: string; dseq: string }): Promise<void> {
+    try {
+      const alertsResult = await this.getDeploymentAlerts(input.userId, input.dseq);
+      const alerts = alertsResult?.data?.data?.alerts;
+
+      if (!alerts) return;
+
+      const { deploymentBalance, deploymentClosed } = alerts;
+      const disableBalance = !!deploymentBalance?.enabled && !deploymentBalance.suppressedBySystem;
+      const disableClosed = !!deploymentClosed?.enabled && !deploymentClosed.suppressedBySystem;
+
+      if (!disableBalance && !disableClosed) return;
+
+      const alertsBody: {
+        deploymentBalance?: { notificationChannelId: string; enabled: boolean; threshold: number };
+        deploymentClosed?: { notificationChannelId: string; enabled: boolean };
+      } = {};
+
+      if (disableBalance) {
+        alertsBody.deploymentBalance = {
+          notificationChannelId: deploymentBalance!.notificationChannelId,
+          enabled: false,
+          threshold: deploymentBalance!.threshold
+        };
+      }
+
+      if (disableClosed) {
+        alertsBody.deploymentClosed = {
+          notificationChannelId: deploymentClosed!.notificationChannelId,
+          enabled: false
+        };
+      }
+
+      await backOff(
+        () =>
+          this.notificationsApi.v1.upsertDeploymentAlert({
+            parameters: {
+              path: { dseq: input.dseq },
+              header: { "x-owner-address": input.walletAddress, "x-user-id": input.userId } as operations["upsertDeploymentAlert"]["parameters"]["header"] & {
+                "x-user-id": string;
+              }
+            },
+            body: {
+              data: {
+                alerts: alertsBody
+              }
+            }
+          }),
+        DEFAULT_BACKOFF_OPTIONS
+      );
+    } catch (error) {
+      this.logger.error({ event: "DISABLE_DEPLOYMENT_ALERTS_FAILED", dseq: input.dseq, error });
+    }
+  }
+
+  private async getDeploymentAlerts(userId: string, dseq: string) {
+    return backOff(
+      () =>
+        this.notificationsApi.v1.getDeploymentAlerts({
+          parameters: {
+            path: { dseq },
+            header: { "x-user-id": userId } as operations["getDeploymentAlerts"]["parameters"]["header"] & {
+              "x-user-id": string;
+            }
+          }
+        }),
+      DEFAULT_BACKOFF_OPTIONS
+    );
+  }
+
   private async upsertDeploymentBalanceAlert(input: { userId: string; walletAddress: string; dseq: string; channelId: string; threshold: number }) {
     await backOff(
       () =>


### PR DESCRIPTION
## Why

When a user intentionally closes a deployment via managed wallet, the `deployment-closed` chain event fires and triggers an unwanted alert notification. This is annoying for users since they deliberately closed the deployment.

## What

Disable deployment alerts **before** the close transaction is signed, so the chain event finds no enabled alerts to trigger.

- Added `disableDeploymentAlerts` method to `NotificationService` that fetches current alerts and upserts them with `enabled: false` (best-effort, errors are caught and logged)
- Added `getDeploymentAlerts` private helper to `NotificationService`
- Hooked into `ManagedSignerService.executeDecodedTxByUserWallet()` to detect `MsgCloseDeployment` and disable alerts before signing — this covers both the direct close endpoint (`DELETE /v1/deployments/{dseq}`) and the generic transaction path (`POST /v1/tx`)
- Alerts must be disabled **before** close because the notifications service validates deployment existence on-chain; after closing, the upsert would fail with "Deployment not found"
- Added 6 unit tests for `disableDeploymentAlerts` covering: both alerts enabled, already disabled, suppressed by system, no alerts, error handling, partial disable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically disable deployment alerts when a deployment is closed to prevent unnecessary notifications.

* **Updates**
  * Notification service now exposes a public operation to disable deployment alerts for a given user/wallet/deployment; managed signing flow invokes it when closes are detected.

* **Tests**
  * Added comprehensive tests covering multiple close events, skipped cases, partial disables, error handling, and retry/backoff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->