### PR TITLE
feat(config): switches from testnet-8 to testnet-oracle

### DIFF
--- a/apps/api/env/.env.testnet
+++ b/apps/api/env/.env.testnet
@@ -1,3 +1,3 @@
-REST_API_NODE_URL=https://testnetapi.akashnet.net
-RPC_NODE_ENDPOINT=https://testnetrpc.akashnet.net:443
+REST_API_NODE_URL=https://testnetoracleapi.akashnet.net
+RPC_NODE_ENDPOINT=https://testnetoraclerpc.akashnet.net:443
 DEPLOYMENT_GRANT_DENOM=uact

--- a/apps/deploy-web/src/chains/akash-testnet.ts
+++ b/apps/deploy-web/src/chains/akash-testnet.ts
@@ -4,13 +4,13 @@ import { akash, akashAssetList } from "./akash";
 
 export const akashTestnet: Chain = {
   ...akash,
-  chain_id: "testnet-8",
+  chain_id: "testnet-oracle",
   network_type: "testnet",
   chain_name: "akash-testnet",
   pretty_name: "Akash-Testnet",
   apis: {
-    rpc: [{ address: "https://testnetrpc.akashnet.net", provider: "ovrclk" }],
-    rest: [{ address: "https://testnetapi.akashnet.net", provider: "ovrclk" }]
+    rpc: [{ address: "https://testnetoraclerpc.akashnet.net", provider: "ovrclk" }],
+    rest: [{ address: "https://testnetoracleapi.akashnet.net", provider: "ovrclk" }]
   }
 };
 

--- a/apps/deploy-web/src/hooks/useSupportsACT/useSupportsACT.spec.ts
+++ b/apps/deploy-web/src/hooks/useSupportsACT/useSupportsACT.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { SettingsContextType } from "@src/context/SettingsProvider";
+import type { NodeStatus } from "@src/types/node";
+import { useSupportsACT } from "./useSupportsACT";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useSupportsACT.name, () => {
+  it("returns true when network is testnet-8", () => {
+    const { result } = setup({ network: "testnet-8" });
+    expect(result.current).toBe(true);
+  });
+
+  it("returns true when network is testnet-oracle", () => {
+    const { result } = setup({ network: "testnet-oracle" });
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when network is mainnet", () => {
+    const { result } = setup({ network: "mainnet" });
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false when selectedNode is null", () => {
+    const { result } = setup({ selectedNode: null });
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false when nodeInfo is null", () => {
+    const { result } = setup({ nodeInfo: null });
+    expect(result.current).toBe(false);
+  });
+
+  function setup(input?: { network?: string; selectedNode?: null; nodeInfo?: null }) {
+    const nodeInfo =
+      input?.selectedNode === null || input?.nodeInfo === null ? null : mock<NodeStatus>({ node_info: { network: input?.network ?? "mainnet" } });
+
+    const selectedNode = input?.selectedNode === null ? null : { api: "", rpc: "", status: "", latency: 0, id: "", nodeInfo };
+
+    const { result } = renderHook(() =>
+      useSupportsACT({
+        dependencies: {
+          useSettings: () =>
+            ({
+              settings: mock({
+                selectedNode
+              })
+            }) as SettingsContextType
+        }
+      })
+    );
+
+    return { result };
+  }
+});

--- a/apps/deploy-web/src/hooks/useSupportsACT/useSupportsACT.ts
+++ b/apps/deploy-web/src/hooks/useSupportsACT/useSupportsACT.ts
@@ -1,7 +1,8 @@
-import { useSettings } from "@src/context/SettingsProvider";
+import { useSettings as useSettingsOriginal } from "@src/context/SettingsProvider";
 
