### PR TITLE
test: fixes flaky alert CRUD test in notifications

### DIFF
--- a/apps/notifications/test/functional/alert-crud.spec.ts
+++ b/apps/notifications/test/functional/alert-crud.spec.ts
@@ -37,7 +37,15 @@ describe("Alerts CRUD", () => {
   async function prepareAlert(userId: string, notificationChannelId: string, app: INestApplication): Promise<AlertOutputMeta> {
     const repository = app.get(AlertRepository);
     const { params, ...input } = generateMock(chainMessageCreateInputSchema);
-    const alert = await repository.create({ ...input, userId, notificationChannelId, enabled: true });
+    const alert = await repository.create({
+      ...input,
+      name: input.name || faker.lorem.words(3),
+      summary: input.summary || faker.lorem.sentence(),
+      description: input.description || faker.lorem.sentence(),
+      userId,
+      notificationChannelId,
+      enabled: true
+    });
 
     return {
       id: alert.id,

--- a/apps/notifications/test/functional/http-tools.spec.ts
+++ b/apps/notifications/test/functional/http-tools.spec.ts
@@ -117,7 +117,7 @@ describe("HTTP Tools", () => {
   function generateValidInput() {
     return {
       foo: faker.lorem.word(),
-      bar: faker.lorem.word()
+      bar: faker.lorem.word({ length: { min: 3, max: 10 } })
     };
   }
 });


### PR DESCRIPTION
## Why

The issue is that `generateMock(chainMessageCreateInputSchema)` from `@anatine/zod-mock` sometimes doesn't generate a value for summary, resulting in null being inserted into the NOT NULL column. This is a known limitation of `@anatine/zod-mock` with extended/strict schemas — mock generation can be non-deterministic.




## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced alert test data preparation to include additional descriptive fields with fallback values, improving coverage for alert creation scenarios.
  * Tightened test input generation by enforcing length constraints on a sample field, aligning test inputs with validation expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->