### PR TITLE
fix(log-collector): triggers release on simple push to main

### DIFF
--- a/.github/workflows/log-collector-release.yml
+++ b/.github/workflows/log-collector-release.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "apps/log-collector/package.json"
 
 jobs:
   release:

--- a/apps/log-collector/package.json
+++ b/apps/log-collector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashnetwork/log-collector",
-  "version": "2.12.7",
+  "version": "1.0.0",
   "description": "A log collector worker to forward logs from provider to logging services for certain deployments ",
   "keywords": [
     "logs",


### PR DESCRIPTION
## Why

To make sure the log collector image is built

## What

Removed change detection path filter from the release workflow
Updated package.json version to 1.0.0 as it would never change from now on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to trigger on all pushes to main branch, removing previous path-based restrictions
  * Reset log-collector package version to 1.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->