### PR TITLE
fix(managed-wallet): ensure auto-reload is scheduled for deployments created via Managed Wallet API

### DIFF
--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -70,15 +70,7 @@ export class ManagedSignerService {
 
   async executeDerivedEncodedTxByUserId(userId: UserWalletOutput["userId"], messages: StringifiedEncodeObject[]) {
     const decoded = this.decodeMessages(messages);
-    const result = await this.executeDerivedDecodedTxByUserId(userId, decoded);
-
-    const hasSpendingTx = decoded.some(message => SPENDING_TXS.some(msg => message.typeUrl.endsWith(msg.$type)));
-
-    if (hasSpendingTx) {
-      await this.walletReloadJobService.scheduleImmediate(userId);
-    }
-
-    return result;
+    return await this.executeDerivedDecodedTxByUserId(userId, decoded);
   }
 
   @Trace()
@@ -132,7 +124,7 @@ export class ManagedSignerService {
     if (createLeaseMessage) {
       await this.domainEvents.publish(
         new EnableDeploymentAlertCommand({
-          userId: userWallet.userId!,
+          userId: userWallet.userId,
           walletAddress: userWallet.address!,
           dseq: createLeaseMessage.value.bidId!.dseq.toString()
         })
@@ -140,6 +132,7 @@ export class ManagedSignerService {
     }
 
     await this.balancesService.refreshUserWalletLimits(userWallet);
+    await this.#ensureAutoReloadSchedule(userWallet.userId, messages);
 
     const result = pick(tx, ["code", "hash", "transactionHash", "rawLog"]) as Pick<IndexedTx, "code" | "hash" | "rawLog">;
 
@@ -151,6 +144,14 @@ export class ManagedSignerService {
     }
 
     return result as Pick<IndexedTx, "code" | "hash" | "rawLog"> & { transactionHash: string };
+  }
+
+  async #ensureAutoReloadSchedule(userId: UserWalletOutput["userId"], messages: EncodeObject[]) {
+    const hasSpendingTx = messages.some(message => SPENDING_TXS.some(msg => message.typeUrl.endsWith(msg.$type)));
+
+    if (hasSpendingTx) {
+      await this.walletReloadJobService.scheduleImmediate(userId);
+    }
   }
 
   /**


### PR DESCRIPTION
## Why

A user reported that their credits were not auto-reloaded after creating several new deployments via the `/v1/deployments` endpoint. The auto-reload scheduling logic was only present in `executeDerivedEncodedTxByUserId`, which is not called by the Managed Wallet API code path.

## What

Moved the spending transaction check and wallet reload scheduling from `executeDerivedEncodedTxByUserId` down to `executeDecodedTxByUserWallet`, ensuring both code paths (console UI and Managed Wallet API) trigger credit auto-reload. Extracted the logic into a private `#ensureAutoReloadSchedule` method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved wallet reload scheduling to more reliably handle spending transactions.
  * Optimized wallet state management during transaction execution.

* **Bug Fixes**
  * Enhanced wallet deployment alert command data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->