### PR TITLE
fix(managed-wallet): propagate 503 when upstream RPC returns 5xx

### DIFF
--- a/apps/tx-signer/src/services/chain-error/chain-error.service.spec.ts
+++ b/apps/tx-signer/src/services/chain-error/chain-error.service.spec.ts
@@ -81,6 +81,21 @@ describe(ChainErrorService.name, () => {
     ).toBe(402);
   });
 
+  it("returns 503 for bad status on response 502 error", () => {
+    const { service } = setup();
+    expect(service.getChainErrorStatus("Bad status on response: 502")).toBe(503);
+  });
+
+  it("returns 503 for bad status on response 503 error", () => {
+    const { service } = setup();
+    expect(service.getChainErrorStatus("Bad status on response: 503")).toBe(503);
+  });
+
+  it("returns 503 for bad status on response 504 error", () => {
+    const { service } = setup();
+    expect(service.getChainErrorStatus("Bad status on response: 504")).toBe(503);
+  });
+
   it("returns undefined for non-matching errors", () => {
     const { service } = setup();
     expect(service.getChainErrorStatus("Failed to sign and broadcast transaction")).toBeUndefined();

--- a/apps/tx-signer/src/services/chain-error/chain-error.service.ts
+++ b/apps/tx-signer/src/services/chain-error/chain-error.service.ts
@@ -15,7 +15,10 @@ export class ChainErrorService {
     "invalid owner address": 400,
     "bid not open": 400,
     "order not open": 400,
-    "insufficient balance": 402
+    "insufficient balance": 402,
+    "bad status on response: 502": 503,
+    "bad status on response: 503": 503,
+    "bad status on response: 504": 503
   };
 
   getChainErrorStatus(message: string): number | undefined {


### PR DESCRIPTION
## Why

When the upstream RPC endpoint returns a 5xx error (e.g. 502), the tx-signer currently responds with a generic 500 Internal Server Error. This makes it difficult for callers to distinguish between an internal tx-signer failure and an upstream service being unavailable. Also **clutters our alerting**

## What

Added upstream 5xx status patterns (502, 503, 504) to `ChainErrorService` so that cosmjs errors like `"Bad status on response: 502"` are mapped to HTTP 503 Service Unavailable instead of 500.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for HTTP 502, 503, and 504 server responses to improve application stability during network disruptions.

* **Tests**
  * Added test coverage for server error status code handling in chain error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->