### PR TITLE
refactor: requires otel inside npm run prod

### DIFF
--- a/.helm/console-api-prod-mainnet-values.yaml
+++ b/.helm/console-api-prod-mainnet-values.yaml
@@ -12,24 +12,32 @@ jobs:
     schedule: "0 * * * *" # 0 minutes past the hour
     command:
       - node
+      - --require
+      - "@opentelemetry/auto-instrumentations-node/register"
       - dist/console.js
       - top-up-deployments
   - name: refill-wallets
     schedule: "45 * * * *" # 45 minutes past the hour
     command:
       - node
+      - --require
+      - "@opentelemetry/auto-instrumentations-node/register"
       - dist/console.js
       - refill-wallets
   - name: cleanup-stale-deployments
     schedule: "30 10,22 * * *" # 10:30 AM and 10:30 PM every day
     command:
       - node
+      - --require
+      - "@opentelemetry/auto-instrumentations-node/register"
       - dist/console.js
       - cleanup-stale-deployments
   - name: gpu-pricing-bot
     schedule: "0 12 * * *"
     command:
       - node
+      - --require
+      - "@opentelemetry/auto-instrumentations-node/register"
       - dist/console.js
       - gpu-pricing-bot
 

--- a/.helm/console-api-prod-mainnet-values.yaml
+++ b/.helm/console-api-prod-mainnet-values.yaml
@@ -1,6 +1,6 @@
 deploymentEnv: production
-nodeOptions:
-  enabledOTEL: true
+otel:
+  enabled: true
 
 chain: mainnet
 hostNames:

--- a/.helm/console-api-prod-sandbox-values.yaml
+++ b/.helm/console-api-prod-sandbox-values.yaml
@@ -1,6 +1,6 @@
 deploymentEnv: production
-nodeOptions:
-  enabledOTEL: true
+otel:
+  enabled: true
 
 chain: sandbox
 hostNames:

--- a/.helm/console-api-staging-mainnet-values.yaml
+++ b/.helm/console-api-staging-mainnet-values.yaml
@@ -1,6 +1,6 @@
 deploymentEnv: staging
-nodeOptions:
-  enabledOTEL: true
+otel:
+  enabled: true
 
 chain: mainnet
 hostNames:

--- a/.helm/console-api-staging-sandbox-values.yaml
+++ b/.helm/console-api-staging-sandbox-values.yaml
@@ -1,6 +1,6 @@
 deploymentEnv: staging
-nodeOptions:
-  enabledOTEL: true
+otel:
+  enabled: true
 
 chain: sandbox
 hostNames:

--- a/.helm/console-api-staging-sandbox-values.yaml
+++ b/.helm/console-api-staging-sandbox-values.yaml
@@ -10,18 +10,24 @@ jobs:
     schedule: "0 * * * *" # 0 minutes past the hour
     command:
       - node
+      - --require
+      - "@opentelemetry/auto-instrumentations-node/register"
       - dist/console.js
       - top-up-deployments
   - name: refill-wallets
     schedule: "45 * * * *" # 45 minutes past the hour
     command:
       - node
+      - --require
+      - "@opentelemetry/auto-instrumentations-node/register"
       - dist/console.js
       - refill-wallets
   - name: cleanup-stale-deployments
     schedule: "30 10 * * 2" # 10:30 AM every Tuesday
     command:
       - node
+      - --require
+      - "@opentelemetry/auto-instrumentations-node/register"
       - dist/console.js
       - cleanup-stale-deployments
 

--- a/.helm/console-api-staging-testnet-values.yaml
+++ b/.helm/console-api-staging-testnet-values.yaml
@@ -1,6 +1,6 @@
 deploymentEnv: staging
-nodeOptions:
-  enabledOTEL: true
+otel:
+  enabled: true
 
 chain: testnet
 hostNames:

--- a/.helm/indexer-prod-mainnet-values.yaml
+++ b/.helm/indexer-prod-mainnet-values.yaml
@@ -1,6 +1,6 @@
 deploymentEnv: production
-nodeOptions:
-  enabledOTEL: true
+otel:
+  enabled: true
 
 chain: mainnet
 nodePort: 30001

--- a/.helm/indexer-prod-sandbox-values.yaml
+++ b/.helm/indexer-prod-sandbox-values.yaml
@@ -1,6 +1,6 @@
 deploymentEnv: production
-nodeOptions:
-  enabledOTEL: true
+otel:
+  enabled: true
 
 chain: sandbox
 nodePort: 30000

--- a/.helm/provider-proxy-prod-mainnet-values.yaml
+++ b/.helm/provider-proxy-prod-mainnet-values.yaml
@@ -1,5 +1,5 @@
 deploymentEnv: production
-nodeOptions:
-  enabledOTEL: false
+otel:
+  enabled: true
 
 chain: mainnet

--- a/.helm/provider-proxy-prod-sandbox-values.yaml
+++ b/.helm/provider-proxy-prod-sandbox-values.yaml
@@ -1,5 +1,5 @@
 deploymentEnv: production
-nodeOptions:
-  enabledOTEL: false
+otel:
+  enabled: true
 
 chain: sandbox

