### PR TITLE
chore(billing): removes amounts reporting

### DIFF
--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.spec.ts
@@ -1,0 +1,72 @@
+import { vi } from "vitest";
+
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn()
+}));
+
+vi.mock("@akashnetwork/logging/otel", () => ({
+  createOtelLogger: () => mockLogger
+}));
+
+import { faker } from "@faker-js/faker";
+import type { Counter, Histogram } from "@opentelemetry/api";
+import { mock } from "vitest-mock-extended";
+
+import type { MetricsService } from "@src/core";
+import { WalletBalanceReloadCheckInstrumentationService } from "./wallet-balance-reload-check-instrumentation.service";
+
+describe(WalletBalanceReloadCheckInstrumentationService.name, () => {
+  describe("recordReloadFailed", () => {
+    it("logs error with context when reload fails with an Error", () => {
+      const { service } = setup();
+      const error = new TypeError(faker.lorem.sentence());
+      const logContext = {
+        walletAddress: faker.string.alphanumeric(44),
+        balance: faker.number.float({ min: 0, max: 100 })
+      };
+
+      service.recordReloadFailed(error, logContext);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...logContext,
+          event: "WALLET_BALANCE_RELOAD_FAILED",
+          error
+        })
+      );
+    });
+
+    it("logs error with context when reload fails with a non-Error", () => {
+      const { service } = setup();
+      const error = faker.lorem.sentence();
+      const logContext = {
+        walletAddress: faker.string.alphanumeric(44),
+        balance: faker.number.float({ min: 0, max: 100 })
+      };
+
+      service.recordReloadFailed(error, logContext);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...logContext,
+          event: "WALLET_BALANCE_RELOAD_FAILED",
+          error
+        })
+      );
+    });
+  });
+
+  function setup() {
+    const metricsService = mock<MetricsService>();
+    metricsService.getMeter.mockReturnValue(mock());
+    metricsService.createCounter.mockReturnValue(mock<Counter>());
+    metricsService.createHistogram.mockReturnValue(mock<Histogram>());
+
+    const service = new WalletBalanceReloadCheckInstrumentationService(metricsService);
+
+    return { service };
+  }
+});

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.ts
@@ -14,7 +14,6 @@ export class WalletBalanceReloadCheckInstrumentationService {
   private readonly reloadFailures: Counter;
   private readonly validationErrors: Counter;
   private readonly schedulingErrors: Counter;
-  private readonly reloadAmounts: Histogram;
   private readonly balanceCoverageRatio: Histogram;
   private readonly projectedCost: Histogram;
 
@@ -52,11 +51,6 @@ export class WalletBalanceReloadCheckInstrumentationService {
       description: "Total number of errors when scheduling next check"
     });
 
-    this.reloadAmounts = this.metricsService.createHistogram(this.meter, "wallet_balance_reload_check_reload_amount_usd", {
-      description: "Amount of wallet balance reloads in USD",
-      unit: "USD"
-    });
-
     this.balanceCoverageRatio = this.metricsService.createHistogram(this.meter, "wallet_balance_reload_check_balance_coverage_ratio", {
       description: "Ratio of current balance to projected cost (balance / costUntilTargetDate)"
     });
@@ -84,7 +78,6 @@ export class WalletBalanceReloadCheckInstrumentationService {
 
   recordReloadTriggered(amount: number, balance: number, threshold: number, costUntilTargetDate: number, logContext: Record<string, unknown>): void {
     this.reloadsTriggered.add(1);
-    this.reloadAmounts.record(amount);
     // Only record balance coverage ratio if cost is greater than 0 to avoid division by zero
     if (costUntilTargetDate > 0) {
       this.balanceCoverageRatio.record(balance / costUntilTargetDate);
@@ -119,11 +112,10 @@ export class WalletBalanceReloadCheckInstrumentationService {
     });
   }
 
-  recordReloadFailed(amount: number, error: unknown, logContext: Record<string, unknown>): void {
+  recordReloadFailed(error: unknown, logContext: Record<string, unknown>): void {
     this.reloadFailures.add(1, {
       error_type: error instanceof Error ? error.constructor.name : "Unknown"
     });
-    this.reloadAmounts.record(amount);
     this.logger.error({
       ...logContext,
       event: "WALLET_BALANCE_RELOAD_FAILED",

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -195,6 +195,31 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
       );
     });
 
+    it("records reload failure and throws when payment intent fails", async () => {
+      const balance = 10.0;
+      const costUntilTargetDateInDenom = 50_000_000;
+      const costUntilTargetDateInFiat = 50.0;
+      const error = new Error("Payment failed");
+
+      const { handler, stripeService, instrumentationService, job, jobMeta } = setup({
+        balance,
+        weeklyCostInDenom: costUntilTargetDateInDenom,
+        weeklyCostInFiat: costUntilTargetDateInFiat
+      });
+      stripeService.createPaymentIntent.mockRejectedValue(error);
+
+      await expect(handler.handle(job, jobMeta)).rejects.toThrow(error);
+
+      expect(instrumentationService.recordReloadFailed).toHaveBeenCalledWith(
+        error,
+        expect.objectContaining({
+          walletAddress: expect.any(String),
+          balance,
+          costUntilTargetDateInFiat
+        })
+      );
+    });
+
     it("logs error and throws when scheduling next check fails", async () => {
       const balance = 50.0;
       const weeklyCostInDenom = 50_000_000;

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.ts
@@ -200,7 +200,7 @@ export class WalletBalanceReloadCheckHandler implements JobHandler<WalletBalance
       });
       this.instrumentationService.recordReloadTriggered(reloadAmountInFiat, resources.balance, threshold, costUntilTargetDateInFiat, log);
     } catch (error) {
-      this.instrumentationService.recordReloadFailed(reloadAmountInFiat, error, log);
+      this.instrumentationService.recordReloadFailed(error, log);
       throw error;
     }
   }


### PR DESCRIPTION
## Why

These metrics aren't helpful

## What

Removes reload amounts reporting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed per-reload amount tracking from wallet reload instrumentation; other operational metrics and failure counters remain intact.

* **Tests**
  * Added tests verifying reload failures are logged and recorded correctly (including error and wallet context), and that failures are handled without including per-reload amounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->