### PR TITLE
test(dx): refactor UserSeeder from class to plain function

### DIFF
--- a/apps/api/src/app/services/trial-started/trial-started.handler.spec.ts
+++ b/apps/api/src/app/services/trial-started/trial-started.handler.spec.ts
@@ -11,7 +11,7 @@ import { startTrialNotification } from "@src/notifications/services/notification
 import type { UserRepository } from "@src/user/repositories";
 import { TrialStartedHandler } from "./trial-started.handler";
 
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 import { mockConfig } from "@test/services/mock-config.service";
 
 describe(TrialStartedHandler.name, () => {
@@ -30,7 +30,7 @@ describe(TrialStartedHandler.name, () => {
     });
 
     it("does not send start trial notification when user has no email but enqueues notification jobs", async () => {
-      const user = UserSeeder.create({
+      const user = createUser({
         id: "user-123",
         email: null,
         emailVerified: false,
@@ -53,7 +53,7 @@ describe(TrialStartedHandler.name, () => {
     it("sends start trial notification when user has email and enqueues notification jobs", async () => {
       const USER_CREATED_AT = new Date("2025-09-22T07:58:47.770Z");
       const TRIAL_ENDS_AT = "2025-10-22T07:58:47.770Z";
-      const user = UserSeeder.create({
+      const user = createUser({
         id: "user-123",
         email: "user@example.com",
         emailVerified: true,
@@ -92,7 +92,7 @@ describe(TrialStartedHandler.name, () => {
     });
 
     it("enqueues all notification jobs with correct timing and data", async () => {
-      const user = UserSeeder.create({
+      const user = createUser({
         id: "user-123",
         email: "user@example.com",
         emailVerified: true,
@@ -168,7 +168,7 @@ describe(TrialStartedHandler.name, () => {
     });
 
     it("handles different trial expiration days configuration", async () => {
-      const user = UserSeeder.create({
+      const user = createUser({
         id: "user-123",
         email: "user@example.com",
         emailVerified: true,

--- a/apps/api/src/auth/services/auth.interceptor.spec.ts
+++ b/apps/api/src/auth/services/auth.interceptor.spec.ts
@@ -13,12 +13,12 @@ import { UserAuthTokenService } from "./user-auth-token/user-auth-token.service"
 import { AuthInterceptor } from "./auth.interceptor";
 import { AuthService } from "./auth.service";
 
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 
 describe(AuthInterceptor.name, () => {
   describe("Regular user", () => {
     it("marks user as active once per 30 minutes", async () => {
-      const { di, callInterceptor } = setup({ user: UserSeeder.create() });
+      const { di, callInterceptor } = setup({ user: createUser() });
 
       await Promise.all([callInterceptor(), callInterceptor()]);
       await callInterceptor();
@@ -28,7 +28,7 @@ describe(AuthInterceptor.name, () => {
     });
 
     it("marks user as active again after 30 minutes", async () => {
-      const { di, callInterceptor } = setup({ user: UserSeeder.create() });
+      const { di, callInterceptor } = setup({ user: createUser() });
 
       await callInterceptor();
       await callInterceptor();
@@ -82,7 +82,7 @@ describe(AuthInterceptor.name, () => {
 
   describe("API key user", () => {
     it("marks user and its api key as active once per 30 minutes", async () => {
-      const { di, callInterceptor } = setup({ apiKey: "123", user: UserSeeder.create() });
+      const { di, callInterceptor } = setup({ apiKey: "123", user: createUser() });
 
       await Promise.all([callInterceptor(), callInterceptor()]);
       await callInterceptor();
@@ -93,7 +93,7 @@ describe(AuthInterceptor.name, () => {
     });
 
     it("marks user and its api key as active again after 30 minutes", async () => {
-      const { di, callInterceptor } = setup({ apiKey: "123", user: UserSeeder.create() });
+      const { di, callInterceptor } = setup({ apiKey: "123", user: createUser() });
 
       await callInterceptor();
       await callInterceptor();
@@ -121,8 +121,8 @@ describe(AuthInterceptor.name, () => {
     di.registerInstance(
       UserRepository,
       mock<UserRepository>({
-        findByUserId: jest.fn().mockImplementation(async () => input?.user ?? UserSeeder.create()),
-        findById: jest.fn().mockImplementation(async () => input?.user ?? UserSeeder.create()),
+        findByUserId: jest.fn().mockImplementation(async () => input?.user ?? createUser()),
+        findById: jest.fn().mockImplementation(async () => input?.user ?? createUser()),
         markAsActive: jest.fn()
       })
     );

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -11,7 +11,7 @@ import type { StripeErrorService } from "@src/billing/services/stripe-error/stri
 import { StripeController } from "./stripe.controller";
 
 import { generateDatabaseStripeTransaction } from "@test/seeders/database-stripe-transaction.seeder";
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 
 describe(StripeController.name, () => {
   describe("confirmPayment", () => {
@@ -172,7 +172,7 @@ describe(StripeController.name, () => {
   });
 
   function setup() {
-    const user = UserSeeder.create();
+    const user = createUser();
     const payingUser: PayingUser = { ...user, stripeCustomerId: user.stripeCustomerId! };
     const stripe = mock<StripeService>();
     const authService = mock<AuthService>({

--- a/apps/api/src/billing/controllers/wallet-settings/wallet-settings.controller.spec.ts
+++ b/apps/api/src/billing/controllers/wallet-settings/wallet-settings.controller.spec.ts
@@ -5,7 +5,7 @@ import { AuthService } from "@src/auth/services/auth.service";
 import type { WalletSettingService } from "@src/billing/services/wallet-settings/wallet-settings.service";
 import { WalletSettingController } from "./wallet-settings.controller";
 
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 import { generateWalletSetting } from "@test/seeders/wallet-setting.seeder";
 
 describe(WalletSettingController.name, () => {
@@ -84,7 +84,7 @@ describe(WalletSettingController.name, () => {
   });
 
   function setup() {
-    const user = UserSeeder.create();
+    const user = createUser();
     const walletSetting = generateWalletSetting({
       userId: user.id
     });

--- a/apps/api/src/billing/controllers/wallet/wallet.controller.spec.ts
+++ b/apps/api/src/billing/controllers/wallet/wallet.controller.spec.ts
@@ -17,11 +17,11 @@ import { UserRepository } from "@src/user/repositories";
 import { WalletController } from "./wallet.controller";
 
 import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 
 describe("WalletController", () => {
   it("forbids starting a trial for a user with not verified email", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       emailVerified: false
     });
     const container = setup({
@@ -39,7 +39,7 @@ describe("WalletController", () => {
   });
 
   it("forbids starting a trial for a user without configured payments methods", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       emailVerified: true,
       stripeCustomerId: faker.string.uuid()
     });
@@ -59,7 +59,7 @@ describe("WalletController", () => {
   });
 
   it("forbids starting a trial for a user with duplicate trial account", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       emailVerified: true,
       stripeCustomerId: faker.string.uuid()
     });
@@ -80,7 +80,7 @@ describe("WalletController", () => {
   });
 
   it("forbids starting a trial for a user with duplicate fingerprint", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       emailVerified: true,
       stripeCustomerId: faker.string.uuid(),
       lastFingerprint: "duplicate-fingerprint"
@@ -102,7 +102,7 @@ describe("WalletController", () => {
   });
 
   it("allows starting a trial when user has no fingerprint", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       emailVerified: true,
       stripeCustomerId: faker.string.uuid(),
       lastFingerprint: null
@@ -122,7 +122,7 @@ describe("WalletController", () => {
   });
 
   it("creates a wallet for a user with all valid requirements", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       emailVerified: true,
       stripeCustomerId: faker.string.uuid()
     });
@@ -141,7 +141,7 @@ describe("WalletController", () => {
   });
 
   it("handles 3DS required scenario in controller", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       emailVerified: true,
       stripeCustomerId: faker.string.uuid()
     });
@@ -177,7 +177,7 @@ describe("WalletController", () => {
   });
 
   it("handles validation failure in controller", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       emailVerified: true,
       stripeCustomerId: faker.string.uuid()
     });
@@ -221,7 +221,7 @@ describe("WalletController", () => {
         }
       ];
       const container = setup({
-        user: UserSeeder.create(),
+        user: createUser(),
         wallets
       });
       const walletController = container.resolve(WalletController);
@@ -237,7 +237,7 @@ describe("WalletController", () => {
     it("returns empty list when no wallets found", async () => {
       const userId = faker.string.uuid();
       const container = setup({
-        user: UserSeeder.create(),
+        user: createUser(),
         wallets: []
       });
       const walletController = container.resolve(WalletController);
@@ -249,7 +249,7 @@ describe("WalletController", () => {
   });
 
   it("handles stripe error in controller", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       emailVerified: true,
       stripeCustomerId: faker.string.uuid()
     });
@@ -289,7 +289,7 @@ describe("WalletController", () => {
             subject: "UserWallet"
           }
         ]),
-        currentUser: input?.user || UserSeeder.create()
+        currentUser: input?.user || createUser()
       })
     });
     rootContainer.register(WalletInitializerService, {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -26,7 +26,7 @@ import type { TxManagerService } from "../tx-manager/tx-manager.service";
 import { ManagedSignerService } from "./managed-signer.service";
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
 describe(ManagedSignerService.name, () => {
@@ -56,7 +56,7 @@ describe(ManagedSignerService.name, () => {
 
     it("throws 402 error when userWallet has no fee allowance", async () => {
       const wallet = UserWalletSeeder.create({ userId: "user-123", feeAllowance: 0 });
-      const user = UserSeeder.create({ userId: "user-123" });
+      const user = createUser({ userId: "user-123" });
       const { service } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
         findById: jest.fn().mockResolvedValue(user),
@@ -72,7 +72,7 @@ describe(ManagedSignerService.name, () => {
         feeAllowance: 100,
         deploymentAllowance: 0
       });
-      const user = UserSeeder.create({ userId: "user-123" });
+      const user = createUser({ userId: "user-123" });
       const deploymentMessage: EncodeObject = {
         typeUrl: MsgCreateDeployment.$type,
         value: MsgCreateDeployment.fromPartial({})
@@ -93,7 +93,7 @@ describe(ManagedSignerService.name, () => {
         feeAllowance: 100,
         deploymentAllowance: 100
       });
-      const user = UserSeeder.create({ userId: "user-123" });
+      const user = createUser({ userId: "user-123" });
       const messages: EncodeObject[] = [
         {
           typeUrl: MsgCreateLease.$type,
@@ -129,7 +129,7 @@ describe(ManagedSignerService.name, () => {
         feeAllowance: 100,
         deploymentAllowance: 100
       });
-      const user = UserSeeder.create({ userId: "user-123" });
+      const user = createUser({ userId: "user-123" });
       const messages: EncodeObject[] = [
         {
           typeUrl: MsgCreateLease.$type,
@@ -174,7 +174,7 @@ describe(ManagedSignerService.name, () => {
         deploymentAllowance: 100,
         isTrialing: true
       });
-      const user = UserSeeder.create({ userId: "user-123" });
+      const user = createUser({ userId: "user-123" });
       const deploymentMessage: EncodeObject = {
         typeUrl: MsgCreateLease.$type,
         value: MsgCreateLease.fromPartial({
@@ -237,7 +237,7 @@ describe(ManagedSignerService.name, () => {
         feeAllowance: 100,
         deploymentAllowance: 100
       });
-      const user = UserSeeder.create({ userId: "user-123" });
+      const user = createUser({ userId: "user-123" });
       const messages: EncodeObject[] = [
         {
           typeUrl: MsgCreateLease.$type,
@@ -263,7 +263,7 @@ describe(ManagedSignerService.name, () => {
     });
 
     it("uses current user when userId matches auth currentUser", async () => {
-      const currentUser = UserSeeder.create({ userId: "user-123" });
+      const currentUser = createUser({ userId: "user-123" });
       const wallet = UserWalletSeeder.create({ userId: "user-123", feeAllowance: 100 });
       const messages: EncodeObject[] = [
         {
@@ -299,7 +299,7 @@ describe(ManagedSignerService.name, () => {
         deploymentAllowance: 100,
         isTrialing: false
       });
-      const user = UserSeeder.create({ userId: "user-123" });
+      const user = createUser({ userId: "user-123" });
       const messages: EncodeObject[] = [
         {
           typeUrl: MsgCreateLease.$type,
@@ -336,7 +336,7 @@ describe(ManagedSignerService.name, () => {
         deploymentAllowance: 100,
         isTrialing: true
       });
-      const user = UserSeeder.create({ userId: "user-123" });
+      const user = createUser({ userId: "user-123" });
       const messages: EncodeObject[] = [
         {
           typeUrl: MsgCreateLease.$type,
@@ -374,7 +374,7 @@ describe(ManagedSignerService.name, () => {
         feeAllowance: 100,
         deploymentAllowance: 100
       });
-      const user = UserSeeder.create({ userId: "user-123" });
+      const user = createUser({ userId: "user-123" });
       const deploymentMessage = {
         typeUrl: MsgCreateDeployment.$type,
         value: Buffer.from(JSON.stringify({ id: { dseq: "123", owner: wallet.address } })).toString("base64")
@@ -402,7 +402,7 @@ describe(ManagedSignerService.name, () => {
         userId: "user-123",
         feeAllowance: 100
       });
-      const user = UserSeeder.create({ userId: "user-123" });
+      const user = createUser({ userId: "user-123" });
       const depositMessage = {
         typeUrl: MsgAccountDeposit.$type,
         value: Buffer.from(JSON.stringify({ owner: wallet.address, amount: "1000" })).toString("base64")
@@ -431,7 +431,7 @@ describe(ManagedSignerService.name, () => {
         feeAllowance: 100,
         deploymentAllowance: 100
       });
-      const user = UserSeeder.create({ userId: "user-123" });
+      const user = createUser({ userId: "user-123" });
       const leaseMessage = {
         typeUrl: MsgCreateLease.$type,
         value: Buffer.from(JSON.stringify({ bidId: { dseq: "123" } })).toString("base64")
@@ -487,7 +487,7 @@ describe(ManagedSignerService.name, () => {
   describe("executeDerivedDecodedTxByUserId - result without hash", () => {
     it("returns result as-is when hash is empty", async () => {
       const wallet = UserWalletSeeder.create({ userId: "user-123", feeAllowance: 100, deploymentAllowance: 100 });
-      const user = UserSeeder.create({ userId: "user-123" });
+      const user = createUser({ userId: "user-123" });
       const messages: EncodeObject[] = [{ typeUrl: MsgCreateLease.$type, value: MsgCreateLease.fromPartial({ bidId: { dseq: 123 } }) }];
 
       const { service } = setup({
@@ -539,7 +539,7 @@ describe(ManagedSignerService.name, () => {
         retrieveDeploymentLimit: input?.retrieveDeploymentLimit ?? jest.fn().mockResolvedValue(5000000)
       }),
       authService: mock<AuthService>({
-        currentUser: input?.currentUser ?? UserSeeder.create({ userId: "current-user" }),
+        currentUser: input?.currentUser ?? createUser({ userId: "current-user" }),
         ability: createMongoAbility<MongoAbility>()
       }),
       chainErrorService: mock<ChainErrorService>({

--- a/apps/api/src/billing/services/remaining-credits/remaining-credits.service.spec.ts
+++ b/apps/api/src/billing/services/remaining-credits/remaining-credits.service.spec.ts
@@ -5,12 +5,12 @@ import type { BalancesService } from "@src/billing/services/balances/balances.se
 import type { LoggerService } from "@src/core/providers/logging.provider";
 import { RemainingCreditsService } from "./remaining-credits.service";
 
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
 describe(RemainingCreditsService.name, () => {
   it("returns remaining credits when user has wallet", async () => {
-    const user = UserSeeder.create();
+    const user = createUser();
     const remainingCreditsInUusdc = 100_000_000;
     const expectedCreditsInUsdc = 100;
 
@@ -28,7 +28,7 @@ describe(RemainingCreditsService.name, () => {
   });
 
   it("throws error when user has no wallet", async () => {
-    const user = UserSeeder.create();
+    const user = createUser();
 
     const { service, userWalletRepository, logger } = setup({
       findOneByUserId: jest.fn().mockResolvedValue(null)
@@ -44,7 +44,7 @@ describe(RemainingCreditsService.name, () => {
   });
 
   it("throws error when user wallet has no address", async () => {
-    const user = UserSeeder.create();
+    const user = createUser();
 
     const userWallet = UserWalletSeeder.create({ address: null });
     const { service, userWalletRepository, logger } = setup({

--- a/apps/api/src/billing/services/stripe/stripe.service.spec.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.spec.ts
@@ -22,7 +22,7 @@ import {
   TEST_CONSTANTS
 } from "@test/seeders/stripe-test-data.seeder";
 import { createTestTransaction } from "@test/seeders/stripe-transaction-test.seeder";
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 import { createTestUser } from "@test/seeders/user-test.seeder";
 
 describe(StripeService.name, () => {
@@ -1131,7 +1131,7 @@ describe(StripeService.name, () => {
     });
 
     it("handles 3D Secure authentication requirement in trialing wallets", async () => {
-      const mockUser = UserSeeder.create({ id: "user_123", stripeCustomerId: "cus_123" });
+      const mockUser = createUser({ id: "user_123", stripeCustomerId: "cus_123" });
       const mockPaymentIntent = createTestPaymentIntent({
         id: "pi_test_123",
         status: "requires_action",
@@ -1176,7 +1176,7 @@ describe(StripeService.name, () => {
 
     it("handles payment intent with requires_capture status", async () => {
       const { service, paymentMethodRepository } = setup();
-      const mockUser = UserSeeder.create({ id: "user_123", stripeCustomerId: "cus_123" });
+      const mockUser = createUser({ id: "user_123", stripeCustomerId: "cus_123" });
       const mockPaymentIntent = {
         id: "pi_test_123",
         status: "requires_capture",
@@ -1360,7 +1360,7 @@ describe(StripeService.name, () => {
 
     it("marks payment method as validated when payment intent succeeded", async () => {
       const { service, paymentMethodRepository } = setup();
-      const mockUser = UserSeeder.create({ id: "user_123", stripeCustomerId: "cus_123" });
+      const mockUser = createUser({ id: "user_123", stripeCustomerId: "cus_123" });
       const mockPaymentIntent = {
         id: "pi_123",
         status: "succeeded",
@@ -1384,7 +1384,7 @@ describe(StripeService.name, () => {
 
     it("marks payment method as validated when payment intent requires_capture", async () => {
       const { service, paymentMethodRepository } = setup();
-      const mockUser = UserSeeder.create({ id: "user_123", stripeCustomerId: "cus_123" });
+      const mockUser = createUser({ id: "user_123", stripeCustomerId: "cus_123" });
       const mockPaymentIntent = {
         id: "pi_123",
         status: "requires_capture",
@@ -1594,7 +1594,7 @@ function setup(
     if (query?.id && lastUser && lastUser.id === query.id) {
       return lastUser;
     }
-    // fallback for tests that don't use UserSeeder
+    // fallback for tests that don't use createUser
     if (query?.stripeCustomerId) {
       return { id: query.stripeCustomerId, stripeCustomerId: query.stripeCustomerId };
     }

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -14,7 +14,7 @@ import { WalletBalanceReloadCheckHandler } from "./wallet-balance-reload-check.h
 import type { WalletBalanceReloadCheckInstrumentationService } from "./wallet-balance-reload-check-instrumentation.service";
 
 import { generateMergedPaymentMethod as generatePaymentMethod } from "@test/seeders/payment-method.seeder";
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 import { generateWalletSetting } from "@test/seeders/wallet-setting.seeder";
 
@@ -268,7 +268,7 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     });
 
     it("logs validation error when user stripe customer ID is not set", async () => {
-      const userWithoutStripe = UserSeeder.create();
+      const userWithoutStripe = createUser();
       const userWithNullStripe = { ...userWithoutStripe, stripeCustomerId: null };
       const { handler, walletSettingRepository, instrumentationService, job, jobMeta } = setup({
         user: userWithNullStripe
@@ -316,9 +316,9 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
     walletSettingNotFound?: boolean;
     autoReloadEnabled?: boolean;
     wallet?: ReturnType<typeof UserWalletSeeder.create>;
-    user?: ReturnType<typeof UserSeeder.create>;
+    user?: ReturnType<typeof createUser>;
   }) {
-    const user = input?.user ?? UserSeeder.create();
+    const user = input?.user ?? createUser();
     const userWithStripe =
       input?.user && input.user.stripeCustomerId === null
         ? user

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
@@ -14,7 +14,7 @@ import { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wa
 import { WalletInitializerService } from "./wallet-initializer.service";
 
 import { createChainWallet } from "@test/seeders/chain-wallet.seeder";
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
 describe(WalletInitializerService.name, () => {
@@ -132,7 +132,7 @@ describe(WalletInitializerService.name, () => {
       AuthService,
       mock<AuthService>({
         ability: {},
-        currentUser: UserSeeder.create({ id: input?.userId })
+        currentUser: createUser({ id: input?.userId })
       })
     );
     di.registerInstance(DomainEventsService, mock<DomainEventsService>());

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
@@ -11,7 +11,7 @@ import type { UserRepository } from "@src/user/repositories";
 import { WalletSettingService } from "./wallet-settings.service";
 
 import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 import { generateWalletSetting } from "@test/seeders/wallet-setting.seeder";
 
@@ -170,7 +170,7 @@ describe(WalletSettingService.name, () => {
   });
 
   function setup() {
-    const user = UserSeeder.create();
+    const user = createUser();
     const userWithStripe = { ...user, stripeCustomerId: faker.string.uuid() };
     const userWallet = UserWalletSeeder.create({ userId: user.id });
     const walletSettingRepository = mock<WalletSettingRepository>();

--- a/apps/api/src/deployment/services/active-deployments-count/active-deployments-count.service.spec.ts
+++ b/apps/api/src/deployment/services/active-deployments-count/active-deployments-count.service.spec.ts
@@ -6,12 +6,12 @@ import type { LoggerService } from "@src/core/providers/logging.provider";
 import type { DeploymentRepository } from "@src/deployment/repositories/deployment/deployment.repository";
 import { ActiveDeploymentsCountService } from "./active-deployments-count.service";
 
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
 describe(ActiveDeploymentsCountService.name, () => {
   it("returns active deployments count when user has wallet", async () => {
-    const user = UserSeeder.create();
+    const user = createUser();
     const activeCount = faker.number.int({ min: 0, max: 10 });
 
     const userWallet = UserWalletSeeder.create();
@@ -28,7 +28,7 @@ describe(ActiveDeploymentsCountService.name, () => {
   });
 
   it("throws error when user has no wallet", async () => {
-    const user = UserSeeder.create();
+    const user = createUser();
 
     const { service, userWalletRepository, logger } = setup({
       findOneByUserId: jest.fn().mockResolvedValue(null)
@@ -44,7 +44,7 @@ describe(ActiveDeploymentsCountService.name, () => {
   });
 
   it("throws error when user wallet has no address", async () => {
-    const user = UserSeeder.create();
+    const user = createUser();
 
     const userWallet = UserWalletSeeder.create({ address: null });
     const { service, userWalletRepository, logger } = setup({

--- a/apps/api/src/notifications/services/notification-data-resolver/notification-data-resolver.service.spec.ts
+++ b/apps/api/src/notifications/services/notification-data-resolver/notification-data-resolver.service.spec.ts
@@ -8,7 +8,7 @@ import type { NotificationDataResolvers } from "@src/notifications/providers/not
 import type { UserOutput } from "@src/user/repositories";
 import { NotificationDataResolverService, RESOLVED_MARKER } from "./notification-data-resolver.service";
 
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 
 describe(NotificationDataResolverService.name, () => {
   it("returns undefined when vars is undefined", async () => {
@@ -27,7 +27,7 @@ describe(NotificationDataResolverService.name, () => {
       activeDeployments: { resolve: vi.fn().mockResolvedValue(activeDeployments) }
     };
     const { service } = setup({ resolvers });
-    const user = UserSeeder.create();
+    const user = createUser();
     const vars = {
       paymentLink: faker.internet.url(),
       trialEndsAt: "2023-11-13T12:00:00Z",
@@ -51,7 +51,7 @@ describe(NotificationDataResolverService.name, () => {
 
   it("logs error and skips resolution for unknown resolver", async () => {
     const { service, logger } = setup();
-    const user = UserSeeder.create();
+    const user = createUser();
     const vars = {
       paymentLink: faker.internet.url(),
       unknownField: RESOLVED_MARKER
@@ -75,7 +75,7 @@ describe(NotificationDataResolverService.name, () => {
         optionalField: { resolve: resolver }
       }
     });
-    const user = UserSeeder.create();
+    const user = createUser();
     const vars = {
       paymentLink: faker.internet.url(),
       optionalField: RESOLVED_MARKER
@@ -98,7 +98,7 @@ describe(NotificationDataResolverService.name, () => {
         failingField: { resolve: resolver }
       }
     });
-    const user = UserSeeder.create();
+    const user = createUser();
     const vars = {
       paymentLink: faker.internet.url(),
       failingField: RESOLVED_MARKER

--- a/apps/api/src/notifications/services/notification-handler/notification.handler.spec.ts
+++ b/apps/api/src/notifications/services/notification-handler/notification.handler.spec.ts
@@ -13,7 +13,7 @@ import { trialEndedNotification } from "../notification-templates/trial-ended-no
 import type { NotificationJob } from "./notification.handler";
 import { NotificationHandler } from "./notification.handler";
 
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 
 describe(NotificationHandler.name, () => {
   it("logs error and returns early for unknown notification template", async () => {
@@ -56,7 +56,7 @@ describe(NotificationHandler.name, () => {
   });
 
   it("logs warning and returns early when user has no email", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       id: "user-123",
       email: null
     });
@@ -84,7 +84,7 @@ describe(NotificationHandler.name, () => {
   });
 
   it("returns early when conditions are not met", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       id: "user-123",
       email: "user@example.com",
       trial: false
@@ -109,7 +109,7 @@ describe(NotificationHandler.name, () => {
   });
 
   it("creates notification when conditions are met", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       id: "user-123",
       email: "user@example.com",
       trial: true
@@ -135,7 +135,7 @@ describe(NotificationHandler.name, () => {
   });
 
   it("creates notification when no conditions are provided", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       id: "user-123",
       email: "user@example.com"
     });
@@ -172,7 +172,7 @@ describe(NotificationHandler.name, () => {
 
     jest.useFakeTimers({ now: currentDate });
 
-    const user = UserSeeder.create({
+    const user = createUser({
       id: "user-123",
       email: "user@example.com",
       createdAt: createdDate,
@@ -206,7 +206,7 @@ describe(NotificationHandler.name, () => {
   });
 
   it("creates afterTrialEnds notification", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       id: "user-123",
       email: "user@example.com",
       trial: true
@@ -232,7 +232,7 @@ describe(NotificationHandler.name, () => {
   });
 
   it("handles complex conditions with multiple properties", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       id: "user-123",
       email: "user@example.com",
       trial: true,
@@ -263,7 +263,7 @@ describe(NotificationHandler.name, () => {
   });
 
   it("returns early when complex conditions are not met", async () => {
-    const user = UserSeeder.create({
+    const user = createUser({
       id: "user-123",
       email: "user@example.com",
       trial: true,

--- a/apps/api/src/provider/controllers/jwt-token/jwt-token.controller.spec.ts
+++ b/apps/api/src/provider/controllers/jwt-token/jwt-token.controller.spec.ts
@@ -2,7 +2,7 @@ import { faker } from "@faker-js/faker";
 import { Ok } from "ts-results";
 import { mock } from "vitest-mock-extended";
 
-import { UserSeeder } from "../../../../test/seeders/user.seeder";
+import { createUser } from "../../../../test/seeders/user.seeder";
 import { UserWalletSeeder } from "../../../../test/seeders/user-wallet.seeder";
 import type { AuthService } from "../../../auth/services/auth.service";
 import type { UserWalletRepository } from "../../../billing/repositories";
@@ -14,7 +14,7 @@ import { JwtTokenController } from "./jwt-token.controller";
 describe(JwtTokenController.name, () => {
   describe("createJwtToken", () => {
     it("creates JWT token successfully when user has wallet", async () => {
-      const user = UserSeeder.create();
+      const user = createUser();
       const { controller, authService, userWalletRepository, providerJwtTokenService, jwtToken, wallet } = setup({ user });
 
       authService.currentUser = user;
@@ -45,7 +45,7 @@ describe(JwtTokenController.name, () => {
     });
 
     it("returns BadRequestError when user has no wallet", async () => {
-      const user = UserSeeder.create();
+      const user = createUser();
       const { controller, authService, userWalletRepository } = setup({ user });
 
       authService.currentUser = user;

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -25,7 +25,7 @@ import { createDeployment } from "@test/seeders/deployment.seeder";
 import { DeploymentInfoSeeder } from "@test/seeders/deployment-info.seeder";
 import { LeaseApiResponseSeeder } from "@test/seeders/lease-api-response.seeder";
 import { LeaseStatusSeeder } from "@test/seeders/lease-status.seeder";
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 import { UserWalletSeeder } from "@test/seeders/user-wallet.seeder";
 
 describe("Deployments API", () => {
@@ -112,7 +112,7 @@ describe("Deployments API", () => {
   async function mockUser() {
     const userId = faker.string.uuid();
     const userApiKeySecret = faker.word.noun();
-    const user = UserSeeder.create({ userId });
+    const user = createUser({ userId });
     const apiKey = ApiKeySeeder.create({ userId });
     const wallets = [UserWalletSeeder.create({ userId, address: "akash13265twfqejnma6cc93rw5dxk4cldyz2zyy8cdm" })];
 

--- a/apps/api/test/seeders/user-test.seeder.ts
+++ b/apps/api/test/seeders/user-test.seeder.ts
@@ -1,8 +1,8 @@
 import { TEST_CONSTANTS } from "./stripe-test-data.seeder";
-import { UserSeeder } from "./user.seeder";
+import { createUser } from "./user.seeder";
 
 export function createTestUser(overrides: Partial<{ id: string; stripeCustomerId: string | null }> = {}) {
-  return UserSeeder.create({
+  return createUser({
     id: TEST_CONSTANTS.USER_ID,
     stripeCustomerId: TEST_CONSTANTS.CUSTOMER_ID,
     ...overrides

--- a/apps/api/test/seeders/user.seeder.ts
+++ b/apps/api/test/seeders/user.seeder.ts
@@ -2,44 +2,42 @@ import { faker } from "@faker-js/faker";
 
 import type { UserOutput } from "@src/user/repositories";
 
-export class UserSeeder {
-  static create({
-    id = faker.string.uuid(),
-    userId = faker.string.uuid(),
-    username = faker.word.noun(),
-    email = faker.internet.email(),
-    emailVerified = faker.datatype.boolean(),
-    stripeCustomerId = faker.string.uuid(),
-    bio = faker.lorem.paragraph(),
-    subscribedToNewsletter = faker.datatype.boolean(),
-    youtubeUsername = faker.word.noun(),
-    twitterUsername = faker.word.noun(),
-    githubUsername = faker.word.noun(),
-    lastActiveAt = faker.date.recent(),
-    lastIp = faker.internet.ip(),
-    lastUserAgent = faker.internet.userAgent(),
-    lastFingerprint = faker.word.noun(),
-    createdAt = faker.date.recent(),
-    trial = false
-  }: Partial<UserOutput> = {}): UserOutput {
-    return {
-      id,
-      userId,
-      username,
-      email,
-      emailVerified,
-      stripeCustomerId,
-      bio,
-      subscribedToNewsletter,
-      youtubeUsername,
-      twitterUsername,
-      githubUsername,
-      lastActiveAt,
-      lastIp,
-      lastUserAgent,
-      lastFingerprint,
-      createdAt,
-      trial
-    };
-  }
+export function createUser({
+  id = faker.string.uuid(),
+  userId = faker.string.uuid(),
+  username = faker.word.noun(),
+  email = faker.internet.email(),
+  emailVerified = faker.datatype.boolean(),
+  stripeCustomerId = faker.string.uuid(),
+  bio = faker.lorem.paragraph(),
+  subscribedToNewsletter = faker.datatype.boolean(),
+  youtubeUsername = faker.word.noun(),
+  twitterUsername = faker.word.noun(),
+  githubUsername = faker.word.noun(),
+  lastActiveAt = faker.date.recent(),
+  lastIp = faker.internet.ip(),
+  lastUserAgent = faker.internet.userAgent(),
+  lastFingerprint = faker.word.noun(),
+  createdAt = faker.date.recent(),
+  trial = false
+}: Partial<UserOutput> = {}): UserOutput {
+  return {
+    id,
+    userId,
+    username,
+    email,
+    emailVerified,
+    stripeCustomerId,
+    bio,
+    subscribedToNewsletter,
+    youtubeUsername,
+    twitterUsername,
+    githubUsername,
+    lastActiveAt,
+    lastIp,
+    lastUserAgent,
+    lastFingerprint,
+    createdAt,
+    trial
+  };
 }


### PR DESCRIPTION
## Why

Refactor class-based seeders to function-based. There is no point to define a class full of static methods.

## What

- Convert UserSeeder to plain exported createUser function
- Update all 16 consumer files plus user-test.seeder.ts helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Test seeder utilities restructured from a class/static factory to a simpler function-based export for creating test users.
  * All affected tests updated to use the new factory function; no changes to test data, assertions, or runtime behavior.
  * No impact on application functionality or end-user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->