### PR TITLE
feat: adds ACT support for authorizations

### DIFF
--- a/apps/deploy-web/src/components/authorizations/Authorizations.tsx
+++ b/apps/deploy-web/src/components/authorizations/Authorizations.tsx
@@ -20,12 +20,12 @@ import Layout from "../layout/Layout";
 import { SettingsLayout, SettingsTabs } from "../settings/SettingsLayout";
 import { ConnectWallet } from "../shared/ConnectWallet";
 import { Title } from "../shared/Title";
+import { DeploymentGrantTable } from "./DeploymentGrantTable/DeploymentGrantTable";
+import { GrantModal } from "./GrantModal/GrantModal";
 import { AllowanceGrantedRow } from "./AllowanceGrantedRow";
 import { AllowanceModal } from "./AllowanceModal";
-import { DeploymentGrantTable } from "./DeploymentGrantTable";
 import { FeeGrantTable } from "./FeeGrantTable";
 import { GranteeRow } from "./GranteeRow";
-import { GrantModal } from "./GrantModal";
 
 type RefreshingType = "granterGrants" | "granteeGrants" | "allowancesIssued" | "allowancesGranted" | null;
 const defaultRefetchInterval = 30 * 1000;

--- a/apps/deploy-web/src/components/authorizations/DeploymentGrantTable/DeploymentGrantTable.spec.tsx
+++ b/apps/deploy-web/src/components/authorizations/DeploymentGrantTable/DeploymentGrantTable.spec.tsx
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { GrantType } from "@src/types/grant";
+import { DEPENDENCIES, DeploymentGrantTable } from "./DeploymentGrantTable";
+
+import { render, screen } from "@testing-library/react";
+import { ComponentMock, MockComponents } from "@tests/unit/mocks";
+
+describe(DeploymentGrantTable.name, () => {
+  it("calls onEditGrant when edit button is clicked", () => {
+    const ButtonMock = vi.fn(ComponentMock);
+    const grant = createGrant();
+    const { onEditGrant } = setup({
+      grants: [grant],
+      dependencies: { Button: ButtonMock }
+    });
+
+    const editCall = ButtonMock.mock.calls.find(c => c[0]["aria-label"] === "Edit Authorization");
+    editCall![0].onClick();
+
+    expect(onEditGrant).toHaveBeenCalledWith(grant);
+  });
+
+  it("calls setDeletingGrants with the grant when revoke button is clicked", () => {
+    const ButtonMock = vi.fn(ComponentMock);
+    const grant = createGrant();
+    const { setDeletingGrants } = setup({
+      grants: [grant],
+      dependencies: { Button: ButtonMock }
+    });
+
+    const revokeCall = ButtonMock.mock.calls.find(c => c[0]["aria-label"] === "Revoke Authorization");
+    revokeCall![0].onClick();
+
+    expect(setDeletingGrants).toHaveBeenCalledWith([grant]);
+  });
+
+  it("adds grant to selection when checkbox is checked", () => {
+    const CheckboxMock = vi.fn(ComponentMock);
+    const grant = createGrant();
+    const { setSelectedGrants } = setup({
+      grants: [grant],
+      dependencies: { Checkbox: CheckboxMock }
+    });
+
+    CheckboxMock.mock.calls[0][0].onCheckedChange(true);
+
+    const updater = setSelectedGrants.mock.calls[0][0];
+    expect(updater([])).toEqual([grant]);
+  });
+
+  it("removes grant from selection when checkbox is unchecked", () => {
+    const CheckboxMock = vi.fn(ComponentMock);
+    const grant = createGrant({ grantee: "akash1abc" });
+    const { setSelectedGrants } = setup({
+      grants: [grant],
+      selectedGrants: [grant],
+      dependencies: { Checkbox: CheckboxMock }
+    });
+
+    CheckboxMock.mock.calls[0][0].onCheckedChange(false);
+
+    const updater = setSelectedGrants.mock.calls[0][0];
+    expect(updater([grant])).toEqual([]);
+  });
+
+  it("shows 'Revoke all' button when grants exist and none selected", () => {
+    setup({ grants: [createGrant()] });
+
+    expect(screen.getByText("Revoke all")).toBeInTheDocument();
+  });
+
+  it("calls setDeletingGrants with all grants when 'Revoke all' is clicked", () => {
+    const ButtonMock = vi.fn(ComponentMock);
+    const grants = [createGrant(), createGrant({ grantee: "akash1def" })];
+    const { setDeletingGrants } = setup({
+      grants,
+      dependencies: { Button: ButtonMock }
+    });
+
+    const revokeAllCall = ButtonMock.mock.calls.find(c => c[0].variant === "outline" && c[0].size === "sm");
+    revokeAllCall![0].onClick();
+
+    expect(setDeletingGrants).toHaveBeenCalledWith(grants);
+  });
+
+  it("shows 'Revoke selected' count when grants are selected", () => {
+    const grant = createGrant();
+    setup({ grants: [grant], selectedGrants: [grant] });
+
+    expect(screen.getByText(/Revoke selected/)).toBeInTheDocument();
+  });
+
+  it("calls setDeletingGrants with selected grants when 'Revoke selected' is clicked", () => {
+    const ButtonMock = vi.fn(ComponentMock);
+    const grant = createGrant();
+    const { setDeletingGrants } = setup({
+      grants: [grant],
+      selectedGrants: [grant],
+      dependencies: { Button: ButtonMock }
+    });
+
+    const revokeSelectedCall = ButtonMock.mock.calls.find(c => c[0].variant === "outline" && c[0].size === "sm");
+    revokeSelectedCall![0].onClick();
+
+    expect(setDeletingGrants).toHaveBeenCalledWith([grant]);
+  });
+
+  it("clears selection when 'Clear' link is clicked", () => {
+    const LinkToMock = vi.fn(ComponentMock);
+    const grant = createGrant();
+    const { setSelectedGrants } = setup({
+      grants: [grant],
+      selectedGrants: [grant],
+      dependencies: { LinkTo: LinkToMock }
+    });
+
+    LinkToMock.mock.calls[0][0].onClick();
+
+    expect(setSelectedGrants).toHaveBeenCalledWith([]);
+  });
+
+  function setup(
+    input: {
+      grants?: GrantType[];
+      selectedGrants?: GrantType[];
+      totalCount?: number;
+      pageIndex?: number;
+      pageSize?: number;
+      dependencies?: Partial<Record<keyof typeof DEPENDENCIES, unknown>>;
+    } = {}
+  ) {
+    const onEditGrant = vi.fn();
+    const setDeletingGrants = vi.fn();
+    const setSelectedGrants = vi.fn();
+    const onPageChange = vi.fn();
+    const grants = input.grants || [];
+    const selectedGrants = input.selectedGrants || [];
+
+    render(
+      <DeploymentGrantTable
+        grants={grants}
+        selectedGrants={selectedGrants}
+        totalCount={input.totalCount ?? grants.length}
+        onEditGrant={onEditGrant}
+        setDeletingGrants={setDeletingGrants}
+        setSelectedGrants={setSelectedGrants}
+        onPageChange={onPageChange}
+        pageIndex={input.pageIndex ?? 0}
+        pageSize={input.pageSize ?? 10}
+        dependencies={
+          {
+            ...MockComponents(DEPENDENCIES),
+            useUsdcDenom: () => "ibc/usdc-test-denom",
+            ...input.dependencies
+          } as typeof DEPENDENCIES
+        }
+      />
+    );
+
+    return { onEditGrant, setDeletingGrants, setSelectedGrants, onPageChange };
+  }
+
+  function createGrant(overrides?: Partial<GrantType>): GrantType {
+    return {
+      granter: "akash1granter",
+      grantee: "akash1grantee",
+      expiration: "2025-12-31T00:00:00Z",
+      authorization: {
+        "@type": "/akash.deployment.v1beta3.DepositDeploymentAuthorization",
+        spend_limit: {
+          denom: "uakt",
+          amount: "1000000"
+        }
+      },
+      ...overrides
+    };
+  }
+});

