### PR TITLE
fix(stats): hide percentage chip when baseline value is zero

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,3 +20,7 @@ See detailed guidelines:
 
 See detailed guidelines:
 @./.claude/instructions/commit-and-pr-conventions.md
+
+## Writing Tests
+
+Always use the `/console-tests` skill when writing, fixing, reviewing, or refactoring tests in this repo.

--- a/apps/deploy-web/src/utils/mathHelpers.spec.ts
+++ b/apps/deploy-web/src/utils/mathHelpers.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { percIncrease } from "./mathHelpers";
+
+describe(percIncrease.name, () => {
+  it("returns standard percentage change for non-zero values", () => {
+    expect(percIncrease(100, 150)).toBe(0.5);
+  });
+
+  it("returns negative percentage for decrease", () => {
+    expect(percIncrease(200, 100)).toBe(-0.5);
+  });
+
+  it("returns 0 when both values are 0", () => {
+    expect(percIncrease(0, 0)).toBe(0);
+  });
+
+  it("returns 0 when baseline is 0 to avoid meaningless percentage", () => {
+    expect(percIncrease(0, 1000)).toBe(0);
+  });
+
+  it("returns 0 when baseline is 0 even for large values", () => {
+    expect(percIncrease(0, 21570000000000)).toBe(0);
+  });
+
+  it("returns -1 when value drops to 0", () => {
+    expect(percIncrease(100, 0)).toBe(-1);
+  });
+
+  it("returns 0 when values are equal", () => {
+    expect(percIncrease(100, 100)).toBe(0);
+  });
+});

--- a/apps/deploy-web/src/utils/mathHelpers.ts
+++ b/apps/deploy-web/src/utils/mathHelpers.ts
@@ -45,15 +45,10 @@ export function ceilDecimal(value: number) {
 }
 
 export function percIncrease(a: number, b: number) {
-  let percent: number;
-  if (b !== 0) {
-    if (a !== 0) {
-      percent = (b - a) / a;
-    } else {
-      percent = b;
-    }
-  } else {
-    percent = -a;
+  if (a === 0) {
+    return 0;
   }
+
+  const percent = b !== 0 ? (b - a) / a : -1;
   return roundDecimal(percent, 4);
 }

--- a/apps/provider-console/src/utils/mathHelpers.ts
+++ b/apps/provider-console/src/utils/mathHelpers.ts
@@ -49,15 +49,10 @@ export function coinsToAmount(coins: Coin[] | Coin, denom: string) {
 }
 
 export function percIncrease(a: number, b: number) {
-  let percent: number;
-  if (b !== 0) {
-    if (a !== 0) {
-      percent = (b - a) / a;
-    } else {
-      percent = b;
-    }
-  } else {
-    percent = -a;
+  if (a === 0) {
+    return 0;
   }
+
+  const percent = b !== 0 ? (b - a) / a : -1;
   return roundDecimal(percent, 4);
 }

--- a/apps/stats-web/src/lib/mathHelpers.spec.ts
+++ b/apps/stats-web/src/lib/mathHelpers.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { percIncrease } from "./mathHelpers";
 
-describe("percIncrease", () => {
+describe(percIncrease.name, () => {
   it("returns standard percentage change for non-zero values", () => {
     expect(percIncrease(100, 150)).toBe(0.5);
   });

--- a/apps/stats-web/src/lib/mathHelpers.spec.ts
+++ b/apps/stats-web/src/lib/mathHelpers.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { percIncrease } from "./mathHelpers";
+
+describe("percIncrease", () => {
+  it("returns standard percentage change for non-zero values", () => {
+    expect(percIncrease(100, 150)).toBe(0.5);
+  });
+
+  it("returns negative percentage for decrease", () => {
+    expect(percIncrease(200, 100)).toBe(-0.5);
+  });
+
+  it("returns 0 when both values are 0", () => {
+    expect(percIncrease(0, 0)).toBe(0);
+  });
+
+  it("returns 0 when baseline is 0 to avoid meaningless percentage", () => {
+    expect(percIncrease(0, 1000)).toBe(0);
+  });
+
+  it("returns 0 when baseline is 0 even for large values", () => {
+    expect(percIncrease(0, 21570000000000)).toBe(0);
+  });
+
+  it("returns -1 when value drops to 0", () => {
+    expect(percIncrease(100, 0)).toBe(-1);
+  });
+
+  it("returns 0 when values are equal", () => {
+    expect(percIncrease(100, 100)).toBe(0);
+  });
+});

--- a/apps/stats-web/src/lib/mathHelpers.ts
+++ b/apps/stats-web/src/lib/mathHelpers.ts
@@ -49,15 +49,10 @@ export function coinsToAmount(coins: Coin[] | Coin, denom: string) {
 }
 
 export function percIncrease(a: number, b: number) {
-  let percent: number;
-  if (b !== 0) {
-    if (a !== 0) {
-      percent = (b - a) / a;
-    } else {
-      percent = b;
-    }
-  } else {
-    percent = -a;
+  if (a === 0) {
+    return 0;
   }
+
+  const percent = b !== 0 ? (b - a) / a : -1;
   return roundDecimal(percent, 4);
 }


### PR DESCRIPTION
## Why

The BME dashboard shows absurd percentage increases (e.g. 2,157,201,574,800%) because it just launched and there's no comparison data from 24h ago. When the baseline value is 0, `percIncrease` returned the raw value as a percentage instead of hiding the chip.

## What

Fixed `percIncrease` in all three copies (`stats-web`, `deploy-web`, `provider-console`):
- When baseline (`a`) is 0: return 0 (hides the chip since `StatsCard` checks `!!diffPercent`)
- When current (`b`) is 0 and baseline is non-zero: return -1 (-100%) instead of the raw negative value
- Added unit tests for `percIncrease` in `stats-web`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined percentage-increase calculation to simplify logic and unify edge-case outputs (notably when baseline or current values are zero).

* **Tests**
  * Added comprehensive test suites validating positive/negative changes, equal values, zero baselines, and drops-to-zero behavior across apps.

* **Documentation**
  * Added repo guidance on writing tests and a new "Writing Tests" section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->