### PR TITLE
fix(deployment): validate fee grants before auto top-up transactions

### DIFF
--- a/.helm/console-api-prod-mainnet-values.yaml
+++ b/.helm/console-api-prod-mainnet-values.yaml
@@ -49,6 +49,6 @@ resources:
     ephemeral-storage: "2Gi"
     memory: "8Gi"
   requests:
-    cpu: "2"
+    cpu: "1"
     ephemeral-storage: "1Gi"
     memory: "4Gi"

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -169,12 +169,19 @@ export class ManagedSignerService {
   async #validateBalances(userWallet: UserWalletOutput, messages: EncodeObject[]) {
     return withSpan("ManagedSignerService.validateBalances", async () => {
       const hasDeploymentMessage = messages.some(message => message.typeUrl.endsWith(".MsgCreateDeployment"));
-      const [existingFeeAllowance, deploymentAllowance] = await Promise.all([
-        this.balancesService.retrieveAndCalcFeeLimit(userWallet),
+      const [feeAllowance, deploymentAllowance] = await Promise.all([
+        this.ensureFeeGrants(userWallet),
         !hasDeploymentMessage ? Promise.resolve(userWallet.deploymentAllowance) : this.balancesService.retrieveDeploymentLimit(userWallet)
       ]);
 
-      let feeAllowance = existingFeeAllowance;
+      assert(feeAllowance > 0, 402, "Not enough funds to cover the transaction fee");
+      assert(!hasDeploymentMessage || deploymentAllowance > 0, 402, "Not enough funds to cover the deployment costs");
+    });
+  }
+
+  async ensureFeeGrants(wallet: Pick<UserWalletOutput, "address" | "isTrialing" | "createdAt">): Promise<number> {
+    return withSpan("ManagedSignerService.ensureFeeGrants", async () => {
+      let feeAllowance = await this.balancesService.retrieveAndCalcFeeLimit(wallet);
       const needsRefill = feeAllowance < this.billingConfigService.get("FEE_ALLOWANCE_REFILL_THRESHOLD");
 
       const span = trace.getSpan(context.active());
@@ -182,12 +189,11 @@ export class ManagedSignerService {
       span?.setAttribute("balance.needsRefill", needsRefill);
 
       if (needsRefill) {
-        await this.managedUserWalletService.refillWalletFees(this, userWallet);
-        feeAllowance = await this.balancesService.retrieveAndCalcFeeLimit(userWallet);
+        await this.managedUserWalletService.refillWalletFees(this, wallet);
+        feeAllowance = await this.balancesService.retrieveAndCalcFeeLimit(wallet);
       }
 
-      assert(feeAllowance > 0, 402, "Not enough funds to cover the transaction fee");
-      assert(!hasDeploymentMessage || deploymentAllowance > 0, 402, "Not enough funds to cover the deployment costs");
+      return feeAllowance;
     });
   }
 

--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.spec.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.spec.ts
@@ -1,0 +1,94 @@
+import type { AuthzHttpService } from "@akashnetwork/http-sdk";
+import type { EncodeObject } from "@cosmjs/proto-signing";
+import { faker } from "@faker-js/faker";
+import addDays from "date-fns/addDays";
+import subDays from "date-fns/subDays";
+import { mock } from "vitest-mock-extended";
+
+import type { BillingConfig } from "@src/billing/providers";
+import type { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
+import type { ManagedSignerService } from "../managed-signer/managed-signer.service";
+import type { RpcMessageService } from "../rpc-message-service/rpc-message.service";
+import { ManagedUserWalletService } from "./managed-user-wallet.service";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+
+describe(ManagedUserWalletService.name, () => {
+  describe("refillWalletFees", () => {
+    it("throws 402 when wallet address is missing", async () => {
+      const { service, signer } = setup();
+
+      await expect(service.refillWalletFees(signer, { address: null, isTrialing: false, createdAt: faker.date.past() })).rejects.toMatchObject({
+        status: 402
+      });
+    });
+
+    it("authorizes fee spending without expiration for non-trialing wallet", async () => {
+      const { service, signer, config, rpcMessageService } = setup();
+      const wallet = { address: createAkashAddress(), isTrialing: false, createdAt: faker.date.past() };
+
+      await service.refillWalletFees(signer, wallet);
+
+      expect(rpcMessageService.getFeesAllowanceGrantMsg).toHaveBeenCalledWith(
+        expect.objectContaining({
+          grantee: wallet.address,
+          limit: config.FEE_ALLOWANCE_REFILL_AMOUNT,
+          expiration: undefined
+        })
+      );
+    });
+
+    it("authorizes fee spending with expiration for trialing wallet in trial window", async () => {
+      const { service, signer, config, rpcMessageService } = setup();
+      const createdAt = subDays(new Date(), 1);
+      const wallet = { address: createAkashAddress(), isTrialing: true, createdAt };
+
+      await service.refillWalletFees(signer, wallet);
+
+      const expectedExpiration = addDays(createdAt, config.TRIAL_ALLOWANCE_EXPIRATION_DAYS);
+      expect(rpcMessageService.getFeesAllowanceGrantMsg).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expiration: expectedExpiration
+        })
+      );
+    });
+
+    it("authorizes fee spending without expiration for trialing wallet outside trial window", async () => {
+      const { service, signer, config, rpcMessageService } = setup();
+      const createdAt = subDays(new Date(), config.TRIAL_ALLOWANCE_EXPIRATION_DAYS + 1);
+      const wallet = { address: createAkashAddress(), isTrialing: true, createdAt };
+
+      await service.refillWalletFees(signer, wallet);
+
+      expect(rpcMessageService.getFeesAllowanceGrantMsg).toHaveBeenCalledWith(
+        expect.objectContaining({
+          expiration: undefined
+        })
+      );
+    });
+  });
+
+  function setup() {
+    const config: BillingConfig = {
+      TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT: 500000,
+      TRIAL_FEES_ALLOWANCE_AMOUNT: 100000,
+      TRIAL_ALLOWANCE_EXPIRATION_DAYS: 14,
+      FEE_ALLOWANCE_REFILL_AMOUNT: 200000,
+      DEPLOYMENT_GRANT_DENOM: "uakt"
+    } as BillingConfig;
+
+    const txManagerService = mock<TxManagerService>();
+    const rpcMessageService = mock<RpcMessageService>();
+    const authzHttpService = mock<AuthzHttpService>();
+    const signer = mock<ManagedSignerService>();
+
+    txManagerService.getFundingWalletAddress.mockResolvedValue(createAkashAddress());
+    authzHttpService.hasFeeAllowance.mockResolvedValue(false);
+    rpcMessageService.getFeesAllowanceGrantMsg.mockReturnValue({ typeUrl: "/fee-grant", value: {} } as unknown as EncodeObject);
+    signer.executeFundingTx.mockResolvedValue({ code: 0, hash: "hash", rawLog: "[]" } as never);
+
+    const service = new ManagedUserWalletService(config, txManagerService, rpcMessageService, authzHttpService);
+
+    return { service, signer, config, txManagerService, rpcMessageService, authzHttpService };
+  }
+});

--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
@@ -96,16 +96,16 @@ export class ManagedUserWalletService {
    * @param userWallet - The user wallet to refill fees for
    */
   @Trace()
-  async refillWalletFees(signer: ManagedSignerService, { address, ...userWallet }: UserWalletOutput) {
-    assert(address, 402, "Wallet is not initialized");
+  async refillWalletFees(signer: ManagedSignerService, wallet: Pick<UserWalletOutput, "address" | "isTrialing" | "createdAt">) {
+    assert(wallet.address, 402, "Wallet is not initialized");
 
     const trialWindowStart = subDays(new Date(), this.config.TRIAL_ALLOWANCE_EXPIRATION_DAYS);
-    const isInTrialWindow = userWallet.isTrialing && isAfter(userWallet.createdAt, trialWindowStart);
-    const expiration = isInTrialWindow ? addDays(userWallet.createdAt, this.config.TRIAL_ALLOWANCE_EXPIRATION_DAYS) : undefined;
+    const isInTrialWindow = wallet.isTrialing && isAfter(wallet.createdAt, trialWindowStart);
+    const expiration = isInTrialWindow ? addDays(wallet.createdAt, this.config.TRIAL_ALLOWANCE_EXPIRATION_DAYS) : undefined;
     const fees = this.config.FEE_ALLOWANCE_REFILL_AMOUNT;
 
     await this.authorizeSpending(signer, {
-      address,
+      address: wallet.address,
       limits: {
         fees
       },

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -21,6 +21,8 @@ export type AutoTopUpDeployment = {
   dseq: string;
   address: string;
   isWalletAutoTopUpEnabled: boolean;
+  walletIsTrialing: boolean;
+  walletCreatedAt: Date;
 };
 
 @singleton()
@@ -74,7 +76,9 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
         dseq: this.table.dseq,
         walletId: UserWallets.id,
         address: UserWallets.address,
-        isWalletAutoTopUpEnabled: sql<boolean>`coalesce(${WalletSetting.autoReloadEnabled}, false)`
+        isWalletAutoTopUpEnabled: sql<boolean>`coalesce(${WalletSetting.autoReloadEnabled}, false)`,
+        walletIsTrialing: sql<boolean>`coalesce(${UserWallets.isTrialing}, true)`,
+        walletCreatedAt: UserWallets.createdAt
       })
       .from(this.table)
       .leftJoin(Users, eq(this.table.userId, Users.id))

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -324,6 +324,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         fee: 5000000,
         deployment: balanceByAddress[wallet.address!] ?? 0
       }));
+      vi.spyOn(balances, "retrieveAndCalcFeeLimit").mockResolvedValue(5000000);
     }
 
     return {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -23,6 +23,7 @@ import { DrainingDeploymentSeeder } from "@test/seeders/draining-deployment.seed
 describe(TopUpManagedDeploymentsService.name, () => {
   const DEPLOYMENT_GRANT_DENOM = "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1";
   const CURRENT_BLOCK_HEIGHT = 7481457;
+  const SUFFICIENT_FEE_ALLOWANCE = 100001;
 
   function createMockCachedBalance(reserveSufficientAmount: (desiredAmount: number) => number) {
     const balance = mock<CachedBalance>();
@@ -433,12 +434,107 @@ describe(TopUpManagedDeploymentsService.name, () => {
       expect(instrumentation.recordChainTxError).toHaveBeenCalledWith(expect.objectContaining({ error }));
       expect(instrumentation.finish).toHaveBeenCalledWith("success", CURRENT_BLOCK_HEIGHT);
     });
+
+    it("should call ensureFeeGrants before executing top-up", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService } = setup();
+      const deployment = AutoTopUpDeploymentSeeder.create();
+      const predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500;
+
+      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
+        (async function* () {
+          yield {
+            address: deployment.address,
+            deployments: [
+              {
+                ...deployment,
+                ...DrainingDeploymentSeeder.create({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
+                dseq: deployment.dseq
+              } as DrainingDeployment
+            ]
+          };
+        })()
+      );
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 500000));
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(managedSignerService.ensureFeeGrants).toHaveBeenCalledWith({
+        address: deployment.address,
+        isTrialing: deployment.walletIsTrialing,
+        createdAt: deployment.walletCreatedAt
+      });
+      expect(managedSignerService.executeDerivedTx).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not execute top-up when fee grant is missing and cannot be refilled", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, instrumentation } = setup({ feeAllowance: 0 });
+      const deployment = AutoTopUpDeploymentSeeder.create();
+      const predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500;
+
+      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
+        (async function* () {
+          yield {
+            address: deployment.address,
+            deployments: [
+              {
+                ...deployment,
+                ...DrainingDeploymentSeeder.create({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
+                dseq: deployment.dseq
+              } as DrainingDeployment
+            ]
+          };
+        })()
+      );
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 500000));
+
+      await service.topUpDeployments({ dryRun: false });
+
+      expect(managedSignerService.ensureFeeGrants).toHaveBeenCalled();
+      expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+      expect(instrumentation.recordChainTxError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          error: expect.objectContaining({ message: expect.stringContaining("Fee grant missing") })
+        })
+      );
+    });
+
+    it("should skip fee grant validation in dry run mode", async () => {
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService } = setup();
+      const deployment = AutoTopUpDeploymentSeeder.create();
+      const predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500;
+
+      drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
+        (async function* () {
+          yield {
+            address: deployment.address,
+            deployments: [
+              {
+                ...deployment,
+                ...DrainingDeploymentSeeder.create({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
+                dseq: deployment.dseq
+              } as DrainingDeployment
+            ]
+          };
+        })()
+      );
+      drainingDeploymentService.calculateTopUpAmount.mockResolvedValue(1000000);
+      cachedBalanceService.get.mockResolvedValue(createMockCachedBalance(() => 500000));
+
+      await service.topUpDeployments({ dryRun: true });
+
+      expect(managedSignerService.ensureFeeGrants).not.toHaveBeenCalled();
+      expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+    });
   });
 
