### PR TITLE
fix(indexer): capture BME vault funding from governance/upgrade transfers

### DIFF
--- a/apps/indexer/src/chain/chainSync.ts
+++ b/apps/indexer/src/chain/chainSync.ts
@@ -11,7 +11,7 @@ import { Op } from "sequelize";
 import * as uuid from "uuid";
 
 import { sequelize } from "@src/db/dbConnection";
-import { BME_EVENT_TYPE_VALUES } from "@src/indexers/bmeIndexer";
+import { BME_EVENT_TYPE_VALUES, BME_EVENT_TYPES } from "@src/indexers/bmeIndexer";
 import { ExecutionMode, executionMode, isProd, lastBlockToSync } from "@src/shared/constants";
 import type { BlockResultType } from "@src/shared/types";
 import { decodeIfBase64 } from "@src/shared/utils/base64";
@@ -270,7 +270,8 @@ async function insertBlocks(startHeight: number, endHeight: number) {
     // Extract BME-relevant events from end_block_events (or finalize_block_events in CometBFT ABCI 2.0+)
     const endBlockEvents = blockResults?.finalize_block_events ?? blockResults?.end_block_events;
     if (endBlockEvents) {
-      for (const [eventIndex, event] of endBlockEvents.entries()) {
+      let bmeEventIndex = 0;
+      for (const event of endBlockEvents) {
         if ((BME_EVENT_TYPE_VALUES as readonly string[]).includes(event.type)) {
           const data: Record<string, string | null> = {};
           for (const attr of event.attributes) {
@@ -279,11 +280,34 @@ async function insertBlocks(startHeight: number, endHeight: number) {
           bmeRawEventsToAdd.push({
             id: uuid.v4(),
             height: i,
-            index: eventIndex,
+            index: bmeEventIndex++,
             type: event.type,
             data: data,
             isProcessed: false
           });
+        }
+
+        // Detect vault funding via uakt transfers to the BME vault module account.
+        // These occur during governance proposal execution or chain upgrades in EndBlocker.
+        // User deposits (MsgMintACT) never appear in finalize_block_events, so this is safe from double-counting.
+        if (activeChain.bmeVaultAddress && event.type === "transfer") {
+          const attrs: Record<string, string> = {};
+          for (const attr of event.attributes) {
+            attrs[decodeIfBase64(attr.key)] = attr.value ? decodeIfBase64(attr.value) : "";
+          }
+          if (attrs.recipient === activeChain.bmeVaultAddress && attrs.amount?.includes("uakt")) {
+            const amountMatch = attrs.amount.match(/^(\d+)uakt$/);
+            if (amountMatch) {
+              bmeRawEventsToAdd.push({
+                id: uuid.v4(),
+                height: i,
+                index: bmeEventIndex++,
+                type: BME_EVENT_TYPES.VAULT_FUNDED_TRANSFER,
+                data: { amount: amountMatch[1], denom: "uakt", sender: attrs.sender || null },
+                isProcessed: false
+              });
+            }
+          }
         }
       }
     }

--- a/apps/indexer/src/chain/chainSync.ts
+++ b/apps/indexer/src/chain/chainSync.ts
@@ -1,4 +1,4 @@
-import { activeChain } from "@akashnetwork/database/chainDefinitions";
+import { activeChain, BME_VAULT_ADDRESS } from "@akashnetwork/database/chainDefinitions";
 import { Block, Message } from "@akashnetwork/database/dbSchemas";
 import { BmeRawEvent } from "@akashnetwork/database/dbSchemas/akash";
 import { Day, Transaction, TransactionEvent, TransactionEventAttribute } from "@akashnetwork/database/dbSchemas/base";
@@ -290,12 +290,12 @@ async function insertBlocks(startHeight: number, endHeight: number) {
         // Detect vault funding via uakt transfers to the BME vault module account.
         // These occur during governance proposal execution or chain upgrades in EndBlocker.
         // User deposits (MsgMintACT) never appear in finalize_block_events, so this is safe from double-counting.
-        if (activeChain.bmeVaultAddress && event.type === "transfer") {
+        if (event.type === "transfer") {
           const attrs: Record<string, string> = {};
           for (const attr of event.attributes) {
             attrs[decodeIfBase64(attr.key)] = attr.value ? decodeIfBase64(attr.value) : "";
           }
-          if (attrs.recipient === activeChain.bmeVaultAddress && attrs.amount?.includes("uakt")) {
+          if (attrs.recipient === BME_VAULT_ADDRESS && attrs.amount?.includes("uakt")) {
             const amountMatch = attrs.amount.match(/^(\d+)uakt$/);
             if (amountMatch) {
               bmeRawEventsToAdd.push({

--- a/apps/indexer/src/indexers/bmeIndexer.ts
+++ b/apps/indexer/src/indexers/bmeIndexer.ts
@@ -13,7 +13,9 @@ export const BME_EVENT_TYPES = {
   LEDGER_RECORD_EXECUTED: "akash.bme.v1.EventLedgerRecordExecuted",
   MINT_STATUS_CHANGE: "akash.bme.v1.EventMintStatusChange",
   VAULT_SEEDED: "akash.bme.v1.EventVaultSeeded",
-  LEDGER_RECORD_CANCELED: "akash.bme.v1.EventLedgerRecordCanceled"
+  LEDGER_RECORD_CANCELED: "akash.bme.v1.EventLedgerRecordCanceled",
+  /** Synthetic event: uakt transfer to vault detected in finalize_block_events (governance/upgrade seed) */
+  VAULT_FUNDED_TRANSFER: "indexer.bme.VaultFundedTransfer"
 } as const;
 
 const BME_EVENT_TYPE_VALUES = Object.values(BME_EVENT_TYPES);
@@ -67,6 +69,7 @@ export class BmeIndexer extends Indexer {
     });
 
     let vaultUaktFromEvent: number | null = null;
+    let vaultFundedAmount = 0;
     const blockLevelSums = zeroBmeSums();
     const ledgerRecords: Array<Parameters<typeof BmeLedgerRecord.bulkCreate>[0][number]> = [];
     const statusChanges: Array<Parameters<typeof BmeStatusChange.bulkCreate>[0][number]> = [];
@@ -85,6 +88,10 @@ export class BmeIndexer extends Indexer {
           const amount = safeParseFloat(parsed.newVaultBalance.amount);
           vaultUaktFromEvent = amount;
         }
+      } else if (rawEvent.type === BME_EVENT_TYPES.VAULT_FUNDED_TRANSFER) {
+        // Synthetic event: uakt transfer to vault from governance/upgrade (not a user deposit).
+        // Adds to vault balance as a delta since we don't have an absolute snapshot.
+        vaultFundedAmount += safeParseFloat(rawEvent.data.amount as string);
       }
       // LEDGER_RECORD_CANCELED: no supply impact (record was canceled before execution).
       // Raw event is kept in bme_raw_event for audit purposes.
@@ -113,8 +120,9 @@ export class BmeIndexer extends Indexer {
       // EventVaultSeeded provides an absolute snapshot of vault balance
       currentBlock.vaultUakt = vaultUaktFromEvent;
     } else {
-      // Delta: AKT deposited via mints minus AKT withdrawn via remints this block
-      currentBlock.vaultUakt = (previousBlock?.vaultUakt ?? 0) + sums.aktBurnedForAct - sums.aktReminted;
+      // Delta: AKT deposited via mints minus AKT withdrawn via remints this block,
+      // plus any vault funding from governance proposals or chain upgrades
+      currentBlock.vaultUakt = (previousBlock?.vaultUakt ?? 0) + sums.aktBurnedForAct - sums.aktReminted + vaultFundedAmount;
     }
 
     // Outstanding uACT = total minted - total burned back - spent on deployments

--- a/packages/database/chainDefinitions.ts
+++ b/packages/database/chainDefinitions.ts
@@ -26,6 +26,9 @@ import type { Block, Message } from "./dbSchemas/base";
 dotenv.config({ path: ".env.local" });
 dotenv.config();
 
+// Derived from the module name hash, so it's the same across all networks
+export const BME_VAULT_ADDRESS = "akash1klpwzlvfnw7j8gtdd0cuu9vaw9ermsmd37sg55";
+
 export interface ChainDef {
   code: string;
   rpcNodes: string[];
@@ -40,7 +43,6 @@ export interface ChainDef {
   denom: string;
   udenom: string;
   startHeight?: number;
-  bmeVaultAddress?: string;
   customBlockModel?: ModelCtor<Block>;
   customMessageModel?: ModelCtor<Message>;
   customModels?: ModelCtor<Model<any, any>>[];
@@ -60,7 +62,6 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
     bech32Prefix: "akash",
     denom: "akt",
     udenom: "uakt",
-    bmeVaultAddress: "akash1klpwzlvfnw7j8gtdd0cuu9vaw9ermsmd37sg55",
     customBlockModel: AkashBlock,
     customMessageModel: AkashMessage,
     customModels: [
@@ -97,7 +98,6 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
     bech32Prefix: "akash",
     denom: "act",
     udenom: "uact",
-    bmeVaultAddress: "akash1klpwzlvfnw7j8gtdd0cuu9vaw9ermsmd37sg55",
     customBlockModel: AkashBlock,
     customMessageModel: AkashMessage,
     customModels: [
@@ -134,7 +134,6 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
     bech32Prefix: "akash",
     denom: "akt",
     udenom: "uakt",
-    bmeVaultAddress: "akash1klpwzlvfnw7j8gtdd0cuu9vaw9ermsmd37sg55",
     customBlockModel: AkashBlock,
     customMessageModel: AkashMessage,
     customModels: [

--- a/packages/database/chainDefinitions.ts
+++ b/packages/database/chainDefinitions.ts
@@ -40,6 +40,7 @@ export interface ChainDef {
   denom: string;
   udenom: string;
   startHeight?: number;
+  bmeVaultAddress?: string;
   customBlockModel?: ModelCtor<Block>;
   customMessageModel?: ModelCtor<Message>;
   customModels?: ModelCtor<Model<any, any>>[];
@@ -59,6 +60,7 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
     bech32Prefix: "akash",
     denom: "akt",
     udenom: "uakt",
+    bmeVaultAddress: "akash1klpwzlvfnw7j8gtdd0cuu9vaw9ermsmd37sg55",
     customBlockModel: AkashBlock,
     customMessageModel: AkashMessage,
     customModels: [
@@ -95,6 +97,7 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
     bech32Prefix: "akash",
     denom: "act",
     udenom: "uact",
+    bmeVaultAddress: "akash1klpwzlvfnw7j8gtdd0cuu9vaw9ermsmd37sg55",
     customBlockModel: AkashBlock,
     customMessageModel: AkashMessage,
     customModels: [
@@ -131,6 +134,7 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
     bech32Prefix: "akash",
     denom: "akt",
     udenom: "uakt",
+    bmeVaultAddress: "akash1klpwzlvfnw7j8gtdd0cuu9vaw9ermsmd37sg55",
     customBlockModel: AkashBlock,
     customMessageModel: AkashMessage,
     customModels: [


### PR DESCRIPTION
## Why

The BME dashboard's "Vault AKT Balance" was showing ~2.88K AKT instead of the correct ~302.9K AKT on-chain value. The indexer was only tracking vault balance changes from user activity (remint credit accrual/issuance via `EventLedgerRecordExecuted`) but completely missing vault seeding from governance proposals and chain upgrades.

**Root cause:** On testnet, the vault was funded via two governance proposals (`MsgFundVault` — proposals #4 and #7 totaling ~300,050 AKT). These execute in EndBlocker and produce standard bank `transfer` events in `finalize_block_events`, but the chain does **not** emit an `EventVaultSeeded` event for `MsgFundVault`. The indexer was only scanning for typed BME events (`akash.bme.v1.*`), so the vault seed transfers were invisible.

On mainnet, the same pattern will occur — the vault will be funded directly during the chain upgrade (transfer from community pool to vault module account), also without an `EventVaultSeeded` event.

## What

- **chainSync.ts**: Also scan `finalize_block_events` for `transfer` events where the recipient is the BME vault module account with uakt. When detected, create a synthetic `VaultFundedTransfer` raw event. This is safe from double-counting because user AKT deposits (`MsgMintACT`) only appear in `txs_results` events, never in `finalize_block_events`.
- **bmeIndexer.ts**: Handle the new `VAULT_FUNDED_TRANSFER` synthetic event type by adding the funded amount to the vault balance delta.
- **chainDefinitions.ts**: Add `bmeVaultAddress` to `ChainDef` interface, configured per network. The address is deterministic (hash of the module name), confirmed to be the same across all networks.

**Verified on testnet after re-index:** DB `vaultUakt` = 302,928,393,874 matches on-chain vault balance exactly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic detection and real-time tracking of transfers sent to the vault during block processing.
  * Improved vault balance calculation with refined event indexing and a new vault-funded transfer event type for more accurate accounting.

* **Chores**
  * Added vault address configuration to chain definitions for supported networks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->