### PR TITLE
feat(wallet): add min mint deposit validation to mint/burn page

### DIFF
--- a/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.spec.tsx
+++ b/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.spec.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { WalletBalance } from "@src/hooks/useWalletBalance";
-import type { BmeParams, BmeStatus } from "@src/types/bme";
+import type { BmeParams } from "@src/types/bme";
 import { DEPENDENCIES, MintBurnPage, PRESET_AMOUNTS } from "./MintBurnPage";
 
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -175,20 +175,20 @@ describe(MintBurnPage.name, () => {
     expect((screen.getByLabelText("To") as HTMLInputElement).value).toBe("");
   });
 
-  it("displays oracle rate when price is loaded in mint mode", () => {
+  it("displays rate information when price is loaded in mint mode", () => {
     setup({ price: 4 });
 
-    expect(screen.getByText(/Oracle: 1 AKT = 4 ACT/)).toBeInTheDocument();
+    expect(screen.getByText(/Rate: 1 AKT = 4 ACT/)).toBeInTheDocument();
   });
 
-  it("displays oracle rate when price is loaded in burn mode", () => {
+  it("displays rate information when price is loaded in burn mode", () => {
     setup({ price: 4 });
 
     act(() => {
       fireEvent.click(screen.getByLabelText("Swap tokens"));
     });
 
-    expect(screen.getByText(/Oracle: 1 AKT = 4 ACT/)).toBeInTheDocument();
+    expect(screen.getByText(/Rate: 1 ACT = 0.25 AKT/)).toBeInTheDocument();
   });
 
   it("renders all preset amount buttons", () => {
@@ -246,32 +246,11 @@ describe(MintBurnPage.name, () => {
     expect((screen.getByLabelText("From") as HTMLInputElement).value).toBe("10");
   });
 
-  it("shows effective rate with spread when bmeParams has non-zero mint spread", () => {
-    setup({
-      price: 4,
-      bmeParams: { minMintUact: 10_000_000, minMintAct: 10, mintSpreadBps: 25, settleSpreadBps: 0 }
-    });
-
-    expect(screen.getByText(/Oracle: 1 AKT = 4 ACT/)).toBeInTheDocument();
-    expect(screen.getByText(/Effective:/)).toBeInTheDocument();
-    expect(screen.getByText(/0\.25% spread/)).toBeInTheDocument();
-  });
-
-  it("does not show effective rate when spread is zero", () => {
-    setup({
-      price: 4,
-      bmeParams: { minMintUact: 10_000_000, minMintAct: 10, mintSpreadBps: 0, settleSpreadBps: 0 }
-    });
-
-    expect(screen.getByText(/Oracle: 1 AKT = 4 ACT/)).toBeInTheDocument();
-    expect(screen.queryByText(/Effective:/)).not.toBeInTheDocument();
-  });
-
   it("shows below-minimum-mint error when estimated output is below minMintAct", () => {
     setup({
       walletBalance: buildWalletBalance({ balanceUAKT: 1_000_000_000 }),
       price: 0.5,
-      bmeParams: { minMintUact: 10_000_000, minMintAct: 10, mintSpreadBps: 0, settleSpreadBps: 0 }
+      bmeParams: { minMintUact: 10_000_000, minMintAct: 10 }
     });
 
     const fromInput = screen.getByLabelText("From") as HTMLInputElement;
@@ -291,7 +270,7 @@ describe(MintBurnPage.name, () => {
     setup({
       walletBalance: buildWalletBalance({ balanceUACT: 1_000_000_000 }),
       price: 0.5,
-      bmeParams: { minMintUact: 10_000_000, minMintAct: 10, mintSpreadBps: 0, settleSpreadBps: 0 }
+      bmeParams: { minMintUact: 10_000_000, minMintAct: 10 }
     });
 
     act(() => {
@@ -305,7 +284,7 @@ describe(MintBurnPage.name, () => {
     setup({
       walletBalance: buildWalletBalance({ balanceUAKT: 1_000_000_000 }),
       price: 0.5,
-      bmeParams: { minMintUact: 10_000_000, minMintAct: 10, mintSpreadBps: 0, settleSpreadBps: 0 }
+      bmeParams: { minMintUact: 10_000_000, minMintAct: 10 }
     });
 
     const fromInput = screen.getByLabelText("From") as HTMLInputElement;
@@ -321,84 +300,7 @@ describe(MintBurnPage.name, () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("disables mint form when mints_allowed is false", () => {
-    setup({
-      walletBalance: buildWalletBalance({ balanceUAKT: 1_000_000_000 }),
-      price: 2,
-      bmeStatus: { mintsAllowed: false, refundsAllowed: true, collateralRatio: 1.5, circuitBreakerWarnThreshold: 1.1 }
-    });
-
-    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Submit" })).toHaveTextContent("Minting Paused");
-    expect(screen.getByText(/Minting is currently disabled/)).toBeInTheDocument();
-  });
-
-  it("disables burn form when refunds_allowed is false", () => {
-    setup({
-      walletBalance: buildWalletBalance({ balanceUACT: 500_000_000 }),
-      price: 2,
-      bmeStatus: { mintsAllowed: true, refundsAllowed: false, collateralRatio: 1.5, circuitBreakerWarnThreshold: 1.1 }
-    });
-
-    act(() => {
-      fireEvent.click(screen.getByLabelText("Swap tokens"));
-    });
-
-    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Submit" })).toHaveTextContent("Settling Paused");
-    expect(screen.getByText(/Settling ACT is currently disabled/)).toBeInTheDocument();
-  });
-
-  it("shows circuit breaker warning when collateral ratio is at warn threshold", () => {
-    setup({
-      price: 2,
-      bmeStatus: { mintsAllowed: true, refundsAllowed: true, collateralRatio: 1.1, circuitBreakerWarnThreshold: 1.1 }
-    });
-
-    expect(screen.getByText(/approaching the circuit breaker threshold/)).toBeInTheDocument();
-  });
-
-  it("does not show circuit breaker warning when collateral ratio is above threshold", () => {
-    setup({
-      price: 2,
-      bmeStatus: { mintsAllowed: true, refundsAllowed: true, collateralRatio: 1.5, circuitBreakerWarnThreshold: 1.1 }
-    });
-
-    expect(screen.queryByText(/approaching the circuit breaker threshold/)).not.toBeInTheDocument();
-  });
-
-  it("does not show circuit breaker warning when circuit breaker is already tripped", () => {
-    setup({
-      price: 2,
-      bmeStatus: { mintsAllowed: false, refundsAllowed: true, collateralRatio: 0.9, circuitBreakerWarnThreshold: 1.1 }
-    });
-
-    expect(screen.queryByText(/approaching the circuit breaker threshold/)).not.toBeInTheDocument();
-    expect(screen.getByText(/Minting is currently disabled/)).toBeInTheDocument();
-  });
-
-  it("applies spread to computed values", () => {
-    setup({
-      walletBalance: buildWalletBalance({ balanceUAKT: 1_000_000_000 }),
-      price: 4,
-      bmeParams: { minMintUact: 10_000_000, minMintAct: 10, mintSpreadBps: 100, settleSpreadBps: 0 }
-    });
-
-    const fromInput = screen.getByLabelText("From") as HTMLInputElement;
-
-    act(() => {
-      fireEvent.focus(fromInput);
-    });
-
-    act(() => {
-      fireEvent.change(fromInput, { target: { value: "100" } });
-    });
-
-    // 100 AKT * 4 (price) * (1 - 100/10000) = 100 * 4 * 0.99 = 396
-    expect((screen.getByLabelText("To") as HTMLInputElement).value).toBe("396");
-  });
-
-  function setup(input?: { walletBalance?: WalletBalance | null; price?: number; bmeParams?: BmeParams; bmeStatus?: BmeStatus }) {
+  function setup(input?: { walletBalance?: WalletBalance | null; price?: number; bmeParams?: BmeParams }) {
     const signAndBroadcastTx = vi.fn().mockResolvedValue(true);
     const refetchBalance = vi.fn();
     const invalidateLedger = vi.fn();
@@ -436,7 +338,6 @@ describe(MintBurnPage.name, () => {
       }),
       useSupportsACT: () => true,
       useBmeParams: () => ({ data: input?.bmeParams, isLoading: false }),
-      useBmeStatus: () => ({ data: input?.bmeStatus, isLoading: false }),
       useLedgerRecords: () => ({
         data: null,
         isLoading: false,

--- a/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.spec.tsx
+++ b/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.spec.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { WalletBalance } from "@src/hooks/useWalletBalance";
+import type { BmeParams, BmeStatus } from "@src/types/bme";
 import { DEPENDENCIES, MintBurnPage, PRESET_AMOUNTS } from "./MintBurnPage";
 
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -174,20 +175,20 @@ describe(MintBurnPage.name, () => {
     expect((screen.getByLabelText("To") as HTMLInputElement).value).toBe("");
   });
 
-  it("displays rate information when price is loaded in mint mode", () => {
+  it("displays oracle rate when price is loaded in mint mode", () => {
     setup({ price: 4 });
 
-    expect(screen.getByText(/Rate: 1 AKT = 4 ACT/)).toBeInTheDocument();
+    expect(screen.getByText(/Oracle: 1 AKT = 4 ACT/)).toBeInTheDocument();
   });
 
-  it("displays rate information when price is loaded in burn mode", () => {
+  it("displays oracle rate when price is loaded in burn mode", () => {
     setup({ price: 4 });
 
     act(() => {
       fireEvent.click(screen.getByLabelText("Swap tokens"));
     });
 
-    expect(screen.getByText(/Rate: 1 ACT = 0.25 AKT/)).toBeInTheDocument();
+    expect(screen.getByText(/Oracle: 1 AKT = 4 ACT/)).toBeInTheDocument();
   });
 
   it("renders all preset amount buttons", () => {
@@ -245,7 +246,159 @@ describe(MintBurnPage.name, () => {
     expect((screen.getByLabelText("From") as HTMLInputElement).value).toBe("10");
   });
 
-  function setup(input?: { walletBalance?: WalletBalance | null; price?: number }) {
+  it("shows effective rate with spread when bmeParams has non-zero mint spread", () => {
+    setup({
+      price: 4,
+      bmeParams: { minMintUact: 10_000_000, minMintAct: 10, mintSpreadBps: 25, settleSpreadBps: 0 }
+    });
+
+    expect(screen.getByText(/Oracle: 1 AKT = 4 ACT/)).toBeInTheDocument();
+    expect(screen.getByText(/Effective:/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.25% spread/)).toBeInTheDocument();
+  });
+
+  it("does not show effective rate when spread is zero", () => {
+    setup({
+      price: 4,
+      bmeParams: { minMintUact: 10_000_000, minMintAct: 10, mintSpreadBps: 0, settleSpreadBps: 0 }
+    });
+
+    expect(screen.getByText(/Oracle: 1 AKT = 4 ACT/)).toBeInTheDocument();
+    expect(screen.queryByText(/Effective:/)).not.toBeInTheDocument();
+  });
+
+  it("shows below-minimum-mint error when estimated output is below minMintAct", () => {
+    setup({
+      walletBalance: buildWalletBalance({ balanceUAKT: 1_000_000_000 }),
+      price: 0.5,
+      bmeParams: { minMintUact: 10_000_000, minMintAct: 10, mintSpreadBps: 0, settleSpreadBps: 0 }
+    });
+
+    const fromInput = screen.getByLabelText("From") as HTMLInputElement;
+
+    act(() => {
+      fireEvent.focus(fromInput);
+    });
+
+    act(() => {
+      fireEvent.change(fromInput, { target: { value: "10" } });
+    });
+
+    expect(screen.getByText(/below the minimum mint amount of 10 ACT/)).toBeInTheDocument();
+  });
+
+  it("does not show below-minimum-mint error in burn mode", () => {
+    setup({
+      walletBalance: buildWalletBalance({ balanceUACT: 1_000_000_000 }),
+      price: 0.5,
+      bmeParams: { minMintUact: 10_000_000, minMintAct: 10, mintSpreadBps: 0, settleSpreadBps: 0 }
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByLabelText("Swap tokens"));
+    });
+
+    expect(screen.queryByText(/below the minimum mint amount/)).not.toBeInTheDocument();
+  });
+
+  it("disables submit button when estimated output is below minMintAct", () => {
+    setup({
+      walletBalance: buildWalletBalance({ balanceUAKT: 1_000_000_000 }),
+      price: 0.5,
+      bmeParams: { minMintUact: 10_000_000, minMintAct: 10, mintSpreadBps: 0, settleSpreadBps: 0 }
+    });
+
+    const fromInput = screen.getByLabelText("From") as HTMLInputElement;
+
+    act(() => {
+      fireEvent.focus(fromInput);
+    });
+
+    act(() => {
+      fireEvent.change(fromInput, { target: { value: "10" } });
+    });
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
+
+  it("disables mint form when mints_allowed is false", () => {
+    setup({
+      walletBalance: buildWalletBalance({ balanceUAKT: 1_000_000_000 }),
+      price: 2,
+      bmeStatus: { mintsAllowed: false, refundsAllowed: true, collateralRatio: 1.5, circuitBreakerWarnThreshold: 1.1 }
+    });
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Submit" })).toHaveTextContent("Minting Paused");
+    expect(screen.getByText(/Minting is currently disabled/)).toBeInTheDocument();
+  });
+
+  it("disables burn form when refunds_allowed is false", () => {
+    setup({
+      walletBalance: buildWalletBalance({ balanceUACT: 500_000_000 }),
+      price: 2,
+      bmeStatus: { mintsAllowed: true, refundsAllowed: false, collateralRatio: 1.5, circuitBreakerWarnThreshold: 1.1 }
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByLabelText("Swap tokens"));
+    });
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Submit" })).toHaveTextContent("Settling Paused");
+    expect(screen.getByText(/Settling ACT is currently disabled/)).toBeInTheDocument();
+  });
+
+  it("shows circuit breaker warning when collateral ratio is at warn threshold", () => {
+    setup({
+      price: 2,
+      bmeStatus: { mintsAllowed: true, refundsAllowed: true, collateralRatio: 1.1, circuitBreakerWarnThreshold: 1.1 }
+    });
+
+    expect(screen.getByText(/approaching the circuit breaker threshold/)).toBeInTheDocument();
+  });
+
+  it("does not show circuit breaker warning when collateral ratio is above threshold", () => {
+    setup({
+      price: 2,
+      bmeStatus: { mintsAllowed: true, refundsAllowed: true, collateralRatio: 1.5, circuitBreakerWarnThreshold: 1.1 }
+    });
+
+    expect(screen.queryByText(/approaching the circuit breaker threshold/)).not.toBeInTheDocument();
+  });
+
+  it("does not show circuit breaker warning when circuit breaker is already tripped", () => {
+    setup({
+      price: 2,
+      bmeStatus: { mintsAllowed: false, refundsAllowed: true, collateralRatio: 0.9, circuitBreakerWarnThreshold: 1.1 }
+    });
+
+    expect(screen.queryByText(/approaching the circuit breaker threshold/)).not.toBeInTheDocument();
+    expect(screen.getByText(/Minting is currently disabled/)).toBeInTheDocument();
+  });
+
+  it("applies spread to computed values", () => {
+    setup({
+      walletBalance: buildWalletBalance({ balanceUAKT: 1_000_000_000 }),
+      price: 4,
+      bmeParams: { minMintUact: 10_000_000, minMintAct: 10, mintSpreadBps: 100, settleSpreadBps: 0 }
+    });
+
+    const fromInput = screen.getByLabelText("From") as HTMLInputElement;
+
+    act(() => {
+      fireEvent.focus(fromInput);
+    });
+
+    act(() => {
+      fireEvent.change(fromInput, { target: { value: "100" } });
+    });
+
+    // 100 AKT * 4 (price) * (1 - 100/10000) = 100 * 4 * 0.99 = 396
+    expect((screen.getByLabelText("To") as HTMLInputElement).value).toBe("396");
+  });
+
+  function setup(input?: { walletBalance?: WalletBalance | null; price?: number; bmeParams?: BmeParams; bmeStatus?: BmeStatus }) {
     const signAndBroadcastTx = vi.fn().mockResolvedValue(true);
     const refetchBalance = vi.fn();
     const invalidateLedger = vi.fn();
@@ -282,6 +435,8 @@ describe(MintBurnPage.name, () => {
         enqueueSnackbar
       }),
       useSupportsACT: () => true,
+      useBmeParams: () => ({ data: input?.bmeParams, isLoading: false }),
+      useBmeStatus: () => ({ data: input?.bmeStatus, isLoading: false }),
       useLedgerRecords: () => ({
         data: null,
         isLoading: false,

--- a/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.tsx
+++ b/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.tsx
@@ -12,7 +12,7 @@ import { useWallet } from "@src/context/WalletProvider";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useSupportsACT } from "@src/hooks/useSupportsACT/useSupportsACT";
 import { useWalletBalance } from "@src/hooks/useWalletBalance";
-import { useBmeParams, useBmeStatus } from "@src/queries/useBmeQuery";
+import { useBmeParams } from "@src/queries/useBmeQuery";
 import { useLedgerRecords } from "@src/queries/useLedgerRecords";
 import { denomToUdenom, roundDecimal, udenomToDenom } from "@src/utils/mathHelpers";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
@@ -48,7 +48,6 @@ export const DEPENDENCIES = {
   useSnackbar,
   useSupportsACT,
   useBmeParams,
-  useBmeStatus,
   useLedgerRecords,
   LedgerRecordsTable
 };
@@ -69,7 +68,6 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
   const { enqueueSnackbar } = d.useSnackbar();
   const isACTSupported = d.useSupportsACT();
   const { data: bmeParams } = d.useBmeParams({ enabled: isACTSupported });
-  const { data: bmeStatus } = d.useBmeStatus({ enabled: isACTSupported });
   const { data: ledgerData, isLoading: isLedgerLoading, invalidate: invalidateLedger } = d.useLedgerRecords(address);
 
   const aktBalance = useMemo(() => (balance ? udenomToDenom(balance.balanceUAKT, 6) : 0), [balance]);
@@ -82,29 +80,15 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
     return Number.isNaN(val) || val < 0 ? 0 : val;
   }, [amount]);
 
-  const effectiveRate = useMemo(() => {
-    if (!price) return undefined;
-    const mintSpread = bmeParams ? bmeParams.mintSpreadBps / 10_000 : 0;
-    const settleSpread = bmeParams ? bmeParams.settleSpreadBps / 10_000 : 0;
-    return {
-      mint: price * (1 - mintSpread),
-      burn: (1 / price) * (1 - settleSpread)
-    };
-  }, [price, bmeParams]);
-
   const aktDisplay = useMemo(() => {
     if (denom === "AKT") return amount;
-    const rate = isMint ? effectiveRate?.mint : effectiveRate?.burn;
-    if (!rate || !effectiveAmount) return "";
-    return isMint ? roundDecimal(effectiveAmount / rate, 6).toString() : roundDecimal(effectiveAmount * rate, 6).toString();
-  }, [denom, amount, effectiveAmount, effectiveRate, isMint]);
+    return price && effectiveAmount ? roundDecimal(effectiveAmount / price, 6).toString() : "";
+  }, [denom, amount, effectiveAmount, price]);
 
   const actDisplay = useMemo(() => {
     if (denom === "ACT") return amount;
-    const rate = isMint ? effectiveRate?.mint : effectiveRate?.burn;
-    if (!rate || !effectiveAmount) return "";
-    return isMint ? roundDecimal(effectiveAmount * rate, 6).toString() : roundDecimal(effectiveAmount / rate, 6).toString();
-  }, [denom, amount, effectiveAmount, effectiveRate, isMint]);
+    return price && effectiveAmount ? roundDecimal(effectiveAmount * price, 6).toString() : "";
+  }, [denom, amount, effectiveAmount, price]);
 
   const fromAmount = isMint ? aktDisplay : actDisplay;
   const toAmount = isMint ? actDisplay : aktDisplay;
@@ -129,11 +113,6 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
     if (!isMint || !bmeParams || !effectiveActAmount) return false;
     return effectiveActAmount < bmeParams.minMintAct;
   }, [isMint, bmeParams, effectiveActAmount]);
-
-  const isMintDisabled = bmeStatus ? !bmeStatus.mintsAllowed : false;
-  const isBurnDisabled = bmeStatus ? !bmeStatus.refundsAllowed : false;
-
-  const isCircuitBreakerWarning = !!bmeStatus && !isMintDisabled && !isBurnDisabled && bmeStatus.collateralRatio <= bmeStatus.circuitBreakerWarnThreshold;
 
   const focusField = useCallback(
     (fieldDenom: "AKT" | "ACT", currentDisplay: string) => {
@@ -197,9 +176,6 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
     return null;
   }
 
-  const spreadBps = isMint ? bmeParams?.mintSpreadBps : bmeParams?.settleSpreadBps;
-  const hasSpread = spreadBps !== undefined && spreadBps > 0;
-
   return (
     <d.Layout>
       <div className="mx-auto max-w-2xl py-6">
@@ -213,27 +189,6 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
           Convert between AKT and ACT (Akash Compute Token). ACT is a USD-pegged token used to pay for deployments. Mint ACT by burning AKT at the current
           oracle rate, or burn unused ACT to redeem AKT. ACT has no expiration and is fully refundable.
         </p>
-
-        {isMint && isMintDisabled && (
-          <d.Alert variant="destructive" className="mb-4">
-            <p className="text-sm">Minting is currently disabled due to the circuit breaker. The collateral ratio has fallen below the safe threshold.</p>
-          </d.Alert>
-        )}
-
-        {!isMint && isBurnDisabled && (
-          <d.Alert variant="destructive" className="mb-4">
-            <p className="text-sm">Settling ACT is currently disabled due to the circuit breaker.</p>
-          </d.Alert>
-        )}
-
-        {isCircuitBreakerWarning && (
-          <d.Alert variant="warning" className="mb-4">
-            <p className="text-sm">
-              The collateral ratio ({roundDecimal(bmeStatus?.collateralRatio ?? 0, 4)}) is approaching the circuit breaker threshold. Minting or settling may be
-              paused soon.
-            </p>
-          </d.Alert>
-        )}
 
         <d.Card className="mb-4">
           <d.CardContent className="space-y-4 p-4">
@@ -279,15 +234,9 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
                 inputClassName="tabular-nums"
               />
               {isPriceLoaded && price && (
-                <div className="mt-1 space-y-0.5 text-xs text-muted-foreground">
-                  <p>Oracle: 1 AKT = {roundDecimal(price, 4)} ACT</p>
-                  {hasSpread && effectiveRate && (
-                    <p>
-                      Effective: 1 {isMint ? "AKT" : "ACT"} = {roundDecimal(isMint ? effectiveRate.mint : effectiveRate.burn, 4)} {isMint ? "ACT" : "AKT"} (
-                      {(spreadBps! / 100).toFixed(2)}% spread)
-                    </p>
-                  )}
-                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Rate: {isMint ? `1 AKT = ${roundDecimal(price, 4)} ACT` : `1 ACT = ${roundDecimal(1 / price, 4)} AKT`}
+                </p>
               )}
             </div>
           </d.CardContent>
@@ -329,20 +278,11 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
         <d.Button
           className="w-full"
           size="lg"
-          disabled={
-            !effectiveFromAmount ||
-            insufficientBalance ||
-            isSubmitting ||
-            isBalanceLoading ||
-            !isPriceLoaded ||
-            belowMinMint ||
-            (isMint && isMintDisabled) ||
-            (!isMint && isBurnDisabled)
-          }
+          disabled={!effectiveFromAmount || insufficientBalance || isSubmitting || isBalanceLoading || !isPriceLoaded || belowMinMint}
           onClick={submitForm}
           aria-label="Submit"
         >
-          {isSubmitting ? "Processing..." : isMint ? (isMintDisabled ? "Minting Paused" : "Mint ACT") : isBurnDisabled ? "Settling Paused" : "Burn ACT"}
+          {isSubmitting ? "Processing..." : isMint ? "Mint ACT" : "Burn ACT"}
         </d.Button>
 
         <d.Card className="mt-6">

--- a/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.tsx
+++ b/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.tsx
@@ -12,6 +12,7 @@ import { useWallet } from "@src/context/WalletProvider";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useSupportsACT } from "@src/hooks/useSupportsACT/useSupportsACT";
 import { useWalletBalance } from "@src/hooks/useWalletBalance";
+import { useBmeParams, useBmeStatus } from "@src/queries/useBmeQuery";
 import { useLedgerRecords } from "@src/queries/useLedgerRecords";
 import { denomToUdenom, roundDecimal, udenomToDenom } from "@src/utils/mathHelpers";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
@@ -46,6 +47,8 @@ export const DEPENDENCIES = {
   useWalletBalance,
   useSnackbar,
   useSupportsACT,
+  useBmeParams,
+  useBmeStatus,
   useLedgerRecords,
   LedgerRecordsTable
 };
@@ -64,6 +67,9 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
   const { balance, isLoading: isBalanceLoading } = d.useWalletBalance();
   const { price, isLoaded: isPriceLoaded } = d.usePricing();
   const { enqueueSnackbar } = d.useSnackbar();
+  const isACTSupported = d.useSupportsACT();
+  const { data: bmeParams } = d.useBmeParams({ enabled: isACTSupported });
+  const { data: bmeStatus } = d.useBmeStatus({ enabled: isACTSupported });
   const { data: ledgerData, isLoading: isLedgerLoading, invalidate: invalidateLedger } = d.useLedgerRecords(address);
 
   const aktBalance = useMemo(() => (balance ? udenomToDenom(balance.balanceUAKT, 6) : 0), [balance]);
@@ -76,15 +82,29 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
     return Number.isNaN(val) || val < 0 ? 0 : val;
   }, [amount]);
 
+  const effectiveRate = useMemo(() => {
+    if (!price) return undefined;
+    const mintSpread = bmeParams ? bmeParams.mintSpreadBps / 10_000 : 0;
+    const settleSpread = bmeParams ? bmeParams.settleSpreadBps / 10_000 : 0;
+    return {
+      mint: price * (1 - mintSpread),
+      burn: (1 / price) * (1 - settleSpread)
+    };
+  }, [price, bmeParams]);
+
   const aktDisplay = useMemo(() => {
     if (denom === "AKT") return amount;
-    return price && effectiveAmount ? roundDecimal(effectiveAmount / price, 6).toString() : "";
-  }, [denom, amount, effectiveAmount, price]);
+    const rate = isMint ? effectiveRate?.mint : effectiveRate?.burn;
+    if (!rate || !effectiveAmount) return "";
+    return isMint ? roundDecimal(effectiveAmount / rate, 6).toString() : roundDecimal(effectiveAmount * rate, 6).toString();
+  }, [denom, amount, effectiveAmount, effectiveRate, isMint]);
 
   const actDisplay = useMemo(() => {
     if (denom === "ACT") return amount;
-    return price && effectiveAmount ? roundDecimal(effectiveAmount * price, 6).toString() : "";
-  }, [denom, amount, effectiveAmount, price]);
+    const rate = isMint ? effectiveRate?.mint : effectiveRate?.burn;
+    if (!rate || !effectiveAmount) return "";
+    return isMint ? roundDecimal(effectiveAmount * rate, 6).toString() : roundDecimal(effectiveAmount / rate, 6).toString();
+  }, [denom, amount, effectiveAmount, effectiveRate, isMint]);
 
   const fromAmount = isMint ? aktDisplay : actDisplay;
   const toAmount = isMint ? actDisplay : aktDisplay;
@@ -104,6 +124,24 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
   }, [isMint, aktBalance, actBalance]);
 
   const insufficientBalance = effectiveFromAmount > maxFromAmount;
+
+  const estimatedOutput = useMemo(() => {
+    if (!effectiveRate || !effectiveFromAmount) return 0;
+    return isMint ? effectiveFromAmount * effectiveRate.mint : effectiveFromAmount * effectiveRate.burn;
+  }, [effectiveFromAmount, effectiveRate, isMint]);
+
+  const belowMinMint = useMemo(() => {
+    if (!isMint || !bmeParams || !effectiveFromAmount || !estimatedOutput) return false;
+    return estimatedOutput < bmeParams.minMintAct;
+  }, [isMint, bmeParams, effectiveFromAmount, estimatedOutput]);
+
+  const isMintDisabled = bmeStatus ? !bmeStatus.mintsAllowed : false;
+  const isBurnDisabled = bmeStatus ? !bmeStatus.refundsAllowed : false;
+
+  const isCircuitBreakerWarning = useMemo(() => {
+    if (!bmeStatus || isMintDisabled || isBurnDisabled) return false;
+    return bmeStatus.collateralRatio <= bmeStatus.circuitBreakerWarnThreshold;
+  }, [bmeStatus, isMintDisabled, isBurnDisabled]);
 
   const focusField = useCallback(
     (fieldDenom: "AKT" | "ACT", currentDisplay: string) => {
@@ -138,7 +176,7 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
   }, []);
 
   const submitForm = useCallback(async () => {
-    if (!address || !effectiveFromAmount || insufficientBalance) return;
+    if (!address || !effectiveFromAmount || insufficientBalance || belowMinMint) return;
 
     setIsSubmitting(true);
     try {
@@ -161,12 +199,14 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
     } finally {
       setIsSubmitting(false);
     }
-  }, [address, effectiveFromAmount, insufficientBalance, isMint, signAndBroadcastTx, enqueueSnackbar, invalidateLedger, resetForm, d]);
-  const isACTSupported = d.useSupportsACT();
+  }, [address, effectiveFromAmount, insufficientBalance, belowMinMint, isMint, signAndBroadcastTx, enqueueSnackbar, invalidateLedger, resetForm, d]);
 
   if (!isACTSupported || !isCustodial) {
     return null;
   }
+
+  const spreadBps = isMint ? bmeParams?.mintSpreadBps : bmeParams?.settleSpreadBps;
+  const hasSpread = spreadBps !== undefined && spreadBps > 0;
 
   return (
     <d.Layout>
@@ -181,6 +221,27 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
           Convert between AKT and ACT (Akash Compute Token). ACT is a USD-pegged token used to pay for deployments. Mint ACT by burning AKT at the current
           oracle rate, or burn unused ACT to redeem AKT. ACT has no expiration and is fully refundable.
         </p>
+
+        {isMint && isMintDisabled && (
+          <d.Alert variant="destructive" className="mb-4">
+            <p className="text-sm">Minting is currently disabled due to the circuit breaker. The collateral ratio has fallen below the safe threshold.</p>
+          </d.Alert>
+        )}
+
+        {!isMint && isBurnDisabled && (
+          <d.Alert variant="destructive" className="mb-4">
+            <p className="text-sm">Settling ACT is currently disabled due to the circuit breaker.</p>
+          </d.Alert>
+        )}
+
+        {isCircuitBreakerWarning && (
+          <d.Alert variant="warning" className="mb-4">
+            <p className="text-sm">
+              The collateral ratio ({roundDecimal(bmeStatus!.collateralRatio, 4)}) is approaching the circuit breaker threshold. Minting or settling may be
+              paused soon.
+            </p>
+          </d.Alert>
+        )}
 
         <d.Card className="mb-4">
           <d.CardContent className="space-y-4 p-4">
@@ -226,9 +287,15 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
                 inputClassName="tabular-nums"
               />
               {isPriceLoaded && price && (
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Rate: {isMint ? `1 AKT = ${roundDecimal(price, 4)} ACT` : `1 ACT = ${roundDecimal(1 / price, 4)} AKT`}
-                </p>
+                <div className="mt-1 space-y-0.5 text-xs text-muted-foreground">
+                  <p>Oracle: 1 AKT = {roundDecimal(price, 4)} ACT</p>
+                  {hasSpread && effectiveRate && (
+                    <p>
+                      Effective: 1 {isMint ? "AKT" : "ACT"} = {roundDecimal(isMint ? effectiveRate.mint : effectiveRate.burn, 4)} {isMint ? "ACT" : "AKT"} (
+                      {(spreadBps! / 100).toFixed(2)}% spread)
+                    </p>
+                  )}
+                </div>
               )}
             </div>
           </d.CardContent>
@@ -244,6 +311,15 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
             Everything
           </d.Button>
         </div>
+
+        {belowMinMint && bmeParams && (
+          <d.Alert variant="destructive" className="mb-4">
+            <p className="text-sm">
+              Estimated output ({roundDecimal(estimatedOutput, 2)} ACT) is below the minimum mint amount of {bmeParams.minMintAct} ACT. Increase the amount to
+              proceed.
+            </p>
+          </d.Alert>
+        )}
 
         {!isBalanceLoading && insufficientBalance && effectiveFromAmount > 0 && (
           <d.Alert variant="destructive" className="mb-4">
@@ -261,11 +337,20 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
         <d.Button
           className="w-full"
           size="lg"
-          disabled={!effectiveFromAmount || insufficientBalance || isSubmitting || isBalanceLoading || !isPriceLoaded}
+          disabled={
+            !effectiveFromAmount ||
+            insufficientBalance ||
+            isSubmitting ||
+            isBalanceLoading ||
+            !isPriceLoaded ||
+            belowMinMint ||
+            (isMint && isMintDisabled) ||
+            (!isMint && isBurnDisabled)
+          }
           onClick={submitForm}
           aria-label="Submit"
         >
-          {isSubmitting ? "Processing..." : isMint ? "Mint ACT" : "Burn ACT"}
+          {isSubmitting ? "Processing..." : isMint ? (isMintDisabled ? "Minting Paused" : "Mint ACT") : isBurnDisabled ? "Settling Paused" : "Burn ACT"}
         </d.Button>
 
         <d.Card className="mt-6">

--- a/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.tsx
+++ b/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.tsx
@@ -125,23 +125,15 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
 
   const insufficientBalance = effectiveFromAmount > maxFromAmount;
 
-  const estimatedOutput = useMemo(() => {
-    if (!effectiveRate || !effectiveFromAmount) return 0;
-    return isMint ? effectiveFromAmount * effectiveRate.mint : effectiveFromAmount * effectiveRate.burn;
-  }, [effectiveFromAmount, effectiveRate, isMint]);
-
   const belowMinMint = useMemo(() => {
-    if (!isMint || !bmeParams || !effectiveFromAmount || !estimatedOutput) return false;
-    return estimatedOutput < bmeParams.minMintAct;
-  }, [isMint, bmeParams, effectiveFromAmount, estimatedOutput]);
+    if (!isMint || !bmeParams || !effectiveActAmount) return false;
+    return effectiveActAmount < bmeParams.minMintAct;
+  }, [isMint, bmeParams, effectiveActAmount]);
 
   const isMintDisabled = bmeStatus ? !bmeStatus.mintsAllowed : false;
   const isBurnDisabled = bmeStatus ? !bmeStatus.refundsAllowed : false;
 
-  const isCircuitBreakerWarning = useMemo(() => {
-    if (!bmeStatus || isMintDisabled || isBurnDisabled) return false;
-    return bmeStatus.collateralRatio <= bmeStatus.circuitBreakerWarnThreshold;
-  }, [bmeStatus, isMintDisabled, isBurnDisabled]);
+  const isCircuitBreakerWarning = !!bmeStatus && !isMintDisabled && !isBurnDisabled && bmeStatus.collateralRatio <= bmeStatus.circuitBreakerWarnThreshold;
 
   const focusField = useCallback(
     (fieldDenom: "AKT" | "ACT", currentDisplay: string) => {
@@ -237,7 +229,7 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
         {isCircuitBreakerWarning && (
           <d.Alert variant="warning" className="mb-4">
             <p className="text-sm">
-              The collateral ratio ({roundDecimal(bmeStatus!.collateralRatio, 4)}) is approaching the circuit breaker threshold. Minting or settling may be
+              The collateral ratio ({roundDecimal(bmeStatus?.collateralRatio ?? 0, 4)}) is approaching the circuit breaker threshold. Minting or settling may be
               paused soon.
             </p>
           </d.Alert>
@@ -315,8 +307,8 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
         {belowMinMint && bmeParams && (
           <d.Alert variant="destructive" className="mb-4">
             <p className="text-sm">
-              Estimated output ({roundDecimal(estimatedOutput, 2)} ACT) is below the minimum mint amount of {bmeParams.minMintAct} ACT. Increase the amount to
-              proceed.
+              Estimated output ({roundDecimal(effectiveActAmount, 2)} ACT) is below the minimum mint amount of {bmeParams.minMintAct} ACT. Increase the amount
+              to proceed.
             </p>
           </d.Alert>
         )}

--- a/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.tsx
+++ b/apps/deploy-web/src/components/MintBurnPage/MintBurnPage.tsx
@@ -67,7 +67,7 @@ export const MintBurnPage: React.FC<MintBurnPageProps> = ({ dependencies: d = DE
   const { price, isLoaded: isPriceLoaded } = d.usePricing();
   const { enqueueSnackbar } = d.useSnackbar();
   const isACTSupported = d.useSupportsACT();
-  const { data: bmeParams } = d.useBmeParams({ enabled: isACTSupported });
+  const { data: bmeParams } = d.useBmeParams();
   const { data: ledgerData, isLoading: isLedgerLoading, invalidate: invalidateLedger } = d.useLedgerRecords(address);
 
   const aktBalance = useMemo(() => (balance ? udenomToDenom(balance.balanceUAKT, 6) : 0), [balance]);

--- a/apps/deploy-web/src/queries/queryKeys.ts
+++ b/apps/deploy-web/src/queries/queryKeys.ts
@@ -47,6 +47,8 @@ export class QueryKeys {
   static getTemplatesKey = () => ["TEMPLATES"];
   static getProviderAttributesSchema = () => ["PROVIDER_ATTRIBUTES_SCHEMA"];
   static getDepositParamsKey = () => ["DEPOSIT_PARAMS"];
+  static getBmeParamsKey = () => ["BME_PARAMS"];
+  static getBmeStatusKey = () => ["BME_STATUS"];
   static getGpuModelsKey = () => ["GPU_MODELS"];
   static getTrialProvidersKey = () => ["TRIAL_PROVIDERS"];
   static getDeploymentSettingKey = (userId: string, dseq: string) => ["DEPLOYMENT_SETTING", userId, dseq];

--- a/apps/deploy-web/src/queries/queryKeys.ts
+++ b/apps/deploy-web/src/queries/queryKeys.ts
@@ -48,7 +48,6 @@ export class QueryKeys {
   static getProviderAttributesSchema = () => ["PROVIDER_ATTRIBUTES_SCHEMA"];
   static getDepositParamsKey = () => ["DEPOSIT_PARAMS"];
   static getBmeParamsKey = () => ["BME_PARAMS"];
-  static getBmeStatusKey = () => ["BME_STATUS"];
   static getGpuModelsKey = () => ["GPU_MODELS"];
   static getTrialProvidersKey = () => ["TRIAL_PROVIDERS"];
   static getDeploymentSettingKey = (userId: string, dseq: string) => ["DEPLOYMENT_SETTING", userId, dseq];

--- a/apps/deploy-web/src/queries/useBmeQuery.ts
+++ b/apps/deploy-web/src/queries/useBmeQuery.ts
@@ -1,15 +1,13 @@
 import type { UseQueryOptions } from "@tanstack/react-query";
 import { useQuery } from "@tanstack/react-query";
 import type { AxiosInstance } from "axios";
+import { millisecondsInMinute } from "date-fns/constants";
 
 import { useServices } from "@src/context/ServicesProvider";
 import type { BmeParams, BmeStatus, RpcBmeParams, RpcBmeStatus } from "@src/types/bme";
 import { ApiUrlService } from "@src/utils/apiUtils";
 import { udenomToDenom } from "@src/utils/mathHelpers";
 import { QueryKeys } from "./queryKeys";
-
-const FIVE_MINUTES_MS = 5 * 60 * 1000;
-const ONE_MINUTE_MS = 60 * 1000;
 
 async function getBmeParams(chainApiHttpClient: AxiosInstance): Promise<BmeParams> {
   const response = await chainApiHttpClient.get<RpcBmeParams>(ApiUrlService.bmeParams(""));
@@ -39,8 +37,8 @@ export function useBmeParams(options?: Omit<UseQueryOptions<BmeParams>, "queryKe
   return useQuery({
     queryKey: QueryKeys.getBmeParamsKey(),
     queryFn: () => getBmeParams(chainApiHttpClient),
-    staleTime: FIVE_MINUTES_MS,
-    gcTime: FIVE_MINUTES_MS,
+    staleTime: 5 * millisecondsInMinute,
+    gcTime: 5 * millisecondsInMinute,
     ...options,
     enabled: options?.enabled !== false && !chainApiHttpClient.isFallbackEnabled
   });
@@ -51,8 +49,8 @@ export function useBmeStatus(options?: Omit<UseQueryOptions<BmeStatus>, "queryKe
   return useQuery({
     queryKey: QueryKeys.getBmeStatusKey(),
     queryFn: () => getBmeStatus(chainApiHttpClient),
-    staleTime: ONE_MINUTE_MS,
-    refetchInterval: ONE_MINUTE_MS,
+    staleTime: millisecondsInMinute,
+    refetchInterval: millisecondsInMinute,
     ...options,
     enabled: options?.enabled !== false && !chainApiHttpClient.isFallbackEnabled
   });

--- a/apps/deploy-web/src/queries/useBmeQuery.ts
+++ b/apps/deploy-web/src/queries/useBmeQuery.ts
@@ -1,0 +1,59 @@
+import type { UseQueryOptions } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
+import type { AxiosInstance } from "axios";
+
+import { useServices } from "@src/context/ServicesProvider";
+import type { BmeParams, BmeStatus, RpcBmeParams, RpcBmeStatus } from "@src/types/bme";
+import { ApiUrlService } from "@src/utils/apiUtils";
+import { udenomToDenom } from "@src/utils/mathHelpers";
+import { QueryKeys } from "./queryKeys";
+
+const FIVE_MINUTES_MS = 5 * 60 * 1000;
+const ONE_MINUTE_MS = 60 * 1000;
+
+async function getBmeParams(chainApiHttpClient: AxiosInstance): Promise<BmeParams> {
+  const response = await chainApiHttpClient.get<RpcBmeParams>(ApiUrlService.bmeParams(""));
+  const { params } = response.data;
+  const minMintUact = parseInt(params.min_mint.amount, 10);
+  return {
+    minMintUact,
+    minMintAct: udenomToDenom(minMintUact),
+    mintSpreadBps: params.mint_spread_bps,
+    settleSpreadBps: params.settle_spread_bps
+  };
+}
+
+async function getBmeStatus(chainApiHttpClient: AxiosInstance): Promise<BmeStatus> {
+  const response = await chainApiHttpClient.get<RpcBmeStatus>(ApiUrlService.bmeStatus(""));
+  const { status } = response.data;
+  return {
+    mintsAllowed: status.mints_allowed,
+    refundsAllowed: status.refunds_allowed,
+    collateralRatio: parseFloat(status.collateral_ratio),
+    circuitBreakerWarnThreshold: parseFloat(status.circuit_breaker_warn_threshold)
+  };
+}
+
+export function useBmeParams(options?: Omit<UseQueryOptions<BmeParams>, "queryKey" | "queryFn">) {
+  const { chainApiHttpClient } = useServices();
+  return useQuery({
+    queryKey: QueryKeys.getBmeParamsKey(),
+    queryFn: () => getBmeParams(chainApiHttpClient),
+    staleTime: FIVE_MINUTES_MS,
+    gcTime: FIVE_MINUTES_MS,
+    ...options,
+    enabled: options?.enabled !== false && !chainApiHttpClient.isFallbackEnabled
+  });
+}
+
+export function useBmeStatus(options?: Omit<UseQueryOptions<BmeStatus>, "queryKey" | "queryFn">) {
+  const { chainApiHttpClient } = useServices();
+  return useQuery({
+    queryKey: QueryKeys.getBmeStatusKey(),
+    queryFn: () => getBmeStatus(chainApiHttpClient),
+    staleTime: ONE_MINUTE_MS,
+    refetchInterval: ONE_MINUTE_MS,
+    ...options,
+    enabled: options?.enabled !== false && !chainApiHttpClient.isFallbackEnabled
+  });
+}

--- a/apps/deploy-web/src/queries/useBmeQuery.ts
+++ b/apps/deploy-web/src/queries/useBmeQuery.ts
@@ -4,7 +4,7 @@ import type { AxiosInstance } from "axios";
 import { millisecondsInMinute } from "date-fns/constants";
 
 import { useServices } from "@src/context/ServicesProvider";
-import type { BmeParams, BmeStatus, RpcBmeParams, RpcBmeStatus } from "@src/types/bme";
+import type { BmeParams, RpcBmeParams } from "@src/types/bme";
 import { ApiUrlService } from "@src/utils/apiUtils";
 import { udenomToDenom } from "@src/utils/mathHelpers";
 import { QueryKeys } from "./queryKeys";
@@ -15,20 +15,7 @@ async function getBmeParams(chainApiHttpClient: AxiosInstance): Promise<BmeParam
   const minMintUact = parseInt(params.min_mint.amount, 10);
   return {
     minMintUact,
-    minMintAct: udenomToDenom(minMintUact),
-    mintSpreadBps: params.mint_spread_bps,
-    settleSpreadBps: params.settle_spread_bps
-  };
-}
-
-async function getBmeStatus(chainApiHttpClient: AxiosInstance): Promise<BmeStatus> {
-  const response = await chainApiHttpClient.get<RpcBmeStatus>(ApiUrlService.bmeStatus(""));
-  const { status } = response.data;
-  return {
-    mintsAllowed: status.mints_allowed,
-    refundsAllowed: status.refunds_allowed,
-    collateralRatio: parseFloat(status.collateral_ratio),
-    circuitBreakerWarnThreshold: parseFloat(status.circuit_breaker_warn_threshold)
+    minMintAct: udenomToDenom(minMintUact)
   };
 }
 
@@ -39,18 +26,6 @@ export function useBmeParams(options?: Omit<UseQueryOptions<BmeParams>, "queryKe
     queryFn: () => getBmeParams(chainApiHttpClient),
     staleTime: 5 * millisecondsInMinute,
     gcTime: 5 * millisecondsInMinute,
-    ...options,
-    enabled: options?.enabled !== false && !chainApiHttpClient.isFallbackEnabled
-  });
-}
-
-export function useBmeStatus(options?: Omit<UseQueryOptions<BmeStatus>, "queryKey" | "queryFn">) {
-  const { chainApiHttpClient } = useServices();
-  return useQuery({
-    queryKey: QueryKeys.getBmeStatusKey(),
-    queryFn: () => getBmeStatus(chainApiHttpClient),
-    staleTime: millisecondsInMinute,
-    refetchInterval: millisecondsInMinute,
     ...options,
     enabled: options?.enabled !== false && !chainApiHttpClient.isFallbackEnabled
   });

--- a/apps/deploy-web/src/types/bme.ts
+++ b/apps/deploy-web/src/types/bme.ts
@@ -1,0 +1,34 @@
+/** Response from /akash/bme/v1/params */
+export interface RpcBmeParams {
+  params: {
+    min_mint: { denom: string; amount: string };
+    mint_spread_bps: number;
+    settle_spread_bps: number;
+  };
+}
+
+/** Response from /akash/bme/v1/status */
+export interface RpcBmeStatus {
+  status: {
+    mints_allowed: boolean;
+    refunds_allowed: boolean;
+    collateral_ratio: string;
+    circuit_breaker_warn_threshold: string;
+  };
+}
+
+/** Parsed BME params for consumer use */
+export interface BmeParams {
+  minMintUact: number;
+  minMintAct: number;
+  mintSpreadBps: number;
+  settleSpreadBps: number;
+}
+
+/** Parsed BME status for consumer use */
+export interface BmeStatus {
+  mintsAllowed: boolean;
+  refundsAllowed: boolean;
+  collateralRatio: number;
+  circuitBreakerWarnThreshold: number;
+}

--- a/apps/deploy-web/src/types/bme.ts
+++ b/apps/deploy-web/src/types/bme.ts
@@ -2,18 +2,6 @@
 export interface RpcBmeParams {
   params: {
     min_mint: { denom: string; amount: string };
-    mint_spread_bps: number;
-    settle_spread_bps: number;
-  };
-}
-
-/** Response from /akash/bme/v1/status */
-export interface RpcBmeStatus {
-  status: {
-    mints_allowed: boolean;
-    refunds_allowed: boolean;
-    collateral_ratio: string;
-    circuit_breaker_warn_threshold: string;
   };
 }
 
@@ -21,14 +9,4 @@ export interface RpcBmeStatus {
 export interface BmeParams {
   minMintUact: number;
   minMintAct: number;
-  mintSpreadBps: number;
-  settleSpreadBps: number;
-}
-
-/** Parsed BME status for consumer use */
-export interface BmeStatus {
-  mintsAllowed: boolean;
-  refundsAllowed: boolean;
-  collateralRatio: number;
-  circuitBreakerWarnThreshold: number;
 }

--- a/apps/deploy-web/src/utils/apiUtils.ts
+++ b/apps/deploy-web/src/utils/apiUtils.ts
@@ -125,6 +125,12 @@ export class ApiUrlService {
   static trialProviders() {
     return `${this.baseApiUrl}/v1/trial-providers`;
   }
+  static bmeParams(apiEndpoint: string) {
+    return `${apiEndpoint}/akash/bme/v1/params`;
+  }
+  static bmeStatus(apiEndpoint: string) {
+    return `${apiEndpoint}/akash/bme/v1/status`;
+  }
 
   static get baseApiUrl() {
     return services.apiUrlService.getBaseApiUrlFor(networkStore.selectedNetworkId);

--- a/apps/deploy-web/src/utils/apiUtils.ts
+++ b/apps/deploy-web/src/utils/apiUtils.ts
@@ -128,9 +128,6 @@ export class ApiUrlService {
   static bmeParams(apiEndpoint: string) {
     return `${apiEndpoint}/akash/bme/v1/params`;
   }
-  static bmeStatus(apiEndpoint: string) {
-    return `${apiEndpoint}/akash/bme/v1/status`;
-  }
 
   static get baseApiUrl() {
     return services.apiUrlService.getBaseApiUrlFor(networkStore.selectedNetworkId);


### PR DESCRIPTION
## Why

Fixes CON-115

When a user tries to mint ACT with insufficient AKT (below `min_mint`), the transaction gets submitted but is silently canceled ~5 blocks later. There is no client-side feedback. This PR adds min mint validation so users get immediate feedback before submitting transactions that will be canceled.

Circuit breaker states and spread display will be handled in separate Linear issues.

## What

- Fetch BME params (`min_mint`) from chain REST endpoint (`/akash/bme/v1/params`)
- Validate mint input: show inline error when estimated ACT output is below `min_mint`
- Disable submit button when below minimum mint threshold
- Graceful degradation: falls back to current oracle-only behavior if BME endpoint is unavailable

**New files:**
- `apps/deploy-web/src/types/bme.ts` — Type definitions for chain REST response
- `apps/deploy-web/src/queries/useBmeQuery.ts` — `useBmeParams` (5min stale) React Query hook

**Modified files:**
- `apps/deploy-web/src/components/MintBurnPage/MintBurnPage.tsx` — min_mint validation UI
- `apps/deploy-web/src/components/MintBurnPage/MintBurnPage.spec.tsx` — 3 new tests for min mint validation (23 total)
- `apps/deploy-web/src/queries/queryKeys.ts` — BME query key
- `apps/deploy-web/src/utils/apiUtils.ts` — BME endpoint URL method

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fetches BME parameters to enforce a minimum-mint threshold: shows a destructive inline “below minimum mint amount” error in mint mode and disables Submit when estimated output is below the minimum.
  * Swap/burn flows do not show the below-minimum mint error.

* **Tests**
  * Added tests covering min-mint validation (mint shows error, burn does not) and Submit disabling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->