--- a/apps/deploy-web/src/components/authorizations/DeploymentGrantTable/DeploymentGrantTable.tsx
+++ b/apps/deploy-web/src/components/authorizations/DeploymentGrantTable/DeploymentGrantTable.tsx
@@ -19,9 +19,29 @@ import { createColumnHelper, flexRender, getCoreRowModel, getPaginationRowModel,
 import { Bin, Edit } from "iconoir-react";
 
 import { AKTAmount } from "@src/components/shared/AKTAmount";
+import { useUsdcDenom as useUsdcDenomOriginal } from "@src/hooks/useDenom";
 import type { GrantType } from "@src/types/grant";
 import { coinToUDenom } from "@src/utils/priceUtils";
-import { LinkTo } from "../shared/LinkTo";
+import { LinkTo } from "../../shared/LinkTo";
+
+export const DEPENDENCIES = {
+  FormattedTime,
+  Address,
+  Button,
+  Checkbox,
+  CustomPagination,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  AKTAmount,
+  LinkTo,
+  Bin,
+  Edit,
+  useUsdcDenom: useUsdcDenomOriginal
+};
 
 interface Props {
   grants: GrantType[];
@@ -33,6 +53,7 @@ interface Props {
   onPageChange: (pageIndex: number, pageSize: number) => void;
   pageIndex: number;
   pageSize: number;
+  dependencies?: typeof DEPENDENCIES;
 }
 
 const logger = LoggerService.forContext("DeploymentGrantTable");
@@ -46,8 +67,10 @@ export const DeploymentGrantTable: React.FC<Props> = ({
   setSelectedGrants,
   selectedGrants,
   pageIndex,
-  pageSize
+  pageSize,
+  dependencies: d = DEPENDENCIES
 }) => {
+  const usdcDenom = d.useUsdcDenom();
   const selectGrants = (checked: boolean, grant: GrantType) => {
     setSelectedGrants(prev => {
       return checked ? prev.concat([grant]) : prev.filter(x => x.grantee !== grant.grantee);
@@ -59,7 +82,7 @@ export const DeploymentGrantTable: React.FC<Props> = ({
   const columns = [
     columnHelper.accessor("grantee", {
       header: () => <div>Grantee</div>,
-      cell: info => <Address address={info.getValue()} isCopyable />
+      cell: info => <d.Address address={info.getValue()} isCopyable />
     }),
     columnHelper.accessor(
       row => {
@@ -72,7 +95,7 @@ export const DeploymentGrantTable: React.FC<Props> = ({
 
           return (
             <div className="text-center">
-              <AKTAmount uakt={coinToUDenom(value)} /> {value.denom === "uakt" ? "AKT" : "USDC"}
+              <d.AKTAmount uakt={coinToUDenom(value)} /> {value.denom === usdcDenom ? "USDC" : value.denom.toUpperCase().replace("U", "")}
             </div>
           );
         },
@@ -83,7 +106,7 @@ export const DeploymentGrantTable: React.FC<Props> = ({
       header: () => <div className="text-center">Expiration</div>,
       cell: info => (
         <div className="text-center">
-          <FormattedTime year="numeric" month={"numeric"} day={"numeric"} value={info.getValue()} />
+          <d.FormattedTime year="numeric" month={"numeric"} day={"numeric"} value={info.getValue()} />
         </div>
       )
     }),
@@ -93,19 +116,19 @@ export const DeploymentGrantTable: React.FC<Props> = ({
         <div>
           {selectedGrants.length > 0 && (
             <div className="flex items-center justify-end space-x-4">
-              <LinkTo onClick={() => setSelectedGrants([])} className="text-xs">
+              <d.LinkTo onClick={() => setSelectedGrants([])} className="text-xs">
                 Clear
-              </LinkTo>
-              <Button onClick={() => setDeletingGrants(selectedGrants)} variant="outline" size="sm" className="h-6 p-2 text-xs">
+              </d.LinkTo>
+              <d.Button onClick={() => setDeletingGrants(selectedGrants)} variant="outline" size="sm" className="h-6 p-2 text-xs">
                 Revoke selected ({selectedGrants.length})
-              </Button>
+              </d.Button>
             </div>
           )}
           {grants.length > 0 && selectedGrants.length === 0 && (
             <div className="flex items-center justify-end">
-              <Button onClick={() => setDeletingGrants(grants)} variant="outline" size="sm" className="h-6 p-2 text-xs">
+              <d.Button onClick={() => setDeletingGrants(grants)} variant="outline" size="sm" className="h-6 p-2 text-xs">
                 Revoke all
-              </Button>
+              </d.Button>
             </div>
           )}
         </div>
@@ -116,7 +139,7 @@ export const DeploymentGrantTable: React.FC<Props> = ({
         return (
           <div className="flex items-center justify-end space-x-2">
             <div className="flex w-[40px] items-center justify-center">
-              <Checkbox
+              <d.Checkbox
                 checked={selectedGrants.some(x => x.grantee === grant.grantee && x.granter === grant.granter)}
                 onClick={event => {
                   event.stopPropagation();
@@ -130,12 +153,12 @@ export const DeploymentGrantTable: React.FC<Props> = ({
                 }}
               />
             </div>
-            <Button variant="ghost" size="icon" onClick={() => onEditGrant(grant)} aria-label="Edit Authorization">
-              <Edit className="text-xs" />
-            </Button>
-            <Button variant="ghost" size="icon" onClick={() => setDeletingGrants([grant])} aria-label="Revoke Authorization">
-              <Bin className="text-xs" />
-            </Button>
+            <d.Button variant="ghost" size="icon" onClick={() => onEditGrant(grant)} aria-label="Edit Authorization">
+              <d.Edit className="text-xs" />
+            </d.Button>
+            <d.Button variant="ghost" size="icon" onClick={() => setDeletingGrants([grant])} aria-label="Revoke Authorization">
+              <d.Bin className="text-xs" />
+            </d.Button>
           </div>
         );
       }
@@ -164,33 +187,33 @@ export const DeploymentGrantTable: React.FC<Props> = ({
 
   return (
     <div>
-      <Table>
-        <TableHeader>
+      <d.Table>
+        <d.TableHeader>
           {table.getHeaderGroups().map(headerGroup => (
-            <TableRow key={headerGroup.id}>
+            <d.TableRow key={headerGroup.id}>
               {headerGroup.headers.map(header => (
-                <TableHead key={header.id} className="w-1/4">
+                <d.TableHead key={header.id} className="w-1/4">
                   {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
-                </TableHead>
+                </d.TableHead>
               ))}
-            </TableRow>
+            </d.TableRow>
           ))}
-        </TableHeader>
+        </d.TableHeader>
 
-        <TableBody>
+        <d.TableBody>
           {table.getRowModel().rows.map(row => (
-            <TableRow key={row.id} className="[&>td]:px-2 [&>td]:py-1">
+            <d.TableRow key={row.id} className="[&>td]:px-2 [&>td]:py-1">
               {row.getVisibleCells().map(cell => (
-                <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+                <d.TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</d.TableCell>
               ))}
-            </TableRow>
+            </d.TableRow>
           ))}
-        </TableBody>
-      </Table>
+        </d.TableBody>
+      </d.Table>
 
       {pageCount > MIN_PAGE_SIZE && (
         <div className="flex items-center justify-center pt-6">
-          <CustomPagination
+          <d.CustomPagination
             totalPageCount={pageCount}
             setPageIndex={table.setPageIndex}
             pageIndex={pagination.pageIndex}

--- a/apps/deploy-web/src/components/authorizations/GrantModal/GrantModal.spec.tsx
+++ b/apps/deploy-web/src/components/authorizations/GrantModal/GrantModal.spec.tsx
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+import type { GrantType } from "@src/types/grant";
+import { DEPENDENCIES, GrantModal } from "./GrantModal";
+
+import { render } from "@testing-library/react";
+import { ComponentMock, MockComponents } from "@tests/unit/mocks";
+
+describe(GrantModal.name, () => {
+  it("renders Popup with 'Authorize Spending' title", () => {
+    const PopupMock = vi.fn(ComponentMock);
+    setup({ dependencies: { Popup: PopupMock } });
+
+    expect(PopupMock.mock.calls[0][0].title).toBe("Authorize Spending");
+  });
+
+  it("calls onClose when cancel action is clicked", () => {
+    const PopupMock = vi.fn(ComponentMock);
+    const { onClose } = setup({ dependencies: { Popup: PopupMock } });
+
+    const cancelAction = PopupMock.mock.calls[0][0].actions.find((a: { label: string }) => a.label === "Cancel");
+    cancelAction.onClick();
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("disables Grant button when amount is 0", () => {
+    const PopupMock = vi.fn(ComponentMock);
+    setup({ dependencies: { Popup: PopupMock } });
+
+    const grantAction = PopupMock.mock.calls[0][0].actions.find((a: { label: string }) => a.label === "Grant");
+
+    expect(grantAction.disabled).toBe(true);
+  });
+
+  it("calls onClose when Popup onClose fires", () => {
+    const PopupMock = vi.fn(ComponentMock);
+    const { onClose } = setup({ dependencies: { Popup: PopupMock } });
+
+    PopupMock.mock.calls[0][0].onClose();
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("renders Popup as open", () => {
+    const PopupMock = vi.fn(ComponentMock);
+    setup({ dependencies: { Popup: PopupMock } });
+
+    expect(PopupMock.mock.calls[0][0].open).toBe(true);
+  });
+
+  it("sets grantee address field to editing grant's grantee", () => {
+    const FormFieldMock = vi.fn(ComponentMock);
+    setup({
+      editingGrant: createGrant({ grantee: "akash1editgrantee" }),
+      dependencies: { FormField: FormFieldMock }
+    });
+
+    const granteeField = FormFieldMock.mock.calls.find(c => c[0].name === "granteeAddress");
+
+    expect(granteeField).toBeDefined();
+  });
+
+  it("sets token field for the form", () => {
+    const FormFieldMock = vi.fn(ComponentMock);
+    setup({ dependencies: { FormField: FormFieldMock } });
+
+    const tokenField = FormFieldMock.mock.calls.find(c => c[0].name === "token");
+
+    expect(tokenField).toBeDefined();
+  });
+
+  function setup(
+    input: {
+      address?: string;
+      editingGrant?: GrantType | null;
+      dependencies?: Partial<Record<keyof typeof DEPENDENCIES, unknown>>;
+    } = {}
+  ) {
+    const onClose = vi.fn();
+    const analyticsService = mock<AnalyticsService>();
+    const signAndBroadcastTx = vi.fn();
+
+    render(
+      <GrantModal
+        address={input.address ?? "akash1testaddress"}
+        editingGrant={input.editingGrant}
+        onClose={onClose}
+        dependencies={
+          {
+            ...MockComponents(DEPENDENCIES),
+            useServices: () => ({ analyticsService }) as unknown as ReturnType<typeof DEPENDENCIES.useServices>,
+            useWallet: () => ({ signAndBroadcastTx }) as unknown as ReturnType<typeof DEPENDENCIES.useWallet>,
+            useUsdcDenom: () => "ibc/usdc-test-denom",
+            useDenomData: () => ({ min: 0, max: 1000, label: "AKT", balance: 500 }),
+            useSupportsACT: () => false,
+            ...input.dependencies
+          } as typeof DEPENDENCIES
+        }
+      />
+    );
+
+    return { onClose, analyticsService, signAndBroadcastTx };
+  }
+
+  function createGrant(overrides?: Partial<GrantType>): GrantType {
+    return {
+      granter: "akash1granter",
+      grantee: "akash1grantee",
+      expiration: "2025-12-31T00:00:00Z",
+      authorization: {
+        "@type": "/akash.deployment.v1beta3.DepositDeploymentAuthorization",
+        spend_limit: {
+          denom: "uakt",
+          amount: "1000000"
+        }
+      },
+      ...overrides
+    };
+  }
+});

--- a/apps/deploy-web/src/components/authorizations/GrantModal/GrantModal.tsx
+++ b/apps/deploy-web/src/components/authorizations/GrantModal/GrantModal.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { FormattedDate } from "react-intl";
 import {
@@ -22,27 +22,47 @@ import { addYears, format } from "date-fns";
 import { z } from "zod";
 
 import { LinkTo } from "@src/components/shared/LinkTo";
-import { UAKT_DENOM } from "@src/config/denom.config";
-import { useServices } from "@src/context/ServicesProvider";
-import { useWallet } from "@src/context/WalletProvider";
-import { useUsdcDenom } from "@src/hooks/useDenom";
-import { useDenomData } from "@src/hooks/useWalletBalance";
+import { UACT_DENOM, UAKT_DENOM } from "@src/config/denom.config";
+import { useServices as useServicesOriginal } from "@src/context/ServicesProvider";
+import { useWallet as useWalletOriginal } from "@src/context/WalletProvider";
+import { useUsdcDenom as useUsdcDenomOriginal } from "@src/hooks/useDenom";
+import { useSupportsACT as useSupportsACTOriginal } from "@src/hooks/useSupportsACT/useSupportsACT";
+import { useDenomData as useDenomDataOriginal } from "@src/hooks/useWalletBalance";
 import type { GrantType } from "@src/types/grant";
 import { denomToUdenom } from "@src/utils/mathHelpers";
-import { aktToUakt, coinToDenom, getUsdcDenom } from "@src/utils/priceUtils";
+import { coinToDenom, getUsdcDenom } from "@src/utils/priceUtils";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
 import { handleDocClick } from "@src/utils/urlUtils";
+
+export const DEPENDENCIES = {
+  Alert,
+  Form,
+  FormField,
+  FormInput,
+  FormLabel,
+  FormMessage,
+  Popup,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  FormattedDate,
+  LinkTo,
+  useServices: useServicesOriginal,
+  useWallet: useWalletOriginal,
+  useUsdcDenom: useUsdcDenomOriginal,
+  useDenomData: useDenomDataOriginal,
+  useSupportsACT: useSupportsACTOriginal
+};
 
 type Props = {
   address: string;
   editingGrant?: GrantType | null;
   onClose: () => void;
+  dependencies?: typeof DEPENDENCIES;
 };
-
-const supportedTokens = [
-  { id: "akt", label: "AKT" },
-  { id: "usdc", label: "USDC" }
-];
 
 const formSchema = z.object({
   token: z.string().min(1, "Token is required."),
@@ -51,15 +71,17 @@ const formSchema = z.object({
   granteeAddress: z.string().min(1, "Grantee address is required.")
 });
 
-export const GrantModal: React.FunctionComponent<Props> = ({ editingGrant, address, onClose }) => {
-  const { analyticsService } = useServices();
+export const GrantModal: React.FunctionComponent<Props> = ({ editingGrant, address, onClose, dependencies: d = DEPENDENCIES }) => {
+  const { analyticsService } = d.useServices();
   const formRef = useRef<HTMLFormElement>(null);
   const [error, setError] = useState("");
-  const { signAndBroadcastTx } = useWallet();
-  const usdcDenom = useUsdcDenom();
+  const { signAndBroadcastTx } = d.useWallet();
+  const usdcDenom = d.useUsdcDenom();
+  const isACTSupported = d.useSupportsACT();
+  const defaultToken = isACTSupported ? UACT_DENOM : UAKT_DENOM;
   const form = useForm<z.infer<typeof formSchema>>({
     defaultValues: {
-      token: editingGrant ? (editingGrant.authorization.spend_limit.denom === usdcDenom ? "usdc" : "akt") : "akt",
+      token: editingGrant?.authorization.spend_limit.denom === usdcDenom ? "usdc" : defaultToken,
       amount: editingGrant ? coinToDenom(editingGrant.authorization.spend_limit) : 0,
       expiration: format(addYears(new Date(), 1), "yyyy-MM-dd'T'HH:mm"),
       granteeAddress: editingGrant?.grantee ?? ""
@@ -68,9 +90,22 @@ export const GrantModal: React.FunctionComponent<Props> = ({ editingGrant, addre
   });
   const { handleSubmit, control, watch, clearErrors, setValue } = form;
   const { amount, granteeAddress, expiration, token } = watch();
+  const denom = token === "usdc" ? usdcDenom : token;
+  const denomData = d.useDenomData(denom);
+  const supportedTokens = useMemo(() => {
+    if (isACTSupported) {
+      return [
+        { id: UACT_DENOM, label: "ACT" },
+        { id: UAKT_DENOM, label: "AKT" }
+      ];
+    }
+
+    return [
+      { id: UAKT_DENOM, label: "AKT" },
+      { id: "usdc", label: "USDC" }
+    ];
+  }, [isACTSupported]);
   const selectedToken = supportedTokens.find(x => x.id === token);
-  const denom = token === "akt" ? UAKT_DENOM : usdcDenom;
-  const denomData = useDenomData(denom);
 
   const onDepositClick = (event: React.MouseEvent) => {
     event.preventDefault();
@@ -80,9 +115,8 @@ export const GrantModal: React.FunctionComponent<Props> = ({ editingGrant, addre
   const onSubmit = async ({ amount, expiration, granteeAddress }: z.infer<typeof formSchema>) => {
     setError("");
     clearErrors();
-    const spendLimit = token === "akt" ? aktToUakt(amount) : denomToUdenom(amount);
-    const usdcDenom = getUsdcDenom();
-    const denom = token === "akt" ? UAKT_DENOM : usdcDenom;
+    const spendLimit = denomToUdenom(amount);
+    const denom = token === "usdc" ? getUsdcDenom() : token;
 
     const expirationDate = new Date(expiration);
     const message = TransactionMessageData.getGrantMsg(address, granteeAddress, spendLimit, expirationDate, denom);
@@ -104,7 +138,7 @@ export const GrantModal: React.FunctionComponent<Props> = ({ editingGrant, addre
   };
 
   return (
-    <Popup
+    <d.Popup
       fullWidth
       open
       variant="custom"
@@ -130,57 +164,57 @@ export const GrantModal: React.FunctionComponent<Props> = ({ editingGrant, addre
       enableCloseOnBackdropClick
       title="Authorize Spending"
     >
-      <Form {...form}>
+      <d.Form {...form}>
         <form onSubmit={handleSubmit(onSubmit)} ref={formRef}>
-          <Alert className="mb-4">
+          <d.Alert className="mb-4">
             <p className="text-sm text-muted-foreground">
-              <LinkTo onClick={ev => handleDocClick(ev, "https://akash.network/docs/network-features/authorized-spend/")}>Authorized Spend</LinkTo> allows users
-              to authorize spending of a set number of tokens from a source wallet to a destination, funded wallet. The authorized spend is restricted to Akash
-              deployment activities and the recipient of the tokens would not have access to those tokens for other operations.
+              <d.LinkTo onClick={ev => handleDocClick(ev, "https://akash.network/docs/network-features/authorized-spend/")}>Authorized Spend</d.LinkTo> allows
+              users to authorize spending of a set number of tokens from a source wallet to a destination, funded wallet. The authorized spend is restricted to
+              Akash deployment activities and the recipient of the tokens would not have access to those tokens for other operations.
             </p>
-          </Alert>
+          </d.Alert>
 
           <div className="mb-2 mt-2 text-right">
-            <LinkTo onClick={() => onBalanceClick()}>
+            <d.LinkTo onClick={() => onBalanceClick()}>
               Balance: {denomData?.balance} {denomData?.label}
-            </LinkTo>
+            </d.LinkTo>
           </div>
 
           <div className="mb-4 flex w-full flex-row items-center">
-            <FormField
+            <d.FormField
               control={control}
               name="token"
               render={({ field }) => {
                 return (
                   <div>
-                    <FormLabel htmlFor="grant-address">Token</FormLabel>
-                    <Select value={field.value || ""} onValueChange={field.onChange}>
-                      <SelectTrigger id="grant-address">
-                        <SelectValue placeholder="Select grant token" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
+                    <d.FormLabel htmlFor="grant-address">Token</d.FormLabel>
+                    <d.Select value={field.value || ""} onValueChange={field.onChange}>
+                      <d.SelectTrigger id="grant-address">
+                        <d.SelectValue placeholder="Select grant token" />
+                      </d.SelectTrigger>
+                      <d.SelectContent>
+                        <d.SelectGroup>
                           {supportedTokens.map(token => (
-                            <SelectItem key={token.id} value={token.id}>
+                            <d.SelectItem key={token.id} value={token.id}>
                               {token.label}
-                            </SelectItem>
+                            </d.SelectItem>
                           ))}
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
+                        </d.SelectGroup>
+                      </d.SelectContent>
+                    </d.Select>
 
-                    <FormMessage />
+                    <d.FormMessage />
                   </div>
                 );
               }}
             />
 
-            <FormField
+            <d.FormField
               control={control}
               name="amount"
               render={({ field }) => {
                 return (
-                  <FormInput
+                  <d.FormInput
                     {...field}
                     type="number"
                     label="Spending Limit"
@@ -197,37 +231,37 @@ export const GrantModal: React.FunctionComponent<Props> = ({ editingGrant, addre
           </div>
 
           <div className="mb-4 w-full">
-            <FormField
+            <d.FormField
               control={control}
               name="granteeAddress"
               render={({ field }) => {
-                return <FormInput {...field} type="text" label="Grantee Address" disabled={!!editingGrant} />;
+                return <d.FormInput {...field} type="text" label="Grantee Address" disabled={!!editingGrant} />;
               }}
             />
           </div>
 
           <div className="mb-4 w-full">
-            <FormField
+            <d.FormField
               control={control}
               name="expiration"
               render={({ field }) => {
-                return <FormInput {...field} type="datetime-local" label="Expiration" />;
+                return <d.FormInput {...field} type="datetime-local" label="Expiration" />;
               }}
             />
           </div>
 
           {!!amount && granteeAddress && (
-            <Alert>
+            <d.Alert>
               <p className="text-sm text-muted-foreground">
                 This address will be able to spend up to {amount} {selectedToken?.label} on your behalf ending on{" "}
-                <FormattedDate value={expiration} year="numeric" month="2-digit" day="2-digit" hour="2-digit" minute="2-digit" />.
+                <d.FormattedDate value={expiration} year="numeric" month="2-digit" day="2-digit" hour="2-digit" minute="2-digit" />.
               </p>
-            </Alert>
+            </d.Alert>
           )}
 
-          {error && <Alert variant="warning">{error}</Alert>}
+          {error && <d.Alert variant="warning">{error}</d.Alert>}
         </form>
-      </Form>
-    </Popup>
+      </d.Form>
+    </d.Popup>
   );
 };

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.spec.tsx
@@ -293,7 +293,8 @@ describe(ManifestEdit.name, () => {
       useRouter: () => mock(),
       useSearchParams: (() => ({
         get: (key: string) => (key === "templateId" ? input?.templateId ?? null : null)
-      })) as unknown as Dependencies["useSearchParams"]
+      })) as unknown as Dependencies["useSearchParams"],
+      useSupportsACT: () => false
     } as unknown as Dependencies;
 
     return render(

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
@@ -1,6 +1,8 @@
 "use client";
 import type { ComponentProps, Dispatch, SetStateAction } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { SDLInput } from "@akashnetwork/chain-sdk/web";
+import { yaml } from "@akashnetwork/chain-sdk/web";
 import { Alert, Button, CustomTooltip, FileButton, Input, Snackbar, Spinner } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import type { EncodeObject } from "@cosmjs/proto-signing";
@@ -11,12 +13,14 @@ import { useAtom } from "jotai";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSnackbar } from "notistack";
 
+import { UACT_DENOM, UAKT_DENOM } from "@src/config/denom.config";
 import { useSdlBuilder } from "@src/context/SdlBuilderProvider/SdlBuilderProvider";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useCertificate } from "@src/hooks/useCertificate/useCertificate";
 import { useImportSimpleSdl } from "@src/hooks/useImportSimpleSdl";
 import { useManagedWalletDenom } from "@src/hooks/useManagedWalletDenom";
+import { useSupportsACT } from "@src/hooks/useSupportsACT/useSupportsACT";
 import { useWhen } from "@src/hooks/useWhen";
 import { useDepositParams } from "@src/queries/useSaveSettings";
 import sdlStore from "@src/store/sdlStore";
@@ -80,7 +84,8 @@ export const DEPENDENCIES = {
   useMediaQuery,
   useSnackbar,
   useRouter,
-  useSearchParams
+  useSearchParams,
+  useSupportsACT
 };
 
 export const ManifestEdit: React.FunctionComponent<Props> = ({
@@ -99,7 +104,18 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
   const [isCheckingPrerequisites, setIsCheckingPrerequisites] = useState(false);
   const [selectedSdlEditMode, setSelectedSdlEditMode] = useAtom(sdlStore.selectedSdlEditMode);
   const [isRepoInputValid, setIsRepoInputValid] = useState(false);
-  const [sdlDenom, setSdlDenom] = useState("uakt");
+  const isACTSupported = d.useSupportsACT();
+  const sdlDenom = useMemo(() => {
+    const defaultValue = isACTSupported ? UACT_DENOM : UAKT_DENOM;
+    if (!editedManifest) return defaultValue;
+
+    try {
+      const sdl: SDLInput = yaml.template(editedManifest);
+      return Object.values(Object.values(sdl.profiles.placement)[0].pricing)[0].denom;
+    } catch {
+      return defaultValue;
+    }
+  }, [editedManifest]);
 
   const { analyticsService, chainApiHttpClient, publicConfig: appConfig, deploymentLocalStorage } = d.useServices();
   const { settings } = d.useSettings();
@@ -124,7 +140,6 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
     wallet.isManaged && sdlDenom === "uakt" && editedManifest,
     () => {
       setEditedManifest(prev => (prev ? prev.replace(/uakt/g, managedDenom) : prev));
-      setSdlDenom(managedDenom);
     },
     [editedManifest, wallet.isManaged, sdlDenom]
   );
@@ -173,9 +188,6 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
 
       const dd = await deploymentData.NewDeploymentData(chainApiHttpClient, yamlStr, dseq, address, deposit);
       validateDeploymentData(dd, selectedTemplate);
-
-      setSdlDenom(dd.deposit.denom);
-
       setParsingError(null);
 
       return dd;

--- a/apps/deploy-web/src/components/shared/PrerequisiteList.tsx
+++ b/apps/deploy-web/src/components/shared/PrerequisiteList.tsx
@@ -29,7 +29,7 @@ export const PrerequisiteList: React.FunctionComponent<Props> = ({ onClose, onCo
       onContinue();
     }
 
-    if (address && (minDeposit.akt || minDeposit.usdc || minDeposit.act) && !!walletBalance) {
+    if (address && (minDeposit.akt !== undefined || minDeposit.usdc !== undefined || minDeposit.act !== undefined) && !!walletBalance) {
       setIsLoadingPrerequisites(true);
 
       const isBalanceValidated =

--- a/apps/deploy-web/src/hooks/useWalletBalance.ts
+++ b/apps/deploy-web/src/hooks/useWalletBalance.ts
@@ -123,7 +123,7 @@ export const useDenomData = (denom?: string) => {
         case UACT_DENOM:
           depositData = {
             min: minDeposit.act,
-            label: "USD",
+            label: "ACT",
             balance: udenomToDenom(walletBalance.balanceUACT, 6) || 0,
             max: udenomToDenom(Math.max(walletBalance.balanceUACT - txFeeBuffer, 0), 6) || 0
           };


### PR DESCRIPTION
## Why

adds ACT support for authorizations. Ref CON-9

## What

If ACT is supported, authorizations can be done only in uAKT or in uACT. uACT is the default option
<img width="629" height="654" alt="Screenshot 2026-03-09 at 10 39 56" src="https://github.com/user-attachments/assets/4fcce8de-d567-4413-a448-43a149ae9f76" />
<img width="1199" height="354" alt="Screenshot 2026-03-09 at 10 43 16" src="https://github.com/user-attachments/assets/62978225-6bdd-4699-976b-bd788ad967a4" />


<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for authorization UI and the grant modal, covering selection, edit/revoke flows, bulk actions, form wiring, and validations.

* **Refactor**
  * Introduced dependency-injection for authorization components to improve modularity and testability.

* **Behavior**
  * ACT token support added: denomination selection and token displays adapt when ACT is supported; managed accounts still show USD.
  * Prerequisite balance checks now correctly consider explicitly defined deposit requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->