-export function useSupportsACT(): boolean {
+export function useSupportsACT(options?: { dependencies?: { useSettings: typeof useSettingsOriginal } }): boolean {
+  const { useSettings } = { useSettings: useSettingsOriginal, ...options?.dependencies };
   const { settings } = useSettings();
   const nodeInfo = settings.selectedNode?.nodeInfo?.node_info;
-  return nodeInfo?.network === "testnet-8";
+  return !!nodeInfo && ["testnet-8", "testnet-oracle"].includes(nodeInfo.network);
 }

--- a/apps/indexer/.gitignore
+++ b/apps/indexer/.gitignore
@@ -1,0 +1,2 @@
+akash-testnet
+akash-sandbox

--- a/apps/provider-proxy/env/.env.testnet
+++ b/apps/provider-proxy/env/.env.testnet
@@ -1,1 +1,1 @@
-REST_API_NODE_URL=https://testnetapi.akashnet.net
+REST_API_NODE_URL=https://testnetoracleapi.akashnet.net

--- a/apps/tx-signer/env/.env.testnet
+++ b/apps/tx-signer/env/.env.testnet
@@ -1,2 +1,2 @@
-REST_API_NODE_URL=https://testnetapi.akashnet.net
-RPC_NODE_ENDPOINT=https://testnetrpc.akashnet.net:443
+REST_API_NODE_URL=https://testnetoracleapi.akashnet.net
+RPC_NODE_ENDPOINT=https://testnetoraclerpc.akashnet.net:443

--- a/config/testnet-oracle-nodes.json
+++ b/config/testnet-oracle-nodes.json
@@ -1,0 +1,7 @@
+[
+  {
+    "id": "testnetoraclerpc.akashnet.net",
+    "api": "https://testnetoracleapi.akashnet.net",
+    "rpc": "https://testnetoraclerpc.akashnet.net"
+  }
+]

--- a/packages/database/chainDefinitions.ts
+++ b/packages/database/chainDefinitions.ts
@@ -83,10 +83,10 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
   },
   akashTestnet: {
     code: "akash-testnet",
-    rpcNodes: ["https://testnetrpc.akashnet.net:443"],
+    rpcNodes: ["https://testnetoraclerpc.akashnet.net:443"],
     cosmosDirectoryId: "akash",
     connectionString: process.env.AKASH_TESTNET_DATABASE_CS,
-    genesisFileUrl: "https://raw.githubusercontent.com/akash-network/net/master/testnet-8/genesis.json",
+    genesisFileUrl: "https://raw.githubusercontent.com/akash-network/net/master/testnet-oracle/genesis.json",
     coinGeckoId: "akash-network",
     logoUrlSVG: "https://raw.githubusercontent.com/cosmos/chain-registry/master/akash/images/akt.svg",
     logoUrlPNG: "https://console.akash.network/images/chains/akash.png",

--- a/packages/net/scripts/generate.ts
+++ b/packages/net/scripts/generate.ts
@@ -9,7 +9,7 @@ const PROJECT_DIR = normalize(joinPath(scriptDir, "..", "..", ".."));
 const PACKAGE_DIR = normalize(joinPath(scriptDir, ".."));
 const OUT_DIR = joinPath(PACKAGE_DIR, "src", "generated");
 const AKASH_NET_BASE = "https://raw.githubusercontent.com/akash-network/net/main";
-const networks = ["mainnet", "sandbox-2", "testnet-8"];
+const networks = ["mainnet", "sandbox-2", "testnet-8", "testnet-oracle"];
 
 const apiSchema = z.object({
   address: z.string()

--- a/packages/net/src/NetConfig/NetConfig.ts
+++ b/packages/net/src/NetConfig/NetConfig.ts
@@ -5,7 +5,7 @@ export type SupportedChainNetworks = keyof typeof netConfigData;
 export class NetConfig {
   readonly networkMap: Partial<Record<string, SupportedChainNetworks>> = {
     sandbox: "sandbox-2",
-    testnet: "testnet-8"
+    testnet: "testnet-oracle"
   };
 
   mapped(network: string): SupportedChainNetworks {

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -39,5 +39,11 @@ export const netConfigData = {
     faucetUrl: "https://faucet.dev.akash.pub/",
     apiUrls: ["https://testnetapi.akashnet.net"],
     rpcUrls: ["https://testnetrpc.akashnet.net:443"]
+  },
+  "testnet-oracle": {
+    version: "v2.1.0-a22",
+    faucetUrl: "https://oraclefaucet.dev.akash.pub/",
+    apiUrls: ["https://testnetoracleapi.akashnet.net"],
+    rpcUrls: ["https://testnetoraclerpc.akashnet.net:443"]
   }
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated testnet REST/RPC endpoints to oracle-hosted nodes.
  * Added a new testnet-oracle network to configs and generation tooling.
  * Updated chain ID mapping for the testnet.
  * Added indexer ignore entries for testnet artifacts.
* **New Features**
  * Published an asset list for the updated testnet.
* **Tests**
  * Added unit tests covering ACT support logic for the new testnet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->