### PR TITLE
fix: ensure react-query-proxy accepts argument during mutation call

### DIFF
--- a/packages/react-query-proxy/src/createProxy/createProxy.spec.ts
+++ b/packages/react-query-proxy/src/createProxy/createProxy.spec.ts
@@ -1,3 +1,5 @@
+import type { UseMutationResult } from "@tanstack/react-query";
+
 import { createProxy } from "./createProxy";
 
 interface User {
@@ -122,7 +124,7 @@ describe(createProxy.name, () => {
         })
       );
 
-      const mutationFn = useMutation.mock.calls[0][0].mutationFn;
+      const mutationFn = useMutation.mock.calls[0][0]?.mutationFn;
       mutationFn({ name: "John" });
       expect(sdk.users.create).toHaveBeenCalledWith({ name: "John" });
     });
@@ -148,6 +150,15 @@ describe(createProxy.name, () => {
           onSuccess
         })
       );
+    });
+
+    it("allows to pass method input as a value to mutation", () => {
+      const { proxy, useMutation } = setup();
+      const mutation = proxy.users.create.useMutation();
+
+      mutation.mutate({ name: "Alice" });
+
+      expect(useMutation).toHaveBeenCalled();
     });
   });
 
@@ -267,7 +278,9 @@ describe(createProxy.name, () => {
   function setup() {
     const sdk = createSdk();
     const useQuery = jest.fn();
-    const useMutation = jest.fn();
+    const useMutation = jest.fn().mockReturnValue({
+      mutate: jest.fn()
+    } as unknown as UseMutationResult<any, any, any, any>);
     const proxy = createProxy(sdk, {
       useQuery,
       useMutation

--- a/packages/react-query-proxy/src/createProxy/createProxy.ts
+++ b/packages/react-query-proxy/src/createProxy/createProxy.ts
@@ -91,15 +91,17 @@ type HooksProxy<T extends (...args: any[]) => any> = undefined extends Parameter
       getKey: (input?: undefined) => PropertyKey[];
       useQuery: (
         input?: undefined,
-        options?: Omit<UseQueryOptions<ReturnType<T>, Error, any, QueryKey>, "queryFn" | "queryKey"> & { queryKey?: QueryKey }
+        options?: Omit<UseQueryOptions<Awaited<ReturnType<T>>, Error, any, QueryKey>, "queryFn" | "queryKey"> & { queryKey?: QueryKey }
       ) => UseQueryResult<Awaited<ReturnType<T>>>;
-      useMutation: (options?: Omit<UseMutationOptions<ReturnType<T>, Error, any, any>, "mutationFn">) => UseMutationResult<Awaited<ReturnType<T>>>;
+      useMutation: (options?: Omit<UseMutationOptions<Awaited<ReturnType<T>>, Error, unknown, any>, "mutationFn">) => UseMutationResult<Awaited<ReturnType<T>>>;
     }
   : {
       getKey: (input: Parameters<T>[0]) => PropertyKey[];
       useQuery: (
         input: Parameters<T>[0],
-        options?: Omit<UseQueryOptions<ReturnType<T>, Error, any, QueryKey>, "queryFn" | "queryKey"> & { queryKey?: QueryKey }
+        options?: Omit<UseQueryOptions<Awaited<ReturnType<T>>, Error, any, QueryKey>, "queryFn" | "queryKey"> & { queryKey?: QueryKey }
       ) => UseQueryResult<Awaited<ReturnType<T>>>;
-      useMutation: (options?: Omit<UseMutationOptions<ReturnType<T>, Error, any, any>, "mutationFn">) => UseMutationResult<Awaited<ReturnType<T>>>;
+      useMutation: (
+        options?: Omit<UseMutationOptions<Awaited<ReturnType<T>>, Error, Parameters<T>[0], any>, "mutationFn">
+      ) => UseMutationResult<Awaited<ReturnType<T>>, Error, Parameters<T>[0], any>;
     };

--- a/packages/react-query-proxy/src/index.ts
+++ b/packages/react-query-proxy/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./createProxy/createProxy";


### PR DESCRIPTION
## Why

bug

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage with proper type mocking
  * Added validation for mutation input handling

* **Refactor**
  * Improved type inference for async function results
  * Refined input parameter type accuracy in hooks
  * Expanded public API exports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->