### PR TITLE
fix(deployment): add backward compat for legacy deposit params endpoint

### DIFF
--- a/apps/deploy-web/src/queries/useSaveSettings.spec.tsx
+++ b/apps/deploy-web/src/queries/useSaveSettings.spec.tsx
@@ -10,6 +10,7 @@ import type { FallbackableHttpClient } from "@src/services/createFallbackableHtt
 import type { ErrorHandlerService } from "@src/services/error-handler/error-handler.service";
 import { CustomSnackbarProvider } from "../../../../packages/ui/context/CustomSnackbarProvider";
 import { setupQuery } from "../../tests/unit/query-client";
+import type { DEPOSIT_PARAMS_DEPS } from "./useSaveSettings";
 import { useDepositParams, useSaveSettings } from "./useSaveSettings";
 
 import { act, screen } from "@testing-library/react";
@@ -79,7 +80,7 @@ describe("Settings management", () => {
   });
 
   describe(useDepositParams.name, () => {
-    it("should fetch deposit params from module endpoint", async () => {
+    it("should fetch deposit params from module endpoint when ACT is supported", async () => {
       const chainApiHttpClient = mock<FallbackableHttpClient>({
         isFallbackEnabled: false
       } as FallbackableHttpClient);
@@ -88,23 +89,33 @@ describe("Settings management", () => {
         { denom: "uact", amount: "500000" }
       ];
       chainApiHttpClient.get.mockResolvedValue({
-        data: {
-          params: {
-            min_deposits: minDeposits
-          }
-        }
+        data: { params: { min_deposits: minDeposits } }
       });
 
-      const { result } = setupQuery(() => useDepositParams(), {
-        services: {
-          chainApiHttpClient: () => chainApiHttpClient
-        }
-      });
+      const { result } = setupDepositParams({ chainApiHttpClient, supportsACT: true });
 
       await vi.waitFor(() => {
         expect(chainApiHttpClient.get).toHaveBeenCalledWith(expect.stringContaining("akash/deployment"));
         expect(result.current.isSuccess).toBe(true);
         expect(result.current.data).toEqual(minDeposits);
+      });
+    });
+
+    it("should fetch deposit params from legacy endpoint when ACT is not supported", async () => {
+      const chainApiHttpClient = mock<FallbackableHttpClient>({
+        isFallbackEnabled: false
+      } as FallbackableHttpClient);
+      const depositParams = [{ denom: "uakt", amount: "500000" }];
+      chainApiHttpClient.get.mockResolvedValue({
+        data: { param: { value: JSON.stringify(depositParams) } }
+      });
+
+      const { result } = setupDepositParams({ chainApiHttpClient, supportsACT: false });
+
+      await vi.waitFor(() => {
+        expect(chainApiHttpClient.get).toHaveBeenCalledWith(expect.stringContaining("cosmos/params/v1beta1/params"));
+        expect(result.current.isSuccess).toBe(true);
+        expect(result.current.data).toEqual(depositParams);
       });
     });
 
@@ -114,15 +125,22 @@ describe("Settings management", () => {
       } as FallbackableHttpClient);
       chainApiHttpClient.get.mockRejectedValue(new Error("Failed to fetch deposit params"));
 
-      const { result } = setupQuery(() => useDepositParams(), {
-        services: {
-          chainApiHttpClient: () => chainApiHttpClient
-        }
-      });
+      const { result } = setupDepositParams({ chainApiHttpClient, supportsACT: true });
 
       await vi.waitFor(() => {
         expect(result.current.isError).toBe(true);
       });
     });
+
+    function setupDepositParams(input: { chainApiHttpClient: FallbackableHttpClient; supportsACT: boolean }) {
+      const dependencies: typeof DEPOSIT_PARAMS_DEPS = {
+        useSupportsACT: () => input.supportsACT
+      };
+      return setupQuery(() => useDepositParams(undefined, dependencies), {
+        services: {
+          chainApiHttpClient: () => input.chainApiHttpClient
+        }
+      });
+    }
   });
 });

