### PR TITLE
refactor(log-collector): unify structured logging and fix Fluent Bit parser

### DIFF
--- a/apps/log-collector/fluent-bit/parsers.conf
+++ b/apps/log-collector/fluent-bit/parsers.conf
@@ -1,6 +1,7 @@
 [PARSER]
     Name        kubernetes
     Format      regex
-    Regex       ^(?<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)\s+(?<message>.*)$
+    Regex       ^(?<timestamp>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3})\d*Z\s+(?<message>.*)$
     Time_Key    timestamp
-    Time_Format %Y-%m-%dT%H:%M:%S.%L 
+    Time_Format %Y-%m-%dT%H:%M:%S.%L
+    Time_Offset +0000

--- a/apps/log-collector/fluent-bit/script/extract_metadata.lua
+++ b/apps/log-collector/fluent-bit/script/extract_metadata.lua
@@ -50,7 +50,7 @@ function extract_metadata(tag, timestamp, record)
     local service = string.match(pod_name, "^(.-)%-%d+$")
     if not service then
         -- Pattern 2: Deployment format "service-hash-random" → service = "service"
-        service = string.match(pod_name, "^(.-)%-.+%-.+$")
+        service = string.match(pod_name, "^(.+)%-%w+%-%w+$")
     end
     if not service then
         -- Pattern 3: Fallback - use entire pod name as service

--- a/apps/log-collector/k8s/target.deployment.yaml
+++ b/apps/log-collector/k8s/target.deployment.yaml
@@ -22,9 +22,9 @@ spec:
             - /bin/sh
             - -c
             - |
-              while true; do 
-                echo "$(date -u +%Y-%m-%dT%H:%M:%S.%NZ) [INFO] Dummy log message from pod dummy-logging-pod"
-                echo "$(date -u +%Y-%m-%dT%H:%M:%S.%NZ) [ERROR] This is a test error message"
-                echo "$(date -u +%Y-%m-%dT%H:%M:%S.%NZ) [DEBUG] Debug information for testing"
-                sleep 5
+              while true; do
+                echo "$(date -u +%Y-%m-%dT%H:%M:%S).000Z [INFO] Dummy log message from pod dummy-logging-pod"
+                echo "$(date -u +%Y-%m-%dT%H:%M:%S).000Z [ERROR] This is a test error message"
+                echo "$(date -u +%Y-%m-%dT%H:%M:%S).000Z [DEBUG] Debug information for testing"
+                sleep 30
               done

--- a/apps/log-collector/src/lib/memoize-async.ts
+++ b/apps/log-collector/src/lib/memoize-async.ts
@@ -1,0 +1,21 @@
+/**
+ * Memoizes an async function so that it is called at most once.
+ * On success the resolved value is cached permanently.
+ * On rejection the cache is cleared so the next call retries.
+ */
+export function memoizeAsync<T>(fn: () => Promise<T>): () => Promise<T> {
+  let cached: Promise<T> | undefined;
+
+  return () => {
+    if (cached) {
+      return cached;
+    }
+
+    cached = fn();
+    cached.catch(() => {
+      cached = undefined;
+    });
+
+    return cached;
+  };
+}

--- a/apps/log-collector/src/services/error-handler/error-handler.service.spec.ts
+++ b/apps/log-collector/src/services/error-handler/error-handler.service.spec.ts
@@ -34,4 +34,42 @@ describe(ErrorHandlerService.name, () => {
 
     expect(result).toEqual([]);
   });
