### PR TITLE
fix(billing): use available balance instead of total for wallet reload threshold

### DIFF
--- a/apps/api/src/billing/services/balances/balances.service.spec.ts
+++ b/apps/api/src/billing/services/balances/balances.service.spec.ts
@@ -69,7 +69,20 @@ describe(BalancesService.name, () => {
     });
   });
 
-  function setup(input?: { limitsUpdate?: Partial<UserWalletInput> }) {
+  describe("getDeploymentBalanceInFiat", () => {
+    it("returns deployment limit converted to fiat", async () => {
+      const deploymentLimit = 50_000_000;
+      const expectedFiat = 50.0;
+      const address = "akash1test";
+      const { service } = setup({ deploymentLimit, fiatAmount: expectedFiat });
+
+      const result = await service.getDeploymentBalanceInFiat(address);
+
+      expect(result).toBe(expectedFiat);
+    });
+  });
+
+  function setup(input?: { limitsUpdate?: Partial<UserWalletInput>; deploymentLimit?: number; fiatAmount?: number }) {
     const billingConfig = mock<BillingConfig>();
     const userWalletRepository = mock<UserWalletRepository>();
     const txManagerService = mock<TxManagerService>();
@@ -80,6 +93,14 @@ describe(BalancesService.name, () => {
     const service = new BalancesService(billingConfig, userWalletRepository, txManagerService, authzHttpService, deploymentHttpService, statsService);
 
     vi.spyOn(service, "getFreshLimitsUpdate").mockResolvedValue(input?.limitsUpdate ?? {});
+
+    if (input?.deploymentLimit !== undefined) {
+      vi.spyOn(service, "retrieveDeploymentLimit").mockResolvedValue(input.deploymentLimit);
+    }
+
+    if (input?.fiatAmount !== undefined) {
+      vi.spyOn(service, "toFiatAmount").mockResolvedValue(input.fiatAmount);
+    }
 
     return { service, userWalletRepository };
   }

--- a/apps/api/src/billing/services/balances/balances.service.ts
+++ b/apps/api/src/billing/services/balances/balances.service.ts
@@ -120,19 +120,9 @@ export class BalancesService {
     };
   }
 
-  @Memoize({ ttlInSeconds: averageBlockTime })
-  async getFullBalanceInFiatMemoized(address: string): Promise<GetBalancesResponseOutput["data"]> {
-    return this.getFullBalanceInFiat(address);
-  }
-
-  async getFullBalanceInFiat(address: string): Promise<GetBalancesResponseOutput["data"]> {
-    const { data } = await this.getFullBalance(address);
-
-    const balance = await this.toFiatAmount(data.balance);
-    const deployments = await this.toFiatAmount(data.deployments);
-    const total = this.ensure2floatingDigits(balance + deployments);
-
-    return { balance, deployments, total };
+  async getDeploymentBalanceInFiat(address: string): Promise<number> {
+    const deployment = await this.retrieveDeploymentLimit({ address });
+    return await this.toFiatAmount(deployment);
   }
 
   async toFiatAmount(uTokenAmount: number) {

--- a/apps/api/src/billing/services/wallet-balance-reload-check/README.md
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/README.md
@@ -87,7 +87,7 @@ WalletBalanceReloadCheckHandler.handle()
     │   ├─► Get user wallet (verify initialized)
     │   ├─► Get user (verify Stripe customer ID)
     │   ├─► Get default payment method
-    │   ├─► Get current balance (in USD)
+    │   ├─► Get available balance excluding escrow (in USD)
     │   └─► Calculate cost for 7 days ahead (deployments with auto top-up enabled)
     │
     ├─► Try to Reload
@@ -141,14 +141,14 @@ This means: reload when balance can only cover less than 25% of the 7-day cost p
 
 ## Cost Calculation
 
-The handler calculates the total cost needed to keep all active deployments with auto top-up enabled running for 7 days:
+The handler calculates the **unfunded** cost for all active deployments with auto top-up enabled — i.e. only the portion not already covered by escrow:
 
 1. Gets all auto-top-up deployments for the user's wallet
-2. For each deployment:
-   - Finds when it would close (predicted closed height)
-   - Calculates blocks needed from closure to target date (7 days from now)
-   - Multiplies by block rate to get cost
-3. Sums all costs to get total 7-day cost
+2. For each deployment that would close before the target date (7 days from now):
+   - Finds when it would close (predicted closed height, when escrow runs out)
+   - Calculates blocks needed from closure to target date
+   - Multiplies by block rate to get the unfunded cost
+3. Sums all unfunded costs (deployments whose escrow lasts beyond 7 days are excluded)
 
 **Note**: Only deployments with auto top-up enabled are considered in the cost calculation.
 

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -13,7 +13,6 @@ import type { JobPayload } from "../../../core";
 import { WalletBalanceReloadCheckHandler } from "./wallet-balance-reload-check.handler";
 import type { WalletBalanceReloadCheckInstrumentationService } from "./wallet-balance-reload-check-instrumentation.service";
 
-import { generateBalance } from "@test/seeders/balance.seeder";
 import { generateMergedPaymentMethod as generatePaymentMethod } from "@test/seeders/payment-method.seeder";
 import { UserSeeder } from "@test/seeders/user.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
@@ -32,7 +31,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       const expectedReloadAmount = 40.0; // max(50 - 10, 20) = 40
 
       const { handler, drainingDeploymentService, stripeService, instrumentationService, walletReloadJobService, job, jobMeta } = setup({
-        balance: { total: balance },
+        balance,
         weeklyCostInDenom: costUntilTargetDateInDenom,
         weeklyCostInFiat: costUntilTargetDateInFiat
       });
@@ -95,7 +94,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       const expectedReloadAmount = 20.0; // max(20 - 4, 20) = 20
 
       const { handler, stripeService, job, jobMeta } = setup({
-        balance: { total: balance },
+        balance,
         weeklyCostInDenom: costUntilTargetDateInDenom,
         weeklyCostInFiat: costUntilTargetDateInFiat
       });
@@ -121,7 +120,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       const costUntilTargetDateInFiat = 50.0;
 
       const { handler, stripeService, instrumentationService, job, jobMeta } = setup({
-        balance: { total: balance },
+        balance,
         weeklyCostInDenom: costUntilTargetDateInDenom,
         weeklyCostInFiat: costUntilTargetDateInFiat
       });
@@ -150,7 +149,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       const costUntilTargetDateInFiat = 50.0;
 
       const { handler, stripeService, instrumentationService, job, jobMeta } = setup({
-        balance: { total: balance },
+        balance,
         weeklyCostInDenom: costUntilTargetDateInDenom,
         weeklyCostInFiat: costUntilTargetDateInFiat
       });
@@ -177,7 +176,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       const weeklyCostInFiat = 50.0;
 
       const { handler, walletReloadJobService, walletSetting, job, jobMeta } = setup({
-        balance: { total: balance },
+        balance,
         weeklyCostInDenom,
         weeklyCostInFiat
       });
@@ -203,7 +202,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       const error = new Error("Failed to schedule");
 
       const { handler, walletReloadJobService, instrumentationService, job, jobMeta } = setup({
-        balance: { total: balance },
+        balance,
         weeklyCostInDenom,
         weeklyCostInFiat
       });
@@ -292,7 +291,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       const balance = 15.0;
 
       const { handler, instrumentationService, stripeService, job, jobMeta } = setup({
-        balance: { total: balance }
+        balance
       });
       stripeService.getDefaultPaymentMethod.mockResolvedValue(undefined);
 
@@ -310,7 +309,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
   });
 
   function setup(input?: {
-    balance?: { total: number };
+    balance?: number;
     weeklyCostInDenom?: number;
     weeklyCostInFiat?: number;
     jobId?: string | null;
@@ -365,7 +364,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       recordSchedulingError: jest.fn()
     });
 
-    const balance = input?.balance ?? { total: 50.0 };
+    const balance = input?.balance ?? 50.0;
     const weeklyCostInDenom = input?.weeklyCostInDenom ?? 50_000_000;
     const weeklyCostInFiat = input?.weeklyCostInFiat ?? 50.0;
     const jobId = input?.jobId ?? faker.string.uuid();
@@ -377,7 +376,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     }
 
     if (!input?.walletSettingNotFound && userWithStripe.stripeCustomerId) {
-      balancesService.getFullBalanceInFiat.mockResolvedValue(generateBalance(balance));
+      balancesService.getDeploymentBalanceInFiat.mockResolvedValue(balance);
       balancesService.toFiatAmount.mockResolvedValue(weeklyCostInFiat);
       drainingDeploymentService.calculateAllDeploymentCostUntilDate.mockResolvedValue(weeklyCostInDenom);
       stripeService.getDefaultPaymentMethod.mockResolvedValue(generatePaymentMethod());

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -93,9 +93,9 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
       return paymentMethod;
     }
 
-    const balance = await this.balancesService.getFullBalanceInFiat(wallet.address);
+    const balance = await this.balancesService.getDeploymentBalanceInFiat(wallet.address);
 
-    return Ok({ ...walletResult.val, paymentMethod: paymentMethod.val, balance: balance.total });
+    return Ok({ ...walletResult.val, paymentMethod: paymentMethod.val, balance });
   }
 
   async #getValidWalletResources(userId: JobPayload<WalletBalanceReloadCheck>["userId"]): Promise<Result<Resources, ValidationError>> {

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -1,7 +1,7 @@
-import { and, desc, eq, isNotNull } from "drizzle-orm";
+import { and, desc, eq, isNotNull, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
-import { UserWallets } from "@src/billing/model-schemas";
+import { UserWallets, WalletSetting } from "@src/billing/model-schemas";
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
 import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
@@ -20,6 +20,7 @@ export type AutoTopUpDeployment = {
   walletId: number;
   dseq: string;
   address: string;
+  isWalletAutoTopUpEnabled: boolean;
 };
 
 @singleton()
@@ -72,11 +73,13 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
         id: this.table.id,
         dseq: this.table.dseq,
         walletId: UserWallets.id,
-        address: UserWallets.address
+        address: UserWallets.address,
+        isWalletAutoTopUpEnabled: sql<boolean>`coalesce(${WalletSetting.autoReloadEnabled}, false)`
       })
       .from(this.table)
       .leftJoin(Users, eq(this.table.userId, Users.id))
       .innerJoin(UserWallets, eq(Users.id, UserWallets.userId))
