### PR TITLE
docs: add env setup step to quick start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ To get started with Akash Console, follow these steps:
 git clone git@github.com:akash-network/console.git ./akash-console
 cd akash-console && npm install
 cp apps/deploy-web/.env.local.sample apps/deploy-web/.env.local
+cp apps/api/env/.env.local.sample apps/api/env/.env.local
 npm run dc:up:dev -- deploy-web
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ To get started with Akash Console, follow these steps:
 ```bash
 git clone git@github.com:akash-network/console.git ./akash-console
 cd akash-console && npm install
-cp apps/deploy-web/.env.local.sample apps/deploy-web/.env.local
-cp apps/api/env/.env.local.sample apps/api/env/.env.local
+cp -n apps/deploy-web/.env.local.sample apps/deploy-web/.env.local
+cp -n apps/api/env/.env.local.sample apps/api/env/.env.local
 npm run dc:up:dev -- deploy-web
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To get started with Akash Console, follow these steps:
 ```bash
 git clone git@github.com:akash-network/console.git ./akash-console
 cd akash-console && npm install
+cp apps/deploy-web/.env.local.sample apps/deploy-web/.env.local
 npm run dc:up:dev -- deploy-web
 ```
 


### PR DESCRIPTION
## Why

<!--
- explain why you created this PR
- include references to issues
-->

The Quick Start guide was missing the step to copy the `.env.local.sample` file, causing the `deploy-web` app to crash on startup due to missing environment variables. This step is mentioned in `docs/apps-configuration.md` but this gives your app a start point where the docker instance starts & your app is live on port 3000. 

Without that `cp` step, deploy-web crashes immediately with a `ZodError` on startup and the `api service` crashes with missing `AMPLITUDE_API_KEY`, `CHAIN_INDEXER_POSTGRES_DB_URI`, `AUTH0_M2M_*`, etc., causing a `Network Error` in the frontend.

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->

- Added `cp apps/deploy-web/.env.local.sample apps/deploy-web/.env.local` step to the Quick Start section in `README`.
- Added `cp apps/api/env/.env.local.sample apps/api/env/.env.local` step to the Quick Start section in `README`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start section with additional setup commands to initialize environment configuration files before starting services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->