### PR TITLE
fix: ensure that react query calls to blockchain are disabled when apiEndpoint is undefined

### DIFF
--- a/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
+++ b/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
@@ -53,7 +53,7 @@ function createAppContainer<T extends Factories>(settingsState: SettingsContextT
       const chainApiHttpClient: FallbackableHttpClient = rootContainer.applyAxiosInterceptors(
         createFallbackableHttpClient(rootContainer.createAxios, rootContainer.fallbackChainApiHttpClient, {
           baseURL: settingsState.settings?.apiEndpoint,
-          shouldFallback: () => isBlockchainDown || !!settingsState.settings?.isBlockchainDown,
+          shouldFallback: () => isBlockchainDown || !!settingsState.settings?.isBlockchainDown || !settingsState.settings?.apiEndpoint,
           onUnavailableError: (error): Promise<void> | void => {
             if (isBlockchainDown) return;
 


### PR DESCRIPTION
## Why

bug, there is a race condition when apiEndpoint is undefined and react-query sends request to blockchain, the query hangs forever and page shows infinite loading

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback mechanism to properly handle cases where the API endpoint configuration is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->