+      .leftJoin(WalletSetting, eq(UserWallets.id, WalletSetting.walletId))
       .where(and(...clauses))
       .orderBy(desc(this.table.id));
 

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -409,7 +409,10 @@ describe(DrainingDeploymentService.name, () => {
           deployments
         });
         const expectedTargetHeight = 1100800;
-        const expectedTotal = 12600000;
+        const expectedTotal = deployments.reduce((sum, d) => {
+          const blocksNeeded = expectedTargetHeight - d.predictedClosedHeight;
+          return sum + Math.floor(d.blockRate * blocksNeeded);
+        }, 0);
 
         const result = await service.calculateAllDeploymentCostUntilDate(address, targetDate);
 

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -126,12 +126,14 @@ export class DrainingDeploymentService {
   }
 
   /**
-   * Calculates the total cost for all deployments that would close before the target date.
-   * This is based on each deployment's block rate and the number of blocks needed to keep them running until the target date.
+   * Calculates the unfunded cost for all deployments that would close before the target date.
+   * For each draining deployment, computes the cost from its predicted close height (when escrow runs out)
+   * to the target height — i.e. only the portion not already covered by escrow.
+   * Deployments whose escrow lasts beyond the target date are excluded (they don't need additional funding).
    *
    * @param address - The address to calculate the deployment costs for
    * @param targetDate - The target date to calculate the costs until and till which deployments would close
-   * @returns The total cost (in credits) needed to keep all draining deployments running until the target date
+   * @returns The unfunded cost (in credits) needed to keep all draining deployments running until the target date
    */
   async calculateAllDeploymentCostUntilDate(address: string, targetDate: Date): Promise<number> {
     const deploymentSettings = await this.#findAutoTopUpDeploymentSettings(address);
@@ -149,7 +151,7 @@ export class DrainingDeploymentService {
 
     return await this.#accumulateDeploymentCost(drainingDeployments, ({ predictedClosedHeight, blockRate }) => {
       if (predictedClosedHeight && predictedClosedHeight >= currentHeight && predictedClosedHeight <= targetHeight) {
-        const blocksNeeded = targetHeight - currentHeight;
+        const blocksNeeded = targetHeight - predictedClosedHeight;
         return Math.floor(blockRate * blocksNeeded);
       }
       return 0;

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
@@ -1,6 +1,7 @@
 import "@test/mocks/logger-service.mock";
 
 import { faker } from "@faker-js/faker";
+import type { Counter } from "@opentelemetry/api";
 import { mock } from "vitest-mock-extended";
 
 import type { LoggerService, MetricsService } from "@src/core";
@@ -85,6 +86,26 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
       expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "MESSAGE_PREPARATION_ERROR" }));
     });
 
