### PR TITLE
fix(billing): use 1:1 rate for ACT denom fiat conversion

### DIFF
--- a/apps/api/src/billing/services/balances/balances.service.spec.ts
+++ b/apps/api/src/billing/services/balances/balances.service.spec.ts
@@ -82,8 +82,40 @@ describe(BalancesService.name, () => {
     });
   });
 
-  function setup(input?: { limitsUpdate?: Partial<UserWalletInput>; deploymentLimit?: number; fiatAmount?: number }) {
+  describe("toFiatAmount", () => {
+    it("converts uakt amount using market price", async () => {
+      const { service, statsService } = setup({ denom: "uakt" });
+      statsService.convertToFiatAmount.mockResolvedValue(25.5);
+
+      const result = await service.toFiatAmount(25_500_000);
+
+      expect(statsService.convertToFiatAmount).toHaveBeenCalledWith(25.5, "akash-network");
+      expect(result).toBe(25.5);
+    });
+
+    it("converts usdc amount using market price", async () => {
+      const { service, statsService } = setup({ denom: "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1" });
+      statsService.convertToFiatAmount.mockResolvedValue(10.0);
+
+      const result = await service.toFiatAmount(10_000_000);
+
+      expect(statsService.convertToFiatAmount).toHaveBeenCalledWith(10, "usd-coin");
+      expect(result).toBe(10);
+    });
+
+    it("returns 1:1 rate for uact denom", async () => {
+      const { service, statsService } = setup({ denom: "uact" });
+
+      const result = await service.toFiatAmount(25_500_000);
+
+      expect(statsService.convertToFiatAmount).not.toHaveBeenCalled();
+      expect(result).toBe(25.5);
+    });
+  });
+
+  function setup(input?: { limitsUpdate?: Partial<UserWalletInput>; deploymentLimit?: number; fiatAmount?: number; denom?: string }) {
     const billingConfig = mock<BillingConfig>();
+    billingConfig.DEPLOYMENT_GRANT_DENOM = input?.denom ?? "uakt";
     const userWalletRepository = mock<UserWalletRepository>();
     const txManagerService = mock<TxManagerService>();
     const authzHttpService = mock<AuthzHttpService>();
@@ -102,6 +134,6 @@ describe(BalancesService.name, () => {
       vi.spyOn(service, "toFiatAmount").mockResolvedValue(input.fiatAmount);
     }
 
-    return { service, userWalletRepository };
+    return { service, userWalletRepository, statsService };
   }
 });

--- a/apps/api/src/billing/services/balances/balances.service.ts
+++ b/apps/api/src/billing/services/balances/balances.service.ts
@@ -127,6 +127,10 @@ export class BalancesService {
   }
 
   async #convertToFiatAmount(amount: number): Promise<number> {
+    if (this.config.DEPLOYMENT_GRANT_DENOM === "uact") {
+      return amount;
+    }
+
     const coin = this.config.DEPLOYMENT_GRANT_DENOM === "uakt" ? "akash-network" : "usd-coin";
     return await this.statsService.convertToFiatAmount(amount, coin);
   }


### PR DESCRIPTION
## Why

Part of CON-101

When migrating to BME with ACT as the deployment grant denom, `BalancesService.#convertToFiatAmount` incorrectly falls through to the USDC CoinGecko price lookup instead of using ACT's 1:1 USD peg. This would cause wrong fiat conversions in both the wallet balance reload check and weekly deployment cost calculation flows.

### Validation of affected flows

**`wallet-balance-reload-check`** — uses `BalancesService.getDeploymentBalanceInFiat` and `toFiatAmount` for balance/cost comparison. The handler itself is denom-agnostic; the fix in `BalancesService` is sufficient.

**`top-up-managed-deployments`** — all amounts stay in denom units throughout the top-up flow (`blockRate`, `calculateTopUpAmount`, `reserveSufficientAmount`, deposit message). No fiat conversion involved, so **no changes needed**. The only fiat conversion is in `DrainingDeploymentService.calculateWeeklyDeploymentCost`, which calls the same `BalancesService.toFiatAmount` fixed here.

## What

- Add early return in `#convertToFiatAmount` for `"uact"` denom that returns the amount directly (1:1 rate)
- Add unit tests for `toFiatAmount` covering `uakt`, USDC, and `uact` denom cases