### PR TITLE
fix(wallet): parse BME min_mint as array and filter for uact denom

### DIFF
--- a/apps/deploy-web/src/queries/useBmeQuery.spec.ts
+++ b/apps/deploy-web/src/queries/useBmeQuery.spec.ts
@@ -37,6 +37,15 @@ describe(getBmeParams.name, () => {
     expect(result.minMintAct).toBe(0);
   });
 
+  it("falls back to 0 when amount is malformed", async () => {
+    const { result } = await setup({
+      min_mint: [{ denom: "uact", amount: "abc123" }]
+    });
+
+    expect(result.minMintUact).toBe(0);
+    expect(result.minMintAct).toBe(0);
+  });
+
   it("falls back to 0 when min_mint array is empty", async () => {
     const { result } = await setup({
       min_mint: []

--- a/apps/deploy-web/src/queries/useBmeQuery.spec.ts
+++ b/apps/deploy-web/src/queries/useBmeQuery.spec.ts
@@ -1,0 +1,59 @@
+import type { AxiosInstance, AxiosResponse } from "axios";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { RpcBmeParams } from "@src/types/bme";
+import { getBmeParams } from "./useBmeQuery";
+
+describe(getBmeParams.name, () => {
+  it("parses uact coin from min_mint array", async () => {
+    const { result } = await setup({
+      min_mint: [{ denom: "uact", amount: "10000000" }]
+    });
+
+    expect(result.minMintUact).toBe(10_000_000);
+    expect(result.minMintAct).toBe(10);
+  });
+
+  it("finds uact coin when multiple denoms are present", async () => {
+    const { result } = await setup({
+      min_mint: [
+        { denom: "uakt", amount: "5000000" },
+        { denom: "uact", amount: "10000000" },
+        { denom: "ibc/usdc", amount: "3000000" }
+      ]
+    });
+
+    expect(result.minMintUact).toBe(10_000_000);
+    expect(result.minMintAct).toBe(10);
+  });
+
+  it("falls back to 0 when uact is not in the array", async () => {
+    const { result } = await setup({
+      min_mint: [{ denom: "uakt", amount: "5000000" }]
+    });
+
+    expect(result.minMintUact).toBe(0);
+    expect(result.minMintAct).toBe(0);
+  });
+
+  it("falls back to 0 when min_mint array is empty", async () => {
+    const { result } = await setup({
+      min_mint: []
+    });
+
+    expect(result.minMintUact).toBe(0);
+    expect(result.minMintAct).toBe(0);
+  });
+
+  async function setup(input: { min_mint: Array<{ denom: string; amount: string }> }) {
+    const chainApiHttpClient = mock<AxiosInstance>();
+    chainApiHttpClient.get.mockResolvedValue({
+      data: { params: { min_mint: input.min_mint } }
+    } as AxiosResponse<RpcBmeParams>);
+
+    const result = await getBmeParams(chainApiHttpClient);
+
+    return { result, chainApiHttpClient };
+  }
+});

--- a/apps/deploy-web/src/queries/useBmeQuery.ts
+++ b/apps/deploy-web/src/queries/useBmeQuery.ts
@@ -3,16 +3,18 @@ import { useQuery } from "@tanstack/react-query";
 import type { AxiosInstance } from "axios";
 import { millisecondsInMinute } from "date-fns/constants";
 
+import { UACT_DENOM } from "@src/config/denom.config";
 import { useServices } from "@src/context/ServicesProvider";
 import type { BmeParams, RpcBmeParams } from "@src/types/bme";
 import { ApiUrlService } from "@src/utils/apiUtils";
 import { udenomToDenom } from "@src/utils/mathHelpers";
 import { QueryKeys } from "./queryKeys";
 
-async function getBmeParams(chainApiHttpClient: AxiosInstance): Promise<BmeParams> {
+export async function getBmeParams(chainApiHttpClient: AxiosInstance): Promise<BmeParams> {
   const response = await chainApiHttpClient.get<RpcBmeParams>(ApiUrlService.bmeParams(""));
   const { params } = response.data;
-  const minMintUact = parseInt(params.min_mint.amount, 10);
+  const uactCoin = params.min_mint.find(coin => coin.denom === UACT_DENOM);
+  const minMintUact = parseInt(uactCoin?.amount ?? "0", 10);
   return {
     minMintUact,
     minMintAct: udenomToDenom(minMintUact)

--- a/apps/deploy-web/src/queries/useBmeQuery.ts
+++ b/apps/deploy-web/src/queries/useBmeQuery.ts
@@ -14,7 +14,7 @@ export async function getBmeParams(chainApiHttpClient: AxiosInstance): Promise<B
   const response = await chainApiHttpClient.get<RpcBmeParams>(ApiUrlService.bmeParams(""));
   const { params } = response.data;
   const uactCoin = params.min_mint.find(coin => coin.denom === UACT_DENOM);
-  const minMintUact = parseInt(uactCoin?.amount ?? "0", 10);
+  const minMintUact = Number(uactCoin?.amount) || 0;
   return {
     minMintUact,
     minMintAct: udenomToDenom(minMintUact)

--- a/apps/deploy-web/src/types/bme.ts
+++ b/apps/deploy-web/src/types/bme.ts
@@ -1,7 +1,7 @@
 /** Response from /akash/bme/v1/params */
 export interface RpcBmeParams {
   params: {
-    min_mint: { denom: string; amount: string };
+    min_mint: Array<{ denom: string; amount: string }>;
   };
 }
 


### PR DESCRIPTION
## Why

The BME params API endpoint (`/akash/bme/v1/params`) returns `min_mint` as a Cosmos SDK Coins array (e.g. `[{denom: "uact", amount: "1000000"}]`), but the TypeScript type definition and parsing code treated it as a single object. This caused `params.min_mint.amount` to be `undefined` at runtime, making `parseInt(undefined)` return `NaN`. Since any comparison against `NaN` returns `false`, the minimum mint validation never triggered — allowing users to mint any amount regardless of the on-chain minimum.

## What

- Fixed `RpcBmeParams.min_mint` type from `{ denom: string; amount: string }` to `Array<{ denom: string; amount: string }>` to match the actual API response
- Updated `getBmeParams` to filter the array for the `uact` denom coin instead of accessing `.amount` directly on the array
- Exported `getBmeParams` for testability
- Added unit tests covering: single uact coin, multiple denoms, missing uact, and empty array

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for minimum-mint parsing across single, multiple, missing, malformed, and empty-denom scenarios.

* **Bug Fixes**
  * Improved parsing to pick the correct mint denomination and reliably fall back to zero for missing or invalid amounts.

* **Chores**
  * Updated parameter shape handling to support multiple denomination entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->