### PR TITLE
chore(dx): refine linear-issue skill to enforce business-level issues

### DIFF
--- a/.claude/skills/linear-issue/SKILL.md
+++ b/.claude/skills/linear-issue/SKILL.md
@@ -1,20 +1,59 @@
 ---
 name: linear-issue
-description: Plan, create, and improve Linear issues by analyzing the codebase and breaking work into small, reviewable chunks. Use this skill whenever the user wants to create a Linear issue, improve an existing one, file a bug, plan a feature, create a chore/enabler, or mentions "linear issue", "file an issue", "create a ticket", "log a bug", "new issue", "plan this work", "improve this issue", or "clean up this ticket". Also trigger when the user says "I found a bug", "we need a ticket for...", "can you create an issue for...", "break this down into issues", or pastes a Linear issue URL/ID. This is the required way to create and maintain issues — it ensures every issue follows the team's format and is scoped for small PRs.
+description: Plan, create, and improve Linear issues with business-level clarity. Use this skill whenever the user wants to create a Linear issue, improve an existing one, file a bug, plan a feature, create a chore/enabler, or mentions "linear issue", "file an issue", "create a ticket", "log a bug", "new issue", "plan this work", "improve this issue", or "clean up this ticket". Also trigger when the user says "I found a bug", "we need a ticket for...", "can you create an issue for...", "break this down into issues", or pastes a Linear issue URL/ID. This is the required way to create and maintain issues — it ensures every issue follows the team's format and is scoped for small PRs.
 ---
 
 # Linear Issue Planner & Creator
 
-This skill does three things: **analyzes** the codebase to understand the problem space, **creates** well-structured Linear issues scoped for small reviewable PRs, and **improves** existing issues to match the team's standards.
+This skill helps **structure** well-defined Linear issues that serve as the source of truth for implementers and testers. Issues describe the **business problem and expected behavior** — never the implementation approach.
 
-The goal is consistency across the team — every issue clearly defines the problem and acceptance criteria, and is small enough that the resulting PR is easy to review. Implementation details (specific files, approach, abstractions) belong in the PR description, not the issue.
+The human provides the business context. Claude helps structure it clearly, fill in gaps by asking questions, and ensure consistency with team standards. Claude does not invent business requirements or prescribe technical solutions.
+
+## The Golden Rule: Business-Level Issues Only
+
+Issues must be written at the **business level**. They define **what** needs to happen and **why** — not how to implement it. The implementer (human or AI) decides the technical approach.
+
+**Never include in an issue:**
+- File paths, class names, function names, or line numbers
+- Step-by-step implementation plans
+- Specific technical approaches or architectural prescriptions
+- Code snippets or pseudo-code
+
+**Always include in an issue:**
+- The business problem or user need
+- Expected behavior described in user-facing terms
+- Affected business flows (e.g., "deployment creation flow", "billing authorization")
+- Links to specs, Figma designs, AEPs, or discussions
+- Acceptance criteria that an implementer or tester can validate against
+
+The issue is the "protection line" — when an implementer says "I did everything the task says," the task must clearly define what success looks like in business terms.
+
+### Good Example (GitHub #2859)
+
+```markdown
+## Why
+We need to adjust prices to be displayed in ACT
+
+## What
+USDC will gone, so ACT needs to replace it in all places but instead of ACT
+AEP-76 requires deploy-web to show `$`
+
+There are few flows that should work:
+1. Deployment creation flow
+2. Money authorization creation flow
+3. Add funds to escrow account
+
+Transactions fee is paid in uAKT
+```
+
+Short. Business-focused. Describes the flows that need to work. No file paths. No implementation plan. An implementer knows exactly what to validate.
 
 ## Modes
 
 This skill operates in two modes. Detect which one based on what the user asks:
 
 1. **Create mode** — User wants new issues. Follow the full workflow below (Phase 1–5).
-2. **Improve mode** — User references an existing Linear issue (by ID like `ENG-123`, or URL). Follow the Improve Existing Issues workflow instead.
+2. **Improve mode** — User references an existing Linear issue (by ID like `CON-123`, or URL). Follow the Improve Existing Issues workflow instead.
 
 ## Issue Types
 
@@ -74,53 +113,36 @@ Use `--status "<status>"` in the CLI command. Default to **Triage** unless the u
 #### From the user
 Ask the user what they need. If they give enough context upfront, don't interrogate — fill in what you can and confirm the rest.
 
