### PR TITLE
refactor(sdl): migrate deploy-web from deprecated SDL class to generateManifest

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
@@ -30,11 +30,11 @@ import Layout from "../layout/Layout";
 import { Title } from "../shared/Title";
 import { CreateCredentialsButton } from "./CreateCredentialsButton/CreateCredentialsButton";
 import { DeploymentDetailTopBar } from "./DeploymentDetailTopBar/DeploymentDetailTopBar";
+import { ManifestUpdate } from "./ManifestUpdate/ManifestUpdate";
 import { DeploymentLeaseShell } from "./DeploymentLeaseShell";
 import { DeploymentLogs } from "./DeploymentLogs";
 import { DeploymentSubHeader } from "./DeploymentSubHeader";
 import { LeaseRow } from "./LeaseRow";
-import { ManifestUpdate } from "./ManifestUpdate";
 
 export interface DeploymentDetailProps {
   dseq: string;

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import type { Manifest } from "@akashnetwork/chain-sdk/web";
 import { Alert, Button, CustomTooltip, Snackbar } from "@akashnetwork/ui/components";
 import { InfoCircle, WarningCircle } from "iconoir-react";
 import yaml from "js-yaml";
@@ -88,7 +89,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     window.open("https://akash.network/docs/deployments/akash-cli/installation/#update-the-deployment", "_blank");
   }
 
