### PR TITLE
fix(billing): allow non-trial users to remove payment methods

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.spec.tsx
@@ -172,9 +172,14 @@ describe(PaymentMethodsContainer.name, () => {
     expect(child.isAutoReloadEnabled).toBe(true);
   });
 
-  it("passes isAutoReloadEnabled as false when wallet settings data is undefined", async () => {
+  it("passes isAutoReloadEnabled as false when wallet settings data is undefined and not loading", async () => {
     const { child } = await setup();
     expect(child.isAutoReloadEnabled).toBe(false);
+  });
+
+  it("passes isAutoReloadEnabled as true when wallet settings are still loading", async () => {
+    const { child } = await setup({ isWalletSettingsLoading: true });
+    expect(child.isAutoReloadEnabled).toBe(true);
   });
 
   async function setup(
@@ -187,6 +192,7 @@ describe(PaymentMethodsContainer.name, () => {
       setupIntent: SetupIntentResponse;
       isTrialing: boolean;
       autoReloadEnabled: boolean;
+      isWalletSettingsLoading: boolean;
     }> = {}
   ) {
     const useDefaultPaymentMethods = !Object.prototype.hasOwnProperty.call(overrides, "paymentMethods");
@@ -236,7 +242,8 @@ describe(PaymentMethodsContainer.name, () => {
       : undefined;
 
     const mockedUseWalletSettingsQuery = vi.fn(() => ({
-      data: walletSettingsData
+      data: walletSettingsData,
+      isLoading: overrides.isWalletSettingsLoading ?? false
     })) as unknown as MockedFunction<typeof useWalletSettingsQuery>;
 
     const dependencies = {

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.spec.tsx
@@ -2,7 +2,8 @@ import React from "react";
 import type { PaymentMethod, SetupIntentResponse } from "@akashnetwork/http-sdk";
 import { describe, expect, it, type MockedFunction, vi } from "vitest";
 
-import type { usePaymentMethodsQuery, usePaymentMutations, useSetupIntentMutation } from "@src/queries";
+import type { useWallet } from "@src/context/WalletProvider";
+import type { usePaymentMethodsQuery, usePaymentMutations, useSetupIntentMutation, useWalletSettingsQuery } from "@src/queries";
 import type { PaymentMethodsViewProps } from "../PaymentMethodsView/PaymentMethodsView";
 import { PaymentMethodsContainer } from "./PaymentMethodsContainer";
 
@@ -151,6 +152,31 @@ describe(PaymentMethodsContainer.name, () => {
     expect(child.isInProgress).toBe(true);
   });
 
+  it("passes isTrialing as false when wallet is not trialing", async () => {
+    const { child } = await setup({ isTrialing: false });
+    expect(child.isTrialing).toBe(false);
+  });
+
+  it("passes isTrialing as true when wallet is trialing", async () => {
+    const { child } = await setup({ isTrialing: true });
+    expect(child.isTrialing).toBe(true);
+  });
+
+  it("passes isAutoReloadEnabled as false when wallet settings have auto-reload disabled", async () => {
+    const { child } = await setup({ autoReloadEnabled: false });
+    expect(child.isAutoReloadEnabled).toBe(false);
+  });
+
+  it("passes isAutoReloadEnabled as true when wallet settings have auto-reload enabled", async () => {
+    const { child } = await setup({ autoReloadEnabled: true });
+    expect(child.isAutoReloadEnabled).toBe(true);
+  });
+
+  it("passes isAutoReloadEnabled as false when wallet settings data is undefined", async () => {
+    const { child } = await setup();
+    expect(child.isAutoReloadEnabled).toBe(false);
+  });
+
   async function setup(
     overrides: Partial<{
       paymentMethods: PaymentMethod[] | undefined;
@@ -159,6 +185,8 @@ describe(PaymentMethodsContainer.name, () => {
       isSetPaymentMethodAsDefaultPending: boolean;
       isRemovePaymentMethodPending: boolean;
       setupIntent: SetupIntentResponse;
+      isTrialing: boolean;
+      autoReloadEnabled: boolean;
     }> = {}
   ) {
     const useDefaultPaymentMethods = !Object.prototype.hasOwnProperty.call(overrides, "paymentMethods");
@@ -199,10 +227,24 @@ describe(PaymentMethodsContainer.name, () => {
       reset: mockResetSetupIntent
     })) as unknown as MockedFunction<typeof useSetupIntentMutation>;
 
+    const mockedUseWallet = vi.fn(() => ({
+      isTrialing: overrides.isTrialing ?? false
+    })) as unknown as MockedFunction<typeof useWallet>;
+
+    const walletSettingsData = Object.prototype.hasOwnProperty.call(overrides, "autoReloadEnabled")
+      ? { autoReloadEnabled: overrides.autoReloadEnabled! }
+      : undefined;
+
+    const mockedUseWalletSettingsQuery = vi.fn(() => ({
+      data: walletSettingsData
+    })) as unknown as MockedFunction<typeof useWalletSettingsQuery>;
+
     const dependencies = {
       usePaymentMethodsQuery: mockedUsePaymentMethodsQuery,
       usePaymentMutations: mockedUsePaymentMutations,
-      useSetupIntentMutation: mockedUseSetupIntentMutation
+      useSetupIntentMutation: mockedUseSetupIntentMutation,
+      useWallet: mockedUseWallet,
+      useWalletSettingsQuery: mockedUseWalletSettingsQuery
     };
 
     const childCapturer = createContainerTestingChildCapturer<PaymentMethodsViewProps>();

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.tsx
@@ -1,12 +1,15 @@
 import React, { useCallback, useState } from "react";
 
-import { usePaymentMethodsQuery, usePaymentMutations, useSetupIntentMutation } from "@src/queries";
+import { useWallet } from "@src/context/WalletProvider";
+import { usePaymentMethodsQuery, usePaymentMutations, useSetupIntentMutation, useWalletSettingsQuery } from "@src/queries";
 import type { PaymentMethodsViewProps } from "../PaymentMethodsView/PaymentMethodsView";
 
 const DEPENDENCIES = {
   usePaymentMethodsQuery,
   usePaymentMutations,
-  useSetupIntentMutation
+  useSetupIntentMutation,
+  useWallet,
+  useWalletSettingsQuery
 };
 
 type PaymentMethodsContainerProps = {
@@ -21,6 +24,9 @@ export const PaymentMethodsContainer: React.FC<PaymentMethodsContainerProps> = (
     refetch: refetchPaymentMethods,
     isRefetching: isRefetchingPaymentMethods
   } = d.usePaymentMethodsQuery();
+  const { isTrialing } = d.useWallet();
+  const { data: walletSettings } = d.useWalletSettingsQuery();
+  const isAutoReloadEnabled = walletSettings?.autoReloadEnabled ?? false;
   const paymentMutations = d.usePaymentMutations();
   const { data: setupIntent, mutate: createSetupIntent, reset: resetSetupIntent } = d.useSetupIntentMutation();
   const [showAddPaymentMethod, setShowAddPaymentMethod] = useState(false);
@@ -68,7 +74,9 @@ export const PaymentMethodsContainer: React.FC<PaymentMethodsContainerProps> = (
         setShowAddPaymentMethod,
         setupIntent,
         onAddCardSuccess,
-        isInProgress
+        isInProgress,
+        isTrialing,
+        isAutoReloadEnabled
       })}
     </>
   );

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.tsx
@@ -25,8 +25,8 @@ export const PaymentMethodsContainer: React.FC<PaymentMethodsContainerProps> = (
     isRefetching: isRefetchingPaymentMethods
   } = d.usePaymentMethodsQuery();
   const { isTrialing } = d.useWallet();
-  const { data: walletSettings } = d.useWalletSettingsQuery();
-  const isAutoReloadEnabled = walletSettings?.autoReloadEnabled ?? false;
+  const { data: walletSettings, isLoading: isWalletSettingsLoading } = d.useWalletSettingsQuery();
+  const isAutoReloadEnabled = walletSettings?.autoReloadEnabled ?? isWalletSettingsLoading;
   const paymentMutations = d.usePaymentMutations();
   const { data: setupIntent, mutate: createSetupIntent, reset: resetSetupIntent } = d.useSetupIntentMutation();
   const [showAddPaymentMethod, setShowAddPaymentMethod] = useState(false);

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.spec.tsx
@@ -291,7 +291,7 @@ describe(PaymentMethodsRow.name, () => {
       });
     });
 
-    it("shows both options for non-default payment method when trialing with other methods", async () => {
+    it("shows only 'Set as default' for non-default payment method when trialing with other methods", async () => {
       const user = userEvent.setup();
       setup({
         paymentMethod: createMockPaymentMethod({ isDefault: false }),
@@ -304,7 +304,7 @@ describe(PaymentMethodsRow.name, () => {
 
       await vi.waitFor(() => {
         expect(screen.getByText("Set as default")).toBeInTheDocument();
-        expect(screen.getByText("Remove")).toBeInTheDocument();
+        expect(screen.queryByText("Remove")).not.toBeInTheDocument();
       });
     });
   });

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.spec.tsx
@@ -153,19 +153,41 @@ describe(PaymentMethodsRow.name, () => {
       expect(button).toBeInTheDocument();
     });
 
-    it("does not render dropdown menu button when hasOtherPaymentMethods is false", () => {
+    it("renders dropdown menu button for the only payment method when not trialing", () => {
       setup({
-        hasOtherPaymentMethods: false
+        hasOtherPaymentMethods: false,
+        isTrialing: false
+      });
+
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("does not render dropdown menu button when hasOtherPaymentMethods is false and trialing", () => {
+      setup({
+        hasOtherPaymentMethods: false,
+        isTrialing: true
       });
 
       expect(screen.queryByRole("button")).not.toBeInTheDocument();
     });
 
-    it("does not render dropdown menu button when payment method is default", () => {
+    it("renders dropdown menu button for default payment method when not trialing", () => {
       setup({
         paymentMethod: createMockPaymentMethod({
           isDefault: true
-        })
+        }),
+        isTrialing: false
+      });
+
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("does not render dropdown menu button when payment method is default and trialing", () => {
+      setup({
+        paymentMethod: createMockPaymentMethod({
+          isDefault: true
+        }),
+        isTrialing: true
       });
 
       expect(screen.queryByRole("button")).not.toBeInTheDocument();
@@ -196,6 +218,85 @@ describe(PaymentMethodsRow.name, () => {
         paymentMethod: createMockPaymentMethod({
           isDefault: false
         })
+      });
+
+      const button = screen.getByRole("button");
+      await user.click(button);
+
+      await vi.waitFor(() => {
+        expect(screen.getByText("Set as default")).toBeInTheDocument();
+        expect(screen.getByText("Remove")).toBeInTheDocument();
+      });
+    });
+
+    it("shows only 'Remove' for default payment method when not trialing", async () => {
+      const user = userEvent.setup();
+      setup({
+        paymentMethod: createMockPaymentMethod({ isDefault: true }),
+        hasOtherPaymentMethods: true,
+        isTrialing: false
+      });
+
+      const button = screen.getByRole("button");
+      await user.click(button);
+
+      await vi.waitFor(() => {
+        expect(screen.queryByText("Set as default")).not.toBeInTheDocument();
+        expect(screen.getByText("Remove")).toBeInTheDocument();
+      });
+    });
+
+    it("shows only 'Remove' for the only payment method when not trialing", async () => {
+      const user = userEvent.setup();
+      setup({
+        paymentMethod: createMockPaymentMethod({ isDefault: true }),
+        hasOtherPaymentMethods: false,
+        isTrialing: false
+      });
+
+      const button = screen.getByRole("button");
+      await user.click(button);
+
+      await vi.waitFor(() => {
+        expect(screen.queryByText("Set as default")).not.toBeInTheDocument();
+        expect(screen.getByText("Remove")).toBeInTheDocument();
+      });
+    });
+
+    it("hides 'Remove' for default payment method when auto-reload is enabled", () => {
+      setup({
+        paymentMethod: createMockPaymentMethod({ isDefault: true }),
+        hasOtherPaymentMethods: true,
+        isTrialing: false,
+        isAutoReloadEnabled: true
+      });
+
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    it("shows 'Remove' for non-default payment method when auto-reload is enabled", async () => {
+      const user = userEvent.setup();
+      setup({
+        paymentMethod: createMockPaymentMethod({ isDefault: false }),
+        hasOtherPaymentMethods: true,
+        isTrialing: false,
+        isAutoReloadEnabled: true
+      });
+
+      const button = screen.getByRole("button");
+      await user.click(button);
+
+      await vi.waitFor(() => {
+        expect(screen.getByText("Remove")).toBeInTheDocument();
+      });
+    });
+
+    it("shows both options for non-default payment method when trialing with other methods", async () => {
+      const user = userEvent.setup();
+      setup({
+        paymentMethod: createMockPaymentMethod({ isDefault: false }),
+        hasOtherPaymentMethods: true,
+        isTrialing: true
       });
 
       const button = screen.getByRole("button");
@@ -392,6 +493,8 @@ describe(PaymentMethodsRow.name, () => {
                 onSetPaymentMethodAsDefault={vi.fn()}
                 onRemovePaymentMethod={vi.fn()}
                 hasOtherPaymentMethods={true}
+                isTrialing={false}
+                isAutoReloadEnabled={false}
                 dependencies={mockDependencies}
               />
             </tbody>
@@ -423,6 +526,8 @@ function setup(
     onSetPaymentMethodAsDefault?: Mock;
     onRemovePaymentMethod?: Mock;
     hasOtherPaymentMethods?: boolean;
+    isTrialing?: boolean;
+    isAutoReloadEnabled?: boolean;
     dependencies?: typeof mockDependencies;
   } = {}
 ) {
@@ -431,6 +536,8 @@ function setup(
     onSetPaymentMethodAsDefault: vi.fn(),
     onRemovePaymentMethod: vi.fn(),
     hasOtherPaymentMethods: true,
+    isTrialing: false,
+    isAutoReloadEnabled: false,
     dependencies: mockDependencies
   };
 

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.tsx
@@ -23,6 +23,8 @@ export type PaymentMethodsRowProps = {
   onSetPaymentMethodAsDefault: (id: string) => void;
   onRemovePaymentMethod: (id: string) => void;
   hasOtherPaymentMethods: boolean;
+  isTrialing: boolean;
+  isAutoReloadEnabled: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -31,6 +33,8 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
   onSetPaymentMethodAsDefault,
   onRemovePaymentMethod,
   hasOtherPaymentMethods,
+  isTrialing,
+  isAutoReloadEnabled,
   dependencies: d = DEPENDENCIES
 }) => {
   const [open, setOpen] = useState(false);
@@ -96,41 +100,48 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
     closeMenu();
   }, [onRemovePaymentMethod, paymentMethod.id]);
 
+  const canSetAsDefault = !paymentMethod.isDefault && hasOtherPaymentMethods;
+  const isDefaultBlockedByAutoReload = paymentMethod.isDefault && isAutoReloadEnabled;
+  const canRemove = !isDefaultBlockedByAutoReload && (!isTrialing || (hasOtherPaymentMethods && !paymentMethod.isDefault));
+  const showActions = canSetAsDefault || canRemove;
+
   return (
     <d.TableRow className="flex border-0 py-2 hover:bg-transparent">
       <d.TableCell className="flex items-center">
         {paymentMethodLabel} {defaultBadge}
       </d.TableCell>
       {validUntilContent && <d.TableCell className="flex flex-grow items-center justify-end">Valid until {validUntilContent}</d.TableCell>}
-      {hasOtherPaymentMethods && (
+      {showActions && (
         <d.TableCell className="min-h-[72px] min-w-[72px]">
-          {!paymentMethod.isDefault && (
-            <d.DropdownMenu modal={false} open={open}>
-              <d.DropdownMenuTrigger asChild>
-                <d.Button onClick={openMenu} size="icon" variant="ghost" className="rounded-full">
-                  <MoreHoriz />
-                </d.Button>
-              </d.DropdownMenuTrigger>
-              <d.DropdownMenuContent
-                align="end"
-                onMouseLeave={() => setOpen(false)}
-                onClick={e => {
-                  e.stopPropagation();
-                }}
-              >
-                <d.ClickAwayListener onClickAway={() => setOpen(false)}>
-                  <div>
+          <d.DropdownMenu modal={false} open={open}>
+            <d.DropdownMenuTrigger asChild>
+              <d.Button onClick={openMenu} size="icon" variant="ghost" className="rounded-full">
+                <MoreHoriz />
+              </d.Button>
+            </d.DropdownMenuTrigger>
+            <d.DropdownMenuContent
+              align="end"
+              onMouseLeave={() => setOpen(false)}
+              onClick={e => {
+                e.stopPropagation();
+              }}
+            >
+              <d.ClickAwayListener onClickAway={() => setOpen(false)}>
+                <div>
+                  {canSetAsDefault && (
                     <d.CustomDropdownLinkItem onClick={setPaymentAsDefault} icon={<CheckCircle fontSize="small" />}>
                       Set as default
                     </d.CustomDropdownLinkItem>
+                  )}
+                  {canRemove && (
                     <d.CustomDropdownLinkItem onClick={removePaymentMethod} icon={<Trash fontSize="small" />}>
                       Remove
                     </d.CustomDropdownLinkItem>
-                  </div>
-                </d.ClickAwayListener>
-              </d.DropdownMenuContent>
-            </d.DropdownMenu>
-          )}
+                  )}
+                </div>
+              </d.ClickAwayListener>
+            </d.DropdownMenuContent>
+          </d.DropdownMenu>
         </d.TableCell>
       )}
     </d.TableRow>

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.tsx
@@ -102,7 +102,7 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
 
   const canSetAsDefault = !paymentMethod.isDefault && hasOtherPaymentMethods;
   const isDefaultBlockedByAutoReload = paymentMethod.isDefault && isAutoReloadEnabled;
-  const canRemove = !isDefaultBlockedByAutoReload && (!isTrialing || (hasOtherPaymentMethods && !paymentMethod.isDefault));
+  const canRemove = !isDefaultBlockedByAutoReload && !isTrialing;
   const showActions = canSetAsDefault || canRemove;
 
   return (

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.spec.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { PaymentMethod, SetupIntentResponse } from "@akashnetwork/http-sdk";
 import { describe, expect, it, type Mock, vi } from "vitest";
 
+import type { PaymentMethodsRowProps } from "./PaymentMethodsRow";
 import type { DEPENDENCIES } from "./PaymentMethodsView";
 import { PaymentMethodsView } from "./PaymentMethodsView";
 
@@ -24,7 +25,7 @@ const MockPaymentMethodsRow = ({
   hasOtherPaymentMethods,
   isTrialing,
   isAutoReloadEnabled
-}: any) => (
+}: PaymentMethodsRowProps) => (
   <tr data-testid={`payment-method-row-${paymentMethod.id}`} data-is-trialing={isTrialing} data-auto-reload={isAutoReloadEnabled}>
     <td>
       <span>{paymentMethod.card?.last4}</span>

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.spec.tsx
@@ -17,12 +17,19 @@ const mockUseTheme = vi.fn(() => ({
   systemTheme: "light" as "light" | "dark" | undefined
 }));
 
-const MockPaymentMethodsRow = ({ paymentMethod, onSetPaymentMethodAsDefault, onRemovePaymentMethod, hasOtherPaymentMethods }: any) => (
-  <tr data-testid={`payment-method-row-${paymentMethod.id}`}>
+const MockPaymentMethodsRow = ({
+  paymentMethod,
+  onSetPaymentMethodAsDefault,
+  onRemovePaymentMethod,
+  hasOtherPaymentMethods,
+  isTrialing,
+  isAutoReloadEnabled
+}: any) => (
+  <tr data-testid={`payment-method-row-${paymentMethod.id}`} data-is-trialing={isTrialing} data-auto-reload={isAutoReloadEnabled}>
     <td>
       <span>{paymentMethod.card?.last4}</span>
       <button onClick={() => onSetPaymentMethodAsDefault(paymentMethod.id)}>Set as Default</button>
-      {hasOtherPaymentMethods && <button onClick={() => onRemovePaymentMethod(paymentMethod.id)}>Remove</button>}
+      {(hasOtherPaymentMethods || !isTrialing) && <button onClick={() => onRemovePaymentMethod(paymentMethod.id)}>Remove</button>}
     </td>
   </tr>
 );
@@ -144,13 +151,20 @@ describe(PaymentMethodsView.name, () => {
       expect(row2.textContent).toContain("Remove");
     });
 
-    it("passes correct canBeRemoved prop when only one payment method exists", () => {
+    it("hides Remove for only payment method when trialing", () => {
       const paymentMethods = [createMockPaymentMethods()[0]];
-      setup({ data: paymentMethods });
+      setup({ data: paymentMethods, isTrialing: true });
 
-      // When there's only 1 payment method, it should not be removable
       const row = screen.getByTestId("payment-method-row-pm_123");
       expect(row.textContent).not.toContain("Remove");
+    });
+
+    it("shows Remove for only payment method when not trialing", () => {
+      const paymentMethods = [createMockPaymentMethods()[0]];
+      setup({ data: paymentMethods, isTrialing: false });
+
+      const row = screen.getByTestId("payment-method-row-pm_123");
+      expect(row.textContent).toContain("Remove");
     });
   });
 
@@ -405,6 +419,8 @@ function setup(
     setupIntent?: SetupIntentResponse;
     onAddCardSuccess?: Mock;
     isInProgress?: boolean;
+    isTrialing?: boolean;
+    isAutoReloadEnabled?: boolean;
     dependencies?: typeof DEPENDENCIES;
   } = {}
 ) {
@@ -419,6 +435,8 @@ function setup(
     setupIntent: undefined,
     onAddCardSuccess: vi.fn(),
     isInProgress: false,
+    isTrialing: false,
+    isAutoReloadEnabled: false,
     dependencies: mockDependencies
   };
 

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.tsx
@@ -34,6 +34,8 @@ export type PaymentMethodsViewProps = {
   setupIntent: SetupIntentResponse | undefined;
   onAddCardSuccess: () => void;
   isInProgress: boolean;
+  isTrialing: boolean;
+  isAutoReloadEnabled: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -48,6 +50,8 @@ export const PaymentMethodsView: React.FC<PaymentMethodsViewProps> = ({
   setupIntent,
   onAddCardSuccess,
   isInProgress,
+  isTrialing,
+  isAutoReloadEnabled,
   dependencies: d = DEPENDENCIES
 }) => {
   const { resolvedTheme } = d.useTheme();
@@ -82,6 +86,8 @@ export const PaymentMethodsView: React.FC<PaymentMethodsViewProps> = ({
                       onSetPaymentMethodAsDefault={onSetPaymentMethodAsDefault}
                       onRemovePaymentMethod={onRemovePaymentMethod}
                       hasOtherPaymentMethods={data.length > 1}
+                      isTrialing={isTrialing}
+                      isAutoReloadEnabled={isAutoReloadEnabled}
                     />
                   ))}
                 </d.TableBody>


### PR DESCRIPTION
## Why

Non-trial users were unable to remove their payment methods. The backend already correctly allows removal for non-trial users, but the frontend unconditionally hid the "Remove" action for default/only payment methods regardless of trial status.

Closes CON-40

## What

- Thread `isTrialing` from `useWallet()` and `isAutoReloadEnabled` from `useWalletSettingsQuery()` through the PaymentMethods component chain (Container → View → Row)
- Relax frontend removal restrictions for non-trial users while keeping them for trial users
- Block removal of the default payment method when auto-reload is enabled to prevent edge cases
- Add comprehensive tests for all trial/non-trial/auto-reload scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payment method actions now respect trial status and auto-reload settings — action menu, "Set as default" and "Remove" options appear or hide appropriately per account state.

* **Tests**
  * Added comprehensive tests covering propagation of trial and auto-reload flags and verifying action visibility and behavior across combinations of states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->