### PR TITLE
feat(wallet): add BalanceWatchProvider for generic balance change polling

### DIFF
--- a/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.spec.tsx
+++ b/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.spec.tsx
@@ -158,9 +158,9 @@ describe(MintBurnPage.name, () => {
     );
   });
 
-  it("resets form and refetches balance after successful mint", async () => {
-    const { refetchBalance } = setup({
-      walletBalance: buildWalletBalance({ balanceUAKT: 1_000_000_000 }),
+  it("resets form and starts balance watch after successful mint", async () => {
+    const { startBalanceWatch } = setup({
+      walletBalance: buildWalletBalance({ balanceUAKT: 1_000_000_000, balanceUACT: 50_000_000 }),
       price: 2
     });
 
@@ -169,7 +169,11 @@ describe(MintBurnPage.name, () => {
     });
 
     await waitFor(() => {
-      expect(refetchBalance).toHaveBeenCalledTimes(1);
+      expect(startBalanceWatch).toHaveBeenCalledWith(
+        50_000_000,
+        "balanceUACT",
+        expect.objectContaining({ onSuccess: expect.any(Function), onTimeOut: expect.any(Function) })
+      );
     });
     expect((screen.getByLabelText("To") as HTMLInputElement).value).toBe("");
   });
@@ -248,7 +252,9 @@ describe(MintBurnPage.name, () => {
   function setup(input?: { walletBalance?: WalletBalance | null; price?: number }) {
     const signAndBroadcastTx = vi.fn().mockResolvedValue(true);
     const refetchBalance = vi.fn();
+    const startBalanceWatch = vi.fn();
     const enqueueSnackbar = vi.fn();
+    const closeSnackbar = vi.fn();
 
     const dependencies = {
       ...DEPENDENCIES,
@@ -278,13 +284,21 @@ describe(MintBurnPage.name, () => {
         isLoaded: input?.price !== undefined
       }),
       useSnackbar: () => ({
-        enqueueSnackbar
+        enqueueSnackbar,
+        closeSnackbar
+      }),
+      useBalanceWatch: () => ({
+        start: startBalanceWatch,
+        stop: vi.fn(),
+        isActive: false,
+        isSuccess: false,
+        isTimeOut: false
       }),
       useSupportsACT: () => true
     } as unknown as typeof DEPENDENCIES;
 
     render(<MintBurnPage dependencies={dependencies} />);
 
-    return { signAndBroadcastTx, refetchBalance, enqueueSnackbar };
+    return { signAndBroadcastTx, refetchBalance, startBalanceWatch, enqueueSnackbar };
   }
 });

--- a/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.tsx
+++ b/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.tsx
@@ -8,10 +8,12 @@ import Link from "next/link";
 import { useSnackbar } from "notistack";
 
 import { UAKT_DENOM } from "@src/config/denom.config";
+import { useBalanceWatch } from "@src/context/BalanceWatchProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useSupportsACT } from "@src/hooks/useSupportsACT/useSupportsACT";
 import { useWalletBalance } from "@src/hooks/useWalletBalance";
+import FourOhFour from "@src/pages/404";
 import { denomToUdenom, roundDecimal, udenomToDenom } from "@src/utils/mathHelpers";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
 import { UrlService } from "@src/utils/urlUtils";
@@ -39,6 +41,7 @@ export const DEPENDENCIES = {
   ArrowUpDown,
   NavArrowLeft,
   FormattedNumber,
+  useBalanceWatch,
   useWallet,
   usePricing,
   useWalletBalance,
@@ -57,9 +60,10 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { address, signAndBroadcastTx, isCustodial } = d.useWallet();
-  const { balance, isLoading: isBalanceLoading, refetch: refetchBalance } = d.useWalletBalance();
+  const { balance, isLoading: isBalanceLoading } = d.useWalletBalance();
   const { price, isLoaded: isPriceLoaded } = d.usePricing();
-  const { enqueueSnackbar } = d.useSnackbar();
+  const { enqueueSnackbar, closeSnackbar } = d.useSnackbar();
+  const balanceWatch = d.useBalanceWatch();
 
   const aktBalance = useMemo(() => (balance ? udenomToDenom(balance.balanceUAKT, 6) : 0), [balance]);
   const actBalance = useMemo(() => (balance ? udenomToDenom(balance.balanceUACT, 6) : 0), [balance]);
@@ -132,8 +136,32 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
     setActiveTab(prev => (prev === MintBurnTab.MINT ? MintBurnTab.BURN : MintBurnTab.MINT));
   }, []);
 
+  const setupNotifications = useCallback(() => {
+    if (!balance) return;
+
+    const balanceKey = isMint ? "balanceUACT" : "balanceUAKT";
+    const pendingKey = enqueueSnackbar(
+      <d.Snackbar title={isMint ? "Minting ACT..." : "Burning ACT..."} subTitle="Please wait while we update your balance" showLoading />,
+      { variant: "info", persist: true, autoHideDuration: null }
+    );
+    balanceWatch.start(balance[balanceKey], balanceKey, {
+      onSuccess: () => {
+        closeSnackbar(pendingKey);
+        enqueueSnackbar(<d.Snackbar title="Conversion complete!" subTitle="Your balance has been updated" iconVariant="success" />, {
+          variant: "success"
+        });
+      },
+      onTimeOut: () => {
+        closeSnackbar(pendingKey);
+        enqueueSnackbar(<d.Snackbar title="Conversion pending" subTitle="Please refresh the page to check your balance" iconVariant="warning" />, {
+          variant: "warning"
+        });
+      }
+    });
+  }, [balance, balanceWatch, closeSnackbar, d, enqueueSnackbar, isMint]);
+
   const submitForm = useCallback(async () => {
-    if (!address || !effectiveFromAmount || insufficientBalance) return;
+    if (!address || !effectiveFromAmount || insufficientBalance || !balance) return;
 
     setIsSubmitting(true);
     try {
@@ -144,7 +172,7 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
       const success = await signAndBroadcastTx([msg]);
 
       if (success) {
-        refetchBalance();
+        setupNotifications();
         resetForm();
       }
     } catch (err) {
@@ -156,11 +184,12 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
     } finally {
       setIsSubmitting(false);
     }
-  }, [address, effectiveFromAmount, insufficientBalance, isMint, signAndBroadcastTx, enqueueSnackbar, refetchBalance, resetForm, d]);
+  }, [address, effectiveFromAmount, insufficientBalance, balance, isMint, signAndBroadcastTx, setupNotifications, resetForm, enqueueSnackbar, d]);
+
   const isACTSupported = d.useSupportsACT();
 
   if (!isACTSupported || !isCustodial) {
-    return null;
+    return <FourOhFour />;
   }
 
   return (
@@ -256,11 +285,13 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
         <d.Button
           className="w-full"
           size="lg"
-          disabled={!effectiveFromAmount || insufficientBalance || isSubmitting || isBalanceLoading || !isPriceLoaded}
+          disabled={!effectiveFromAmount || insufficientBalance || isSubmitting || balanceWatch.isActive || isBalanceLoading || !isPriceLoaded}
           onClick={submitForm}
           aria-label="Submit"
         >
-          {isSubmitting ? "Processing..." : isMint ? "Mint ACT" : "Burn ACT"}
+          {isSubmitting && "Processing..."}
+          {!isSubmitting && balanceWatch.isActive && "Updating balance..."}
+          {!isSubmitting && !balanceWatch.isActive && (isMint ? "Mint ACT" : "Burn ACT")}
         </d.Button>
       </div>
     </d.Layout>

--- a/apps/deploy-web/src/context/BalanceWatchProvider/BalanceWatchProvider.spec.tsx
+++ b/apps/deploy-web/src/context/BalanceWatchProvider/BalanceWatchProvider.spec.tsx
@@ -322,6 +322,110 @@ describe(BalanceWatchProvider.name, () => {
     vi.useRealTimers();
   });
 
+  it("calls onSuccess callback when balance increases", async () => {
+    const initialBalance = buildWalletBalance({ totalUsd: 100 });
+    const refetchBalance = vi.fn();
+    const onSuccess = vi.fn();
+    const onTimeOut = vi.fn();
+    const useWalletBalance = vi.fn(() => ({
+      balance: initialBalance,
+      refetch: refetchBalance,
+      isLoading: false
+    }));
+
+    const dependencies = {
+      ...DEPENDENCIES,
+      useWalletBalance
+    } as unknown as typeof DEPENDENCIES;
+
+    const TestComponent = () => {
+      const { start } = useBalanceWatch();
+      return (
+        <button data-testid="start" onClick={() => start(100, "totalUsd", { onSuccess, onTimeOut })}>
+          Start
+        </button>
+      );
+    };
+
+    vi.useFakeTimers();
+
+    const { rerender } = render(
+      <BalanceWatchProvider dependencies={dependencies}>
+        <TestComponent />
+      </BalanceWatchProvider>
+    );
+
+    await act(async () => {
+      screen.getByTestId("start").click();
+    });
+
+    useWalletBalance.mockReturnValue({
+      balance: buildWalletBalance({ totalUsd: 200 }),
+      refetch: refetchBalance,
+      isLoading: false
+    });
+
+    await act(async () => {
+      rerender(
+        <BalanceWatchProvider dependencies={dependencies}>
+          <TestComponent />
+        </BalanceWatchProvider>
+      );
+    });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onTimeOut).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
+  it("calls onTimeOut callback after max attempts", async () => {
+    const onSuccess = vi.fn();
+    const onTimeOut = vi.fn();
+
+    vi.useFakeTimers();
+
+    const refetchBalance = vi.fn();
+    const walletBalance = buildWalletBalance({ totalUsd: 100 });
+
+    const dependencies = {
+      ...DEPENDENCIES,
+      useWalletBalance: vi.fn(() => ({
+        balance: walletBalance,
+        refetch: refetchBalance,
+        isLoading: false
+      }))
+    } as unknown as typeof DEPENDENCIES;
+
+    const TestComponent = () => {
+      const { start } = useBalanceWatch();
+      return (
+        <button data-testid="start" onClick={() => start(100, "totalUsd", { onSuccess, onTimeOut })}>
+          Start
+        </button>
+      );
+    };
+
+    render(
+      <BalanceWatchProvider dependencies={dependencies}>
+        <TestComponent />
+      </BalanceWatchProvider>
+    );
+
+    await act(async () => {
+      screen.getByTestId("start").click();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(30000);
+    });
+
+    expect(onTimeOut).toHaveBeenCalledTimes(1);
+    expect(onSuccess).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
   it("throws error when used outside provider", () => {
     const TestComponent = () => {
       useBalanceWatch();

--- a/apps/deploy-web/src/context/BalanceWatchProvider/BalanceWatchProvider.spec.tsx
+++ b/apps/deploy-web/src/context/BalanceWatchProvider/BalanceWatchProvider.spec.tsx
@@ -1,0 +1,387 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BalanceWatchProvider, DEPENDENCIES, useBalanceWatch } from "./BalanceWatchProvider";
+
+import { act, render, screen } from "@testing-library/react";
+import { buildWalletBalance } from "@tests/seeders";
+
+describe(BalanceWatchProvider.name, () => {
+  it("provides context to children", () => {
+    setup({
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    expect(screen.queryByTestId("is-active")).toHaveTextContent("false");
+    expect(screen.queryByTestId("is-success")).toHaveTextContent("false");
+    expect(screen.queryByTestId("is-time-out")).toHaveTextContent("false");
+    expect(screen.queryByTestId("start")).toBeInTheDocument();
+    expect(screen.queryByTestId("stop")).toBeInTheDocument();
+  });
+
+  it("starts polling and calls refetchBalance on interval", async () => {
+    const { refetchBalance, cleanup } = setup({
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start").click();
+    });
+
+    expect(screen.queryByTestId("is-active")).toHaveTextContent("true");
+    expect(refetchBalance).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(refetchBalance).toHaveBeenCalledTimes(2);
+
+    cleanup();
+  });
+
+  it("sets isSuccess to true when balance increases", async () => {
+    const initialBalance = buildWalletBalance({ totalUsd: 100 });
+    const refetchBalance = vi.fn();
+    const useWalletBalance = vi.fn(() => ({
+      balance: initialBalance,
+      refetch: refetchBalance,
+      isLoading: false
+    }));
+
+    const dependencies = {
+      ...DEPENDENCIES,
+      useWalletBalance
+    } as unknown as typeof DEPENDENCIES;
+
+    const TestComponent = () => {
+      const { start, isActive, isSuccess } = useBalanceWatch();
+      return (
+        <div>
+          <div data-testid="is-active">{isActive.toString()}</div>
+          <div data-testid="is-success">{isSuccess.toString()}</div>
+          <button data-testid="start" onClick={() => start(100)}>
+            Start
+          </button>
+        </div>
+      );
+    };
+
+    vi.useFakeTimers();
+
+    const { rerender } = render(
+      <BalanceWatchProvider dependencies={dependencies}>
+        <TestComponent />
+      </BalanceWatchProvider>
+    );
+
+    await act(async () => {
+      screen.getByTestId("start").click();
+    });
+
+    expect(screen.queryByTestId("is-active")).toHaveTextContent("true");
+
+    const increasedBalance = buildWalletBalance({ totalUsd: 200 });
+    useWalletBalance.mockReturnValue({
+      balance: increasedBalance,
+      refetch: refetchBalance,
+      isLoading: false
+    });
+
+    await act(async () => {
+      rerender(
+        <BalanceWatchProvider dependencies={dependencies}>
+          <TestComponent />
+        </BalanceWatchProvider>
+      );
+    });
+
+    expect(screen.queryByTestId("is-success")).toHaveTextContent("true");
+    expect(screen.queryByTestId("is-active")).toHaveTextContent("false");
+
+    vi.useRealTimers();
+  });
+
+  it("detects change using custom balanceKey", async () => {
+    const initialBalance = buildWalletBalance({ totalUsd: 100, balanceUACT: 500 });
+    const refetchBalance = vi.fn();
+    const useWalletBalance = vi.fn(() => ({
+      balance: initialBalance,
+      refetch: refetchBalance,
+      isLoading: false
+    }));
+
+    const dependencies = {
+      ...DEPENDENCIES,
+      useWalletBalance
+    } as unknown as typeof DEPENDENCIES;
+
+    const TestComponent = () => {
+      const { start, isActive, isSuccess } = useBalanceWatch();
+      return (
+        <div>
+          <div data-testid="is-active">{isActive.toString()}</div>
+          <div data-testid="is-success">{isSuccess.toString()}</div>
+          <button data-testid="start" onClick={() => start(500, "balanceUACT")}>
+            Start
+          </button>
+        </div>
+      );
+    };
+
+    vi.useFakeTimers();
+
+    const { rerender } = render(
+      <BalanceWatchProvider dependencies={dependencies}>
+        <TestComponent />
+      </BalanceWatchProvider>
+    );
+
+    await act(async () => {
+      screen.getByTestId("start").click();
+    });
+
+    expect(screen.queryByTestId("is-active")).toHaveTextContent("true");
+
+    // totalUsd stays the same, but balanceUACT increases
+    const updatedBalance = buildWalletBalance({ totalUsd: 100, balanceUACT: 1000 });
+    useWalletBalance.mockReturnValue({
+      balance: updatedBalance,
+      refetch: refetchBalance,
+      isLoading: false
+    });
+
+    await act(async () => {
+      rerender(
+        <BalanceWatchProvider dependencies={dependencies}>
+          <TestComponent />
+        </BalanceWatchProvider>
+      );
+    });
+
+    expect(screen.queryByTestId("is-success")).toHaveTextContent("true");
+    expect(screen.queryByTestId("is-active")).toHaveTextContent("false");
+
+    vi.useRealTimers();
+  });
+
+  it("sets isTimeOut to true after max attempts", async () => {
+    const { cleanup } = setup({
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start").click();
+    });
+
+    expect(screen.queryByTestId("is-active")).toHaveTextContent("true");
+
+    await act(async () => {
+      vi.advanceTimersByTime(30000);
+    });
+
+    expect(screen.queryByTestId("is-time-out")).toHaveTextContent("true");
+    expect(screen.queryByTestId("is-active")).toHaveTextContent("false");
+
+    cleanup();
+  });
+
+  it("stops polling on manual stop()", async () => {
+    setup({
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start").click();
+    });
+
+    expect(screen.queryByTestId("is-active")).toHaveTextContent("true");
+
+    await act(async () => {
+      screen.getByTestId("stop").click();
+    });
+
+    expect(screen.queryByTestId("is-active")).toHaveTextContent("false");
+  });
+
+  it("prevents concurrent polling", async () => {
+    const { refetchBalance } = setup({
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start").click();
+    });
+
+    const initialCallCount = refetchBalance.mock.calls.length;
+
+    await act(async () => {
+      screen.getByTestId("start").click();
+    });
+
+    expect(refetchBalance.mock.calls.length).toBe(initialCallCount);
+  });
+
+  it("cleans up on unmount", async () => {
+    const { unmount, cleanup } = setup({
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start").click();
+    });
+
+    expect(screen.queryByTestId("is-active")).toHaveTextContent("true");
+
+    unmount();
+
+    expect(screen.queryByTestId("is-active")).not.toBeInTheDocument();
+
+    cleanup();
+  });
+
+  it("resets isSuccess and isTimeOut on new start", async () => {
+    const initialBalance = buildWalletBalance({ totalUsd: 100 });
+    const refetchBalance = vi.fn();
+    const useWalletBalance = vi.fn(() => ({
+      balance: initialBalance,
+      refetch: refetchBalance,
+      isLoading: false
+    }));
+
+    const dependencies = {
+      ...DEPENDENCIES,
+      useWalletBalance
+    } as unknown as typeof DEPENDENCIES;
+
+    const TestComponent = () => {
+      const { start, stop, isActive, isSuccess, isTimeOut } = useBalanceWatch();
+      return (
+        <div>
+          <div data-testid="is-active">{isActive.toString()}</div>
+          <div data-testid="is-success">{isSuccess.toString()}</div>
+          <div data-testid="is-time-out">{isTimeOut.toString()}</div>
+          <button data-testid="start" onClick={() => start(100)}>
+            Start
+          </button>
+          <button data-testid="stop" onClick={stop}>
+            Stop
+          </button>
+        </div>
+      );
+    };
+
+    vi.useFakeTimers();
+
+    const { rerender } = render(
+      <BalanceWatchProvider dependencies={dependencies}>
+        <TestComponent />
+      </BalanceWatchProvider>
+    );
+
+    await act(async () => {
+      screen.getByTestId("start").click();
+    });
+
+    const increasedBalance = buildWalletBalance({ totalUsd: 200 });
+    useWalletBalance.mockReturnValue({
+      balance: increasedBalance,
+      refetch: refetchBalance,
+      isLoading: false
+    });
+
+    await act(async () => {
+      rerender(
+        <BalanceWatchProvider dependencies={dependencies}>
+          <TestComponent />
+        </BalanceWatchProvider>
+      );
+    });
+
+    expect(screen.queryByTestId("is-success")).toHaveTextContent("true");
+
+    useWalletBalance.mockReturnValue({
+      balance: initialBalance,
+      refetch: refetchBalance,
+      isLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start").click();
+    });
+
+    expect(screen.queryByTestId("is-success")).toHaveTextContent("false");
+    expect(screen.queryByTestId("is-time-out")).toHaveTextContent("false");
+
+    vi.useRealTimers();
+  });
+
+  it("throws error when used outside provider", () => {
+    const TestComponent = () => {
+      useBalanceWatch();
+      return <div>Test</div>;
+    };
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => {
+      render(<TestComponent />);
+    }).toThrow("useBalanceWatch must be used within a BalanceWatchProvider");
+
+    consoleSpy.mockRestore();
+  });
+
+  function setup(input: { balance: { totalUsd: number } | null; isWalletBalanceLoading: boolean }) {
+    vi.useFakeTimers();
+
+    const refetchBalance = vi.fn();
+    const walletBalance = input.balance ? buildWalletBalance(input.balance) : null;
+
+    const dependencies = {
+      ...DEPENDENCIES,
+      useWalletBalance: vi.fn(() => ({
+        balance: walletBalance,
+        refetch: refetchBalance,
+        isLoading: input.isWalletBalanceLoading
+      }))
+    } as unknown as typeof DEPENDENCIES;
+
+    const TestComponent = () => {
+      const { start, stop, isActive, isSuccess, isTimeOut } = useBalanceWatch();
+      return (
+        <div>
+          <div data-testid="is-active">{isActive.toString()}</div>
+          <div data-testid="is-success">{isSuccess.toString()}</div>
+          <div data-testid="is-time-out">{isTimeOut.toString()}</div>
+          <button data-testid="start" onClick={() => start(100)}>
+            Start
+          </button>
+          <button data-testid="stop" onClick={stop}>
+            Stop
+          </button>
+        </div>
+      );
+    };
+
+    const { rerender, unmount } = render(
+      <BalanceWatchProvider dependencies={dependencies}>
+        <TestComponent />
+      </BalanceWatchProvider>
+    );
+
+    return {
+      refetchBalance,
+      rerender,
+      unmount,
+      cleanup: () => {
+        vi.useRealTimers();
+      }
+    };
+  }
+});

--- a/apps/deploy-web/src/context/BalanceWatchProvider/BalanceWatchProvider.tsx
+++ b/apps/deploy-web/src/context/BalanceWatchProvider/BalanceWatchProvider.tsx
@@ -1,0 +1,135 @@
+"use client";
+import React, { createContext, useCallback, useContext, useEffect, useRef } from "react";
+
+import type { WalletBalance } from "@src/hooks/useWalletBalance";
+import { useWalletBalance } from "@src/hooks/useWalletBalance";
+
+const POLLING_INTERVAL_MS = 2000;
+const MAX_POLLING_DURATION_MS = 30000;
+const MAX_ATTEMPTS = MAX_POLLING_DURATION_MS / POLLING_INTERVAL_MS;
+
+export const DEPENDENCIES = {
+  useWalletBalance
+};
+
+export interface BalanceWatchContextType {
+  /** Start watching for a balance increase. Only one watch can be active at a time; calls while already active are no-ops. */
+  start: (snapshotBalance: number, balanceKey?: keyof WalletBalance) => void;
+  stop: () => void;
+  isActive: boolean;
+  /** Becomes true once the polled balance exceeds the snapshot. Resets on next start. */
+  isSuccess: boolean;
+  /** True if polling timed out without detecting a change. Resets on next start. */
+  isTimeOut: boolean;
+}
+
+interface ActivePoll {
+  snapshotBalance: number;
+  balanceKey: keyof WalletBalance;
+  attemptCount: number;
+  interval: ReturnType<typeof setInterval>;
+}
+
+const BalanceWatchContext = createContext<BalanceWatchContextType | null>(null);
+
+export interface BalanceWatchProviderProps {
+  children: React.ReactNode;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export const BalanceWatchProvider: React.FC<BalanceWatchProviderProps> = ({ children, dependencies: d = DEPENDENCIES }) => {
+  const { balance: currentBalance, refetch: refetchBalance } = d.useWalletBalance();
+
+  const [isActive, setIsActive] = React.useState(false);
+  const [isSuccess, setIsSuccess] = React.useState(false);
+  const [isTimeOut, setIsTimeOut] = React.useState(false);
+
+  const pollRef = useRef<ActivePoll | null>(null);
+
+  const stop = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current.interval);
+      pollRef.current = null;
+    }
+    setIsActive(false);
+  }, []);
+
+  const start = useCallback(
+    (snapshotBalance: number, balanceKey: keyof WalletBalance = "totalUsd") => {
+      if (pollRef.current) {
+        return;
+      }
+
+      setIsActive(true);
+      setIsSuccess(false);
+      setIsTimeOut(false);
+
+      refetchBalance();
+
+      pollRef.current = {
+        snapshotBalance,
+        balanceKey,
+        attemptCount: 0,
+        interval: setInterval(() => {
+          if (!pollRef.current) {
+            return;
+          }
+
+          pollRef.current.attemptCount++;
+
+          if (pollRef.current.attemptCount >= MAX_ATTEMPTS) {
+            setIsTimeOut(true);
+            clearInterval(pollRef.current.interval);
+            pollRef.current = null;
+            setIsActive(false);
+            return;
+          }
+
+          refetchBalance();
+        }, POLLING_INTERVAL_MS)
+      };
+    },
+    [refetchBalance]
+  );
+
+  useEffect(
+    function checkBalanceChange() {
+      if (!isActive || !currentBalance || !pollRef.current) {
+        return;
+      }
+
+      if (currentBalance[pollRef.current.balanceKey] > pollRef.current.snapshotBalance) {
+        setIsSuccess(true);
+        stop();
+      }
+    },
+    [isActive, currentBalance, stop]
+  );
+
+  useEffect(
+    function stopOnUnmount() {
+      return () => {
+        stop();
+      };
+    },
+    [stop]
+  );
+
+  const contextValue: BalanceWatchContextType = {
+    start,
+    stop,
+    isActive,
+    isSuccess,
+    isTimeOut
+  };
+
+  return <BalanceWatchContext.Provider value={contextValue}>{children}</BalanceWatchContext.Provider>;
+};
+
+export const useBalanceWatch = (): BalanceWatchContextType => {
+  const context = useContext(BalanceWatchContext);
+  if (!context) {
+    throw new Error("useBalanceWatch must be used within a BalanceWatchProvider");
+  }
+  return context;
+};

--- a/apps/deploy-web/src/context/BalanceWatchProvider/BalanceWatchProvider.tsx
+++ b/apps/deploy-web/src/context/BalanceWatchProvider/BalanceWatchProvider.tsx
@@ -12,9 +12,14 @@ export const DEPENDENCIES = {
   useWalletBalance
 };
 
+export interface BalanceWatchCallbacks {
+  onSuccess?: () => void;
+  onTimeOut?: () => void;
+}
+
 export interface BalanceWatchContextType {
   /** Start watching for a balance increase. Only one watch can be active at a time; calls while already active are no-ops. */
-  start: (snapshotBalance: number, balanceKey?: keyof WalletBalance) => void;
+  start: (snapshotBalance: number, balanceKey?: keyof WalletBalance, callbacks?: BalanceWatchCallbacks) => void;
   stop: () => void;
   isActive: boolean;
   /** Becomes true once the polled balance exceeds the snapshot. Resets on next start. */
@@ -28,6 +33,7 @@ interface ActivePoll {
   balanceKey: keyof WalletBalance;
   attemptCount: number;
   interval: ReturnType<typeof setInterval>;
+  callbacks: BalanceWatchCallbacks | null;
 }
 
 const BalanceWatchContext = createContext<BalanceWatchContextType | null>(null);
@@ -55,7 +61,7 @@ export const BalanceWatchProvider: React.FC<BalanceWatchProviderProps> = ({ chil
   }, []);
 
   const start = useCallback(
-    (snapshotBalance: number, balanceKey: keyof WalletBalance = "totalUsd") => {
+    (snapshotBalance: number, balanceKey: keyof WalletBalance = "totalUsd", callbacks?: BalanceWatchCallbacks) => {
       if (pollRef.current) {
         return;
       }
@@ -70,6 +76,7 @@ export const BalanceWatchProvider: React.FC<BalanceWatchProviderProps> = ({ chil
         snapshotBalance,
         balanceKey,
         attemptCount: 0,
+        callbacks: callbacks ?? null,
         interval: setInterval(() => {
           if (!pollRef.current) {
             return;
@@ -79,6 +86,7 @@ export const BalanceWatchProvider: React.FC<BalanceWatchProviderProps> = ({ chil
 
           if (pollRef.current.attemptCount >= MAX_ATTEMPTS) {
             setIsTimeOut(true);
+            pollRef.current.callbacks?.onTimeOut?.();
             clearInterval(pollRef.current.interval);
             pollRef.current = null;
             setIsActive(false);
@@ -100,6 +108,7 @@ export const BalanceWatchProvider: React.FC<BalanceWatchProviderProps> = ({ chil
 
       if (currentBalance[pollRef.current.balanceKey] > pollRef.current.snapshotBalance) {
         setIsSuccess(true);
+        pollRef.current.callbacks?.onSuccess?.();
         stop();
       }
     },

--- a/apps/deploy-web/src/context/BalanceWatchProvider/index.ts
+++ b/apps/deploy-web/src/context/BalanceWatchProvider/index.ts
@@ -1,0 +1,2 @@
+export { BalanceWatchProvider, useBalanceWatch, DEPENDENCIES } from "./BalanceWatchProvider";
+export type { BalanceWatchContextType, BalanceWatchProviderProps } from "./BalanceWatchProvider";

--- a/apps/deploy-web/src/pages/_app.tsx
+++ b/apps/deploy-web/src/pages/_app.tsx
@@ -22,6 +22,7 @@ import { CustomIntlProvider } from "@src/components/layout/CustomIntlProvider";
 import { PageHead } from "@src/components/layout/PageHead";
 import { OnboardingRedirectEffect } from "@src/components/onboarding/OnboardingRedirectEffect/OnboardingRedirectEffect";
 import { UserProviders } from "@src/components/user/UserProviders/UserProviders";
+import { BalanceWatchProvider } from "@src/context/BalanceWatchProvider";
 import { CustomChainProvider } from "@src/context/CustomChainProvider";
 import { ColorModeProvider } from "@src/context/CustomThemeContext";
 import { FlagProvider } from "@src/context/FlagProvider/FlagProvider";
@@ -57,12 +58,14 @@ const App: React.FunctionComponent<Props> = props => {
         <UserProviders>
           <FlagProvider>
             <WalletProvider>
-              <PaymentPollingProvider>
-                <NavigationGuardProvider>
-                  <OnboardingRedirectEffect />
-                  <Component {...pageProps} />
-                </NavigationGuardProvider>
-              </PaymentPollingProvider>
+              <BalanceWatchProvider>
+                <PaymentPollingProvider>
+                  <NavigationGuardProvider>
+                    <OnboardingRedirectEffect />
+                    <Component {...pageProps} />
+                  </NavigationGuardProvider>
+                </PaymentPollingProvider>
+              </BalanceWatchProvider>
             </WalletProvider>
           </FlagProvider>
         </UserProviders>


### PR DESCRIPTION
## Why

Part of CON-94

Multiple features (credit card payments, ACT minting) need to detect when a user's balance has increased after an async operation. `PaymentPollingProvider` handles this for payments but is tightly coupled to payment-specific logic (trial status, analytics, snackbar messages). We need a generic, reusable provider that only tracks balance changes — callers decide what to do with the result via callbacks.

## What

- **New `BalanceWatchProvider`** — generic provider mounted in `_app.tsx` that polls `refetchBalance` and signals when a specified balance field increases. Supports custom balance keys (e.g. `balanceUACT` for mint/burn) with `totalUsd` as default.
- **Callback support** — `start()` accepts optional `onSuccess`/`onTimeOut` callbacks stored in a ref, so they survive page navigations.
- **Integrated into `MintBurnPage`** — after a successful mint/burn tx, starts balance watch with callbacks that manage persistent pending/success/timeout snackbars.
- **Follow-up work**: `PaymentPollingProvider` can be simplified to use `BalanceWatchProvider` + callbacks. Trial-to-paid transition detection can be handled by checking `isTrialing` in the payment flow's `onSuccess` callback — no separate provider needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic balance monitoring after mint/burn with real-time polling and callbacks
  * Submit button shows "Updating balance..." and is disabled while syncing
  * Enhanced notifications flow: persistent info, success ("Conversion complete!"), and timeout warnings

* **Bug Fixes**
  * Non-supported/non-custodial wallets render a 404-style page instead of blank

* **Tests**
  * New comprehensive tests for balance-watching behavior and provider integration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->