### PR TITLE
fix(sdl): update SDL templates to use uact denom

### DIFF
--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.spec.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.spec.ts
@@ -3,7 +3,7 @@ import "@test/mocks/logger-service.mock";
 import type { BidHttpService, BlockHttpService } from "@akashnetwork/http-sdk";
 import type { Registry } from "@cosmjs/proto-signing";
 import type { SigningStargateClient } from "@cosmjs/stargate";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
@@ -15,9 +15,34 @@ import { sdlTemplateWithRam, sdlTemplateWithRamAndInterface } from "./sdl-templa
 
 import { mockConfigService } from "@test/mocks/config-service.mock";
 
+const mockSigningClient = mock<SigningStargateClient>();
+
 vi.mock("timers/promises", () => ({
   setTimeout: vi.fn().mockResolvedValue(undefined)
 }));
+
+vi.mock("@cosmjs/proto-signing", async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as Record<string, unknown>),
+    DirectSecp256k1HdWallet: {
+      fromMnemonic: vi.fn().mockResolvedValue({
+        getAccounts: vi.fn().mockResolvedValue([{ address: "akash1testaddr" }])
+      })
+    }
+  };
+});
+
+vi.mock("@cosmjs/stargate", async importOriginal => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as Record<string, unknown>),
+    SigningStargateClient: {
+      connectWithSigner: vi.fn().mockImplementation(() => Promise.resolve(mockSigningClient))
+    },
+    calculateFee: vi.fn().mockReturnValue({ amount: [{ denom: "uact", amount: "2500" }], gas: "100000" })
+  };
+});
 
 describe(GpuBidsCreatorService.name, () => {
   describe("getModelSdl", () => {
@@ -90,6 +115,22 @@ describe(GpuBidsCreatorService.name, () => {
       const { service } = setup({ rpcNodeEndpoint: undefined });
 
       await expect(service.createGpuBids()).rejects.toThrow("RPC_NODE_ENDPOINT");
+    });
+
+    it("fetches balances with uact denom and creates bids for all models", async () => {
+      const { service, gpuService } = setup();
+      gpuService.getGpuList.mockResolvedValue({
+        gpus: { total: { allocatable: 1, allocated: 0 }, details: {} }
+      } as any);
+      mockSigningClient.getBalance.mockResolvedValue({ amount: "1000000", denom: "uact" });
+      mockSigningClient.simulate.mockResolvedValue(100000);
+      mockSigningClient.sign.mockResolvedValue({ authInfoBytes: new Uint8Array(), bodyBytes: new Uint8Array(), signatures: [] } as any);
+      mockSigningClient.broadcastTx.mockResolvedValue({ code: 0, rawLog: "" } as any);
+
+      await service.createGpuBids();
+
+      expect(mockSigningClient.getBalance).toHaveBeenCalledWith("akash1testaddr", "uact");
+      expect(mockSigningClient.getBalance).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
@@ -151,7 +151,7 @@ export class GpuBidsCreatorService {
         deposit: {
           amount: {
             denom: "uact",
-            amount: "500000" // 0.5 AKT
+            amount: "500000" // 0.5 ACT
           },
           sources: [Source.balance]
         }

--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
@@ -48,7 +48,7 @@ export class GpuBidsCreatorService {
       registry: this.typeRegistry,
       broadcastTimeoutMs: 30_000
     });
-    const balanceBefore = await client.getBalance(account.address, "uakt");
+    const balanceBefore = await client.getBalance(account.address, "uact");
     const balanceBeforeUAkt = parseFloat(balanceBefore.amount);
     const akt = Math.round((balanceBeforeUAkt / 1_000_000) * 100) / 100;
     this.logger.info({ event: "CLIENT_CONNECTED", balance: akt });
@@ -58,7 +58,7 @@ export class GpuBidsCreatorService {
     await this.createBidsForAllModels(gpuModels, client, account.address, false);
     await this.createBidsForAllModels(gpuModels, client, account.address, true);
 
-    const balanceAfter = await client.getBalance(account.address, "uakt");
+    const balanceAfter = await client.getBalance(account.address, "uact");
     const balanceAfterUAkt = parseFloat(balanceAfter.amount);
     const diff = balanceBeforeUAkt - balanceAfterUAkt;
 
@@ -68,7 +68,7 @@ export class GpuBidsCreatorService {
   private async signAndBroadcast(address: string, client: SigningStargateClient, messages: readonly EncodeObject[]) {
     const simulation = await client.simulate(address, messages, "");
 
-    const fee = calculateFee(Math.round(simulation * 1.35), `${this.config.get("AVERAGE_GAS_PRICE")}uakt`);
+    const fee = calculateFee(Math.round(simulation * 1.35), `${this.config.get("AVERAGE_GAS_PRICE")}uact`);
 
     const txRaw = await client.sign(address, messages, fee, "");
 
@@ -150,7 +150,7 @@ export class GpuBidsCreatorService {
         hash: manifestVersion,
         deposit: {
           amount: {
-            denom: "uakt",
+            denom: "uact",
             amount: "500000" // 0.5 AKT
           },
           sources: [Source.balance]

--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
@@ -49,9 +49,9 @@ export class GpuBidsCreatorService {
       broadcastTimeoutMs: 30_000
     });
     const balanceBefore = await client.getBalance(account.address, "uact");
-    const balanceBeforeUAkt = parseFloat(balanceBefore.amount);
-    const akt = Math.round((balanceBeforeUAkt / 1_000_000) * 100) / 100;
-    this.logger.info({ event: "CLIENT_CONNECTED", balance: akt });
+    const balanceBeforeUAct = parseFloat(balanceBefore.amount);
+    const act = Math.round((balanceBeforeUAct / 1_000_000) * 100) / 100;
+    this.logger.info({ event: "CLIENT_CONNECTED", balance: act });
 
     const gpuModels = await this.gpuService.getGpuList();
 
@@ -59,8 +59,8 @@ export class GpuBidsCreatorService {
     await this.createBidsForAllModels(gpuModels, client, account.address, true);
 
     const balanceAfter = await client.getBalance(account.address, "uact");
-    const balanceAfterUAkt = parseFloat(balanceAfter.amount);
-    const diff = balanceBeforeUAkt - balanceAfterUAkt;
+    const balanceAfterUAct = parseFloat(balanceAfter.amount);
+    const diff = balanceBeforeUAct - balanceAfterUAct;
 
     this.logger.info({ event: "GPU_BIDS_CREATED", cost: diff / 1_000_000 });
   }

--- a/apps/api/src/deployment/services/gpu-bids-creator/sdl-templates.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/sdl-templates.ts
@@ -37,7 +37,7 @@ profiles:
     akash:
       pricing:
         obtaingpu:
-          denom: uakt
+          denom: uact
           amount: 100000
 deployment:
   obtaingpuone:
@@ -83,7 +83,7 @@ profiles:
     akash:
       pricing:
         obtaingpu:
-          denom: uakt
+          denom: uact
           amount: 100000
 deployment:
   obtaingpuone:

--- a/apps/api/test/mocks/hello-world-sdl-update.yml
+++ b/apps/api/test/mocks/hello-world-sdl-update.yml
@@ -24,7 +24,7 @@ profiles:
     dcloud:
       pricing:
         web:
-          denom: uakt
+          denom: uact
           amount: 1000
 deployment:
   web:

--- a/apps/api/test/mocks/hello-world-sdl.yml
+++ b/apps/api/test/mocks/hello-world-sdl.yml
@@ -22,7 +22,7 @@ profiles:
     dcloud:
       pricing:
         web:
-          denom: uakt
+          denom: uact
           amount: 1000
 deployment:
   web:

--- a/apps/api/test/seeders/denom.seeder.ts
+++ b/apps/api/test/seeders/denom.seeder.ts
@@ -2,5 +2,5 @@ import type { Denom } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
 
 export function createDenom(): Denom {
-  return faker.helpers.arrayElement(["uakt", "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1"]);
+  return faker.helpers.arrayElement(["uact", "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1"]);
 }

--- a/apps/deploy-web/deploy.yml
+++ b/apps/deploy-web/deploy.yml
@@ -49,10 +49,10 @@ profiles:
     dcloud:
       pricing:
         web:
-          denom: uakt
+          denom: uact
           amount: 1000
         proxy:
-          denom: uakt
+          denom: uact
           amount: 1000
 
 deployment:

--- a/apps/deploy-web/src/utils/sdl/data.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/data.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { UACT_DENOM } from "@src/config/denom.config";
+import { getDefaultService, sshVmDistros } from "./data";
+
+describe(getDefaultService.name, () => {
+  it("sets denom to uact when supportsACT is true", () => {
+    const result = getDefaultService({ supportsACT: true });
+
+    expect(result.placement.pricing.denom).toBe(UACT_DENOM);
+  });
+
+  it("keeps default denom when supportsACT is false", () => {
+    const result = getDefaultService({ supportsACT: false });
+
+    expect(result.placement.pricing.denom).toBe("uact");
+  });
+
+  it("configures SSH image and clears expose when supportsSSH is true", () => {
+    const result = getDefaultService({ supportsACT: false, supportsSSH: true });
+
+    expect(result.image).toBe(sshVmDistros[0]);
+    expect(result.expose).toEqual([]);
+  });
+
+  it("returns independent instances on each call", () => {
+    const a = getDefaultService({ supportsACT: false });
+    const b = getDefaultService({ supportsACT: false });
+
+    a.placement.name = "modified";
+
+    expect(b.placement.name).not.toBe("modified");
+  });
+});

--- a/apps/deploy-web/src/utils/sdl/data.ts
+++ b/apps/deploy-web/src/utils/sdl/data.ts
@@ -1,7 +1,7 @@
 import cloneDeep from "lodash/cloneDeep";
 import { nanoid } from "nanoid";
 
-import { UAKT_DENOM } from "@src/config/denom.config";
+import { UACT_DENOM } from "@src/config/denom.config";
 import type { ServiceType } from "@src/types";
 
 export const protoTypes = [
@@ -66,7 +66,7 @@ const defaultService: ServiceType = {
     name: "dcloud",
     pricing: {
       amount: 100000,
-      denom: "uakt"
+      denom: "uact"
     },
     signedBy: {
       anyOf: [],
@@ -121,7 +121,7 @@ export const getDefaultService = (options: { supportsACT: boolean; supportsSSH?:
   }
 
   if (options.supportsACT) {
-    res.placement.pricing.denom = UAKT_DENOM;
+    res.placement.pricing.denom = UACT_DENOM;
   }
 
   return res;

--- a/apps/deploy-web/src/utils/templates.ts
+++ b/apps/deploy-web/src/utils/templates.ts
@@ -60,7 +60,7 @@ profiles:
       pricing:
         # The name of the service
         web:
-          denom: uakt
+          denom: uact
           amount: 10000
 
 # The deployment section defines how to deploy the services. It is a mapping of service name to deployment configuration.

--- a/apps/deploy-web/tests/mocks/two-services-sdl.yml
+++ b/apps/deploy-web/tests/mocks/two-services-sdl.yml
@@ -39,10 +39,10 @@ profiles:
     dcloud:
       pricing:
         web:
-          denom: uakt
+          denom: uact
           amount: 1000
         service-2:
-          denom: uakt
+          denom: uact
           amount: 100000
       attributes:
         console/trials: "true"

--- a/apps/deploy-web/tests/seeders/manifest.ts
+++ b/apps/deploy-web/tests/seeders/manifest.ts
@@ -27,7 +27,7 @@ export const helloWorldManifest = `
         pricing:
           # The name of the service
           web:
-            denom: uakt
+            denom: uact
             amount: 10000
 
   deployment:

--- a/apps/deploy-web/tests/seeders/sdlService.ts
+++ b/apps/deploy-web/tests/seeders/sdlService.ts
@@ -10,7 +10,7 @@ export const buildSDLService = (overrides: Partial<ServiceType> = {}): ServiceTy
     name: faker.lorem.word(),
     pricing: {
       amount: faker.number.int({ min: 100, max: 10000 }),
-      denom: faker.helpers.arrayElement(["uakt", "uakt"])
+      denom: faker.helpers.arrayElement(["uact", "uact"])
     },
     signedBy: {
       anyOf: [],

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -1,6 +1,6 @@
 export const netConfigData = {
   mainnet: {
-    version: "v1.2.0",
+    version: "v2.0.1",
     faucetUrl: null,
     apiUrls: [
       "https://rest-akash.ecostake.com",


### PR DESCRIPTION
## Why

Fixes CON-75

All SDL templates in deploy-web still reference the legacy `uakt` denom. These need to be updated to `uact` to reflect the current native denom.

## What

- Updated `denom: uakt` → `denom: uact` in all SDL templates and defaults:
  - `src/utils/templates.ts` (helloWorldTemplate)
  - `src/utils/sdl/data.ts` (default service pricing + `getDefaultService` supportsACT branch)
  - `deploy.yml` (deploy-web deployment manifest)
  - `tests/mocks/two-services-sdl.yml`
  - `tests/seeders/manifest.ts`
  - `tests/seeders/sdlService.ts`
- Fixed `getDefaultService`: the `supportsACT` branch now correctly sets `UACT_DENOM` instead of `UAKT_DENOM`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized the pricing denomination used across deployment configs, templates, service payment/fee handling, and test fixtures for platform consistency.
* **Tests**
  * Added unit tests validating denomination behavior, default service values, and instance isolation in service defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->