--- a/.helm/provider-proxy-staging-mainnet-values.yaml
+++ b/.helm/provider-proxy-staging-mainnet-values.yaml
@@ -1,5 +1,5 @@
 deploymentEnv: staging
-nodeOptions:
-  enabledOTEL: false
+otel:
+  enabled: true
 
 chain: mainnet

--- a/.helm/provider-proxy-staging-sandbox-values.yaml
+++ b/.helm/provider-proxy-staging-sandbox-values.yaml
@@ -1,5 +1,5 @@
 deploymentEnv: staging
-nodeOptions:
-  enabledOTEL: false
+otel:
+  enabled: true
 
 chain: sandbox

--- a/.helm/provider-proxy-staging-testnet-values.yaml
+++ b/.helm/provider-proxy-staging-testnet-values.yaml
@@ -1,5 +1,5 @@
 deploymentEnv: staging
-nodeOptions:
-  enabledOTEL: false
+otel:
+  enabled: true
 
 chain: testnet

--- a/.helm/tx-signer-prod-mainnet-values.yaml
+++ b/.helm/tx-signer-prod-mainnet-values.yaml
@@ -1,4 +1,4 @@
 deploymentEnv: production
 chain: mainnet
-nodeOptions:
-  enabledOTEL: true
+otel:
+  enabled: true

--- a/.helm/tx-signer-prod-sandbox-values.yaml
+++ b/.helm/tx-signer-prod-sandbox-values.yaml
@@ -1,4 +1,4 @@
 deploymentEnv: production
 chain: sandbox
-nodeOptions:
-  enabledOTEL: true
+otel:
+  enabled: true

--- a/.helm/tx-signer-staging-mainnet-values.yaml
+++ b/.helm/tx-signer-staging-mainnet-values.yaml
@@ -1,4 +1,4 @@
 deploymentEnv: staging
 chain: mainnet
-nodeOptions:
-  enabledOTEL: true
+otel:
+  enabled: true

--- a/.helm/tx-signer-staging-sandbox-values.yaml
+++ b/.helm/tx-signer-staging-sandbox-values.yaml
@@ -1,4 +1,4 @@
 deploymentEnv: staging
 chain: sandbox
-nodeOptions:
-  enabledOTEL: true
+otel:
+  enabled: true

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,7 +20,7 @@
     "format": "prettier --write ./*.{js,json} **/*.{ts,js,json}",
     "lint": "eslint .",
     "migration:gen": "drizzle-kit generate",
-    "prod": "doppler run -- node dist/server.js",
+    "prod": "node --require @opentelemetry/auto-instrumentations-node/register dist/server.js",
     "start": "tsup --watch",
     "start:dev": "tsup src/server.ts --watch",
     "test": "vitest run --project=unit --project=functional --project=integration",

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint .",
     "migration:exec": "drizzle-kit migrate",
     "migration:pull": "drizzle-kit pull",
-    "prod": "node --max-old-space-size=8192 dist/index.js",
+    "prod": "node --max-old-space-size=8192 --require @opentelemetry/auto-instrumentations-node/register dist/index.js",
     "start": "tsup --watch",
     "validate:types": "tsc -p tsconfig.strict.json --noEmit && echo"
   },

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -24,7 +24,7 @@
     "start": "nest start",
     "start:debug": "nest start --debug --watch",
     "start:dev": "nest start --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "node --require @opentelemetry/auto-instrumentations-node/register dist/main",
     "test": "vitest run --project=unit --project=functional",
     "test:ci-setup": "dc up -d --wait --wait-timeout 60 db",
     "test:ci-teardown": "dc down",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -12,7 +12,7 @@
     "dev-nodc": "npm run start",
     "format": "prettier --write ./*.{ts,js,json} **/*.{ts,js,json}",
     "lint": "eslint .",
-    "prod": "node dist/server.js",
+    "prod": "node --require @opentelemetry/auto-instrumentations-node/register dist/server.js",
     "start": "tsup --watch",
     "start:dev": "tsup src/server.ts --watch",
     "test": "jest --selectProjects unit functional",


### PR DESCRIPTION
## Why

Every app requires own set of instrumentation tools. Key reasons why embedding it in the prod script is better than NODE_OPTIONS in Helm:

1. Visibility — The instrumentation requirement is visible in the app's own package.json, right where the app starts. Developers don't need to inspect Helm values to understand what flags the process runs with.

2. Dev/prod parity — Anyone running npm run prod locally gets the same behavior as production. With Helm-only config, local runs silently skip instrumentation, making issues harder to reproduce.

3. Colocation with the app — The startup configuration lives with the code it belongs to, following the principle of least surprise.

4. Less fragile — NODE_OPTIONS is a global catch-all env var. If multiple Helm templates, CI configs, or Dockerfiles all append to it, ordering and override conflicts can silently break things. An explicit --require in the command is deterministic.

5. Reviewability — Changes to app startup are tracked in the same repo/PR as the app code, go through the same review process, and show up in the same git blame. Helm value changes often live in a separate flow.

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automatic OpenTelemetry runtime instrumentation across multiple backend services to improve observability.
  * Consolidated telemetry configuration in deployment values so telemetry toggles are exposed under a dedicated otel.enabled setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->