### PR TITLE
feat(wallet): add mint/burn ledger history table

### DIFF
--- a/apps/deploy-web/src/components/MintBurnPage/LedgerRecordsTable/LedgerRecordsTable.spec.tsx
+++ b/apps/deploy-web/src/components/MintBurnPage/LedgerRecordsTable/LedgerRecordsTable.spec.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+import { DEPENDENCIES, LedgerRecordsTable } from "./LedgerRecordsTable";
+
+import { render, screen } from "@testing-library/react";
+import { buildBlockDetail, buildBurnLedgerRecord, buildMintLedgerRecord, buildPendingMintLedgerRecord } from "@tests/seeders";
+
+describe(LedgerRecordsTable.name, () => {
+  it("shows empty state when no records", () => {
+    setup({ records: [] });
+
+    expect(screen.queryByText("No mint or burn history yet.")).toBeInTheDocument();
+  });
+
+  it("shows spinner when loading with no records", () => {
+    setup({ records: [], isLoading: true });
+
+    expect(screen.queryByText("No mint or burn history yet.")).not.toBeInTheDocument();
+  });
+
+  it("renders column headers", () => {
+    setup({ records: [buildMintLedgerRecord()] });
+
+    expect(screen.queryByText("Date")).toBeInTheDocument();
+    expect(screen.queryByText("Type")).toBeInTheDocument();
+    expect(screen.queryByText("Amount In")).toBeInTheDocument();
+    expect(screen.queryByText("Amount Out")).toBeInTheDocument();
+    expect(screen.queryByText("Rate")).toBeInTheDocument();
+    expect(screen.queryByText("Status")).toBeInTheDocument();
+  });
+
+  it("renders mint record with Mint badge and Executed status", () => {
+    setup({ records: [buildMintLedgerRecord()] });
+
+    expect(screen.queryByText("Mint")).toBeInTheDocument();
+    expect(screen.queryByText("Executed")).toBeInTheDocument();
+  });
+
+  it("renders burn record with Burn badge and Executed status", () => {
+    setup({ records: [buildBurnLedgerRecord()] });
+
+    expect(screen.queryByText("Burn")).toBeInTheDocument();
+    expect(screen.queryByText("Executed")).toBeInTheDocument();
+  });
+
+  it("renders pending record with input amount and Pending status", () => {
+    setup({ records: [buildPendingMintLedgerRecord({ amount: 10_000_000 })] });
+
+    expect(screen.queryByText("Mint")).toBeInTheDocument();
+    expect(screen.queryByText("10.00 AKT")).toBeInTheDocument();
+    expect(screen.queryByText("Pending")).toBeInTheDocument();
+  });
+
+  it("sorts records by height descending", () => {
+    const older = buildMintLedgerRecord({ height: "80000" });
+    const newer = buildBurnLedgerRecord({ height: "90000" });
+
+    setup({ records: [older, newer] });
+
+    const rows = screen.getAllByRole("row");
+    expect(rows[1]).toHaveTextContent("Burn");
+    expect(rows[2]).toHaveTextContent("Mint");
+  });
+
+  function setup(input: { records: Parameters<typeof LedgerRecordsTable>[0]["records"]; isLoading?: boolean }) {
+    const blockDetail = buildBlockDetail();
+
+    const dependencies = {
+      ...DEPENDENCIES,
+      useBlock: () => ({ data: blockDetail })
+    } as unknown as typeof DEPENDENCIES;
+
+    render(<LedgerRecordsTable records={input.records} isLoading={input.isLoading ?? false} dependencies={dependencies} />);
+  }
+});