+The user's input is the primary source of business context. Claude cannot invent business requirements — if something is unclear, ask. Focus on understanding:
+- What business problem are we solving?
+- What user-facing behavior should change?
+- Which business flows are affected?
+- Are there specs, AEPs, Figma designs, or discussions to reference?
+
 Infer the **source** from how the user describes the issue (customer report, error log, internal idea, roadmap item). If unclear, ask.
 
 #### From observability tools (when relevant)
-Before diving into code, check if observability data can inform the issue — especially for bugs and production incidents.
+For bugs and production incidents, observability data adds real evidence to the issue description.
 
-**Grafana** — Use when investigating errors, performance issues, or production behavior. Search logs for errors and stack traces, find elevated error patterns, identify slow requests, check metrics (error rates, latency, resource usage), find relevant dashboards, and check for existing alerts or active incidents.
+**Grafana** — Search logs for errors and stack traces, find error patterns, check error rates and latency. Include links to dashboards and key log lines in the issue.
 
-**Amplitude** — Use when understanding user behavior or impact. Query event data to understand scope/frequency, watch session replays, find relevant charts or experiments, and check if users have reported the issue.
+**Amplitude** — Query event data to understand scope/frequency, check if users have reported the issue. Include usage numbers to quantify impact.
 
-Use ToolSearch to discover available methods on these MCP servers before calling them. Only query what's relevant — don't run every tool on every issue. For bugs, Grafana logs and error patterns are usually most valuable. For features, Amplitude usage data helps scope the impact.
+Use ToolSearch to discover available methods on these MCP servers before calling them. Only query what's relevant. Redact tokens, emails, user IDs, and any sensitive payload fields before posting.
 
-Include findings in the issue description — link to specific dashboards, paste key log lines, or note error rates. Redact tokens, emails, user IDs, and any sensitive payload fields before posting. This gives reviewers and implementers real data instead of guesses.
-
-#### From the codebase
-Explore the codebase to understand what exists and what needs to change. This is the most important step — good issues come from understanding the code, not guessing.
-
-Use Glob, Grep, and Read to:
-- Find the files and modules that will need changes
-- Understand existing patterns, abstractions, and conventions in the affected area
-- Identify dependencies between components
-- Spot potential edge cases or risks
-- Check for existing tests that will need updating
-
-For features/enablers, also look for:
-- Similar implementations to follow as a pattern
-- Shared utilities or abstractions that should be reused
-- Database schemas that may need migration
-- API contracts that may need versioning
+The goal is to add **evidence** (error rates, affected user counts, log links) to the issue — not to derive implementation plans from the data.
 
 ### Phase 2: Define the Problem
 
-Issues should clearly capture **what** needs to happen and **why**. This is the core of the issue — it lives in Linear forever and must be useful to anyone who reads it.
+Write the issue at the business level. It should be useful to anyone — implementer, tester, product manager, tech lead — as a source of truth for what needs to happen.
 
 What belongs in the issue:
-- **Problem statement** — what's wrong or what's needed
-- **Acceptance criteria** — how we know it's done
-- **Risks / edge cases** — anything tricky the implementer should know
+- **Problem statement** — what's wrong or what's needed, in business terms
+- **Expected behavior** — what the user should experience when this is done
+- **Affected flows** — which user-facing flows are impacted (e.g., "deployment creation", "wallet funding")
+- **Acceptance criteria** — business-level conditions that define "done"
+- **References** — links to AEPs, Figma, GitHub discussions, specs
 - **Dependencies** — does this depend on or block other work?
-- **Scope** — which area of the codebase is affected
-
-#### Suggested Solution
-
-Add a high-level suggested approach — enough to scope the work and unblock the implementer, but not so detailed that it becomes stale or creates pressure to execute as written.
-
-Keep it directional (e.g., "add a polling mechanism to the deploy status page" not "modify `src/components/DeployStatus.tsx` line 42"). Specific file paths, prescribed abstractions, and line-by-line plans go stale fast and belong in the PR description — written by the implementer who has full context from actually working in the code.
-
-**For non-trivial work, suggest a throwaway spike first.** 20 minutes of exploration on a throwaway branch surfaces where existing abstractions don't fit and where the plan would break down. The issue written after a spike is significantly better than one written from static analysis alone.
 
 ### Phase 3: Break Into Small Issues
 
