### PR TITLE
feat(provider): add address filtering to provider list endpoint

### DIFF
--- a/apps/api/src/provider/controllers/provider/provider.controller.ts
+++ b/apps/api/src/provider/controllers/provider/provider.controller.ts
@@ -3,7 +3,7 @@ import { singleton } from "tsyringe";
 import { ProviderCleanupService } from "@src/billing/services/provider-cleanup/provider-cleanup.service";
 import { ProviderCleanupParams } from "@src/billing/types/provider-cleanup";
 import { cacheKeys, cacheResponse } from "@src/caching/helpers";
-import { ProviderListQuery } from "@src/provider/http-schemas/provider.schema";
+import type { ProviderListQuery } from "@src/provider/http-schemas/provider.schema";
 import { ProviderService } from "@src/provider/services/provider/provider.service";
 import { ProviderStatsService } from "@src/provider/services/provider-stats/provider-stats.service";
 import { TrialProvidersService } from "@src/provider/services/trial-providers/trial-providers.service";
@@ -34,6 +34,10 @@ export class ProviderController {
       const json = JSON.stringify(data);
       return encoder.encode(json);
     });
+  }
+
+  async getFilteredProviderList(scope: ProviderListQuery["scope"], addresses: string[]) {
+    return this.providerService.getProviderListByAddresses(addresses, scope === "trial");
   }
 
   async getProvider(address: string) {

--- a/apps/api/src/provider/http-schemas/provider.schema.ts
+++ b/apps/api/src/provider/http-schemas/provider.schema.ts
@@ -3,8 +3,21 @@ import { z } from "zod";
 import { openApiExampleProviderAddress } from "@src/utils/constants";
 import { AkashAddressSchema } from "@src/utils/schema";
 
+const MAX_ADDRESSES = 20;
+
+const AddressesSchema = z
+  .string()
+  .transform(val =>
+    val
+      .split(",")
+      .map(a => a.trim())
+      .filter(Boolean)
+  )
+  .pipe(z.array(z.string().min(1)).min(1).max(MAX_ADDRESSES));
+
 export const ProviderListQuerySchema = z.object({
-  scope: z.enum(["all", "trial"]).default("all")
+  scope: z.enum(["all", "trial"]).default("all"),
+  addresses: AddressesSchema.optional()
 });
 export const ProviderListResponseSchema = z.array(
   z.object({

--- a/apps/api/src/provider/repositories/provider/provider.repository.ts
+++ b/apps/api/src/provider/repositories/provider/provider.repository.ts
@@ -126,10 +126,16 @@ export class ProviderRepository {
     return rows.map(row => row.hostUri);
   }
 
-  async getWithAttributesAndAuditors({ trial = false, limit, offset }: { trial?: boolean; limit?: number; offset?: number } = {}) {
+  async getWithAttributesAndAuditors({
+    trial = false,
+    addresses,
+    limit,
+    offset
+  }: { trial?: boolean; addresses?: string[]; limit?: number; offset?: number } = {}) {
     return await Provider.findAll({
       where: {
-        deletedHeight: null
+        deletedHeight: null,
+        ...(addresses && { owner: { [Op.in]: addresses } })
       },
       order: [["createdHeight", "ASC"]],
       limit,
@@ -155,11 +161,12 @@ export class ProviderRepository {
     });
   }
 
-  async getProviderWithNodes({ limit, offset }: { limit?: number; offset?: number } = {}) {
+  async getProviderWithNodes({ addresses, limit, offset }: { addresses?: string[]; limit?: number; offset?: number } = {}) {
     return await Provider.findAll({
       attributes: ["owner"],
       where: {
-        deletedHeight: null
+        deletedHeight: null,
+        ...(addresses && { owner: { [Op.in]: addresses } })
       },
       limit,
       offset,

--- a/apps/api/src/provider/routes/providers/providers.router.ts
+++ b/apps/api/src/provider/routes/providers/providers.router.ts
@@ -40,8 +40,13 @@ const providerListRoute = createRoute({
 });
 
 providersRouter.openapi(providerListRoute, async function routeListProviders(c) {
-  const { scope } = c.req.valid("query");
+  const { scope, addresses } = c.req.valid("query");
   const controller = container.resolve(ProviderController);
+
+  if (addresses) {
+    const data = await controller.getFilteredProviderList(scope, addresses);
+    return c.json(data) as TypedResponse<ProviderListResponse, 200, "json">;
+  }
 
   const buffer = await controller.getProviderListBuffer(scope);
   return new Response(buffer, {

--- a/apps/api/src/provider/services/provider/provider.service.spec.ts
+++ b/apps/api/src/provider/services/provider/provider.service.spec.ts
@@ -1,5 +1,6 @@
 import type { JwtTokenPayload } from "@akashnetwork/chain-sdk";
 import type { Provider } from "@akashnetwork/database/dbSchemas/akash";
+import type { ProviderAttributesSchema } from "@akashnetwork/http-sdk";
 import { netConfig } from "@akashnetwork/net";
 import { faker } from "@faker-js/faker";
 import { AxiosError } from "axios";
@@ -7,9 +8,10 @@ import { Ok } from "ts-results";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { AUDITOR } from "@src/deployment/config/provider.config";
 import { mockConfigService } from "../../../../test/mocks/config-service.mock";
 import { LeaseStatusSeeder } from "../../../../test/seeders/lease-status.seeder";
-import { createProviderSeed } from "../../../../test/seeders/provider.seeder";
+import { createProviderSeed, createProviderWithAttributeSignatures } from "../../../../test/seeders/provider.seeder";
 import { UserWalletSeeder } from "../../../../test/seeders/user-wallet.seeder";
 import type { BillingConfigService } from "../../../billing/services/billing-config/billing-config.service";
 import type { ProviderRepository } from "../../repositories/provider/provider.repository";
@@ -18,6 +20,37 @@ import type { ProviderAttributesSchemaService } from "../provider-attributes-sch
 import type { ProviderJwtTokenService } from "../provider-jwt-token/provider-jwt-token.service";
 import { ProviderService } from "./provider.service";
 import type { ProviderProxyService } from "./provider-proxy.service";
+
+const schemaDetail = { key: "test", type: "string" as const, required: false, description: "test", values: null };
+const providerAttributeSchemaStub: ProviderAttributesSchema = {
+  host: schemaDetail,
+  email: schemaDetail,
+  organization: schemaDetail,
+  website: schemaDetail,
+  tier: schemaDetail,
+  "status-page": schemaDetail,
+  "location-region": schemaDetail,
+  country: schemaDetail,
+  city: schemaDetail,
+  timezone: schemaDetail,
+  "location-type": schemaDetail,
+  "hosting-provider": schemaDetail,
+  "hardware-cpu": schemaDetail,
+  "hardware-cpu-arch": schemaDetail,
+  "hardware-gpu": schemaDetail,
+  "hardware-gpu-model": schemaDetail,
+  "hardware-disk": schemaDetail,
+  "hardware-memory": schemaDetail,
+  "network-provider": schemaDetail,
+  "network-speed-up": schemaDetail,
+  "network-speed-down": schemaDetail,
+  "feat-persistent-storage": schemaDetail,
+  "feat-persistent-storage-type": schemaDetail,
+  "workload-support-chia": schemaDetail,
+  "workload-support-chia-capabilities": schemaDetail,
+  "feat-endpoint-ip": schemaDetail,
+  "feat-endpoint-custom-domain": schemaDetail
+};
 
 describe(ProviderService.name, () => {
   describe("sendManifest", () => {
@@ -342,6 +375,71 @@ describe(ProviderService.name, () => {
       await expect(
         service.getLeaseStatus(provider.owner, dseq, gseq, oseq, await service.toProviderAuth({ walletId: wallet.id, provider: provider.owner }))
       ).rejects.toThrow(`Provider ${provider.owner} not found`);
+    });
+  });
+
+  describe("getProviderListByAddresses", () => {
+    it("should return mapped providers for given addresses", async () => {
+      const { service, providerRepository, auditorsService, providerAttributesSchemaService } = setup();
+
+      const provider1 = createProviderWithAttributeSignatures(AUDITOR) as unknown as Provider;
+      const provider2 = createProviderWithAttributeSignatures(AUDITOR) as unknown as Provider;
+      const addresses = [provider1.owner, provider2.owner];
+
+      providerRepository.getWithAttributesAndAuditors.mockResolvedValue([provider1, provider2]);
+      providerRepository.getProviderWithNodes.mockResolvedValue([]);
+      auditorsService.getAuditors.mockResolvedValue([]);
+      providerAttributesSchemaService.getProviderAttributesSchema.mockResolvedValue(providerAttributeSchemaStub);
+
+      const result = await service.getProviderListByAddresses(addresses);
+
+      expect(providerRepository.getWithAttributesAndAuditors).toHaveBeenCalledWith({ trial: false, addresses });
+      expect(providerRepository.getProviderWithNodes).toHaveBeenCalledWith({ addresses });
+      expect(result).toHaveLength(2);
+      expect(result.map(p => p.owner)).toEqual([provider1.owner, provider2.owner]);
+    });
+
+    it("should pass trial flag to repository", async () => {
+      const { service, providerRepository, auditorsService, providerAttributesSchemaService } = setup();
+
+      providerRepository.getWithAttributesAndAuditors.mockResolvedValue([]);
+      providerRepository.getProviderWithNodes.mockResolvedValue([]);
+      auditorsService.getAuditors.mockResolvedValue([]);
+      providerAttributesSchemaService.getProviderAttributesSchema.mockResolvedValue(providerAttributeSchemaStub);
+
+      await service.getProviderListByAddresses(["addr1"], true);
+
+      expect(providerRepository.getWithAttributesAndAuditors).toHaveBeenCalledWith({ trial: true, addresses: ["addr1"] });
+    });
+
+    it("should deduplicate providers with the same hostUri", async () => {
+      const { service, providerRepository, auditorsService, providerAttributesSchemaService } = setup();
+
+      const provider1 = createProviderWithAttributeSignatures(AUDITOR) as unknown as Provider;
+      const provider2 = { ...createProviderWithAttributeSignatures(AUDITOR), hostUri: provider1.hostUri } as unknown as Provider;
+
+      providerRepository.getWithAttributesAndAuditors.mockResolvedValue([provider1, provider2]);
+      providerRepository.getProviderWithNodes.mockResolvedValue([]);
+      auditorsService.getAuditors.mockResolvedValue([]);
+      providerAttributesSchemaService.getProviderAttributesSchema.mockResolvedValue(providerAttributeSchemaStub);
+
+      const result = await service.getProviderListByAddresses([provider1.owner, provider2.owner]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].owner).toBe(provider1.owner);
+    });
+
+    it("should return empty array when no providers match", async () => {
+      const { service, providerRepository, auditorsService, providerAttributesSchemaService } = setup();
+
+      providerRepository.getWithAttributesAndAuditors.mockResolvedValue([]);
+      providerRepository.getProviderWithNodes.mockResolvedValue([]);
+      auditorsService.getAuditors.mockResolvedValue([]);
+      providerAttributesSchemaService.getProviderAttributesSchema.mockResolvedValue(providerAttributeSchemaStub);
+
+      const result = await service.getProviderListByAddresses(["unknown-addr"]);
+
+      expect(result).toEqual([]);
     });
   });
 

--- a/apps/api/src/provider/services/provider/provider.service.spec.ts
+++ b/apps/api/src/provider/services/provider/provider.service.spec.ts
@@ -412,18 +412,18 @@ describe(ProviderService.name, () => {
       expect(providerRepository.getWithAttributesAndAuditors).toHaveBeenCalledWith({ trial: true, addresses: ["addr1"] });
     });
 
-    it("should deduplicate providers with the same hostUri", async () => {
+    it("should deduplicate providers with the same owner", async () => {
       const { service, providerRepository, auditorsService, providerAttributesSchemaService } = setup();
 
       const provider1 = createProviderWithAttributeSignatures(AUDITOR) as unknown as Provider;
-      const provider2 = { ...createProviderWithAttributeSignatures(AUDITOR), hostUri: provider1.hostUri } as unknown as Provider;
+      const provider2 = { ...createProviderWithAttributeSignatures(AUDITOR), owner: provider1.owner } as unknown as Provider;
 
       providerRepository.getWithAttributesAndAuditors.mockResolvedValue([provider1, provider2]);
       providerRepository.getProviderWithNodes.mockResolvedValue([]);
       auditorsService.getAuditors.mockResolvedValue([]);
       providerAttributesSchemaService.getProviderAttributesSchema.mockResolvedValue(providerAttributeSchemaStub);
 
-      const result = await service.getProviderListByAddresses([provider1.owner, provider2.owner]);
+      const result = await service.getProviderListByAddresses([provider1.owner]);
 
       expect(result).toHaveLength(1);
       expect(result[0].owner).toBe(provider1.owner);

--- a/apps/api/src/provider/services/provider/provider.service.ts
+++ b/apps/api/src/provider/services/provider/provider.service.ts
@@ -205,8 +205,8 @@ export class ProviderService {
     const seenProviders = new Set<string>();
     const distinctProviders: Provider[] = [];
     for (const provider of providersWithAttributesAndAuditors) {
-      if (!seenProviders.has(provider.hostUri)) {
-        seenProviders.add(provider.hostUri);
+      if (!seenProviders.has(provider.owner)) {
+        seenProviders.add(provider.owner);
         distinctProviders.push(provider);
       }
     }

--- a/apps/api/src/provider/services/provider/provider.service.ts
+++ b/apps/api/src/provider/services/provider/provider.service.ts
@@ -1,4 +1,5 @@
 import { Provider, ProviderSnapshot, ProviderSnapshotNode, ProviderSnapshotNodeGPU } from "@akashnetwork/database/dbSchemas/akash";
+import type { ProviderAttributesSchema } from "@akashnetwork/http-sdk";
 import { NetConfig, SupportedChainNetworks } from "@akashnetwork/net";
 import { AxiosError } from "axios";
 import { add } from "date-fns";
@@ -10,6 +11,7 @@ import { singleton } from "tsyringe";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { Memoize } from "@src/caching/helpers";
 import { LeaseStatusResponse } from "@src/deployment/http-schemas/lease.schema";
+import type { Auditor } from "@src/provider/http-schemas/auditor.schema";
 import { ProviderRepository } from "@src/provider/repositories/provider/provider.repository";
 import { ProviderAuth, ProviderIdentity, ProviderProxyService } from "@src/provider/services/provider/provider-proxy.service";
 import { ProviderJwtTokenService } from "@src/provider/services/provider-jwt-token/provider-jwt-token.service";
@@ -181,6 +183,43 @@ export class ProviderService {
     });
 
     return finalProviders;
+  }
+
+  async getProviderListByAddresses(addresses: string[], trial = false): Promise<ProviderList[]> {
+    const [providersWithAttributesAndAuditors, providerWithNodes, auditors, providerAttributeSchema] = await Promise.all([
+      this.providerRepository.getWithAttributesAndAuditors({ trial, addresses }),
+      this.providerRepository.getProviderWithNodes({ addresses }),
+      this.auditorsService.getAuditors(),
+      this.providerAttributesSchemaService.getProviderAttributesSchema()
+    ]);
+
+    return this.mapProviderResults(providersWithAttributesAndAuditors, providerWithNodes, auditors, providerAttributeSchema);
+  }
+
+  private mapProviderResults(
+    providersWithAttributesAndAuditors: Provider[],
+    providerWithNodes: Provider[],
+    auditors: Auditor[],
+    providerAttributeSchema: ProviderAttributesSchema
+  ): ProviderList[] {
+    const seenProviders = new Set<string>();
+    const distinctProviders: Provider[] = [];
+    for (const provider of providersWithAttributesAndAuditors) {
+      if (!seenProviders.has(provider.hostUri)) {
+        seenProviders.add(provider.hostUri);
+        distinctProviders.push(provider);
+      }
+    }
+
+    const providerByOwner = new Map<string, Provider>();
+    for (const provider of providerWithNodes) {
+      providerByOwner.set(provider.owner, provider);
+    }
+
+    return distinctProviders.map(provider => {
+      const lastSuccessfulSnapshot = providerByOwner.get(provider.owner)?.lastSuccessfulSnapshot;
+      return mapProviderToList(provider, providerAttributeSchema, auditors, lastSuccessfulSnapshot);
+    });
   }
 
   @Memoize({ ttlInSeconds: 30 })

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -11062,6 +11062,14 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
               "type": "string",
             },
           },
+          {
+            "in": "query",
+            "name": "addresses",
+            "required": false,
+            "schema": {
+              "type": "string",
+            },
+          },
         ],
         "responses": {
           "200": {

--- a/apps/api/test/functional/providers.spec.ts
+++ b/apps/api/test/functional/providers.spec.ts
@@ -121,6 +121,40 @@ describe("Providers", () => {
       expect(response.status).toBe(200);
       expectProviders(data, [providers[0]]);
     });
+
+    it("returns only providers matching the addresses filter", async () => {
+      const response = await app.request(`/v1/providers?addresses=${providers[0].owner},${providers[2].owner}`);
+
+      const data = (await response.json()) as any;
+
+      expect(response.status).toBe(200);
+      expectProviders(data, [providers[0], providers[2]]);
+    });
+
+    it("returns only matching trial providers when addresses and scope=trial are combined", async () => {
+      const response = await app.request(`/v1/providers?scope=trial&addresses=${providers[0].owner},${providers[1].owner}`);
+
+      const data = (await response.json()) as any;
+
+      expect(response.status).toBe(200);
+      expectProviders(data, [providers[0]]);
+    });
+
+    it("returns an empty array for unknown addresses", async () => {
+      const response = await app.request("/v1/providers?addresses=akash1unknown");
+
+      const data = (await response.json()) as any;
+
+      expect(response.status).toBe(200);
+      expect(data).toEqual([]);
+    });
+
+    it("returns 400 when more than 20 addresses are provided", async () => {
+      const addresses = Array.from({ length: 21 }, (_, i) => `akash1addr${i}`).join(",");
+      const response = await app.request(`/v1/providers?addresses=${addresses}`);
+
+      expect(response.status).toBe(400);
+    });
   });
 
   describe("GET /v1/providers/:address", () => {

--- a/apps/api/test/functional/providers.spec.ts
+++ b/apps/api/test/functional/providers.spec.ts
@@ -7,6 +7,7 @@ import { container } from "tsyringe";
 
 import { cacheEngine } from "@src/caching/helpers";
 import { AUDITOR, TRIAL_ATTRIBUTE } from "@src/deployment/config/provider.config";
+import type { ProviderListResponse, ProviderResponse } from "@src/provider/http-schemas/provider.schema";
 import { app, initDb } from "@src/rest-app";
 
 import { createDay, createDeployment, createDeploymentGroup, createLease, createProvider, createProviderSnapshot } from "@test/seeders";
@@ -85,7 +86,7 @@ describe("Providers", () => {
     nock.cleanAll();
   });
 
-  const expectProviders = (providersFound: Provider[], providersExpected: Provider[]) => {
+  const expectProviders = (providersFound: { owner: string }[], providersExpected: { owner: string }[]) => {
     expect(providersFound.length).toBe(providersExpected.length);
 
     const ownersFound = map(providersFound, "owner");
@@ -98,7 +99,7 @@ describe("Providers", () => {
     it("returns all providers by default", async () => {
       const response = await app.request("/v1/providers");
 
-      const data = (await response.json()) as any;
+      const data = (await response.json()) as ProviderListResponse;
 
       expect(response.status).toBe(200);
       expectProviders(data, providers);
@@ -107,7 +108,7 @@ describe("Providers", () => {
     it("returns all providers when scope=all", async () => {
       const response = await app.request("/v1/providers?scope=all");
 
-      const data = (await response.json()) as any;
+      const data = (await response.json()) as ProviderListResponse;
 
       expect(response.status).toBe(200);
       expectProviders(data, providers);
@@ -116,7 +117,7 @@ describe("Providers", () => {
     it("returns trial providers when scope=trial", async () => {
       const response = await app.request("/v1/providers?scope=trial");
 
-      const data = (await response.json()) as any;
+      const data = (await response.json()) as ProviderListResponse;
 
       expect(response.status).toBe(200);
       expectProviders(data, [providers[0]]);
@@ -125,7 +126,7 @@ describe("Providers", () => {
     it("returns only providers matching the addresses filter", async () => {
       const response = await app.request(`/v1/providers?addresses=${providers[0].owner},${providers[2].owner}`);
 
-      const data = (await response.json()) as any;
+      const data = (await response.json()) as ProviderListResponse;
 
       expect(response.status).toBe(200);
       expectProviders(data, [providers[0], providers[2]]);
@@ -134,7 +135,7 @@ describe("Providers", () => {
     it("returns only matching trial providers when addresses and scope=trial are combined", async () => {
       const response = await app.request(`/v1/providers?scope=trial&addresses=${providers[0].owner},${providers[1].owner}`);
 
-      const data = (await response.json()) as any;
+      const data = (await response.json()) as ProviderListResponse;
 
       expect(response.status).toBe(200);
       expectProviders(data, [providers[0]]);
@@ -143,7 +144,7 @@ describe("Providers", () => {
     it("returns an empty array for unknown addresses", async () => {
       const response = await app.request("/v1/providers?addresses=akash1unknown");
 
-      const data = (await response.json()) as any;
+      const data = (await response.json()) as ProviderListResponse;
 
       expect(response.status).toBe(200);
       expect(data).toEqual([]);
@@ -161,7 +162,7 @@ describe("Providers", () => {
     it("returns a provider by address", async () => {
       const response = await app.request(`/v1/providers/${providers[0].owner}`);
 
-      const data = (await response.json()) as any;
+      const data = (await response.json()) as ProviderResponse;
 
       expect(response.status).toBe(200);
       expect(data.owner).toEqual(providers[0].owner);


### PR DESCRIPTION
## Why

Frontend components need to look up 1-3 providers by address but currently must fetch the entire provider list (~3 MB). A filter parameter reduces payload size to a few KB for targeted lookups.

closes CON-61

## What

- Add optional `addresses` query parameter to `GET /v1/providers` accepting a comma-separated list (max 20)
- Filter at the SQL level (`WHERE owner IN (...)`) instead of loading the full list
- Return 400 if more than 20 addresses are provided
- Existing behavior (no `addresses` param) is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added address-based filtering for provider lists via a query parameter; works with standard and trial scopes and returns deduplicated provider results.
  * Limits requests to 20 addresses and returns 400 when exceeded.

* **Tests**
  * Added functional tests for address filtering, trial-scope combinations, empty-results, and max-address validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->