### PR TITLE
refactor(sdl): migrate API from deprecated SDL class to generateManifest

### DIFF
--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -1,0 +1,236 @@
+import type { BlockHttpService } from "@akashnetwork/http-sdk";
+import { mock, type MockProxy } from "vitest-mock-extended";
+
+import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import type { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc-message.service";
+import type { WalletInitialized, WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
+import type { GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
+import type { SdlService } from "@src/deployment/services/sdl/sdl.service";
+import type { ProviderService } from "@src/provider/services/provider/provider.service";
+import type { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
+import { DeploymentWriterService } from "./deployment-writer.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+
+describe(DeploymentWriterService.name, () => {
+  const wallet: WalletInitialized = {
+    id: 1,
+    userId: "user-1",
+    address: "akash1testaddr",
+    creditAmount: 100,
+    deploymentAllowance: 50,
+    feeAllowance: 10
+  } as WalletInitialized;
+
+  const manifestValue = {
+    groups: [{ name: "test-group" }],
+    groupSpecs: [{ name: "test-group", resources: [] }]
+  };
+
+  const deploymentData: GetDeploymentResponse["data"] = {
+    deployment: {
+      id: { owner: wallet.address, dseq: "100" },
+      state: "active",
+      hash: Buffer.from(new Uint8Array([1, 2, 3])).toString("base64"),
+      created_at: "2026-01-01"
+    },
+    leases: [
+      {
+        id: { owner: wallet.address, dseq: "100", gseq: 1, oseq: 1, provider: "provider-1", bseq: 1 },
+        state: "active",
+        price: { denom: "uakt", amount: "1000" },
+        created_at: "2026-01-01",
+        closed_on: "",
+        status: null
+      }
+    ],
+    escrow_account: {
+      id: { scope: "deployment", xid: "100" },
+      state: {
+        owner: wallet.address,
+        state: "open",
+        transferred: [],
+        settled_at: "0",
+        funds: [],
+        deposits: []
+      }
+    }
+  };
+
+  describe("create", () => {
+    it("creates a deployment and returns dseq, manifest, and signTx", async () => {
+      const { service, blockHttpService, signerService, rpcMessageService } = setup();
+      const dseq = 200;
+      blockHttpService.getCurrentHeight.mockResolvedValue(dseq);
+      const txResult = { code: 0, transactionHash: "tx-hash" };
+      signerService.executeDerivedDecodedTxByUserId.mockResolvedValue(txResult);
+      const createMsg = { typeUrl: "/create", value: {} };
+      rpcMessageService.getCreateDeploymentMsg.mockReturnValue(createMsg);
+
+      const result = await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 });
+
+      expect(result.dseq).toBe("200");
+      expect(result.signTx).toBe(txResult);
+      expect(rpcMessageService.getCreateDeploymentMsg).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: wallet.address,
+          dseq,
+          groups: manifestValue.groupSpecs,
+          denom: "uakt",
+          amount: 5000000
+        })
+      );
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledWith("user-1", [createMsg]);
+    });
+
+    it("throws 400 when SDL is invalid", async () => {
+      const { service, sdlService } = setup();
+      sdlService.generateManifest.mockReturnValue({
+        ok: false,
+        value: [{ message: "invalid version" }]
+      } as any);
+
+      await expect(service.create({ userId: "user-1", sdl: "bad-sdl", deposit: 5 })).rejects.toThrow();
+    });
+  });
+
+  describe("closeByUserIdAndDseq", () => {
+    it("fetches wallet and closes deployment", async () => {
+      const { service, signerService, rpcMessageService } = setup();
+      const closeMsg = { typeUrl: "/close", value: {} };
+      rpcMessageService.getCloseDeploymentMsg.mockReturnValue(closeMsg);
+
+      await service.closeByUserIdAndDseq("user-1", "100");
+
+      expect(rpcMessageService.getCloseDeploymentMsg).toHaveBeenCalledWith(wallet.address, "100");
+      expect(signerService.executeDecodedTxByUserWallet).toHaveBeenCalledWith(wallet, [closeMsg]);
+    });
+  });
+
+  describe("close", () => {
+    it("closes deployment by wallet and dseq", async () => {
+      const { service, signerService, rpcMessageService } = setup();
+      const closeMsg = { typeUrl: "/close", value: {} };
+      rpcMessageService.getCloseDeploymentMsg.mockReturnValue(closeMsg);
+
+      await service.close(wallet, "100");
+
+      expect(rpcMessageService.getCloseDeploymentMsg).toHaveBeenCalledWith(wallet.address, "100");
+      expect(signerService.executeDecodedTxByUserWallet).toHaveBeenCalledWith(wallet, [closeMsg]);
+    });
+  });
+
+  describe("deposit", () => {
+    it("deposits funds and returns updated deployment", async () => {
+      const { service, rpcMessageService, signerService, deploymentReaderService } = setup();
+      const updatedDeployment = { ...deploymentData };
+      deploymentReaderService.findByWalletAndDseq.mockResolvedValue(updatedDeployment);
+      const depositMsg = { typeUrl: "/deposit", value: {} };
+      rpcMessageService.getDepositDeploymentMsg.mockReturnValue(depositMsg);
+
+      const result = await service.deposit({ userId: "user-1", dseq: "100", amount: 3 });
+
+      expect(rpcMessageService.getDepositDeploymentMsg).toHaveBeenCalledWith({
+        owner: wallet.address,
+        dseq: "100",
+        amount: 3000000,
+        denom: "uakt",
+        signer: wallet.address
+      });
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledWith("user-1", [depositMsg]);
+      expect(result).toBe(updatedDeployment);
+    });
+  });
+
+  describe("updateByUserIdAndDseq", () => {
+    it("sends update tx when manifest hash differs", async () => {
+      const { service, signerService, rpcMessageService, deploymentReaderService } = setup();
+      const staleDeployment = {
+        ...deploymentData,
+        deployment: { ...deploymentData.deployment, hash: "stale-hash" }
+      };
+      deploymentReaderService.findByWalletAndDseq.mockResolvedValueOnce(staleDeployment).mockResolvedValueOnce(deploymentData);
+      const updateMsg = { typeUrl: "/update", value: {} };
+      rpcMessageService.getUpdateDeploymentMsg.mockReturnValue(updateMsg);
+
+      const result = await service.updateByUserIdAndDseq("user-1", "100", { sdl: "valid-sdl" });
+
+      expect(rpcMessageService.getUpdateDeploymentMsg).toHaveBeenCalledWith(expect.objectContaining({ owner: wallet.address, dseq: "100" }));
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledWith("user-1", [updateMsg]);
+      expect(result).toBe(deploymentData);
+    });
+
+    it("skips update tx when manifest hash matches", async () => {
+      const { service, signerService, rpcMessageService, sdlService } = setup();
+      const manifestVersion = new Uint8Array([1, 2, 3]);
+      sdlService.generateManifestVersion.mockResolvedValue(manifestVersion);
+
+      await service.updateByUserIdAndDseq("user-1", "100", { sdl: "valid-sdl" });
+
+      expect(rpcMessageService.getUpdateDeploymentMsg).not.toHaveBeenCalled();
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+    });
+
+    it("sends manifest to all unique lease providers", async () => {
+      const { service, providerService, deploymentReaderService } = setup();
+      const deploymentWithMultipleLeases = {
+        ...deploymentData,
+        leases: [
+          { ...deploymentData.leases[0], id: { ...deploymentData.leases[0].id, provider: "provider-1" } },
+          { ...deploymentData.leases[0], id: { ...deploymentData.leases[0].id, provider: "provider-2" } },
+          { ...deploymentData.leases[0], id: { ...deploymentData.leases[0].id, provider: "provider-1" } }
+        ]
+      };
+      deploymentReaderService.findByWalletAndDseq.mockResolvedValueOnce(deploymentWithMultipleLeases).mockResolvedValueOnce(deploymentData);
+      providerService.toProviderAuth.mockResolvedValue({ certPem: "cert", keyPem: "key" });
+
+      await service.updateByUserIdAndDseq("user-1", "100", { sdl: "valid-sdl" });
+
+      expect(providerService.sendManifest).toHaveBeenCalledTimes(2);
+      expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ provider: "provider-1" }));
+      expect(providerService.sendManifest).toHaveBeenCalledWith(expect.objectContaining({ provider: "provider-2" }));
+    });
+  });
+
+  function setup() {
+    const blockHttpService = mock<BlockHttpService>();
+    const signerService = mock<ManagedSignerService>();
+    const rpcMessageService = mock<RpcMessageService>();
+    const sdlService = mock<SdlService>();
+    const billingConfig: MockProxy<BillingConfigService> = mockConfigService<BillingConfigService>({
+      DEPLOYMENT_GRANT_DENOM: "uakt"
+    });
+    const providerService = mock<ProviderService>();
+    const deploymentReaderService = mock<DeploymentReaderService>();
+    const walletReaderService = mock<WalletReaderService>();
+
+    walletReaderService.getWalletByUserId.mockResolvedValue(wallet);
+    sdlService.generateManifest.mockReturnValue({ ok: true, value: manifestValue } as any);
+    sdlService.generateManifestVersion.mockResolvedValue(new Uint8Array([4, 5, 6]));
+    deploymentReaderService.findByWalletAndDseq.mockResolvedValue(deploymentData);
+
+    const service = new DeploymentWriterService(
+      blockHttpService,
+      signerService,
+      rpcMessageService,
+      sdlService,
+      billingConfig,
+      providerService,
+      deploymentReaderService,
+      walletReaderService
+    );
+
+    return {
+      service,
+      blockHttpService,
+      signerService,
+      rpcMessageService,
+      sdlService,
+      billingConfig,
+      providerService,
+      deploymentReaderService,
+      walletReaderService
+    };
+  }
+});

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -1,3 +1,4 @@
+import { manifestToSortedJSON } from "@akashnetwork/chain-sdk";
 import { BlockHttpService } from "@akashnetwork/http-sdk";
 import assert from "http-assert";
 import { singleton } from "tsyringe";
