### PR TITLE
test(dx): refactor LeaseApiResponseSeeder from class to plain functions

### DIFF
--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
@@ -14,7 +14,7 @@ import { DeploymentReaderService } from "./deployment-reader.service";
 
 import { createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
 import { createDeploymentListResponseSeed } from "@test/seeders/deployment-list-response.seeder";
-import { LeaseApiResponseSeeder } from "@test/seeders/lease-api-response.seeder";
+import { createLeaseApiResponse } from "@test/seeders/lease-api-response.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
 describe(DeploymentReaderService.name, () => {
@@ -38,7 +38,7 @@ describe(DeploymentReaderService.name, () => {
       const wallet = UserWalletSeeder.create() as WalletInitialized;
       const dseq = "12345";
       const deploymentInfo = createDeploymentInfoSeed({ owner: wallet.address, dseq });
-      const lease = LeaseApiResponseSeeder.create({ owner: wallet.address, dseq, state: "active" });
+      const lease = createLeaseApiResponse({ owner: wallet.address, dseq, state: "active" });
       const { service, leaseHttpService, fallbackLeaseReaderService } = setup({
         fallbackDeploymentInfo: deploymentInfo,
         fallbackLeases: [lease]
@@ -101,7 +101,7 @@ describe(DeploymentReaderService.name, () => {
       wallet?: WalletInitialized;
       fallbackDeploymentInfo?: ReturnType<typeof createDeploymentInfoSeed>;
       fallbackDeploymentList?: ReturnType<typeof createDeploymentListResponseSeed>;
-      fallbackLeases?: ReturnType<typeof LeaseApiResponseSeeder.create>[];
+      fallbackLeases?: ReturnType<typeof createLeaseApiResponse>[];
     } = {}
   ) {
     const defaultWallet = UserWalletSeeder.create() as WalletInitialized;

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
@@ -9,7 +9,7 @@ import { DrainingDeploymentRpcService } from "./draining-deployment-rpc.service"
 
 import { createAkashAddress } from "@test/seeders";
 import { createDeploymentListResponseSeed } from "@test/seeders/deployment-list-response.seeder";
-import { LeaseApiResponseSeeder } from "@test/seeders/lease-api-response.seeder";
+import { createLeaseApiResponse } from "@test/seeders/lease-api-response.seeder";
 
 describe(DrainingDeploymentRpcService.name, () => {
   describe("findManyByDseqAndOwner", () => {
@@ -219,8 +219,8 @@ describe(DrainingDeploymentRpcService.name, () => {
     const closureHeight = 1000000;
 
     const dseqs: string[] = [];
-    const leases: ReturnType<typeof LeaseApiResponseSeeder.create>[] = [];
     const deployments: ReturnType<typeof createDeploymentListResponseSeed>[] = [];
+    const leases: ReturnType<typeof createLeaseApiResponse>[] = [];
 
     inputs.forEach(input => {
       const dseq = input.deployment?.dseq ?? faker.string.numeric({ length: 6, allowLeadingZeros: false });
@@ -228,7 +228,7 @@ describe(DrainingDeploymentRpcService.name, () => {
 
       input.leases.forEach((lease, leaseIdx) => {
         leases.push(
-          LeaseApiResponseSeeder.create({
+          createLeaseApiResponse({
             owner,
             dseq,
             gseq: lease.gseq ?? leaseIdx,

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.integration.ts
@@ -13,7 +13,7 @@ import { TopUpManagedDeploymentsService } from "./top-up-managed-deployments.ser
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 import { createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
-import { LeaseApiResponseSeeder } from "@test/seeders/lease-api-response.seeder";
+import { createLeaseApiResponse } from "@test/seeders/lease-api-response.seeder";
 
 const CURRENT_HEIGHT = 1000000;
 const CLOSED_HEIGHT = String(CURRENT_HEIGHT - 500);
@@ -201,7 +201,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
   });
 
   function createActiveLease(owner: string, dseq: string) {
-    return LeaseApiResponseSeeder.create({
+    return createLeaseApiResponse({
       owner,
       dseq,
       state: "active",
@@ -210,7 +210,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
   }
 
   function createClosedLease(owner: string, dseq: string) {
-    return LeaseApiResponseSeeder.create({
+    return createLeaseApiResponse({
       owner,
       dseq,
       state: "closed",
@@ -305,7 +305,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       return results[0];
     }
 
-    function mockLeasesForOwner(owner: string, leases: ReturnType<typeof LeaseApiResponseSeeder.create>[]) {
+    function mockLeasesForOwner(owner: string, leases: ReturnType<typeof createLeaseApiResponse>[]) {
       nock(apiNodeUrl)
         .get("/akash/market/v1beta5/leases/list")
         .query(query => query["filters.owner"] === owner)

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -23,7 +23,7 @@ import { deploymentVersion, marketVersion } from "@src/utils/constants";
 import { createApiKey } from "@test/seeders/api-key.seeder";
 import { createDeployment } from "@test/seeders/deployment.seeder";
 import { createDeploymentInfoErrorSeed, createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
-import { LeaseApiResponseSeeder } from "@test/seeders/lease-api-response.seeder";
+import { createManyLeaseApiResponses } from "@test/seeders/lease-api-response.seeder";
 import { createLeaseStatus } from "@test/seeders/lease-status.seeder";
 import { createUser } from "@test/seeders/user.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
@@ -168,7 +168,7 @@ describe("Deployments API", () => {
       });
     await createDeployment({ owner: wallets[0].address!, dseq });
 
-    const leases = LeaseApiResponseSeeder.createMany(2, {
+    const leases = createManyLeaseApiResponses(2, {
       owner: address!,
       dseq,
       state: "active"
@@ -219,7 +219,7 @@ describe("Deployments API", () => {
         .get(`/akash/deployment/${deploymentVersion}/deployments/info?id.owner=${address}&id.dseq=${dseq}`)
         .reply(200, deploymentInfo);
 
-      const leases = LeaseApiResponseSeeder.createMany(2, {
+      const leases = createManyLeaseApiResponses(2, {
         owner: address!,
         dseq,
         state: "active"

--- a/apps/api/test/seeders/lease-api-response.seeder.ts
+++ b/apps/api/test/seeders/lease-api-response.seeder.ts
@@ -68,78 +68,76 @@ export interface LeaseOutput {
   };
 }
 
-export class LeaseApiResponseSeeder {
-  static create(input: LeaseInput = {}): LeaseOutput {
-    const {
-      owner = createAkashAddress(),
-      dseq = faker.string.numeric(10),
-      gseq = faker.number.int({ min: 1, max: 10 }),
-      oseq = faker.number.int({ min: 1, max: 10 }),
-      provider = createAkashAddress(),
-      state = faker.helpers.arrayElement(["active", "closed", "insufficient_funds"]),
-      price = {
-        denom: createDenom(),
-        amount: faker.string.numeric(6)
+export function createLeaseApiResponse(input: LeaseInput = {}): LeaseOutput {
+  const {
+    owner = createAkashAddress(),
+    dseq = faker.string.numeric(10),
+    gseq = faker.number.int({ min: 1, max: 10 }),
+    oseq = faker.number.int({ min: 1, max: 10 }),
+    provider = createAkashAddress(),
+    state = faker.helpers.arrayElement(["active", "closed", "insufficient_funds"]),
+    price = {
+      denom: createDenom(),
+      amount: faker.string.numeric(6)
+    },
+    created_at = faker.date.past().toISOString(),
+    closed_on = state === "closed" ? faker.date.recent().toISOString() : undefined
+  } = input;
+
+  const denom = price.denom || createDenom();
+  const amount = price.amount || faker.string.numeric(6);
+
+  return {
+    lease: {
+      id: {
+        owner,
+        dseq,
+        gseq,
+        oseq,
+        provider,
+        bseq: faker.number.int({ min: 0, max: 10 })
       },
-      created_at = faker.date.past().toISOString(),
-      closed_on = state === "closed" ? faker.date.recent().toISOString() : undefined
-    } = input;
-
-    const denom = price.denom || createDenom();
-    const amount = price.amount || faker.string.numeric(6);
-
-    return {
-      lease: {
-        id: {
-          owner,
-          dseq,
-          gseq,
-          oseq,
-          provider,
-          bseq: faker.number.int({ min: 0, max: 10 })
+      state,
+      price: {
+        denom,
+        amount
+      },
+      created_at,
+      closed_on: closed_on || "0",
+      reason: state === "closed" ? faker.helpers.arrayElement(["insufficient_funds", "provider_closed", "user_closed"]) : undefined
+    },
+    escrow_payment: {
+      id: {
+        aid: {
+          scope: "deployment",
+          xid: `${owner}/${dseq}`
         },
-        state,
-        price: {
+        xid: `${gseq}/${oseq}/${provider}`
+      },
+      state: {
+        owner,
+        state: state === "active" ? "open" : "closed",
+        rate: {
           denom,
           amount
         },
-        created_at,
-        closed_on: closed_on || "0",
-        reason: state === "closed" ? faker.helpers.arrayElement(["insufficient_funds", "provider_closed", "user_closed"]) : undefined
-      },
-      escrow_payment: {
-        id: {
-          aid: {
-            scope: "deployment",
-            xid: `${owner}/${dseq}`
-          },
-          xid: `${gseq}/${oseq}/${provider}`
+        balance: {
+          denom,
+          amount: faker.string.numeric(6)
         },
-        state: {
-          owner,
-          state: state === "active" ? "open" : "closed",
-          rate: {
-            denom,
-            amount
-          },
-          balance: {
-            denom,
-            amount: faker.string.numeric(6)
-          },
-          unsettled: {
-            denom,
-            amount: faker.string.numeric(6)
-          },
-          withdrawn: {
-            denom,
-            amount: faker.string.numeric(6)
-          }
+        unsettled: {
+          denom,
+          amount: faker.string.numeric(6)
+        },
+        withdrawn: {
+          denom,
+          amount: faker.string.numeric(6)
         }
       }
-    };
-  }
+    }
+  };
+}
 
-  static createMany(count: number, input: LeaseInput = {}): LeaseOutput[] {
-    return Array.from({ length: count }, () => LeaseApiResponseSeeder.create(input));
-  }
+export function createManyLeaseApiResponses(count: number, input: LeaseInput = {}): LeaseOutput[] {
+  return Array.from({ length: count }, () => createLeaseApiResponse(input));
 }

--- a/apps/notifications/src/infrastructure/broker/services/broker/broker.service.spec.ts
+++ b/apps/notifications/src/infrastructure/broker/services/broker/broker.service.spec.ts
@@ -4,10 +4,10 @@ import type { TestingModule } from "@nestjs/testing";
 import { Test } from "@nestjs/testing";
 import type { PoolClient } from "pg";
 import { Pool } from "pg";
+import { PgBoss } from "pg-boss";
 import { describe, expect, it, vi } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
-import { PgBoss } from "pg-boss";
 
 import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import { LoggerService } from "@src/common/services/logger/logger.service";


### PR DESCRIPTION
## Why

Refactor class-based seeders to function-based. There is no point to define a class full of static methods.

## What

- Convert LeaseApiResponseSeeder to plain exported functions (createLeaseApiResponse, createManyLeaseApiResponses)
- Update all consumer files to use the new function names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the test seeder API from a class-based approach to a simpler, clearer interface.

* **Tests**
  * Updated test suites to use the new seeder interface.
  * Improved lease fixtures with richer structure: enhanced IDs, detailed state, pricing, timestamps, closing reason, and more detailed escrow/payment fields for better realism and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->