### PR TITLE
test(dx): refactor deployment-info, list-response, grant-response seeders

### DIFF
--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
@@ -12,8 +12,8 @@ import type { MessageService } from "@src/deployment/services/message-service/me
 import type { ProviderService } from "@src/provider/services/provider/provider.service";
 import { DeploymentReaderService } from "./deployment-reader.service";
 
-import { DeploymentInfoSeeder } from "@test/seeders/deployment-info.seeder";
-import { DeploymentListResponseSeeder } from "@test/seeders/deployment-list-response.seeder";
+import { createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
+import { createDeploymentListResponseSeed } from "@test/seeders/deployment-list-response.seeder";
 import { LeaseApiResponseSeeder } from "@test/seeders/lease-api-response.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
@@ -22,7 +22,7 @@ describe(DeploymentReaderService.name, () => {
     it("falls back to database for deployment data when blockchain node is unreachable", async () => {
       const wallet = UserWalletSeeder.create() as WalletInitialized;
       const dseq = "12345";
-      const deploymentInfo = DeploymentInfoSeeder.create({ owner: wallet.address, dseq });
+      const deploymentInfo = createDeploymentInfoSeed({ owner: wallet.address, dseq });
       const { service, deploymentHttpService, fallbackDeploymentReaderService } = setup({
         fallbackDeploymentInfo: deploymentInfo
       });
@@ -37,7 +37,7 @@ describe(DeploymentReaderService.name, () => {
     it("falls back to database for lease data when blockchain node is unreachable", async () => {
       const wallet = UserWalletSeeder.create() as WalletInitialized;
       const dseq = "12345";
-      const deploymentInfo = DeploymentInfoSeeder.create({ owner: wallet.address, dseq });
+      const deploymentInfo = createDeploymentInfoSeed({ owner: wallet.address, dseq });
       const lease = LeaseApiResponseSeeder.create({ owner: wallet.address, dseq, state: "active" });
       const { service, leaseHttpService, fallbackLeaseReaderService } = setup({
         fallbackDeploymentInfo: deploymentInfo,
@@ -66,7 +66,7 @@ describe(DeploymentReaderService.name, () => {
   describe("list", () => {
     it("falls back to database when blockchain node is unreachable", async () => {
       const wallet = UserWalletSeeder.create() as WalletInitialized;
-      const deploymentList = DeploymentListResponseSeeder.create({}, 2);
+      const deploymentList = createDeploymentListResponseSeed({}, 2);
       const { service, deploymentHttpService, fallbackDeploymentReaderService } = setup({
         wallet,
         fallbackDeploymentList: deploymentList
@@ -99,15 +99,15 @@ describe(DeploymentReaderService.name, () => {
   function setup(
     input: {
       wallet?: WalletInitialized;
-      fallbackDeploymentInfo?: ReturnType<typeof DeploymentInfoSeeder.create>;
-      fallbackDeploymentList?: ReturnType<typeof DeploymentListResponseSeeder.create>;
+      fallbackDeploymentInfo?: ReturnType<typeof createDeploymentInfoSeed>;
+      fallbackDeploymentList?: ReturnType<typeof createDeploymentListResponseSeed>;
       fallbackLeases?: ReturnType<typeof LeaseApiResponseSeeder.create>[];
     } = {}
   ) {
     const defaultWallet = UserWalletSeeder.create() as WalletInitialized;
     const wallet = input.wallet ?? defaultWallet;
-    const defaultDeploymentInfo = DeploymentInfoSeeder.create();
-    const defaultDeploymentList = DeploymentListResponseSeeder.create({}, 0);
+    const defaultDeploymentInfo = createDeploymentInfoSeed();
+    const defaultDeploymentList = createDeploymentListResponseSeed({}, 0);
 
     const mocks = {
       providerService: mock<ProviderService>({

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
@@ -8,7 +8,7 @@ import type { LoggerService } from "@src/core";
 import { DrainingDeploymentRpcService } from "./draining-deployment-rpc.service";
 
 import { createAkashAddress } from "@test/seeders";
-import { DeploymentListResponseSeeder } from "@test/seeders/deployment-list-response.seeder";
+import { createDeploymentListResponseSeed } from "@test/seeders/deployment-list-response.seeder";
 import { LeaseApiResponseSeeder } from "@test/seeders/lease-api-response.seeder";
 
 describe(DrainingDeploymentRpcService.name, () => {
@@ -220,7 +220,7 @@ describe(DrainingDeploymentRpcService.name, () => {
 
     const dseqs: string[] = [];
     const leases: ReturnType<typeof LeaseApiResponseSeeder.create>[] = [];
-    const deployments: ReturnType<typeof DeploymentListResponseSeeder.create>[] = [];
+    const deployments: ReturnType<typeof createDeploymentListResponseSeed>[] = [];
 
     inputs.forEach(input => {
       const dseq = input.deployment?.dseq ?? faker.string.numeric({ length: 6, allowLeadingZeros: false });
@@ -244,7 +244,7 @@ describe(DrainingDeploymentRpcService.name, () => {
         const funds = input.deployment.funds ?? 40000;
         const transferred = input.deployment.transferred ?? 20000;
 
-        const deployment = DeploymentListResponseSeeder.create(
+        const deployment = createDeploymentListResponseSeed(
           {
             owner,
             dseq,

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -12,7 +12,7 @@ import { UserRepository } from "@src/user/repositories";
 import { TopUpManagedDeploymentsService } from "./top-up-managed-deployments.service";
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
-import { DeploymentInfoSeeder } from "@test/seeders/deployment-info.seeder";
+import { createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
 import { LeaseApiResponseSeeder } from "@test/seeders/lease-api-response.seeder";
 
 const CURRENT_HEIGHT = 1000000;
@@ -93,7 +93,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       mockLeasesForOwner(address, [createActiveLease(address, drainingDseq), createActiveLease(address, notYetDrainingDseq)]);
       mockDeploymentsForOwner(address, [
         createActiveDeployment(address, drainingDseq),
-        DeploymentInfoSeeder.create({
+        createDeploymentInfoSeed({
           owner: address,
           dseq: notYetDrainingDseq,
           state: "active",
@@ -220,7 +220,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
   }
 
   function createActiveDeployment(owner: string, dseq: string) {
-    return DeploymentInfoSeeder.create({
+    return createDeploymentInfoSeed({
       owner,
       dseq,
       state: "active",
@@ -231,7 +231,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
   }
 
   function createClosedDeployment(owner: string, dseq: string) {
-    return DeploymentInfoSeeder.create({
+    return createDeploymentInfoSeed({
       owner,
       dseq,
       state: "closed",
@@ -312,7 +312,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         .reply(200, { leases, pagination: { next_key: null, total: String(leases.length) } });
     }
 
-    function mockDeploymentsForOwner(owner: string, deployments: ReturnType<typeof DeploymentInfoSeeder.create>[]) {
+    function mockDeploymentsForOwner(owner: string, deployments: ReturnType<typeof createDeploymentInfoSeed>[]) {
       nock(apiNodeUrl)
         .get("/akash/deployment/v1beta4/deployments/list")
         .query(query => String(query["filters.owner"]) === owner)

--- a/apps/api/test/functional/balances.spec.ts
+++ b/apps/api/test/functional/balances.spec.ts
@@ -13,8 +13,8 @@ import { app } from "@src/rest-app";
 import { UserRepository } from "@src/user/repositories";
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
-import { DeploymentGrantResponseSeeder } from "@test/seeders/deployment-grant-response.seeder";
-import { DeploymentListResponseSeeder } from "@test/seeders/deployment-list-response.seeder";
+import { createDeploymentGrantResponseSeed } from "@test/seeders/deployment-grant-response.seeder";
+import { createDeploymentListResponseSeed } from "@test/seeders/deployment-list-response.seeder";
 import { FeeAllowanceResponseSeeder } from "@test/seeders/fee-allowance-response.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
@@ -199,7 +199,7 @@ describe("Balances", () => {
       .get(/\/cosmos\/authz\/v1beta1\/grants\?.*/)
       .reply(
         200,
-        DeploymentGrantResponseSeeder.create({
+        createDeploymentGrantResponseSeed({
           granter: mockMasterWalletAddress,
           grantee: wallet.address || undefined,
           amount: "5000000"
@@ -211,7 +211,7 @@ describe("Balances", () => {
       .get(/\/akash\/deployment\/v1beta4\/deployments\/list\?.*/)
       .reply(
         200,
-        DeploymentListResponseSeeder.create({
+        createDeploymentListResponseSeed({
           owner: wallet.address || undefined,
           amount: "1000000"
         })

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -22,7 +22,7 @@ import { deploymentVersion, marketVersion } from "@src/utils/constants";
 
 import { ApiKeySeeder } from "@test/seeders/api-key.seeder";
 import { createDeployment } from "@test/seeders/deployment.seeder";
-import { DeploymentInfoSeeder } from "@test/seeders/deployment-info.seeder";
+import { createDeploymentInfoErrorSeed, createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
 import { LeaseApiResponseSeeder } from "@test/seeders/lease-api-response.seeder";
 import { LeaseStatusSeeder } from "@test/seeders/lease-status.seeder";
 import { UserSeeder } from "@test/seeders/user.seeder";
@@ -129,7 +129,7 @@ describe("Deployments API", () => {
     const address = wallets[0].address;
     const defaultDeploymentInfo =
       deploymentInfo ||
-      DeploymentInfoSeeder.create({
+      createDeploymentInfoSeed({
         owner: address!,
         dseq
       });
@@ -207,7 +207,7 @@ describe("Deployments API", () => {
 
     for (let i = 0; i < count; i++) {
       const dseq = faker.string.numeric();
-      const deploymentInfo = DeploymentInfoSeeder.create({
+      const deploymentInfo = createDeploymentInfoSeed({
         owner: address!,
         dseq,
         state
@@ -256,7 +256,7 @@ describe("Deployments API", () => {
     it("returns 404 for an error in deployment info", async () => {
       const dseq = "1234";
       const { userApiKeySecret, wallets } = await mockUser();
-      await setupDeploymentInfoMock(wallets, dseq, DeploymentInfoSeeder.createError());
+      await setupDeploymentInfoMock(wallets, dseq, createDeploymentInfoErrorSeed());
 
       const response = await app.request(`/v1/deployments/${dseq}`, {
         method: "GET",

--- a/apps/api/test/functional/sign-and-broadcast-tx.spec.ts
+++ b/apps/api/test/functional/sign-and-broadcast-tx.spec.ts
@@ -14,8 +14,8 @@ import { CORE_CONFIG } from "@src/core";
 import { app } from "@src/rest-app";
 import { certVersion, deploymentVersion } from "@src/utils/constants";
 
-import { DeploymentGrantResponseSeeder } from "@test/seeders/deployment-grant-response.seeder";
-import { DeploymentListResponseSeeder } from "@test/seeders/deployment-list-response.seeder";
+import { createDeploymentGrantResponseSeed } from "@test/seeders/deployment-grant-response.seeder";
+import { createDeploymentListResponseSeed } from "@test/seeders/deployment-list-response.seeder";
 import { FeeAllowanceResponseSeeder } from "@test/seeders/fee-allowance-response.seeder";
 import { WalletTestingService } from "@test/services/wallet-testing.service";
 
@@ -224,14 +224,14 @@ describe("Tx Sign", () => {
       .get(/\/cosmos\/authz\/v1beta1\/grants\?.*/)
       .reply(
         200,
-        DeploymentGrantResponseSeeder.create({
+        createDeploymentGrantResponseSeed({
           grantee: wallet.address,
           amount: input?.deploymentAllowance?.toString() ?? "0",
           grantType: "/akash.escrow.v1.DepositAuthorization"
         })
       )
       .get(/\/akash\/deployment\/.*\/deployments\/list\?.*/)
-      .reply(200, DeploymentListResponseSeeder.create({ owner: wallet.address }))
+      .reply(200, createDeploymentListResponseSeed({ owner: wallet.address }))
       .get("/cosmos/base/tendermint/v1beta1/blocks/latest")
       .reply(200, { block: { header: { height: Math.floor(Math.random() * 1000000).toString() } } });
 

--- a/apps/api/test/functional/wallets-refill.spec.ts
+++ b/apps/api/test/functional/wallets-refill.spec.ts
@@ -13,7 +13,7 @@ import { POSTGRES_DB, resolveTable } from "@src/core";
 import { UserRepository } from "@src/user/repositories";
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
-import { DeploymentGrantResponseSeeder } from "@test/seeders/deployment-grant-response.seeder";
+import { createDeploymentGrantResponseSeed } from "@test/seeders/deployment-grant-response.seeder";
 import { FeeAllowanceResponseSeeder } from "@test/seeders/fee-allowance-response.seeder";
 
 describe("Wallets Refill", () => {
@@ -56,7 +56,7 @@ describe("Wallets Refill", () => {
     nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
       .persist()
       .get(/\/cosmos\/authz\/v1beta1\/grants\?.*/)
-      .reply(200, DeploymentGrantResponseSeeder.create({ amount: String(config.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT) }));
+      .reply(200, createDeploymentGrantResponseSeed({ amount: String(config.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT) }));
 
     const NUMBER_OF_WALLETS = 5;
     return Promise.all(

--- a/apps/api/test/seeders/deployment-grant-response.seeder.ts
+++ b/apps/api/test/seeders/deployment-grant-response.seeder.ts
@@ -8,30 +8,28 @@ export interface DeploymentGrantResponseSeederInput {
   grantType?: string;
 }
 
-export class DeploymentGrantResponseSeeder {
-  static create(input: DeploymentGrantResponseSeederInput = {}) {
-    return merge(
-      {
-        grants: [
-          {
-            granter: input.granter || "akash1testmasterwalletaddress",
-            grantee: input.grantee || "akash1testwalletaddress",
-            authorization: {
-              "@type": input.grantType || "/akash.escrow.v1.MsgAccountDeposit",
-              spend_limit: {
-                denom: "uakt",
-                amount: input.amount || "5000000"
-              }
-            },
-            expiration: faker.date.future().toISOString()
-          }
-        ],
-        pagination: {
-          next_key: null,
-          total: "1"
+export function createDeploymentGrantResponseSeed(input: DeploymentGrantResponseSeederInput = {}) {
+  return merge(
+    {
+      grants: [
+        {
+          granter: input.granter || "akash1testmasterwalletaddress",
+          grantee: input.grantee || "akash1testwalletaddress",
+          authorization: {
+            "@type": input.grantType || "/akash.escrow.v1.MsgAccountDeposit",
+            spend_limit: {
+              denom: "uakt",
+              amount: input.amount || "5000000"
+            }
+          },
+          expiration: faker.date.future().toISOString()
         }
-      },
-      input
-    );
-  }
+      ],
+      pagination: {
+        next_key: null,
+        total: "1"
+      }
+    },
+    input
+  );
 }

--- a/apps/api/test/seeders/deployment-info.seeder.ts
+++ b/apps/api/test/seeders/deployment-info.seeder.ts
@@ -21,77 +21,75 @@ export interface DeploymentInfoErrorSeederInput {
   details?: any[];
 }
 
-export class DeploymentInfoSeeder {
-  static create(input: DeploymentInfoSeederInput = {}): RestAkashDeploymentInfoResponse {
-    const {
-      owner = createAkashAddress(),
-      dseq = faker.string.numeric(),
-      state = "active",
-      version = deploymentVersion,
-      createdAt = "2021-01-01T00:00:00Z",
-      amount = "5000000",
-      denom = DenomSeeder.create()
-    } = input;
+export function createDeploymentInfoSeed(input: DeploymentInfoSeederInput = {}): RestAkashDeploymentInfoResponse {
+  const {
+    owner = createAkashAddress(),
+    dseq = faker.string.numeric(),
+    state = "active",
+    version = deploymentVersion,
+    createdAt = "2021-01-01T00:00:00Z",
+    amount = "5000000",
+    denom = DenomSeeder.create()
+  } = input;
 
-    return {
-      deployment: {
-        id: {
-          owner,
-          dseq
-        },
-        state,
-        hash: version,
-        created_at: createdAt
+  return {
+    deployment: {
+      id: {
+        owner,
+        dseq
       },
-      groups: [],
-      escrow_account: {
-        id: {
-          scope: "deployment",
-          xid: dseq
-        },
-        state: {
-          owner,
-          state: "open",
-          transferred: [
-            {
-              denom,
-              amount: "0"
-            }
-          ],
-          settled_at: new Date().toISOString(),
-          funds: [
-            {
+      state,
+      hash: version,
+      created_at: createdAt
+    },
+    groups: [],
+    escrow_account: {
+      id: {
+        scope: "deployment",
+        xid: dseq
+      },
+      state: {
+        owner,
+        state: "open",
+        transferred: [
+          {
+            denom,
+            amount: "0"
+          }
+        ],
+        settled_at: new Date().toISOString(),
+        funds: [
+          {
+            denom,
+            amount
+          }
+        ],
+        deposits: [
+          {
+            owner,
+            height: "1",
+            source: "balance",
+            balance: {
               denom,
               amount
             }
-          ],
-          deposits: [
-            {
-              owner,
-              height: "1",
-              source: "balance",
-              balance: {
-                denom,
-                amount
-              }
-            }
-          ]
-        }
+          }
+        ]
       }
-    };
-  }
+    }
+  };
+}
 
-  static createMany(count: number, input: DeploymentInfoSeederInput = {}): RestAkashDeploymentInfoResponse[] {
-    return Array.from({ length: count }, () => DeploymentInfoSeeder.create(input));
-  }
+export function createManyDeploymentInfoSeeds(count: number, input: DeploymentInfoSeederInput = {}): RestAkashDeploymentInfoResponse[] {
+  return Array.from({ length: count }, () => createDeploymentInfoSeed(input));
+}
 
-  static createError(input: DeploymentInfoErrorSeederInput = {}): RestAkashDeploymentInfoResponse {
-    const { code = 404, message = "Deployment not found", details = [] } = input;
+export function createDeploymentInfoErrorSeed(input: DeploymentInfoErrorSeederInput = {}): RestAkashDeploymentInfoResponse {
+  const { code = 404, message = "Deployment not found", details = [] } = input;
 
-    return {
-      code,
-      message,
-      details
-    };
-  }
+  return {
+    code,
+    message,
+    details
+  };
 }

--- a/apps/api/test/seeders/deployment-list-response.seeder.ts
+++ b/apps/api/test/seeders/deployment-list-response.seeder.ts
@@ -1,19 +1,17 @@
 import { merge } from "lodash";
 
 import type { DeploymentInfoSeederInput } from "./deployment-info.seeder";
-import { DeploymentInfoSeeder } from "./deployment-info.seeder";
+import { createManyDeploymentInfoSeeds } from "./deployment-info.seeder";
 
-export class DeploymentListResponseSeeder {
-  static create(input: DeploymentInfoSeederInput = {}, count: number = 1) {
-    return merge(
-      {
-        deployments: DeploymentInfoSeeder.createMany(count, input),
-        pagination: {
-          next_key: null,
-          total: count.toString()
-        }
-      },
-      input
-    );
-  }
+export function createDeploymentListResponseSeed(input: DeploymentInfoSeederInput = {}, count: number = 1) {
+  return merge(
+    {
+      deployments: createManyDeploymentInfoSeeds(count, input),
+      pagination: {
+        next_key: null,
+        total: count.toString()
+      }
+    },
+    input
+  );
 }


### PR DESCRIPTION
## Why

Refactor class-based seeders to function-based. There is no point to define a class full of static methods.

## What

- Convert DeploymentInfoSeeder, DeploymentListResponseSeeder, DeploymentGrantResponseSeeder to plain exported functions
- Update all consumer files to use the new function names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored deployment test data seeding: class-style seeders replaced with function-style seed factories and all deployment-related tests updated to the new seed API for improved clarity and consistency.
  * Result: more consistent test setup and easier maintenance of deployment-related test suites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->