### PR TITLE
refactor: migrates api keys to sha256

### DIFF
--- a/.github/workflows/reusable-validate-app.yml
+++ b/.github/workflows/reusable-validate-app.yml
@@ -68,6 +68,7 @@ jobs:
           DOCKER_BUILDKIT_CACHE_SCOPE: ${{ github.workflow }}-${{ inputs.app }}
           DOCKER_BUILDKIT_CACHE_FALLBACK_SCOPE: ${{ github.workflow }}-${{ inputs.app }}-${{ env.BRANCH_NAME_SAFE }}
           BUILDX_BAKE_ENTITLEMENTS_FS: 0
+          POSTGRES_SKIP_IMPORT: "true"
         run: |
           npm run --if-present --workspace=apps/${{ inputs.app }} test:ci-setup
 

--- a/apps/api/src/auth/repositories/api-key/api-key.repository.integration.ts
+++ b/apps/api/src/auth/repositories/api-key/api-key.repository.integration.ts
@@ -1,0 +1,214 @@
+import { faker } from "@faker-js/faker";
+import { hash } from "bcryptjs";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { UserRepository } from "@src/user/repositories/user/user.repository";
+import { ApiKeyRepository } from "./api-key.repository";
+
+describe(ApiKeyRepository.name, () => {
+  describe("findBcryptKeysByKeyFormat", () => {
+    it("returns keys with bcrypt hashes matching the key format", async () => {
+      const { apiKeyRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      const keyFormat = `ac.sk.test.abc123***def456`;
+      const bcryptHash = await hash("some-api-key", 10);
+
+      const apiKey = await apiKeyRepository.create({
+        userId: user.id,
+        name: faker.company.name(),
+        hashedKey: bcryptHash,
+        keyFormat
+      });
+
+      const result = await apiKeyRepository.findBcryptKeysByKeyFormat(keyFormat);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(apiKey.id);
+    });
+
+    it("excludes keys with sha256 hashes", async () => {
+      const { apiKeyRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      const keyFormat = `ac.sk.test.abc123***def456`;
+      const sha256Hash = faker.string.hexadecimal({ length: 64, prefix: "" });
+
+      await apiKeyRepository.create({
+        userId: user.id,
+        name: faker.company.name(),
+        hashedKey: sha256Hash,
+        keyFormat
+      });
+
+      const result = await apiKeyRepository.findBcryptKeysByKeyFormat(keyFormat);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it("excludes keys with different key format", async () => {
+      const { apiKeyRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      const bcryptHash = await hash("some-api-key", 10);
+
+      await apiKeyRepository.create({
+        userId: user.id,
+        name: faker.company.name(),
+        hashedKey: bcryptHash,
+        keyFormat: `ac.sk.test.aaaaaa***bbbbbb`
+      });
+
+      const result = await apiKeyRepository.findBcryptKeysByKeyFormat(`ac.sk.test.cccccc***dddddd`);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it("returns empty array when no keys exist", async () => {
+      const { apiKeyRepository } = setup();
+
+      const result = await apiKeyRepository.findBcryptKeysByKeyFormat(`ac.sk.test.abc123***def456`);
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("updateHash", () => {
+    it("updates the hashed key when values differ", async () => {
+      const { apiKeyRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      const bcryptHash = await hash("some-api-key", 10);
+      const newHash = faker.string.hexadecimal({ length: 64, prefix: "" });
+
+      const apiKey = await apiKeyRepository.create({
+        userId: user.id,
+        name: faker.company.name(),
+        hashedKey: bcryptHash,
+        keyFormat: `ac.sk.test.abc123***def456`
+      });
+
+      await apiKeyRepository.updateHash(apiKey.id, newHash);
+
+      const updated = await apiKeyRepository.findById(apiKey.id);
+      expect(updated?.hashedKey).toBe(newHash);
+    });
+
+    it("does not update when hashed key is the same", async () => {
+      const { apiKeyRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      const existingHash = faker.string.hexadecimal({ length: 64, prefix: "" });
+
+      const apiKey = await apiKeyRepository.create({
+        userId: user.id,
+        name: faker.company.name(),
+        hashedKey: existingHash,
+        keyFormat: `ac.sk.test.abc123***def456`
+      });
+
+      await apiKeyRepository.updateHash(apiKey.id, existingHash);
+
+      const result = await apiKeyRepository.findById(apiKey.id);
+      expect(result?.hashedKey).toBe(existingHash);
+    });
+  });
+
+  describe("markAsUsed", () => {
+    it("updates lastUsedAt when last used longer ago than throttle", async () => {
+      const { apiKeyRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      const oldDate = new Date();
+      oldDate.setHours(oldDate.getHours() - 1);
+
+      const apiKey = await apiKeyRepository.create({
+        userId: user.id,
+        name: faker.company.name(),
+        hashedKey: faker.string.hexadecimal({ length: 64, prefix: "" }),
+        keyFormat: `ac.sk.test.abc123***def456`,
+        lastUsedAt: oldDate
+      });
+
+      await apiKeyRepository.markAsUsed(apiKey.id, 60);
+
+      const updated = await apiKeyRepository.findById(apiKey.id);
+      expect(updated?.lastUsedAt).not.toBe(apiKey.lastUsedAt);
+    });
+
+    it("does not update lastUsedAt when recently used", async () => {
+      const { apiKeyRepository, createTestUser } = setup();
+      const user = await createTestUser();
+
+      const apiKey = await apiKeyRepository.create({
+        userId: user.id,
+        name: faker.company.name(),
+        hashedKey: faker.string.hexadecimal({ length: 64, prefix: "" }),
+        keyFormat: `ac.sk.test.abc123***def456`,
+        lastUsedAt: new Date()
+      });
+
+      const before = await apiKeyRepository.findById(apiKey.id);
+
+      await apiKeyRepository.markAsUsed(apiKey.id, 3600);
+
+      const after = await apiKeyRepository.findById(apiKey.id);
+      expect(after?.lastUsedAt).toBe(before?.lastUsedAt);
+    });
+
+    it("does not update lastUsedAt when it is null", async () => {
+      const { apiKeyRepository, createTestUser } = setup();
+      const user = await createTestUser();
+
+      const apiKey = await apiKeyRepository.create({
+        userId: user.id,
+        name: faker.company.name(),
+        hashedKey: faker.string.hexadecimal({ length: 64, prefix: "" }),
+        keyFormat: `ac.sk.test.abc123***def456`
+      });
+
+      await apiKeyRepository.markAsUsed(apiKey.id, 60);
+
+      const updated = await apiKeyRepository.findById(apiKey.id);
+      expect(updated?.lastUsedAt).toBeNull();
+    });
+  });
+
+  let cleanup: () => Promise<void>;
+  afterEach(async () => {
+    await cleanup?.();
+  });
+
+  function setup() {
+    const apiKeyRepository = container.resolve(ApiKeyRepository);
+    const userRepository = container.resolve(UserRepository);
+    const createdApiKeyIds: string[] = [];
+    const createdUserIds: string[] = [];
+
+    const originalCreate = apiKeyRepository.create.bind(apiKeyRepository);
+    apiKeyRepository.create = async (...args: Parameters<typeof originalCreate>) => {
+      const result = await originalCreate(...args);
+      createdApiKeyIds.push(result.id);
+      return result;
+    };
+
+    cleanup = async () => {
+      if (createdApiKeyIds.length > 0) {
+        await apiKeyRepository.deleteById(createdApiKeyIds);
+      }
+      if (createdUserIds.length > 0) {
+        await userRepository.deleteById(createdUserIds);
+      }
+    };
+
+    async function createTestUser() {
+      const user = await userRepository.create({
+        id: faker.string.uuid(),
+        userId: faker.string.uuid(),
+        username: `testuser_${Date.now()}_${faker.string.alphanumeric(6)}`,
+        email: faker.internet.email(),
+        emailVerified: faker.datatype.boolean(),
+        subscribedToNewsletter: false
+      });
+      createdUserIds.push(user.id);
+      return user;
+    }
+
+    return { apiKeyRepository, createTestUser };
+  }
+});

--- a/apps/api/src/auth/repositories/api-key/api-key.repository.ts
+++ b/apps/api/src/auth/repositories/api-key/api-key.repository.ts
@@ -1,4 +1,4 @@
-import { eq, lt, sql } from "drizzle-orm";
+import { eq, lt, ne, sql } from "drizzle-orm";
 import { and } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
@@ -31,11 +31,27 @@ export class ApiKeyRepository extends BaseRepository<Table, ApiKeyInput, ApiKeyO
     return new ApiKeyRepository(this.pg, this.table, this.txManager).withAbility(...abilityParams) as this;
   }
 
+  async findBcryptKeysByKeyFormat(keyFormat: string): Promise<ApiKeyOutput[]> {
+    const isBcryptHashSql = sql`${this.table.hashedKey} LIKE '$2%'`;
+    const items = await this.cursor
+      .select()
+      .from(this.table)
+      .where(and(eq(this.table.keyFormat, keyFormat), isBcryptHashSql));
+    return this.toOutputList(items);
+  }
+
   async markAsUsed(id: ApiKeyOutput["id"], throttleTimeSeconds: number) {
     await this.cursor
       .update(this.table)
       .set({ lastUsedAt: sql`now()` })
       .where(and(eq(this.table.id, id), lt(this.table.lastUsedAt, sql`now() - make_interval(secs => ${throttleTimeSeconds})`)));
+  }
+
+  async updateHash(id: ApiKeyOutput["id"], hashedKey: string): Promise<void> {
+    await this.cursor
+      .update(this.table)
+      .set({ hashedKey })
+      .where(and(eq(this.table.id, id), ne(this.table.hashedKey, hashedKey)));
   }
 
   protected toOutput(payload: ApiKeyDbOutput): ApiKeyOutput {

--- a/apps/api/src/auth/services/api-key/api-key-auth.service.spec.ts
+++ b/apps/api/src/auth/services/api-key/api-key-auth.service.spec.ts
@@ -1,4 +1,3 @@
-import { container } from "tsyringe";
 import { mock, type MockProxy } from "vitest-mock-extended";
 
 import type { ApiKeyRepository } from "@src/auth/repositories/api-key/api-key.repository";
@@ -9,102 +8,157 @@ import { ApiKeyGeneratorService } from "./api-key-generator.service";
 import { ApiKeySeeder } from "@test/seeders/api-key.seeder";
 
 describe("ApiKeyAuthService", () => {
-  let service: ApiKeyAuthService;
-  let apiKeyGenerator: ApiKeyGeneratorService;
-  let apiKeyRepository: MockProxy<ApiKeyRepository>;
-  let config: MockProxy<CoreConfigService>;
-
-  beforeEach(() => {
-    config = mock<CoreConfigService>({ get: jest.fn() });
-    config.get.mockReturnValue("test");
-    apiKeyGenerator = new ApiKeyGeneratorService(config);
-    apiKeyRepository = mock<ApiKeyRepository>({ findOneBy: jest.fn(), find: jest.fn() });
-
-    service = new ApiKeyAuthService(apiKeyGenerator, apiKeyRepository, config);
-  });
-
-  afterEach(() => {
-    container.clearInstances();
-    jest.resetAllMocks();
-  });
-
-  describe("validateApiKeyFromHeader", () => {
+  describe("getAndValidateApiKeyFromHeader", () => {
     it("should throw for undefined key", async () => {
+      const { service } = setup();
       await expect(service.getAndValidateApiKeyFromHeader(undefined)).rejects.toThrow("Invalid API key");
     });
 
     it("should throw for invalid format", async () => {
+      const { service } = setup();
       await expect(service.getAndValidateApiKeyFromHeader("invalid-key")).rejects.toThrow("Invalid API key format");
     });
 
     it("should throw for wrong prefix", async () => {
+      const { service, apiKeyGenerator } = setup();
       const key = apiKeyGenerator.generateApiKey().replace("ac", "wrong");
       await expect(service.getAndValidateApiKeyFromHeader(key)).rejects.toThrow("Invalid API key format");
     });
 
     it("should throw for wrong type", async () => {
+      const { service, apiKeyGenerator } = setup();
       const key = apiKeyGenerator.generateApiKey().replace("sk", "wrong");
       await expect(service.getAndValidateApiKeyFromHeader(key)).rejects.toThrow("Invalid API key format");
     });
 
     it("should throw for wrong environment", async () => {
-      config.get.mockReturnValue("live");
-      const testApiKeyGeneratorService = new ApiKeyGeneratorService(config);
-      const testApiKeyAuthService = new ApiKeyAuthService(testApiKeyGeneratorService, apiKeyRepository, config);
-      const key = testApiKeyGeneratorService.generateApiKey().replace("live", "test");
-      await expect(testApiKeyAuthService.getAndValidateApiKeyFromHeader(key)).rejects.toThrow("Invalid API key format");
+      const { service, apiKeyGenerator } = setup({ env: "live" });
+      const key = apiKeyGenerator.generateApiKey().replace("live", "test");
+      await expect(service.getAndValidateApiKeyFromHeader(key)).rejects.toThrow("Invalid API key format");
     });
 
     it("should throw when key not found in database", async () => {
+      const { service, apiKeyGenerator, apiKeyRepository } = setup();
       const key = apiKeyGenerator.generateApiKey();
-      apiKeyRepository.find.mockResolvedValue([]);
+      apiKeyRepository.findOneBy.mockResolvedValue(undefined);
+      apiKeyRepository.findBcryptKeysByKeyFormat.mockResolvedValue([]);
 
       await expect(service.getAndValidateApiKeyFromHeader(key)).rejects.toThrow("API key not found");
     });
 
-    it("should throw for expired key", async () => {
-      const pastDate = new Date();
-      pastDate.setDate(pastDate.getDate() - 1);
+    describe("sha256 lookup", () => {
+      it("should return key found by sha256 hash", async () => {
+        const { service, apiKeyGenerator, apiKeyRepository } = setup();
+        const apiKey = apiKeyGenerator.generateApiKey();
+        const data = ApiKeySeeder.create({
+          hashedKey: apiKeyGenerator.hashApiKeySha256(apiKey),
+          keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
+        });
 
-      const apiKey = apiKeyGenerator.generateApiKey();
-      const data = ApiKeySeeder.create({
-        expiresAt: pastDate.toISOString(),
-        hashedKey: await apiKeyGenerator.hashApiKey(apiKey),
-        keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
+        apiKeyRepository.findOneBy.mockResolvedValue(data);
+
+        const result = await service.getAndValidateApiKeyFromHeader(apiKey);
+        expect(result).toBe(data);
+        expect(apiKeyRepository.findBcryptKeysByKeyFormat).not.toHaveBeenCalled();
       });
 
-      apiKeyRepository.find.mockResolvedValue([data]);
+      it("should throw for expired key found by sha256", async () => {
+        const { service, apiKeyGenerator, apiKeyRepository } = setup();
+        const pastDate = new Date();
+        pastDate.setDate(pastDate.getDate() - 1);
 
-      await expect(service.getAndValidateApiKeyFromHeader(apiKey)).rejects.toThrow("API key has expired");
+        const apiKey = apiKeyGenerator.generateApiKey();
+        const data = ApiKeySeeder.create({
+          expiresAt: pastDate.toISOString(),
+          hashedKey: apiKeyGenerator.hashApiKeySha256(apiKey),
+          keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
+        });
+
+        apiKeyRepository.findOneBy.mockResolvedValue(data);
+
+        await expect(service.getAndValidateApiKeyFromHeader(apiKey)).rejects.toThrow("API key has expired");
+      });
+
+      it("should return key with future expiration", async () => {
+        const { service, apiKeyGenerator, apiKeyRepository } = setup();
+        const futureDate = new Date();
+        futureDate.setUTCFullYear(futureDate.getUTCFullYear() + 1);
+
+        const apiKey = apiKeyGenerator.generateApiKey();
+        const data = ApiKeySeeder.create({
+          expiresAt: futureDate.toISOString(),
+          hashedKey: apiKeyGenerator.hashApiKeySha256(apiKey),
+          keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
+        });
+
+        apiKeyRepository.findOneBy.mockResolvedValue(data);
+
+        const result = await service.getAndValidateApiKeyFromHeader(apiKey);
+        expect(result).toBe(data);
+      });
     });
 
-    it("should return API key data for valid key with future expiration", async () => {
-      const futureDate = new Date();
-      futureDate.setUTCFullYear(futureDate.getUTCFullYear() + 1);
+    describe("bcrypt fallback", () => {
+      it("should fallback to bcrypt when sha256 not found", async () => {
+        const { service, apiKeyGenerator, apiKeyRepository } = setup();
+        const apiKey = apiKeyGenerator.generateApiKey();
+        const data = ApiKeySeeder.create({
+          hashedKey: await apiKeyGenerator.hashApiKey(apiKey),
+          keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
+        });
 
-      const apiKey = apiKeyGenerator.generateApiKey();
-      const data = ApiKeySeeder.create({
-        expiresAt: futureDate.toISOString(),
-        hashedKey: await apiKeyGenerator.hashApiKey(apiKey),
-        keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
+        apiKeyRepository.findOneBy.mockResolvedValue(undefined);
+        apiKeyRepository.findBcryptKeysByKeyFormat.mockResolvedValue([data]);
+
+        const result = await service.getAndValidateApiKeyFromHeader(apiKey);
+        expect(result).toBe(data);
       });
 
-      apiKeyRepository.find.mockResolvedValue([data]);
+      it("should update hashedKey to sha256 after bcrypt match", async () => {
+        const { service, apiKeyGenerator, apiKeyRepository } = setup();
+        const apiKey = apiKeyGenerator.generateApiKey();
+        const data = ApiKeySeeder.create({
+          hashedKey: await apiKeyGenerator.hashApiKey(apiKey),
+          keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
+        });
 
-      const result = await service.getAndValidateApiKeyFromHeader(apiKey);
-      expect(result).toBe(data);
-    });
+        apiKeyRepository.findOneBy.mockResolvedValue(undefined);
+        apiKeyRepository.findBcryptKeysByKeyFormat.mockResolvedValue([data]);
 
-    it("should return API key data for valid key with no expiration", async () => {
-      const apiKey = apiKeyGenerator.generateApiKey();
-      const data = ApiKeySeeder.create({
-        hashedKey: await apiKeyGenerator.hashApiKey(apiKey),
-        keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
+        await service.getAndValidateApiKeyFromHeader(apiKey);
+
+        const expectedSha256 = apiKeyGenerator.hashApiKeySha256(apiKey);
+        expect(apiKeyRepository.updateHash).toHaveBeenCalledWith(data.id, expectedSha256);
       });
-      apiKeyRepository.find.mockResolvedValue([data]);
 
-      const result = await service.getAndValidateApiKeyFromHeader(apiKey);
-      expect(result).toBe(data);
+      it("should throw for expired key found by bcrypt", async () => {
+        const { service, apiKeyGenerator, apiKeyRepository } = setup();
+        const pastDate = new Date();
+        pastDate.setDate(pastDate.getDate() - 1);
+
+        const apiKey = apiKeyGenerator.generateApiKey();
+        const data = ApiKeySeeder.create({
+          expiresAt: pastDate.toISOString(),
+          hashedKey: await apiKeyGenerator.hashApiKey(apiKey),
+          keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
+        });
+
+        apiKeyRepository.findOneBy.mockResolvedValue(undefined);
+        apiKeyRepository.findBcryptKeysByKeyFormat.mockResolvedValue([data]);
+
+        await expect(service.getAndValidateApiKeyFromHeader(apiKey)).rejects.toThrow("API key has expired");
+      });
     });
   });
+
+  function setup(input: { env?: string } = {}) {
+    const config = mock<CoreConfigService>();
+    config.get.mockReturnValue(input.env ?? "test");
+
+    const apiKeyGenerator = new ApiKeyGeneratorService(config);
+    const apiKeyRepository: MockProxy<ApiKeyRepository> = mock<ApiKeyRepository>();
+    const service = new ApiKeyAuthService(apiKeyGenerator, apiKeyRepository, config);
+
+    return { service, apiKeyGenerator, apiKeyRepository, config };
+  }
 });

--- a/apps/api/src/auth/services/api-key/api-key-auth.service.ts
+++ b/apps/api/src/auth/services/api-key/api-key-auth.service.ts
@@ -21,22 +21,16 @@ export class ApiKeyAuthService {
     private readonly config: CoreConfigService
   ) {}
 
-  private async findMatchingKey(apiKey: string, apiKeys: ApiKeyOutput[]): Promise<ApiKeyOutput | undefined> {
-    const comparisons = await Promise.all(apiKeys.map(k => compare(apiKey, k.hashedKey)));
-    return apiKeys[comparisons.findIndex(result => result)];
-  }
-
   @Trace()
   async getAndValidateApiKeyFromHeader(apiKey: string | undefined): Promise<ApiKeyOutput> {
     assert(apiKey, 401, "Invalid API key");
 
-    const [prefix, type, env] = apiKey.split(".");
+    const [prefix, type, env] = apiKey.split(".", 3);
     assert(prefix === this.API_KEY_PREFIX && type === this.API_KEY_TYPE && env === this.DEPLOYMENT_ENV, 401, "Invalid API key format");
 
-    const apiKeys = await this.apiKeyRepository.find();
-    const key = await this.findMatchingKey(apiKey, apiKeys);
+    const key = await this.findApiKey(apiKey);
 
-    assert(key && (await this.apiKeyGenerator.validateApiKey(apiKey, key.hashedKey)), 401, "API key not found");
+    assert(key, 401, "API key not found");
 
     if (key.expiresAt) {
       const expirationDate = parseISO(key.expiresAt);
@@ -46,5 +40,32 @@ export class ApiKeyAuthService {
     }
 
     return key;
+  }
+
+  private async findApiKey(apiKey: string): Promise<ApiKeyOutput | undefined> {
+    const sha256Hash = this.apiKeyGenerator.hashApiKeySha256(apiKey);
+    const keyBySha256 = await this.apiKeyRepository.findOneBy({ hashedKey: sha256Hash });
+    if (keyBySha256) return keyBySha256;
+
+    const key = await this.findMatchingKeyByBcrypt(apiKey);
+
+    if (key) {
+      await this.apiKeyRepository.updateHash(key.id, sha256Hash);
+    }
+
+    return key;
+  }
+
+  private async findMatchingKeyByBcrypt(apiKey: string): Promise<ApiKeyOutput | undefined> {
+    const keyFormat = this.apiKeyGenerator.obfuscateApiKey(apiKey);
+    const apiKeys = await this.apiKeyRepository.findBcryptKeysByKeyFormat(keyFormat);
+
+    for (const key of apiKeys) {
+      if (await compare(apiKey, key.hashedKey)) {
+        return key;
+      }
+    }
+
+    return undefined;
   }
 }

--- a/apps/api/src/auth/services/api-key/api-key-generator.service.spec.ts
+++ b/apps/api/src/auth/services/api-key/api-key-generator.service.spec.ts
@@ -71,6 +71,24 @@ describe("ApiKeyGeneratorService", () => {
     });
   });
 
+  describe("hashApiKeySha256", () => {
+    it("should generate consistent hashes", () => {
+      const apiKey = service.generateApiKey();
+      const hash1 = service.hashApiKeySha256(apiKey);
+      const hash2 = service.hashApiKeySha256(apiKey);
+
+      expect(hash1).toBe(hash2);
+      expect(hash1).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it("should generate different hashes for different keys", () => {
+      const key1 = service.generateApiKey();
+      const key2 = service.generateApiKey();
+
+      expect(service.hashApiKeySha256(key1)).not.toBe(service.hashApiKeySha256(key2));
+    });
+  });
+
   describe("obfuscateApiKey", () => {
     it("should obfuscate API key correctly", () => {
       const apiKey = service.generateApiKey();

--- a/apps/api/src/auth/services/api-key/api-key-generator.service.ts
+++ b/apps/api/src/auth/services/api-key/api-key-generator.service.ts
@@ -1,5 +1,5 @@
 import { compare, hash } from "bcryptjs";
-import { randomBytes } from "crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { singleton } from "tsyringe";
 
 import { CoreConfigService } from "@src/core/services/core-config/core-config.service";
@@ -22,6 +22,10 @@ export class ApiKeyGeneratorService {
 
   async hashApiKey(apiKey: string): Promise<string> {
     return hash(apiKey, this.SALT_ROUNDS);
+  }
+
+  hashApiKeySha256(apiKey: string): string {
+    return createHash("sha256").update(apiKey).digest("hex");
   }
 
   async validateApiKey(apiKey: string, hashedKey: string): Promise<boolean> {

--- a/apps/api/src/auth/services/api-key/api-key.service.ts
+++ b/apps/api/src/auth/services/api-key/api-key.service.ts
@@ -26,7 +26,7 @@ export class ApiKeyService {
 
   async create(input: ApiKeyInput): Promise<ApiKeyOutput & { apiKey: string }> {
     const apiKey = this.apiKeyGenerator.generateApiKey();
-    const hashedKey = await this.apiKeyGenerator.hashApiKey(apiKey);
+    const hashedKey = this.apiKeyGenerator.hashApiKeySha256(apiKey);
     const obfuscatedKey = this.apiKeyGenerator.obfuscateApiKey(apiKey);
 
     const created = await this.apiKeyRepository.accessibleBy(this.authService.ability, "create").create({

--- a/apps/api/test/functional/balances.spec.ts
+++ b/apps/api/test/functional/balances.spec.ts
@@ -158,23 +158,21 @@ describe("Balances", () => {
       return undefined;
     });
 
-    vi.spyOn(apiKeyRepository, "find").mockImplementation(async () => {
-      const now = new Date().toISOString();
-      return [
-        {
-          id: faker.string.uuid(),
-          userId: userWithId.id,
-          key: apiKey,
-          hashedKey: await apiKeyGenerator.hashApiKey(apiKey),
-          keyFormat: "sk",
-          name: "test",
-          createdAt: now,
-          updatedAt: now,
-          expiresAt: null,
-          lastUsedAt: null
-        }
-      ];
-    });
+    const apiKeyData = {
+      id: faker.string.uuid(),
+      userId: userWithId.id,
+      hashedKey: await apiKeyGenerator.hashApiKey(apiKey),
+      keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey),
+      name: "test",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      expiresAt: null,
+      lastUsedAt: null
+    };
+
+    vi.spyOn(apiKeyRepository, "findOneBy").mockResolvedValue(undefined);
+    vi.spyOn(apiKeyRepository, "findBcryptKeysByKeyFormat").mockResolvedValue([apiKeyData]);
+    vi.spyOn(apiKeyRepository, "updateHash").mockResolvedValue(undefined as any);
 
     vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue(userWalletRepository);
     vi.spyOn(userWalletRepository, "findOneByUserId").mockImplementation(async id => {


### PR DESCRIPTION
## Why

API key authentication was blocking the Node.js event loop. The previous implementation stored API keys as bcrypt hashes, which made direct database lookups impossible, bcrypt uses unique salts per hash, so the same plaintext produces different hashes each time. This forced the service to load all API keys from the database and compare them one-by-one using `bcrypt.compare()`, resulting in O(n) CPU-intensive comparisons per request. As the number of API keys grew, this caused event loop stalls visible in monitoring.

**Why SHA-256 (not HMAC-SHA-256):**
SHA-256 is deterministic, enabling O(1) database lookups by hashed value. HMAC-SHA-256 was considered but rejected because it requires a server-side secret (API_KEY_SECRET), and rotating that secret would require re-hashing every key in the database - effectively impossible without the original plaintext keys. Since API keys are cryptographically random high-entropy strings (not user-chosen passwords), they are not vulnerable to dictionary or rainbow table attacks.

## What

**SHA-256 lookup path (new, fast):**
On each request, the API key is hashed with SHA-256 and looked up directly in the database via hashedKey column. This is a single indexed query — O(1).

**Bcrypt fallback path (migration):**
If the SHA-256 lookup finds no match (i.e., the key was created before the migration and still has a bcrypt hash), the service falls back to bcrypt comparison. To minimize the number of bcrypt comparisons, candidates are narrowed down using the keyFormat column — an obfuscated representation of the key (e.g., ac.sk.local.4b1c45***7d5a95) — which filters keys by their visible prefix and suffix. The remaining candidates are compared sequentially with early exit on the first match.

**Automatic hash migration:**
When a key is matched via the bcrypt fallback, its hashedKey is updated to the SHA-256 value in-place. This means each bcrypt key is migrated on first use, and subsequent requests for the same key hit the fast SHA-256 path. Concurrent updates are safe because the same plaintext always produces the same SHA-256 hash — duplicate writes are idempotent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API keys now use SHA-256 for hashing; legacy bcrypt keys are automatically detected and migrated to SHA-256 on first use.

* **Tests**
  * Expanded test coverage for API key creation, SHA-256 hashing, authentication flows, bcrypt fallback/migration, and repository behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->