@@ -33,30 +34,15 @@ export class DeploymentWriterService {
 
   public async create(input: CreateDeploymentRequest["data"] & { userId: string }): Promise<CreateDeploymentResponse["data"]> {
     const wallet = await this.walletReaderService.getWalletByUserId(input.userId);
-    let sdl: string = input.sdl;
-    const deploymentGrantDenom = this.billingConfig.get("DEPLOYMENT_GRANT_DENOM");
+    const manifest = this.#parseManifest(input.sdl);
 
-    assert(this.sdlService.validateSdl(sdl), 400, "Invalid SDL");
-
-    if (deploymentGrantDenom !== "uakt") {
-      sdl = sdl.replace(/uakt/g, deploymentGrantDenom);
-    }
-
-    const allowedAuditors = this.billingConfig.get("MANAGED_WALLET_LEASE_ALLOWED_AUDITORS");
-    if (allowedAuditors && allowedAuditors.length > 0) {
-      sdl = this.sdlService.appendAuditorRequirement(sdl, allowedAuditors);
-    }
-
-    const dseq = await this.blockHttpService.getCurrentHeight();
-    const groups = this.sdlService.getDeploymentGroups(sdl, "beta3");
-    const manifestVersion = await this.sdlService.getManifestVersion(sdl, "beta3");
-    const manifest = this.sdlService.getManifest(sdl, "beta3", true) as string;
+    const [dseq, manifestVersion] = await Promise.all([this.blockHttpService.getCurrentHeight(), this.sdlService.generateManifestVersion(manifest.groups)]);
 
     const message = this.rpcMessageService.getCreateDeploymentMsg({
       owner: wallet.address,
       dseq,
-      groups,
-      denom: deploymentGrantDenom,
+      groups: manifest.groupSpecs,
+      denom: this.billingConfig.get("DEPLOYMENT_GRANT_DENOM"),
       amount: denomToUdenom(input.deposit),
       hash: manifestVersion
     });
@@ -64,7 +50,7 @@ export class DeploymentWriterService {
     const result = await this.signerService.executeDerivedDecodedTxByUserId(wallet.userId, [message]);
     return {
       dseq: dseq.toString(),
-      manifest,
+      manifest: manifestToSortedJSON(manifest.groups),
       signTx: result
     };
   }
@@ -100,24 +86,24 @@ export class DeploymentWriterService {
 
   public async updateByUserIdAndDseq(userId: string, dseq: string, input: UpdateDeploymentRequest["data"]): Promise<GetDeploymentResponse["data"]> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
-    let sdl = input.sdl;
+    const manifest = this.#parseManifest(input.sdl);
 
-    assert(this.sdlService.validateSdl(sdl), 400, "Invalid SDL");
-
-    const allowedAuditors = this.billingConfig.get("MANAGED_WALLET_LEASE_ALLOWED_AUDITORS");
-    if (allowedAuditors && allowedAuditors.length > 0) {
-      sdl = this.sdlService.appendAuditorRequirement(sdl, allowedAuditors);
-    }
-
-    const deployment = await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
-    const manifestVersion = await this.sdlService.getManifestVersion(sdl, "beta3");
-    const manifest = this.sdlService.getManifest(sdl, "beta3", true) as string;
+    const [deployment, manifestVersion] = await Promise.all([
+      this.deploymentReaderService.findByWalletAndDseq(wallet, dseq),
+      this.sdlService.generateManifestVersion(manifest.groups)
+    ]);
 
     await this.ensureDeploymentIsUpToDate(wallet, dseq, manifestVersion, deployment);
     const auth = { walletId: wallet.id };
-    await this.sendManifestToProviders({ auth, dseq, manifest, leases: deployment.leases });
+    await this.sendManifestToProviders({ auth, dseq, manifest: manifestToSortedJSON(manifest.groups), leases: deployment.leases });
 
     return await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
+  }
+
+  #parseManifest(sdl: string) {
+    const manifestResult = this.sdlService.generateManifest(sdl);
+    assert(manifestResult.ok, 400, `Invalid SDL: ${manifestResult.ok === false ? manifestResult.value.map(e => e.message).join(", ") : ""}`);
+    return manifestResult.value;
   }
 
   private async ensureDeploymentIsUpToDate(
@@ -147,7 +133,7 @@ export class DeploymentWriterService {
     leases: GetDeploymentResponse["data"]["leases"];
     auth: { walletId: number };
   }): Promise<void> {
-    const leaseProviders = leases.map(lease => lease.id.provider).filter((v, i, s) => s.indexOf(v) === i);
+    const leaseProviders = new Set(leases.map(lease => lease.id.provider));
     for (const provider of leaseProviders) {
       await this.providerService.sendManifest({
         provider,

--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.spec.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.spec.ts
@@ -1,0 +1,344 @@
+import "@test/mocks/logger-service.mock";
+
+import type { NetworkId, SDLInput } from "@akashnetwork/chain-sdk";
+import { generateManifest, yaml as sdlYaml } from "@akashnetwork/chain-sdk";
+import type { BidHttpService, BlockHttpService } from "@akashnetwork/http-sdk";
+import type { DirectSecp256k1HdWallet, Registry } from "@cosmjs/proto-signing";
+import type { SigningStargateClient } from "@cosmjs/stargate";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentConfig } from "@src/deployment/config/config.provider";
+import type { GpuService } from "@src/gpu/services/gpu.service";
+
+import { mockConfigService } from "@test/mocks/config-service.mock";
+
+import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { GpuBidsCreatorService } from "./gpu-bids-creator.service";
+import { sdlTemplateWithRam, sdlTemplateWithRamAndInterface } from "./sdl-templates";
+
+vi.mock("@akashnetwork/chain-sdk", async importOriginal => {
+  const actual = await importOriginal<typeof import("@akashnetwork/chain-sdk")>();
+  return {
+    ...actual,
+    generateManifest: vi.fn(),
+    generateManifestVersion: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]))
+  };
+});
+
+vi.mock("@cosmjs/proto-signing", async importOriginal => {
+  const actual = await importOriginal<typeof import("@cosmjs/proto-signing")>();
+  return {
+    ...actual,
+    DirectSecp256k1HdWallet: {
+      fromMnemonic: vi.fn()
+    }
+  };
+});
+
+vi.mock("@cosmjs/stargate", async importOriginal => {
+  const actual = await importOriginal<typeof import("@cosmjs/stargate")>();
+  return {
+    ...actual,
+    calculateFee: vi.fn().mockReturnValue({ amount: [{ denom: "uakt", amount: "5000" }], gas: "200000" }),
+    SigningStargateClient: {
+      connectWithSigner: vi.fn()
+    }
+  };
+});
+
+vi.mock("timers/promises", () => ({
+  setTimeout: vi.fn().mockResolvedValue(undefined)
+}));
+
+describe(GpuBidsCreatorService.name, () => {
+  describe("getModelSdl", () => {
+    it("generates SDL with ram only when no interface provided", () => {
+      const { service } = setup();
+
+      const result = service["getModelSdl"]("nvidia", "a100", "80Gi");
+
+      const expected = sdlTemplateWithRam.replace("<VENDOR>", "nvidia").replace("<MODEL>", "a100").replace("<RAM>", "80Gi");
+      expect(result).toBe(expected);
+    });
+
+    it("generates SDL with ram and interface when interface provided", () => {
+      const { service } = setup();
+
+      const result = service["getModelSdl"]("nvidia", "a100", "80Gi", "pcie");
+
+      const expected = sdlTemplateWithRamAndInterface
+        .replace("<VENDOR>", "nvidia")
+        .replace("<MODEL>", "a100")
+        .replace("<RAM>", "80Gi")
+        .replace("<INTERFACE>", "pcie");
+      expect(result).toBe(expected);
+    });
+
+    it("lowercases interface", () => {
+      const { service } = setup();
+
+      const result = service["getModelSdl"]("nvidia", "a100", "80Gi", "PCIe");
+
+      expect(result).toContain("interface: pcie");
+    });
+
+    it("normalizes SXM interface variants to sxm", () => {
+      const { service } = setup();
+
+      const result = service["getModelSdl"]("nvidia", "a100", "80Gi", "SXM4");
+
+      expect(result).toContain("interface: sxm");
+    });
+  });
+
+  describe("createDeployment", () => {
+    it("creates deployment with valid SDL", async () => {
+      const { service, signingClient } = setup();
+      const sdlStr = sdlTemplateWithRam.replace("<VENDOR>", "nvidia").replace("<MODEL>", "a100").replace("<RAM>", "80Gi");
+
+      const mockGroups = [{ name: "akash" }];
+      const mockGroupSpecs = [{ name: "akash", requirements: {} }];
+      vi.mocked(generateManifest).mockReturnValue({
+        ok: true,
+        value: { groups: mockGroups, groupSpecs: mockGroupSpecs, meta: undefined }
+      } as any);
+
+      await service["createDeployment"](signingClient, sdlStr, "akash1owner", "12345");
+
+      expect(generateManifest).toHaveBeenCalledWith(expect.anything(), "mainnet");
+      expect(signingClient.simulate).toHaveBeenCalled();
+      expect(signingClient.sign).toHaveBeenCalled();
+      expect(signingClient.broadcastTx).toHaveBeenCalled();
+    });
+
+    it("throws when SDL is invalid", async () => {
+      const { service, signingClient } = setup();
+      const sdlStr = "invalid sdl";
+
+      vi.mocked(generateManifest).mockReturnValue({
+        ok: false,
+        value: [{ message: "Invalid manifest" }]
+      } as any);
+
+      await expect(service["createDeployment"](signingClient, sdlStr, "akash1owner", "12345")).rejects.toThrow();
+    });
+  });
+
+  describe("createGpuBids", () => {
+    it("throws when GPU_BOT_WALLET_MNEMONIC is not set", async () => {
+      const { service } = setup({ gpuBotWalletMnemonic: undefined });
+
+      await expect(service.createGpuBids()).rejects.toThrow("GPU_BOT_WALLET_MNEMONIC");
+    });
+
+    it("throws when RPC_NODE_ENDPOINT is not set", async () => {
+      const { service } = setup({ rpcNodeEndpoint: undefined });
+
+      await expect(service.createGpuBids()).rejects.toThrow("RPC_NODE_ENDPOINT");
+    });
+  });
+
+  describe("createBidsForAllModels", () => {
+    it("creates deployments for each GPU model, waits for bids, and closes", async () => {
+      const { service, signingClient, bidHttpService, blockHttpService } = setup();
+      const gpuModels = {
+        gpus: {
+          total: { allocatable: 10, allocated: 5 },
+          details: {
+            nvidia: [{ model: "a100", ram: "80Gi", interface: "pcie", allocatable: 5, allocated: 2 }]
+          }
+        }
+      };
+
+      vi.mocked(generateManifest).mockReturnValue({
+        ok: true,
+        value: { groups: [], groupSpecs: [], meta: undefined }
+      } as any);
+
+      bidHttpService.list.mockResolvedValue([]);
+
+      await service["createBidsForAllModels"](gpuModels as any, signingClient, "akash1owner", false);
+
+      expect(blockHttpService.getCurrentHeight).toHaveBeenCalled();
+      expect(signingClient.simulate).toHaveBeenCalledTimes(2);
+      expect(bidHttpService.list).toHaveBeenCalledWith("akash1owner", "100000");
+    });
+
+    it("skips duplicate model+ram combos when includeInterface is false", async () => {
+      const { service, signingClient, bidHttpService, blockHttpService } = setup();
+      const gpuModels = {
+        gpus: {
+          total: { allocatable: 10, allocated: 5 },
+          details: {
+            nvidia: [
+              { model: "a100", ram: "80Gi", interface: "pcie", allocatable: 3, allocated: 1 },
+              { model: "a100", ram: "80Gi", interface: "sxm", allocatable: 2, allocated: 1 }
+            ]
+          }
+        }
+      };
+
+      vi.mocked(generateManifest).mockReturnValue({
+        ok: true,
+        value: { groups: [], groupSpecs: [], meta: undefined }
+      } as any);
+
+      bidHttpService.list.mockResolvedValue([]);
+
+      await service["createBidsForAllModels"](gpuModels as any, signingClient, "akash1owner", false);
+
+      expect(signingClient.simulate).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not skip duplicate model+ram combos when includeInterface is true", async () => {
+      const { service, signingClient, bidHttpService } = setup();
+      const gpuModels = {
+        gpus: {
+          total: { allocatable: 10, allocated: 5 },
+          details: {
+            nvidia: [
+              { model: "a100", ram: "80Gi", interface: "pcie", allocatable: 3, allocated: 1 },
+              { model: "a100", ram: "80Gi", interface: "sxm", allocatable: 2, allocated: 1 }
+            ]
+          }
+        }
+      };
+
+      vi.mocked(generateManifest).mockReturnValue({
+        ok: true,
+        value: { groups: [], groupSpecs: [], meta: undefined }
+      } as any);
+
+      bidHttpService.list.mockResolvedValue([]);
+
+      await service["createBidsForAllModels"](gpuModels as any, signingClient, "akash1owner", true);
+
+      expect(signingClient.simulate).toHaveBeenCalledTimes(4);
+    });
+
+    it("filters out UNKNOWN vendor", async () => {
+      const { service, signingClient, bidHttpService } = setup();
+      const gpuModels = {
+        gpus: {
+          total: { allocatable: 10, allocated: 5 },
+          details: {
+            "<UNKNOWN>": [{ model: "unknown", ram: "8Gi", interface: "pcie", allocatable: 1, allocated: 0 }],
+            nvidia: [{ model: "a100", ram: "80Gi", interface: "pcie", allocatable: 5, allocated: 2 }]
+          }
+        }
+      };
+
+      vi.mocked(generateManifest).mockReturnValue({
+        ok: true,
+        value: { groups: [], groupSpecs: [], meta: undefined }
+      } as any);
+
+      bidHttpService.list.mockResolvedValue([]);
+
+      await service["createBidsForAllModels"](gpuModels as any, signingClient, "akash1owner", false);
+
+      expect(signingClient.simulate).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("signAndBroadcast", () => {
+    it("throws when broadcast returns non-zero code", async () => {
+      const { service, signingClient } = setup();
+      signingClient.broadcastTx.mockResolvedValue({ code: 1, rawLog: "some error" } as any);
+
+      await expect(service["signAndBroadcast"]("akash1owner", signingClient, [])).rejects.toThrow("Error broadcasting transaction");
+    });
+
+    it("broadcasts successfully when code is 0", async () => {
+      const { service, signingClient } = setup();
+
+      const result = await service["signAndBroadcast"]("akash1owner", signingClient, []);
+
+      expect(result).toEqual(expect.objectContaining({ code: 0 }));
+    });
+  });
+
+  describe("getCurrentHeight", () => {
+    it("returns current height from block service", async () => {
+      const { service } = setup();
+
+      const height = await service["getCurrentHeight"]();
+
+      expect(height).toBe(100000);
+    });
+
+    it("throws when height is NaN", async () => {
+      const { service, blockHttpService } = setup();
+      blockHttpService.getCurrentHeight.mockResolvedValue(NaN);
+
+      await expect(service["getCurrentHeight"]()).rejects.toThrow("Failed to get current height");
+    });
+  });
+
+  function setup(input: { gpuBotWalletMnemonic?: string; rpcNodeEndpoint?: string } = {}) {
+    const config = mockConfigService<BillingConfigService>({
+      NETWORK: "mainnet",
+      AVERAGE_GAS_PRICE: 0.025,
+      ...(input.rpcNodeEndpoint !== undefined ? {} : { RPC_NODE_ENDPOINT: "https://rpc.example.com" })
+    });
+
+    if (input.rpcNodeEndpoint === undefined && !("rpcNodeEndpoint" in input)) {
+      config.get.mockImplementation((key: string) => {
+        const values: Record<string, any> = {
+          NETWORK: "mainnet",
+          AVERAGE_GAS_PRICE: 0.025,
+          RPC_NODE_ENDPOINT: "https://rpc.example.com"
+        };
+        if (key in values) return values[key];
+        throw new Error(`Missing mock for config key "${key}"`);
+      });
+    } else if (input.rpcNodeEndpoint === undefined) {
+      config.get.mockImplementation((key: string) => {
+        if (key === "RPC_NODE_ENDPOINT") return "";
+        const values: Record<string, any> = {
+          NETWORK: "mainnet",
+          AVERAGE_GAS_PRICE: 0.025
+        };
+        if (key in values) return values[key];
+        throw new Error(`Missing mock for config key "${key}"`);
+      });
+    }
+
+    const bidHttpService = mock<BidHttpService>();
+    bidHttpService.list.mockResolvedValue([]);
+
+    const gpuService = mock<GpuService>();
+    gpuService.getGpuList.mockResolvedValue({
+      gpus: { total: { allocatable: 0, allocated: 0 }, details: {} }
+    } as any);
+
+    const blockHttpService = mock<BlockHttpService>();
+    blockHttpService.getCurrentHeight.mockResolvedValue(100000);
+
+    const typeRegistry = mock<Registry>();
+
+    const deploymentConfig: DeploymentConfig = {
+      GPU_BOT_WALLET_MNEMONIC: "gpuBotWalletMnemonic" in input ? input.gpuBotWalletMnemonic : "test mnemonic words here",
+      PROVIDER_PROXY_URL: "https://proxy.example.com"
+    };
+
+    const signingClient = mock<SigningStargateClient>();
+    signingClient.simulate.mockResolvedValue(100000);
+    signingClient.sign.mockResolvedValue({ authInfoBytes: new Uint8Array(), bodyBytes: new Uint8Array(), signatures: [] } as any);
+    signingClient.broadcastTx.mockResolvedValue({ code: 0, rawLog: "" } as any);
+    signingClient.getBalance.mockResolvedValue({ amount: "1000000", denom: "uakt" });
+
+    const service = new GpuBidsCreatorService(config, bidHttpService, gpuService, blockHttpService, typeRegistry, deploymentConfig);
+
+    return {
+      service,
+      config,
+      bidHttpService,
+      gpuService,
+      blockHttpService,
+      typeRegistry,
+      deploymentConfig,
+      signingClient
+    };
+  }
+});

--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.spec.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.spec.ts
@@ -1,50 +1,19 @@
 import "@test/mocks/logger-service.mock";
 
-import type { NetworkId, SDLInput } from "@akashnetwork/chain-sdk";
-import { generateManifest, yaml as sdlYaml } from "@akashnetwork/chain-sdk";
 import type { BidHttpService, BlockHttpService } from "@akashnetwork/http-sdk";
-import type { DirectSecp256k1HdWallet, Registry } from "@cosmjs/proto-signing";
+import type { Registry } from "@cosmjs/proto-signing";
 import type { SigningStargateClient } from "@cosmjs/stargate";
+import { vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import type { LoggerService } from "@src/core";
 import type { DeploymentConfig } from "@src/deployment/config/config.provider";
 import type { GpuService } from "@src/gpu/services/gpu.service";
-
-import { mockConfigService } from "@test/mocks/config-service.mock";
-
-import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { GpuBidsCreatorService } from "./gpu-bids-creator.service";
 import { sdlTemplateWithRam, sdlTemplateWithRamAndInterface } from "./sdl-templates";
 
-vi.mock("@akashnetwork/chain-sdk", async importOriginal => {
-  const actual = await importOriginal<typeof import("@akashnetwork/chain-sdk")>();
-  return {
-    ...actual,
-    generateManifest: vi.fn(),
-    generateManifestVersion: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]))
-  };
-});
-
-vi.mock("@cosmjs/proto-signing", async importOriginal => {
-  const actual = await importOriginal<typeof import("@cosmjs/proto-signing")>();
-  return {
-    ...actual,
-    DirectSecp256k1HdWallet: {
-      fromMnemonic: vi.fn()
-    }
-  };
-});
-
-vi.mock("@cosmjs/stargate", async importOriginal => {
-  const actual = await importOriginal<typeof import("@cosmjs/stargate")>();
-  return {
-    ...actual,
-    calculateFee: vi.fn().mockReturnValue({ amount: [{ denom: "uakt", amount: "5000" }], gas: "200000" }),
-    SigningStargateClient: {
-      connectWithSigner: vi.fn()
-    }
-  };
-});
+import { mockConfigService } from "@test/mocks/config-service.mock";
 
 vi.mock("timers/promises", () => ({
   setTimeout: vi.fn().mockResolvedValue(undefined)
@@ -96,16 +65,7 @@ describe(GpuBidsCreatorService.name, () => {
       const { service, signingClient } = setup();
       const sdlStr = sdlTemplateWithRam.replace("<VENDOR>", "nvidia").replace("<MODEL>", "a100").replace("<RAM>", "80Gi");
 
-      const mockGroups = [{ name: "akash" }];
-      const mockGroupSpecs = [{ name: "akash", requirements: {} }];
-      vi.mocked(generateManifest).mockReturnValue({
-        ok: true,
-        value: { groups: mockGroups, groupSpecs: mockGroupSpecs, meta: undefined }
-      } as any);
-
       await service["createDeployment"](signingClient, sdlStr, "akash1owner", "12345");
-
-      expect(generateManifest).toHaveBeenCalledWith(expect.anything(), "mainnet");
       expect(signingClient.simulate).toHaveBeenCalled();
       expect(signingClient.sign).toHaveBeenCalled();
       expect(signingClient.broadcastTx).toHaveBeenCalled();
@@ -114,11 +74,6 @@ describe(GpuBidsCreatorService.name, () => {
     it("throws when SDL is invalid", async () => {
       const { service, signingClient } = setup();
       const sdlStr = "invalid sdl";
-
-      vi.mocked(generateManifest).mockReturnValue({
-        ok: false,
-        value: [{ message: "Invalid manifest" }]
-      } as any);
 
       await expect(service["createDeployment"](signingClient, sdlStr, "akash1owner", "12345")).rejects.toThrow();
     });
@@ -150,11 +105,6 @@ describe(GpuBidsCreatorService.name, () => {
         }
       };
 
-      vi.mocked(generateManifest).mockReturnValue({
-        ok: true,
-        value: { groups: [], groupSpecs: [], meta: undefined }
-      } as any);
-
       bidHttpService.list.mockResolvedValue([]);
 
       await service["createBidsForAllModels"](gpuModels as any, signingClient, "akash1owner", false);
@@ -165,7 +115,7 @@ describe(GpuBidsCreatorService.name, () => {
     });
 
     it("skips duplicate model+ram combos when includeInterface is false", async () => {
-      const { service, signingClient, bidHttpService, blockHttpService } = setup();
+      const { service, signingClient, bidHttpService } = setup();
       const gpuModels = {
         gpus: {
           total: { allocatable: 10, allocated: 5 },
@@ -177,11 +127,6 @@ describe(GpuBidsCreatorService.name, () => {
           }
         }
       };
-
-      vi.mocked(generateManifest).mockReturnValue({
-        ok: true,
-        value: { groups: [], groupSpecs: [], meta: undefined }
-      } as any);
 
       bidHttpService.list.mockResolvedValue([]);
 
@@ -204,11 +149,6 @@ describe(GpuBidsCreatorService.name, () => {
         }
       };
 
-      vi.mocked(generateManifest).mockReturnValue({
-        ok: true,
-        value: { groups: [], groupSpecs: [], meta: undefined }
-      } as any);
-
       bidHttpService.list.mockResolvedValue([]);
 
       await service["createBidsForAllModels"](gpuModels as any, signingClient, "akash1owner", true);
@@ -227,11 +167,6 @@ describe(GpuBidsCreatorService.name, () => {
           }
         }
       };
-
-      vi.mocked(generateManifest).mockReturnValue({
-        ok: true,
-        value: { groups: [], groupSpecs: [], meta: undefined }
-      } as any);
 
       bidHttpService.list.mockResolvedValue([]);
 
@@ -317,10 +252,10 @@ describe(GpuBidsCreatorService.name, () => {
 
     const typeRegistry = mock<Registry>();
 
-    const deploymentConfig: DeploymentConfig = {
+    const deploymentConfig = {
       GPU_BOT_WALLET_MNEMONIC: "gpuBotWalletMnemonic" in input ? input.gpuBotWalletMnemonic : "test mnemonic words here",
       PROVIDER_PROXY_URL: "https://proxy.example.com"
-    };
+    } as DeploymentConfig;
 
     const signingClient = mock<SigningStargateClient>();
     signingClient.simulate.mockResolvedValue(100000);
@@ -328,7 +263,7 @@ describe(GpuBidsCreatorService.name, () => {
     signingClient.broadcastTx.mockResolvedValue({ code: 0, rawLog: "" } as any);
     signingClient.getBalance.mockResolvedValue({ amount: "1000000", denom: "uakt" });
 
-    const service = new GpuBidsCreatorService(config, bidHttpService, gpuService, blockHttpService, typeRegistry, deploymentConfig);
+    const service = new GpuBidsCreatorService(config, bidHttpService, gpuService, blockHttpService, typeRegistry, deploymentConfig, mock<LoggerService>());
 
     return {
       service,

--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
@@ -4,7 +4,6 @@ import { Source } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { MsgCloseDeployment, MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { TxRaw } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import { BidHttpService, BlockHttpService } from "@akashnetwork/http-sdk";
-import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { DirectSecp256k1HdWallet, EncodeObject, Registry } from "@cosmjs/proto-signing";
 import { calculateFee, SigningStargateClient } from "@cosmjs/stargate";
 import assert from "http-assert";
@@ -14,13 +13,13 @@ import { inject, singleton } from "tsyringe";
 
 import { InjectTypeRegistry } from "@src/billing/providers/type-registry.provider";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import { LoggerService } from "@src/core";
 import { DEPLOYMENT_CONFIG, type DeploymentConfig } from "@src/deployment/config/config.provider";
 import { GpuService } from "@src/gpu/services/gpu.service";
 import { sdlTemplateWithRam, sdlTemplateWithRamAndInterface } from "./sdl-templates";
 
 @singleton()
 export class GpuBidsCreatorService {
-  private readonly logger = createOtelLogger({ context: GpuBidsCreatorService.name });
   readonly #deploymentConfig: DeploymentConfig;
 
   constructor(
@@ -29,9 +28,11 @@ export class GpuBidsCreatorService {
     private readonly gpuService: GpuService,
     private readonly blockHttpService: BlockHttpService,
     @InjectTypeRegistry() private readonly typeRegistry: Registry,
-    @inject(DEPLOYMENT_CONFIG) deploymentConfig: DeploymentConfig
+    @inject(DEPLOYMENT_CONFIG) deploymentConfig: DeploymentConfig,
+    private readonly logger: LoggerService
   ) {
     this.#deploymentConfig = deploymentConfig;
+    this.logger.setContext(GpuBidsCreatorService.name);
   }
 
   async createGpuBids() {

--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
@@ -1,4 +1,4 @@
-import type { SDLInput } from "@akashnetwork/chain-sdk";
+import type { NetworkId, SDLInput } from "@akashnetwork/chain-sdk";
 import { generateManifest, generateManifestVersion, yaml as sdlYaml } from "@akashnetwork/chain-sdk";
 import { Source } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { MsgCloseDeployment, MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
@@ -133,7 +133,8 @@ export class GpuBidsCreatorService {
 
   private async createDeployment(client: SigningStargateClient, sdlStr: string, owner: string, dseq: string) {
     const sdlInput = sdlYaml.template<SDLInput>(sdlStr);
-    const manifest = generateManifest(sdlInput);
+    const networkId = this.config.get("NETWORK") as NetworkId;
+    const manifest = generateManifest(sdlInput, networkId);
     assert(manifest.ok, 400, `Invalid SDL: ${manifest.ok === false ? manifest.value.map(e => e.message).join(", ") : ""}`);
 
     const manifestVersion = await generateManifestVersion(manifest.value.groups);

--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
@@ -7,6 +7,7 @@ import { BidHttpService, BlockHttpService } from "@akashnetwork/http-sdk";
 import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { DirectSecp256k1HdWallet, EncodeObject, Registry } from "@cosmjs/proto-signing";
 import { calculateFee, SigningStargateClient } from "@cosmjs/stargate";
+import assert from "http-assert";
 import pick from "lodash/pick";
 import { setTimeout as sleep } from "timers/promises";
 import { inject, singleton } from "tsyringe";
@@ -133,9 +134,7 @@ export class GpuBidsCreatorService {
   private async createDeployment(client: SigningStargateClient, sdlStr: string, owner: string, dseq: string) {
     const sdlInput = sdlYaml.template<SDLInput>(sdlStr);
     const manifest = generateManifest(sdlInput);
-    if (!manifest.ok) {
-      throw new Error(manifest.value.map(e => e.message).join(", "));
-    }
+    assert(manifest.ok, 400, `Invalid SDL: ${manifest.ok === false ? manifest.value.map(e => e.message).join(", ") : ""}`);
 
     const manifestVersion = await generateManifestVersion(manifest.value.groups);
     const message = {

--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
@@ -1,4 +1,5 @@
-import { SDL } from "@akashnetwork/chain-sdk";
+import type { SDLInput } from "@akashnetwork/chain-sdk";
+import { generateManifest, generateManifestVersion, yaml as sdlYaml } from "@akashnetwork/chain-sdk";
 import { Source } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { MsgCloseDeployment, MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { TxRaw } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
@@ -130,9 +131,13 @@ export class GpuBidsCreatorService {
   }
 
   private async createDeployment(client: SigningStargateClient, sdlStr: string, owner: string, dseq: string) {
-    const sdl = SDL.fromString(sdlStr, "beta3");
+    const sdlInput = sdlYaml.template<SDLInput>(sdlStr);
+    const manifest = generateManifest(sdlInput);
+    if (!manifest.ok) {
+      throw new Error(manifest.value.map(e => e.message).join(", "));
+    }
 
-    const manifestVersion = await sdl.manifestVersion();
+    const manifestVersion = await generateManifestVersion(manifest.value.groups);
     const message = {
       typeUrl: `/${MsgCreateDeployment.$type}`,
       value: MsgCreateDeployment.fromPartial({
@@ -140,7 +145,7 @@ export class GpuBidsCreatorService {
           owner: owner,
           dseq: dseq
         },
-        groups: sdl.groups(),
+        groups: manifest.value.groupSpecs,
         hash: manifestVersion,
         deposit: {
           amount: {

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -1,4 +1,4 @@
-import type { v2Sdl } from "@akashnetwork/chain-sdk";
+import type { SDLInput } from "@akashnetwork/chain-sdk";
 import yaml from "js-yaml";
 
 import type { BillingConfig } from "@src/billing/providers";
@@ -49,9 +49,9 @@ deployment:
 `;
 
       const result = service.appendAuditorRequirement(inputSdl, [auditor]);
-      const parsedResult = yaml.load(result) as v2Sdl;
+      const parsedResult = yaml.load(result) as SDLInput;
 
-      expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor);
+      expect(parsedResult.profiles.placement.westcoast.signedBy!.anyOf).toContain(auditor);
     });
 
     it("does not duplicate auditor if already present in anyOf", () => {
@@ -100,9 +100,9 @@ deployment:
 `;
 
       const result = service.appendAuditorRequirement(inputSdl, [auditor]);
-      const parsedResult = yaml.load(result) as v2Sdl;
+      const parsedResult = yaml.load(result) as SDLInput;
 
-      const anyOfCount = parsedResult.profiles.placement.westcoast.signedBy.anyOf.filter((a: string) => a === auditor).length;
+      const anyOfCount = parsedResult.profiles.placement.westcoast.signedBy!.anyOf!.filter((a: string) => a === auditor).length;
       expect(anyOfCount).toBe(1);
     });
 
@@ -150,10 +150,10 @@ deployment:
 `;
 
       const result = service.appendAuditorRequirement(inputSdl, [auditor1, auditor2]);
-      const parsedResult = yaml.load(result) as v2Sdl;
+      const parsedResult = yaml.load(result) as SDLInput;
 
-      expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor1);
-      expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor2);
+      expect(parsedResult.profiles.placement.westcoast.signedBy!.anyOf).toContain(auditor1);
+      expect(parsedResult.profiles.placement.westcoast.signedBy!.anyOf).toContain(auditor2);
     });
 
     it("preserves existing signedBy allOf when adding anyOf", () => {
@@ -203,10 +203,10 @@ deployment:
 `;
 
       const result = service.appendAuditorRequirement(inputSdl, [auditor]);
-      const parsedResult = yaml.load(result) as v2Sdl;
+      const parsedResult = yaml.load(result) as SDLInput;
 
-      expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor);
-      expect(parsedResult.profiles.placement.westcoast.signedBy.allOf).toContain(existingAllOf);
+      expect(parsedResult.profiles.placement.westcoast.signedBy!.anyOf).toContain(auditor);
+      expect(parsedResult.profiles.placement.westcoast.signedBy!.allOf).toContain(existingAllOf);
     });
 
     it("applies auditor requirement to all placement profiles", () => {
@@ -284,10 +284,10 @@ deployment:
 `;
 
       const result = service.appendAuditorRequirement(inputSdl, [auditor]);
-      const parsedResult = yaml.load(result) as v2Sdl;
+      const parsedResult = yaml.load(result) as SDLInput;
 
-      expect(parsedResult.profiles.placement.westcoast.signedBy.anyOf).toContain(auditor);
-      expect(parsedResult.profiles.placement.eastcoast.signedBy.anyOf).toContain(auditor);
+      expect(parsedResult.profiles.placement.westcoast.signedBy!.anyOf).toContain(auditor);
+      expect(parsedResult.profiles.placement.eastcoast.signedBy!.anyOf).toContain(auditor);
     });
   });
 

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -1,18 +1,8 @@
-import type { SDLInput } from "@akashnetwork/chain-sdk";
-import yaml from "js-yaml";
-
 import type { BillingConfig } from "@src/billing/providers";
 import { SdlService } from "./sdl.service";
 
-describe(SdlService.name, () => {
-  describe("appendAuditorRequirement", () => {
-    it("adds auditor to signedBy anyOf when not present", () => {
-      const { service } = setup();
-      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
-
-      const inputSdl = `---
+const VALID_SDL = `
 version: "2.0"
-
 services:
   web:
     image: nginx
@@ -21,7 +11,6 @@ services:
         as: 80
         to:
           - global: true
-
 profiles:
   compute:
     web:
@@ -34,13 +23,10 @@ profiles:
           size: 1Gi
   placement:
     westcoast:
-      attributes:
-        region: us-west
       pricing:
         web:
           denom: uakt
           amount: 1000
-
 deployment:
   web:
     westcoast:
@@ -48,174 +34,8 @@ deployment:
       count: 1
 `;
 
-      const result = service.appendAuditorRequirement(inputSdl, [auditor]);
-      const parsedResult = yaml.load(result) as SDLInput;
-
-      expect(parsedResult.profiles.placement.westcoast.signedBy!.anyOf).toContain(auditor);
-    });
-
-    it("does not duplicate auditor if already present in anyOf", () => {
-      const { service } = setup();
-      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
-
-      const inputSdl = `---
+const MULTI_PLACEMENT_SDL = `
 version: "2.0"
-
-services:
-  web:
-    image: nginx
-    expose:
-      - port: 80
-        as: 80
-        to:
-          - global: true
-
-profiles:
-  compute:
-    web:
-      resources:
-        cpu:
-          units: 0.5
-        memory:
-          size: 512Mi
-        storage:
-          size: 1Gi
-  placement:
-    westcoast:
-      attributes:
-        region: us-west
-      signedBy:
-        anyOf:
-          - ${auditor}
-      pricing:
-        web:
-          denom: uakt
-          amount: 1000
-
-deployment:
-  web:
-    westcoast:
-      profile: web
-      count: 1
-`;
-
-      const result = service.appendAuditorRequirement(inputSdl, [auditor]);
-      const parsedResult = yaml.load(result) as SDLInput;
-
-      const anyOfCount = parsedResult.profiles.placement.westcoast.signedBy!.anyOf!.filter((a: string) => a === auditor).length;
-      expect(anyOfCount).toBe(1);
-    });
-
-    it("adds multiple auditors to signedBy anyOf", () => {
-      const { service } = setup();
-      const auditor1 = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
-      const auditor2 = "akash1another7awdyj3n2sav7xfx76adc6dnmlx64";
-
-      const inputSdl = `---
-version: "2.0"
-
-services:
-  web:
-    image: nginx
-    expose:
-      - port: 80
-        as: 80
-        to:
-          - global: true
-
-profiles:
-  compute:
-    web:
-      resources:
-        cpu:
-          units: 0.5
-        memory:
-          size: 512Mi
-        storage:
-          size: 1Gi
-  placement:
-    westcoast:
-      attributes:
-        region: us-west
-      pricing:
-        web:
-          denom: uakt
-          amount: 1000
-
-deployment:
-  web:
-    westcoast:
-      profile: web
-      count: 1
-`;
-
-      const result = service.appendAuditorRequirement(inputSdl, [auditor1, auditor2]);
-      const parsedResult = yaml.load(result) as SDLInput;
-
-      expect(parsedResult.profiles.placement.westcoast.signedBy!.anyOf).toContain(auditor1);
-      expect(parsedResult.profiles.placement.westcoast.signedBy!.anyOf).toContain(auditor2);
-    });
-
-    it("preserves existing signedBy allOf when adding anyOf", () => {
-      const { service } = setup();
-      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
-      const existingAllOf = "akash1existingauditor";
-
-      const inputSdl = `---
-version: "2.0"
-
-services:
-  web:
-    image: nginx
-    expose:
-      - port: 80
-        as: 80
-        to:
-          - global: true
-
-profiles:
-  compute:
-    web:
-      resources:
-        cpu:
-          units: 0.5
-        memory:
-          size: 512Mi
-        storage:
-          size: 1Gi
-  placement:
-    westcoast:
-      attributes:
-        region: us-west
-      signedBy:
-        allOf:
-          - ${existingAllOf}
-      pricing:
-        web:
-          denom: uakt
-          amount: 1000
-
-deployment:
-  web:
-    westcoast:
-      profile: web
-      count: 1
-`;
-
-      const result = service.appendAuditorRequirement(inputSdl, [auditor]);
-      const parsedResult = yaml.load(result) as SDLInput;
-
-      expect(parsedResult.profiles.placement.westcoast.signedBy!.anyOf).toContain(auditor);
-      expect(parsedResult.profiles.placement.westcoast.signedBy!.allOf).toContain(existingAllOf);
-    });
-
-    it("applies auditor requirement to all placement profiles", () => {
-      const { service } = setup();
-      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
-
-      const inputSdl = `---
-version: "2.0"
-
 services:
   web:
     image: nginx
@@ -225,13 +45,12 @@ services:
         to:
           - global: true
   api:
-    image: node
+    image: nginx
     expose:
       - port: 3000
         as: 3000
         to:
           - global: true
-
 profiles:
   compute:
     web:
@@ -245,33 +64,22 @@ profiles:
     api:
       resources:
         cpu:
-          units: 1
+          units: 0.5
         memory:
-          size: 1Gi
+          size: 512Mi
         storage:
-          size: 2Gi
+          size: 1Gi
   placement:
     westcoast:
-      attributes:
-        region: us-west
       pricing:
         web:
           denom: uakt
           amount: 1000
-        api:
-          denom: uakt
-          amount: 2000
     eastcoast:
-      attributes:
-        region: us-east
       pricing:
-        web:
-          denom: uakt
-          amount: 1000
         api:
           denom: uakt
-          amount: 2000
-
+          amount: 1000
 deployment:
   web:
     westcoast:
@@ -283,24 +91,181 @@ deployment:
       count: 1
 `;
 
-      const result = service.appendAuditorRequirement(inputSdl, [auditor]);
-      const parsedResult = yaml.load(result) as SDLInput;
+const SDL_WITH_AUDITOR = (auditor: string) => `
+version: "2.0"
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 1Gi
+  placement:
+    westcoast:
+      signedBy:
+        anyOf:
+          - ${auditor}
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1
+`;
 
-      expect(parsedResult.profiles.placement.westcoast.signedBy!.anyOf).toContain(auditor);
-      expect(parsedResult.profiles.placement.eastcoast.signedBy!.anyOf).toContain(auditor);
+const SDL_WITH_ALLOF = (allOf: string) => `
+version: "2.0"
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 1Gi
+  placement:
+    westcoast:
+      signedBy:
+        allOf:
+          - ${allOf}
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1
+`;
+
+describe(SdlService.name, () => {
+  describe("generateManifest", () => {
+    it("adds auditor to signedBy anyOf when not present", () => {
+      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
+      const { result } = setup({ sdl: VALID_SDL, allowedAuditors: [auditor] });
+
+      expect(result.ok).toBe(true);
+      expect(getSignedBy(result, "westcoast").anyOf).toContain(auditor);
+    });
+
+    it("does not duplicate auditor if already present in anyOf", () => {
+      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
+      const { result } = setup({ sdl: SDL_WITH_AUDITOR(auditor), allowedAuditors: [auditor] });
+
+      expect(result.ok).toBe(true);
+      const anyOfCount = getSignedBy(result, "westcoast").anyOf.filter((a: string) => a === auditor).length;
+      expect(anyOfCount).toBe(1);
+    });
+
+    it("adds multiple auditors to signedBy anyOf", () => {
+      const auditor1 = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
+      const auditor2 = "akash1another7awdyj3n2sav7xfx76adc6dnmlx64";
+      const { result } = setup({ sdl: VALID_SDL, allowedAuditors: [auditor1, auditor2] });
+
+      expect(result.ok).toBe(true);
+      const anyOf = getSignedBy(result, "westcoast").anyOf;
+      expect(anyOf).toContain(auditor1);
+      expect(anyOf).toContain(auditor2);
+    });
+
+    it("preserves existing signedBy allOf when adding anyOf", () => {
+      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
+      const existingAllOf = "akash1existingauditor";
+      const { result } = setup({ sdl: SDL_WITH_ALLOF(existingAllOf), allowedAuditors: [auditor] });
+
+      expect(result.ok).toBe(true);
+      const signedBy = getSignedBy(result, "westcoast");
+      expect(signedBy.anyOf).toContain(auditor);
+      expect(signedBy.allOf).toContain(existingAllOf);
+    });
+
+    it("applies auditor requirement to all placement profiles", () => {
+      const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
+      const { result } = setup({ sdl: MULTI_PLACEMENT_SDL, allowedAuditors: [auditor] });
+
+      expect(result.ok).toBe(true);
+      expect(getSignedBy(result, "westcoast").anyOf).toContain(auditor);
+      expect(getSignedBy(result, "eastcoast").anyOf).toContain(auditor);
+    });
+
+    it("replaces denom in pricing when deploymentGrantDenom differs from uakt", () => {
+      const { result } = setup({ sdl: VALID_SDL, deploymentGrantDenom: "uact" });
+
+      expect(result.ok).toBe(true);
+      expect(getPrice(result, "westcoast").denom).toBe("uact");
+    });
+
+    it("does not replace denom when deploymentGrantDenom is uakt", () => {
+      const { result } = setup({ sdl: VALID_SDL, deploymentGrantDenom: "uakt" });
+
+      expect(result.ok).toBe(true);
+      expect(getPrice(result, "westcoast").denom).toBe("uakt");
+    });
+
+    it("does not append auditors when allowedAuditors is empty", () => {
+      const { result } = setup({ sdl: VALID_SDL, allowedAuditors: [] });
+
+      expect(result.ok).toBe(true);
+      expect(getSignedBy(result, "westcoast").anyOf).toEqual([]);
+    });
+
+    it("returns error result for invalid SDL", () => {
+      const { result } = setup({ sdl: "invalid" });
+
+      expect(result.ok).toBeFalsy();
     });
   });
 
-  function setup() {
-    const config: BillingConfig = {
-      NETWORK: "sandbox"
+  function setup(input?: { sdl?: string; allowedAuditors?: string[]; deploymentGrantDenom?: string }) {
+    const config = {
+      NETWORK: "sandbox",
+      DEPLOYMENT_GRANT_DENOM: input?.deploymentGrantDenom ?? "uakt",
+      MANAGED_WALLET_LEASE_ALLOWED_AUDITORS: input?.allowedAuditors ?? []
     } as BillingConfig;
 
     const service = new SdlService(config);
+    const result = service.generateManifest(input?.sdl ?? VALID_SDL);
 
-    return {
-      service,
-      config
-    };
+    return { service, result };
+  }
+
+  function getGroupSpec(result: ReturnType<SdlService["generateManifest"]>, placementName: string) {
+    if (!result.ok) throw new Error("Expected ok result");
+    const groupSpec = result.value.groupSpecs.find(gs => gs.name === placementName);
+    if (!groupSpec) throw new Error(`Placement "${placementName}" not found`);
+    return groupSpec;
+  }
+
+  function getSignedBy(result: ReturnType<SdlService["generateManifest"]>, placementName: string) {
+    return getGroupSpec(result, placementName).requirements!.signedBy!;
+  }
+
+  function getPrice(result: ReturnType<SdlService["generateManifest"]>, placementName: string) {
+    return getGroupSpec(result, placementName).resources[0].price!;
   }
 });

--- a/apps/api/src/deployment/services/sdl/sdl.service.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.ts
@@ -1,5 +1,6 @@
 import type { Manifest, NetworkId, SDLInput } from "@akashnetwork/chain-sdk";
 import { generateManifest, generateManifestVersion, manifestToSortedJSON, yaml as sdlYaml } from "@akashnetwork/chain-sdk";
+import assert from "http-assert";
 import jsYaml from "js-yaml";
 import { singleton } from "tsyringe";
 
@@ -21,9 +22,7 @@ export class SdlService {
 
   private buildManifest(sdlInput: SDLInput) {
     const result = generateManifest(sdlInput, this.networkId);
-    if (!result.ok) {
-      throw new Error(result.value.map(e => e.message).join(", "));
-    }
+    assert(result.ok, 400, `Invalid SDL: ${result.ok === false ? result.value.map(e => e.message).join(", ") : ""}`);
     return result.value;
   }
 

--- a/apps/api/src/deployment/services/sdl/sdl.service.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.ts
@@ -1,96 +1,61 @@
-import type { Manifest, NetworkId, SDLInput } from "@akashnetwork/chain-sdk";
-import { generateManifest, generateManifestVersion, manifestToSortedJSON, yaml as sdlYaml } from "@akashnetwork/chain-sdk";
-import assert from "http-assert";
-import jsYaml from "js-yaml";
+import type { GenerateManifestResult, Manifest, NetworkId, SDLInput } from "@akashnetwork/chain-sdk";
+import { generateManifest, generateManifestVersion, yaml } from "@akashnetwork/chain-sdk";
 import { singleton } from "tsyringe";
 
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 
-type NetworkType = "beta2" | "beta3";
-
 @singleton()
 export class SdlService {
-  private readonly networkId: NetworkId;
+  readonly #networkId: NetworkId;
+  readonly #config: BillingConfig;
 
-  constructor(@InjectBillingConfig() private readonly config: BillingConfig) {
-    this.networkId = this.config.NETWORK as NetworkId;
+  constructor(@InjectBillingConfig() config: BillingConfig) {
+    this.#networkId = config.NETWORK as NetworkId;
+    this.#config = config;
   }
 
-  private parseSdlInput(yamlJson: string | SDLInput): SDLInput {
-    return typeof yamlJson === "string" ? sdlYaml.template<SDLInput>(yamlJson) : yamlJson;
-  }
+  generateManifest(rawSDL: string): GenerateManifestResult {
+    const potentiallyInvalidSDL = yaml.template<SDLInput>(rawSDL);
+    const deploymentGrantDenom = this.#config.DEPLOYMENT_GRANT_DENOM;
+    const sdlPlacement =
+      potentiallyInvalidSDL?.profiles?.placement && typeof potentiallyInvalidSDL?.profiles?.placement === "object"
+        ? potentiallyInvalidSDL.profiles.placement
+        : {};
 
-  private buildManifest(sdlInput: SDLInput) {
-    const result = generateManifest(sdlInput, this.networkId);
-    assert(result.ok, 400, `Invalid SDL: ${result.ok === false ? result.value.map(e => e.message).join(", ") : ""}`);
-    return result.value;
-  }
+    Object.values(sdlPlacement).forEach(profile => {
+      if (typeof profile !== "object" || !profile || !profile.pricing || typeof profile.pricing !== "object") return;
+      Object.values(profile.pricing).forEach(price => {
+        if (typeof price !== "object" || !price || price.denom === deploymentGrantDenom) return;
+        price.denom = deploymentGrantDenom;
+      });
+    });
 
-  public getDeploymentGroups(yamlJson: string | SDLInput, _networkType: NetworkType) {
-    const sdlInput = this.parseSdlInput(yamlJson);
-    return this.buildManifest(sdlInput).groupSpecs;
-  }
-
-  public getManifest(yamlJson: string | SDLInput, _networkType: NetworkType, asString: true): string;
-  public getManifest(yamlJson: string | SDLInput, _networkType: NetworkType, asString?: false): Manifest;
-  public getManifest(yamlJson: string | SDLInput, _networkType: NetworkType, asString = false): string | Manifest {
-    const sdlInput = this.parseSdlInput(yamlJson);
-    const { groups } = this.buildManifest(sdlInput);
-    if (asString) {
-      return manifestToSortedJSON(groups);
+    const allowedAuditors = this.#config.MANAGED_WALLET_LEASE_ALLOWED_AUDITORS;
+    if (allowedAuditors && allowedAuditors.length > 0) {
+      this.#appendAuditorRequirement(sdlPlacement, allowedAuditors);
     }
-    return groups;
+
+    const result = generateManifest(potentiallyInvalidSDL, this.#networkId);
+    if (!result.ok) return result;
+
+    return result;
   }
 
-  public async getManifestVersion(yamlJson: string | SDLInput, _networkType: NetworkType) {
-    const sdlInput = this.parseSdlInput(yamlJson);
-    const { groups } = this.buildManifest(sdlInput);
-    return generateManifestVersion(groups);
+  async generateManifestVersion(manifest: Manifest): Promise<Uint8Array> {
+    return generateManifestVersion(manifest);
   }
 
-  public getManifestYaml(sdlConfig: SDLInput, _networkType: NetworkType) {
-    const { groups } = this.buildManifest(sdlConfig);
-    return manifestToSortedJSON(groups);
-  }
-
-  public validateSdl(yamlJson: string) {
-    try {
-      const sdlInput = sdlYaml.template<SDLInput>(yamlJson);
-      const result = generateManifest(sdlInput, this.networkId);
-      return !!result.ok;
-    } catch {
-      return false;
-    }
-  }
-
-  public appendAuditorRequirement(yamlStr: string, allowedAuditors: string[]): string {
-    const sdlData = jsYaml.load(yamlStr) as SDLInput;
-    const placementData = sdlData?.profiles?.placement || {};
-
-    for (const [, value] of Object.entries(placementData)) {
-      if (!value.signedBy?.anyOf || !value.signedBy?.allOf) {
-        value.signedBy = {
-          anyOf: value.signedBy?.anyOf || [],
-          allOf: value.signedBy?.allOf || []
-        };
-      }
+  #appendAuditorRequirement(placement: SDLInput["profiles"]["placement"], allowedAuditors: string[]): void {
+    for (const value of Object.values(placement)) {
+      if (!value) continue;
 
       for (const auditor of allowedAuditors) {
-        if (!value.signedBy!.anyOf!.includes(auditor)) {
-          value.signedBy!.anyOf!.push(auditor);
+        if (!value.signedBy?.anyOf || !value.signedBy.anyOf.includes(auditor)) {
+          value.signedBy ??= {};
+          value.signedBy.anyOf ??= [];
+          value.signedBy.anyOf.push(auditor);
         }
       }
     }
-
-    const result = jsYaml.dump(sdlData, {
-      indent: 2,
-      quotingType: '"',
-      styles: {
-        "!!null": "empty"
-      }
-    });
-
-    return `---
-${result}`;
   }
 }

--- a/apps/api/src/deployment/services/sdl/sdl.service.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.ts
@@ -1,7 +1,6 @@
-import type { v2Manifest, v2Sdl, v3Manifest } from "@akashnetwork/chain-sdk";
-import type { NetworkId } from "@akashnetwork/chain-sdk";
-import { SDL } from "@akashnetwork/chain-sdk";
-import yaml from "js-yaml";
+import type { Manifest, NetworkId, SDLInput } from "@akashnetwork/chain-sdk";
+import { generateManifest, generateManifestVersion, manifestToSortedJSON, yaml as sdlYaml } from "@akashnetwork/chain-sdk";
+import jsYaml from "js-yaml";
 import { singleton } from "tsyringe";
 
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
@@ -16,52 +15,57 @@ export class SdlService {
     this.networkId = this.config.NETWORK as NetworkId;
   }
 
-  private isValidString(value: unknown): value is string {
-    return typeof value === "string" && !!value;
+  private parseSdlInput(yamlJson: string | SDLInput): SDLInput {
+    return typeof yamlJson === "string" ? sdlYaml.template<SDLInput>(yamlJson) : yamlJson;
   }
 
-  private getSdl(yamlJson: string | v2Sdl, networkType: NetworkType) {
-    return this.isValidString(yamlJson) ? SDL.fromString(yamlJson, networkType, this.networkId) : new SDL(yamlJson, networkType, this.networkId);
-  }
-
-  public getDeploymentGroups(yamlJson: string | v2Sdl, networkType: NetworkType) {
-    const sdl = this.getSdl(yamlJson, networkType);
-    return sdl.groups();
-  }
-
-  public getManifest(yamlJson: string | v2Sdl, networkType: NetworkType, asString: true): string;
-  public getManifest(yamlJson: string | v2Sdl, networkType: NetworkType, asString?: false): v2Manifest | v3Manifest;
-  public getManifest(yamlJson: string | v2Sdl, networkType: NetworkType, asString = false): string | v2Manifest | v3Manifest {
-    const sdl = this.getSdl(yamlJson, networkType);
-    const manifest = sdl.manifest(asString) as v2Manifest | v3Manifest | string;
-    if (asString) {
-      return JSON.stringify(manifest);
+  private buildManifest(sdlInput: SDLInput) {
+    const result = generateManifest(sdlInput, this.networkId);
+    if (!result.ok) {
+      throw new Error(result.value.map(e => e.message).join(", "));
     }
-    return manifest;
+    return result.value;
   }
 
-  public async getManifestVersion(yamlJson: string | v2Sdl, networkType: NetworkType) {
-    const sdl = this.getSdl(yamlJson, networkType);
-    return sdl.manifestVersion();
+  public getDeploymentGroups(yamlJson: string | SDLInput, _networkType: NetworkType) {
+    const sdlInput = this.parseSdlInput(yamlJson);
+    return this.buildManifest(sdlInput).groupSpecs;
   }
 
-  public getManifestYaml(sdlConfig: v2Sdl, networkType: NetworkType) {
-    const sdl = this.getSdl(sdlConfig, networkType);
-    return sdl.manifestSortedJSON();
+  public getManifest(yamlJson: string | SDLInput, _networkType: NetworkType, asString: true): string;
+  public getManifest(yamlJson: string | SDLInput, _networkType: NetworkType, asString?: false): Manifest;
+  public getManifest(yamlJson: string | SDLInput, _networkType: NetworkType, asString = false): string | Manifest {
+    const sdlInput = this.parseSdlInput(yamlJson);
+    const { groups } = this.buildManifest(sdlInput);
+    if (asString) {
+      return manifestToSortedJSON(groups);
+    }
+    return groups;
+  }
+
+  public async getManifestVersion(yamlJson: string | SDLInput, _networkType: NetworkType) {
+    const sdlInput = this.parseSdlInput(yamlJson);
+    const { groups } = this.buildManifest(sdlInput);
+    return generateManifestVersion(groups);
+  }
+
+  public getManifestYaml(sdlConfig: SDLInput, _networkType: NetworkType) {
+    const { groups } = this.buildManifest(sdlConfig);
+    return manifestToSortedJSON(groups);
   }
 
   public validateSdl(yamlJson: string) {
     try {
-      SDL.fromString(yamlJson, "beta3");
-      return true;
+      const sdlInput = sdlYaml.template<SDLInput>(yamlJson);
+      const result = generateManifest(sdlInput);
+      return !!result.ok;
     } catch {
       return false;
     }
   }
 
   public appendAuditorRequirement(yamlStr: string, allowedAuditors: string[]): string {
-    const sdl = this.getSdl(yamlStr, "beta3");
-    const sdlData = sdl.data as v2Sdl;
+    const sdlData = jsYaml.load(yamlStr) as SDLInput;
     const placementData = sdlData?.profiles?.placement || {};
 
     for (const [, value] of Object.entries(placementData)) {
@@ -73,13 +77,13 @@ export class SdlService {
       }
 
       for (const auditor of allowedAuditors) {
-        if (!value.signedBy.anyOf.includes(auditor)) {
-          value.signedBy.anyOf.push(auditor);
+        if (!value.signedBy!.anyOf!.includes(auditor)) {
+          value.signedBy!.anyOf!.push(auditor);
         }
       }
     }
 
-    const result = yaml.dump(sdlData, {
+    const result = jsYaml.dump(sdlData, {
       indent: 2,
       quotingType: '"',
       styles: {

--- a/apps/api/src/deployment/services/sdl/sdl.service.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.ts
@@ -56,7 +56,7 @@ export class SdlService {
   public validateSdl(yamlJson: string) {
     try {
       const sdlInput = sdlYaml.template<SDLInput>(yamlJson);
-      const result = generateManifest(sdlInput);
+      const result = generateManifest(sdlInput, this.networkId);
       return !!result.ok;
     } catch {
       return false;

--- a/apps/api/test/mocks/invalid-sdl.yml
+++ b/apps/api/test/mocks/invalid-sdl.yml
@@ -15,7 +15,7 @@ profiles:
         cpu:
           units: 0.5
         memory:
-          size: 512Mi
+          size2: 512Mi
         storage:
           - size: 512Mi
   placement:

--- a/apps/api/test/mocks/template.ts
+++ b/apps/api/test/mocks/template.ts
@@ -1,4 +1,4 @@
-import type { v2Sdl } from "@akashnetwork/chain-sdk";
+import type { SDLInput } from "@akashnetwork/chain-sdk";
 import dot from "dot-object";
 import update, { type CustomCommands, type Spec } from "immutability-helper";
 import { dump } from "js-yaml";
@@ -7,8 +7,8 @@ import sdlBasic from "./sdl-basic.json";
 
 type AnySpec = Spec<object, CustomCommands<object>>;
 
-export const createSdlJson = ($spec: AnySpec = {}): v2Sdl => {
-  return update(sdlBasic, dot.object($spec)) as unknown as v2Sdl;
+export const createSdlJson = ($spec: AnySpec = {}): SDLInput => {
+  return update(sdlBasic, dot.object($spec)) as unknown as SDLInput;
 };
 
 export const createSdlYml = ($spec: AnySpec = {}): string => {


### PR DESCRIPTION
## Why

The currently used `SDL` class from `@akashnetwork/chain-sdk` is deprecated. This PR migrates `apps/api` to use the new standalone functions.

## What

Replace `SDL` class usage in `apps/api` with new functions from `@akashnetwork/chain-sdk`:
- `generateManifest` — replaces `SDL.fromString()` + `.groups()` / `.manifest()`
- `generateManifestVersion` — replaces `sdl.manifestVersion()`
- `manifestToSortedJSON` — replaces `sdl.manifestSortedJSON()`
- `yaml.template()` — replaces `SDL.fromString()` for YAML parsing
- `js-yaml` used directly for SDL data manipulation in `appendAuditorRequirement` (replacing `sdl.data` access)
- `v2Sdl` type replaced with `SDLInput` type throughout

Files changed:
- `apps/api/src/deployment/services/sdl/sdl.service.ts` — SDL service
- `apps/api/src/deployment/services/sdl/sdl.service.spec.ts` — SDL service tests
- `apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts` — GPU bids creator
- `apps/api/test/mocks/template.ts` — test mock template

> 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and error reporting for invalid deployment inputs; clearer assertions and error handling when manifests can't be generated.
  * Enhanced logging around deployment and manifest errors.

* **Refactor**
  * Switched deployment processing to a manifest-driven workflow for consistent group handling, stable manifest versioning, and unified manifest outputs.
  * Manifest generation and retrieval now accept both textual and structured SDL inputs.

* **Tests**
  * Expanded unit tests for GPU bid creation, deployment flows, validation, signing/broadcasting, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->