+
+  describe("isForbidden", () => {
+    it("should return true for error with statusCode 403", () => {
+      const errorHandlerService = new ErrorHandlerService();
+      const error = Object.assign(new Error("Forbidden"), { statusCode: 403 });
+
+      expect(errorHandlerService.isForbidden(error)).toBe(true);
+    });
+
+    it("should return true for error with code 403", () => {
+      const errorHandlerService = new ErrorHandlerService();
+      const error = Object.assign(new Error("Forbidden"), { code: 403 });
+
+      expect(errorHandlerService.isForbidden(error)).toBe(true);
+    });
+
+    it("should return true for AggregateError where all errors are forbidden", () => {
+      const errorHandlerService = new ErrorHandlerService();
+      const error = new AggregateError([Object.assign(new Error("Forbidden"), { statusCode: 403 }), Object.assign(new Error("Forbidden"), { code: 403 })]);
+
+      expect(errorHandlerService.isForbidden(error)).toBe(true);
+    });
+
+    it("should return false for empty AggregateError", () => {
+      const errorHandlerService = new ErrorHandlerService();
+      const error = new AggregateError([]);
+
+      expect(errorHandlerService.isForbidden(error)).toBe(false);
+    });
+
+    it("should return false for non-forbidden errors", () => {
+      const errorHandlerService = new ErrorHandlerService();
+
+      expect(errorHandlerService.isForbidden(new Error("not forbidden"))).toBe(false);
+      expect(errorHandlerService.isForbidden(null)).toBe(false);
+      expect(errorHandlerService.isForbidden("string")).toBe(false);
+    });
+  });
 });

--- a/apps/log-collector/src/services/error-handler/error-handler.service.ts
+++ b/apps/log-collector/src/services/error-handler/error-handler.service.ts
@@ -40,4 +40,24 @@ export class ErrorHandlerService {
 
     return successfulResults;
   }
+
+  isForbidden(error: unknown): boolean {
+    if (typeof error !== "object" || error === null) {
+      return false;
+    }
+
+    if ("statusCode" in error && (error as { statusCode: number }).statusCode === 403) {
+      return true;
+    }
+
+    if ("code" in error && (error as { code: number }).code === 403) {
+      return true;
+    }
+
+    if (error instanceof AggregateError) {
+      return error.errors.length > 0 && error.errors.every(e => this.isForbidden(e));
+    }
+
+    return false;
+  }
 }

--- a/apps/log-collector/src/services/file-destination/file-destination.service.spec.ts
+++ b/apps/log-collector/src/services/file-destination/file-destination.service.spec.ts
@@ -43,7 +43,7 @@ describe(FileDestinationService.name, () => {
 
       expect(mockFs.promises.mkdir).toHaveBeenCalledWith(logDir, { recursive: true });
       expect(loggerService.info).toHaveBeenCalledWith({
-        message: "Created log directory",
+        event: "LOG_DIR_CREATED",
         path: logDir
       });
     });
