### PR TITLE
fix: update @akashnetwork/chain-sdk to 1.0.0-alpha.25

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "^1.3.0",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/logging": "*",

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "^1.3.0",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@cosmjs/crypto": "~0.36.1",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.0",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "^1.3.0",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/logging": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -951,7 +951,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/logging": "*",
@@ -3434,7 +3434,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@cosmjs/crypto": "~0.36.1",
@@ -5930,7 +5930,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.0",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/logging": "*",
@@ -7591,7 +7591,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -7762,7 +7762,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -8913,7 +8913,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/logging": "*",
@@ -9548,7 +9548,9 @@
       }
     },
     "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.24",
+      "version": "1.0.0-alpha.25",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.25.tgz",
+      "integrity": "sha512-92E6tKYv6ebNEbTSspYZBKjUFiNj2QnWbwDrdx8E+h2CU+l1i8yfYLGHrRzorPumkHhi38JUXGUCQxkRRvb8dA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.3",
@@ -52970,7 +52972,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       }

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.24",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.25",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   }


### PR DESCRIPTION
## Why
New version has a fix for new generateManifest & co functions + chain transactions support

## What
Update `@akashnetwork/chain-sdk` from `1.0.0-alpha.24` to `1.0.0-alpha.25` across all apps and packages:
- `apps/api`
- `apps/deploy-web`
- `apps/indexer`
- `apps/notifications`
- `apps/provider-proxy`
- `apps/stats-web`
- `apps/tx-signer`
- `packages/network-store`

All `test:cov` suites pass. The only failures were in `apps/notifications` functional tests which require Docker services (database) and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core infrastructure dependencies across all major applications and services including API platforms, web interfaces, data indexing, notifications, and backend infrastructure to maintain system stability, ensure platform-wide consistency, and guarantee compatibility with latest ecosystem components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->