### PR TITLE
fix: allow to specify sdl yaml with vars in envs

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "^1.3.0",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/logging": "*",

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
@@ -110,7 +110,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
     if (!editedManifest) return defaultValue;
 
     try {
-      const sdl: SDLInput = yaml.template(editedManifest);
+      const sdl: SDLInput = yaml.raw(editedManifest);
       return Object.values(Object.values(sdl.profiles.placement)[0].pricing)[0].denom;
     } catch {
       return defaultValue;

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "^1.3.0",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.0",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "^1.3.0",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -503,7 +503,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/logging": "*",
@@ -2986,7 +2986,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
@@ -5044,7 +5044,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.0",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/logging": "*",
@@ -6656,7 +6656,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -6826,7 +6826,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -7977,7 +7977,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -8173,9 +8173,9 @@
       }
     },
     "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.26",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.26.tgz",
-      "integrity": "sha512-1aAVo2wDTT4AIsjpyVbUaiUZYxXfxHdK62B80UsMoY7gHdI1b/p4jeE9K0rcylINLDHpKb+KOI+OpjPiK8U3Pw==",
+      "version": "1.0.0-alpha.27",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.27.tgz",
+      "integrity": "sha512-+euzAdDWO7ZU9MNj+1DaFFmRu4r8h0//S9ojt2meyUwgibWOCMWcdPoEm0LrmO6/LR/Sr5ate/VWN88JmE/c1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.3",
@@ -49217,7 +49217,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       }

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.26",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.27",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   }


### PR DESCRIPTION
## Why

Some people use `${VAR}` inside SDL's env vars

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the chain SDK dependency across multiple applications to the latest alpha version.

* **Bug Fixes**
  * Improved SDL manifest parsing to ensure correct denomination extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->