### PR TITLE
fix(deployment): resolve race condition in CachedBalanceService.get()

### DIFF
--- a/apps/api/src/caching/helpers.ts
+++ b/apps/api/src/caching/helpers.ts
@@ -111,10 +111,10 @@ export async function cacheResponse<T>(seconds: number, key: string, refreshRequ
   return await pendingRequest;
 }
 
-export function memoizeAsync<T extends (...args: unknown[]) => Promise<unknown>>(fn: T): T {
-  const cache = new LRUCache<string, ReturnType<T>>({ max: 100 });
+export function memoizeAsync<A extends unknown[], R>(fn: (...args: A) => Promise<R>, options?: { cacheItemLimit: number }): (...args: A) => Promise<R> {
+  const cache = new LRUCache<string, Promise<R>>({ max: options?.cacheItemLimit ?? 100 });
 
-  return ((...args: Parameters<T>) => {
+  return (...args: A) => {
     const key = JSON.stringify(args);
 
     const cached = cache.get(key);
@@ -122,7 +122,7 @@ export function memoizeAsync<T extends (...args: unknown[]) => Promise<unknown>>
       return cached;
     }
 
-    const promise = fn(...args) as ReturnType<T>;
+    const promise = fn(...args);
 
     promise.catch(() => {
       cache.delete(key);
@@ -130,7 +130,7 @@ export function memoizeAsync<T extends (...args: unknown[]) => Promise<unknown>>
 
     cache.set(key, promise);
     return promise;
-  }) as unknown as T;
+  };
 }
 
 export const cacheKeys = {

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.ts
@@ -1,7 +1,7 @@
-import { LRUCache } from "lru-cache";
 import { singleton } from "tsyringe";
 
 import { BalancesService } from "@src/billing/services/balances/balances.service";
+import { memoizeAsync } from "@src/caching/helpers";
 
 export class CachedBalance {
   constructor(private value: number) {}
@@ -21,18 +21,13 @@ export class CachedBalance {
 
 @singleton()
 export class CachedBalanceService {
-  private readonly balanceCache = new LRUCache<string, CachedBalance>({ max: 10000 });
+  public get = memoizeAsync(
+    async (address: string) => {
+      const limits = await this.balancesService.getFreshLimits({ address });
+      return new CachedBalance(limits.deployment);
+    },
+    { cacheItemLimit: 10_000 }
+  );
 
   constructor(private readonly balancesService: BalancesService) {}
-
-  public async get(address: string): Promise<CachedBalance> {
-    let cachedBalance = this.balanceCache.get(address);
-    if (!cachedBalance) {
-      const limits = await this.balancesService.getFreshLimits({ address });
-      cachedBalance = new CachedBalance(limits.deployment);
-      this.balanceCache.set(address, cachedBalance);
-    }
-
-    return cachedBalance;
-  }
 }

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -1,6 +1,6 @@
 export const netConfigData = {
   mainnet: {
-    version: "v1.1.0",
+    version: "v1.2.0",
     faucetUrl: null,
     apiUrls: [
       "https://rest-akash.ecostake.com",


### PR DESCRIPTION
## Why

Race condition in `CachedBalanceService.get()` causes over-allocation of grants when multiple deployments for the same owner are processed concurrently.

When concurrent calls hit `get(address)` simultaneously, each triggers a separate `getFreshLimits` fetch and creates an independent `CachedBalance` instance — both initialized with the full balance. This defeats the reservation mechanism, allowing deposits that exceed the actual grant balance (e.g., 80M total deposit attempted against a 50M grant).

## What

- Refactor `CachedBalanceService.get()` to use `memoizeAsync`, which caches the **Promise** synchronously before yielding. Concurrent callers for the same address now share one `CachedBalance` instance.
- Improve `memoizeAsync` generic signature (`<A extends unknown[], R>`) to properly infer argument and return types, eliminating the need for unsafe casts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned async memoization with stronger typing and an optional cache-size setting (default 100) for safer, configurable caching.
  * Cached balance logic now uses the new memoized async cache (configured with a 10,000-item limit) and removes the previous manual cache handling for simpler, more consistent caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->