### PR TITLE
feat(indexer): add uact denom spend tracking

### DIFF
--- a/apps/indexer/drizzle/0006_add_total_uact_spent_to_block.sql
+++ b/apps/indexer/drizzle/0006_add_total_uact_spent_to_block.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "block" ADD COLUMN IF NOT EXISTS "totalUActSpent" double precision;

--- a/apps/indexer/drizzle/meta/_journal.json
+++ b/apps/indexer/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1762600000000,
       "tag": "0005_add_height_to_address_reference",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1762700000000,
+      "tag": "0006_add_total_uact_spent_to_block",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/indexer/drizzle/schema.ts
+++ b/apps/indexer/drizzle/schema.ts
@@ -255,6 +255,7 @@ export const block = pgTable(
     totalTxCount: bigint({ mode: "number" }).notNull(),
     totalUAktSpent: doublePrecision(),
     totalUUsdcSpent: doublePrecision(),
+    totalUActSpent: doublePrecision(),
     activeLeaseCount: integer(),
     totalLeaseCount: integer(),
     activeCPU: integer(),

--- a/apps/indexer/src/indexers/akashStatsIndexer.ts
+++ b/apps/indexer/src/indexers/akashStatsIndexer.ts
@@ -45,10 +45,12 @@ class IActiveLeases {
   persistentStorageSum: number;
   priceSumUAKT: number;
   priceSumUUSDC: number;
+  priceSumUACT: number;
 }
 
 const denomMapping = {
   uakt: "uakt",
+  uact: "uact",
   "ibc/12C6A0C374171B595A0A9E18B83FA09D295FB1F2D8C6DAA3AC28683471752D84": "uusdc", // USDC on Sandbox
   "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1": "uusdc" // USDC on Mainnet
 };
@@ -200,6 +202,7 @@ export class AkashStatsIndexer extends Indexer {
     currentBlock.activePersistentStorage = this.activeLeases.persistentStorageSum;
     currentBlock.totalUAktSpent = (previousBlock?.totalUAktSpent || 0) + this.activeLeases.priceSumUAKT;
     currentBlock.totalUUsdcSpent = (previousBlock?.totalUUsdcSpent || 0) + this.activeLeases.priceSumUUSDC;
+    currentBlock.totalUActSpent = (previousBlock?.totalUActSpent || 0) + this.activeLeases.priceSumUACT;
   }
 
   @benchmark.measureMethodAsync
@@ -237,6 +240,10 @@ export class AkashStatsIndexer extends Indexer {
         .reduce((a, b) => a + b, 0),
       priceSumUUSDC: activeLeases
         .filter(x => x.denom === "uusdc")
+        .map(x => x.price)
+        .reduce((a, b) => a + b, 0),
+      priceSumUACT: activeLeases
+        .filter(x => x.denom === "uact")
         .map(x => x.price)
         .reduce((a, b) => a + b, 0)
     };

--- a/apps/indexer/src/tasks/usdSpendingTracker.ts
+++ b/apps/indexer/src/tasks/usdSpendingTracker.ts
@@ -56,13 +56,14 @@ export async function updateUsdSpending() {
 
     const totalUUAktSpentEndOfPreviousDay = lastBlockOfPreviousDay?.totalUAktSpent ?? 0;
     const totalUUsdcSpentEndOfPreviousDay = lastBlockOfPreviousDay?.totalUUsdcSpent ?? 0;
+    const totalUActSpentEndOfPreviousDay = lastBlockOfPreviousDay?.totalUActSpent ?? 0;
     const totalUUsdSpentEndOfPreviousDay = lastBlockOfPreviousDay?.totalUUsdSpent ?? 0;
     const uaktToUUsd = day.aktPrice ?? 0;
 
     const [affectedCount] = await AkashBlock.update(
       {
         totalUUsdSpent: sequelize.literal(
-          `${totalUUsdSpentEndOfPreviousDay} + ("totalUUsdcSpent" - ${totalUUsdcSpentEndOfPreviousDay}) + ("totalUAktSpent" - ${totalUUAktSpentEndOfPreviousDay}) * ${uaktToUUsd}`
+          `${totalUUsdSpentEndOfPreviousDay} + ("totalUUsdcSpent" - ${totalUUsdcSpentEndOfPreviousDay}) + ("totalUAktSpent" - ${totalUUAktSpentEndOfPreviousDay}) * ${uaktToUUsd} + (COALESCE("totalUActSpent", 0) - ${totalUActSpentEndOfPreviousDay})`
         )
       },
       {

--- a/packages/database/dbSchemas/akash/akashBlock.ts
+++ b/packages/database/dbSchemas/akash/akashBlock.ts
@@ -24,6 +24,10 @@ export class AkashBlock extends Block {
    */
   @Column(DataTypes.DOUBLE) totalUUsdcSpent?: number;
   /**
+   * Total amount of ACT spent at current block height in uact
+   */
+  @Column(DataTypes.DOUBLE) totalUActSpent?: number;
+  /**
    * Total amount of USD spent at current block height in usd
    */
   @Column(DataTypes.DOUBLE) totalUUsdSpent?: number;


### PR DESCRIPTION
## Why

With the denom transition from USDC to ACT, the indexer needs to track `uact` spend alongside existing `uakt` and `uusdc` to ensure accurate spend calculations for both pre- and post-upgrade periods.

closes CON-13 CON-34 CON-36 CON-37

## What

- Add `totalUActSpent` column to AkashBlock schema with Drizzle migration
- Add `uact` to `denomMapping` in the stats indexer
- Add `priceSumUACT` to active lease aggregation and per-block spend accumulation
- Include ACT spend in USD spending tracker formula (1:1 USD, like USDC) with `COALESCE` for NULL safety on pre-upgrade blocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracking of total UACT spent at each block height (new per-block metric).
  * Extended active-lease analytics to include UACT denomination and incorporated UACT into daily USD spending calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->