+    it("increments auto-reload counter when insufficient balance and wallet auto-reload is enabled", () => {
+      const { service, countersByName } = setup();
+      service.start(100, { dryRun: false });
+      const deployment = createDrainingDeployment({ isWalletAutoTopUpEnabled: true });
+
+      service.recordMessagePreparationError({ deployment, error: new Error("Insufficient balance for address") });
+
+      expect(countersByName["auto_top_up_insufficient_balance_with_auto_reload_total"]?.add).toHaveBeenCalledWith(1);
+    });
+
+    it("does not increment auto-reload counter when insufficient balance and wallet auto-reload is disabled", () => {
+      const { service, countersByName } = setup();
+      service.start(100, { dryRun: false });
+      const deployment = createDrainingDeployment({ isWalletAutoTopUpEnabled: false });
+
+      service.recordMessagePreparationError({ deployment, error: new Error("Insufficient balance for address") });
+
+      expect(countersByName["auto_top_up_insufficient_balance_with_auto_reload_total"]?.add).not.toHaveBeenCalled();
+    });
+
     it("tracks other errors as deployment errors", () => {
       const { service, logger, summarizer } = setup();
       service.start(100, { dryRun: false });
@@ -152,10 +173,10 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
     });
   });
 
-  function createDrainingDeployment(): DrainingDeployment {
-    const base = AutoTopUpDeploymentSeeder.create();
+  function createDrainingDeployment(overrides?: Partial<DrainingDeployment>): DrainingDeployment {
+    const base = AutoTopUpDeploymentSeeder.create(overrides);
     const extra = DrainingDeploymentSeeder.create({ dseq: Number(base.dseq), owner: base.address });
-    return { ...base, ...extra, dseq: base.dseq } as DrainingDeployment;
+    return { ...base, ...extra, dseq: base.dseq, ...overrides } as DrainingDeployment;
   }
 
   function createDepositDetails() {
@@ -178,9 +199,14 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
   }
 
   function setup() {
+    const countersByName: Record<string, Counter> = {};
     const metricsService = mock<MetricsService>();
     metricsService.getMeter.mockReturnValue(mock());
-    metricsService.createCounter.mockReturnValue(mock());
+    metricsService.createCounter.mockImplementation((_meter, name) => {
+      const counter = mock<Counter>();
+      countersByName[name] = counter;
+      return counter;
+    });
     metricsService.createHistogram.mockReturnValue(mock());
 
     const summarizer = new TopUpSummarizer();
@@ -188,6 +214,6 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
 
     const service = new TopUpManagedDeploymentsInstrumentationService(metricsService, summarizer, logger);
 
-    return { service, metricsService, summarizer, logger };
+    return { service, metricsService, countersByName, summarizer, logger };
   }
 });

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.ts
@@ -18,6 +18,7 @@ export class TopUpManagedDeploymentsInstrumentationService {
   private readonly deploymentsMarkedClosed: Counter;
   private readonly depositAmount: Histogram;
   private readonly predictedCloseBlocks: Histogram;
+  private readonly insufficientBalanceWithAutoReload: Counter;
   private readonly settingToggles: Counter;
   private startTime: number | undefined;
   private options: DryRunOptions | undefined;
@@ -63,6 +64,10 @@ export class TopUpManagedDeploymentsInstrumentationService {
 
     this.predictedCloseBlocks = this.metricsService.createHistogram(this.meter, "auto_top_up_predicted_close_blocks", {
       description: "Number of blocks until predicted closure at detection time"
+    });
+
+    this.insufficientBalanceWithAutoReload = this.metricsService.createCounter(this.meter, "auto_top_up_insufficient_balance_with_auto_reload_total", {
+      description: "Total number of insufficient balance errors where wallet auto-reload is enabled"
     });
 
     this.settingToggles = this.metricsService.createCounter(this.meter, "auto_top_up_setting_toggles_total", {
@@ -170,6 +175,10 @@ export class TopUpManagedDeploymentsInstrumentationService {
 
       this.execWhenEnabled(() => {
         this.messagePreparationErrors.add(1, { error_type: "insufficient_balance" });
+
+        if (errorDetails.deployment.isWalletAutoTopUpEnabled) {
+          this.insufficientBalanceWithAutoReload.add(1);
+        }
       });
     } else {
       this.topUpSummarizer.inc("deploymentTopUpErrorCount");

--- a/apps/api/test/seeders/auto-top-up-deployment.seeder.ts
+++ b/apps/api/test/seeders/auto-top-up-deployment.seeder.ts
@@ -10,6 +10,7 @@ export class AutoTopUpDeploymentSeeder {
       walletId: faker.number.int(),
       dseq: faker.string.numeric(),
       address: createAkashAddress(),
+      isWalletAutoTopUpEnabled: false,
       ...overrides
     };
   }


### PR DESCRIPTION
## Why

The wallet balance reload check incorrectly determined that users had sufficient funds by comparing total balance (available + escrowed) against the threshold and computing the full deployment cost from `currentHeight` instead of only the unfunded portion from `predictedClosedHeight`. Together, these caused reload to be skipped for users whose available balance was too low to cover upcoming top-ups.

## What

- **Wallet reload handler**: use `getDeploymentBalanceInFiat` (available balance only) instead of `getFullBalanceInFiat` (available + escrowed)
- **Draining deployment cost calculation**: compute unfunded cost as `targetHeight - predictedClosedHeight` instead of `targetHeight - currentHeight`, excluding deployments whose escrow lasts beyond the target date
- **Insufficient balance metric**: add a dedicated OTel counter (`auto_top_up_insufficient_balance_with_auto_reload_total`) for insufficient balance errors when wallet auto-reload is enabled
- **Repository**: add `isWalletAutoTopUpEnabled` to `findAutoTopUpDeploymentsByOwner` query via `WalletSetting` join
- Updated unit tests and JSDoc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deployment-focused balance calculations for improved fiat conversions.
  * Added enhanced tracking for wallet auto-reload errors during top-up operations.

* **Improvements**
  * Refined deployment cost calculations to more accurately exclude deployments with sufficient escrow beyond target dates.
  * Improved caching mechanism with better configurability for balance data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->