### PR TITLE
fix(deployment): use yaml.raw instead of yaml.template for SDL parsing

### DIFF
--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -163,8 +163,49 @@ deployment:
       count: 1
 `;
 
+const SDL_WITH_VARS = `
+version: "2.0"
+services:
+  web:
+    image: nginx
+    env:
+      - GITHUB_PAT=\${GITHUB_PAT}
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 1Gi
+  placement:
+    westcoast:
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1
+`;
+
 describe(SdlService.name, () => {
   describe("generateManifest", () => {
+    it("parses SDL containing template variables without throwing", () => {
+      const { result } = setup({ sdl: SDL_WITH_VARS });
+
+      expect(result.ok).toBe(true);
+    });
+
     it("adds auditor to signedBy anyOf when not present", () => {
       const auditor = "akash1365yvmc4s7awdyj3n2sav7xfx76adc6dnmlx63";
       const { result } = setup({ sdl: VALID_SDL, allowedAuditors: [auditor] });

--- a/apps/api/src/deployment/services/sdl/sdl.service.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.ts
@@ -15,7 +15,7 @@ export class SdlService {
   }
 
   generateManifest(rawSDL: string): GenerateManifestResult {
-    const potentiallyInvalidSDL = yaml.template<SDLInput>(rawSDL);
+    const potentiallyInvalidSDL = yaml.raw<SDLInput>(rawSDL);
     const deploymentGrantDenom = this.#config.DEPLOYMENT_GRANT_DENOM;
     const sdlPlacement =
       potentiallyInvalidSDL?.profiles?.placement && typeof potentiallyInvalidSDL?.profiles?.placement === "object"


### PR DESCRIPTION
## Why

The API's `SdlService.generateManifest` used `yaml.template()` to parse user-submitted SDL. This throws a `ReferenceError` when the SDL contains environment variable references like `${GITHUB_PAT}`, because `yaml.template` attempts variable substitution and fails when no variables are provided.

This was already fixed in deploy-web (PRs #2948, #2951) but the same issue remained in the API.

## What

- Replace `yaml.template()` with `yaml.raw()` in `SdlService.generateManifest` — the API doesn't need variable substitution, just YAML parsing
- Add a test verifying SDL with template variables parses successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced SDL parsing logic to properly validate and process deployment configurations containing template variable definitions in environment entries.

* **Tests**
  * Added new test fixtures and comprehensive unit test cases to verify that SDL containing template variable placeholders parses successfully without errors, ensuring robust handling of environment variable configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->