### PR TITLE
fix: reduces nodejs runtime monitoring value

### DIFF
--- a/packages/instrumentation/src/instrumentation.ts
+++ b/packages/instrumentation/src/instrumentation.ts
@@ -11,7 +11,7 @@ import { NodeSDK } from "@opentelemetry/sdk-node";
 export const sdk = new NodeSDK({
   instrumentations: [
     new RuntimeNodeInstrumentation({
-      monitoringPrecision: 5000
+      monitoringPrecision: 10 // this is actually a resolution option for nodejs perf_hooks not a reporting option
     }),
     new HttpInstrumentation(),
     new PgInstrumentation(),


### PR DESCRIPTION
## Why

The `monitoringPrecision` sounds as it controls how often metrics are collected and reported, not the sampling resolution.  And example code in the runtime instrumentation is also misleading 

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance monitoring resolution for more granular tracking of system metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->