@@ -57,7 +57,7 @@ describe(FileDestinationService.name, () => {
 
       expect(mockFs.promises.writeFile).toHaveBeenCalledWith(expectedPath, "");
       expect(loggerService.info).toHaveBeenCalledWith({
-        message: "Created log file",
+        event: "LOG_FILE_CREATED",
         filePath: expectedPath,
         namespace: "test-namespace",
         podName: "test-pod"

--- a/apps/log-collector/src/services/file-destination/file-destination.service.ts
+++ b/apps/log-collector/src/services/file-destination/file-destination.service.ts
@@ -1,11 +1,11 @@
 import * as fsGlobal from "fs";
-import memoize from "lodash/memoize";
 import { once } from "node:events";
 import * as pathGlobal from "path";
 import * as readlineGlobal from "readline";
 import { PassThrough } from "stream";
 import { setTimeout as delay } from "timers/promises";
 
+import { memoizeAsync } from "@src/lib/memoize-async";
 import type { ConfigService } from "@src/services/config/config.service";
 import type { LoggerService } from "@src/services/logger/logger.service";
 import type { PodInfo } from "@src/services/pod-discovery/pod-discovery.service";
@@ -22,7 +22,7 @@ interface ParsedLine {
  * - Creating and managing log files for individual pods
  * - Automatic log file rotation based on configurable size limits
  * - Retrieving the last log lines with the same timestamp for resumption purposes
- * - Memoized log path generation and last log line retrieval for performance
+ * - Memoized log path generation for performance
  * - Graceful error handling for file system operations
  * - Streaming-based log reading to avoid memory issues with large files
  *
@@ -52,8 +52,8 @@ export class FileDestinationService {
     private readonly path = pathGlobal,
     private readonly readline = readlineGlobal
   ) {
-    this.getLogPath = memoize(this.getLogPath.bind(this));
-    this.getLastLogLines = memoize(this.getLastLogLines.bind(this));
+    this.getLogPath = memoizeAsync(this.getLogPath.bind(this));
+    this.createWriteStream = memoizeAsync(this.createWriteStream.bind(this));
   }
 
   /**
@@ -158,14 +158,14 @@ export class FileDestinationService {
       } catch (dirError) {
         await this.fs.promises.mkdir(logDir, { recursive: true });
         this.loggerService.info({
-          message: "Created log directory",
+          event: "LOG_DIR_CREATED",
           path: logDir
         });
       }
 
       await this.fs.promises.writeFile(filePath, "");
       this.loggerService.info({
-        message: "Created log file",
+        event: "LOG_FILE_CREATED",
         filePath,
         namespace: this.podInfo.namespace,
         podName: this.podInfo.podName
@@ -219,7 +219,7 @@ export class FileDestinationService {
                   ]);
                 } catch (error) {
                   this.loggerService.warn({
-                    message: "Write stream close failed, proceeding with rotation",
+                    event: "WRITE_STREAM_CLOSE_FAILED",
                     filePath,
                     error
                   });
@@ -235,13 +235,13 @@ export class FileDestinationService {
                 stableStream.pipe(currentWriteStream);
 
                 this.loggerService.info({
-                  message: "Log file rotated successfully",
+                  event: "LOG_FILE_ROTATED",
                   filePath
                 });
               } catch (error) {
                 this.loggerService.error({
+                  event: "LOG_FILE_ROTATION_FAILED",
                   error,
-                  message: "Failed to rotate log file",
                   filePath
                 });
                 stableStream.emit("error", error);
@@ -250,8 +250,8 @@ export class FileDestinationService {
             }
           } catch (error) {
             this.loggerService.error({
+              event: "LOG_FILE_SIZE_CHECK_FAILED",
               error,
-              message: "Failed to check file size for rotation",
               filePath
             });
           }
@@ -260,8 +260,8 @@ export class FileDestinationService {
 
       checkFileSizePeriodically().catch(error => {
         this.loggerService.error({
+          event: "LOG_FILE_SIZE_CHECK_LOOP_FAILED",
           error,
-          message: "File size checking loop failed",
           filePath
         });
         stableStream.emit("error", error);
@@ -302,11 +302,18 @@ export class FileDestinationService {
       try {
         lastLines = await this.readLastLineFromSpecificFile(rotatedFilePath);
       } catch (error) {
-        this.loggerService.debug({
-          message: "No rotated file found or readable",
-          rotatedFilePath,
-          error
-        });
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          this.loggerService.debug({
+            event: "ROTATED_FILE_NOT_FOUND",
+            rotatedFilePath
+          });
+        } else {
+          this.loggerService.error({
+            event: "ROTATED_FILE_READ_ERROR",
+            rotatedFilePath,
+            error
+          });
+        }
       }
     }
 
@@ -382,22 +389,8 @@ export class FileDestinationService {
    * @throws Error if file system operations fail (except for missing files)
    */
   private async rotateLogFile(filePath: string): Promise<void> {
-    try {
-      await this.shiftRotatedFiles(filePath);
-      await this.removeOldestRotatedFile(filePath);
-      this.loggerService.info({
-        message: "Log file rotated",
-        filePath
-      });
-    } catch (error) {
-      this.loggerService.error({
-        error,
-        message: "Failed to rotate log file",
-        filePath
-      });
-
-      throw error;
-    }
+    await this.shiftRotatedFiles(filePath);
+    await this.removeOldestRotatedFile(filePath);
   }
 
   /**

--- a/apps/log-collector/src/services/pod-discovery/pod-discovery.service.spec.ts
+++ b/apps/log-collector/src/services/pod-discovery/pod-discovery.service.spec.ts
@@ -58,16 +58,16 @@ describe(PodDiscoveryService.name, () => {
     });
 
     expect(loggerService.info).toHaveBeenCalledWith({
-      message: "Discovering pods in namespace",
+      event: "POD_DISCOVERY_STARTED",
       namespace
     });
 
     expect(loggerService.info).toHaveBeenCalledWith({
+      event: "POD_DISCOVERY_COMPLETED",
       namespace,
       totalPods: 5,
       targetPods: 2,
-      currentPodName,
-      message: "Pod discovery completed"
+      currentPodName
     });
   });
 
@@ -151,11 +151,11 @@ describe(PodDiscoveryService.name, () => {
 
     expect(result).toHaveLength(0);
     expect(loggerService.info).toHaveBeenCalledWith({
+      event: "POD_DISCOVERY_COMPLETED",
       namespace,
       totalPods: 0,
       targetPods: 0,
-      currentPodName,
-      message: "Pod discovery completed"
+      currentPodName
     });
   });
 
@@ -186,11 +186,11 @@ describe(PodDiscoveryService.name, () => {
     expect(result[1].podName).toBe("other-pod");
 
     expect(loggerService.info).toHaveBeenCalledWith({
+      event: "POD_DISCOVERY_COMPLETED",
       namespace,
       totalPods: 2,
       targetPods: 2,
-      currentPodName: "simple-pod",
-      message: "Pod discovery completed"
+      currentPodName: "simple-pod"
     });
   });
 
@@ -331,6 +331,7 @@ describe(PodDiscoveryService.name, () => {
     await podDiscoveryService.discoverPodsInNamespace();
 
     expect(loggerService.info).toHaveBeenCalledWith({
+      event: "NAMESPACE_RESOLVED",
       namespace: kubeconfigNamespace,
       source: "kubeconfig"
     });

--- a/apps/log-collector/src/services/pod-discovery/pod-discovery.service.ts
+++ b/apps/log-collector/src/services/pod-discovery/pod-discovery.service.ts
@@ -75,7 +75,7 @@ export class PodDiscoveryService {
   async discoverPodsInNamespace(): Promise<PodInfo[]> {
     const namespace = this.getCurrentNamespace();
 
-    this.loggerService.info({ message: "Discovering pods in namespace", namespace });
+    this.loggerService.info({ event: "POD_DISCOVERY_STARTED", namespace });
 
     const { items: podsRaw } = await this.k8sClient.listNamespacedPod({
       namespace,
@@ -88,11 +88,11 @@ export class PodDiscoveryService {
     const targetPods = this.filterOutPodsFromSameDeployment(pods, currentPodName);
 
     this.loggerService.info({
+      event: "POD_DISCOVERY_COMPLETED",
       namespace,
       totalPods: pods.length,
       targetPods: targetPods.length,
-      currentPodName,
-      message: "Pod discovery completed"
+      currentPodName
     });
 
     return targetPods;
@@ -128,10 +128,10 @@ export class PodDiscoveryService {
    */
   private getNamespaceFromKubeConfig(): string {
     const currentContext = this.kubeConfig.getCurrentContext();
-    this.loggerService.debug({ currentContext });
+    this.loggerService.debug({ event: "KUBE_CONFIG_CONTEXT", currentContext });
 
     const context = this.kubeConfig.getContextObject(currentContext);
-    this.loggerService.debug({ context });
+    this.loggerService.debug({ event: "KUBE_CONFIG_CONTEXT_OBJECT", context });
 
     if (!context) {
       throw new Error(`Context object not found for current context: ${currentContext}`);
@@ -143,7 +143,7 @@ export class PodDiscoveryService {
       throw new Error(`No namespace provided in k8s context: ${currentContext}. Please set namespace in context or provide KUBERNETES_NAMESPACE_OVERRIDE`);
     }
 
-    this.loggerService.info({ namespace, source: "kubeconfig" });
+    this.loggerService.info({ event: "NAMESPACE_RESOLVED", namespace, source: "kubeconfig" });
 
     return namespace;
   }

--- a/apps/log-collector/src/services/pod-logs-collector/pod-logs-collector.service.spec.ts
+++ b/apps/log-collector/src/services/pod-logs-collector/pod-logs-collector.service.spec.ts
@@ -58,14 +58,14 @@ describe(PodLogsCollectorService.name, () => {
       podName: "test-pod",
       namespace: "test-namespace",
       containerName: "app",
-      message: "Starting log collection for container"
+      event: "CONTAINER_LOG_COLLECTION_STARTED"
     });
 
     expect(loggerService.info).toHaveBeenCalledWith({
       podName: "test-pod",
       namespace: "test-namespace",
       containerName: "sidecar",
-      message: "Starting log collection for container"
+      event: "CONTAINER_LOG_COLLECTION_STARTED"
     });
   });
 
@@ -78,7 +78,7 @@ describe(PodLogsCollectorService.name, () => {
     expect(loggerService.warn).toHaveBeenCalledWith({
       podName: "test-pod",
       namespace: "test-namespace",
-      message: "No containers found in pod"
+      event: "POD_LOGS_NO_CONTAINERS"
     });
   });
 
@@ -134,7 +134,7 @@ describe(PodLogsCollectorService.name, () => {
       podName: "test-pod",
       namespace: "test-namespace",
       containerName: "app",
-      message: "Starting log collection for container"
+      event: "CONTAINER_LOG_COLLECTION_STARTED"
     });
   });
 
@@ -227,6 +227,41 @@ describe(PodLogsCollectorService.name, () => {
     );
   });
 
+  it("should log warning and return on 403 Forbidden", async () => {
+    const { podLogsCollectorService, fileDestination, errorHandlerService, loggerService } = setup({
+      containerNames: ["app"]
+    });
+
+    fileDestination.getLastLogLines.mockResolvedValue([]);
+    fileDestination.createWriteStream.mockResolvedValue(mock<NodeJS.WritableStream>());
+
+    const forbiddenError = Object.assign(new Error("Forbidden"), { statusCode: 403 });
+    errorHandlerService.aggregateConcurrentResults.mockRejectedValue(new AggregateError([forbiddenError], "container log collection"));
+
+    await podLogsCollectorService.collectPodLogs();
+
+    expect(loggerService.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "POD_LOGS_COLLECTION_FORBIDDEN",
+        message: expect.stringContaining("permissions")
+      })
+    );
+  });
+
+  it("should re-throw non-forbidden errors", async () => {
+    const { podLogsCollectorService, fileDestination, errorHandlerService } = setup({
+      containerNames: ["app"]
+    });
+
+    fileDestination.getLastLogLines.mockResolvedValue([]);
+    fileDestination.createWriteStream.mockResolvedValue(mock<NodeJS.WritableStream>());
+
+    const error = new Error("Something went wrong");
+    errorHandlerService.aggregateConcurrentResults.mockRejectedValue(error);
+
+    await expect(podLogsCollectorService.collectPodLogs()).rejects.toThrow("Something went wrong");
+  });
+
   function setup(overrides: { containerNames: string[] } = { containerNames: ["app"] }) {
     container.clearInstances();
 
@@ -238,6 +273,8 @@ describe(PodLogsCollectorService.name, () => {
     const fileDestination = mockProvider(FileDestinationService);
     const k8sLogClient = mockProvider(K8sLog);
     const errorHandlerService = mockProvider(ErrorHandlerService);
+    const realErrorHandler = new ErrorHandlerService();
+    errorHandlerService.isForbidden.mockImplementation((error: unknown) => realErrorHandler.isForbidden(error));
     const loggerService = mockProvider(LoggerService);
 
     const podLogsCollectorService = new PodLogsCollectorService(podInfo, fileDestination, k8sLogClient, errorHandlerService, loggerService);

--- a/apps/log-collector/src/services/pod-logs-collector/pod-logs-collector.service.ts
+++ b/apps/log-collector/src/services/pod-logs-collector/pod-logs-collector.service.ts
@@ -67,14 +67,27 @@ export class PodLogsCollectorService {
 
     if (this.podInfo.containerNames.length === 0) {
       this.loggerService.warn({
+        event: "POD_LOGS_NO_CONTAINERS",
         podName: this.podInfo.podName,
-        namespace: this.podInfo.namespace,
-        message: "No containers found in pod"
+        namespace: this.podInfo.namespace
       });
       return;
     }
 
-    await this.startLogCollectionForAllContainers(this.podInfo.containerNames, logLine[0]?.timestamp);
+    try {
+      await this.startLogCollectionForAllContainers(this.podInfo.containerNames, logLine[0]?.timestamp);
+    } catch (error) {
+      if (this.errorHandlerService.isForbidden(error)) {
+        this.loggerService.warn({
+          event: "POD_LOGS_COLLECTION_FORBIDDEN",
+          podName: this.podInfo.podName,
+          namespace: this.podInfo.namespace,
+          message: 'Logs collection is forbidden. Ensure the SDL includes permissions: { read: ["logs"] }'
+        });
+        return;
+      }
+      throw error;
+    }
   }
 
   /**
@@ -94,10 +107,10 @@ export class PodLogsCollectorService {
       const writePromise = this.write(logStream);
 
       this.loggerService.info({
+        event: "CONTAINER_LOG_COLLECTION_STARTED",
         podName: this.podInfo.podName,
         namespace: this.podInfo.namespace,
-        containerName,
-        message: "Starting log collection for container"
+        containerName
       });
 
       const k8sPromise = this.startKubernetesLogStream(containerName, logStream, lastTimestamp);
@@ -135,8 +148,8 @@ export class PodLogsCollectorService {
 
           writeStream.on("error", error => {
             this.loggerService.error({
+              event: "WRITE_STREAM_ERROR",
               error,
-              message: "Write stream error during log collection",
               podName: this.podInfo.podName,
               namespace: this.podInfo.namespace
             });
@@ -145,8 +158,8 @@ export class PodLogsCollectorService {
 
           logStream.on("error", error => {
             this.loggerService.error({
+              event: "LOG_STREAM_ERROR",
               error,
-              message: "Log stream error during log collection",
               podName: this.podInfo.podName,
               namespace: this.podInfo.namespace
             });
@@ -172,9 +185,9 @@ export class PodLogsCollectorService {
 
               if (isFirstChunk && lastLogLines.length > 0 && lastLogLines.some(lastLogLine => lastLogLine.line === line)) {
                 this.loggerService.info({
+                  event: "LOG_LINE_DUPLICATE_SKIPPED",
                   podName: this.podInfo.podName,
                   namespace: this.podInfo.namespace,
-                  message: "Skipping duplicate log line",
                   duplicateLine: line.substring(0, 100) + "..."
                 });
                 continue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -31632,6 +31632,8 @@
     },
     "node_modules/cockatiel": {
       "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
+      "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16"


### PR DESCRIPTION
## Why

Preparation for pod lifecycle watching and events collection (#2839). Standardizes logging across all services to use structured event fields and fixes several parsing/config issues discovered during testing.

## What

- Add `event` fields (UPPER_SNAKE_CASE) to all log calls across services for machine-readable filtering
- Fix Fluent Bit parser regex to capture 3-digit ms from K8s 9-digit nanosecond timestamps
- Fix `extract_metadata.lua` deployment name pattern
- Fix BusyBox test target date format (`.000Z` instead of unsupported `%N`)
- Add `isForbidden()` helper to `ErrorHandlerService` for 403/AggregateError handling
- Remove duplicate logs from `rotateLogFile`
- Memoize `createWriteStream` in `FileDestinationService`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More tolerant timestamp parsing and updated time format handling
  * Improved service extraction from pod names
  * Correct classification of forbidden (403) errors

* **New Features / Improvements**
  * Ability to gracefully stop log rotation
  * Widespread switch to structured event-based logging for clearer observability
  * Async memoization to avoid redundant async operations

* **Performance**
  * In-container log generation interval increased from 5s to 30s

* **Tests**
  * Added tests for forbidden-error handling and updated event-based log expectations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->