### PR TITLE
fix(billing): add chain error middleware to tx-signer

### DIFF
--- a/apps/tx-signer/src/server.ts
+++ b/apps/tx-signer/src/server.ts
@@ -9,6 +9,7 @@ import { container } from "tsyringe";
 
 import { healthzRouter, txRouter } from "@src/routes";
 import { AppConfigService } from "@src/services/app-config/app-config.service";
+import { ChainErrorMiddleware } from "@src/services/chain-error/chain-error.middleware";
 import { HonoErrorHandlerService } from "@src/services/hono-error-handler/hono-error-handler.service";
 import { startServer } from "@src/services/start-server/start-server";
 import type { AppEnv } from "@src/types/app-context";
@@ -16,6 +17,7 @@ import type { AppEnv } from "@src/types/app-context";
 export const app = new Hono<AppEnv>();
 app.use("*", otel());
 app.use(container.resolve(HttpLoggerInterceptor).intercept());
+app.use("/v1/tx/*", container.resolve(ChainErrorMiddleware).intercept());
 app.route("/", healthzRouter);
 app.route("/", txRouter);
 app.onError(container.resolve(HonoErrorHandlerService).handle);

--- a/apps/tx-signer/src/services/chain-error/chain-error.middleware.spec.ts
+++ b/apps/tx-signer/src/services/chain-error/chain-error.middleware.spec.ts
@@ -1,0 +1,147 @@
+import type { Context, Next } from "hono";
+import { isHttpError } from "http-errors";
+import { mock } from "jest-mock-extended";
+
+import { ChainErrorMiddleware } from "./chain-error.middleware";
+
+describe(ChainErrorMiddleware.name, () => {
+  it("passes through when no error is thrown", async () => {
+    const { intercept, next, context } = setup();
+    await intercept(context, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("returns 400 for insufficient funds error", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue(new Error("insufficient funds: 10uakt is smaller than 20uakt"));
+
+    await expect(intercept(context, next)).rejects.toMatchObject({ status: 400, message: "insufficient funds: 10uakt is smaller than 20uakt" });
+  });
+
+  it("returns 400 for deposit too low error", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue(new Error("Deposit too low: minimum is 5000000uakt"));
+
+    await expect(intercept(context, next)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("returns 400 for deployment closed error", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue(new Error("Deployment closed"));
+
+    await expect(intercept(context, next)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("returns 400 for invalid coin denominations error", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue(new Error("invalid coin denominations"));
+
+    await expect(intercept(context, next)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("returns 400 for invalid gpu attributes error", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue(new Error("invalid gpu attributes"));
+
+    await expect(intercept(context, next)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("returns 400 for invalid deployment version error", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue(new Error("invalid: deployment version"));
+
+    await expect(intercept(context, next)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("returns 400 for invalid deployment hash error", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue(
+      new Error("Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 0: Invalid: deployment hash")
+    );
+
+    await expect(intercept(context, next)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("returns 400 for fee allowance expired error", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue(new Error("fee allowance expired"));
+
+    await expect(intercept(context, next)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("returns 400 for deployment exists error", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue(new Error("Deployment exists"));
+
+    await expect(intercept(context, next)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("returns 400 for invalid owner address error", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue(new Error("Invalid Owner Address: invalid address"));
+
+    await expect(intercept(context, next)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("returns 400 for bid not open error", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue(new Error("bid not open"));
+
+    await expect(intercept(context, next)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("returns 400 for order not open error", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue(new Error("order not open"));
+
+    await expect(intercept(context, next)).rejects.toMatchObject({ status: 400 });
+  });
+
+  it("returns 402 for insufficient balance error", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue(new Error("insufficient balance"));
+
+    await expect(intercept(context, next)).rejects.toMatchObject({ status: 402 });
+  });
+
+  it("preserves original error message", async () => {
+    const { intercept, next, context } = setup();
+    const originalMessage =
+      "Query failed with (6): rpc error: code = Unknown desc = failed to execute message; message index: 1: Deposit invalid: insufficient balance";
+    next.mockRejectedValue(new Error(originalMessage));
+
+    await expect(intercept(context, next)).rejects.toMatchObject({ message: originalMessage });
+  });
+
+  it("converts matched errors to http errors", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue(new Error("insufficient funds: 10uakt is smaller than 20uakt"));
+    const error = await intercept(context, next).catch((e: unknown) => e);
+
+    expect(isHttpError(error)).toBe(true);
+  });
+
+  it("passes through non-matching errors unchanged", async () => {
+    const { intercept, next, context } = setup();
+    const error = new Error("Failed to sign and broadcast transaction");
+    next.mockRejectedValue(error);
+
+    await expect(intercept(context, next)).rejects.toBe(error);
+  });
+
+  it("passes through non-Error values unchanged", async () => {
+    const { intercept, next, context } = setup();
+    next.mockRejectedValue("string error");
+
+    await expect(intercept(context, next)).rejects.toBe("string error");
+  });
+
+  function setup() {
+    const middleware = new ChainErrorMiddleware();
+    const next: jest.MockedFn<Next> = jest.fn();
+    const context = mock<Context>();
+
+    return { intercept: middleware.intercept(), next, context };
+  }
+});

--- a/apps/tx-signer/src/services/chain-error/chain-error.middleware.ts
+++ b/apps/tx-signer/src/services/chain-error/chain-error.middleware.ts
@@ -1,0 +1,50 @@
+import type { MiddlewareHandler } from "hono";
+import createError from "http-errors";
+import { singleton } from "tsyringe";
+
+@singleton()
+export class ChainErrorMiddleware {
+  private readonly CHAIN_ERROR_STATUS_CODES: Record<string, number> = {
+    "insufficient funds": 400,
+    "deposit too low": 400,
+    "deployment closed": 400,
+    "invalid coin denominations": 400,
+    "invalid gpu attributes": 400,
+    "invalid: deployment version": 400,
+    "invalid: deployment hash": 400,
+    "fee allowance expired": 400,
+    "deployment exists": 400,
+    "invalid owner address": 400,
+    "bid not open": 400,
+    "order not open": 400,
+    "insufficient balance": 402
+  };
+
+  intercept(): MiddlewareHandler {
+    return async (_c, next) => {
+      try {
+        await next();
+      } catch (error) {
+        if (error instanceof Error) {
+          const status = this.getChainErrorStatus(error.message);
+          if (status) {
+            throw createError(status, error.message);
+          }
+        }
+        throw error;
+      }
+    };
+  }
+
+  private getChainErrorStatus(message: string): number | undefined {
+    const lowerMessage = message.toLowerCase();
+
+    for (const [pattern, status] of Object.entries(this.CHAIN_ERROR_STATUS_CODES)) {
+      if (lowerMessage.includes(pattern)) {
+        return status;
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -29,7 +29,7 @@ export const netConfigData = {
     ]
   },
   "sandbox-2": {
-    version: "v1.1.0",
+    version: "v1.2.0",
     faucetUrl: "http://faucet.sandbox-2.aksh.pw/",
     apiUrls: ["https://api.sandbox-2.aksh.pw:443"],
     rpcUrls: ["https://rpc.sandbox-2.aksh.pw:443"]


### PR DESCRIPTION
## Why

The tx-signer service is too noisy in alerting because all errors are returned as 500 (Internal Server Error), even when they are caused by invalid client input (e.g., insufficient funds, deployment closed, invalid GPU attributes). This makes it difficult to distinguish actual server issues from expected client errors.

## What

Added a ChainErrorMiddleware Hono middleware to tx-signer that classifies known chain/blockchain error patterns into proper HTTP status codes (400/402) instead of letting them fall through as 500s. The middleware:

- Matches 13 known chain error patterns (mirroring the API's ChainErrorService)
- Preserves the original error message so the API layer can still parse it for its own classification
- Only applies to /v1/tx/* routes
- Non-matching errors pass through unchanged to the existing HonoErrorHandlerService as 500s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced error handling for transaction operations, providing clearer and more appropriate error messages for common blockchain-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->