@@ -136,13 +158,13 @@ This is critical. Every issue should map to a **single small PR** that's easy to
 | **L** | 500–999 | Too large — split further |
 | **XL** | 1000+ | Never — always split |
 
-When estimating, count additions + deletions across all non-excluded files. If an issue would likely produce an L or XL PR, it **must** be split into smaller issues.
+When splitting, each issue should still be a **business-level slice** — not a technical layer. "Add ACT pricing to deployment creation flow" is a good split. "Update utility functions" is not.
 
 **How to split:**
-- **Vertical slices** (preferred) — each issue delivers a narrow but complete slice of functionality across layers, giving reviewers full context. A reviewer seeing "add deploy status polling" understands the change; "add utils layer" does not.
+- **By business flow** (preferred) — each issue covers one user-facing flow end-to-end
 - **By feature boundary** — each independent piece of functionality gets its own issue
 - **By risk** — risky changes (migrations, breaking API changes) get isolated into their own issue
-- **Enablers first** — if the feature needs refactoring or new abstractions, those go in a separate preceding issue
+- **Enablers first** — if the feature needs prerequisite work, that goes in a separate preceding issue
 
 **Issue ordering:**
 - Number the issues or note dependencies explicitly (e.g., "blocked by #1")
@@ -150,7 +172,7 @@ When estimating, count additions + deletions across all non-excluded files. If a
 - Each issue should be mergeable on its own without breaking anything
 
 **When NOT to split:**
-- Simple bug fixes that touch 1-3 files and stay under 200 lines — just create one issue
+- Simple bug fixes that are clearly small — just create one issue
 - Small chores that are already atomic
 
 ### Phase 4: Fill Templates & Create Issues
@@ -161,55 +183,46 @@ For each issue, fill the appropriate template.
 
 ```markdown
 ## What's broken
-[One sentence. Link to Sentry/Grafana logs if available.]
+[One sentence describing the broken behavior. Link to Sentry/Grafana if available.]
 
 ## Repro
 1. ...
 2. ...
 
 ## Expected vs Actual
-Expected: ...
-Actual: ...
-
-## Technical Analysis
-[What you found in the codebase — root cause, affected files, relevant code paths.]
-
-## Scope
-- Area: <area from .commitlintrc.json scopes>
+Expected: [what the user should see/experience]
+Actual: [what happens instead]
 ```
 
 #### Feature / Story
 
 ```markdown
 ## Why
-[One sentence on the user problem or business need.]
+[The business need or user problem.]
 
 ## What
-[What we're building. Link Figma/discussion if applicable.]
+[What we're building, described in user-facing terms. Link Figma/AEP/discussion if applicable.]
+
+Flows that should work:
+1. [Business flow 1]
+2. [Business flow 2]
 
 ## Acceptance Criteria
+- [ ] [Business-level criterion a tester can validate]
 - [ ] ...
-- [ ] ...
-
-## Scope
-- Area: <area from .commitlintrc.json scopes>
 
 ## Notes
-[Dependencies, migrations, edge cases, observability data.]
+[Dependencies, references, edge cases.]
 ```
 
 #### Enabler / Chore
 
 ```markdown
 ## Why
-[What this unblocks or improves.]
+[What this unblocks or improves — in business terms.]
 
 ## What
-- [ ] Task 1
-- [ ] Task 2
-
-## Scope
-- Area: <area from .commitlintrc.json scopes>
+[What needs to change, described at the business level.]
 ```
 
 **Drop any section that has no content** — empty placeholders are worse than no section.
@@ -257,10 +270,6 @@ For multi-issue plans, create the parent issue first, then create child issues w
 
 After creation, show the user all issue identifiers/URLs.
 
-## Valid Scope Values
-
-Area values come from the `scopes` field in `.commitlintrc.json`. Always read that file for the current list — do not hardcode values. These are business domains (e.g., `deployment`, `billing`, `auth`), not app names.
-
 ## Labeling Convention
 
 Each issue gets **two labels** — one for type and one for source:
@@ -280,7 +289,7 @@ Use multiple `--label` flags in the CLI command to apply both labels.
 
 ## Improve Existing Issues
 
-When the user references an existing issue, the goal is to bring it up to team standards — add missing sections, enrich with codebase analysis, and optionally split it into smaller issues.
+When the user references an existing issue, the goal is to bring it up to team standards — add missing business context and ensure it serves as a clear source of truth.
 
 ### Step 1: Fetch the issue
 