--- a/apps/deploy-web/src/queries/useSaveSettings.ts
+++ b/apps/deploy-web/src/queries/useSaveSettings.ts
@@ -5,7 +5,8 @@ import { useSnackbar } from "notistack";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
-import type { DepositParams, RpcDeploymentParams } from "@src/types/deployment";
+import { useSupportsACT } from "@src/hooks/useSupportsACT/useSupportsACT";
+import type { DepositParams, RpcDeploymentParams, RpcDepositParams } from "@src/types/deployment";
 import type { UserSettings } from "@src/types/user";
 import { ApiUrlService } from "@src/utils/apiUtils";
 import { QueryKeys } from "./queryKeys";
@@ -40,12 +41,24 @@ async function getDepositParams(chainApiHttpClient: AxiosInstance): Promise<Depo
   return response.data.params?.min_deposits ?? [];
 }
 
+async function getLegacyDepositParams(chainApiHttpClient: AxiosInstance): Promise<DepositParams[]> {
+  const response = await chainApiHttpClient.get<RpcDepositParams>(ApiUrlService.legacyDepositParams(""));
+  return response.data.param.value ? JSON.parse(response.data.param.value) : [];
+}
+
 const ONE_HOUR_IN_MS = 60 * 60 * 1000;
-export function useDepositParams(options?: Omit<UseQueryOptions<DepositParams[]>, "queryKey" | "queryFn">) {
+const DEPOSIT_PARAMS_DEPS = { useSupportsACT };
+export { DEPOSIT_PARAMS_DEPS };
+export function useDepositParams(
+  options?: Omit<UseQueryOptions<DepositParams[]>, "queryKey" | "queryFn">,
+  dependencies: typeof DEPOSIT_PARAMS_DEPS = DEPOSIT_PARAMS_DEPS
+) {
   const { chainApiHttpClient } = useServices();
+  const supportsACT = dependencies.useSupportsACT();
+
   return useQuery({
     queryKey: QueryKeys.getDepositParamsKey(),
-    queryFn: () => getDepositParams(chainApiHttpClient),
+    queryFn: () => (supportsACT ? getDepositParams(chainApiHttpClient) : getLegacyDepositParams(chainApiHttpClient)),
     staleTime: ONE_HOUR_IN_MS,
     gcTime: ONE_HOUR_IN_MS,
     ...options,

--- a/apps/deploy-web/src/utils/apiUtils.ts
+++ b/apps/deploy-web/src/utils/apiUtils.ts
@@ -8,6 +8,9 @@ export class ApiUrlService {
   static depositParams(apiEndpoint: string) {
     return `${apiEndpoint}/akash/deployment/${networkStore.deploymentVersion}/params`;
   }
+  static legacyDepositParams(apiEndpoint: string) {
+    return `${apiEndpoint}/cosmos/params/v1beta1/params?subspace=deployment&key=MinDeposits`;
+  }
   static certificatesList(apiEndpoint: string, address: string) {
     return `${apiEndpoint}/akash/cert/${networkStore.certVersion}/certificates/list?filter.state=valid&filter.owner=${address}`;
   }


### PR DESCRIPTION
## Why

PR #2971 removes the legacy cosmos params endpoint entirely, but nodes running pre-2.0.0 don't serve the module-native `/akash/deployment/v1beta4/params` endpoint. This breaks backward compatibility for users connected to older nodes.

Part of CON-116

## What

- Add `legacyDepositParams` URL builder to `ApiUrlService` preserving the old `/cosmos/params/v1beta1/params` endpoint
- Add `getLegacyDepositParams` fetcher that parses the legacy response format
- `useDepositParams` now calls `useSupportsACT` to pick the correct endpoint and parser
- Injectable `DEPOSIT_PARAMS_DEPS` for testability following existing codebase patterns
- Tests cover both ACT-supported (module endpoint) and legacy (cosmos params) paths