### PR TITLE
test(dx): refactor medium seeders from classes to plain functions

### DIFF
--- a/apps/api/src/bid/services/bid/bid.service.spec.ts
+++ b/apps/api/src/bid/services/bid/bid.service.spec.ts
@@ -10,7 +10,7 @@ import type { ProviderRepository } from "@src/provider/repositories/provider/pro
 import { BidService } from "./bid.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
-import { BidSeeder } from "@test/seeders/bid.seeder";
+import { createBid } from "@test/seeders/bid.seeder";
 import { createProviderSeed, createProviderWithAttributeSignatures } from "@test/seeders/provider.seeder";
 
 describe(BidService.name, () => {
@@ -21,7 +21,7 @@ describe(BidService.name, () => {
       });
 
       const userWallet = { address: faker.finance.ethereumAddress(), userId: 1 };
-      const mockBids = [BidSeeder.create(), BidSeeder.create(), BidSeeder.create()];
+      const mockBids = [createBid(), createBid(), createBid()];
 
       authService.ability = {} as unknown as AuthService["ability"];
       userWalletRepository.accessibleBy.mockReturnValue({
@@ -51,9 +51,9 @@ describe(BidService.name, () => {
       } as unknown as Provider;
 
       const mockBids = [
-        BidSeeder.create({ provider: auditedProvider1.owner }),
-        BidSeeder.create({ provider: auditedProvider2.owner }),
-        BidSeeder.create({ provider: unauditedProvider.owner })
+        createBid({ provider: auditedProvider1.owner }),
+        createBid({ provider: auditedProvider2.owner }),
+        createBid({ provider: unauditedProvider.owner })
       ];
 
       authService.ability = {} as unknown as AuthService["ability"];
@@ -92,7 +92,7 @@ describe(BidService.name, () => {
         providerAttributes: []
       } as unknown as Provider;
 
-      const mockBids = [BidSeeder.create({ provider: unauditedProvider1.owner }), BidSeeder.create({ provider: unauditedProvider2.owner })];
+      const mockBids = [createBid({ provider: unauditedProvider1.owner }), createBid({ provider: unauditedProvider2.owner })];
 
       authService.ability = {} as unknown as AuthService["ability"];
       userWalletRepository.accessibleBy.mockReturnValue({

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -20,15 +20,15 @@ import { DrainingDeploymentService } from "./draining-deployment.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createAkashAddress } from "@test/seeders";
-import { AutoTopUpDeploymentSeeder } from "@test/seeders/auto-top-up-deployment.seeder";
-import { DrainingDeploymentSeeder } from "@test/seeders/draining-deployment.seeder";
+import { createManyAutoTopUpDeployments } from "@test/seeders/auto-top-up-deployment.seeder";
+import { createDrainingDeployment } from "@test/seeders/draining-deployment.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
 describe(DrainingDeploymentService.name, () => {
   describe("findDrainingDeploymentsByOwner", () => {
     it("paginates draining deployments by owner and marks closed ones as such", async () => {
       const { service, deploymentSettingRepository, leaseRepository, loggerService, currentHeight } = setup();
-      const deploymentSettings = AutoTopUpDeploymentSeeder.createMany(4);
+      const deploymentSettings = createManyAutoTopUpDeployments(4);
       const addresses = deploymentSettings.map(s => s.address);
       const dseqs = deploymentSettings.map(s => Number(s.dseq));
 
@@ -115,8 +115,8 @@ describe(DrainingDeploymentService.name, () => {
       const owner = createAkashAddress();
       const dseqs = [faker.string.numeric(6), faker.string.numeric(6)];
       const expectedLeases: DrainingDeploymentOutput[] = [
-        DrainingDeploymentSeeder.create({ owner, dseq: Number(dseqs[0]) }),
-        DrainingDeploymentSeeder.create({ owner, dseq: Number(dseqs[1]) })
+        createDrainingDeployment({ owner, dseq: Number(dseqs[0]) }),
+        createDrainingDeployment({ owner, dseq: Number(dseqs[1]) })
       ];
 
       rpcService.findManyByDseqAndOwner.mockResolvedValue(expectedLeases);
@@ -134,8 +134,8 @@ describe(DrainingDeploymentService.name, () => {
       const dseqs = [faker.string.numeric(6), faker.string.numeric(6)];
       const rpcError = new Error("RPC error");
       const expectedLeases: DrainingDeploymentOutput[] = [
-        DrainingDeploymentSeeder.create({ owner, dseq: Number(dseqs[0]) }),
-        DrainingDeploymentSeeder.create({ owner, dseq: Number(dseqs[1]) })
+        createDrainingDeployment({ owner, dseq: Number(dseqs[0]) }),
+        createDrainingDeployment({ owner, dseq: Number(dseqs[1]) })
       ];
 
       rpcService.findManyByDseqAndOwner.mockRejectedValue(rpcError);
@@ -188,7 +188,7 @@ describe(DrainingDeploymentService.name, () => {
       const dseq = faker.string.numeric(6);
       const address = createAkashAddress();
       const userWallet = UserWalletSeeder.create({ address });
-      const deployment = DrainingDeploymentSeeder.create();
+      const deployment = createDrainingDeployment();
       const expectedTopUpAmount = 100000;
 
       const { service, userWalletRepository, leaseRepository } = setup();
@@ -358,12 +358,12 @@ describe(DrainingDeploymentService.name, () => {
       baseSetup.userWalletRepository.findOneByUserId.mockResolvedValue(userWallet);
 
       baseSetup.deploymentSettingRepository.accessibleBy.mockReturnValue(baseSetup.deploymentSettingRepository);
-      const deploymentSettings = AutoTopUpDeploymentSeeder.createMany(input.deployments.length, { address });
+      const deploymentSettings = createManyAutoTopUpDeployments(input.deployments.length, { address });
 
       const drainingDeployments = deploymentSettings.map((setting, idx) => {
         const deployment = input.deployments[idx];
         const predictedClosedHeight = deployment?.predictedClosedHeight;
-        return DrainingDeploymentSeeder.create({
+        return createDrainingDeployment({
           dseq: Number(setting.dseq),
           owner: address,
           blockRate: deployment?.blockRate ?? 0,
@@ -497,12 +497,12 @@ describe(DrainingDeploymentService.name, () => {
       const baseSetup = setup();
       baseSetup.userWalletRepository.findOneBy.mockResolvedValue(userWallet);
 
-      const deploymentSettings = AutoTopUpDeploymentSeeder.createMany(input.deployments.length, { address });
+      const deploymentSettings = createManyAutoTopUpDeployments(input.deployments.length, { address });
 
       const drainingDeployments = deploymentSettings.map((setting, idx) => {
         const deployment = input.deployments[idx];
         const predictedClosedHeight = deployment?.predictedClosedHeight ?? undefined;
-        return DrainingDeploymentSeeder.create({
+        return createDrainingDeployment({
           dseq: Number(setting.dseq),
           owner: address,
           predictedClosedHeight: predictedClosedHeight === null ? undefined : predictedClosedHeight,

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
@@ -9,8 +9,8 @@ import { TopUpSummarizer } from "@src/deployment/lib/top-up-summarizer/top-up-su
 import type { DrainingDeployment } from "@src/deployment/types/draining-deployment";
 import { TopUpManagedDeploymentsInstrumentationService } from "./top-up-managed-deployments-instrumentation.service";
 
-import { AutoTopUpDeploymentSeeder } from "@test/seeders/auto-top-up-deployment.seeder";
-import { DrainingDeploymentSeeder } from "@test/seeders/draining-deployment.seeder";
+import { createAutoTopUpDeployment } from "@test/seeders/auto-top-up-deployment.seeder";
+import { createDrainingDeployment as createDrainingDeploymentSeed } from "@test/seeders/draining-deployment.seeder";
 
 describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
   describe("finish", () => {
@@ -174,8 +174,8 @@ describe(TopUpManagedDeploymentsInstrumentationService.name, () => {
   });
 
   function createDrainingDeployment(overrides?: Partial<DrainingDeployment>): DrainingDeployment {
-    const base = AutoTopUpDeploymentSeeder.create(overrides);
-    const extra = DrainingDeploymentSeeder.create({ dseq: Number(base.dseq), owner: base.address });
+    const base = createAutoTopUpDeployment(overrides);
+    const extra = createDrainingDeploymentSeed({ dseq: Number(base.dseq), owner: base.address });
     return { ...base, ...extra, dseq: base.dseq, ...overrides } as DrainingDeployment;
   }
 

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -17,8 +17,8 @@ import { TopUpManagedDeploymentsService } from "./top-up-managed-deployments.ser
 import type { TopUpManagedDeploymentsInstrumentationService } from "./top-up-managed-deployments-instrumentation.service";
 
 import { createAkashAddress } from "@test/seeders";
-import { AutoTopUpDeploymentSeeder } from "@test/seeders/auto-top-up-deployment.seeder";
-import { DrainingDeploymentSeeder } from "@test/seeders/draining-deployment.seeder";
+import { createAutoTopUpDeployment, createManyAutoTopUpDeployments } from "@test/seeders/auto-top-up-deployment.seeder";
+import { createDrainingDeployment } from "@test/seeders/draining-deployment.seeder";
 
 describe(TopUpManagedDeploymentsService.name, () => {
   const DEPLOYMENT_GRANT_DENOM = "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1";
@@ -34,7 +34,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
   describe("topUpDeployments", () => {
     it("should top up draining deployments", async () => {
       const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, instrumentation } = setup();
-      const deployments = AutoTopUpDeploymentSeeder.createMany(2);
+      const deployments = createManyAutoTopUpDeployments(2);
       const desiredAmount = faker.number.int({ min: 3500000, max: 4000000 });
       const sufficientAmount = faker.number.int({ min: 1000000, max: 2000000 });
       const predictedClosedHeight1 = CURRENT_BLOCK_HEIGHT + 1500;
@@ -49,7 +49,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
               }
               acc[deployment.address].push({
                 ...deployment,
-                ...DrainingDeploymentSeeder.create({
+                ...createDrainingDeployment({
                   dseq: Number(deployment.dseq),
                   owner: deployment.address,
                   predictedClosedHeight: index === 0 ? predictedClosedHeight1 : predictedClosedHeight2,
@@ -128,7 +128,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
     it("should handle errors and continue processing", async () => {
       const { service, drainingDeploymentService, cachedBalanceService, managedSignerService } = setup();
-      const deployments = AutoTopUpDeploymentSeeder.createMany(2);
+      const deployments = createManyAutoTopUpDeployments(2);
       const predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500;
 
       drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
@@ -140,7 +140,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
               }
               acc[deployment.address].push({
                 ...deployment,
-                ...DrainingDeploymentSeeder.create({
+                ...createDrainingDeployment({
                   dseq: Number(deployment.dseq),
                   owner: deployment.address,
                   predictedClosedHeight
@@ -169,7 +169,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
     it("should not execute transactions in dry run mode", async () => {
       const { service, drainingDeploymentService, cachedBalanceService, managedSignerService } = setup();
-      const deployments = AutoTopUpDeploymentSeeder.createMany(2);
+      const deployments = createManyAutoTopUpDeployments(2);
       const predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500;
 
       drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
@@ -181,7 +181,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
               }
               acc[deployment.address].push({
                 ...deployment,
-                ...DrainingDeploymentSeeder.create({
+                ...createDrainingDeployment({
                   dseq: Number(deployment.dseq),
                   owner: deployment.address,
                   predictedClosedHeight
@@ -219,7 +219,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       const { service, drainingDeploymentService, cachedBalanceService, managedSignerService } = setup();
       const owner = createAkashAddress();
       const walletId = faker.number.int({ min: 1000000, max: 9999999 });
-      const deployments = [AutoTopUpDeploymentSeeder.create({ address: owner, walletId }), AutoTopUpDeploymentSeeder.create({ address: owner, walletId })];
+      const deployments = [createAutoTopUpDeployment({ address: owner, walletId }), createAutoTopUpDeployment({ address: owner, walletId })];
       const desiredAmount = faker.number.int({ min: 3500000, max: 4000000 });
       const sufficientAmount = faker.number.int({ min: 1000000, max: 2000000 });
       const predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500;
@@ -233,7 +233,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
               }
               acc[deployment.address].push({
                 ...deployment,
-                ...DrainingDeploymentSeeder.create({
+                ...createDrainingDeployment({
                   dseq: Number(deployment.dseq),
                   owner: deployment.address,
                   predictedClosedHeight
@@ -297,7 +297,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
     it("should log errors when message preparation fails", async () => {
       const { service, drainingDeploymentService, instrumentation } = setup();
-      const deployment = AutoTopUpDeploymentSeeder.create();
+      const deployment = createAutoTopUpDeployment();
       const error = new Error("Failed to calculate amount");
 
       drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
@@ -305,7 +305,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
           const items: DrainingDeployment[] = [
             {
               ...deployment,
-              ...DrainingDeploymentSeeder.create({
+              ...createDrainingDeployment({
                 dseq: Number(deployment.dseq),
                 owner: deployment.address,
                 predictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500
@@ -336,7 +336,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
     it("should handle master wallet insufficient funds error and stop processing", async () => {
       const { service, chainErrorService, managedSignerService, drainingDeploymentService, cachedBalanceService, instrumentation } = setup();
-      const deployments = AutoTopUpDeploymentSeeder.createMany(3);
+      const deployments = createManyAutoTopUpDeployments(3);
       const error = new Error(`insufficient funds: 10uakt is smaller than 20uakt`);
       const mockTx = mock<IndexedTx>({ code: 0, hash: "tx-hash", rawLog: "success" });
 
@@ -352,7 +352,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
               }
               acc[deployment.address].push({
                 ...deployment,
-                ...DrainingDeploymentSeeder.create({
+                ...createDrainingDeployment({
                   dseq: Number(deployment.dseq),
                   owner: deployment.address,
                   predictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500,
@@ -388,7 +388,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
     it("should handle user wallet insufficient funds error and continue processing", async () => {
       const { service, chainErrorService, managedSignerService, drainingDeploymentService, cachedBalanceService, instrumentation } = setup();
-      const deployments = AutoTopUpDeploymentSeeder.createMany(3);
+      const deployments = createManyAutoTopUpDeployments(3);
       const error = new Error(`insufficient funds: 10uakt is smaller than 20uakt`);
 
       chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(false);
@@ -408,7 +408,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
               }
               acc[deployment.address].push({
                 ...deployment,
-                ...DrainingDeploymentSeeder.create({
+                ...createDrainingDeployment({
                   dseq: Number(deployment.dseq),
                   owner: deployment.address,
                   predictedClosedHeight: CURRENT_BLOCK_HEIGHT + 1500,
@@ -437,7 +437,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
     it("should call ensureFeeGrants before executing top-up", async () => {
       const { service, drainingDeploymentService, cachedBalanceService, managedSignerService } = setup();
-      const deployment = AutoTopUpDeploymentSeeder.create();
+      const deployment = createAutoTopUpDeployment();
       const predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500;
 
       drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
@@ -447,7 +447,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
             deployments: [
               {
                 ...deployment,
-                ...DrainingDeploymentSeeder.create({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
+                ...createDrainingDeployment({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
                 dseq: deployment.dseq
               } as DrainingDeployment
             ]
@@ -469,7 +469,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
     it("should not execute top-up when fee grant is missing and cannot be refilled", async () => {
       const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, instrumentation } = setup({ feeAllowance: 0 });
-      const deployment = AutoTopUpDeploymentSeeder.create();
+      const deployment = createAutoTopUpDeployment();
       const predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500;
 
       drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
@@ -479,7 +479,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
             deployments: [
               {
                 ...deployment,
-                ...DrainingDeploymentSeeder.create({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
+                ...createDrainingDeployment({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
                 dseq: deployment.dseq
               } as DrainingDeployment
             ]
@@ -502,7 +502,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
     it("should skip fee grant validation in dry run mode", async () => {
       const { service, drainingDeploymentService, cachedBalanceService, managedSignerService } = setup();
-      const deployment = AutoTopUpDeploymentSeeder.create();
+      const deployment = createAutoTopUpDeployment();
       const predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500;
 
       drainingDeploymentService.findDrainingDeploymentsByOwner.mockImplementation(() =>
@@ -512,7 +512,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
             deployments: [
               {
                 ...deployment,
-                ...DrainingDeploymentSeeder.create({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
+                ...createDrainingDeployment({ dseq: Number(deployment.dseq), owner: deployment.address, predictedClosedHeight }),
                 dseq: deployment.dseq
               } as DrainingDeployment
             ]

--- a/apps/api/src/provider/services/provider/provider.service.spec.ts
+++ b/apps/api/src/provider/services/provider/provider.service.spec.ts
@@ -10,7 +10,7 @@ import { mock } from "vitest-mock-extended";
 
 import { AUDITOR } from "@src/deployment/config/provider.config";
 import { mockConfigService } from "../../../../test/mocks/config-service.mock";
-import { LeaseStatusSeeder } from "../../../../test/seeders/lease-status.seeder";
+import { createLeaseStatus } from "../../../../test/seeders/lease-status.seeder";
 import { createProviderSeed, createProviderWithAttributeSignatures } from "../../../../test/seeders/provider.seeder";
 import { UserWalletSeeder } from "../../../../test/seeders/user-wallet.seeder";
 import type { BillingConfigService } from "../../../billing/services/billing-config/billing-config.service";
@@ -323,7 +323,7 @@ describe(ProviderService.name, () => {
       const oseq = faker.number.int({ min: 1, max: 10 });
       const jwtToken = faker.string.alphanumeric(32);
 
-      const leaseStatus = LeaseStatusSeeder.create();
+      const leaseStatus = createLeaseStatus();
 
       const leases: JwtTokenPayload["leases"] = {
         access: "granular",

--- a/apps/api/test/functional/balances.spec.ts
+++ b/apps/api/test/functional/balances.spec.ts
@@ -15,7 +15,7 @@ import { UserRepository } from "@src/user/repositories";
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 import { createDeploymentGrantResponseSeed } from "@test/seeders/deployment-grant-response.seeder";
 import { createDeploymentListResponseSeed } from "@test/seeders/deployment-list-response.seeder";
-import { FeeAllowanceResponseSeeder } from "@test/seeders/fee-allowance-response.seeder";
+import { createFeeAllowanceResponse } from "@test/seeders/fee-allowance-response.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
 const mockMasterWalletAddress = "akash1testmasterwalletaddress";
@@ -187,7 +187,7 @@ describe("Balances", () => {
       .get(/\/cosmos\/feegrant\/v1beta1\/allowance\/.*\/.*/)
       .reply(
         200,
-        FeeAllowanceResponseSeeder.create({
+        createFeeAllowanceResponse({
           granter: mockMasterWalletAddress,
           grantee: wallet.address || undefined,
           amount: "1000000"

--- a/apps/api/test/functional/bids.spec.ts
+++ b/apps/api/test/functional/bids.spec.ts
@@ -12,7 +12,7 @@ import { UserRepository } from "@src/user/repositories";
 import { marketVersion } from "@src/utils/constants";
 
 import { createAkashAddress, createProvider } from "@test/seeders";
-import { BidSeeder } from "@test/seeders/bid.seeder";
+import { createBid } from "@test/seeders/bid.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
 describe("Bids API", () => {
@@ -78,8 +78,8 @@ describe("Bids API", () => {
       })
       .reply(200, {
         bids: [
-          BidSeeder.create({ dseq, owner: wallet.address!, provider: providers[0].owner }),
-          BidSeeder.create({ dseq, owner: wallet.address!, provider: providers[1].owner })
+          createBid({ dseq, owner: wallet.address!, provider: providers[0].owner }),
+          createBid({ dseq, owner: wallet.address!, provider: providers[1].owner })
         ]
       });
 

--- a/apps/api/test/functional/deployment-setting.spec.ts
+++ b/apps/api/test/functional/deployment-setting.spec.ts
@@ -10,7 +10,7 @@ import { app } from "@src/rest-app";
 import { UserRepository } from "@src/user/repositories/user/user.repository";
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
-import { DrainingDeploymentSeeder } from "@test/seeders/draining-deployment.seeder";
+import { createDrainingDeployment } from "@test/seeders/draining-deployment.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
 describe("Deployment Settings", () => {
@@ -343,7 +343,7 @@ describe("Deployment Settings", () => {
     vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue(userWalletRepository);
     vi.spyOn(userWalletRepository, "findFirst").mockResolvedValue(wallet);
     vi.spyOn(userWalletRepository, "findOneByUserId").mockResolvedValue(wallet);
-    vi.spyOn(leaseRepository, "findOneByDseqAndOwner").mockResolvedValue(DrainingDeploymentSeeder.create());
+    vi.spyOn(leaseRepository, "findOneByDseqAndOwner").mockResolvedValue(createDrainingDeployment());
 
     return { user, token, wallet };
   }

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -24,7 +24,7 @@ import { createApiKey } from "@test/seeders/api-key.seeder";
 import { createDeployment } from "@test/seeders/deployment.seeder";
 import { createDeploymentInfoErrorSeed, createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
 import { LeaseApiResponseSeeder } from "@test/seeders/lease-api-response.seeder";
-import { LeaseStatusSeeder } from "@test/seeders/lease-status.seeder";
+import { createLeaseStatus } from "@test/seeders/lease-status.seeder";
 import { createUser } from "@test/seeders/user.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
@@ -95,7 +95,7 @@ describe("Deployments API", () => {
     });
 
     jest.spyOn(providerService, "sendManifest").mockResolvedValue(true);
-    jest.spyOn(providerService, "getLeaseStatus").mockResolvedValue(LeaseStatusSeeder.create());
+    jest.spyOn(providerService, "getLeaseStatus").mockResolvedValue(createLeaseStatus());
   });
 
   afterEach(async () => {

--- a/apps/api/test/functional/sign-and-broadcast-tx.spec.ts
+++ b/apps/api/test/functional/sign-and-broadcast-tx.spec.ts
@@ -16,7 +16,7 @@ import { certVersion, deploymentVersion } from "@src/utils/constants";
 
 import { createDeploymentGrantResponseSeed } from "@test/seeders/deployment-grant-response.seeder";
 import { createDeploymentListResponseSeed } from "@test/seeders/deployment-list-response.seeder";
-import { FeeAllowanceResponseSeeder } from "@test/seeders/fee-allowance-response.seeder";
+import { createFeeAllowanceResponse } from "@test/seeders/fee-allowance-response.seeder";
 import { WalletTestingService } from "@test/services/wallet-testing.service";
 
 describe("Tx Sign", () => {
@@ -184,7 +184,7 @@ describe("Tx Sign", () => {
     nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
       .get(/\/cosmos\/feegrant\/v1beta1\/allowances\/.*/)
       .once()
-      .reply(200, { allowances: [FeeAllowanceResponseSeeder.create()] });
+      .reply(200, { allowances: [createFeeAllowanceResponse()] });
 
     const { user, token, wallet } = await walletService.createUserAndWallet();
 
@@ -220,7 +220,7 @@ describe("Tx Sign", () => {
     nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
       .persist()
       .get(/\/cosmos\/feegrant\/v1beta1\/allowance\/.*\/.*/)
-      .reply(200, FeeAllowanceResponseSeeder.create({ grantee: wallet.address, amount: "5000000" }))
+      .reply(200, createFeeAllowanceResponse({ grantee: wallet.address, amount: "5000000" }))
       .get(/\/cosmos\/authz\/v1beta1\/grants\?.*/)
       .reply(
         200,

--- a/apps/api/test/functional/wallets-refill.spec.ts
+++ b/apps/api/test/functional/wallets-refill.spec.ts
@@ -14,7 +14,7 @@ import { UserRepository } from "@src/user/repositories";
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 import { createDeploymentGrantResponseSeed } from "@test/seeders/deployment-grant-response.seeder";
-import { FeeAllowanceResponseSeeder } from "@test/seeders/fee-allowance-response.seeder";
+import { createFeeAllowanceResponse } from "@test/seeders/fee-allowance-response.seeder";
 
 describe("Wallets Refill", () => {
   const managedUserWalletService = container.resolve(ManagedUserWalletService);
@@ -51,7 +51,7 @@ describe("Wallets Refill", () => {
     nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
       .persist()
       .get(/\/cosmos\/feegrant\/v1beta1\/allowance\/.*\/.*/)
-      .reply(200, FeeAllowanceResponseSeeder.create({ amount: String(config.FEE_ALLOWANCE_REFILL_AMOUNT) }));
+      .reply(200, createFeeAllowanceResponse({ amount: String(config.FEE_ALLOWANCE_REFILL_AMOUNT) }));
 
     nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
       .persist()

--- a/apps/api/test/seeders/auto-top-up-deployment.seeder.ts
+++ b/apps/api/test/seeders/auto-top-up-deployment.seeder.ts
@@ -3,21 +3,19 @@ import { faker } from "@faker-js/faker";
 import type { AutoTopUpDeployment } from "@src/deployment/repositories/deployment-setting/deployment-setting.repository";
 import { createAkashAddress } from "./akash-address.seeder";
 
-export class AutoTopUpDeploymentSeeder {
-  static create(overrides: Partial<AutoTopUpDeployment> = {}): AutoTopUpDeployment {
-    return {
-      id: faker.string.uuid(),
-      walletId: faker.number.int(),
-      dseq: faker.string.numeric(),
-      address: createAkashAddress(),
-      isWalletAutoTopUpEnabled: false,
-      walletIsTrialing: false,
-      walletCreatedAt: faker.date.recent(),
-      ...overrides
-    };
-  }
+export function createAutoTopUpDeployment(overrides: Partial<AutoTopUpDeployment> = {}): AutoTopUpDeployment {
+  return {
+    id: faker.string.uuid(),
+    walletId: faker.number.int(),
+    dseq: faker.string.numeric(),
+    address: createAkashAddress(),
+    isWalletAutoTopUpEnabled: false,
+    walletIsTrialing: false,
+    walletCreatedAt: faker.date.recent(),
+    ...overrides
+  };
+}
 
-  static createMany(count: number, overrides: Partial<AutoTopUpDeployment> = {}): AutoTopUpDeployment[] {
-    return Array.from({ length: count }, () => AutoTopUpDeploymentSeeder.create(overrides));
-  }
+export function createManyAutoTopUpDeployments(count: number, overrides: Partial<AutoTopUpDeployment> = {}): AutoTopUpDeployment[] {
+  return Array.from({ length: count }, () => createAutoTopUpDeployment(overrides));
 }

--- a/apps/api/test/seeders/bid.seeder.ts
+++ b/apps/api/test/seeders/bid.seeder.ts
@@ -4,104 +4,105 @@ import { merge } from "lodash";
 
 import { createAkashAddress } from "./akash-address.seeder";
 
-export class BidSeeder {
-  static create(params?: { owner?: string; provider?: string; dseq?: string; gseq?: number; oseq?: number; bseq?: number }, overrides?: Partial<Bid>): Bid {
-    const owner = params?.owner ?? createAkashAddress();
-    const provider = params?.provider ?? createAkashAddress();
-    const dseq = params?.dseq ?? faker.string.numeric(8);
-    const gseq = params?.gseq ?? faker.number.int({ min: 1, max: 10 });
-    const oseq = params?.oseq ?? faker.number.int({ min: 1, max: 10 });
-    const bseq = params?.bseq ?? faker.number.int({ min: 1, max: 10 });
+export function createBid(
+  params?: { owner?: string; provider?: string; dseq?: string; gseq?: number; oseq?: number; bseq?: number },
+  overrides?: Partial<Bid>
+): Bid {
+  const owner = params?.owner ?? createAkashAddress();
+  const provider = params?.provider ?? createAkashAddress();
+  const dseq = params?.dseq ?? faker.string.numeric(8);
+  const gseq = params?.gseq ?? faker.number.int({ min: 1, max: 10 });
+  const oseq = params?.oseq ?? faker.number.int({ min: 1, max: 10 });
+  const bseq = params?.bseq ?? faker.number.int({ min: 1, max: 10 });
 
-    const defaultBid: Bid = {
-      bid: {
-        id: {
-          owner,
-          dseq,
-          gseq,
-          oseq,
-          bseq,
-          provider
-        },
-        state: "open",
-        price: {
-          denom: "uakt",
-          amount: faker.number.float({ min: 1, max: 1000 }).toString()
-        },
-        created_at: faker.date.recent().toISOString(),
-        resources_offer: [
-          {
-            resources: {
-              id: 1,
-              cpu: {
-                units: {
-                  val: faker.number.int({ min: 100, max: 1000 }).toString()
-                },
-                attributes: []
+  const defaultBid: Bid = {
+    bid: {
+      id: {
+        owner,
+        dseq,
+        gseq,
+        oseq,
+        bseq,
+        provider
+      },
+      state: "open",
+      price: {
+        denom: "uakt",
+        amount: faker.number.float({ min: 1, max: 1000 }).toString()
+      },
+      created_at: faker.date.recent().toISOString(),
+      resources_offer: [
+        {
+          resources: {
+            id: 1,
+            cpu: {
+              units: {
+                val: faker.number.int({ min: 100, max: 1000 }).toString()
               },
-              memory: {
+              attributes: []
+            },
+            memory: {
+              quantity: {
+                val: faker.number.int({ min: 100000000, max: 1000000000 }).toString()
+              },
+              attributes: []
+            },
+            storage: [
+              {
+                name: "default",
                 quantity: {
                   val: faker.number.int({ min: 100000000, max: 1000000000 }).toString()
                 },
                 attributes: []
+              }
+            ],
+            gpu: {
+              units: {
+                val: "0"
               },
-              storage: [
-                {
-                  name: "default",
-                  quantity: {
-                    val: faker.number.int({ min: 100000000, max: 1000000000 }).toString()
-                  },
-                  attributes: []
-                }
-              ],
-              gpu: {
-                units: {
-                  val: "0"
-                },
-                attributes: []
-              },
-              endpoints: [
-                {
-                  kind: "SHARED_HTTP",
-                  sequence_number: 0
-                }
-              ]
+              attributes: []
             },
-            count: 1
-          }
-        ]
+            endpoints: [
+              {
+                kind: "SHARED_HTTP",
+                sequence_number: 0
+              }
+            ]
+          },
+          count: 1
+        }
+      ]
+    },
+    escrow_account: {
+      id: {
+        scope: "bid",
+        xid: `${owner}/${dseq}/${gseq}/${oseq}/${provider}`
       },
-      escrow_account: {
-        id: {
-          scope: "bid",
-          xid: `${owner}/${dseq}/${gseq}/${oseq}/${provider}`
-        },
-        state: {
-          owner: owner,
-          state: "open",
-          transferred: [
-            {
+      state: {
+        owner: owner,
+        state: "open",
+        transferred: [
+          {
+            denom: "uakt",
+            amount: "0.000000000000000000"
+          }
+        ],
+        settled_at: faker.date.recent().toISOString(),
+        funds: [],
+        deposits: [
+          {
+            owner: owner,
+            height: faker.string.numeric(8),
+            source: "bid",
+            balance: {
               denom: "uakt",
               amount: "0.000000000000000000"
             }
-          ],
-          settled_at: faker.date.recent().toISOString(),
-          funds: [],
-          deposits: [
-            {
-              owner: owner,
-              height: faker.string.numeric(8),
-              source: "bid",
-              balance: {
-                denom: "uakt",
-                amount: "0.000000000000000000"
-              }
-            }
-          ]
-        }
+          }
+        ]
       }
-    };
+    }
+  };
 
-    return merge(defaultBid, overrides);
-  }
+  return merge(defaultBid, overrides);
 }

--- a/apps/api/test/seeders/draining-deployment.seeder.ts
+++ b/apps/api/test/seeders/draining-deployment.seeder.ts
@@ -4,22 +4,20 @@ import type { DrainingDeploymentOutput } from "@src/deployment/repositories/leas
 
 import { createDenom } from "@test/seeders/denom.seeder";
 
-export class DrainingDeploymentSeeder {
-  static create({
-    dseq = faker.number.int({ min: 1, max: 99999999 }),
-    denom = createDenom(),
-    blockRate = faker.number.int({ min: 1, max: 100 }),
-    predictedClosedHeight = faker.number.int({ min: 1, max: 99999999 }),
-    owner = faker.string.alpha(),
-    closedHeight = undefined
-  }: Partial<DrainingDeploymentOutput> = {}): DrainingDeploymentOutput {
-    return {
-      dseq,
-      denom,
-      blockRate,
-      predictedClosedHeight,
-      owner,
-      closedHeight
-    };
-  }
+export function createDrainingDeployment({
+  dseq = faker.number.int({ min: 1, max: 99999999 }),
+  denom = createDenom(),
+  blockRate = faker.number.int({ min: 1, max: 100 }),
+  predictedClosedHeight = faker.number.int({ min: 1, max: 99999999 }),
+  owner = faker.string.alpha(),
+  closedHeight = undefined
+}: Partial<DrainingDeploymentOutput> = {}): DrainingDeploymentOutput {
+  return {
+    dseq,
+    denom,
+    blockRate,
+    predictedClosedHeight,
+    owner,
+    closedHeight
+  };
 }

--- a/apps/api/test/seeders/fee-allowance-response.seeder.ts
+++ b/apps/api/test/seeders/fee-allowance-response.seeder.ts
@@ -7,26 +7,24 @@ export interface FeeAllowanceResponseSeederInput {
   amount?: string;
 }
 
-export class FeeAllowanceResponseSeeder {
-  static create(input: FeeAllowanceResponseSeederInput = {}) {
-    return merge(
-      {
+export function createFeeAllowanceResponse(input: FeeAllowanceResponseSeederInput = {}) {
+  return merge(
+    {
+      allowance: {
+        granter: input.granter || "akash1testmasterwalletaddress",
+        grantee: input.grantee || "akash1testwalletaddress",
         allowance: {
-          granter: input.granter || "akash1testmasterwalletaddress",
-          grantee: input.grantee || "akash1testwalletaddress",
-          allowance: {
-            "@type": "/cosmos.feegrant.v1beta1.BasicAllowance",
-            spend_limit: [
-              {
-                denom: "uakt",
-                amount: input.amount || "1000000"
-              }
-            ],
-            expiration: faker.date.future().toISOString()
-          }
+          "@type": "/cosmos.feegrant.v1beta1.BasicAllowance",
+          spend_limit: [
+            {
+              denom: "uakt",
+              amount: input.amount || "1000000"
+            }
+          ],
+          expiration: faker.date.future().toISOString()
         }
-      },
-      input
-    );
-  }
+      }
+    },
+    input
+  );
 }

--- a/apps/api/test/seeders/lease-status.seeder.ts
+++ b/apps/api/test/seeders/lease-status.seeder.ts
@@ -30,42 +30,40 @@ export interface LeaseStatusOutput {
   };
 }
 
-export class LeaseStatusSeeder {
-  static create(serviceName = "web"): LeaseStatusOutput {
-    return {
-      services: {
-        [serviceName]: {
-          name: serviceName,
-          available: 1,
-          total: 1,
-          uris: ["http://example.com"],
-          observed_generation: 1,
-          replicas: 1,
-          updated_replicas: 1,
-          ready_replicas: 1,
-          available_replicas: 1
-        }
-      },
-      forwarded_ports: {
-        [serviceName]: [
-          {
-            port: 80,
-            externalPort: 30000,
-            host: "example.com",
-            available: 1
-          }
-        ]
-      },
-      ips: {
-        [serviceName]: [
-          {
-            IP: "192.168.1.1",
-            Port: 80,
-            ExternalPort: 30000,
-            Protocol: "tcp"
-          }
-        ]
+export function createLeaseStatus(serviceName = "web"): LeaseStatusOutput {
+  return {
+    services: {
+      [serviceName]: {
+        name: serviceName,
+        available: 1,
+        total: 1,
+        uris: ["http://example.com"],
+        observed_generation: 1,
+        replicas: 1,
+        updated_replicas: 1,
+        ready_replicas: 1,
+        available_replicas: 1
       }
-    };
-  }
+    },
+    forwarded_ports: {
+      [serviceName]: [
+        {
+          port: 80,
+          externalPort: 30000,
+          host: "example.com",
+          available: 1
+        }
+      ]
+    },
+    ips: {
+      [serviceName]: [
+        {
+          IP: "192.168.1.1",
+          Port: 80,
+          ExternalPort: 30000,
+          Protocol: "tcp"
+        }
+      ]
+    }
+  };
 }


### PR DESCRIPTION
## Why

Refactor class-based seeders to function-based. There is no point to define a class full of static methods.

## What

- Convert BidSeeder, FeeAllowanceResponseSeeder, LeaseStatusSeeder, DrainingDeploymentSeeder, AutoTopUpDeploymentSeeder to plain exported functions
- Update all consumer files to use the new function names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated numerous test suites and mocks to use new standalone factory helpers for generating test data; test behavior and mocked responses remain unchanged.

* **Refactor**
  * Simplified test seeding API from class-based to function-based factories for consistency and easier maintenance; no changes to runtime/production behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->