### PR TITLE
fix(managed-wallet): switch sandbox denom from uakt to uact

### DIFF
--- a/apps/api/env/.env.sandbox
+++ b/apps/api/env/.env.sandbox
@@ -1,3 +1,3 @@
 REST_API_NODE_URL=https://api.sandbox-2.aksh.pw:443
 RPC_NODE_ENDPOINT=https://rpc.sandbox-2.aksh.pw:443
-DEPLOYMENT_GRANT_DENOM=uakt
+DEPLOYMENT_GRANT_DENOM=uact

--- a/packages/database/chainDefinitions.ts
+++ b/packages/database/chainDefinitions.ts
@@ -132,8 +132,8 @@ export const chainDefinitions: { [key: string]: ChainDef } = {
     logoUrlPNG: "https://console.akash.network/images/chains/akash.png",
     customIndexers: ["AkashStatsIndexer", "BmeIndexer"],
     bech32Prefix: "akash",
-    denom: "akt",
-    udenom: "uakt",
+    denom: "act",
+    udenom: "uact",
     customBlockModel: AkashBlock,
     customMessageModel: AkashMessage,
     customModels: [


### PR DESCRIPTION
## Why

Sandbox chain has migrated to uact as its native denom with the BME upgrade. Managed wallets and the indexer need to use the correct denom.

## What

- Update `DEPLOYMENT_GRANT_DENOM` from `uakt` to `uact` in sandbox env
- Update sandbox chain definition `denom`/`udenom` from `akt`/`uakt` to `act`/`uact`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated denomination configuration values across environment variables and application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->