-  async function sendManifest(providerInfo: ApiProviderList, manifest: any) {
+  async function sendManifest(providerInfo: ApiProviderList, manifest: Manifest) {
     try {
       return await providerProxy.sendManifest(providerInfo, manifest, {
         dseq: deployment.dseq,

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -1,0 +1,418 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+import type { DeploymentStorageService } from "@src/services/deployment-storage/deployment-storage.service";
+import type { ProviderProxyService } from "@src/services/provider-proxy/provider-proxy.service";
+import { DEPENDENCIES, ManifestUpdate } from "./ManifestUpdate";
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { ComponentMock, MockComponents } from "@tests/unit/mocks";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
+
+describe(ManifestUpdate.name, () => {
+  it("shows outside deployment message when no local manifest exists", () => {
+    setup({
+      deploymentLocalStorage: {
+        get: vi.fn().mockReturnValue(null)
+      }
+    });
+
+    expect(screen.getByText(/it looks like this deployment was created using another deploy tool/i)).toBeInTheDocument();
+  });
+
+  it("hides outside deployment message and shows editor after clicking Continue", async () => {
+    const ButtonMock = vi.fn(ComponentMock);
+    setup({
+      deploymentLocalStorage: {
+        get: vi.fn().mockReturnValue(null)
+      },
+      dependencies: {
+        Button: ButtonMock
+      }
+    });
+
+    expect(screen.getByText(/it looks like this deployment was created using another deploy tool/i)).toBeInTheDocument();
+
+    const continueButton = ButtonMock.mock.calls.find(call => call[0].children === "Continue");
+
+    await act(() => {
+      continueButton?.[0].onClick();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/it looks like this deployment was created using another deploy tool/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it("loads manifest from local storage and calls onManifestChange", async () => {
+    const onManifestChange = vi.fn();
+    setup({
+      onManifestChange,
+      deploymentLocalStorage: {
+        get: vi.fn().mockReturnValue({ manifest: "version: '2.0'" })
+      },
+      dependencies: {
+        deploymentData: {
+          getManifestVersion: vi.fn().mockResolvedValue("abc123")
+        }
+      }
+    });
+
+    await waitFor(() => {
+      expect(onManifestChange).toHaveBeenCalledWith("version: '2.0'");
+    });
+  });
+
+  it("shows parsing error when manifest version retrieval fails", async () => {
+    setup({
+      deploymentLocalStorage: {
+        get: vi.fn().mockReturnValue({ manifest: "version: '2.0'" })
+      },
+      dependencies: {
+        deploymentData: {
+          getManifestVersion: vi.fn().mockRejectedValue(new Error("parse error"))
+        }
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Error getting manifest version.")).toBeInTheDocument();
+    });
+  });
+
+  it("disables update button when manifest is empty", () => {
+    const ButtonMock = vi.fn(ComponentMock);
+    setup({
+      editedManifest: "",
+      dependencies: {
+        Button: ButtonMock
+      }
+    });
+
+    const updateButton = ButtonMock.mock.calls.find(call => call[0].children === "Update Deployment");
+    expect(updateButton?.[0].disabled).toBe(true);
+  });
+
+  it("disables update button when deployment is not active", () => {
+    const ButtonMock = vi.fn(ComponentMock);
+    setup({
+      deployment: { dseq: "123", state: "closed", hash: "abc" },
+      dependencies: {
+        Button: ButtonMock
+      }
+    });
+
+    const updateButton = ButtonMock.mock.calls.find(call => call[0].children === "Update Deployment");
+    expect(updateButton?.[0].disabled).toBe(true);
+  });
+
+  it("shows CreateCredentialsButton when credentials are not usable", () => {
+    const CreateCredentialsButtonMock = vi.fn(ComponentMock);
+    setup({
+      providerCredentials: {
+        details: { usable: false, isExpired: true, type: "jwt" as const, value: null }
+      },
+      dependencies: {
+        CreateCredentialsButton: CreateCredentialsButtonMock
+      }
+    });
+
+    expect(CreateCredentialsButtonMock).toHaveBeenCalled();
+  });
+
+  it("renders SDLEditor when not remote deploy", () => {
+    const SDLEditorMock = vi.fn(ComponentMock);
+    setup({
+      isRemoteDeploy: false,
+      editedManifest: "some-manifest",
+      dependencies: {
+        SDLEditor: SDLEditorMock
+      }
+    });
+
+    expect(SDLEditorMock).toHaveBeenCalled();
+    expect(SDLEditorMock.mock.calls[0][0].value).toBe("some-manifest");
+  });
+
+  it("renders RemoteDeployUpdate when remote deploy", () => {
+    const RemoteDeployUpdateMock = vi.fn(ComponentMock);
+    setup({
+      isRemoteDeploy: true,
+      editedManifest: "some-manifest",
+      dependencies: {
+        RemoteDeployUpdate: RemoteDeployUpdateMock
+      }
+    });
+
+    expect(RemoteDeployUpdateMock).toHaveBeenCalled();
+    expect(RemoteDeployUpdateMock.mock.calls[0][0].sdlString).toBe("some-manifest");
+  });
+
+  it("sends update transaction and manifest when hash differs", async () => {
+    const ButtonMock = vi.fn(ComponentMock);
+    const closeManifestEditor = vi.fn();
+    const signAndBroadcastTx = vi.fn().mockResolvedValue(true);
+    const { providerProxy, analyticsService } = setup({
+      editedManifest: "version: '2.0'",
+      deployment: { dseq: "123", state: "active", hash: "different-hash" },
+      leases: [{ provider: "provider1" }],
+      closeManifestEditor,
+      providers: [{ owner: "provider1", hostUri: "https://provider1.com" }],
+      wallet: {
+        address: "akash1abc",
+        signAndBroadcastTx,
+        isManaged: false
+      },
+      dependencies: {
+        Button: ButtonMock,
+        deploymentData: {
+          NewDeploymentData: vi.fn().mockResolvedValue({
+            hash: Buffer.from("new-hash"),
+            deploymentId: { dseq: "123" }
+          }),
+          getManifest: vi.fn().mockReturnValue([])
+        },
+        TransactionMessageData: {
+          getUpdateDeploymentMsg: vi.fn().mockReturnValue({ typeUrl: "/update", value: {} })
+        }
+      }
+    });
+
+    const updateButton = ButtonMock.mock.calls.find(call => call[0].children === "Update Deployment");
+
+    await act(async () => {
+      await updateButton?.[0].onClick();
+    });
+
+    await waitFor(() => {
+      expect(signAndBroadcastTx).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(providerProxy.sendManifest).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(analyticsService.track).toHaveBeenCalledWith("update_deployment", {
+        category: "deployments",
+        label: "Update deployment"
+      });
+    });
+    await waitFor(() => {
+      expect(closeManifestEditor).toHaveBeenCalled();
+    });
+  });
+
+  it("skips transaction when hash matches and only sends manifest", async () => {
+    const hashBytes = Buffer.from("matching-hash");
+    const base64Hash = hashBytes.toString("base64");
+    const ButtonMock = vi.fn(ComponentMock);
+    const closeManifestEditor = vi.fn();
+    const signAndBroadcastTx = vi.fn();
+    const { providerProxy } = setup({
+      editedManifest: "version: '2.0'",
+      deployment: { dseq: "123", state: "active", hash: base64Hash },
+      leases: [{ provider: "provider1" }],
+      closeManifestEditor,
+      providers: [{ owner: "provider1", hostUri: "https://provider1.com" }],
+      wallet: {
+        address: "akash1abc",
+        signAndBroadcastTx,
+        isManaged: false
+      },
+      dependencies: {
+        Button: ButtonMock,
+        deploymentData: {
+          NewDeploymentData: vi.fn().mockResolvedValue({
+            hash: hashBytes,
+            deploymentId: { dseq: "123" }
+          }),
+          getManifest: vi.fn().mockReturnValue([])
+        }
+      }
+    });
+
+    const updateButton = ButtonMock.mock.calls.find(call => call[0].children === "Update Deployment");
+
+    await act(async () => {
+      await updateButton?.[0].onClick();
+    });
+
+    await waitFor(() => {
+      expect(signAndBroadcastTx).not.toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(providerProxy.sendManifest).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(closeManifestEditor).toHaveBeenCalled();
+    });
+  });
+
+  it("shows YAML parsing error on update failure", async () => {
+    const ButtonMock = vi.fn(ComponentMock);
+    setup({
+      editedManifest: "version: '2.0'",
+      dependencies: {
+        Button: ButtonMock,
+        deploymentData: {
+          NewDeploymentData: vi.fn().mockRejectedValue(Object.assign(new Error("bad yaml"), { name: "YAMLException" })),
+          getManifest: vi.fn()
+        }
+      }
+    });
+
+    const updateButton = ButtonMock.mock.calls.find(call => call[0].children === "Update Deployment");
+
+    await act(async () => {
+      await updateButton?.[0].onClick();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("bad yaml")).toBeInTheDocument();
+    });
+  });
+
+  it("clears deployment version when text changes in editor", async () => {
+    const SDLEditorMock = vi.fn(ComponentMock);
+    const onManifestChange = vi.fn();
+    setup({
+      onManifestChange,
+      dependencies: {
+        SDLEditor: SDLEditorMock,
+        deploymentData: {
+          getManifestVersion: vi.fn().mockResolvedValue("version123")
+        }
+      },
+      deploymentLocalStorage: {
+        get: vi.fn().mockReturnValue({ manifest: "version: '2.0'" })
+      }
+    });
+
+    await waitFor(() => {
+      expect(onManifestChange).toHaveBeenCalledWith("version: '2.0'");
+    });
+
+    act(() => {
+      SDLEditorMock.mock.calls[0][0].onChange("updated manifest");
+    });
+
+    expect(onManifestChange).toHaveBeenCalledWith("updated manifest");
+  });
+
+  function setup(input?: {
+    deployment?: Partial<{ dseq: string; state: string; hash: string }>;
+    leases?: Array<Partial<{ provider: string }>>;
+    editedManifest?: string;
+    isRemoteDeploy?: boolean;
+    closeManifestEditor?: () => void;
+    onManifestChange?: (value: string) => void;
+    providers?: Array<Partial<{ owner: string; hostUri: string }>>;
+    wallet?: Partial<{ address: string; signAndBroadcastTx: ReturnType<typeof vi.fn>; isManaged: boolean }>;
+    providerCredentials?: Partial<{ details: { usable: boolean; isExpired: boolean; type: "jwt" | "mtls"; value: string | null } }>;
+    deploymentLocalStorage?: Partial<{ get: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> }>;
+    dependencies?: Partial<typeof DEPENDENCIES>;
+  }) {
+    const providerProxy = mock<ProviderProxyService>();
+    const analyticsService = mock<AnalyticsService>();
+    const deploymentLocalStorage = {
+      get: input?.deploymentLocalStorage?.get || vi.fn().mockReturnValue({ manifest: "version: '2.0'" }),
+      set: vi.fn(),
+      update: input?.deploymentLocalStorage?.update || vi.fn()
+    };
+
+    const useWallet: typeof DEPENDENCIES.useWallet = () =>
+      ({
+        address: input?.wallet?.address || "akash1test",
+        signAndBroadcastTx: input?.wallet?.signAndBroadcastTx || vi.fn(),
+        isManaged: input?.wallet?.isManaged ?? false,
+        walletName: "",
+        isWalletConnected: true,
+        isWalletLoaded: true,
+        connectManagedWallet: vi.fn(),
+        logout: vi.fn(),
+        isCustodial: false,
+        isWalletLoading: false,
+        isTrialing: false,
+        isOnboarding: false,
+        switchWalletType: vi.fn(),
+        hasManagedWallet: false
+      }) as ReturnType<typeof DEPENDENCIES.useWallet>;
+
+    const useProviderList: typeof DEPENDENCIES.useProviderList = () =>
+      ({
+        data: input?.providers || [{ owner: "provider1", hostUri: "https://provider1.com" }]
+      }) as ReturnType<typeof DEPENDENCIES.useProviderList>;
+
+    const useProviderCredentials: typeof DEPENDENCIES.useProviderCredentials = () => ({
+      details: input?.providerCredentials?.details || {
+        usable: true,
+        isExpired: false,
+        type: "jwt" as const,
+        value: "test-token"
+      },
+      generate: vi.fn()
+    });
+
+    const useSnackbar: typeof DEPENDENCIES.useSnackbar = () => ({
+      enqueueSnackbar: vi.fn(),
+      closeSnackbar: vi.fn()
+    });
+
+    const useSettings: typeof DEPENDENCIES.useSettings = () =>
+      ({
+        settings: { isBlockchainDown: false }
+      }) as ReturnType<typeof DEPENDENCIES.useSettings>;
+
+    render(
+      <TestContainerProvider
+        services={{
+          providerProxy: () => providerProxy,
+          analyticsService: () => analyticsService,
+          deploymentLocalStorage: () => deploymentLocalStorage as unknown as DeploymentStorageService
+        }}
+      >
+        <ManifestUpdate
+          deployment={
+            {
+              dseq: "123",
+              state: "active",
+              hash: "abc",
+              ...input?.deployment
+            } as Parameters<typeof ManifestUpdate>[0]["deployment"]
+          }
+          leases={(input?.leases || [{ provider: "provider1" }]) as Parameters<typeof ManifestUpdate>[0]["leases"]}
+          closeManifestEditor={input?.closeManifestEditor || vi.fn()}
+          isRemoteDeploy={input?.isRemoteDeploy ?? false}
+          editedManifest={input?.editedManifest ?? "version: '2.0'"}
+          onManifestChange={input?.onManifestChange || vi.fn()}
+          dependencies={{
+            ...MockComponents(DEPENDENCIES),
+            useWallet,
+            useProviderList,
+            useProviderCredentials,
+            useSnackbar,
+            useSettings,
+            deploymentData: {
+              getManifestVersion: vi.fn().mockResolvedValue("test-version"),
+              getManifest: vi.fn().mockReturnValue([]),
+              NewDeploymentData: vi.fn().mockResolvedValue({
+                hash: Buffer.from("test-hash"),
+                deploymentId: { dseq: "123" }
+              })
+            } as unknown as typeof DEPENDENCIES.deploymentData,
+            TransactionMessageData: {
+              getUpdateDeploymentMsg: vi.fn().mockReturnValue({ typeUrl: "/update", value: {} })
+            } as unknown as typeof DEPENDENCIES.TransactionMessageData,
+            ...input?.dependencies
+          }}
+        />
+      </TestContainerProvider>
+    );
+
+    return {
+      providerProxy,
+      analyticsService,
+      deploymentLocalStorage
+    };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -4,25 +4,49 @@ import type { Manifest } from "@akashnetwork/chain-sdk/web";
 import { Alert, Button, CustomTooltip, Snackbar } from "@akashnetwork/ui/components";
 import { InfoCircle, WarningCircle } from "iconoir-react";
 import yaml from "js-yaml";
-import { useSnackbar } from "notistack";
+import { useSnackbar as useSnackbarOriginal } from "notistack";
 
 import { LinearLoadingSkeleton } from "@src/components/shared/LinearLoadingSkeleton";
 import { LinkTo } from "@src/components/shared/LinkTo";
 import ViewPanel from "@src/components/shared/ViewPanel";
 import { useServices } from "@src/context/ServicesProvider";
-import { useSettings } from "@src/context/SettingsProvider";
-import { useWallet } from "@src/context/WalletProvider";
-import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
-import { useProviderList } from "@src/queries/useProvidersQuery";
+import { useSettings as useSettingsOriginal } from "@src/context/SettingsProvider";
+import { useWallet as useWalletOriginal } from "@src/context/WalletProvider";
+import { useProviderCredentials as useProviderCredentialsOriginal } from "@src/hooks/useProviderCredentials/useProviderCredentials";
+import { useProviderList as useProviderListOriginal } from "@src/queries/useProvidersQuery";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
-import { deploymentData } from "@src/utils/deploymentData";
-import { TransactionMessageData } from "@src/utils/TransactionMessageData";
-import RemoteDeployUpdate from "../remote-deploy/update/RemoteDeployUpdate";
-import { SDLEditor } from "../sdl/SDLEditor/SDLEditor";
-import { ManifestErrorSnackbar } from "../shared/ManifestErrorSnackbar/ManifestErrorSnackbar";
-import { Title } from "../shared/Title";
-import { CreateCredentialsButton } from "./CreateCredentialsButton/CreateCredentialsButton";
+import { deploymentData as deploymentDataOriginal } from "@src/utils/deploymentData";
+import { TransactionMessageData as TransactionMessageDataOriginal } from "@src/utils/TransactionMessageData";
+import RemoteDeployUpdate from "../../remote-deploy/update/RemoteDeployUpdate";
+import { SDLEditor } from "../../sdl/SDLEditor/SDLEditor";
+import { ManifestErrorSnackbar } from "../../shared/ManifestErrorSnackbar/ManifestErrorSnackbar";
+import { Title } from "../../shared/Title";
+import { CreateCredentialsButton } from "../CreateCredentialsButton/CreateCredentialsButton";
+
+export const DEPENDENCIES = {
+  Alert,
+  Button,
+  CustomTooltip,
+  Snackbar,
+  LinearLoadingSkeleton,
+  LinkTo,
+  ViewPanel,
+  RemoteDeployUpdate,
+  SDLEditor,
+  ManifestErrorSnackbar,
+  Title,
+  CreateCredentialsButton,
+  InfoCircle,
+  WarningCircle,
+  useWallet: useWalletOriginal,
+  useProviderList: useProviderListOriginal,
+  useProviderCredentials: useProviderCredentialsOriginal,
+  useSnackbar: useSnackbarOriginal,
+  useSettings: useSettingsOriginal,
+  deploymentData: deploymentDataOriginal,
+  TransactionMessageData: TransactionMessageDataOriginal
+};
 
 type Props = {
   deployment: DeploymentDto;
@@ -31,6 +55,7 @@ type Props = {
   isRemoteDeploy: boolean;
   editedManifest: string;
   onManifestChange: (value: string) => void;
+  dependencies?: typeof DEPENDENCIES;
 };
 
 export const ManifestUpdate: React.FunctionComponent<Props> = ({
@@ -39,18 +64,19 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   closeManifestEditor,
   isRemoteDeploy,
   editedManifest,
-  onManifestChange
+  onManifestChange,
+  dependencies: d = DEPENDENCIES
 }) => {
   const { providerProxy, analyticsService, chainApiHttpClient, deploymentLocalStorage } = useServices();
   const [parsingError, setParsingError] = useState<string | null>(null);
   const [deploymentVersion, setDeploymentVersion] = useState<string | null>(null);
   const [showOutsideDeploymentMessage, setShowOutsideDeploymentMessage] = useState(false);
   const [isSendingManifest, setIsSendingManifest] = useState(false);
-  const { address, signAndBroadcastTx, isManaged: isManagedWallet } = useWallet();
-  const { data: providers } = useProviderList();
-  const providerCredentials = useProviderCredentials();
-  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
-  const { settings } = useSettings();
+  const { address, signAndBroadcastTx, isManaged: isManagedWallet } = d.useWallet();
+  const { data: providers } = d.useProviderList();
+  const providerCredentials = d.useProviderCredentials();
+  const { enqueueSnackbar, closeSnackbar } = d.useSnackbar();
+  const { settings } = d.useSettings();
 
   useEffect(() => {
     const init = async () => {
@@ -61,7 +87,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
 
         try {
           const yamlVersion = yaml.load(localDeploymentData.manifest);
-          const version = await deploymentData.getManifestVersion(yamlVersion);
+          const version = await d.deploymentData.getManifestVersion(yamlVersion);
           setDeploymentVersion(version);
         } catch (error) {
           console.error(error);
@@ -96,7 +122,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
         credentials: providerCredentials.details
       });
     } catch (err) {
-      enqueueSnackbar(<ManifestErrorSnackbar err={err} />, { variant: "error", autoHideDuration: null });
+      enqueueSnackbar(<d.ManifestErrorSnackbar err={err} />, { variant: "error", autoHideDuration: null });
       throw err;
     }
   }
@@ -107,12 +133,12 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     try {
       const doc = yaml.load(editedManifest);
 
-      const dd = await deploymentData.NewDeploymentData(chainApiHttpClient, editedManifest, deployment.dseq, address); // TODO Flags
-      const mani = deploymentData.getManifest(doc, true);
+      const dd = await d.deploymentData.NewDeploymentData(chainApiHttpClient, editedManifest, deployment.dseq, address); // TODO Flags
+      const mani = d.deploymentData.getManifest(doc, true);
 
       // If it's actual update, send a transaction, else just send the manifest
       if (Buffer.from(dd.hash).toString("base64") !== deployment.hash) {
-        const message = TransactionMessageData.getUpdateDeploymentMsg(dd);
+        const message = d.TransactionMessageData.getUpdateDeploymentMsg(dd);
         response = await signAndBroadcastTx([message]);
       } else {
         response = true;
@@ -128,7 +154,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
 
         sendManifestKey =
           !isManagedWallet &&
-          enqueueSnackbar(<Snackbar title="Deploying! 🚀" subTitle="Please wait a few seconds..." showLoading />, {
+          enqueueSnackbar(<d.Snackbar title="Deploying! 🚀" subTitle="Please wait a few seconds..." showLoading />, {
             variant: "info",
             autoHideDuration: null
           });
@@ -172,55 +198,55 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     <>
       {showOutsideDeploymentMessage ? (
         <div className="p-2">
-          <Alert>
+          <d.Alert>
             It looks like this deployment was created using another deploy tool. We can't show you the configuration file that was used initially, but you can
             still update it. Simply continue and enter the configuration you want to use.
             <div className="mt-1">
-              <Button onClick={() => setShowOutsideDeploymentMessage(false)} size="sm">
+              <d.Button onClick={() => setShowOutsideDeploymentMessage(false)} size="sm">
                 Continue
-              </Button>
+              </d.Button>
             </div>
-          </Alert>
+          </d.Alert>
         </div>
       ) : (
         <>
           <div>
             <div className="flex h-[50px] items-center justify-between space-x-2 px-2 py-1">
               <div className="flex items-center space-x-2">
-                <Title subTitle className="!text-base">
+                <d.Title subTitle className="!text-base">
                   Update Deployment
-                </Title>
+                </d.Title>
 
-                <CustomTooltip
+                <d.CustomTooltip
                   title={
                     <div>
                       Akash Groups are translated into Kubernetes Deployments, this means that only a few fields from the Akash SDL are mutable. For example
                       image, command, args, env and exposed ports can be modified, but compute resources and placement criteria cannot. (
-                      <LinkTo onClick={handleUpdateDocClick}>View doc</LinkTo>)
+                      <d.LinkTo onClick={handleUpdateDocClick}>View doc</d.LinkTo>)
                     </div>
                   }
                 >
-                  <InfoCircle className="text-xs text-muted-foreground" />
-                </CustomTooltip>
+                  <d.InfoCircle className="text-xs text-muted-foreground" />
+                </d.CustomTooltip>
 
                 {!!deploymentVersion && deploymentVersion !== deployment.hash && (
-                  <CustomTooltip
+                  <d.CustomTooltip
                     title={
-                      <Alert variant="warning">
+                      <d.Alert variant="warning">
                         Your local deployment file version doesn't match the one on-chain. If you click update, you will override the deployed version.
-                      </Alert>
+                      </d.Alert>
                     }
                   >
-                    <WarningCircle className="text-xs text-warning" />
-                  </CustomTooltip>
+                    <d.WarningCircle className="text-xs text-warning" />
+                  </d.CustomTooltip>
                 )}
               </div>
 
               <div>
                 {!providerCredentials.details.usable ? (
-                  <CreateCredentialsButton containerClassName="flex items-center space-x-4 text-sm" className="" size="sm" />
+                  <d.CreateCredentialsButton containerClassName="flex items-center space-x-4 text-sm" className="" size="sm" />
                 ) : (
-                  <Button
+                  <d.Button
                     disabled={
                       !!parsingError || !editedManifest || !providers || isSendingManifest || deployment.state !== "active" || settings.isBlockchainDown
                     }
@@ -229,22 +255,22 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
                     type="button"
                   >
                     Update Deployment
-                  </Button>
+                  </d.Button>
                 )}
               </div>
             </div>
 
-            {parsingError && <Alert variant="warning">{parsingError}</Alert>}
+            {parsingError && <d.Alert variant="warning">{parsingError}</d.Alert>}
 
-            <LinearLoadingSkeleton isLoading={isSendingManifest} />
+            <d.LinearLoadingSkeleton isLoading={isSendingManifest} />
 
-            <ViewPanel stickToBottom style={{ overflow: isRemoteDeploy ? "unset" : "hidden" }}>
+            <d.ViewPanel stickToBottom style={{ overflow: isRemoteDeploy ? "unset" : "hidden" }}>
               {isRemoteDeploy ? (
-                <RemoteDeployUpdate sdlString={editedManifest} onManifestChange={onManifestChange} />
+                <d.RemoteDeployUpdate sdlString={editedManifest} onManifestChange={onManifestChange} />
               ) : (
-                <SDLEditor value={editedManifest} onChange={handleTextChange} onValidate={() => setParsingError(null)} />
+                <d.SDLEditor value={editedManifest} onChange={handleTextChange} onValidate={() => setParsingError(null)} />
               )}
-            </ViewPanel>
+            </d.ViewPanel>
           </div>
         </>
       )}

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
@@ -1,3 +1,5 @@
+import type { Manifest } from "@akashnetwork/chain-sdk/web";
+import { manifestToSortedJSON } from "@akashnetwork/chain-sdk/web";
 import type { HttpClient } from "@akashnetwork/http-sdk";
 import type { LoggerService } from "@akashnetwork/logging";
 import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
@@ -17,7 +19,7 @@ describe(ProviderProxyService.name, () => {
   describe("sendManifest", () => {
     it("does nothing if provider is undefined", () => {
       const { service, httpClient } = setup();
-      service.sendManifest(undefined, {}, { dseq: "1" });
+      service.sendManifest(undefined, [] as Manifest, { dseq: "1" });
       expect(httpClient.post).not.toHaveBeenCalled();
     });
 
@@ -32,31 +34,48 @@ describe(ProviderProxyService.name, () => {
       const provider = buildProvider();
 
       const dseq = "1";
-      const manifest = [
+      const manifest: Manifest = [
         {
-          profiles: {
-            compute: {
-              web: {
-                resources: {
-                  cpu: {
-                    units: {
-                      val: "0.5"
-                    }
-                  }
+          name: "web",
+          services: [
+            {
+              name: "web",
+              image: "test",
+              command: ["test"],
+              args: [],
+              count: 1,
+              env: [],
+              expose: [],
+              credentials: undefined,
+              params: undefined,
+              resources: {
+                id: 1,
+                cpu: {
+                  units: {
+                    val: new TextEncoder().encode("0.5")
+                  },
+                  attributes: []
                 },
                 memory: {
                   quantity: {
-                    val: "512Mi"
-                  }
+                    val: new TextEncoder().encode("512Mi")
+                  },
+                  attributes: []
                 },
-                storage: {
-                  quantity: {
-                    val: "512Mi"
+                storage: [
+                  {
+                    name: "test",
+                    quantity: {
+                      val: new TextEncoder().encode("512Mi")
+                    },
+                    attributes: []
                   }
-                }
+                ],
+                gpu: undefined,
+                endpoints: []
               }
             }
-          }
+          ]
         }
       ];
       const credentials: ProviderCredentials = { type: "mtls", value: { cert: "certPem", key: "keyPem" } };
@@ -75,33 +94,7 @@ describe(ProviderProxyService.name, () => {
             certPem: credentials.value?.cert,
             keyPem: credentials.value?.key
           },
-          body: JSON.stringify([
-            {
-              profiles: {
-                compute: {
-                  web: {
-                    resources: {
-                      cpu: {
-                        units: {
-                          val: "0.5"
-                        }
-                      }
-                    },
-                    memory: {
-                      size: {
-                        val: "512Mi"
-                      }
-                    },
-                    storage: {
-                      size: {
-                        val: "512Mi"
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          ])
+          body: manifestToSortedJSON(manifest)
         },
         { timeout: expect.any(Number) }
       );

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
@@ -1,3 +1,4 @@
+import { type Manifest, manifestToSortedJSON } from "@akashnetwork/chain-sdk/web";
 import type { HttpClient } from "@akashnetwork/http-sdk";
 import type { LoggerService } from "@akashnetwork/logging";
 import type { AxiosResponse } from "axios";
@@ -39,21 +40,14 @@ export class ProviderProxyService {
     );
   }
 
-  async sendManifest(providerInfo: ApiProviderList | undefined | null, manifest: unknown, options: SendManifestToProviderOptions) {
+  async sendManifest(providerInfo: ApiProviderList | undefined | null, manifest: Manifest, options: SendManifestToProviderOptions) {
     if (!providerInfo) return;
     this.logger.info({ event: "START_SEND_MANIFEST", providerAddress: providerInfo.owner, dseq: options.dseq });
-
-    const jsonStr = JSON.stringify(manifest, (_, value) => {
-      if (typeof value !== "object" || value === null || !("quantity" in value)) return value;
-
-      const { quantity, ...rest } = value;
-      if (typeof quantity !== "object" || quantity === null || !("val" in quantity)) return value;
-      return { ...rest, size: quantity };
-    });
 
     // Waiting for provider to have lease
     await wait(ProviderProxyService.BEFORE_SEND_MANIFEST_DELAY);
 
+    const serializedManifest = manifestToSortedJSON(manifest);
     let response: AxiosResponse | undefined;
 
     for (let i = 1; i <= 3 && !response; i++) {
@@ -63,7 +57,7 @@ export class ProviderProxyService {
           response = await this.request(`/deployment/${options.dseq}/manifest`, {
             method: "PUT",
             credentials: options.credentials,
-            body: jsonStr,
+            body: serializedManifest,
             timeout: 60_000,
             providerIdentity: providerInfo
           });

--- a/apps/deploy-web/src/utils/deploymentData/helpers.ts
+++ b/apps/deploy-web/src/utils/deploymentData/helpers.ts
@@ -1,5 +1,5 @@
-import type { NetworkId } from "@akashnetwork/chain-sdk/web";
-import { SDL } from "@akashnetwork/chain-sdk/web";
+import type { Manifest as AkashManifest, NetworkId, SDLInput } from "@akashnetwork/chain-sdk/web";
+import { generateManifest, generateManifestVersion, manifestToSortedJSON, yaml as sdlYaml } from "@akashnetwork/chain-sdk/web";
 
 export class CustomValidationError extends Error {
   constructor(message: string) {
@@ -48,30 +48,37 @@ export function parseSizeStr(str: string) {
 
 type NetworkType = "beta2" | "beta3";
 
-function isValidString(value: unknown): value is string {
-  return typeof value === "string" && !!value;
+export function parseSdlInput(yamlJson: string | SDLInput): SDLInput {
+  return typeof yamlJson === "string" ? sdlYaml.template<SDLInput>(yamlJson) : yamlJson;
 }
 
-export function getSdl(yamlJson: string, networkType: NetworkType, networkId: NetworkId) {
-  return isValidString(yamlJson) ? SDL.fromString(yamlJson, networkType, networkId) : new SDL(yamlJson, networkType, networkId);
+export function buildManifest(sdlInput: SDLInput, networkId: NetworkId) {
+  const result = generateManifest(sdlInput, networkId);
+  if (!result.ok) {
+    throw new Error(result.value.map(e => e.message).join(", "));
+  }
+  return result.value;
 }
 
-export function DeploymentGroups(yamlJson: string, networkType: NetworkType, networkId: NetworkId) {
-  const sdl = getSdl(yamlJson, networkType, networkId);
-  return sdl.groups();
+export function DeploymentGroups(yamlJson: string | SDLInput, _networkType: NetworkType, networkId: NetworkId) {
+  const sdlInput = parseSdlInput(yamlJson);
+  return buildManifest(sdlInput, networkId).groupSpecs;
 }
 
-export function Manifest(yamlJson: string, networkType: NetworkType, networkId: NetworkId, asString = false) {
-  const sdl = getSdl(yamlJson, networkType, networkId);
-  return sdl.manifest(asString);
+export function Manifest(yamlJson: string | SDLInput, _networkType: NetworkType, networkId: NetworkId, _asString = false): AkashManifest {
+  const sdlInput = parseSdlInput(yamlJson);
+  const { groups } = buildManifest(sdlInput, networkId);
+  return groups;
 }
 
-export async function ManifestVersion(yamlJson: string, networkType: NetworkType, networkId: NetworkId) {
-  const sdl = getSdl(yamlJson, networkType, networkId);
-  return sdl.manifestVersion();
+export async function ManifestVersion(yamlJson: string | SDLInput, _networkType: NetworkType, networkId: NetworkId) {
+  const sdlInput = parseSdlInput(yamlJson);
+  const { groups } = buildManifest(sdlInput, networkId);
+  return generateManifestVersion(groups);
 }
 
-export function ManifestYaml(sdlConfig: string, networkType: NetworkType, networkId: NetworkId) {
-  const sdl = getSdl(sdlConfig, networkType, networkId);
-  return sdl.manifestSortedJSON();
+export function ManifestYaml(sdlConfig: string, _networkType: NetworkType, networkId: NetworkId) {
+  const sdlInput = parseSdlInput(sdlConfig);
+  const { groups } = buildManifest(sdlInput, networkId);
+  return manifestToSortedJSON(groups);
 }

--- a/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
+++ b/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
@@ -1,11 +1,14 @@
 import type { Attribute } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import type { GroupSpec } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import type { Manifest as AkashManifest, SDLInput } from "@akashnetwork/chain-sdk/web";
+import { generateManifestVersion } from "@akashnetwork/chain-sdk/web";
 import type { HttpClient } from "@akashnetwork/http-sdk";
 import yaml from "js-yaml";
 
 import { browserEnvConfig } from "@src/config/browser-env.config";
 import networkStore from "@src/store/networkStore";
 import type { DepositParams } from "@src/types/deployment";
-import { CustomValidationError, getSdl, Manifest, ManifestVersion } from "./helpers";
+import { buildManifest, CustomValidationError, Manifest, ManifestVersion, parseSdlInput } from "./helpers";
 
 export const ENDPOINT_NAME_VALIDATION_REGEX = /^[a-z]+[-_\da-z]+$/;
 export const TRIAL_ATTRIBUTE = "console/trials";
@@ -13,7 +16,7 @@ export const TRIAL_REGISTERED_ATTRIBUTE = "console/trials-registered";
 export const AUDITOR = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
 export const MANAGED_WALLET_ALLOWED_AUDITORS = [AUDITOR];
 
-export function getManifest(yamlJson: any, asString: boolean) {
+export function getManifest(yamlJson: any, asString: boolean): AkashManifest {
   return Manifest(yamlJson, "beta3", networkStore.selectedNetworkId, asString);
 }
 
@@ -23,27 +26,27 @@ export async function getManifestVersion(yamlJson: any) {
   return Buffer.from(version).toString("base64");
 }
 
-const getDenomFromSdl = (groups: any[]): string => {
-  const denoms = groups.flatMap(g => g.resources).map(resource => resource.price.denom);
+const getDenomFromSdl = (groups: GroupSpec[]): string => {
+  const denoms = groups.flatMap(g => g.resources).map(resource => resource.price?.denom);
 
   // TODO handle multiple denoms in an sdl? (different denom for each service?)
-  return denoms[0];
+  return denoms.find(d => !!d)!;
 };
 
 export function appendTrialAttribute(yamlStr: string, attributeKey: string) {
-  const sdl = getSdl(yamlStr, "beta3", networkStore.selectedNetworkId);
-  const placementData = sdl.data?.profiles?.placement || {};
+  const sdlData = yaml.load(yamlStr) as SDLInput;
+  const placementData = sdlData?.profiles?.placement || {};
 
   for (const [, value] of Object.entries(placementData)) {
     if (!value.attributes) {
-      value.attributes = [];
-    } else if (!Array.isArray(value.attributes)) {
-      value.attributes = Object.entries(value.attributes).map(([key, value]) => ({ key, value: value as string }));
+      value.attributes = {};
+    } else if (Array.isArray(value.attributes)) {
+      value.attributes = (value.attributes as unknown as Attribute[]).reduce<Record<string, unknown>>((acc, curr) => ((acc[curr.key] = curr.value), acc), {});
     }
 
-    const hasTrialAttribute = value.attributes.find(attr => attr.key === attributeKey);
-    if (!hasTrialAttribute) {
-      value.attributes.push({ key: attributeKey, value: "true" });
+    const attrs = value.attributes as Record<string, unknown>;
+    if (!(attributeKey in attrs)) {
+      attrs[attributeKey] = "true";
     }
 
     if (!value.signedBy?.anyOf || !value.signedBy?.allOf) {
@@ -53,23 +56,16 @@ export function appendTrialAttribute(yamlStr: string, attributeKey: string) {
       };
     }
 
-    if (!value.signedBy.allOf.includes(AUDITOR)) {
+    if (value?.signedBy?.allOf && !value.signedBy.allOf.includes(AUDITOR)) {
       value.signedBy.allOf.push(AUDITOR);
     }
   }
 
-  const result = yaml.dump(sdl.data, {
+  const result = yaml.dump(sdlData, {
     indent: 2,
     quotingType: '"',
     styles: {
       "!!null": "empty" // dump null as empty value
-    },
-    replacer: (key, value) => {
-      const isCurrentKeyProviderAttributes = key === "attributes" && Array.isArray(value) && value.some(attr => attr.key === attributeKey);
-      if (isCurrentKeyProviderAttributes) {
-        return mapProviderAttributes(value);
-      }
-      return value;
     }
   });
 
@@ -78,8 +74,8 @@ ${result}`;
 }
 
 export function appendAuditorRequirement(yamlStr: string) {
-  const sdl = getSdl(yamlStr, "beta3", networkStore.selectedNetworkId);
-  const placementData = sdl.data?.profiles?.placement || {};
+  const sdlData = yaml.load(yamlStr) as SDLInput;
+  const placementData = sdlData?.profiles?.placement || {};
 
   for (const [, value] of Object.entries(placementData)) {
     if (!value.signedBy?.anyOf || !value.signedBy?.allOf) {
@@ -90,13 +86,13 @@ export function appendAuditorRequirement(yamlStr: string) {
     }
 
     for (const auditor of MANAGED_WALLET_ALLOWED_AUDITORS) {
-      if (!value.signedBy.anyOf.includes(auditor)) {
+      if (value?.signedBy?.anyOf && !value.signedBy.anyOf.includes(auditor)) {
         value.signedBy.anyOf.push(auditor);
       }
     }
   }
 
-  const result = yaml.dump(sdl.data, {
+  const result = yaml.dump(sdlData, {
     indent: 2,
     quotingType: '"',
     styles: {
@@ -108,11 +104,6 @@ export function appendAuditorRequirement(yamlStr: string) {
 ${result}`;
 }
 
-// Attributes is a key value pair object, but we store it as an array of objects with key and value
-function mapProviderAttributes(attributes: Attribute[]) {
-  return attributes?.reduce<Record<string, string>>((acc, curr) => ((acc[curr.key] = curr.value), acc), {});
-}
-
 export async function NewDeploymentData(
   chainApiHttpClient: HttpClient,
   yamlStr: string,
@@ -122,11 +113,12 @@ export async function NewDeploymentData(
 ) {
   try {
     const networkId = networkStore.selectedNetworkId;
-    const sdl = getSdl(yamlStr, "beta3", networkId);
-    const groups = sdl.groups();
-    const mani = sdl.manifest();
+    const sdlInput = parseSdlInput(yamlStr);
+    const manifest = buildManifest(sdlInput, networkId);
+    const groups = manifest.groupSpecs;
+    const mani = manifest.groups;
     const denom = getDenomFromSdl(groups);
-    const version = await sdl.manifestVersion();
+    const version = await generateManifestVersion(manifest.groups);
     const _deposit = (Array.isArray(deposit) && deposit.find(d => d.denom === denom)) || { denom, amount: deposit.toString() };
 
     let finalDseq: string = dseq || "";
@@ -136,7 +128,7 @@ export async function NewDeploymentData(
     }
 
     return {
-      sdl: sdl.data,
+      sdl: sdlInput,
       manifest: mani,
       groups: groups,
       deploymentId: {


### PR DESCRIPTION
## Why

The currently used `SDL` class from `@akashnetwork/chain-sdk` is deprecated. This PR migrates `apps/deploy-web` to use the new standalone functions.

## What

Replace `SDL` class usage in `apps/deploy-web` with new functions from `@akashnetwork/chain-sdk/web`:
- `generateManifest` / `buildManifest` — replaces `SDL.fromString()` + `.groups()` / `.manifest()`
- `generateManifestVersion` — replaces `sdl.manifestVersion()`
- `manifestToSortedJSON` — replaces `sdl.manifestSortedJSON()`
- `yaml.template()` — replaces `SDL.fromString()` for YAML parsing
- `js-yaml` used directly for SDL data manipulation in `appendTrialAttribute` / `appendAuditorRequirement` (replacing `sdl.data` access)

Files changed:
- `apps/deploy-web/src/utils/deploymentData/helpers.ts` — core helper functions
- `apps/deploy-web/src/utils/deploymentData/v1beta3.ts` — deployment data utilities

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accept manifest input as YAML string or structured configuration; components now support injected dependencies for easier customization.

* **Bug Fixes**
  * Improved manifest generation, validation and serialization for provider submissions; better handling of attributes and auditor/trial requirements; clearer error messages during updates.

* **Tests**
  * Extensive unit tests covering manifest update flows, error cases, UI state, and edge scenarios.

* **Refactor**
  * Unified parsing/building pathway for consistent deployment data handling and manifest versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->