### PR TITLE
fix(indexer): rename EventVaultSeeded to EventVaultFunded

### DIFF
--- a/apps/indexer/src/indexers/bmeIndexer.helpers.ts
+++ b/apps/indexer/src/indexers/bmeIndexer.helpers.ts
@@ -1,4 +1,4 @@
-import type { BmeSums, CoinPrice, LedgerRecordID, ParsedLedgerRecord, ParsedPriceData, ParsedStatusChange, ParsedVaultSeeded } from "./bmeIndexer.types";
+import type { BmeSums, CoinPrice, LedgerRecordID, ParsedLedgerRecord, ParsedPriceData, ParsedStatusChange, ParsedVaultFunded } from "./bmeIndexer.types";
 
 function parseJsonValue<T>(value: string | null | undefined): T | null {
   if (!value) return null;
@@ -85,11 +85,11 @@ export function parseStatusChangeEvent(data: Record<string, string | null>): Par
 }
 
 /**
- * Parse EventVaultSeeded attributes.
+ * Parse EventVaultFunded attributes.
  *
  * Proto fields: amount (Coin), source (string), new_vault_balance (Coin)
  */
-export function parseVaultSeededEvent(data: Record<string, string | null>): ParsedVaultSeeded {
+export function parseVaultFundedEvent(data: Record<string, string | null>): ParsedVaultFunded {
   const amount = parseJsonValue<{ amount: string; denom: string }>(data.amount);
   const newVaultBalance = parseJsonValue<{ amount: string; denom: string }>(data.new_vault_balance);
 

--- a/apps/indexer/src/indexers/bmeIndexer.ts
+++ b/apps/indexer/src/indexers/bmeIndexer.ts
@@ -13,7 +13,7 @@ import {
   parseLedgerRecordEvent,
   parsePriceDataEvent,
   parseStatusChangeEvent,
-  parseVaultSeededEvent,
+  parseVaultFundedEvent,
   safeParseFloat,
   zeroBmeSums
 } from "./bmeIndexer.helpers";
@@ -22,7 +22,7 @@ import { Indexer } from "./indexer";
 export const BME_EVENT_TYPES = {
   LEDGER_RECORD_EXECUTED: "akash.bme.v1.EventLedgerRecordExecuted",
   MINT_STATUS_CHANGE: "akash.bme.v1.EventMintStatusChange",
-  VAULT_SEEDED: "akash.bme.v1.EventVaultSeeded",
+  VAULT_FUNDED: "akash.bme.v1.EventVaultFunded",
   LEDGER_RECORD_CANCELED: "akash.bme.v1.EventLedgerRecordCanceled",
   /** Synthetic event: uakt transfer to vault detected in finalize_block_events (governance/upgrade seed) */
   VAULT_FUNDED_TRANSFER: "indexer.bme.VaultFundedTransfer",
@@ -42,7 +42,7 @@ export { BME_EVENT_TYPE_VALUES };
 const NATIVE_BME_EVENT_TYPES: readonly string[] = [
   BME_EVENT_TYPES.LEDGER_RECORD_EXECUTED,
   BME_EVENT_TYPES.MINT_STATUS_CHANGE,
-  BME_EVENT_TYPES.VAULT_SEEDED,
+  BME_EVENT_TYPES.VAULT_FUNDED,
   BME_EVENT_TYPES.LEDGER_RECORD_CANCELED
 ];
 
@@ -139,8 +139,8 @@ export class BmeIndexer extends Indexer {
       } else if (rawEvent.type === BME_EVENT_TYPES.MINT_STATUS_CHANGE) {
         const parsed = parseStatusChangeEvent(rawEvent.data);
         statusChanges.push({ height: currentBlock.height, ...parsed });
-      } else if (rawEvent.type === BME_EVENT_TYPES.VAULT_SEEDED) {
-        const parsed = parseVaultSeededEvent(rawEvent.data);
+      } else if (rawEvent.type === BME_EVENT_TYPES.VAULT_FUNDED) {
+        const parsed = parseVaultFundedEvent(rawEvent.data);
         if (parsed.newVaultBalance && parsed.newVaultBalance.denom === "uakt") {
           const amount = safeParseFloat(parsed.newVaultBalance.amount);
           vaultUaktFromEvent = amount;
@@ -249,7 +249,7 @@ export class BmeIndexer extends Indexer {
 
     // Vault uAKT: carry forward previous balance and apply this block's delta
     if (vaultUaktFromEvent !== null) {
-      // EventVaultSeeded provides an absolute snapshot of vault balance
+      // EventVaultFunded provides an absolute snapshot of vault balance
       currentBlock.vaultUakt = vaultUaktFromEvent;
     } else {
       // Delta: AKT deposited via mints minus AKT withdrawn via remints this block,

--- a/apps/indexer/src/indexers/bmeIndexer.types.ts
+++ b/apps/indexer/src/indexers/bmeIndexer.types.ts
@@ -39,7 +39,7 @@ export interface ParsedStatusChange {
   collateralRatio: string;
 }
 
-export interface ParsedVaultSeeded {
+export interface ParsedVaultFunded {
   amount: string;
   denom: string;
   newVaultBalance: { amount: string; denom: string } | null;

--- a/packages/database/dbSchemas/akash/bmeRawEvent.ts
+++ b/packages/database/dbSchemas/akash/bmeRawEvent.ts
@@ -8,7 +8,7 @@ import { Required } from "../decorators/requiredDecorator";
  * BmeRawEvent model
  *
  * Staging table for BME block-level events extracted from end_block_events.
- * Only BME-relevant events are stored (EventLedgerRecordExecuted, EventMintStatusChange, EventVaultSeeded).
+ * Only BME-relevant events are stored (EventLedgerRecordExecuted, EventMintStatusChange, EventVaultFunded).
  * Marked as processed after the BmeIndexer consumes them.
  */
 @Table({


### PR DESCRIPTION
## Why

The chain-sdk renamed `EventVaultSeeded` → `EventVaultFunded` in [chain-sdk PR #266](https://github.com/akash-network/chain-sdk/pull/266) (March 20), 3 days before the mainnet upgrade. The indexer was written against the original proto name and the rename happened after, causing the native event to be silently dropped at the upgrade block.

Vault balance still tracked correctly via the `VAULT_FUNDED_TRANSFER` synthetic fallback (bank transfer detection), but the absolute `new_vault_balance` snapshot from the native event was lost.

Confirmed on both sandbox (upgrade block 2,552,650) and mainnet (upgrade block 26,063,777) — both chains emit `EventVaultFunded`.

## What

- Renamed `BME_EVENT_TYPES.VAULT_SEEDED` → `VAULT_FUNDED` with updated event string
- Renamed `ParsedVaultSeeded` → `ParsedVaultFunded` type
- Renamed `parseVaultSeededEvent` → `parseVaultFundedEvent` helper
- Updated all references and comments