### PR TITLE
test(dx): refactor UserWalletSeeder from class to plain function

### DIFF
--- a/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.spec.ts
@@ -11,7 +11,7 @@ import type { DeploymentWriterService } from "@src/deployment/services/deploymen
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
 import { CloseTrialDeployment, CloseTrialDeploymentHandler } from "./close-trial-deployment.handler";
 
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(CloseTrialDeploymentHandler.name, () => {
   it("logs warning and returns early when wallet is not found", async () => {
@@ -40,7 +40,7 @@ describe(CloseTrialDeploymentHandler.name, () => {
   });
 
   it("logs debug and returns early when wallet is not in trial", async () => {
-    const wallet = UserWalletSeeder.create({
+    const wallet = createUserWallet({
       id: 123,
       userId: "user-123",
       address: "akash1test",
@@ -73,7 +73,7 @@ describe(CloseTrialDeploymentHandler.name, () => {
   });
 
   it("closes deployment and enqueues notification when wallet is found and in trial", async () => {
-    const wallet = UserWalletSeeder.create({
+    const wallet = createUserWallet({
       id: 123,
       userId: "user-123",
       address: "akash1test",
@@ -118,7 +118,7 @@ describe(CloseTrialDeploymentHandler.name, () => {
   });
 
   it("logs debug and skips close and notification when deployment is already closed", async () => {
-    const wallet = UserWalletSeeder.create({
+    const wallet = createUserWallet({
       id: 123,
       userId: "user-123",
       address: "akash1test",
@@ -152,7 +152,7 @@ describe(CloseTrialDeploymentHandler.name, () => {
   });
 
   it("skips notification when close deployment fails", async () => {
-    const wallet = UserWalletSeeder.create({
+    const wallet = createUserWallet({
       id: 123,
       userId: "user-123",
       address: "akash1test",
@@ -179,7 +179,7 @@ describe(CloseTrialDeploymentHandler.name, () => {
   });
 
   it("logs error when find deployment returns an error", async () => {
-    const wallet = UserWalletSeeder.create({ id: 123, userId: "user-123", address: "akash1test", isTrialing: true });
+    const wallet = createUserWallet({ id: 123, userId: "user-123", address: "akash1test", isTrialing: true });
 
     const errorResponse = { code: "error_code", message: "Error message", details: "Error details" };
     const { handler, jobQueueService, logger } = setup({
@@ -208,7 +208,7 @@ describe(CloseTrialDeploymentHandler.name, () => {
   });
 
   it("logs error when find deployment returns an error", async () => {
-    const wallet = UserWalletSeeder.create({
+    const wallet = createUserWallet({
       id: 123,
       userId: "user-123",
       address: "akash1test",
@@ -251,7 +251,7 @@ describe(CloseTrialDeploymentHandler.name, () => {
         findById:
           input?.findWalletById ??
           vi.fn(async () =>
-            UserWalletSeeder.create({
+            createUserWallet({
               id: 123,
               userId: "user-123",
               address: "akash1test",

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
@@ -12,7 +12,7 @@ import { NotificationJob } from "@src/notifications/services/notification-handle
 import { CloseTrialDeployment } from "../close-trial-deployment/close-trial-deployment.handler";
 import { TrialDeploymentLeaseCreatedHandler } from "./trial-deployment-lease-created.handler";
 
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(TrialDeploymentLeaseCreatedHandler.name, () => {
   it("logs a warning when wallet is not found", async () => {
@@ -41,7 +41,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
   });
 
   it("ignores non-trialing wallets", async () => {
-    const wallet = UserWalletSeeder.create({
+    const wallet = createUserWallet({
       id: 123,
       userId: "user-123",
       address: "akash1test",
@@ -75,7 +75,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
   });
 
   it("enqueues notification and close job when wallet is in trial", async () => {
-    const wallet = UserWalletSeeder.create({
+    const wallet = createUserWallet({
       id: 123,
       userId: "user-123",
       address: "akash1test",
@@ -132,7 +132,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
   });
 
   it("logs a warning when wallet address is missing", async () => {
-    const wallet = UserWalletSeeder.create({
+    const wallet = createUserWallet({
       id: 789,
       userId: "user-789",
       address: null,
@@ -165,7 +165,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
   });
 
   it("enqueues additional notification when it's the first lease", async () => {
-    const wallet = UserWalletSeeder.create({
+    const wallet = createUserWallet({
       id: 123,
       userId: "user-123",
       address: "akash1test",

--- a/apps/api/src/billing/services/balances/balances.service.spec.ts
+++ b/apps/api/src/billing/services/balances/balances.service.spec.ts
@@ -8,12 +8,12 @@ import { BalancesService } from "@src/billing/services/balances/balances.service
 import type { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
 import type { StatsService } from "@src/dashboard/services/stats/stats.service";
 
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(BalancesService.name, () => {
   describe("refreshUserWalletLimits", () => {
     it("updates both limits and isTrialing when limits changed and endTrial is true", async () => {
-      const wallet = UserWalletSeeder.create({ isTrialing: true });
+      const wallet = createUserWallet({ isTrialing: true });
       const limitsUpdate: Partial<UserWalletInput> = { feeAllowance: 300, deploymentAllowance: 400 };
       const { service, userWalletRepository } = setup({ limitsUpdate });
 
@@ -27,7 +27,7 @@ describe(BalancesService.name, () => {
     });
 
     it("updates isTrialing even when limits are unchanged", async () => {
-      const wallet = UserWalletSeeder.create({ isTrialing: true });
+      const wallet = createUserWallet({ isTrialing: true });
       const { service, userWalletRepository } = setup({ limitsUpdate: {} });
 
       await service.refreshUserWalletLimits(wallet, { endTrial: true });
@@ -38,7 +38,7 @@ describe(BalancesService.name, () => {
     });
 
     it("does not update when limits are unchanged and endTrial is not set", async () => {
-      const wallet = UserWalletSeeder.create({ isTrialing: true });
+      const wallet = createUserWallet({ isTrialing: true });
       const { service, userWalletRepository } = setup({ limitsUpdate: {} });
 
       await service.refreshUserWalletLimits(wallet);
@@ -47,7 +47,7 @@ describe(BalancesService.name, () => {
     });
 
     it("updates limits only when limits changed and endTrial is not set", async () => {
-      const wallet = UserWalletSeeder.create({ isTrialing: true });
+      const wallet = createUserWallet({ isTrialing: true });
       const limitsUpdate: Partial<UserWalletInput> = { feeAllowance: 300, deploymentAllowance: 400 };
       const { service, userWalletRepository } = setup({ limitsUpdate });
 
@@ -60,7 +60,7 @@ describe(BalancesService.name, () => {
     });
 
     it("does not set isTrialing when wallet is not trialing", async () => {
-      const wallet = UserWalletSeeder.create({ isTrialing: false });
+      const wallet = createUserWallet({ isTrialing: false });
       const { service, userWalletRepository } = setup({ limitsUpdate: {} });
 
       await service.refreshUserWalletLimits(wallet, { endTrial: true });

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -27,7 +27,7 @@ import { ManagedSignerService } from "./managed-signer.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createUser } from "@test/seeders/user.seeder";
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(ManagedSignerService.name, () => {
   describe("executeDerivedDecodedTxByUserId", () => {
@@ -55,8 +55,8 @@ describe(ManagedSignerService.name, () => {
     });
 
     it("throws 402 error when userWallet has no fee allowance", async () => {
-      const wallet = UserWalletSeeder.create({ userId: "user-123", feeAllowance: 0 });
       const user = createUser({ userId: "user-123" });
+      const wallet = createUserWallet({ userId: "user-123", feeAllowance: 0 });
       const { service } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
         findById: jest.fn().mockResolvedValue(user),
@@ -67,7 +67,7 @@ describe(ManagedSignerService.name, () => {
     });
 
     it("throws 402 error when userWallet has no deployment allowance for deployment message", async () => {
-      const wallet = UserWalletSeeder.create({
+      const wallet = createUserWallet({
         userId: "user-123",
         feeAllowance: 100,
         deploymentAllowance: 0
@@ -88,7 +88,7 @@ describe(ManagedSignerService.name, () => {
     });
 
     it("skips trial validation when anonymous free trial is disabled", async () => {
-      const wallet = UserWalletSeeder.create({
+      const wallet = createUserWallet({
         userId: "user-123",
         feeAllowance: 100,
         deploymentAllowance: 100
@@ -124,7 +124,7 @@ describe(ManagedSignerService.name, () => {
     });
 
     it("executes transaction successfully and returns result", async () => {
-      const wallet = UserWalletSeeder.create({
+      const wallet = createUserWallet({
         userId: "user-123",
         feeAllowance: 100,
         deploymentAllowance: 100
@@ -168,7 +168,7 @@ describe(ManagedSignerService.name, () => {
     });
 
     it("publishes TrialDeploymentLeaseCreated event for trialing wallet with deployment message when anonymous trial is disabled", async () => {
-      const wallet = UserWalletSeeder.create({
+      const wallet = createUserWallet({
         userId: "user-123",
         feeAllowance: 100,
         deploymentAllowance: 100,
@@ -232,7 +232,7 @@ describe(ManagedSignerService.name, () => {
     });
 
     it("handles chain errors properly", async () => {
-      const wallet = UserWalletSeeder.create({
+      const wallet = createUserWallet({
         userId: "user-123",
         feeAllowance: 100,
         deploymentAllowance: 100
@@ -264,7 +264,7 @@ describe(ManagedSignerService.name, () => {
 
     it("uses current user when userId matches auth currentUser", async () => {
       const currentUser = createUser({ userId: "user-123" });
-      const wallet = UserWalletSeeder.create({ userId: "user-123", feeAllowance: 100 });
+      const wallet = createUserWallet({ userId: "user-123", feeAllowance: 100 });
       const messages: EncodeObject[] = [
         {
           typeUrl: MsgCreateLease.$type,
@@ -293,7 +293,7 @@ describe(ManagedSignerService.name, () => {
     });
 
     it("validates lease provider for all leases regardless of trial status", async () => {
-      const wallet = UserWalletSeeder.create({
+      const wallet = createUserWallet({
         userId: "user-123",
         feeAllowance: 100,
         deploymentAllowance: 100,
@@ -330,7 +330,7 @@ describe(ManagedSignerService.name, () => {
     });
 
     it("validates lease provider for trial wallets", async () => {
-      const wallet = UserWalletSeeder.create({
+      const wallet = createUserWallet({
         userId: "user-123",
         feeAllowance: 100,
         deploymentAllowance: 100,
@@ -369,7 +369,7 @@ describe(ManagedSignerService.name, () => {
 
   describe("executeDerivedEncodedTxByUserId", () => {
     it("executes transaction and calls scheduleImmediate when transaction contains MsgCreateDeployment", async () => {
-      const wallet = UserWalletSeeder.create({
+      const wallet = createUserWallet({
         userId: "user-123",
         feeAllowance: 100,
         deploymentAllowance: 100
@@ -398,7 +398,7 @@ describe(ManagedSignerService.name, () => {
     });
 
     it("executes transaction and calls scheduleImmediate when transaction contains MsgAccountDeposit", async () => {
-      const wallet = UserWalletSeeder.create({
+      const wallet = createUserWallet({
         userId: "user-123",
         feeAllowance: 100
       });
@@ -426,7 +426,7 @@ describe(ManagedSignerService.name, () => {
     });
 
     it("executes transaction and does not call scheduleImmediate when transaction does not contain spending messages", async () => {
-      const wallet = UserWalletSeeder.create({
+      const wallet = createUserWallet({
         userId: "user-123",
         feeAllowance: 100,
         deploymentAllowance: 100
@@ -486,8 +486,8 @@ describe(ManagedSignerService.name, () => {
 
   describe("executeDerivedDecodedTxByUserId - result without hash", () => {
     it("returns result as-is when hash is empty", async () => {
-      const wallet = UserWalletSeeder.create({ userId: "user-123", feeAllowance: 100, deploymentAllowance: 100 });
       const user = createUser({ userId: "user-123" });
+      const wallet = createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: 100 });
       const messages: EncodeObject[] = [{ typeUrl: MsgCreateLease.$type, value: MsgCreateLease.fromPartial({ bidId: { dseq: 123 } }) }];
 
       const { service } = setup({

--- a/apps/api/src/billing/services/refill/refill.service.spec.ts
+++ b/apps/api/src/billing/services/refill/refill.service.spec.ts
@@ -8,7 +8,7 @@ import { RefillService } from "@src/billing/services/refill/refill.service";
 import type { WalletInitializerService } from "@src/billing/services/wallet-initializer/wallet-initializer.service";
 import type { AnalyticsService } from "@src/core/services/analytics/analytics.service";
 
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(RefillService.name, () => {
   describe("topUpWallet", () => {
@@ -18,7 +18,7 @@ describe(RefillService.name, () => {
     it("should top up existing wallet", async () => {
       const { service, userWalletRepository, managedUserWalletService, managedSignerService, balancesService, walletInitializerService, analyticsService } =
         setup();
-      const existingWallet = UserWalletSeeder.create({ userId });
+      const existingWallet = createUserWallet({ userId });
       userWalletRepository.findOneBy.mockResolvedValue(existingWallet);
       managedUserWalletService.authorizeSpending.mockResolvedValue();
       balancesService.retrieveDeploymentLimit.mockResolvedValue(5000);
@@ -39,7 +39,7 @@ describe(RefillService.name, () => {
 
     it("does not end trial when endTrial option is false", async () => {
       const { service, userWalletRepository, managedUserWalletService, balancesService } = setup();
-      const existingWallet = UserWalletSeeder.create({ userId });
+      const existingWallet = createUserWallet({ userId });
       userWalletRepository.findOneBy.mockResolvedValue(existingWallet);
       managedUserWalletService.authorizeSpending.mockResolvedValue();
       balancesService.retrieveDeploymentLimit.mockResolvedValue(5000);
@@ -53,7 +53,7 @@ describe(RefillService.name, () => {
     it("should create new wallet when none exists", async () => {
       const { service, userWalletRepository, walletInitializerService, balancesService, managedUserWalletService, managedSignerService, analyticsService } =
         setup();
-      const newWallet = UserWalletSeeder.create({ userId });
+      const newWallet = createUserWallet({ userId });
       userWalletRepository.findOneBy.mockResolvedValue(undefined);
       walletInitializerService.initialize.mockResolvedValue(newWallet);
       managedUserWalletService.authorizeSpending.mockResolvedValue();
@@ -111,7 +111,7 @@ describe(RefillService.name, () => {
 
     it("reduces wallet balance by the specified amount", async () => {
       const { service, userWalletRepository, managedUserWalletService, managedSignerService, balancesService, analyticsService } = setup();
-      const existingWallet = UserWalletSeeder.create({ userId, address: "akash1test..." });
+      const existingWallet = createUserWallet({ userId, address: "akash1test..." });
 
       userWalletRepository.findOneBy.mockResolvedValue(existingWallet);
       balancesService.retrieveDeploymentLimit.mockResolvedValue(5000000); // Current limit (500 usd worth)
@@ -133,7 +133,7 @@ describe(RefillService.name, () => {
 
     it("does not reduce balance below zero", async () => {
       const { service, userWalletRepository, managedUserWalletService, managedSignerService, balancesService, analyticsService } = setup();
-      const existingWallet = UserWalletSeeder.create({ userId, address: "akash1test..." });
+      const existingWallet = createUserWallet({ userId, address: "akash1test..." });
 
       userWalletRepository.findOneBy.mockResolvedValue(existingWallet);
       balancesService.retrieveDeploymentLimit.mockResolvedValue(50000); // Current limit $0.50
@@ -164,7 +164,7 @@ describe(RefillService.name, () => {
 
     it("does nothing when wallet has no address", async () => {
       const { service, userWalletRepository, managedUserWalletService, balancesService, analyticsService } = setup();
-      const walletWithoutAddress = UserWalletSeeder.create({ userId, address: null });
+      const walletWithoutAddress = createUserWallet({ userId, address: null });
 
       userWalletRepository.findOneBy.mockResolvedValue(walletWithoutAddress);
 

--- a/apps/api/src/billing/services/remaining-credits/remaining-credits.service.spec.ts
+++ b/apps/api/src/billing/services/remaining-credits/remaining-credits.service.spec.ts
@@ -6,7 +6,7 @@ import type { LoggerService } from "@src/core/providers/logging.provider";
 import { RemainingCreditsService } from "./remaining-credits.service";
 
 import { createUser } from "@test/seeders/user.seeder";
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(RemainingCreditsService.name, () => {
   it("returns remaining credits when user has wallet", async () => {
@@ -14,7 +14,7 @@ describe(RemainingCreditsService.name, () => {
     const remainingCreditsInUusdc = 100_000_000;
     const expectedCreditsInUsdc = 100;
 
-    const userWallet = UserWalletSeeder.create();
+    const userWallet = createUserWallet();
     const { service, userWalletRepository, balanceService } = setup({
       findOneByUserId: jest.fn().mockResolvedValue(userWallet),
       retrieveDeploymentLimit: jest.fn().mockResolvedValue(remainingCreditsInUusdc)
@@ -46,7 +46,7 @@ describe(RemainingCreditsService.name, () => {
   it("throws error when user wallet has no address", async () => {
     const user = createUser();
 
-    const userWallet = UserWalletSeeder.create({ address: null });
+    const userWallet = createUserWallet({ address: null });
     const { service, userWalletRepository, logger } = setup({
       findOneByUserId: jest.fn().mockResolvedValue(userWallet)
     });

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -15,7 +15,7 @@ import type { WalletBalanceReloadCheckInstrumentationService } from "./wallet-ba
 
 import { generateMergedPaymentMethod as generatePaymentMethod } from "@test/seeders/payment-method.seeder";
 import { createUser } from "@test/seeders/user.seeder";
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 import { generateWalletSetting } from "@test/seeders/wallet-setting.seeder";
 
 describe(WalletBalanceReloadCheckHandler.name, () => {
@@ -251,7 +251,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
     it("logs validation error when wallet is not initialized", async () => {
       const { handler, walletSettingRepository, instrumentationService, job, jobMeta } = setup({
-        wallet: UserWalletSeeder.create({ address: null })
+        wallet: createUserWallet({ address: null })
       });
 
       await handler.handle(job, jobMeta);
@@ -315,8 +315,8 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     jobId?: string | null;
     walletSettingNotFound?: boolean;
     autoReloadEnabled?: boolean;
-    wallet?: ReturnType<typeof UserWalletSeeder.create>;
     user?: ReturnType<typeof createUser>;
+    wallet?: ReturnType<typeof createUserWallet>;
   }) {
     const user = input?.user ?? createUser();
     const userWithStripe =
@@ -327,7 +327,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
           : user.stripeCustomerId
             ? user
             : { ...user, stripeCustomerId: faker.string.uuid() };
-    const wallet = input?.wallet ?? UserWalletSeeder.create({ userId: user.id });
+    const wallet = input?.wallet ?? createUserWallet({ userId: user.id });
     const walletSetting = generateWalletSetting({
       userId: user.id,
       walletId: wallet.id,

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
@@ -15,13 +15,13 @@ import { WalletInitializerService } from "./wallet-initializer.service";
 
 import { createChainWallet } from "@test/seeders/chain-wallet.seeder";
 import { createUser } from "@test/seeders/user.seeder";
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(WalletInitializerService.name, () => {
   describe("initializeAndGrantTrialLimits", () => {
     it("creates a new wallet and authorizes trial spending when no wallet exists", async () => {
       const userId = "test-user-id";
-      const newWallet = UserWalletSeeder.create({ userId });
+      const newWallet = createUserWallet({ userId });
       const chainWallet = createChainWallet();
       const getOrCreateWallet = jest.fn().mockImplementation(async () => ({ wallet: newWallet, isNew: true }));
       const updateWalletById = jest.fn().mockImplementation(async () => newWallet);
@@ -50,7 +50,7 @@ describe(WalletInitializerService.name, () => {
 
     it("does not authorizes trial spending for existing wallet", async () => {
       const userId = "test-user-id";
-      const existingWallet = UserWalletSeeder.create({ userId });
+      const existingWallet = createUserWallet({ userId });
       const getOrCreateWallet = jest.fn().mockResolvedValue({ wallet: existingWallet, isNew: false });
 
       const di = setup({
@@ -66,7 +66,7 @@ describe(WalletInitializerService.name, () => {
 
     it("throws an error when cannot authorize trial spending and deletes user wallet", async () => {
       const userId = "test-user-id";
-      const newWallet = UserWalletSeeder.create({ userId });
+      const newWallet = createUserWallet({ userId });
       const getOrCreateWallet = jest.fn().mockImplementation(async () => ({ wallet: newWallet, isNew: true }));
       const deleteWalletById = jest.fn().mockImplementation(async () => null);
 
@@ -85,7 +85,7 @@ describe(WalletInitializerService.name, () => {
 
     it(`publishes "TrialStarted" event`, async () => {
       const userId = "test-user-id";
-      const newWallet = UserWalletSeeder.create({ userId });
+      const newWallet = createUserWallet({ userId });
       const chainWallet = createChainWallet();
       const getOrCreateWallet = jest.fn().mockImplementation(async () => ({ wallet: newWallet, isNew: true }));
       const updateWalletById = jest.fn().mockImplementation(async () => newWallet);

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
@@ -12,7 +12,7 @@ import { WalletSettingService } from "./wallet-settings.service";
 
 import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
 import { createUser } from "@test/seeders/user.seeder";
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 import { generateWalletSetting } from "@test/seeders/wallet-setting.seeder";
 
 describe(WalletSettingService.name, () => {
@@ -172,7 +172,7 @@ describe(WalletSettingService.name, () => {
   function setup() {
     const user = createUser();
     const userWithStripe = { ...user, stripeCustomerId: faker.string.uuid() };
-    const userWallet = UserWalletSeeder.create({ userId: user.id });
+    const userWallet = createUserWallet({ userId: user.id });
     const walletSettingRepository = mock<WalletSettingRepository>();
     walletSettingRepository.accessibleBy.mockReturnValue(walletSettingRepository);
     const userWalletRepository = mock<UserWalletRepository>();

--- a/apps/api/src/deployment/services/active-deployments-count/active-deployments-count.service.spec.ts
+++ b/apps/api/src/deployment/services/active-deployments-count/active-deployments-count.service.spec.ts
@@ -7,14 +7,14 @@ import type { DeploymentRepository } from "@src/deployment/repositories/deployme
 import { ActiveDeploymentsCountService } from "./active-deployments-count.service";
 
 import { createUser } from "@test/seeders/user.seeder";
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(ActiveDeploymentsCountService.name, () => {
   it("returns active deployments count when user has wallet", async () => {
     const user = createUser();
     const activeCount = faker.number.int({ min: 0, max: 10 });
 
-    const userWallet = UserWalletSeeder.create();
+    const userWallet = createUserWallet();
     const { service, userWalletRepository, deploymentRepository } = setup({
       findOneByUserId: jest.fn().mockResolvedValue(userWallet),
       countActiveByOwner: jest.fn().mockResolvedValue(activeCount)
@@ -46,7 +46,7 @@ describe(ActiveDeploymentsCountService.name, () => {
   it("throws error when user wallet has no address", async () => {
     const user = createUser();
 
-    const userWallet = UserWalletSeeder.create({ address: null });
+    const userWallet = createUserWallet({ address: null });
     const { service, userWalletRepository, logger } = setup({
       findOneByUserId: jest.fn().mockResolvedValue(userWallet)
     });

--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
@@ -15,12 +15,12 @@ import { DeploymentReaderService } from "./deployment-reader.service";
 import { createDeploymentInfoSeed } from "@test/seeders/deployment-info.seeder";
 import { createDeploymentListResponseSeed } from "@test/seeders/deployment-list-response.seeder";
 import { createLeaseApiResponse } from "@test/seeders/lease-api-response.seeder";
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(DeploymentReaderService.name, () => {
   describe("findByWalletAndDseq", () => {
     it("falls back to database for deployment data when blockchain node is unreachable", async () => {
-      const wallet = UserWalletSeeder.create() as WalletInitialized;
+      const wallet = createUserWallet() as WalletInitialized;
       const dseq = "12345";
       const deploymentInfo = createDeploymentInfoSeed({ owner: wallet.address, dseq });
       const { service, deploymentHttpService, fallbackDeploymentReaderService } = setup({
@@ -35,7 +35,7 @@ describe(DeploymentReaderService.name, () => {
     });
 
     it("falls back to database for lease data when blockchain node is unreachable", async () => {
-      const wallet = UserWalletSeeder.create() as WalletInitialized;
+      const wallet = createUserWallet() as WalletInitialized;
       const dseq = "12345";
       const deploymentInfo = createDeploymentInfoSeed({ owner: wallet.address, dseq });
       const lease = createLeaseApiResponse({ owner: wallet.address, dseq, state: "active" });
@@ -53,7 +53,7 @@ describe(DeploymentReaderService.name, () => {
     });
 
     it("does not fall back to database for non-network errors", async () => {
-      const wallet = UserWalletSeeder.create() as WalletInitialized;
+      const wallet = createUserWallet() as WalletInitialized;
       const dseq = "12345";
       const { service, fallbackDeploymentReaderService, deploymentHttpService } = setup();
 
@@ -65,8 +65,8 @@ describe(DeploymentReaderService.name, () => {
 
   describe("list", () => {
     it("falls back to database when blockchain node is unreachable", async () => {
-      const wallet = UserWalletSeeder.create() as WalletInitialized;
       const deploymentList = createDeploymentListResponseSeed({}, 2);
+      const wallet = createUserWallet() as WalletInitialized;
       const { service, deploymentHttpService, fallbackDeploymentReaderService } = setup({
         wallet,
         fallbackDeploymentList: deploymentList
@@ -104,7 +104,7 @@ describe(DeploymentReaderService.name, () => {
       fallbackLeases?: ReturnType<typeof createLeaseApiResponse>[];
     } = {}
   ) {
-    const defaultWallet = UserWalletSeeder.create() as WalletInitialized;
+    const defaultWallet = createUserWallet() as WalletInitialized;
     const wallet = input.wallet ?? defaultWallet;
     const defaultDeploymentInfo = createDeploymentInfoSeed();
     const defaultDeploymentList = createDeploymentListResponseSeed({}, 0);

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
@@ -14,7 +14,7 @@ import type { TopUpManagedDeploymentsInstrumentationService } from "../top-up-ma
 import { DeploymentSettingService } from "./deployment-setting.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(DeploymentSettingService.name, () => {
   describe("findOrCreateByUserIdAndDseq", () => {
@@ -36,7 +36,7 @@ describe(DeploymentSettingService.name, () => {
     it("creates with autoTopUpEnabled true when user has managed wallet", async () => {
       const { service, deploymentSettingRepository, userWalletRepository } = setup();
       const params = { userId: faker.string.uuid(), dseq: faker.string.numeric(6) };
-      const userWallet = UserWalletSeeder.create({ userId: params.userId });
+      const userWallet = createUserWallet({ userId: params.userId });
       const created = createDeploymentSettingsOutput({ ...params, autoTopUpEnabled: true });
 
       deploymentSettingRepository.accessibleBy.mockReturnValue(deploymentSettingRepository);

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -22,7 +22,7 @@ import { mockConfigService } from "@test/mocks/config-service.mock";
 import { createAkashAddress } from "@test/seeders";
 import { createManyAutoTopUpDeployments } from "@test/seeders/auto-top-up-deployment.seeder";
 import { createDrainingDeployment } from "@test/seeders/draining-deployment.seeder";
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(DrainingDeploymentService.name, () => {
   describe("findDrainingDeploymentsByOwner", () => {
@@ -187,8 +187,8 @@ describe(DrainingDeploymentService.name, () => {
       const userId = faker.string.uuid();
       const dseq = faker.string.numeric(6);
       const address = createAkashAddress();
-      const userWallet = UserWalletSeeder.create({ address });
       const deployment = createDrainingDeployment();
+      const userWallet = createUserWallet({ address });
       const expectedTopUpAmount = 100000;
 
       const { service, userWalletRepository, leaseRepository } = setup();
@@ -221,7 +221,7 @@ describe(DrainingDeploymentService.name, () => {
       const userId = faker.string.uuid();
       const dseq = faker.string.numeric(6);
       const address = createAkashAddress();
-      const userWallet = UserWalletSeeder.create({ address });
+      const userWallet = createUserWallet({ address });
       const { service, userWalletRepository, leaseRepository } = setup();
       userWalletRepository.findOneByUserId.mockResolvedValue(userWallet);
       leaseRepository.findOneByDseqAndOwner.mockResolvedValue(null);
@@ -286,7 +286,7 @@ describe(DrainingDeploymentService.name, () => {
 
     it("returns 0 when user wallet has no address", async () => {
       const { service, userId, ability } = await setupCalculateWeeklyCost({
-        userWallet: UserWalletSeeder.create({ address: null }),
+        userWallet: createUserWallet({ address: null }),
         deployments: [{ predictedClosedHeight: 1000100, blockRate: 50 }]
       });
 
@@ -344,13 +344,13 @@ describe(DrainingDeploymentService.name, () => {
     });
 
     async function setupCalculateWeeklyCost(input: {
-      userWallet?: ReturnType<typeof UserWalletSeeder.create> | undefined;
+      userWallet?: ReturnType<typeof createUserWallet> | undefined;
       deployments: Array<{ predictedClosedHeight: number | null; blockRate: number }>;
       expectedFiatAmount?: number;
     }) {
       const userId = faker.string.uuid();
       const address = createAkashAddress();
-      const userWallet = "userWallet" in input ? input.userWallet : UserWalletSeeder.create({ address, userId });
+      const userWallet = "userWallet" in input ? input.userWallet : createUserWallet({ address, userId });
       const ability = mock<AnyAbility>();
 
       const baseSetup = setup();
@@ -436,7 +436,7 @@ describe(DrainingDeploymentService.name, () => {
 
     it("returns 0 when user wallet has no address", async () => {
       const { service, address, targetDate } = await setupCalculateCost({
-        userWallet: UserWalletSeeder.create({ address: null }),
+        userWallet: createUserWallet({ address: null }),
         deployments: [{ predictedClosedHeight: 1000100, blockRate: 50 }]
       });
 
@@ -486,11 +486,11 @@ describe(DrainingDeploymentService.name, () => {
     });
 
     async function setupCalculateCost(input: {
-      userWallet?: ReturnType<typeof UserWalletSeeder.create> | undefined;
+      userWallet?: ReturnType<typeof createUserWallet> | undefined;
       deployments: Array<{ predictedClosedHeight: number | null; blockRate: number }>;
     }) {
       const address = createAkashAddress();
-      const userWallet = "userWallet" in input ? input.userWallet : UserWalletSeeder.create({ address });
+      const userWallet = "userWallet" in input ? input.userWallet : createUserWallet({ address });
       const now = new Date();
       const targetDate = addWeeks(now, 1);
 

--- a/apps/api/src/provider/controllers/jwt-token/jwt-token.controller.spec.ts
+++ b/apps/api/src/provider/controllers/jwt-token/jwt-token.controller.spec.ts
@@ -3,7 +3,7 @@ import { Ok } from "ts-results";
 import { mock } from "vitest-mock-extended";
 
 import { createUser } from "../../../../test/seeders/user.seeder";
-import { UserWalletSeeder } from "../../../../test/seeders/user-wallet.seeder";
+import { createUserWallet } from "../../../../test/seeders/user-wallet.seeder";
 import type { AuthService } from "../../../auth/services/auth.service";
 import type { UserWalletRepository } from "../../../billing/repositories";
 import type { UserOutput } from "../../../user/repositories/user/user.repository";
@@ -64,7 +64,7 @@ describe(JwtTokenController.name, () => {
 
     const controller = new JwtTokenController(providerJwtTokenService, authService, userWalletRepository);
 
-    const wallet = UserWalletSeeder.create({ userId: input?.user?.id });
+    const wallet = createUserWallet({ userId: input?.user?.id });
     const jwtToken = faker.string.alphanumeric(64);
 
     return {

--- a/apps/api/src/provider/services/provider/provider.service.spec.ts
+++ b/apps/api/src/provider/services/provider/provider.service.spec.ts
@@ -12,7 +12,7 @@ import { AUDITOR } from "@src/deployment/config/provider.config";
 import { mockConfigService } from "../../../../test/mocks/config-service.mock";
 import { createLeaseStatus } from "../../../../test/seeders/lease-status.seeder";
 import { createProviderSeed, createProviderWithAttributeSignatures } from "../../../../test/seeders/provider.seeder";
-import { UserWalletSeeder } from "../../../../test/seeders/user-wallet.seeder";
+import { createUserWallet } from "../../../../test/seeders/user-wallet.seeder";
 import type { BillingConfigService } from "../../../billing/services/billing-config/billing-config.service";
 import type { ProviderRepository } from "../../repositories/provider/provider.repository";
 import type { AuditorService } from "../auditors/auditors.service";
@@ -62,7 +62,7 @@ describe(ProviderService.name, () => {
       const { service, jwtTokenService, providerRepository, providerProxyService } = setup();
 
       const provider = createProviderSeed() as unknown as Provider;
-      const wallet = UserWalletSeeder.create();
+      const wallet = createUserWallet();
       const dseq = faker.string.numeric(6);
       const manifest = '{"quantity":{"val":"1"}}';
       const jwtToken = faker.string.alphanumeric(32);
@@ -109,7 +109,7 @@ describe(ProviderService.name, () => {
       vi.useFakeTimers();
 
       const provider = createProviderSeed() as unknown as Provider;
-      const wallet = UserWalletSeeder.create();
+      const wallet = createUserWallet();
       const dseq = faker.string.numeric(6);
       const manifest = '{"quantity":{"val":"1"}}';
       const jwtToken = faker.string.alphanumeric(32);
@@ -138,7 +138,7 @@ describe(ProviderService.name, () => {
       const { service, providerRepository } = setup();
 
       const provider = createProviderSeed() as unknown as Provider;
-      const wallet = UserWalletSeeder.create();
+      const wallet = createUserWallet();
       const dseq = faker.string.numeric(6);
       const manifest = '{"quantity":{"val":"1"}}';
 
@@ -160,7 +160,7 @@ describe(ProviderService.name, () => {
       vi.useFakeTimers();
 
       const provider = createProviderSeed() as unknown as Provider;
-      const wallet = UserWalletSeeder.create();
+      const wallet = createUserWallet();
       const dseq = faker.number.int({ min: 1, max: 1000 }).toString();
       const manifest = '{"quantity":{"val":"1"}}';
       const jwtToken = faker.string.alphanumeric(32);
@@ -202,7 +202,7 @@ describe(ProviderService.name, () => {
       const { service, jwtTokenService, providerRepository, providerProxyService } = setup();
 
       const provider = createProviderSeed() as unknown as Provider;
-      const wallet = UserWalletSeeder.create();
+      const wallet = createUserWallet();
       const dseq = faker.number.int({ min: 1, max: 1000 }).toString();
       const manifest = '{"quantity":{"val":"1"}}';
       const jwtToken = faker.string.alphanumeric(32);
@@ -241,7 +241,7 @@ describe(ProviderService.name, () => {
       const { service, jwtTokenService, providerRepository, providerProxyService } = setup();
 
       const provider = createProviderSeed() as unknown as Provider;
-      const wallet = UserWalletSeeder.create();
+      const wallet = createUserWallet();
       const dseq = faker.string.numeric(6);
       const manifest = '{"quantity":{"val":"1"}}';
       const jwtToken = faker.string.alphanumeric(32);
@@ -278,7 +278,7 @@ describe(ProviderService.name, () => {
       const { service, jwtTokenService, providerRepository, providerProxyService } = setup();
 
       const provider = createProviderSeed() as unknown as Provider;
-      const wallet = UserWalletSeeder.create();
+      const wallet = createUserWallet();
       const dseq = faker.string.numeric(6);
       const manifest = '{"quantity":{"val":"1"}}';
       const jwtToken = faker.string.alphanumeric(32);
@@ -317,7 +317,7 @@ describe(ProviderService.name, () => {
       const { service, jwtTokenService, providerRepository, providerProxyService } = setup();
 
       const provider = createProviderSeed() as unknown as Provider;
-      const wallet = UserWalletSeeder.create();
+      const wallet = createUserWallet();
       const dseq = faker.string.numeric(6);
       const gseq = faker.number.int({ min: 1, max: 10 });
       const oseq = faker.number.int({ min: 1, max: 10 });
@@ -365,7 +365,7 @@ describe(ProviderService.name, () => {
       const { service, providerRepository } = setup();
 
       const provider = createProviderSeed() as unknown as Provider;
-      const wallet = UserWalletSeeder.create();
+      const wallet = createUserWallet();
       const dseq = faker.string.numeric(6);
       const gseq = faker.number.int({ min: 1, max: 10 });
       const oseq = faker.number.int({ min: 1, max: 10 });

--- a/apps/api/test/functional/balances.spec.ts
+++ b/apps/api/test/functional/balances.spec.ts
@@ -16,7 +16,7 @@ import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 import { createDeploymentGrantResponseSeed } from "@test/seeders/deployment-grant-response.seeder";
 import { createDeploymentListResponseSeed } from "@test/seeders/deployment-list-response.seeder";
 import { createFeeAllowanceResponse } from "@test/seeders/fee-allowance-response.seeder";
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 const mockMasterWalletAddress = "akash1testmasterwalletaddress";
 
@@ -139,7 +139,7 @@ describe("Balances", () => {
 
     const user = await userRepository.create({});
     const userWithId = { ...user, userId: faker.string.uuid() };
-    const wallet = UserWalletSeeder.create({ userId: user.id, address: createAkashAddress() });
+    const wallet = createUserWallet({ userId: user.id, address: createAkashAddress() });
 
     const config = mock<CoreConfigService>({
       get: vi.fn().mockReturnValue("test")

--- a/apps/api/test/functional/bids.spec.ts
+++ b/apps/api/test/functional/bids.spec.ts
@@ -13,7 +13,7 @@ import { marketVersion } from "@src/utils/constants";
 
 import { createAkashAddress, createProvider } from "@test/seeders";
 import { createBid } from "@test/seeders/bid.seeder";
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe("Bids API", () => {
   const userRepository = container.resolve(UserRepository);
@@ -56,7 +56,7 @@ describe("Bids API", () => {
     await connectUsingSequelize();
     const user = await userRepository.create({ userId: faker.string.uuid() });
     const token = faker.string.alphanumeric(40);
-    const wallet = UserWalletSeeder.create({ userId: user.id, address: createAkashAddress() });
+    const wallet = createUserWallet({ userId: user.id, address: createAkashAddress() });
 
     vi.spyOn(userAuthTokenService, "getValidUserId").mockResolvedValue(user.userId);
     vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue(userWalletRepository);

--- a/apps/api/test/functional/deployment-setting.spec.ts
+++ b/apps/api/test/functional/deployment-setting.spec.ts
@@ -11,7 +11,7 @@ import { UserRepository } from "@src/user/repositories/user/user.repository";
 
 import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 import { createDrainingDeployment } from "@test/seeders/draining-deployment.seeder";
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe("Deployment Settings", () => {
   const deploymentSettingRepository = container.resolve(DeploymentSettingRepository);
@@ -337,7 +337,7 @@ describe("Deployment Settings", () => {
     const walletAddress = createAkashAddress();
     const token = faker.string.alphanumeric(40);
 
-    const wallet = UserWalletSeeder.create({ userId: user.id, address: walletAddress });
+    const wallet = createUserWallet({ userId: user.id, address: walletAddress });
 
     vi.spyOn(userAuthTokenService, "getValidUserId").mockResolvedValue(user.userId);
     vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue(userWalletRepository);

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -26,7 +26,7 @@ import { createDeploymentInfoErrorSeed, createDeploymentInfoSeed } from "@test/s
 import { createManyLeaseApiResponses } from "@test/seeders/lease-api-response.seeder";
 import { createLeaseStatus } from "@test/seeders/lease-status.seeder";
 import { createUser } from "@test/seeders/user.seeder";
-import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe("Deployments API", () => {
   const userRepository = container.resolve(UserRepository);
@@ -114,7 +114,7 @@ describe("Deployments API", () => {
     const userApiKeySecret = faker.word.noun();
     const user = createUser({ userId });
     const apiKey = createApiKey({ userId });
-    const wallets = [UserWalletSeeder.create({ userId, address: "akash13265twfqejnma6cc93rw5dxk4cldyz2zyy8cdm" })];
+    const wallets = [createUserWallet({ userId, address: "akash13265twfqejnma6cc93rw5dxk4cldyz2zyy8cdm" })];
 
     currentUser = user;
     knownUsers[userId] = user;

--- a/apps/api/test/seeders/user-wallet.seeder.ts
+++ b/apps/api/test/seeders/user-wallet.seeder.ts
@@ -3,27 +3,25 @@ import { faker } from "@faker-js/faker";
 import type { UserWalletOutput } from "@src/billing/repositories";
 import { createAkashAddress } from "./akash-address.seeder";
 
-export class UserWalletSeeder {
-  static create({
-    id = faker.number.int({ min: 0, max: 1000 }),
-    userId = faker.string.uuid(),
-    address = createAkashAddress(),
-    deploymentAllowance = faker.number.float({ min: 0, max: 1000000 }),
-    feeAllowance = faker.number.float({ min: 0, max: 1000000 }),
-    isTrialing = faker.helpers.arrayElement([true, false]),
-    createdAt = faker.date.past(),
-    updatedAt = faker.date.past()
-  }: Partial<UserWalletOutput> = {}): UserWalletOutput {
-    return {
-      id,
-      userId,
-      address,
-      deploymentAllowance,
-      feeAllowance,
-      isTrialing,
-      creditAmount: deploymentAllowance,
-      createdAt,
-      updatedAt
-    };
-  }
+export function createUserWallet({
+  id = faker.number.int({ min: 0, max: 1000 }),
+  userId = faker.string.uuid(),
+  address = createAkashAddress(),
+  deploymentAllowance = faker.number.float({ min: 0, max: 1000000 }),
+  feeAllowance = faker.number.float({ min: 0, max: 1000000 }),
+  isTrialing = faker.helpers.arrayElement([true, false]),
+  createdAt = faker.date.past(),
+  updatedAt = faker.date.past()
+}: Partial<UserWalletOutput> = {}): UserWalletOutput {
+  return {
+    id,
+    userId,
+    address,
+    deploymentAllowance,
+    feeAllowance,
+    isTrialing,
+    creditAmount: deploymentAllowance,
+    createdAt,
+    updatedAt
+  };
 }


### PR DESCRIPTION
## Why

Refactor class-based seeders to function-based. There is no point to define a class full of static methods.

## What

- Convert UserWalletSeeder to plain exported createUserWallet function
- Update all 19 consumer files to use the new function name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored the wallet-seeding helper into a simplified factory and updated many unit, integration, and functional tests to use it.
  * Improved test maintainability and typings across suites.
  * No changes to test behavior, assertions, or runtime logic; no user-facing impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->