### PR TITLE
fix(notifications): fix hung shutdown on crashed poller

### DIFF
--- a/apps/notifications/src/interfaces/chain-events/chain-events.module.ts
+++ b/apps/notifications/src/interfaces/chain-events/chain-events.module.ts
@@ -2,12 +2,12 @@ import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 
 import { CommonModule } from "@src/common/common.module";
-import { WorkerHealthzController } from "@src/common/controllers/worker-healthz/worker-healthz.controller";
 import { BrokerModule } from "@src/infrastructure/broker";
+import { HealthzController } from "@src/interfaces/chain-events/controllers/healthz/healthz.controller";
 import { ChainModule } from "@src/modules/chain/chain.module";
 
 @Module({
   imports: [CommonModule, ChainModule, BrokerModule, ConfigModule.forRoot({ isGlobal: true })],
-  controllers: [WorkerHealthzController]
+  controllers: [HealthzController]
 })
 export default class ChainEventsModule {}

--- a/apps/notifications/src/interfaces/chain-events/controllers/healthz/healthz.controller.spec.ts
+++ b/apps/notifications/src/interfaces/chain-events/controllers/healthz/healthz.controller.spec.ts
@@ -1,0 +1,79 @@
+import { ServiceUnavailableException } from "@nestjs/common";
+import type { TestingModule } from "@nestjs/testing";
+import { Test } from "@nestjs/testing";
+import { describe, expect, it } from "vitest";
+import type { MockProxy } from "vitest-mock-extended";
+
+import { HealthzHelperService } from "@src/common/services/healthz-helper/healthz-helper.service";
+import { BrokerHealthzService } from "@src/infrastructure/broker/services/broker-healthz/broker-healthz.service";
+import { DbHealthzService } from "@src/infrastructure/db/services/db-healthz/db-healthz.service";
+import { ChainEventsPollerService } from "@src/modules/chain/services/chain-events-poller/chain-events-poller.service";
+import { HealthzController } from "./healthz.controller";
+
+import { MockProvider } from "@test/mocks/provider.mock";
+
+describe(HealthzController.name, () => {
+  describe("getReadiness", () => {
+    it("passes all services including chain events poller to healthz helper", async () => {
+      const { controller, healthzHelperService, dbHealthzService, brokerHealthzService, chainEventsPollerService } = await setup();
+      healthzHelperService.throwUnlessHealthy.mockResolvedValue({ status: "ok", data: {} });
+
+      await controller.getReadiness();
+
+      expect(healthzHelperService.throwUnlessHealthy).toHaveBeenCalledWith("readiness", dbHealthzService, brokerHealthzService, chainEventsPollerService);
+    });
+
+    it("throws when healthz helper throws", async () => {
+      const { controller, healthzHelperService } = await setup();
+      healthzHelperService.throwUnlessHealthy.mockRejectedValue(new ServiceUnavailableException());
+
+      await expect(controller.getReadiness()).rejects.toThrow(ServiceUnavailableException);
+    });
+  });
+
+  describe("getLiveness", () => {
+    it("passes all services including chain events poller to healthz helper", async () => {
+      const { controller, healthzHelperService, dbHealthzService, brokerHealthzService, chainEventsPollerService } = await setup();
+      healthzHelperService.throwUnlessHealthy.mockResolvedValue({ status: "ok", data: {} });
+
+      await controller.getLiveness();
+
+      expect(healthzHelperService.throwUnlessHealthy).toHaveBeenCalledWith("liveness", dbHealthzService, brokerHealthzService, chainEventsPollerService);
+    });
+
+    it("throws when healthz helper throws", async () => {
+      const { controller, healthzHelperService } = await setup();
+      healthzHelperService.throwUnlessHealthy.mockRejectedValue(new ServiceUnavailableException());
+
+      await expect(controller.getLiveness()).rejects.toThrow(ServiceUnavailableException);
+    });
+  });
+
+  async function setup(): Promise<{
+    module: TestingModule;
+    controller: HealthzController;
+    healthzHelperService: MockProxy<HealthzHelperService>;
+    dbHealthzService: MockProxy<DbHealthzService>;
+    brokerHealthzService: MockProxy<BrokerHealthzService>;
+    chainEventsPollerService: MockProxy<ChainEventsPollerService>;
+  }> {
+    const module = await Test.createTestingModule({
+      controllers: [HealthzController],
+      providers: [
+        MockProvider(HealthzHelperService),
+        MockProvider(DbHealthzService),
+        MockProvider(BrokerHealthzService),
+        MockProvider(ChainEventsPollerService)
+      ]
+    }).compile();
+
+    return {
+      module,
+      controller: module.get(HealthzController),
+      healthzHelperService: module.get(HealthzHelperService),
+      dbHealthzService: module.get(DbHealthzService),
+      brokerHealthzService: module.get(BrokerHealthzService),
+      chainEventsPollerService: module.get(ChainEventsPollerService)
+    };
+  }
+});

