### PR TITLE
feat(notifications): skips alerting on balances in case of multiple denom in escrow

### DIFF
--- a/apps/notifications/src/modules/alert/services/deployment-balance-alerts/deployment-balance-alerts.service.spec.ts
+++ b/apps/notifications/src/modules/alert/services/deployment-balance-alerts/deployment-balance-alerts.service.spec.ts
@@ -215,6 +215,35 @@ describe(DeploymentBalanceAlertsService.name, () => {
       });
     });
 
+    it("should only update minBlockHeight when deployment has multiple denominations", async () => {
+      const { service, alertRepository, deploymentService, alertMessageService } = await setup();
+      const owner = mockAkashAddress();
+      const dseq = faker.string.numeric(6);
+      const alert = generateDeploymentBalanceAlert({
+        params: {
+          owner,
+          dseq
+        },
+        conditions: { field: "balance", value: 10000000, operator: "lt" },
+        minBlockHeight: 1000
+      });
+      const alerts: DeploymentBalanceAlertOutput[] = [alert];
+      alertRepository.paginateAll.mockImplementation(async options => {
+        await options.callback(alerts as any);
+      });
+
+      deploymentService.getDeploymentBalance.mockResolvedValue(Err(new RichError("Multiple denominations are not supported", "MULTIPLE_DENOMINATIONS")));
+      const onMessage = vi.fn();
+
+      await service.alertFor({ height: 1000 }, onMessage);
+
+      expect(alertRepository.updateById).toHaveBeenCalledWith(alert.id, {
+        minBlockHeight: 1010
+      });
+      expect(alertMessageService.getMessage).not.toHaveBeenCalled();
+      expect(onMessage).not.toHaveBeenCalled();
+    });
+
     it("should log error if alert repository call fails and reject", async () => {
       const { service, alertRepository, loggerService, alertMessageService } = await setup();
       const error = new Error("test");

--- a/apps/notifications/src/modules/alert/services/deployment-balance-alerts/deployment-balance-alerts.service.ts
+++ b/apps/notifications/src/modules/alert/services/deployment-balance-alerts/deployment-balance-alerts.service.ts
@@ -52,6 +52,15 @@ export class DeploymentBalanceAlertsService {
   private async processSingleAlert(block: ChainBlockCreatedDto, alert: DeploymentBalanceAlertOutput, onMessage: MessageCallback) {
     try {
       const balanceResult = await this.deploymentService.getDeploymentBalance(alert.params.owner, alert.params.dseq, block.height);
+      const hasMultipleDenominations = balanceResult.err && balanceResult.val.code === "MULTIPLE_DENOMINATIONS";
+
+      if (hasMultipleDenominations) {
+        await this.alertRepository.updateById(alert.id, {
+          minBlockHeight: block.height + this.configService.getOrThrow("alert.DEPLOYMENT_BALANCE_BLOCKS_THROTTLE")
+        });
+        return;
+      }
+
       if (balanceResult.err) {
         const payload = await this.suspendErroneousAlert(balanceResult.val, alert);
 

--- a/apps/notifications/src/modules/alert/services/deployment/deployment.service.spec.ts
+++ b/apps/notifications/src/modules/alert/services/deployment/deployment.service.spec.ts
@@ -53,6 +53,49 @@ describe(DeploymentService.name, () => {
       expect(deploymentHttpService.findByOwnerAndDseq).toHaveBeenCalledWith(owner, dseq);
     });
 
+    it("should return error for multiple denominations", async () => {
+      const { service, deploymentHttpService, CURRENT_HEIGHT, leaseHttpService } = await setup();
+      deploymentHttpService.findByOwnerAndDseq.mockResolvedValue(
+        generateDeploymentBalanceResponse({
+          state: "active",
+          funds: [
+            {
+              denom: "uakt",
+              amount: 400000
+            },
+            {
+              denom: "uusdc",
+              amount: 400000
+            }
+          ],
+          settledAt: 900
+        })
+      );
+      const owner = mockAkashAddress();
+      const dseq = faker.string.alphanumeric(6);
+      leaseHttpService.list.mockResolvedValue({
+        leases: [
+          {
+            lease: {
+              price: {
+                amount: "1000"
+              }
+            }
+          }
+        ]
+      } as RestAkashLeaseListResponse);
+
+      const balance = await service.getDeploymentBalance(owner, dseq, CURRENT_HEIGHT);
+
+      expect(balance).toMatchObject({
+        err: true,
+        val: {
+          message: "Multiple denominations are not supported",
+          code: "MULTIPLE_DENOMINATIONS"
+        }
+      });
+    });
+
     it("should return null if deployment is closed", async () => {
       const { service, deploymentHttpService, leaseHttpService, CURRENT_HEIGHT } = await setup();
       deploymentHttpService.findByOwnerAndDseq.mockResolvedValue(

--- a/apps/notifications/src/modules/alert/services/deployment/deployment.service.ts
+++ b/apps/notifications/src/modules/alert/services/deployment/deployment.service.ts
@@ -40,11 +40,23 @@ export class DeploymentService {
       }
 
       const blocksPassed = Math.abs(parseInt(deploymentInfo.escrow_account.state.settled_at, 10) - block);
-      const balance = parseFloat(deploymentInfo.escrow_account.state.funds.reduce((sum, { amount }) => sum + parseFloat(amount), 0).toFixed(18));
+      const { balance, denoms } = deploymentInfo.escrow_account.state.funds.reduce(
+        (result, { amount, denom }) => {
+          result.balance += parseFloat(amount);
+          result.denoms.add(denom);
+          return result;
+        },
+        { balance: 0, denoms: new Set() }
+      );
+
+      if (denoms.size > 1) {
+        return Err(new RichError("Multiple denominations are not supported", "MULTIPLE_DENOMINATIONS"));
+      }
+
       const blocksLeft = balance / pricePerBlock - blocksPassed;
       const escrow = Math.max(blocksLeft * pricePerBlock, 0);
 
-      return Ok({ balance: escrow });
+      return Ok({ balance: parseFloat(escrow.toFixed(18)) });
     } catch (error: unknown) {
       return Err(RichError.enrich(error, "UNKNOWN"));
     }


### PR DESCRIPTION
## Why

During chain upgrade existing deployments can have multiple denoms in escrow

## What

Postpones alerting till a single denom is in escrow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to detect multiple denominations in deployment balances and return appropriate error handling
  * Refined balance calculation with improved decimal precision (18 decimals)

* **Tests**
  * Added test coverage for multiple denomination error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->