### PR TITLE
fix(deployment): use correct denom for managed wallet deposit modal

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
@@ -2,7 +2,6 @@
 import type { ComponentProps, Dispatch, SetStateAction } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { SDLInput } from "@akashnetwork/chain-sdk/web";
-import { yaml } from "@akashnetwork/chain-sdk/web";
 import { Alert, Button, CustomTooltip, FileButton, Input, Snackbar, Spinner } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import type { EncodeObject } from "@cosmjs/proto-signing";
@@ -10,6 +9,7 @@ import { useTheme as useMuiTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { ArrowRight, InfoCircle, Upload } from "iconoir-react";
 import { useAtom } from "jotai";
+import jsYaml from "js-yaml";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSnackbar } from "notistack";
 
@@ -110,7 +110,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
     if (!editedManifest) return defaultValue;
 
     try {
-      const sdl: SDLInput = yaml.template(editedManifest);
+      const sdl = jsYaml.load(editedManifest) as SDLInput;
       return Object.values(Object.values(sdl.profiles.placement)[0].pricing)[0].denom;
     } catch {
       return defaultValue;
@@ -451,7 +451,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
         <d.DeploymentDepositModal
           handleCancel={() => setIsDepositingDeployment(false)}
           onDeploymentDeposit={onDeploymentDeposit}
-          denom={sdlDenom}
+          denom={wallet.isManaged ? managedDenom : sdlDenom}
           title="Confirm deployment creation?"
           infoText={
             <d.Alert className="mb-6 text-xs" variant="default">

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
@@ -2,6 +2,7 @@
 import type { ComponentProps, Dispatch, SetStateAction } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { SDLInput } from "@akashnetwork/chain-sdk/web";
+import { yaml } from "@akashnetwork/chain-sdk/web";
 import { Alert, Button, CustomTooltip, FileButton, Input, Snackbar, Spinner } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import type { EncodeObject } from "@cosmjs/proto-signing";
@@ -9,7 +10,6 @@ import { useTheme as useMuiTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { ArrowRight, InfoCircle, Upload } from "iconoir-react";
 import { useAtom } from "jotai";
-import jsYaml from "js-yaml";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useSnackbar } from "notistack";
 
@@ -110,7 +110,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
     if (!editedManifest) return defaultValue;
 
     try {
-      const sdl = jsYaml.load(editedManifest) as SDLInput;
+      const sdl: SDLInput = yaml.template(editedManifest);
       return Object.values(Object.values(sdl.profiles.placement)[0].pricing)[0].denom;
     } catch {
       return defaultValue;


### PR DESCRIPTION
## Why

Fixes CON-93

Managed wallet users see "Balance: 0 USD" and incorrect deposit amounts in the deployment creation confirmation modal. Two root causes:

1. `yaml.template()` interprets `${VAR}` env variable syntax in SDLs as template variables, throwing a `ReferenceError` and silently falling back to `uakt` as the denom
2. The deposit modal always receives `sdlDenom` (which defaults to `uakt`) instead of the managed wallet's actual denom (USDC)

## What

- Replace `yaml.template()` with `js-yaml`'s `load()` for SDL denom extraction — it treats `${VAR}` as literal strings instead of template variables
- Pass `managedDenom` to `DeploymentDepositModal` when wallet is managed, so `useDenomData` reads the correct USDC balance instead of the (empty) AKT balance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployment fee denomination selection to correctly use the managed wallet denomination when applicable.
  * Improved manifest editor YAML parsing and error handling to reduce parsing failures during manifest edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->