### PR TITLE
fix(auth): redirect unauthenticated users to login on /api-keys page

### DIFF
--- a/apps/deploy-web/src/components/api-keys/ApiKeysPage/ApiKeysPage.spec.tsx
+++ b/apps/deploy-web/src/components/api-keys/ApiKeysPage/ApiKeysPage.spec.tsx
@@ -1,0 +1,218 @@
+import type { ApiKeyResponse } from "@akashnetwork/http-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+import { ApiKeysPage, DEPENDENCIES } from "./ApiKeysPage";
+
+import { act, render } from "@testing-library/react";
+import { ComponentMock, MockComponents } from "@tests/unit/mocks";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
+
+describe(ApiKeysPage.name, () => {
+  it("passes api keys to ApiKeyList", () => {
+    const ApiKeyListMock = vi.fn(ComponentMock);
+    const apiKeys = [createApiKey()];
+    setup({
+      apiKeys,
+      dependencies: {
+        ApiKeyList: ApiKeyListMock
+      }
+    });
+
+    expect(ApiKeyListMock.mock.calls[0][0].apiKeys).toEqual(apiKeys);
+  });
+
+  it("passes isDeleting as false initially", () => {
+    const ApiKeyListMock = vi.fn(ComponentMock);
+    setup({
+      dependencies: {
+        ApiKeyList: ApiKeyListMock
+      }
+    });
+
+    expect(ApiKeyListMock.mock.calls[0][0].isDeleting).toBe(false);
+  });
+
+  it("passes apiKeyToDelete as null initially", () => {
+    const ApiKeyListMock = vi.fn(ComponentMock);
+    setup({
+      dependencies: {
+        ApiKeyList: ApiKeyListMock
+      }
+    });
+
+    expect(ApiKeyListMock.mock.calls[0][0].apiKeyToDelete).toBeNull();
+  });
+
+  it("sets apiKeyToDelete when updateApiKeyToDelete is called", () => {
+    const ApiKeyListMock = vi.fn(ComponentMock);
+    const apiKey = createApiKey();
+    setup({
+      dependencies: {
+        ApiKeyList: ApiKeyListMock
+      }
+    });
+
+    act(() => {
+      ApiKeyListMock.mock.calls[0][0].updateApiKeyToDelete(apiKey);
+    });
+
+    expect(ApiKeyListMock.mock.lastCall![0].apiKeyToDelete).toEqual(apiKey);
+  });
+
+  it("resets apiKeyToDelete when onDeleteClose is called", () => {
+    const ApiKeyListMock = vi.fn(ComponentMock);
+    const apiKey = createApiKey();
+    setup({
+      dependencies: {
+        ApiKeyList: ApiKeyListMock
+      }
+    });
+
+    act(() => {
+      ApiKeyListMock.mock.calls[0][0].updateApiKeyToDelete(apiKey);
+    });
+
+    act(() => {
+      ApiKeyListMock.mock.lastCall![0].onDeleteClose();
+    });
+
+    expect(ApiKeyListMock.mock.lastCall![0].apiKeyToDelete).toBeNull();
+  });
+
+  it("calls deleteApiKey and tracks analytics when onDeleteApiKey is called", () => {
+    const ApiKeyListMock = vi.fn(ComponentMock);
+    const deleteApiKey = vi.fn();
+    const { analyticsService } = setup({
+      deleteApiKeyMutate: deleteApiKey,
+      dependencies: {
+        ApiKeyList: ApiKeyListMock
+      }
+    });
+
+    act(() => {
+      ApiKeyListMock.mock.calls[0][0].onDeleteApiKey();
+    });
+
+    expect(deleteApiKey).toHaveBeenCalled();
+    expect(analyticsService.track).toHaveBeenCalledWith("delete_api_key", {
+      category: "settings",
+      label: "Delete API key"
+    });
+  });
+
+  it("passes loading state to Layout when api keys are loading", () => {
+    const LayoutMock = vi.fn(ComponentMock);
+    setup({
+      isLoadingApiKeys: true,
+      dependencies: {
+        Layout: LayoutMock
+      }
+    });
+
+    expect(LayoutMock.mock.calls[0][0].isLoading).toBe(true);
+  });
+
+  it("passes loading state to Layout when deleting", () => {
+    const LayoutMock = vi.fn(ComponentMock);
+    setup({
+      isDeleting: true,
+      dependencies: {
+        Layout: LayoutMock
+      }
+    });
+
+    expect(LayoutMock.mock.calls[0][0].isLoading).toBe(true);
+  });
+
+  it("sets page title via NextSeo", () => {
+    const NextSeoMock = vi.fn(() => null);
+    setup({
+      dependencies: {
+        NextSeo: NextSeoMock
+      }
+    });
+
+    expect(NextSeoMock.mock.calls[0][0].title).toBe("API Keys");
+  });
+
+  it("calls enqueueSnackbar on successful deletion", () => {
+    const enqueueSnackbar = vi.fn();
+    let onSuccessCallback: (() => void) | undefined;
+    const useDeleteApiKey: typeof DEPENDENCIES.useDeleteApiKey = (_id, onSuccess) => {
+      onSuccessCallback = onSuccess;
+      return { mutate: vi.fn(), isPending: false } as unknown as ReturnType<typeof DEPENDENCIES.useDeleteApiKey>;
+    };
+
+    setup({
+      dependencies: {
+        useDeleteApiKey,
+        enqueueSnackbar
+      }
+    });
+
+    act(() => {
+      onSuccessCallback!();
+    });
+
+    expect(enqueueSnackbar).toHaveBeenCalledWith("API Key deleted successfully", {
+      variant: "success"
+    });
+  });
+
+  function setup(
+    input: {
+      apiKeys?: ApiKeyResponse[];
+      isLoadingApiKeys?: boolean;
+      isDeleting?: boolean;
+      deleteApiKeyMutate?: ReturnType<typeof vi.fn>;
+      dependencies?: Partial<typeof DEPENDENCIES>;
+    } = {}
+  ) {
+    const useUserApiKeys: typeof DEPENDENCIES.useUserApiKeys = () =>
+      ({
+        data: input.apiKeys,
+        isLoading: input.isLoadingApiKeys ?? false
+      }) as unknown as ReturnType<typeof DEPENDENCIES.useUserApiKeys>;
+
+    const useDeleteApiKey: typeof DEPENDENCIES.useDeleteApiKey = () =>
+      ({
+        mutate: input.deleteApiKeyMutate ?? vi.fn(),
+        isPending: input.isDeleting ?? false
+      }) as unknown as ReturnType<typeof DEPENDENCIES.useDeleteApiKey>;
+
+    const analyticsService = mock<AnalyticsService>();
+
+    render(
+      <TestContainerProvider services={{ analyticsService: () => analyticsService }}>
+        <ApiKeysPage
+          dependencies={{
+            ...MockComponents(DEPENDENCIES),
+            useUserApiKeys,
+            useDeleteApiKey,
+            enqueueSnackbar: vi.fn(),
+            ...input.dependencies
+          }}
+        />
+      </TestContainerProvider>
+    );
+
+    return {
+      analyticsService
+    };
+  }
+
+  function createApiKey(overrides: Partial<ApiKeyResponse> = {}): ApiKeyResponse {
+    return {
+      id: "test-id",
+      name: "test-key",
+      expiresAt: null,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      lastUsedAt: null,
+      keyFormat: "ak_****1234",
+      ...overrides
+    };
+  }
+});

