### PR TITLE
fix(auth): handle OAuth access_denied error on callback

### DIFF
--- a/apps/deploy-web/src/pages/api/auth/[...auth0].ts
+++ b/apps/deploy-web/src/pages/api/auth/[...auth0].ts
@@ -5,7 +5,7 @@ import { once } from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { Session } from "@src/lib/auth0";
-import { AccessTokenError, AccessTokenErrorCode, CallbackHandlerError, MissingStateCookieError } from "@src/lib/auth0";
+import { AccessTokenError, AccessTokenErrorCode, CallbackHandlerError, IdentityProviderError, MissingStateCookieError } from "@src/lib/auth0";
 import { handleAuth, handleCallback, handleLogin, handleLogout } from "@src/lib/auth0";
 import { defineApiHandler } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
 import type { AppServices } from "@src/services/app-di-container/server-di-container.service";
@@ -52,6 +52,13 @@ const authHandler = once((services: AppServices) =>
       } catch (error) {
         if (isMissingStateCookieError(error)) {
           services.logger.warn({ event: "AUTH_CALLBACK_MISSING_STATE_COOKIE", error });
+          res.writeHead(302, { Location: "/login" });
+          res.end();
+          return;
+        }
+
+        if (isAccessDeniedError(error)) {
+          services.logger.info({ event: "AUTH_CALLBACK_ACCESS_DENIED" });
           res.writeHead(302, { Location: "/login" });
           res.end();
           return;
@@ -132,6 +139,10 @@ function isGeneralAxiosError(error: unknown): error is AxiosError {
 
 function isMissingStateCookieError(error: unknown): boolean {
   return error instanceof CallbackHandlerError && error.cause instanceof MissingStateCookieError;
+}
+
+function isAccessDeniedError(error: unknown): boolean {
+  return error instanceof CallbackHandlerError && error.cause instanceof IdentityProviderError && error.cause.error === "access_denied";
 }
 
 function clearSessionAndRedirectToLogin(req: NextApiRequest, res: NextApiResponse): void {


### PR DESCRIPTION
## Why

When a user declines the OAuth application consent (e.g. clicks "Deny" on GitHub/Google authorization), Auth0 returns an `access_denied` error via `IdentityProviderError`. This was not handled explicitly, causing it to be reported to our observability stack as an unexpected `AUTH_CALLBACK_ERROR` and returning a 500 to the user — even though it's an expected user action.

## What

- Added handling for `access_denied` errors from identity providers in the Auth0 callback handler
- On decline, the user is redirected to `/login` instead of seeing a 500 error
- The event is logged at `info` level (`AUTH_CALLBACK_ACCESS_DENIED`) and **not** reported to the error handler, since it is expected behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication access denial handling. Users denied access during the authentication callback are now properly redirected to the login page instead of encountering an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->