### PR TITLE
fix(wallet): use remint_credit_issued for burn rate in ledger table

### DIFF
--- a/apps/deploy-web/src/components/MintBurnPage/LedgerRecordsTable/LedgerRecordsTable.spec.tsx
+++ b/apps/deploy-web/src/components/MintBurnPage/LedgerRecordsTable/LedgerRecordsTable.spec.tsx
@@ -52,6 +52,36 @@ describe(LedgerRecordsTable.name, () => {
     expect(screen.queryByText("Pending")).toBeInTheDocument();
   });
 
+  it("renders mint record amounts and rate", () => {
+    const record = buildMintLedgerRecord();
+    setup({ records: [record] });
+
+    const accrued = record.executed_record!.remint_credit_accrued!;
+    const minted = record.executed_record!.minted!;
+    const amountIn = (parseInt(accrued.coin.amount) / 1_000_000).toFixed(2);
+    const amountOut = (parseInt(minted.coin.amount) / 1_000_000).toFixed(2);
+    const rate = parseFloat(accrued.price).toFixed(4);
+
+    expect(screen.queryByText(`${amountIn} AKT`)).toBeInTheDocument();
+    expect(screen.queryByText(`${amountOut} ACT`)).toBeInTheDocument();
+    expect(screen.queryByText(rate)).toBeInTheDocument();
+  });
+
+  it("renders burn record amounts and rate", () => {
+    const record = buildBurnLedgerRecord();
+    setup({ records: [record] });
+
+    const burned = record.executed_record!.burned!;
+    const issued = record.executed_record!.remint_credit_issued!;
+    const amountIn = (parseInt(burned.coin.amount) / 1_000_000).toFixed(2);
+    const amountOut = (parseInt(issued.coin.amount) / 1_000_000).toFixed(2);
+    const rate = parseFloat(issued.price).toFixed(4);
+
+    expect(screen.queryByText(`${amountIn} ACT`)).toBeInTheDocument();
+    expect(screen.queryByText(`${amountOut} AKT`)).toBeInTheDocument();
+    expect(screen.queryByText(rate)).toBeInTheDocument();
+  });
+
   it("sorts records by height descending", () => {
     const older = buildMintLedgerRecord({ height: "80000" });
     const newer = buildBurnLedgerRecord({ height: "90000" });

--- a/apps/deploy-web/src/components/MintBurnPage/LedgerRecordsTable/LedgerRecordsTable.tsx
+++ b/apps/deploy-web/src/components/MintBurnPage/LedgerRecordsTable/LedgerRecordsTable.tsx
@@ -203,8 +203,8 @@ function getRate(record: BmeLedgerRecord): number {
     const accrued = record.executed_record?.remint_credit_accrued;
     return accrued ? parseFloat(accrued.price) : 0;
   }
-  const burned = record.executed_record?.burned;
-  return burned ? parseFloat(burned.price) : 0;
+  const issued = record.executed_record?.remint_credit_issued;
+  return issued ? parseFloat(issued.price) : 0;
 }
 
 function getStatusLabel(status: string): string {


### PR DESCRIPTION
## Why

The burn rate column in the ledger records table was always showing `1.0000` because it read from `burned.price` (the nominal ACT price) instead of the actual exchange rate from `remint_credit_issued.price`.

## What

- Changed `getRate()` to read from `remint_credit_issued.price` for burn records, which contains the actual AKT/ACT exchange rate
- Renamed the local variable from `burned` to `issued` to match the field
- Added tests for rendered amounts and rate values for both mint and burn records

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the burn rate calculation in the ledger records table to reference the proper data source, ensuring accurate exchange rate information is displayed.

* **Tests**
  * Added validation tests for mint and burn transaction records to verify correct numerical display of transaction amounts, rates, and currency denominations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->