### PR TITLE
chore: removes jest-mock-extended in console-api

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -145,7 +145,6 @@
     "eslint-config-next": "^14.2.3",
     "eslint-plugin-simple-import-sort": "^12.1.0",
     "immutability-helper": "^3.1.1",
-    "jest-mock-extended": "^4.0.0-beta1",
     "nock": "^14.0.11",
     "openapi3-ts": "^4.5.0",
     "prettier": "^3.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,6 @@
         "eslint-config-next": "^14.2.3",
         "eslint-plugin-simple-import-sort": "^12.1.0",
         "immutability-helper": "^3.1.1",
-        "jest-mock-extended": "^4.0.0-beta1",
         "nock": "^14.0.11",
         "openapi3-ts": "^4.5.0",
         "prettier": "^3.3.0",


### PR DESCRIPTION
## Why

we don't use jest anymore in console-api

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed development dependency to streamline the API package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->