### PR TITLE
chore: migrate react-query-proxy from jest to vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52943,10 +52943,9 @@
         "eslint": "^8.57.0",
         "eslint-config-next": "^14.2.3",
         "eslint-plugin-simple-import-sort": "^12.1.0",
-        "jest": "^29.7.0",
         "prettier": "^3.3.0",
-        "ts-jest": "^29.4.0",
-        "typescript": "~5.8.2"
+        "typescript": "~5.8.2",
+        "vitest": "^4.0.0"
       }
     },
     "packages/react-query-sdk": {

--- a/packages/react-query-proxy/jest.config.ts
+++ b/packages/react-query-proxy/jest.config.ts
@@ -1,8 +1,0 @@
-import type { Config } from "jest";
-
-export default {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  testMatch: ["**/src/**/*.spec.ts"],
-  verbose: true
-} satisfies Config;

--- a/packages/react-query-proxy/package.json
+++ b/packages/react-query-proxy/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "format": "prettier --write ./*.{ts,json} **/*.{ts,json}",
     "lint": "eslint .",
-    "test": "jest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
@@ -23,9 +24,8 @@
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.3",
     "eslint-plugin-simple-import-sort": "^12.1.0",
-    "jest": "^29.7.0",
     "prettier": "^3.3.0",
-    "ts-jest": "^29.4.0",
+    "vitest": "^4.0.0",
     "typescript": "~5.8.2"
   }
 }

--- a/packages/react-query-proxy/src/createProxy/createProxy.spec.ts
+++ b/packages/react-query-proxy/src/createProxy/createProxy.spec.ts
@@ -1,4 +1,5 @@
 import type { UseMutationResult } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
 
 import { createProxy } from "./createProxy";
 
@@ -102,8 +103,8 @@ describe(createProxy.name, () => {
         }
       }
       const userService = new UserService();
-      jest.spyOn(userService, "getById");
-      const useQuery = jest.fn();
+      vi.spyOn(userService, "getById");
+      const useQuery = vi.fn();
       const proxy = createProxy(userService, { useQuery });
       proxy.getById.useQuery({ id: 1 });
       const queryFn = useQuery.mock.calls[0][0].queryFn;
@@ -141,7 +142,7 @@ describe(createProxy.name, () => {
     });
 
     it("passes through additional options to useMutation", () => {
-      const onSuccess = jest.fn();
+      const onSuccess = vi.fn();
       const { proxy, useMutation } = setup();
       proxy.users.create.useMutation({ onSuccess });
 
@@ -229,7 +230,7 @@ describe(createProxy.name, () => {
 
     it("applies custom inputToKey in useQuery", () => {
       const sdk = createSdk();
-      const useQuery = jest.fn();
+      const useQuery = vi.fn();
       const proxy = createProxy(sdk, {
         inputToKey: (input: unknown) => (input ? [JSON.stringify(input)] : []),
         useQuery
@@ -266,7 +267,7 @@ describe(createProxy.name, () => {
       const sdk = {
         nullValue: null as null,
         users: {
-          list: jest.fn()
+          list: vi.fn()
         }
       };
       const proxy = createProxy(sdk);
@@ -277,9 +278,9 @@ describe(createProxy.name, () => {
 
   function setup() {
     const sdk = createSdk();
-    const useQuery = jest.fn();
-    const useMutation = jest.fn().mockReturnValue({
-      mutate: jest.fn()
+    const useQuery = vi.fn();
+    const useMutation = vi.fn().mockReturnValue({
+      mutate: vi.fn()
     } as unknown as UseMutationResult<any, any, any, any>);
     const proxy = createProxy(sdk, {
       useQuery,
@@ -291,13 +292,13 @@ describe(createProxy.name, () => {
   function createSdk(): Sdk {
     return {
       users: {
-        list: jest.fn().mockResolvedValue([]),
-        getById: jest.fn().mockResolvedValue({ id: 1 }),
-        create: jest.fn().mockResolvedValue({ id: 1 })
+        list: vi.fn().mockResolvedValue([]),
+        getById: vi.fn().mockResolvedValue({ id: 1 }),
+        create: vi.fn().mockResolvedValue({ id: 1 })
       },
       admin: {
         settings: {
-          update: jest.fn().mockResolvedValue({ success: true })
+          update: vi.fn().mockResolvedValue({ success: true })
         }
       }
     };

--- a/packages/react-query-proxy/vitest.config.ts
+++ b/packages/react-query-proxy/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    name: "react-query-proxy",
+    include: ["**/src/**/*.spec.ts"],
+    environment: "node"
+  }
+});


### PR DESCRIPTION
## Why

Standardize test tooling across packages by migrating `react-query-proxy` from Jest to Vitest, consistent with other packages like `logging` and `net`.

## What

- Replaced `jest.config.ts` with `vitest.config.ts`
- Swapped `jest` and `ts-jest` dev dependencies for `vitest`
- Updated test scripts to use `vitest run` and added `test:watch`
- Replaced `jest.fn()` / `jest.spyOn` with `vi.fn()` / `vi.spyOn` in test file
- Added explicit vitest imports (`describe`, `expect`, `it`, `vi`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched test runner from Jest to Vitest.
  * Updated package scripts to use Vitest (including watch mode).
  * Added a Vitest configuration file and removed the prior Jest configuration.
  * Migrated test suites to Vitest-compatible APIs and mocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->