### PR TITLE
fix: strips "v" prefix from rpc application version

### DIFF
--- a/apps/deploy-web/src/hooks/useSupportsACT/useSupportsACT.spec.ts
+++ b/apps/deploy-web/src/hooks/useSupportsACT/useSupportsACT.spec.ts
@@ -56,6 +56,11 @@ describe(useSupportsACT.name, () => {
     expect(result.current).toBe(false);
   });
 
+  it('can remove "v" prefix from appVersion', () => {
+    const { result } = setup({ appVersion: "v2.0.0" });
+    expect(result.current).toBe(true);
+  });
+
   function setup(input?: { appVersion?: string; selectedNode?: null; isCustomNode?: boolean; customNode?: { appVersion?: string } | null }) {
     const selectedNode =
       input?.selectedNode === null ? null : { api: "", rpc: "", status: "", latency: 0, id: "", nodeInfo: null, appVersion: input?.appVersion };

--- a/apps/deploy-web/src/hooks/useSupportsACT/useSupportsACT.ts
+++ b/apps/deploy-web/src/hooks/useSupportsACT/useSupportsACT.ts
@@ -9,6 +9,6 @@ interface HookInput {
 export function useSupportsACT({ dependencies: d = DEPENDENCIES }: HookInput = { dependencies: DEPENDENCIES }): boolean {
   const { settings } = d.useSettings();
   const chainNode = settings.isCustomNode ? settings.customNode : settings.selectedNode;
-  const appVersion = chainNode?.appVersion;
+  const appVersion = chainNode?.appVersion?.startsWith("v") ? chainNode.appVersion.slice(1) : chainNode?.appVersion;
   return !!appVersion && compareVersions(appVersion, "2.0.0") >= 0;
 }

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -34,12 +34,6 @@ export const netConfigData = {
     apiUrls: ["https://api.sandbox-2.aksh.pw:443"],
     rpcUrls: ["https://rpc.sandbox-2.aksh.pw:443"]
   },
-  "testnet-8": {
-    version: "v2.1.0-a22",
-    faucetUrl: "https://faucet.dev.akash.pub/",
-    apiUrls: ["https://testnetapi.akashnet.net"],
-    rpcUrls: ["https://testnetrpc.akashnet.net:443"]
-  },
   "testnet-oracle": {
     version: "v2.1.0-a22",
     faucetUrl: "https://oraclefaucet.dev.akash.pub/",


### PR DESCRIPTION
## Why

Right now, sandbox rpc node application version if `v1.2.0` and testnet rpc node application version is `2.0.0-rc10` (doesn't have prefix). So, semver version comparison doesn't work correctly and assumes that `v1.2.0` supports ACT but it doesn't

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Version strings prefixed with "v" (e.g., "v2.0.0") are now properly normalized and handled correctly.

* **Tests**
  * Added test coverage for version strings with "v" prefix validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->