--- a/apps/deploy-web/src/components/api-keys/ApiKeysPage/ApiKeysPage.tsx
+++ b/apps/deploy-web/src/components/api-keys/ApiKeysPage/ApiKeysPage.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import type { ApiKeyResponse } from "@akashnetwork/http-sdk";
+import { NextSeo } from "next-seo";
+import { enqueueSnackbar } from "notistack";
+
+import { ApiKeyList } from "@src/components/api-keys/ApiKeyList";
+import Layout from "@src/components/layout/Layout";
+import { useServices } from "@src/context/ServicesProvider";
+import { useDeleteApiKey, useUserApiKeys } from "@src/queries/useApiKeysQuery";
+
+export const DEPENDENCIES = {
+  Layout,
+  NextSeo,
+  ApiKeyList,
+  useUserApiKeys,
+  useDeleteApiKey,
+  enqueueSnackbar
+};
+
+interface Props {
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export function ApiKeysPage({ dependencies: d = DEPENDENCIES }: Props = {}) {
+  const { analyticsService } = useServices();
+  const [apiKeyToDelete, setApiKeyToDelete] = useState<ApiKeyResponse | null>(null);
+  const { data: apiKeys, isLoading: isLoadingApiKeys } = d.useUserApiKeys();
+  const { mutate: deleteApiKey, isPending: isDeleting } = d.useDeleteApiKey(apiKeyToDelete?.id ?? "", () => {
+    setApiKeyToDelete(null);
+    d.enqueueSnackbar("API Key deleted successfully", {
+      variant: "success"
+    });
+  });
+  const isLoading = isLoadingApiKeys || isDeleting;
+
+  const onDeleteApiKey = () => {
+    deleteApiKey();
+
+    analyticsService.track("delete_api_key", {
+      category: "settings",
+      label: "Delete API key"
+    });
+  };
+
+  const onDeleteClose = () => {
+    setApiKeyToDelete(null);
+  };
+
+  return (
+    <d.Layout isLoading={isLoading}>
+      <d.NextSeo title="API Keys" />
+
+      <d.ApiKeyList
+        apiKeys={apiKeys}
+        onDeleteApiKey={onDeleteApiKey}
+        onDeleteClose={onDeleteClose}
+        isDeleting={isDeleting}
+        apiKeyToDelete={apiKeyToDelete}
+        updateApiKeyToDelete={apiKey => setApiKeyToDelete(apiKey)}
+      />
+    </d.Layout>
+  );
+}

--- a/apps/deploy-web/src/pages/user/api-keys/index.tsx
+++ b/apps/deploy-web/src/pages/user/api-keys/index.tsx
@@ -8,9 +8,16 @@ import Layout from "@src/components/layout/Layout";
 import { useServices } from "@src/context/ServicesProvider";
 import { Guard } from "@src/hoc/guard/guard.hoc";
 import { useIsRegisteredUser } from "@src/hooks/useUser";
+import { defineServerSideProps } from "@src/lib/nextjs/defineServerSideProps/defineServerSideProps";
+import { redirectIfAccessTokenExpired } from "@src/lib/nextjs/pageGuards/pageGuards";
 import { useDeleteApiKey, useUserApiKeys } from "@src/queries/useApiKeysQuery";
 
 export default Guard(ApiKeysPage, useIsRegisteredUser);
+
+export const getServerSideProps = defineServerSideProps({
+  if: redirectIfAccessTokenExpired,
+  route: "/user/api-keys"
+});
 
 function ApiKeysPage() {
   const { analyticsService } = useServices();

--- a/apps/deploy-web/src/pages/user/api-keys/index.tsx
+++ b/apps/deploy-web/src/pages/user/api-keys/index.tsx
@@ -1,16 +1,10 @@
-import { useState } from "react";
-import type { ApiKeyResponse } from "@akashnetwork/http-sdk";
-import { NextSeo } from "next-seo";
-import { enqueueSnackbar } from "notistack";
+/* v8 ignore start */
 
-import { ApiKeyList } from "@src/components/api-keys/ApiKeyList";
-import Layout from "@src/components/layout/Layout";
-import { useServices } from "@src/context/ServicesProvider";
+import { ApiKeysPage } from "@src/components/api-keys/ApiKeysPage/ApiKeysPage";
 import { Guard } from "@src/hoc/guard/guard.hoc";
 import { useIsRegisteredUser } from "@src/hooks/useUser";
 import { defineServerSideProps } from "@src/lib/nextjs/defineServerSideProps/defineServerSideProps";
 import { redirectIfAccessTokenExpired } from "@src/lib/nextjs/pageGuards/pageGuards";
-import { useDeleteApiKey, useUserApiKeys } from "@src/queries/useApiKeysQuery";
 
 export default Guard(ApiKeysPage, useIsRegisteredUser);
 
@@ -18,44 +12,3 @@ export const getServerSideProps = defineServerSideProps({
   if: redirectIfAccessTokenExpired,
   route: "/user/api-keys"
 });
-
-function ApiKeysPage() {
-  const { analyticsService } = useServices();
-  const [apiKeyToDelete, setApiKeyToDelete] = useState<ApiKeyResponse | null>(null);
-  const { data: apiKeys, isLoading: isLoadingApiKeys } = useUserApiKeys();
-  const { mutate: deleteApiKey, isPending: isDeleting } = useDeleteApiKey(apiKeyToDelete?.id ?? "", () => {
-    setApiKeyToDelete(null);
-    enqueueSnackbar("API Key deleted successfully", {
-      variant: "success"
-    });
-  });
-  const isLoading = isLoadingApiKeys || isDeleting;
-
-  const onDeleteApiKey = () => {
-    deleteApiKey();
-
-    analyticsService.track("delete_api_key", {
-      category: "settings",
-      label: "Delete API key"
-    });
-  };
-
-  const onDeleteClose = () => {
-    setApiKeyToDelete(null);
-  };
-
-  return (
-    <Layout isLoading={isLoading}>
-      <NextSeo title="API Keys" />
-
-      <ApiKeyList
-        apiKeys={apiKeys}
-        onDeleteApiKey={onDeleteApiKey}
-        onDeleteClose={onDeleteClose}
-        isDeleting={isDeleting}
-        apiKeyToDelete={apiKeyToDelete}
-        updateApiKeyToDelete={apiKey => setApiKeyToDelete(apiKey)}
-      />
-    </Layout>
-  );
-}


### PR DESCRIPTION
## Why

Unauthenticated users navigating to `/api-keys` see a 404 page instead of being redirected to the login page. This is because the page only has a client-side `Guard` HOC (which falls back to the 404 component) but lacks the server-side authentication check that redirects to login with a `returnTo` parameter.

Closes #2909

## What

- Added `getServerSideProps` with `redirectIfAccessTokenExpired` to the `/user/api-keys` page, matching the existing pattern used in `/user/settings`
- This ensures unauthenticated users are redirected to the login page with a `returnTo=/user/api-keys` parameter, so they return to the api-keys page after logging in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Server-side authentication check for the API Keys page — users with expired access tokens are now automatically redirected.

* **New Features**
  * API Keys page: improved deletion flow with confirmation, loading indicators, and success notifications for clearer feedback and state handling.

* **Tests**
  * Added comprehensive unit tests to improve reliability of the API Keys UI and deletion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->