### PR TITLE
chore(billing): remove EXTERNAL_TX_SIGNER feature flag and local signing

### DIFF
--- a/apps/api/src/billing/services/tx-manager/tx-manager.service.spec.ts
+++ b/apps/api/src/billing/services/tx-manager/tx-manager.service.spec.ts
@@ -2,62 +2,27 @@ import type { EncodeObject } from "@cosmjs/proto-signing";
 import type { IndexedTx } from "@cosmjs/stargate/build/stargateclient";
 import { mock } from "vitest-mock-extended";
 
-import type { BatchSigningClientService, SignAndBroadcastOptions } from "@src/billing/lib/batch-signing-client/batch-signing-client.service";
+import type { SignAndBroadcastOptions } from "@src/billing/lib/batch-signing-client/batch-signing-client.service";
 import type { Wallet } from "@src/billing/lib/wallet/wallet";
 import type { ExternalSignerHttpSdkService } from "@src/billing/services/external-signer-http-sdk/external-signer-http-sdk.service";
 import type { LoggerService } from "@src/core";
-import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import { TxManagerService } from "./tx-manager.service";
 
 import { createAkashAddress } from "@test/seeders";
 
 describe(TxManagerService.name, () => {
   describe("signAndBroadcastWithFundingWallet", () => {
-    it("signs and broadcasts messages using funding wallet", async () => {
-      const messages: EncodeObject[] = [
-        {
-          typeUrl: "/test.MsgTest",
-          value: {}
-        }
-      ];
-      const txResult = mock<IndexedTx>({
-        code: 0,
-        hash: "tx-hash",
-        rawLog: "success"
-      });
+    it("delegates to external signer", async () => {
+      const messages: EncodeObject[] = [{ typeUrl: "/test.MsgTest", value: {} }];
+      const txResult = mock<IndexedTx>({ code: 0, hash: "tx-hash", rawLog: "success" });
 
-      const { service, fundingSigningClient } = setup({
-        fundingSignAndBroadcast: jest.fn().mockResolvedValue(txResult)
-      });
-
-      const result = await service.signAndBroadcastWithFundingWallet(messages);
-
-      expect(fundingSigningClient.signAndBroadcast).toHaveBeenCalledWith(messages);
-      expect(result).toEqual(txResult);
-    });
-
-    it("delegates to external signer when feature flag is enabled", async () => {
-      const messages: EncodeObject[] = [
-        {
-          typeUrl: "/test.MsgTest",
-          value: {}
-        }
-      ];
-      const txResult = mock<IndexedTx>({
-        code: 0,
-        hash: "external-tx-hash",
-        rawLog: "success"
-      });
-
-      const { service, fundingSigningClient, externalSignerHttpSdkService } = setup({
-        featureFlagsEnabled: true,
+      const { service, externalSignerHttpSdkService } = setup({
         externalFundingResult: txResult
       });
 
       const result = await service.signAndBroadcastWithFundingWallet(messages);
 
       expect(externalSignerHttpSdkService.signAndBroadcastWithFundingWallet).toHaveBeenCalledWith(messages);
-      expect(fundingSigningClient.signAndBroadcast).not.toHaveBeenCalled();
       expect(result).toEqual(txResult);
     });
   });
@@ -65,9 +30,7 @@ describe(TxManagerService.name, () => {
   describe("getFundingWalletAddress", () => {
     it("returns funding wallet address", async () => {
       const address = createAkashAddress();
-      const { service, fundingWallet } = setup({
-        fundingWalletAddress: address
-      });
+      const { service, fundingWallet } = setup({ fundingWalletAddress: address });
 
       const result = await service.getFundingWalletAddress();
 
@@ -77,139 +40,20 @@ describe(TxManagerService.name, () => {
   });
 
   describe("signAndBroadcastWithDerivedWallet", () => {
-    it("creates new client when not cached and signs transaction", async () => {
+    it("delegates to external signer", async () => {
       const derivationIndex = 1;
-      const address = createAkashAddress();
-      const messages: EncodeObject[] = [
-        {
-          typeUrl: "/test.MsgTest",
-          value: {}
-        }
-      ];
-      const options: SignAndBroadcastOptions = {
-        fee: { granter: createAkashAddress() }
-      };
-      const txResult = mock<IndexedTx>({
-        code: 0,
-        hash: "tx-hash",
-        rawLog: "success"
-      });
+      const messages: EncodeObject[] = [{ typeUrl: "/test.MsgTest", value: {} }];
+      const options: SignAndBroadcastOptions = { fee: { granter: createAkashAddress() } };
+      const txResult = mock<IndexedTx>({ code: 0, hash: "tx-hash", rawLog: "success" });
 
-      const { service, logger, derivedWallet, batchSigningClientServiceFactory } = setup({
-        derivedWalletAddress: address,
-        derivedSignAndBroadcast: jest.fn().mockResolvedValue(txResult),
-        hasPendingTransactions: false
-      });
-
-      const result = await service.signAndBroadcastWithDerivedWallet(derivationIndex, messages, options);
-
-      expect(derivedWallet.getFirstAddress).toHaveBeenCalled();
-      expect(batchSigningClientServiceFactory).toHaveBeenCalledWith(derivedWallet);
-      expect(logger.debug).toHaveBeenCalledWith({ event: "DERIVED_SIGNING_CLIENT_CREATE", address });
-      expect(result).toEqual(txResult);
-    });
-
-    it("delegates to external signer when feature flag is enabled", async () => {
-      const derivationIndex = 1;
-      const messages: EncodeObject[] = [
-        {
-          typeUrl: "/test.MsgTest",
-          value: {}
-        }
-      ];
-      const options: SignAndBroadcastOptions = {
-        fee: { granter: createAkashAddress() }
-      };
-      const txResult = mock<IndexedTx>({
-        code: 0,
-        hash: "external-derived-hash",
-        rawLog: "success"
-      });
-
-      const { service, batchSigningClientServiceFactory, externalSignerHttpSdkService } = setup({
-        featureFlagsEnabled: true,
+      const { service, externalSignerHttpSdkService } = setup({
         externalDerivedResult: txResult
       });
 
       const result = await service.signAndBroadcastWithDerivedWallet(derivationIndex, messages, options);
 
       expect(externalSignerHttpSdkService.signAndBroadcastWithDerivedWallet).toHaveBeenCalledWith(derivationIndex, messages, options);
-      expect(batchSigningClientServiceFactory).not.toHaveBeenCalled();
       expect(result).toEqual(txResult);
-    });
-
-    it("cleans up client when no pending transactions", async () => {
-      const derivationIndex = 1;
-      const address = createAkashAddress();
-      const messages: EncodeObject[] = [
-        {
-          typeUrl: "/test.MsgTest",
-          value: {}
-        }
-      ];
-      const txResult = mock<IndexedTx>({
-        code: 0,
-        hash: "tx-hash",
-        rawLog: "success"
-      });
-
-      const { service, logger } = setup({
-        derivedWalletAddress: address,
-        derivedSignAndBroadcast: jest.fn().mockResolvedValue(txResult),
-        hasPendingTransactions: false
-      });
-
-      await service.signAndBroadcastWithDerivedWallet(derivationIndex, messages);
-
-      expect(logger.debug).toHaveBeenCalledWith({ event: "DEDUPE_SIGNING_CLIENT_CLEAN_UP", address });
-    });
-
-    it("keeps client when has pending transactions", async () => {
-      const derivationIndex = 1;
-      const address = createAkashAddress();
-      const messages: EncodeObject[] = [
-        {
-          typeUrl: "/test.MsgTest",
-          value: {}
-        }
-      ];
-      const txResult = mock<IndexedTx>({
-        code: 0,
-        hash: "tx-hash",
-        rawLog: "success"
-      });
-
-      const { service, logger } = setup({
-        derivedWalletAddress: address,
-        derivedSignAndBroadcast: jest.fn().mockResolvedValue(txResult),
-        hasPendingTransactions: true
-      });
-
-      await service.signAndBroadcastWithDerivedWallet(derivationIndex, messages);
-
-      expect(logger.debug).not.toHaveBeenCalledWith({ event: "DEDUPE_SIGNING_CLIENT_CLEAN_UP", address });
-    });
-
-    it("cleans up client even when transaction fails", async () => {
-      const derivationIndex = 1;
-      const address = createAkashAddress();
-      const messages: EncodeObject[] = [
-        {
-          typeUrl: "/test.MsgTest",
-          value: {}
-        }
-      ];
-      const error = new Error("Transaction failed");
-
-      const { service, logger } = setup({
-        derivedWalletAddress: address,
-        derivedSignAndBroadcast: jest.fn().mockRejectedValue(error),
-        hasPendingTransactions: false
-      });
-
-      await expect(service.signAndBroadcastWithDerivedWallet(derivationIndex, messages)).rejects.toThrow("Transaction failed");
-
-      expect(logger.debug).toHaveBeenCalledWith({ event: "DEDUPE_SIGNING_CLIENT_CLEAN_UP", address });
     });
   });
 
@@ -217,9 +61,7 @@ describe(TxManagerService.name, () => {
     it("returns derived wallet address for given index", async () => {
       const index = 5;
       const address = createAkashAddress();
-      const { service, derivedWallet } = setup({
-        derivedWalletAddress: address
-      });
+      const { service, derivedWallet } = setup({ derivedWalletAddress: address });
 
       const result = await service.getDerivedWalletAddress(index);
 
@@ -243,102 +85,47 @@ describe(TxManagerService.name, () => {
   function setup(input?: {
     fundingWalletAddress?: string;
     derivedWalletAddress?: string;
-    fundingSignAndBroadcast?: BatchSigningClientService["signAndBroadcast"];
-    derivedSignAndBroadcast?: BatchSigningClientService["signAndBroadcast"];
-    hasPendingTransactions?: boolean;
-    featureFlagsEnabled?: boolean;
     externalFundingResult?: IndexedTx;
     externalDerivedResult?: IndexedTx;
   }) {
-    const fundingWalletAddress = input?.fundingWalletAddress ?? createAkashAddress();
-    const derivedWalletAddress = input?.derivedWalletAddress ?? createAkashAddress();
-
     const fundingWallet = mock<Wallet>({
-      getFirstAddress: jest.fn().mockResolvedValue(fundingWalletAddress)
-    });
-
-    const oldMasterWallet = mock<Wallet>({
-      getFirstAddress: jest.fn().mockResolvedValue(createAkashAddress())
+      getFirstAddress: jest.fn().mockResolvedValue(input?.fundingWalletAddress ?? createAkashAddress())
     });
 
     const derivedWallet = mock<Wallet>({
-      getFirstAddress: jest.fn().mockResolvedValue(derivedWalletAddress)
+      getFirstAddress: jest.fn().mockResolvedValue(input?.derivedWalletAddress ?? createAkashAddress())
     });
 
-    const fundingSigningClient = mock<BatchSigningClientService>({
-      signAndBroadcast: input?.fundingSignAndBroadcast ?? jest.fn()
-    });
-
-    const oldMasterSigningClient = mock<BatchSigningClientService>({
-      signAndBroadcast: jest.fn()
-    });
-
-    const derivedSigningClient = mock<BatchSigningClientService>({
-      signAndBroadcast: input?.derivedSignAndBroadcast ?? jest.fn(),
-      hasPendingTransactions: input?.hasPendingTransactions ?? false
-    });
-
-    const walletFactory = jest.fn().mockImplementation((_index: number) => {
-      return derivedWallet;
-    });
-
-    const oldWalletFactory = jest.fn().mockImplementation((_index: number) => {
-      return derivedWallet;
-    });
-
-    const batchSigningClientServiceFactory = jest.fn().mockImplementation((_wallet: Wallet) => {
-      return derivedSigningClient;
-    });
-
-    const logger = mock<LoggerService>();
-    const featureFlagsService = mock<FeatureFlagsService>({
-      isEnabled: jest.fn().mockReturnValue(input?.featureFlagsEnabled ?? false)
-    });
-    const externalSignerHttpSdkService = mock<ExternalSignerHttpSdkService>({
-      signAndBroadcastWithFundingWallet: jest.fn().mockResolvedValue(
-        input?.externalFundingResult ??
-          mock<IndexedTx>({
-            code: 0,
-            hash: "external-default-hash",
-            rawLog: "success"
-          })
-      ),
-      signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue(
-        input?.externalDerivedResult ??
-          mock<IndexedTx>({
-            code: 0,
-            hash: "external-default-hash",
-            rawLog: "success"
-          })
-      )
-    });
+    const walletFactory = jest.fn().mockReturnValue(derivedWallet);
 
     const walletResources = {
       v1: {
-        masterWallet: oldMasterWallet,
-        masterSigningClient: oldMasterSigningClient,
-        derivedWalletFactory: oldWalletFactory
+        masterWallet: fundingWallet,
+        derivedWalletFactory: walletFactory
       },
       v2: {
         masterWallet: fundingWallet,
-        masterSigningClient: fundingSigningClient,
         derivedWalletFactory: walletFactory
       }
     };
 
-    const service = new TxManagerService(walletResources, batchSigningClientServiceFactory, logger, featureFlagsService, externalSignerHttpSdkService);
+    const logger = mock<LoggerService>();
+    const externalSignerHttpSdkService = mock<ExternalSignerHttpSdkService>({
+      signAndBroadcastWithFundingWallet: jest
+        .fn()
+        .mockResolvedValue(input?.externalFundingResult ?? mock<IndexedTx>({ code: 0, hash: "default-hash", rawLog: "success" })),
+      signAndBroadcastWithDerivedWallet: jest
+        .fn()
+        .mockResolvedValue(input?.externalDerivedResult ?? mock<IndexedTx>({ code: 0, hash: "default-hash", rawLog: "success" }))
+    });
+
+    const service = new TxManagerService(walletResources, logger, externalSignerHttpSdkService);
 
     return {
       service,
-      walletFactory,
-      oldWalletFactory,
       fundingWallet,
-      oldMasterWallet,
       derivedWallet,
-      fundingSigningClient,
-      oldMasterSigningClient,
-      derivedSigningClient,
-      batchSigningClientServiceFactory,
+      walletFactory,
       logger,
       externalSignerHttpSdkService
     };

--- a/apps/api/src/billing/services/tx-manager/tx-manager.service.ts
+++ b/apps/api/src/billing/services/tx-manager/tx-manager.service.ts
@@ -1,30 +1,15 @@
 import type { EncodeObject } from "@cosmjs/proto-signing";
 import { container, inject, type InjectionToken, instancePerContainerCachingFactory, singleton } from "tsyringe";
 
-import { BatchSigningClientService, SignAndBroadcastOptions } from "@src/billing/lib/batch-signing-client/batch-signing-client.service";
-import { createSigningStargateClient } from "@src/billing/lib/signing-stargate-client-factory/signing-stargate-client.factory";
+import type { SignAndBroadcastOptions } from "@src/billing/lib/batch-signing-client/batch-signing-client.service";
 import { Wallet } from "@src/billing/lib/wallet/wallet";
-import { TYPE_REGISTRY } from "@src/billing/providers/type-registry.provider";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { ExternalSignerHttpSdkService } from "@src/billing/services/external-signer-http-sdk/external-signer-http-sdk.service";
 import { LoggerService } from "@src/core";
-import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
-import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
-
-export type BatchSigningClientServiceFactory = (wallet: Wallet, loggerContext?: string) => BatchSigningClientService;
-const BATCH_SIGNING_CLIENT_FACTORY: InjectionToken<BatchSigningClientServiceFactory> = Symbol("BATCH_SIGNING_CLIENT_FACTORY");
-container.register(BATCH_SIGNING_CLIENT_FACTORY, {
-  useFactory: c => {
-    return (wallet: Wallet, loggerContext?: string) => {
-      return new BatchSigningClientService(c.resolve(BillingConfigService), wallet, c.resolve(TYPE_REGISTRY), createSigningStargateClient, loggerContext);
-    };
-  }
-});
 
 export type WalletFactory = (walletIndex?: number) => Wallet;
 type WalletVersionConfig = {
   masterWallet: Wallet;
-  masterSigningClient: BatchSigningClientService;
   derivedWalletFactory: WalletFactory;
 };
 
@@ -36,7 +21,6 @@ const WALLET_RESOURCES: InjectionToken<WalletResources> = Symbol("WALLET_RESOURC
 container.register(WALLET_RESOURCES, {
   useFactory: instancePerContainerCachingFactory(c => {
     const config = c.resolve(BillingConfigService);
-    const batchSigningClientFactory = c.resolve<BatchSigningClientServiceFactory>(BATCH_SIGNING_CLIENT_FACTORY);
 
     const v1MasterWallet = new Wallet(config.get("FUNDING_WALLET_MNEMONIC_V1") ?? config.get("OLD_MASTER_WALLET_MNEMONIC"));
     const v2MasterWallet = new Wallet(config.get("FUNDING_WALLET_MNEMONIC_V2") ?? config.get("FUNDING_WALLET_MNEMONIC"));
@@ -52,22 +36,15 @@ container.register(WALLET_RESOURCES, {
     return {
       v1: {
         masterWallet: v1MasterWallet,
-        masterSigningClient: batchSigningClientFactory(v1MasterWallet, "V1_MASTER_SIGNING_CLIENT"),
         derivedWalletFactory: v1DerivedWalletFactory
       },
       v2: {
         masterWallet: v2MasterWallet,
-        masterSigningClient: batchSigningClientFactory(v2MasterWallet, "V2_MASTER_SIGNING_CLIENT"),
         derivedWalletFactory: v2DerivedWalletFactory
       }
     };
   })
 });
-
-type CachedClient = {
-  address: string;
-  client: BatchSigningClientService;
-};
 
 type WalletOptions = {
   walletVersion?: WalletVersion;
@@ -75,15 +52,11 @@ type WalletOptions = {
 
 @singleton()
 export class TxManagerService {
-  readonly #clientsByAddress: Map<string, CachedClient> = new Map();
-
   readonly #DEFAULT_WALLET_VERSION: WalletVersion = "v2";
 
   constructor(
     @inject(WALLET_RESOURCES) private readonly walletResources: WalletResources,
-    @inject(BATCH_SIGNING_CLIENT_FACTORY) private readonly batchSigningClientServiceFactory: BatchSigningClientServiceFactory,
     private readonly logger: LoggerService,
-    private readonly featureFlagsService: FeatureFlagsService,
     private readonly externalSignerHttpSdkService: ExternalSignerHttpSdkService
   ) {
     this.logger.setContext(TxManagerService.name);
@@ -96,12 +69,7 @@ export class TxManagerService {
   }
 
   async signAndBroadcastWithFundingWallet(messages: readonly EncodeObject[]) {
-    if (this.featureFlagsService.isEnabled(FeatureFlags.EXTERNAL_TX_SIGNER)) {
-      return await this.externalSignerHttpSdkService.signAndBroadcastWithFundingWallet(messages);
-    }
-
-    const { masterSigningClient } = this.#getWalletResources();
-    return await masterSigningClient.signAndBroadcast(messages);
+    return await this.externalSignerHttpSdkService.signAndBroadcastWithFundingWallet(messages);
   }
 
   async getFundingWalletAddress() {
@@ -110,39 +78,11 @@ export class TxManagerService {
   }
 
   async signAndBroadcastWithDerivedWallet(derivationIndex: number, messages: readonly EncodeObject[], options?: SignAndBroadcastOptions) {
-    if (this.featureFlagsService.isEnabled(FeatureFlags.EXTERNAL_TX_SIGNER)) {
-      return await this.externalSignerHttpSdkService.signAndBroadcastWithDerivedWallet(derivationIndex, messages, options);
-    }
-
-    const { client, address } = await this.#getClient(derivationIndex);
-
-    try {
-      return await client.signAndBroadcast(messages, options);
-    } finally {
-      if (!client.hasPendingTransactions && this.#clientsByAddress.has(address)) {
-        this.logger.debug({ event: "DEDUPE_SIGNING_CLIENT_CLEAN_UP", address });
-        this.#clientsByAddress.delete(address);
-      }
-    }
+    return await this.externalSignerHttpSdkService.signAndBroadcastWithDerivedWallet(derivationIndex, messages, options);
   }
 
   async getDerivedWalletAddress(index: number, options?: WalletOptions) {
     return await this.getDerivedWallet(index, options).getFirstAddress();
-  }
-
-  async #getClient(derivationIndex: number): Promise<CachedClient> {
-    const wallet = this.getDerivedWallet(derivationIndex);
-    const address = await wallet.getFirstAddress();
-
-    if (!this.#clientsByAddress.has(address)) {
-      this.logger.debug({ event: "DERIVED_SIGNING_CLIENT_CREATE", address });
-      this.#clientsByAddress.set(address, {
-        address,
-        client: this.batchSigningClientServiceFactory(wallet)
-      });
-    }
-
-    return this.#clientsByAddress.get(address)!;
   }
 
   getDerivedWallet(index: number, options?: WalletOptions) {

--- a/apps/api/src/core/config/env.config.ts
+++ b/apps/api/src/core/config/env.config.ts
@@ -38,10 +38,6 @@ export const envSchema = z
       .string()
       .default("false")
       .transform(value => value === "true"),
-    FEATURE_FLAGS_EXTERNAL_TX_SIGNER_DISABLED: z
-      .string()
-      .default("false")
-      .transform(value => value === "true"),
     REST_API_NODE_URL: z
       .string()
       .url()

--- a/apps/api/src/core/services/feature-flags/feature-flags.service.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.service.ts
@@ -6,7 +6,7 @@ import { APP_INITIALIZER, AppInitializer, ON_APP_START } from "@src/core/provide
 import type { AppContext } from "@src/core/types/app-context";
 import { CoreConfigService } from "../core-config/core-config.service";
 import { ExecutionContextService } from "../execution-context/execution-context.service";
-import { FeatureFlags, FeatureFlagValue } from "./feature-flags";
+import { FeatureFlagValue } from "./feature-flags";
 
 @registry([{ token: APP_INITIALIZER, useToken: FeatureFlagsService }])
 @singleton()
@@ -28,7 +28,6 @@ export class FeatureFlagsService implements Disposable, AppInitializer {
   }
 
   isEnabled(featureFlag: FeatureFlagValue): boolean {
-    if (featureFlag === FeatureFlags.EXTERNAL_TX_SIGNER && this.configService.get("FEATURE_FLAGS_EXTERNAL_TX_SIGNER_DISABLED")) return false;
     if (this.configService.get("FEATURE_FLAGS_ENABLE_ALL")) return true;
 
     assert(this.client, "Feature flags service was not initialized. Call initialize() method first.");

--- a/apps/api/src/core/services/feature-flags/feature-flags.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.ts
@@ -2,7 +2,6 @@ export const FeatureFlags = {
   NOTIFICATIONS_ALERT_CREATE: "notifications_general_alerts_create",
   NOTIFICATIONS_ALERT_UPDATE: "notifications_general_alerts_update",
   AUTO_CREDIT_RELOAD: "auto_credit_reload",
-  EXTERNAL_TX_SIGNER: "external_tx_signer",
   TRIAL_FINGERPRINT_CHECK: "trial_fingerprint_check"
 } as const;
 


### PR DESCRIPTION
## Why

The external tx-signer service has been fully rolled out and the `EXTERNAL_TX_SIGNER` feature flag is no longer needed. The local in-process signing code path is dead code at this point.

## What

- Remove `EXTERNAL_TX_SIGNER` from `FeatureFlags` enum
- Remove `FEATURE_FLAGS_EXTERNAL_TX_SIGNER_DISABLED` env var from core config
- Remove feature flag check override in `FeatureFlagsService`
- Remove `BATCH_SIGNING_CLIENT_FACTORY` DI token and registration
- Remove `masterSigningClient` from `WalletVersionConfig`
- Remove `BatchSigningClientServiceFactory` type
- Remove `CachedClient` type and `#clientsByAddress` map
- Remove `#getClient` private method for derived signing client caching
- Remove feature flag branching in `signAndBroadcastWithFundingWallet` and `signAndBroadcastWithDerivedWallet` — both now always delegate to `ExternalSignerHttpSdkService`
- Simplify `TxManagerService` constructor (drop `batchSigningClientServiceFactory` and `featureFlagsService` params)
- Update tests to reflect external-only signing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified transaction manager by consolidating all wallet signing and broadcasting through the external signer service, removing internal client caching and creation logic.
  * Removed feature flags and environment configurations that previously allowed switching between different signing implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->