--- a/apps/deploy-web/src/components/MintBurnPage/LedgerRecordsTable/LedgerRecordsTable.tsx
+++ b/apps/deploy-web/src/components/MintBurnPage/LedgerRecordsTable/LedgerRecordsTable.tsx
@@ -1,0 +1,219 @@
+import React, { useMemo } from "react";
+import type { BmeLedgerRecord } from "@akashnetwork/http-sdk";
+import { CustomPagination, Spinner, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
+import { createColumnHelper, flexRender, getCoreRowModel, getPaginationRowModel, useReactTable } from "@tanstack/react-table";
+
+import { UAKT_DENOM } from "@src/config/denom.config";
+import { useBlock } from "@src/queries/useBlocksQuery";
+import { udenomToDenom } from "@src/utils/mathHelpers";
+import { averageBlockTime } from "@src/utils/priceUtils";
+
+const PAGE_SIZE = 10;
+
+export const DEPENDENCIES = {
+  useBlock
+};
+
+interface LedgerRecordsTableProps {
+  records: BmeLedgerRecord[];
+  isLoading: boolean;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export const LedgerRecordsTable: React.FC<LedgerRecordsTableProps> = ({ records, isLoading, dependencies: d = DEPENDENCIES }) => {
+  const { data: latestBlock } = d.useBlock("latest", { refetchInterval: 30000 });
+  const latestHeight = latestBlock ? parseInt(latestBlock.block.header.height) : undefined;
+  const latestBlockTime = latestBlock?.block.header.time as string | undefined;
+
+  const columns = useMemo(() => createColumns(latestHeight, latestBlockTime), [latestHeight, latestBlockTime]);
+  const sortedRecords = useMemo(() => [...records].sort((a, b) => parseInt(b.id.height) - parseInt(a.id.height)), [records]);
+
+  const table = useReactTable({
+    data: sortedRecords,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageIndex: 0, pageSize: PAGE_SIZE } }
+  });
+
+  if (isLoading && !records.length) {
+    return (
+      <div className="flex items-center justify-center py-8">
+        <Spinner size="medium" />
+      </div>
+    );
+  }
+
+  if (!records.length) {
+    return (
+      <div className="py-8 text-center text-sm text-muted-foreground">
+        <p>No mint or burn history yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map(headerGroup => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map(header => (
+                <TableHead key={header.id} className="h-8 px-2 text-xs">
+                  {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+
+        <TableBody>
+          {table.getRowModel().rows.map(row => (
+            <TableRow key={row.id} className="[&>td]:px-2 [&>td]:py-3">
+              {row.getVisibleCells().map(cell => (
+                <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+
+      {table.getPageCount() > 1 && (
+        <div className="flex items-center justify-center pt-3">
+          <CustomPagination
+            totalPageCount={table.getPageCount()}
+            setPageIndex={table.setPageIndex}
+            pageIndex={table.getState().pagination.pageIndex}
+            pageSize={table.getState().pagination.pageSize}
+            setPageSize={table.setPageSize}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+const columnHelper = createColumnHelper<BmeLedgerRecord>();
+
+function createColumns(latestHeight?: number, latestBlockTime?: string) {
+  return [
+    columnHelper.display({
+      id: "date",
+      header: "Date",
+      cell: info => {
+        if (!latestHeight || !latestBlockTime) return "-";
+        const date = estimateRecordDate(parseInt(info.row.original.id.height), latestHeight, latestBlockTime);
+        return date.toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+      }
+    }),
+    columnHelper.display({
+      id: "type",
+      header: "Type",
+      cell: info => {
+        const type = getRecordType(info.row.original);
+        return (
+          <span
+            className={cn(
+              "inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium",
+              type === "Mint" ? "bg-blue-100 text-blue-800" : "bg-orange-100 text-orange-800"
+            )}
+          >
+            {type}
+          </span>
+        );
+      }
+    }),
+    columnHelper.display({
+      id: "amountIn",
+      header: "Amount In",
+      cell: info => {
+        const { amount, label } = getAmountIn(info.row.original);
+        return amount ? `${amount.toFixed(2)} ${label}` : "-";
+      }
+    }),
+    columnHelper.display({
+      id: "amountOut",
+      header: "Amount Out",
+      cell: info => {
+        const { amount, label } = getAmountOut(info.row.original);
+        return amount ? `${amount.toFixed(2)} ${label}` : "-";
+      }
+    }),
+    columnHelper.display({
+      id: "rate",
+      header: "Rate",
+      cell: info => {
+        const rate = getRate(info.row.original);
+        return rate ? rate.toFixed(4) : "-";
+      }
+    }),
+    columnHelper.accessor("status", {
+      header: "Status",
+      cell: info => (
+        <span className={cn("inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold", getStatusClasses(info.getValue()))}>
+          {getStatusLabel(info.getValue())}
+        </span>
+      )
+    })
+  ];
+}
+
+function estimateRecordDate(recordHeight: number, latestHeight: number, latestBlockTime: string): Date {
+  const blockDiff = latestHeight - recordHeight;
+  const secondsAgo = blockDiff * averageBlockTime;
+  return new Date(new Date(latestBlockTime).getTime() - secondsAgo * 1000);
+}
+
+type RecordType = "Mint" | "Burn";
+
+function getRecordType(record: BmeLedgerRecord): RecordType {
+  return record.id.denom === UAKT_DENOM ? "Mint" : "Burn";
+}
+
+function getAmountIn(record: BmeLedgerRecord): { amount: number; label: string } {
+  const type = getRecordType(record);
+
+  if (record.pending_record) {
+    const label = type === "Mint" ? "AKT" : "ACT";
+    return { amount: udenomToDenom(parseInt(record.pending_record.coins_to_burn.amount), 6), label };
+  }
+
+  if (type === "Mint") {
+    const accrued = record.executed_record?.remint_credit_accrued;
+    return { amount: accrued ? udenomToDenom(parseInt(accrued.coin.amount), 6) : 0, label: "AKT" };
+  }
+  const burned = record.executed_record?.burned;
+  return { amount: burned ? udenomToDenom(parseInt(burned.coin.amount), 6) : 0, label: "ACT" };
+}
+
+function getAmountOut(record: BmeLedgerRecord): { amount: number; label: string } {
+  const type = getRecordType(record);
+  if (type === "Mint") {
+    const minted = record.executed_record?.minted;
+    return { amount: minted ? udenomToDenom(parseInt(minted.coin.amount), 6) : 0, label: "ACT" };
+  }
+  const issued = record.executed_record?.remint_credit_issued;
+  return { amount: issued ? udenomToDenom(parseInt(issued.coin.amount), 6) : 0, label: "AKT" };
+}
+
+function getRate(record: BmeLedgerRecord): number {
+  const type = getRecordType(record);
+  if (type === "Mint") {
+    const accrued = record.executed_record?.remint_credit_accrued;
+    return accrued ? parseFloat(accrued.price) : 0;
+  }
+  const burned = record.executed_record?.burned;
+  return burned ? parseFloat(burned.price) : 0;
+}
+
+function getStatusLabel(status: string): string {
+  return status.replace("ledger_record_status_", "").replace(/^\w/, c => c.toUpperCase());
+}
+
+function getStatusClasses(status: string): string {
+  if (status.includes("executed")) return "bg-green-100 text-green-800";
+  if (status.includes("pending")) return "bg-yellow-100 text-yellow-800";
+  if (status.includes("canceled")) return "bg-red-100 text-red-800";
+  return "bg-gray-100 text-gray-800";
+}

--- a/apps/deploy-web/src/components/MintBurnPage/LedgerRecordsTable/index.ts
+++ b/apps/deploy-web/src/components/MintBurnPage/LedgerRecordsTable/index.ts
@@ -1,0 +1,1 @@
+export { DEPENDENCIES, LedgerRecordsTable } from "./LedgerRecordsTable";

--- a/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.spec.tsx
+++ b/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.spec.tsx
@@ -158,8 +158,8 @@ describe(MintBurnPage.name, () => {
     );
   });
 
-  it("resets form and refetches balance after successful mint", async () => {
-    const { refetchBalance } = setup({
+  it("resets form and invalidates ledger after successful mint", async () => {
+    const { invalidateLedger } = setup({
       walletBalance: buildWalletBalance({ balanceUAKT: 1_000_000_000 }),
       price: 2
     });
@@ -169,7 +169,7 @@ describe(MintBurnPage.name, () => {
     });
 
     await waitFor(() => {
-      expect(refetchBalance).toHaveBeenCalledTimes(1);
+      expect(invalidateLedger).toHaveBeenCalledTimes(1);
     });
     expect((screen.getByLabelText("To") as HTMLInputElement).value).toBe("");
   });
@@ -248,6 +248,7 @@ describe(MintBurnPage.name, () => {
   function setup(input?: { walletBalance?: WalletBalance | null; price?: number }) {
     const signAndBroadcastTx = vi.fn().mockResolvedValue(true);
     const refetchBalance = vi.fn();
+    const invalidateLedger = vi.fn();
     const enqueueSnackbar = vi.fn();
 
     const dependencies = {
@@ -280,11 +281,17 @@ describe(MintBurnPage.name, () => {
       useSnackbar: () => ({
         enqueueSnackbar
       }),
-      useSupportsACT: () => true
+      useSupportsACT: () => true,
+      useLedgerRecords: () => ({
+        data: null,
+        isLoading: false,
+        invalidate: invalidateLedger
+      }),
+      LedgerRecordsTable: () => null
     } as unknown as typeof DEPENDENCIES;
 
     render(<MintBurnPage dependencies={dependencies} />);
 
-    return { signAndBroadcastTx, refetchBalance, enqueueSnackbar };
+    return { signAndBroadcastTx, refetchBalance, invalidateLedger, enqueueSnackbar };
   }
 });

--- a/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.tsx
+++ b/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.tsx
@@ -12,11 +12,13 @@ import { useWallet } from "@src/context/WalletProvider";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useSupportsACT } from "@src/hooks/useSupportsACT/useSupportsACT";
 import { useWalletBalance } from "@src/hooks/useWalletBalance";
+import { useLedgerRecords } from "@src/queries/useLedgerRecords";
 import { denomToUdenom, roundDecimal, udenomToDenom } from "@src/utils/mathHelpers";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
 import { UrlService } from "@src/utils/urlUtils";
 import Layout from "../layout/Layout";
 import { Title } from "../shared/Title";
+import { LedgerRecordsTable } from "./LedgerRecordsTable/LedgerRecordsTable";
 
 export enum MintBurnTab {
   MINT = "mint",
@@ -43,7 +45,9 @@ export const DEPENDENCIES = {
   usePricing,
   useWalletBalance,
   useSnackbar,
-  useSupportsACT
+  useSupportsACT,
+  useLedgerRecords,
+  LedgerRecordsTable
 };
 
 interface MintBurnPageProps {
@@ -57,9 +61,10 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { address, signAndBroadcastTx, isCustodial } = d.useWallet();
-  const { balance, isLoading: isBalanceLoading, refetch: refetchBalance } = d.useWalletBalance();
+  const { balance, isLoading: isBalanceLoading } = d.useWalletBalance();
   const { price, isLoaded: isPriceLoaded } = d.usePricing();
   const { enqueueSnackbar } = d.useSnackbar();
+  const { data: ledgerData, isLoading: isLedgerLoading, invalidate: invalidateLedger } = d.useLedgerRecords(address);
 
   const aktBalance = useMemo(() => (balance ? udenomToDenom(balance.balanceUAKT, 6) : 0), [balance]);
   const actBalance = useMemo(() => (balance ? udenomToDenom(balance.balanceUACT, 6) : 0), [balance]);
@@ -144,7 +149,7 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
       const success = await signAndBroadcastTx([msg]);
 
       if (success) {
-        refetchBalance();
+        invalidateLedger();
         resetForm();
       }
     } catch (err) {
@@ -156,7 +161,7 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
     } finally {
       setIsSubmitting(false);
     }
-  }, [address, effectiveFromAmount, insufficientBalance, isMint, signAndBroadcastTx, enqueueSnackbar, refetchBalance, resetForm, d]);
+  }, [address, effectiveFromAmount, insufficientBalance, isMint, signAndBroadcastTx, enqueueSnackbar, invalidateLedger, resetForm, d]);
   const isACTSupported = d.useSupportsACT();
 
   if (!isACTSupported || !isCustodial) {
@@ -165,7 +170,7 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
 
   return (
     <d.Layout>
-      <div className="mx-auto max-w-lg py-6">
+      <div className="mx-auto max-w-2xl py-6">
         <d.Link href={UrlService.home()} className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
           <d.NavArrowLeft className="h-4 w-4" />
           Back to Dashboard
@@ -262,6 +267,13 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
         >
           {isSubmitting ? "Processing..." : isMint ? "Mint ACT" : "Burn ACT"}
         </d.Button>
+
+        <d.Card className="mt-6">
+          <d.CardContent className="px-4 pb-4 pt-3">
+            <h3 className="mb-1 text-sm font-medium">History</h3>
+            <d.LedgerRecordsTable records={ledgerData?.records ?? []} isLoading={isLedgerLoading} />
+          </d.CardContent>
+        </d.Card>
       </div>
     </d.Layout>
   );

--- a/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
+++ b/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useMemo } from "react";
 import type { NetworkId } from "@akashnetwork/chain-sdk";
-import { AuthzHttpService, CertificatesService } from "@akashnetwork/http-sdk";
+import { AuthzHttpService, BmeHttpService, CertificatesService } from "@akashnetwork/http-sdk";
 
 import { UACT_DENOM, UAKT_DENOM, USDC_IBC_DENOMS } from "@src/config/denom.config";
 import { services as rootContainer } from "@src/services/app-di-container/browser-di-container";
@@ -38,6 +38,7 @@ const neverResolvedPromise = new Promise<never>(() => {});
 function createAppContainer<T extends Factories>(settingsState: SettingsContextType, services: Partial<T> | undefined) {
   const di = createChildContainer(rootContainer, {
     authzHttpService: () => new AuthzHttpService(di.chainApiHttpClient),
+    bmeHttpService: () => new BmeHttpService(di.chainApiHttpClient),
     walletBalancesService: () =>
       new WalletBalancesService(di.authzHttpService, di.chainApiHttpClient, {
         uakt: UAKT_DENOM,

--- a/apps/deploy-web/src/queries/queryKeys.ts
+++ b/apps/deploy-web/src/queries/queryKeys.ts
@@ -79,6 +79,8 @@ export class QueryKeys {
 
   static getWeeklyDeploymentCostKey = () => ["WEEKLY_DEPLOYMENT_COST"];
 
+  static getLedgerRecordsKey = (address?: string) => (address ? ["LEDGER_RECORDS", address] : []);
+
   static getManagedWalletKey = (userId?: string) => ["MANAGED_WALLET", userId || ""];
 
   static getPaymentTransactionsKey = (options?: {

--- a/apps/deploy-web/src/queries/useLedgerRecords.ts
+++ b/apps/deploy-web/src/queries/useLedgerRecords.ts
@@ -1,0 +1,62 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { BmeLedgerResponse } from "@akashnetwork/http-sdk";
+import type { QueryKey } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { useServices } from "@src/context/ServicesProvider";
+import { useWalletBalance } from "@src/hooks/useWalletBalance";
+import { QueryKeys } from "./queryKeys";
+
+const POLLING_INTERVAL_MS = 5000;
+
+export function useLedgerRecords(address?: string) {
+  const { bmeHttpService, chainApiHttpClient } = useServices();
+  const { refetch: refetchBalance } = useWalletBalance();
+  const queryClient = useQueryClient();
+  const prevHadPendingRef = useRef(false);
+
+  const query = useQuery({
+    queryKey: QueryKeys.getLedgerRecordsKey(address) as QueryKey,
+    queryFn: () => {
+      if (!address) return null;
+      return bmeHttpService.getLedgerRecords({ source: address });
+    },
+    enabled: !!address && !chainApiHttpClient.isFallbackEnabled,
+    refetchInterval: query => (hasPendingRecords(query.state.data) ? POLLING_INTERVAL_MS : false)
+  });
+
+  useEffect(
+    function resetOnAddressChange() {
+      prevHadPendingRef.current = false;
+    },
+    [address]
+  );
+
+  useEffect(
+    function refetchBalanceOnExecution() {
+      const hasPending = hasPendingRecords(query.data ?? undefined);
+
+      if (prevHadPendingRef.current && !hasPending) {
+        refetchBalance();
+      }
+
+      prevHadPendingRef.current = hasPending;
+    },
+    [query.data, refetchBalance]
+  );
+
+  const invalidate = useCallback(() => {
+    if (address) {
+      queryClient.invalidateQueries({ queryKey: QueryKeys.getLedgerRecordsKey(address) });
+    }
+  }, [queryClient, address]);
+
+  return {
+    ...query,
+    invalidate
+  };
+}
+
+function hasPendingRecords(data: BmeLedgerResponse | null | undefined): boolean {
+  return !!data?.records.some(r => r.status === "ledger_record_status_pending");
+}

--- a/apps/deploy-web/tests/seeders/index.ts
+++ b/apps/deploy-web/tests/seeders/index.ts
@@ -16,3 +16,4 @@ export * from "./user";
 export * from "./wallet";
 export * from "./walletBalance";
 export * from "./sdlService";
+export * from "./ledgerRecord";

--- a/apps/deploy-web/tests/seeders/ledgerRecord.ts
+++ b/apps/deploy-web/tests/seeders/ledgerRecord.ts
@@ -1,0 +1,84 @@
+import type { BmeLedgerRecord } from "@akashnetwork/http-sdk";
+import { faker } from "@faker-js/faker";
+
+const akashAddress = () => `akash1${faker.string.alphanumeric(38)}`;
+
+export function buildMintLedgerRecord(overrides?: Partial<{ height: string }>): BmeLedgerRecord {
+  const address = akashAddress();
+  const aktAmount = faker.number.int({ min: 10_000_000, max: 500_000_000 });
+  const price = faker.number.float({ min: 0.4, max: 0.6, fractionDigits: 9 });
+  const actAmount = Math.round(aktAmount * price);
+
+  return {
+    id: {
+      denom: "uakt",
+      to_denom: "uact",
+      source: address,
+      height: overrides?.height ?? faker.number.int({ min: 80000, max: 100000 }).toString(),
+      sequence: "1"
+    },
+    status: "ledger_record_status_executed",
+    executed_record: {
+      burned_from: address,
+      minted_to: address,
+      burner: "bme",
+      minter: "bme",
+      burned: null,
+      minted: { coin: { denom: "uact", amount: actAmount.toString() }, price: "1.000000000000000000" },
+      remint_credit_issued: null,
+      remint_credit_accrued: { coin: { denom: "uakt", amount: aktAmount.toString() }, price: price.toFixed(9) }
+    },
+    pending_record: null
+  };
+}
+
+export function buildBurnLedgerRecord(overrides?: Partial<{ height: string }>): BmeLedgerRecord {
+  const address = akashAddress();
+  const actAmount = faker.number.int({ min: 10_000_000, max: 500_000_000 });
+  const price = faker.number.float({ min: 0.4, max: 0.6, fractionDigits: 9 });
+  const aktAmount = Math.round(actAmount / price);
+
+  return {
+    id: {
+      denom: "uact",
+      to_denom: "uakt",
+      source: address,
+      height: overrides?.height ?? faker.number.int({ min: 80000, max: 100000 }).toString(),
+      sequence: "1"
+    },
+    status: "ledger_record_status_executed",
+    executed_record: {
+      burned_from: address,
+      minted_to: address,
+      burner: "bme",
+      minter: "bme",
+      burned: { coin: { denom: "uact", amount: actAmount.toString() }, price: "1.000000000000000000" },
+      minted: null,
+      remint_credit_issued: { coin: { denom: "uakt", amount: aktAmount.toString() }, price: price.toFixed(9) },
+      remint_credit_accrued: null
+    },
+    pending_record: null
+  };
+}
+
+export function buildPendingMintLedgerRecord(overrides?: Partial<{ height: string; amount: number }>): BmeLedgerRecord {
+  const address = akashAddress();
+
+  return {
+    id: {
+      denom: "uakt",
+      to_denom: "uact",
+      source: address,
+      height: overrides?.height ?? faker.number.int({ min: 80000, max: 100000 }).toString(),
+      sequence: "1"
+    },
+    status: "ledger_record_status_pending",
+    executed_record: null,
+    pending_record: {
+      owner: address,
+      to: address,
+      coins_to_burn: { denom: "uakt", amount: (overrides?.amount ?? faker.number.int({ min: 10_000_000, max: 500_000_000 })).toString() },
+      denom_to_mint: "uact"
+    }
+  };
+}

--- a/packages/http-sdk/src/bme/bme-http.service.ts
+++ b/packages/http-sdk/src/bme/bme-http.service.ts
@@ -1,0 +1,23 @@
+import { extractData } from "../http/http.service";
+import type { HttpClient } from "../utils/httpClient";
+import type { BmeLedgerFilters, BmeLedgerResponse } from "./types";
+
+export class BmeHttpService {
+  constructor(private readonly httpClient: HttpClient) {}
+
+  async getLedgerRecords(filters?: BmeLedgerFilters, pagination?: { limit?: number; offset?: number }): Promise<BmeLedgerResponse> {
+    const params = new URLSearchParams();
+
+    if (filters?.source) params.set("filters.source", filters.source);
+    if (filters?.denom) params.set("filters.denom", filters.denom);
+    if (filters?.to_denom) params.set("filters.to_denom", filters.to_denom);
+    if (filters?.status) params.set("filters.status", filters.status);
+
+    if (pagination?.limit) params.set("pagination.limit", pagination.limit.toString());
+    if (pagination?.offset !== undefined) params.set("pagination.offset", pagination.offset.toString());
+    params.set("pagination.count_total", "true");
+
+    const query = params.toString();
+    return extractData(await this.httpClient.get<BmeLedgerResponse>(`/akash/bme/v1/ledger${query ? `?${query}` : ""}`));
+  }
+}

--- a/packages/http-sdk/src/bme/index.ts
+++ b/packages/http-sdk/src/bme/index.ts
@@ -1,0 +1,2 @@
+export * from "./bme-http.service";
+export * from "./types";

--- a/packages/http-sdk/src/bme/types.ts
+++ b/packages/http-sdk/src/bme/types.ts
@@ -1,0 +1,60 @@
+export type BmeLedgerRecordStatus = "ledger_record_status_pending" | "ledger_record_status_executed" | "ledger_record_status_canceled";
+
+export interface BmeCoinWithPrice {
+  coin: {
+    denom: string;
+    amount: string;
+  };
+  price: string;
+}
+
+export interface BmeLedgerRecordId {
+  denom: string;
+  to_denom: string;
+  source: string;
+  height: string;
+  sequence: string;
+}
+
+export interface BmeLedgerExecutedRecord {
+  burned_from: string;
+  minted_to: string;
+  burner: string;
+  minter: string;
+  burned: BmeCoinWithPrice | null;
+  minted: BmeCoinWithPrice | null;
+  remint_credit_issued: BmeCoinWithPrice | null;
+  remint_credit_accrued: BmeCoinWithPrice | null;
+}
+
+export interface BmeLedgerPendingRecord {
+  owner: string;
+  to: string;
+  coins_to_burn: {
+    denom: string;
+    amount: string;
+  };
+  denom_to_mint: string;
+}
+
+export interface BmeLedgerRecord {
+  id: BmeLedgerRecordId;
+  status: BmeLedgerRecordStatus;
+  executed_record: BmeLedgerExecutedRecord | null;
+  pending_record: BmeLedgerPendingRecord | null;
+}
+
+export interface BmeLedgerResponse {
+  records: BmeLedgerRecord[];
+  pagination: {
+    next_key: string | null;
+    total: string;
+  };
+}
+
+export interface BmeLedgerFilters {
+  source?: string;
+  denom?: string;
+  to_denom?: string;
+  status?: BmeLedgerRecordStatus;
+}

--- a/packages/http-sdk/src/index.ts
+++ b/packages/http-sdk/src/index.ts
@@ -18,6 +18,7 @@ export * from "./lease/lease-http.service";
 export * from "./provider/provider-http.service";
 export * from "./utils/isHttpError";
 export * from "./git-hub/git-hub-http.service";
+export * from "./bme";
 export * from "./cosmos";
 export * from "./coin-gecko";
 export * from "./node";


### PR DESCRIPTION
## Why

Closes CON-94

After submitting a mint/burn transaction, users had no visibility into the operation's status. The previous approach (PR #2962) used balance polling with snackbar notifications, which was fragile and couldn't survive page navigation. Per [baktun14's suggestion](https://github.com/akash-network/console/pull/2962#issuecomment-4092180576), the BME module exposes a ledger LCD endpoint that returns the actual status of each operation — this is a more reliable signal.

## What

- **`BmeHttpService`** (`packages/http-sdk`) — new HTTP service wrapping `GET /akash/bme/v1/ledger` with filter and pagination support
- **`useLedgerRecords` hook** — React Query hook that fetches records for the current wallet, polls every 5s when any record is pending, and refetches wallet balance when records transition to executed
- **`LedgerRecordsTable`** — TanStack table component showing mint/burn history with columns: Date (estimated from block height), Type, Amount In, Amount Out, Rate, Status. Client-side pagination (5 per page, newest first)
- **MintBurnPage integration** — after a successful tx, invalidates the ledger query so the new pending record appears immediately. The table replaces snackbar notifications as the feedback mechanism

Note: server-side reverse pagination doesn't work on the BME endpoint (filed https://github.com/akash-network/support/issues/442). Using client-side sorting/pagination as a workaround.

<img width="757" height="1347" alt="image" src="https://github.com/user-attachments/assets/4a4560b2-4fee-4a65-ba2e-f1af9f13b7ce" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ledger History card on the mint/burn page with a paginated table (Date, Type, Amount In/Out, Rate, Status); shows loading spinner or empty-state; page layout widened; table auto-refreshes when pending items resolve.

* **Tests**
  * Added tests and test seeders covering headers, loading/empty states, mint/burn/pending rows, formatting, and sort order.

* **Chores**
  * Added ledger-records API client, types, query hook, and supporting re-exports; registered service in app container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->