-  function setup(input?: { currentBlockHeight?: number }) {
+  function setup(input?: { currentBlockHeight?: number; feeAllowance?: number }) {
     const currentBlockHeight = input?.currentBlockHeight ?? CURRENT_BLOCK_HEIGHT;
+    const feeAllowance = input?.feeAllowance ?? SUFFICIENT_FEE_ALLOWANCE;
 
     const managedSignerService = mock<ManagedSignerService>();
+    managedSignerService.ensureFeeGrants.mockResolvedValue(feeAllowance);
     const billingConfig = mockConfigService<BillingConfigService>({
       DEPLOYMENT_GRANT_DENOM,
       USDC_IBC_DENOMS: {

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -118,6 +118,18 @@ export class TopUpManagedDeploymentsService {
 
     try {
       if (!options.dryRun) {
+        const { address, walletIsTrialing: isTrialing, walletCreatedAt: createdAt } = ownerInputs[0].deployment;
+        const feeAllowance = await this.managedSignerService.ensureFeeGrants({ address, isTrialing, createdAt });
+
+        if (feeAllowance <= 0) {
+          this.instrumentation.recordChainTxError({
+            owner,
+            items: ownerInputs,
+            error: new Error(`Fee grant missing for wallet ${owner}, unable to top up deployments`)
+          });
+          return;
+        }
+
         await this.managedSignerService.executeDerivedTx(
           walletId,
           ownerInputs.map(i => i.message)

--- a/apps/api/test/seeders/auto-top-up-deployment.seeder.ts
+++ b/apps/api/test/seeders/auto-top-up-deployment.seeder.ts
@@ -11,6 +11,8 @@ export class AutoTopUpDeploymentSeeder {
       dseq: faker.string.numeric(),
       address: createAkashAddress(),
       isWalletAutoTopUpEnabled: false,
+      walletIsTrialing: false,
+      walletCreatedAt: faker.date.recent(),
       ...overrides
     };
   }


### PR DESCRIPTION
## Why

The auto top-up job called `ManagedSignerService.executeDerivedTx()` directly, bypassing fee grant validation that exists in the user-facing `executeDecodedTxByUserWallet()` flow. When a wallet's fee grant was missing or expired, the job would fail with an unrecoverable chain error instead of gracefully handling the situation.

## What

- Extracted fee grant validation from `ManagedSignerService.#validateBalances()` into a public `ensureFeeGrants()` method that checks fee allowance, refills if below threshold, and returns the current allowance
- Added `walletIsTrialing` and `walletCreatedAt` fields to `AutoTopUpDeployment` type so fee grant validation can be performed without an extra DB lookup
- `TopUpManagedDeploymentsService.topUpForOwner()` now calls `ensureFeeGrants()` before broadcasting — if allowance is zero, it logs the error and skips the owner instead of crashing
- Narrowed `ManagedUserWalletService.refillWalletFees()` wallet parameter type to `Pick<UserWalletOutput, "address" | "isTrialing" | "createdAt">`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fee-grant validation that checks and refills wallet fee allowances before executing managed top-ups.

* **Bug Fixes**
  * Prevents top-up execution when fee allowance is insufficient and logs the error.

* **Tests**
  * Expanded and added tests covering fee-grant checks, refill behaviors, and dry-run scenarios.

* **Chores**
  * Reduced CPU request for a production deployment value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->