--- a/apps/notifications/src/interfaces/chain-events/controllers/healthz/healthz.controller.ts
+++ b/apps/notifications/src/interfaces/chain-events/controllers/healthz/healthz.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get } from "@nestjs/common";
+import { ApiExcludeController } from "@nestjs/swagger";
+
+import { HealthzHelperService } from "@src/common/services/healthz-helper/healthz-helper.service";
+import { BrokerHealthzService } from "@src/infrastructure/broker/services/broker-healthz/broker-healthz.service";
+import { DbHealthzService } from "@src/infrastructure/db/services/db-healthz/db-healthz.service";
+import { ChainEventsPollerService } from "@src/modules/chain/services/chain-events-poller/chain-events-poller.service";
+
+@ApiExcludeController()
+@Controller("healthz")
+export class HealthzController {
+  constructor(
+    private readonly dbHealthzService: DbHealthzService,
+    private readonly brokerHealthzService: BrokerHealthzService,
+    private readonly healthzHelperService: HealthzHelperService,
+    private readonly chainEventsPollerService: ChainEventsPollerService
+  ) {}
+
+  @Get("readiness")
+  async getReadiness() {
+    return await this.healthzHelperService.throwUnlessHealthy("readiness", this.dbHealthzService, this.brokerHealthzService, this.chainEventsPollerService);
+  }
+
+  @Get("liveness")
+  async getLiveness() {
+    return await this.healthzHelperService.throwUnlessHealthy("liveness", this.dbHealthzService, this.brokerHealthzService, this.chainEventsPollerService);
+  }
+}

--- a/apps/notifications/src/modules/chain/chain.module.ts
+++ b/apps/notifications/src/modules/chain/chain.module.ts
@@ -35,6 +35,6 @@ import * as schema from "./model-schemas";
     BlockCursorRepository,
     DbHealthzService
   ],
-  exports: [BlockMessageService, MessageDecoderService, DbHealthzService]
+  exports: [BlockMessageService, MessageDecoderService, DbHealthzService, ChainEventsPollerService]
 })
 export class ChainModule {}

--- a/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.spec.ts
+++ b/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.spec.ts
@@ -89,6 +89,53 @@ describe(ChainEventsPollerService.name, () => {
     expect(module.get(ShutdownService).shutdown).toHaveBeenCalled();
   });
 
