### PR TITLE
refactor: removes chainNetwork parameter from provider-proxy requests from console-api

### DIFF
--- a/apps/api/src/provider/services/provider/provider-proxy.service.spec.ts
+++ b/apps/api/src/provider/services/provider/provider-proxy.service.spec.ts
@@ -22,8 +22,7 @@ describe(ProviderProxyService.name, () => {
           auth: options.auth,
           method: "GET",
           url: options.providerIdentity.hostUri + url,
-          providerAddress: options.providerIdentity.owner,
-          network: options.chainNetwork
+          providerAddress: options.providerIdentity.owner
         },
         {}
       );
@@ -76,7 +75,6 @@ describe(ProviderProxyService.name, () => {
     const service = new ProviderProxyService(httpClient);
     const url = `/${faker.word.noun()}`;
     const options: ProviderProxyPayload = {
-      chainNetwork: faker.word.noun(),
       providerIdentity: {
         owner: faker.string.alphanumeric(44),
         hostUri: faker.internet.url({ appendSlash: false })

--- a/apps/api/src/provider/services/provider/provider-proxy.service.ts
+++ b/apps/api/src/provider/services/provider/provider-proxy.service.ts
@@ -17,7 +17,6 @@ export interface ProviderProxyPayload {
   method?: "GET" | "POST" | "PUT" | "DELETE";
   body?: string;
   timeout?: number;
-  chainNetwork: string;
   providerIdentity: ProviderIdentity;
   headers?: Record<string, string>;
   auth: ProviderAuth;
@@ -32,7 +31,7 @@ export class ProviderProxyService {
   }
 
   async request<T>(url: string, options: ProviderProxyPayload): Promise<T> {
-    const { chainNetwork, providerIdentity, timeout, ...params } = options;
+    const { providerIdentity, timeout, ...params } = options;
     const response = await this.#httpClient.post(
       "/",
       {
@@ -40,7 +39,6 @@ export class ProviderProxyService {
         method: options.method || "GET",
         url: providerIdentity.hostUri + url,
         providerAddress: providerIdentity.owner,
-        network: chainNetwork,
         timeout // this is per attempt timeout on provider-proxy side
       },
       {

--- a/apps/api/src/provider/services/provider/provider.service.spec.ts
+++ b/apps/api/src/provider/services/provider/provider.service.spec.ts
@@ -1,7 +1,6 @@
 import type { JwtTokenPayload } from "@akashnetwork/chain-sdk";
 import type { Provider } from "@akashnetwork/database/dbSchemas/akash";
 import type { ProviderAttributesSchema } from "@akashnetwork/http-sdk";
-import { netConfig } from "@akashnetwork/net";
 import { faker } from "@faker-js/faker";
 import { AxiosError } from "axios";
 import { Ok } from "ts-results";
@@ -9,11 +8,9 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { AUDITOR } from "@src/deployment/config/provider.config";
-import { mockConfigService } from "../../../../test/mocks/config-service.mock";
 import { createLeaseStatus } from "../../../../test/seeders/lease-status.seeder";
 import { createProviderSeed, createProviderWithAttributeSignatures } from "../../../../test/seeders/provider.seeder";
 import { createUserWallet } from "../../../../test/seeders/user-wallet.seeder";
-import type { BillingConfigService } from "../../../billing/services/billing-config/billing-config.service";
 import type { ProviderRepository } from "../../repositories/provider/provider.repository";
 import type { AuditorService } from "../auditors/auditors.service";
 import type { ProviderAttributesSchemaService } from "../provider-attributes-schema/provider-attributes-schema.service";
@@ -93,7 +90,6 @@ describe(ProviderService.name, () => {
         method: "PUT",
         body: '{"size":{"val":"1"}}',
         auth: { type: "jwt", token: jwtToken },
-        chainNetwork: "sandbox-2",
         providerIdentity: {
           owner: provider.owner,
           hostUri: provider.hostUri
@@ -351,7 +347,6 @@ describe(ProviderService.name, () => {
       expect(providerProxyService.request).toHaveBeenCalledWith(`/lease/${dseq}/${gseq}/${oseq}/status`, {
         method: "GET",
         auth: { type: "jwt", token: jwtToken },
-        chainNetwork: "sandbox-2",
         providerIdentity: {
           owner: provider.owner,
           hostUri: provider.hostUri
@@ -451,19 +446,8 @@ describe(ProviderService.name, () => {
     const jwtTokenService = mock<ProviderJwtTokenService>({
       generateJwtToken: jest.fn().mockResolvedValue(Ok("mock-jwt-token"))
     });
-    const config = mockConfigService<BillingConfigService>({
-      NETWORK: "sandbox"
-    });
 
-    const service = new ProviderService(
-      providerProxyService,
-      providerRepository,
-      providerAttributesSchemaService,
-      auditorsService,
-      jwtTokenService,
-      config,
-      netConfig
-    );
+    const service = new ProviderService(providerProxyService, providerRepository, providerAttributesSchemaService, auditorsService, jwtTokenService);
 
     return {
       service,

--- a/apps/api/src/provider/services/provider/provider.service.ts
+++ b/apps/api/src/provider/services/provider/provider.service.ts
@@ -1,6 +1,5 @@
 import { Provider, ProviderSnapshot, ProviderSnapshotNode, ProviderSnapshotNodeGPU } from "@akashnetwork/database/dbSchemas/akash";
 import type { ProviderAttributesSchema } from "@akashnetwork/http-sdk";
-import { NetConfig, SupportedChainNetworks } from "@akashnetwork/net";
 import { AxiosError } from "axios";
 import { add } from "date-fns";
 import assert from "http-assert";
@@ -8,7 +7,6 @@ import createError from "http-errors";
 import { Op } from "sequelize";
 import { singleton } from "tsyringe";
 
-import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { Memoize } from "@src/caching/helpers";
 import { LeaseStatusResponse } from "@src/deployment/http-schemas/lease.schema";
 import type { Auditor } from "@src/provider/http-schemas/auditor.schema";
@@ -28,19 +26,14 @@ const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 export class ProviderService {
   private readonly MANIFEST_SEND_MAX_RETRIES = 3;
   private readonly MANIFEST_SEND_RETRY_DELAY = 6000;
-  private readonly chainNetwork: SupportedChainNetworks;
 
   constructor(
     private readonly providerProxy: ProviderProxyService,
     private readonly providerRepository: ProviderRepository,
     private readonly providerAttributesSchemaService: ProviderAttributesSchemaService,
     private readonly auditorsService: AuditorService,
-    private readonly jwtTokenService: ProviderJwtTokenService,
-    private readonly config: BillingConfigService,
-    netConfig: NetConfig
-  ) {
-    this.chainNetwork = netConfig.mapped(this.config.get("NETWORK"));
-  }
+    private readonly jwtTokenService: ProviderJwtTokenService
+  ) {}
 
   async sendManifest(options: { provider: string; dseq: string; manifest: string; auth: ProviderAuth }) {
     const provider = await this.providerRepository.findActiveByAddress(options.provider);
@@ -81,7 +74,6 @@ export class ProviderService {
           method: "PUT",
           body: options.manifest,
           auth: options.auth,
-          chainNetwork: this.chainNetwork,
           providerIdentity: options.providerIdentity,
           timeout: 15_000
         });
@@ -130,7 +122,6 @@ export class ProviderService {
     return await this.providerProxy.request<LeaseStatusResponse>(`/lease/${dseq}/${gseq}/${oseq}/status`, {
       method: "GET",
       auth,
-      chainNetwork: this.chainNetwork,
       providerIdentity,
       timeout: 15000
     });


### PR DESCRIPTION
## Why

Provider proxy no more accept `chainNetwork` parameter and has a separate instance per blockchain network. So, no need to pass it anymore

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed the network identifier from provider requests and payloads.
  * Simplified provider service initialization by removing external network/config wiring, reducing constructor complexity and public surface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->