### PR TITLE
fix: ensure that tsup bundles even nested internal packages into app bundle

### DIFF
--- a/packages/dev-config/tsup-plugins.ts
+++ b/packages/dev-config/tsup-plugins.ts
@@ -101,43 +101,44 @@ interface ApplyDefaultsOptions extends Options {
   prependEffectsToEntries?: string[];
 }
 
-async function getExternalConfig(packageJson: Record<string, any>): Promise<Required<Pick<Options, "noExternal" | "external">>> {
-  const isInternalPackage = (name: string, packageDetails: Record<string, any>) =>
-    name !== "@akashnetwork/env-loader" && name.startsWith("@akashnetwork/") && packageDetails.dependencies[name] === "*";
-  const internalPackages = Object.keys(packageJson.dependencies).filter(dep => isInternalPackage(dep, packageJson));
-
-  const internalDeps = new Set<string>(internalPackages);
+async function getExternalConfig(packageJson: Record<string, any>) {
+  const deps = { ...packageJson.dependencies, ...packageJson.peerDependencies };
+  const bundledDeps = new Set<string>();
   const externalDeps = new Set<string>();
-  await Promise.all(
-    internalPackages.map(async internalPackageName => {
-      const pkgJsonPath = fileURLToPath(import.meta.resolve(`${internalPackageName}/package.json`));
-      const pkgJson = JSON.parse(await fs.readFile(pkgJsonPath, "utf8"));
-      const deps = { ...pkgJson.dependencies, ...pkgJson.peerDependencies };
-      Object.keys(deps).forEach(dep => {
-        if (internalDeps.has(dep)) return;
 
-        if (isInternalPackage(dep, pkgJson)) {
-          internalDeps.add(dep);
-          return;
-        }
+  for (const dep of Object.keys(deps)) {
+    const isInternal = dep !== "@akashnetwork/env-loader" && dep.startsWith("@akashnetwork/") && packageJson.dependencies[dep] === "*";
+    if (!isInternal) {
+      externalDeps.add(dep);
+      continue;
+    }
 
-        if (hasOwnCopyOfPackage(internalPackageName, dep)) {
-          // if package is not hoisted, we need to bundle it inside the app
-          // otherwise this package won't be found in runtime
-          console.warn(
-            `\x1b[33mWARN\x1b[0m: Bundling "${dep}" internal package dependency of "${internalPackageName}" inside app. Use "npm ls ${dep}" to check why it's not hoisted.`
-          );
-        } else {
-          externalDeps.add(dep);
-        }
-      });
-    })
-  );
+    bundledDeps.add(dep);
 
-  return { noExternal: [...internalDeps], external: [...externalDeps] };
+    const pkgJsonPath = fileURLToPath(import.meta.resolve(`${dep}/package.json`));
+    const pkgJson = JSON.parse(await fs.readFile(pkgJsonPath, "utf8"));
+    const depConfig = await getExternalConfig(pkgJson);
+    depConfig.noExternal.forEach(d => bundledDeps.add(d));
+
+    depConfig.external.forEach(nestedDep => {
+      if (hasOwnCopyOfDependency(dep, nestedDep)) {
+        bundledDeps.add(nestedDep);
+        externalDeps.delete(nestedDep);
+        // if package is not hoisted, we need to bundle it inside the app
+        // otherwise this package won't be found in runtime
+        console.warn(
+          `\x1b[33mWARN\x1b[0m: Bundling "${nestedDep}" internal package dependency of "${dep}" inside app. Use "npm ls ${nestedDep}" to check why it's not hoisted.`
+        );
+      } else if (!bundledDeps.has(nestedDep)) {
+        externalDeps.add(nestedDep);
+      }
+    });
+  }
+
+  return { noExternal: [...bundledDeps], external: [...externalDeps] };
 }
 
-function hasOwnCopyOfPackage(packageName: string, dependency: string): boolean {
+function hasOwnCopyOfDependency(packageName: string, dependency: string): boolean {
   const pathToPackage = import.meta.resolve(join(packageName, "package.json"));
   const possiblyInternalPackagePath = fileURLToPath(import.meta.resolve(join(pathToPackage, "..", "node_modules", dependency)));
   return existsSync(possiblyInternalPackagePath);

--- a/packages/dev-config/tsup-plugins.ts
+++ b/packages/dev-config/tsup-plugins.ts
@@ -102,10 +102,11 @@ interface ApplyDefaultsOptions extends Options {
 }
 
 async function getExternalConfig(packageJson: Record<string, any>): Promise<Required<Pick<Options, "noExternal" | "external">>> {
-  const internalPackages = Object.keys(packageJson.dependencies).filter(
-    name => name !== "@akashnetwork/env-loader" && name.startsWith("@akashnetwork/") && packageJson.dependencies[name] === "*"
-  );
+  const isInternalPackage = (name: string, packageDetails: Record<string, any>) =>
+    name !== "@akashnetwork/env-loader" && name.startsWith("@akashnetwork/") && packageDetails.dependencies[name] === "*";
+  const internalPackages = Object.keys(packageJson.dependencies).filter(dep => isInternalPackage(dep, packageJson));
 
+  const internalDeps = new Set<string>(internalPackages);
   const externalDeps = new Set<string>();
   await Promise.all(
     internalPackages.map(async internalPackageName => {
@@ -113,8 +114,14 @@ async function getExternalConfig(packageJson: Record<string, any>): Promise<Requ
       const pkgJson = JSON.parse(await fs.readFile(pkgJsonPath, "utf8"));
       const deps = { ...pkgJson.dependencies, ...pkgJson.peerDependencies };
       Object.keys(deps).forEach(dep => {
-        if (internalPackages.includes(dep)) return;
-        if (isInternalPackageDependency(internalPackageName, dep)) {
+        if (internalDeps.has(dep)) return;
+
+        if (isInternalPackage(dep, pkgJson)) {
+          internalDeps.add(dep);
+          return;
+        }
+
+        if (hasOwnCopyOfPackage(internalPackageName, dep)) {
           // if package is not hoisted, we need to bundle it inside the app
           // otherwise this package won't be found in runtime
           console.warn(
@@ -127,10 +134,10 @@ async function getExternalConfig(packageJson: Record<string, any>): Promise<Requ
     })
   );
 
-  return { noExternal: internalPackages, external: [...externalDeps] };
+  return { noExternal: [...internalDeps], external: [...externalDeps] };
 }
 
-function isInternalPackageDependency(packageName: string, dependency: string): boolean {
+function hasOwnCopyOfPackage(packageName: string, dependency: string): boolean {
   const pathToPackage = import.meta.resolve(join(packageName, "package.json"));
   const possiblyInternalPackagePath = fileURLToPath(import.meta.resolve(join(pathToPackage, "..", "node_modules", dependency)));
   return existsSync(possiblyInternalPackagePath);


### PR DESCRIPTION
## Why

tsup didn't automatically bundle nested internal packages (when internal package depends on another internal package), that's why indexer build is broken right now. 

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved dependency resolution during builds with recursive analysis of transitive dependencies for more accurate bundling.
  * Reworked bundling workflow to detect and include nested internal dependencies, reducing unexpected externalization.
  * Aggregated tracking of bundled vs external dependencies for clearer build outputs.
  * Updated build warnings to more clearly reference nested bundled dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->