@@ -288,35 +297,33 @@ When the user references an existing issue, the goal is to bring it up to team s
 linear issue view <issue-id> --json --no-pager
 ```
 
-This returns the full issue data as JSON including title, description, state, labels, assignee, parent, and sub-issues.
-
 ### Step 2: Analyze gaps
 
 Compare the current description against the appropriate template (Bug / Feature / Enabler). Identify:
-- **Missing sections** — e.g., no Scope, no Acceptance Criteria
-- **Vague content** — sections that exist but lack specifics (e.g., "fix the bug" with no repro steps)
-- **Missing context** — no codebase references, no observability data
+- **Missing business context** — no "Why", no description of affected flows
+- **Implementation details that don't belong** — file paths, code snippets, step-by-step plans
+- **Vague acceptance criteria** — criteria that can't be validated by a tester
 - **Too large** — the issue describes work that should be multiple PRs
-- **Wrong format** — uses non-standard headers or structure
+- **Missing source label**
 
 ### Step 3: Enrich
 
-Run the same codebase analysis and observability queries as in Create mode (Phase 1). Use the findings to:
-- Add a **Technical Analysis** section for bugs (root cause, affected area)
-- Fill in missing **Scope** (Area)
-- Add concrete **Acceptance Criteria** if missing
-- Add **sanitized observability data** (Grafana log links, Amplitude usage data) if relevant — redact PII/secrets
-- Tighten vague descriptions with specifics from the code
+Focus on adding **business clarity**:
+- Add or improve the **Why** — what business problem does this solve?
+- Describe **affected flows** in user-facing terms
+- Write **acceptance criteria** a tester can validate without reading code
+- Add **observability data** if relevant (error rates, user impact numbers, dashboard links)
+- Remove any implementation details (file paths, code snippets, technical approach)
 
 ### Step 4: Split if needed
 
-If the issue is too large for a single PR, propose splitting it into child issues following the same rules as Phase 3 in Create mode. Present the split plan to the user before executing.
+If the issue is too large for a single PR, propose splitting it into child issues — each covering a business flow or feature boundary. Present the split plan to the user before executing.
 
 ### Step 5: Confirm & Update
 
-Show the user a diff — what the description looks like now vs what you propose. Let them adjust.
+Show the user what you propose to change. Let them adjust.
 
-Then update the existing issue:
+Then update:
 
 ```bash
 DESC_FILE=$(mktemp /tmp/linear-issue-desc.XXXXXX.md)
@@ -325,8 +332,7 @@ cat <<'EOF' > "$DESC_FILE"
 EOF
 
 linear issue update <issue-id> \
-  --description-file "$DESC_FILE" \
-  --no-interactive
+  --description-file "$DESC_FILE"
 
 rm "$DESC_FILE"
 ```
@@ -337,8 +343,8 @@ If the title also needs improvement, add `--title "<improved title>"` to the upd
 
 ## Tips
 
-- If the user dumps a Sentry error or stack trace, extract the key info and query Grafana Loki for related logs
-- If the user references a Figma link or GitHub discussion, include it in the "What" section
+- If the user dumps a Sentry error or stack trace, extract the business impact (what's broken for users) and link the log — don't diagnose the code in the issue
+- If the user references a Figma link, AEP, or GitHub discussion, include it in the "What" section
 - Multiple areas affected? List the primary one first and consider splitting by area
-- For large features, the parent issue should describe the overall goal and acceptance criteria; child issues handle individual slices
-- When in doubt about PR size, err on the side of smaller — aim for S (50–199 lines). An L label on a PR is a code review red flag
+- For large features, the parent issue should describe the overall goal; child issues handle individual business flows
+- When in doubt about PR size, err on the side of smaller — aim for S (50–199 lines)


### PR DESCRIPTION
## Why

The linear-issue skill was generating overly technical issues with file paths, implementation steps, and codebase analysis. Issues should define the business problem and acceptance criteria — not prescribe the implementation approach.

## What

Refined the linear-issue skill to:
- Add the "Golden Rule" — issues must be business-level only
- Remove codebase analysis directives that led to over-specified issues
- Add concrete good/bad examples (modeled after real issue #2859)
- Clarify that Claude structures what the human provides, rather than inventing requirements
- Update issue ID prefix from `ENG-` to `CON-`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Linear issue creation guidance to prioritize business context, affected user flows, and testable acceptance criteria over implementation details. Templates now emphasize user-facing behavior and business problems for clearer issue communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->