+  describe("getReadinessStatus", () => {
+    it("returns ok before poller has started", async () => {
+      const { service } = await setup();
+
+      const result = await service.getReadinessStatus();
+
+      expect(result).toEqual({ status: "ok", data: { poller: true } });
+    });
+
+    it("returns ok while poller is running", async () => {
+      const { service, blockMessageService } = await setup();
+      blockMessageService.getMessages.mockResolvedValue(generateMockBlockData({ time: new Date().toISOString() }));
+
+      await service.onModuleInit();
+      await delay(50);
+
+      const result = await service.getReadinessStatus();
+
+      expect(result).toEqual({ status: "ok", data: { poller: true } });
+
+      await service.onModuleDestroy();
+    });
+
+    it("returns error after poller crashes", async () => {
+      const { service, blockCursorRepository } = await setup();
+      blockCursorRepository.getNextBlockForProcessing.mockRejectedValue(new Error("fail"));
+
+      service.onModuleInit();
+      await delay(500);
+
+      const result = await service.getReadinessStatus();
+
+      expect(result).toEqual({ status: "error", data: { poller: false } });
+    });
+  });
+
+  describe("getLivenessStatus", () => {
+    it("delegates to getReadinessStatus", async () => {
+      const { service } = await setup();
+
+      const readiness = await service.getReadinessStatus();
+      const liveness = await service.getLivenessStatus();
+
+      expect(liveness).toEqual(readiness);
+    });
+  });
+
   it("completes currently processed block before shutdown is finalized", async () => {
     const { service, blockMessageService } = await setup();
     const controller = Promise.withResolvers<ReturnType<typeof generateMockBlockData>>();

--- a/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.ts
+++ b/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.ts
@@ -9,6 +9,7 @@ import { setTimeout as delay } from "timers/promises";
 import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import { LoggerService } from "@src/common/services/logger/logger.service";
 import { ShutdownService } from "@src/common/services/shutdown/shutdown.service";
+import type { HealthzService, ProbeResult } from "@src/common/types/healthz.type";
 import { BrokerService } from "@src/infrastructure/broker";
 import type { ChainEventsConfig } from "@src/modules/chain/config";
 import { BlockCursorRepository } from "@src/modules/chain/repositories/block-cursor/block-cursor.repository";
@@ -17,7 +18,9 @@ import { TxEventsService } from "@src/modules/chain/services/tx-events-service/t
 import { BlockMessageService } from "../block-message/block-message.service";
 
 @Injectable()
-export class ChainEventsPollerService implements OnModuleInit, OnModuleDestroy {
+export class ChainEventsPollerService implements OnModuleInit, OnModuleDestroy, HealthzService {
+  readonly name = "chain-events-poller";
+
   private abortController?: AbortController;
 
   constructor(
@@ -134,12 +137,24 @@ export class ChainEventsPollerService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
+  async getReadinessStatus(): Promise<ProbeResult> {
+    const isLive = !this.abortController?.signal?.aborted;
+    return {
+      status: isLive ? "ok" : "error",
+      data: { poller: isLive }
+    };
+  }
+
+  async getLivenessStatus(): Promise<ProbeResult> {
+    return this.getReadinessStatus();
+  }
+
   async onModuleDestroy() {
     await this.finishPolling();
   }
 
   private async finishPolling() {
-    if (this.abortController) {
+    if (this.abortController && !this.abortController.signal.aborted) {
       const completePolling = once(this.abortController.signal, "complete");
       this.abortController.abort();
       await completePolling;


### PR DESCRIPTION
## Why

Incident: the chain events poller silently crashed and went undetected for 5 days.

**Root cause:** `finishPolling()` in `onModuleDestroy` did not check whether the abort signal was already aborted. When the poller crashed, the `.catch` handler aborted the signal, but `finishPolling` still called `once(signal, "complete")` waiting for an event that would never fire (since `processBlocksLooping` had already rejected and never reached the line that dispatches `"complete"`). This caused `app.close()` to hang indefinitely, preventing the full shutdown lifecycle — so the container stayed alive with a dead poller and passing health checks.

When a release eventually restarted the container, the poller recovered and processed all ~72,000 missed blocks without delay, triggering spurious notifications to users.

## What

- Fix `finishPolling` to skip waiting when the abort signal is already aborted
- Implement `HealthzService` on `ChainEventsPollerService` so liveness/readiness probes fail when the poller is down (defense in depth)
- Add a dedicated `HealthzController` for the `chain-events` interface that includes the poller in health checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added health check endpoints (readiness and liveness probes) for the notifications service to enable monitoring of service health and chain events poller status.

* **Tests**
  * Added comprehensive unit tests for health check functionality and chain events poller status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->