### PR TITLE
fix: resolve Swagger UI validation errors for dseq and market-data endpoints (Issue #2778)

### DIFF
--- a/apps/api/src/dashboard/routes/market-data/market-data.router.ts
+++ b/apps/api/src/dashboard/routes/market-data/market-data.router.ts
@@ -10,7 +10,7 @@ export const marketDataRouter = new OpenApiHonoHandler();
 
 const marketDataRoute = createRoute({
   method: "get",
-  path: "/v1/market-data/{coin?}",
+  path: "/v1/market-data/{coin}",
   tags: ["Analytics"],
   security: SECURITY_NONE,
   cache: { maxAge: 300, staleWhileRevalidate: 600 },

--- a/apps/api/src/utils/schema.ts
+++ b/apps/api/src/utils/schema.ts
@@ -5,7 +5,4 @@ import { isValidBech32Address } from "./addresses";
 export const AkashAddressSchema = z.string().refine(val => isValidBech32Address(val, "akash"), { message: "Invalid address" });
 export const AkashValidatorAddressSchema = z.string().refine(val => isValidBech32Address(val, "akashvaloper"), { message: "Invalid address" });
 
-export const DseqSchema = z
-  .bigint({ coerce: true })
-  .positive()
-  .transform(val => val.toString());
+export const DseqSchema = z.string().regex(/^\d+$/, "Value must be a positive integer");

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar.tsx
@@ -77,12 +77,15 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
       return;
     }
 
+    //push to deployment list immediately to avoid showing a deployment that is in the process of closing,
+    // the deployment detail page will handle showing the correct state while the transaction is being processed
+    router.push(UrlService.deploymentList());
+
     const message = TransactionMessageData.getCloseDeploymentMsg(address, deployment.dseq);
     const response = await signAndBroadcastTx([message]);
     if (response) {
       onDeploymentClose();
       removeLeases();
-      loadDeploymentDetail();
 
       analyticsService.track("close_deployment", {
         category: "deployments",

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -1,6 +1,6 @@
 export const netConfigData = {
   mainnet: {
-    version: "v1.1.0",
+    version: "v1.2.0",
     faucetUrl: null,
     apiUrls: [
       "https://rest-akash.ecostake.com",


### PR DESCRIPTION
## Why

Several Swagger UI endpoints were unusable for testing due to validation errors:
- `GET /v1/market-data/{coin}` was sending the literal string `{coin}` instead of the selected enum value

- `GET /v1/deployments/{dseq}`, `GET /v1/bids`, `GET /v1/bids/{dseq}` were rejecting valid numeric input with `Value must follow pattern ^d+$`
## What

- Removed `?` from `{coin?}` path param in the market-data router — `?` is not valid OpenAPI syntax and caused Swagger to not resolve the parameter
- Changed `DseqSchema` from `z.bigint({ coerce: true })` to `z.string().regex(/^\d+$/)` — `bigint` is not a standard OpenAPI type, causing Swagger to generate a broken regex pattern

Fixes #2778

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced deployment closing experience with improved navigation timing and reduced UI delays.

* **Updates**
  * Market-data API endpoint now requires explicit coin parameter in requests.
  * Refined validation for numeric identifiers with stricter string pattern enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->