### PR TITLE
refactor: allows to define root .env.local file with configs for different services

### DIFF
--- a/packages/docker/.env.sandbox.docker-compose-dev
+++ b/packages/docker/.env.sandbox.docker-compose-dev
@@ -29,3 +29,5 @@ POSTGRES_DBS=console-users,console-akash-sandbox,notification_service,events
 POSTGRES_SKIP_IMPORT=${POSTGRES_SKIP_IMPORT:-false}
 POSTGRES_DBS_FOR_IMPORT=console-akash-sandbox
 POSTGRES_USERS_DB=console-users
+
+ALLOW_LOCAL_DOTENV=true

--- a/packages/docker/docker-compose.runtime.yml
+++ b/packages/docker/docker-compose.runtime.yml
@@ -6,6 +6,8 @@ services:
       GITHUB_PAT: ${GITHUB_PAT}
     env_file:
       - .env.sandbox.docker-compose-dev
+      - path: ../../.env.local
+        required: false
     ports:
       - "3080:3000"
       - "3081:3001" # background jobs server
@@ -16,6 +18,8 @@ services:
       PORT: 3000
     env_file:
       - .env.sandbox.docker-compose-dev
+      - path: ../../.env.local
+        required: false
     ports:
       - "3091:3000"
 
@@ -25,6 +29,8 @@ services:
       PORT: 3000
     env_file:
       - .env.sandbox.docker-compose-dev
+      - path: ../../.env.local
+        required: false
     ports:
       - '3090:3000'
 
@@ -32,6 +38,8 @@ services:
     restart: always
     env_file:
       - .env.sandbox.docker-compose-dev
+      - path: ../../.env.local
+        required: false
 
   provider-proxy:
     restart: always
@@ -39,6 +47,8 @@ services:
       PORT: 3000
     env_file:
       - .env.sandbox.docker-compose-dev
+      - path: ../../.env.local
+        required: false
     ports:
       - '3040:3000'
 
@@ -48,6 +58,8 @@ services:
       API_HOST: api
     env_file:
       - .env.sandbox.docker-compose-dev
+      - path: ../../.env.local
+        required: false
     ports:
       - '3000:3000'
     depends_on:
@@ -59,6 +71,8 @@ services:
     restart: always
     env_file:
       - .env.sandbox.docker-compose-dev
+      - path: ../../.env.local
+        required: false
     ports:
       - '3001:3000'
     depends_on:
@@ -69,5 +83,7 @@ services:
     restart: always
     env_file:
       - .env.sandbox.docker-compose-dev
+      - path: ../../.env.local
+        required: false
     ports:
       - '3003:3000'

--- a/packages/docker/script/dc.sh
+++ b/packages/docker/script/dc.sh
@@ -107,7 +107,7 @@ REQUESTED_SERVICES=()
 DC_FILES_DIR="$(dirname "$(dirname "$(readlink -f "$0")")")/"
 COMPOSE_FILES=(
   "${DC_FILES_DIR}docker-compose.build.yml"
-  "${DC_FILES_DIR}docker-compose.prod.yml"
+  "${DC_FILES_DIR}docker-compose.runtime.yml"
   "${DC_FILES_DIR}docker-compose.prod-with-db.yml"
   "${DC_FILES_DIR}docker-compose.dev.yml"
 )

--- a/packages/env-loader/src/index.js
+++ b/packages/env-loader/src/index.js
@@ -31,12 +31,18 @@ if (process.env.DEPLOYMENT_ENV === "") {
   delete process.env.DEPLOYMENT_ENV;
 }
 
-if (!process.env.DEPLOYMENT_ENV) {
-  config("../../.env.local");
+if (process.env.ALLOW_LOCAL_DOTENV === "true" || process.env.DEPLOYMENT_ENV !== "production") {
+  config("env/.env.local");
 }
 
-config(`env/.env.${process.env.DEPLOYMENT_ENV || "local"}`);
-config(`env/.env.${process.env.NETWORK}`);
+const WORD_REGEX = /^\w+$/;
+
+if (WORD_REGEX.test(process.env.DEPLOYMENT_ENV ?? "")) {
+  config(`env/.env.${process.env.DEPLOYMENT_ENV}`);
+}
+if (WORD_REGEX.test(process.env.NETWORK ?? "")) {
+  config(`env/.env.${process.env.NETWORK}`);
+}
 config("env/.env");
 
 logger.info(`Loaded env files: ${files.join(", ")}`);


### PR DESCRIPTION
## Why

Switching NETWORK or DEPLOYMENT_ENV across multiple per-app env/.env.local files is tedious and error-prone — it's easy to forget one and waste time debugging the wrong environment.

## What

* Adds a root-level .env.local that's loaded into Docker containers at runtime via env_file with required: false, keeping it in .dockerignore to prevent accidental inclusion in production images
* Updates env-loader to support env/.env.local for non-production environments (and opt-in via ALLOW_LOCAL_DOTENV in production), with regex validation on DEPLOYMENT_ENV and NETWORK values
* Renames docker-compose.prod.yml to docker-compose.runtime.yml to better reflect that its directives are runtime-only

**LIMITATION**

Changes to the root .env.local are not automatically applied to running containers. A docker compose restart is required to pick up updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved environment configuration to support conditional loading of local environment files across different deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->