### PR TITLE
fix: allow user to navigate freely while waiting for the deployment to close

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar.tsx
@@ -77,12 +77,15 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
       return;
     }
 
+    //push to deployment list immediately to avoid showing a deployment that is in the process of closing,
+    // the deployment detail page will handle showing the correct state while the transaction is being processed
+    router.push(UrlService.deploymentList());
+
     const message = TransactionMessageData.getCloseDeploymentMsg(address, deployment.dseq);
     const response = await signAndBroadcastTx([message]);
     if (response) {
       onDeploymentClose();
       removeLeases();
-      loadDeploymentDetail();
 
       analyticsService.track("close_deployment", {
         category: "deployments",

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -1,6 +1,6 @@
 export const netConfigData = {
   mainnet: {
-    version: "v1.1.0",
+    version: "v1.2.0",
     faucetUrl: null,
     apiUrls: [
       "https://rest-akash.ecostake.com",


### PR DESCRIPTION
## Why
When closing a deployment, a blocking popup prevents the user from 
interacting with the rest of the app until the transaction completes.

## What
When closing a deployment, a modal blocks the user from interacting with the app until the transaction completes.

This fix navigates the user back to the deployments list immediately after they confirm closing, allowing them to freely use the app while the transaction processes in the background. The existing snackbar notification system handles the issue by showing progress, success, or error feedback.

Closes #2776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness of the close deployment flow by displaying the deployment list immediately when the action is initiated, rather than waiting for the transaction to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->