### PR TITLE
test(dx): refactor small seeders from classes to plain functions

### DIFF
--- a/apps/api/src/auth/services/api-key/api-key-auth.service.spec.ts
+++ b/apps/api/src/auth/services/api-key/api-key-auth.service.spec.ts
@@ -5,7 +5,7 @@ import type { CoreConfigService } from "@src/core/services/core-config/core-conf
 import { ApiKeyAuthService } from "./api-key-auth.service";
 import { ApiKeyGeneratorService } from "./api-key-generator.service";
 
-import { ApiKeySeeder } from "@test/seeders/api-key.seeder";
+import { createApiKey } from "@test/seeders/api-key.seeder";
 
 describe("ApiKeyAuthService", () => {
   describe("getAndValidateApiKeyFromHeader", () => {
@@ -50,7 +50,7 @@ describe("ApiKeyAuthService", () => {
       it("should return key found by sha256 hash", async () => {
         const { service, apiKeyGenerator, apiKeyRepository } = setup();
         const apiKey = apiKeyGenerator.generateApiKey();
-        const data = ApiKeySeeder.create({
+        const data = createApiKey({
           hashedKey: apiKeyGenerator.hashApiKeySha256(apiKey),
           keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
         });
@@ -68,7 +68,7 @@ describe("ApiKeyAuthService", () => {
         pastDate.setDate(pastDate.getDate() - 1);
 
         const apiKey = apiKeyGenerator.generateApiKey();
-        const data = ApiKeySeeder.create({
+        const data = createApiKey({
           expiresAt: pastDate.toISOString(),
           hashedKey: apiKeyGenerator.hashApiKeySha256(apiKey),
           keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
@@ -85,7 +85,7 @@ describe("ApiKeyAuthService", () => {
         futureDate.setUTCFullYear(futureDate.getUTCFullYear() + 1);
 
         const apiKey = apiKeyGenerator.generateApiKey();
-        const data = ApiKeySeeder.create({
+        const data = createApiKey({
           expiresAt: futureDate.toISOString(),
           hashedKey: apiKeyGenerator.hashApiKeySha256(apiKey),
           keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
@@ -102,7 +102,7 @@ describe("ApiKeyAuthService", () => {
       it("should fallback to bcrypt when sha256 not found", async () => {
         const { service, apiKeyGenerator, apiKeyRepository } = setup();
         const apiKey = apiKeyGenerator.generateApiKey();
-        const data = ApiKeySeeder.create({
+        const data = createApiKey({
           hashedKey: await apiKeyGenerator.hashApiKey(apiKey),
           keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
         });
@@ -117,7 +117,7 @@ describe("ApiKeyAuthService", () => {
       it("should update hashedKey to sha256 after bcrypt match", async () => {
         const { service, apiKeyGenerator, apiKeyRepository } = setup();
         const apiKey = apiKeyGenerator.generateApiKey();
-        const data = ApiKeySeeder.create({
+        const data = createApiKey({
           hashedKey: await apiKeyGenerator.hashApiKey(apiKey),
           keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)
         });
@@ -137,7 +137,7 @@ describe("ApiKeyAuthService", () => {
         pastDate.setDate(pastDate.getDate() - 1);
 
         const apiKey = apiKeyGenerator.generateApiKey();
-        const data = ApiKeySeeder.create({
+        const data = createApiKey({
           expiresAt: pastDate.toISOString(),
           hashedKey: await apiKeyGenerator.hashApiKey(apiKey),
           keyFormat: apiKeyGenerator.obfuscateApiKey(apiKey)

--- a/apps/api/src/auth/services/auth0/auth0.service.spec.ts
+++ b/apps/api/src/auth/services/auth0/auth0.service.spec.ts
@@ -5,13 +5,13 @@ import { mock } from "vitest-mock-extended";
 import type { AuthConfigService } from "@src/auth/services/auth-config/auth-config.service";
 import { Auth0Service } from "./auth0.service";
 
-import { Auth0UserSeeder } from "@test/seeders";
+import { createAuth0User } from "@test/seeders";
 
 describe(Auth0Service.name, () => {
   describe("getUserByEmail", () => {
     it("should return user when user is found", async () => {
       const email = faker.internet.email();
-      const mockUser: Partial<GetUsers200ResponseOneOfInner> = Auth0UserSeeder.create({
+      const mockUser: Partial<GetUsers200ResponseOneOfInner> = createAuth0User({
         email: email,
         email_verified: true
       });
@@ -42,11 +42,11 @@ describe(Auth0Service.name, () => {
     it("should return first user when multiple users are found", async () => {
       const email = faker.internet.email();
       const mockUsers: Partial<GetUsers200ResponseOneOfInner>[] = [
-        Auth0UserSeeder.create({
+        createAuth0User({
           email,
           email_verified: true
         }),
-        Auth0UserSeeder.create({
+        createAuth0User({
           email,
           email_verified: false
         })

--- a/apps/api/src/billing/services/usage/usage.service.spec.ts
+++ b/apps/api/src/billing/services/usage/usage.service.spec.ts
@@ -7,7 +7,7 @@ import type { DeploymentRepository } from "@src/deployment/repositories/deployme
 import { UsageService } from "./usage.service";
 
 import { createAkashAddress } from "@test/seeders";
-import { BillingUsageSeeder } from "@test/seeders/billing-usage.seeder";
+import { createBillingUsage } from "@test/seeders/billing-usage.seeder";
 
 describe(UsageService.name, () => {
   describe("getHistory", () => {
@@ -132,7 +132,7 @@ describe(UsageService.name, () => {
         const { address, startDate, endDate, service, usageRepository, deploymentRepository } = setup();
 
         const mockUsageData = [
-          BillingUsageSeeder.create({
+          createBillingUsage({
             date: "2024-01-01",
             activeDeployments: 1,
             dailyAktSpent: 5.5,
@@ -154,7 +154,7 @@ describe(UsageService.name, () => {
         const { address, startDate, endDate, service, usageRepository, deploymentRepository } = setup();
 
         const mockUsageData = [
-          BillingUsageSeeder.create({
+          createBillingUsage({
             date: "2024-01-01",
             activeDeployments: 1,
             dailyAktSpent: 100.123456789,
@@ -164,7 +164,7 @@ describe(UsageService.name, () => {
             dailyUsdSpent: 151.11111111,
             totalUsdSpent: 151.11111111
           }),
-          BillingUsageSeeder.create({
+          createBillingUsage({
             date: "2024-01-02",
             activeDeployments: 1,
             dailyAktSpent: 200.987654321,
@@ -195,7 +195,7 @@ describe(UsageService.name, () => {
     const totalDeployments = input?.totalDeployments ?? faker.number.int({ min: 1, max: 20 });
 
     const mockUsageData = input?.usageData || [
-      BillingUsageSeeder.create({
+      createBillingUsage({
         date: format(startDate, "yyyy-MM-dd"),
         activeDeployments: 1,
         dailyAktSpent: 5.5,
@@ -205,7 +205,7 @@ describe(UsageService.name, () => {
         dailyUsdSpent: 7.75,
         totalUsdSpent: 7.75
       }),
-      BillingUsageSeeder.create({
+      createBillingUsage({
         date: format(addDays(startDate, 1), "yyyy-MM-dd"),
         activeDeployments: 2,
         dailyAktSpent: 3.2,
@@ -215,7 +215,7 @@ describe(UsageService.name, () => {
         dailyUsdSpent: 4.7,
         totalUsdSpent: 12.45
       }),
-      BillingUsageSeeder.create({
+      createBillingUsage({
         date: format(addDays(startDate, 2), "yyyy-MM-dd"),
         activeDeployments: 1,
         dailyAktSpent: 2.1,

--- a/apps/api/test/functional/api-key.spec.ts
+++ b/apps/api/test/functional/api-key.spec.ts
@@ -10,7 +10,7 @@ import type { CoreConfigService } from "@src/core/services/core-config/core-conf
 import { app } from "@src/rest-app";
 import { UserRepository } from "@src/user/repositories/user/user.repository";
 
-import { ApiKeySeeder } from "@test/seeders/api-key.seeder";
+import { createApiKey } from "@test/seeders/api-key.seeder";
 
 const OBFUSCATED_API_KEY_PATTERN = /^ac\.sk\.test\.[A-Za-z0-9]{6}\*{3}[A-Za-z0-9]{6}$/;
 const FULL_API_KEY_PATTERN = /^ac\.sk\.test\.[A-Za-z0-9]{64}$/;
@@ -45,7 +45,7 @@ describe("API Keys", () => {
       const { user: user1, token, createUser } = await setup();
       const { token: token2 } = await createUser();
 
-      const key1 = ApiKeySeeder.create({
+      const key1 = createApiKey({
         userId: user1.id,
         name: "Test key 1"
       });
@@ -81,13 +81,13 @@ describe("API Keys", () => {
       const hashedKey2 = await apiKeyGenerator.hashApiKey(apiKey2);
       const obfuscatedKey2 = apiKeyGenerator.obfuscateApiKey(apiKey2);
 
-      const key1 = ApiKeySeeder.create({
+      const key1 = createApiKey({
         userId: user.id,
         name: "Test key 1",
         hashedKey,
         keyFormat: obfuscatedKey
       });
-      const key2 = ApiKeySeeder.create({
+      const key2 = createApiKey({
         userId: user.id,
         name: "Test key 2",
         hashedKey: hashedKey2,

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -20,7 +20,7 @@ import type { UserOutput } from "@src/user/repositories";
 import { UserRepository } from "@src/user/repositories";
 import { deploymentVersion, marketVersion } from "@src/utils/constants";
 
-import { ApiKeySeeder } from "@test/seeders/api-key.seeder";
+import { createApiKey } from "@test/seeders/api-key.seeder";
 import { createDeployment } from "@test/seeders/deployment.seeder";
 import { createDeploymentInfoErrorSeed, createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
 import { LeaseApiResponseSeeder } from "@test/seeders/lease-api-response.seeder";
@@ -113,7 +113,7 @@ describe("Deployments API", () => {
     const userId = faker.string.uuid();
     const userApiKeySecret = faker.word.noun();
     const user = createUser({ userId });
-    const apiKey = ApiKeySeeder.create({ userId });
+    const apiKey = createApiKey({ userId });
     const wallets = [UserWalletSeeder.create({ userId, address: "akash13265twfqejnma6cc93rw5dxk4cldyz2zyy8cdm" })];
 
     currentUser = user;

--- a/apps/api/test/seeders/api-key.seeder.ts
+++ b/apps/api/test/seeders/api-key.seeder.ts
@@ -2,28 +2,26 @@ import { faker } from "@faker-js/faker";
 
 import type { ApiKeyOutput } from "@src/auth/repositories/api-key/api-key.repository";
 
-export class ApiKeySeeder {
-  static create({
-    id = faker.string.uuid(),
-    userId = faker.string.uuid(),
-    name = faker.company.name(),
-    hashedKey = faker.string.alphanumeric(64),
-    keyFormat = `ac.sk.test.${faker.string.alphanumeric(15)}`,
-    expiresAt = null,
-    createdAt = new Date().toISOString(),
-    updatedAt = new Date().toISOString(),
-    lastUsedAt = null
-  }: Partial<ApiKeyOutput> = {}): ApiKeyOutput {
-    return {
-      id,
-      userId,
-      name,
-      hashedKey,
-      keyFormat,
-      expiresAt,
-      createdAt,
-      updatedAt,
-      lastUsedAt
-    };
-  }
+export function createApiKey({
+  id = faker.string.uuid(),
+  userId = faker.string.uuid(),
+  name = faker.company.name(),
+  hashedKey = faker.string.alphanumeric(64),
+  keyFormat = `ac.sk.test.${faker.string.alphanumeric(15)}`,
+  expiresAt = null,
+  createdAt = new Date().toISOString(),
+  updatedAt = new Date().toISOString(),
+  lastUsedAt = null
+}: Partial<ApiKeyOutput> = {}): ApiKeyOutput {
+  return {
+    id,
+    userId,
+    name,
+    hashedKey,
+    keyFormat,
+    expiresAt,
+    createdAt,
+    updatedAt,
+    lastUsedAt
+  };
 }

--- a/apps/api/test/seeders/auth0-user.seeder.ts
+++ b/apps/api/test/seeders/auth0-user.seeder.ts
@@ -1,22 +1,20 @@
 import { faker } from "@faker-js/faker";
 import type { GetUsers200ResponseOneOfInner } from "auth0";
 
-export class Auth0UserSeeder {
-  static create({
-    user_id = faker.string.uuid(),
-    email = faker.internet.email(),
-    email_verified = faker.datatype.boolean(),
-    name = faker.person.fullName(),
-    created_at = faker.date.past().toISOString(),
-    updated_at = faker.date.recent().toISOString()
-  }: Partial<GetUsers200ResponseOneOfInner> = {}): Partial<GetUsers200ResponseOneOfInner> {
-    return {
-      user_id,
-      email,
-      email_verified,
-      name,
-      created_at,
-      updated_at
-    };
-  }
+export function createAuth0User({
+  user_id = faker.string.uuid(),
+  email = faker.internet.email(),
+  email_verified = faker.datatype.boolean(),
+  name = faker.person.fullName(),
+  created_at = faker.date.past().toISOString(),
+  updated_at = faker.date.recent().toISOString()
+}: Partial<GetUsers200ResponseOneOfInner> = {}): Partial<GetUsers200ResponseOneOfInner> {
+  return {
+    user_id,
+    email,
+    email_verified,
+    name,
+    created_at,
+    updated_at
+  };
 }

--- a/apps/api/test/seeders/balance.seeder.ts
+++ b/apps/api/test/seeders/balance.seeder.ts
@@ -4,18 +4,16 @@ import { merge } from "lodash";
 
 import type { GetBalancesResponseOutput } from "@src/billing/http-schemas/balance.schema";
 
-import { DenomSeeder } from "@test/seeders/denom.seeder";
+import { createDenom } from "@test/seeders/denom.seeder";
 
-export class BalanceSeeder {
-  static create(input: Partial<Balance> = {}): Balance {
-    return merge(
-      {
-        denom: DenomSeeder.create(),
-        amount: faker.number.int({ min: 0, max: 10000000 }).toString()
-      },
-      input
-    );
-  }
+export function createBalance(input: Partial<Balance> = {}): Balance {
+  return merge(
+    {
+      denom: createDenom(),
+      amount: faker.number.int({ min: 0, max: 10000000 }).toString()
+    },
+    input
+  );
 }
 
 export function generateBalance(overrides: Partial<GetBalancesResponseOutput["data"]> = {}): GetBalancesResponseOutput["data"] {

--- a/apps/api/test/seeders/billing-usage.seeder.ts
+++ b/apps/api/test/seeders/billing-usage.seeder.ts
@@ -2,26 +2,24 @@ import { faker } from "@faker-js/faker";
 
 import type { BillingUsageRawResult } from "@src/billing/repositories/usage/usage.repository";
 
-export class BillingUsageSeeder {
-  static create({
-    date = faker.date.recent().toISOString().split("T")[0],
-    activeDeployments = faker.number.int({ min: 0, max: 10 }),
-    dailyAktSpent = faker.number.float({ min: 0, max: 100, precision: 0.01 }),
-    totalAktSpent = faker.number.float({ min: 0, max: 1000, precision: 0.01 }),
-    dailyUsdcSpent = faker.number.float({ min: 0, max: 100, precision: 0.01 }),
-    totalUsdcSpent = faker.number.float({ min: 0, max: 1000, precision: 0.01 }),
-    dailyUsdSpent = faker.number.float({ min: 0, max: 100, precision: 0.01 }),
-    totalUsdSpent = faker.number.float({ min: 0, max: 1000, precision: 0.01 })
-  }: Partial<BillingUsageRawResult> = {}): BillingUsageRawResult {
-    return {
-      date,
-      activeDeployments,
-      dailyAktSpent,
-      totalAktSpent,
-      dailyUsdcSpent,
-      totalUsdcSpent,
-      dailyUsdSpent,
-      totalUsdSpent
-    };
-  }
+export function createBillingUsage({
+  date = faker.date.recent().toISOString().split("T")[0],
+  activeDeployments = faker.number.int({ min: 0, max: 10 }),
+  dailyAktSpent = faker.number.float({ min: 0, max: 100, precision: 0.01 }),
+  totalAktSpent = faker.number.float({ min: 0, max: 1000, precision: 0.01 }),
+  dailyUsdcSpent = faker.number.float({ min: 0, max: 100, precision: 0.01 }),
+  totalUsdcSpent = faker.number.float({ min: 0, max: 1000, precision: 0.01 }),
+  dailyUsdSpent = faker.number.float({ min: 0, max: 100, precision: 0.01 }),
+  totalUsdSpent = faker.number.float({ min: 0, max: 1000, precision: 0.01 })
+}: Partial<BillingUsageRawResult> = {}): BillingUsageRawResult {
+  return {
+    date,
+    activeDeployments,
+    dailyAktSpent,
+    totalAktSpent,
+    dailyUsdcSpent,
+    totalUsdcSpent,
+    dailyUsdSpent,
+    totalUsdSpent
+  };
 }

--- a/apps/api/test/seeders/denom.seeder.ts
+++ b/apps/api/test/seeders/denom.seeder.ts
@@ -1,8 +1,6 @@
 import type { Denom } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
 
-export class DenomSeeder {
-  static create(): Denom {
-    return faker.helpers.arrayElement(["uakt", "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1"]);
-  }
+export function createDenom(): Denom {
+  return faker.helpers.arrayElement(["uakt", "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1"]);
 }

--- a/apps/api/test/seeders/deployment-info.seeder.ts
+++ b/apps/api/test/seeders/deployment-info.seeder.ts
@@ -3,7 +3,7 @@ import { faker } from "@faker-js/faker";
 import type { RestAkashDeploymentInfoResponse } from "@src/types/rest";
 import { deploymentVersion } from "@src/utils/constants";
 import { createAkashAddress } from "./akash-address.seeder";
-import { DenomSeeder } from "./denom.seeder";
+import { createDenom } from "./denom.seeder";
 
 export interface DeploymentInfoSeederInput {
   owner?: string;
@@ -29,7 +29,7 @@ export function createDeploymentInfoSeed(input: DeploymentInfoSeederInput = {}):
     version = deploymentVersion,
     createdAt = "2021-01-01T00:00:00Z",
     amount = "5000000",
-    denom = DenomSeeder.create()
+    denom = createDenom()
   } = input;
 
   return {

--- a/apps/api/test/seeders/draining-deployment.seeder.ts
+++ b/apps/api/test/seeders/draining-deployment.seeder.ts
@@ -2,12 +2,12 @@ import { faker } from "@faker-js/faker";
 
 import type { DrainingDeploymentOutput } from "@src/deployment/repositories/lease/lease.repository";
 
-import { DenomSeeder } from "@test/seeders/denom.seeder";
+import { createDenom } from "@test/seeders/denom.seeder";
 
 export class DrainingDeploymentSeeder {
   static create({
     dseq = faker.number.int({ min: 1, max: 99999999 }),
-    denom = DenomSeeder.create(),
+    denom = createDenom(),
     blockRate = faker.number.int({ min: 1, max: 100 }),
     predictedClosedHeight = faker.number.int({ min: 1, max: 99999999 }),
     owner = faker.string.alpha(),

--- a/apps/api/test/seeders/lease-api-response.seeder.ts
+++ b/apps/api/test/seeders/lease-api-response.seeder.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 
 import { createAkashAddress } from "./akash-address.seeder";
-import { DenomSeeder } from "./denom.seeder";
+import { createDenom } from "./denom.seeder";
 
 export interface LeaseInput {
   owner?: string;
@@ -78,14 +78,14 @@ export class LeaseApiResponseSeeder {
       provider = createAkashAddress(),
       state = faker.helpers.arrayElement(["active", "closed", "insufficient_funds"]),
       price = {
-        denom: DenomSeeder.create(),
+        denom: createDenom(),
         amount: faker.string.numeric(6)
       },
       created_at = faker.date.past().toISOString(),
       closed_on = state === "closed" ? faker.date.recent().toISOString() : undefined
     } = input;
 
-    const denom = price.denom || DenomSeeder.create();
+    const denom = price.denom || createDenom();
     const amount = price.amount || faker.string.numeric(6);
 
     return {

--- a/apps/api/test/seeders/node.seeder.ts
+++ b/apps/api/test/seeders/node.seeder.ts
@@ -1,16 +1,14 @@
 import type { NetworkNode } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
 
-export class NodeSeeder {
-  static create({
-    id = faker.string.alphanumeric(),
-    api = faker.string.alphanumeric(),
-    rpc = faker.string.alphanumeric()
-  }: Partial<NetworkNode> = {}): NetworkNode {
-    return {
-      id,
-      api,
-      rpc
-    };
-  }
+export function createNode({
+  id = faker.string.alphanumeric(),
+  api = faker.string.alphanumeric(),
+  rpc = faker.string.alphanumeric()
+}: Partial<NetworkNode> = {}): NetworkNode {
+  return {
+    id,
+    api,
+    rpc
+  };
 }

--- a/apps/api/test/seeders/stale-deployment.seeder.ts
+++ b/apps/api/test/seeders/stale-deployment.seeder.ts
@@ -2,10 +2,8 @@ import { faker } from "@faker-js/faker";
 
 import type { StaleDeploymentsOutput } from "@src/deployment/repositories/deployment/deployment.repository";
 
-export class StaleDeploymentSeeder {
-  static create({ dseq = faker.number.int({ min: 1, max: 99999999 }) }: Partial<StaleDeploymentsOutput> = {}): StaleDeploymentsOutput {
-    return {
-      dseq
-    };
-  }
+export function createStaleDeployment({ dseq = faker.number.int({ min: 1, max: 99999999 }) }: Partial<StaleDeploymentsOutput> = {}): StaleDeploymentsOutput {
+  return {
+    dseq
+  };
 }


### PR DESCRIPTION
## Why

Refactor class-based seeders to function-based. There is no point to define a class full of static methods.

## What

- Convert ApiKeySeeder, Auth0UserSeeder, BalanceSeeder, BillingUsageSeeder, DenomSeeder, NodeSeeder, StaleDeploymentSeeder to plain exported functions
- Update all consumer files to use the new function names
- Update DenomSeeder references in other seeders (draining-deployment, lease-api-response, deployment-info) that will be refactored in follow-up PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Converted many test seeding utilities from class-based factories to standalone functions to simplify test setup; preserved existing test data shapes and behavior.
  * Added a new optional field to one deployment test fixture to enable additional test scenarios.

* **Chores**
  * Updated test infrastructure and seed utilities; no changes to runtime behavior or end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->