### PR TITLE
fix(indexer): handle bare IP addresses in provider geolocation lookup

### DIFF
--- a/apps/indexer/src/providers/ipLocationProvider.ts
+++ b/apps/indexer/src/providers/ipLocationProvider.ts
@@ -1,6 +1,7 @@
 import { Provider } from "@akashnetwork/database/dbSchemas/akash";
 import axios from "axios";
 import dns from "dns/promises";
+import { isIP } from "net";
 import { setTimeout as sleep } from "node:timers/promises";
 
 const IpLookupDelay = 2_000;
@@ -34,14 +35,20 @@ export async function updateProvidersLocation() {
   for (const provider of providers) {
     try {
       const parsedUri = new URL(provider.hostUri);
-      const ips = await dns.resolve4(parsedUri.hostname);
+      let ip: string;
 
-      if (ips.length === 0) {
-        console.log(`Could not resolve ip for ${provider.hostUri}`);
-        continue;
+      if (isIP(parsedUri.hostname)) {
+        ip = parsedUri.hostname;
+      } else {
+        const ips = await dns.resolve4(parsedUri.hostname);
+
+        if (ips.length === 0) {
+          console.log(`Could not resolve ip for ${provider.hostUri}`);
+          continue;
+        }
+
+        ip = ips.sort()[0]; // Always use the first ip
       }
-
-      const ip = ips.sort()[0]; // Always use the first ip
 
       if (provider.ip === ip) {
         console.log(`Ip for ${provider.hostUri} is the same`);


### PR DESCRIPTION
## Why

Providers with bare IP addresses in their `hostUri` (e.g., `https://58.111.97.208:8443`) never get their geolocation fields populated. `dns.resolve4()` fails on IP addresses since it expects a hostname, causing the `ip`, `ipRegion`, `ipCountry`, etc. fields to remain `NULL`.

## What

- Skip DNS resolution when the provider's hostname is already an IP address (detected via `net.isIP()`)
- Use the IP directly for geolocation lookup instead of attempting DNS resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Provider location detection now accepts literal IP hosts and uses them directly, avoiding unnecessary DNS lookups.
  * Improved handling and logging when DNS resolution yields no addresses, increasing reliability of provider IP assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->