### PR TITLE
fix(sdl): remove AKT from supported denoms when ACT is active

### DIFF
--- a/apps/deploy-web/src/hooks/useDenom.spec.ts
+++ b/apps/deploy-web/src/hooks/useDenom.spec.ts
@@ -22,23 +22,17 @@ describe(useSupportedDenoms.name, () => {
     expect(result.current.map(d => d.id)).toEqual(["uakt", "uusdc"]);
   });
 
-  it("returns ACT and AKT when ACT is supported", () => {
+  it("returns only ACT when ACT is supported", () => {
     const { result } = renderHook(() => useSupportedDenoms(buildDependencies({ supportsACT: true })));
 
-    expect(result.current).toHaveLength(2);
-    expect(result.current.map(d => d.id)).toEqual(["uact", "uakt"]);
+    expect(result.current).toHaveLength(1);
+    expect(result.current.map(d => d.id)).toEqual(["uact"]);
   });
 
   it("sets correct properties for ACT denom", () => {
     const { result } = renderHook(() => useSupportedDenoms(buildDependencies({ supportsACT: true })));
 
     expect(result.current[0]).toEqual({ id: "uact", label: "uACT", tokenLabel: "ACT", value: "uact" });
-  });
-
-  it("sets correct properties for AKT denom when ACT is supported", () => {
-    const { result } = renderHook(() => useSupportedDenoms(buildDependencies({ supportsACT: true })));
-
-    expect(result.current[1]).toEqual({ id: "uakt", label: "uAKT", tokenLabel: "AKT", value: "uakt" });
   });
 });
 

--- a/apps/deploy-web/src/hooks/useDenom.ts
+++ b/apps/deploy-web/src/hooks/useDenom.ts
@@ -23,7 +23,7 @@ export const useSupportedDenoms = (dependencies: typeof DEPENDENCIES = DEPENDENC
     const UAKT = { id: "uakt", label: "uAKT", tokenLabel: "AKT", value: "uakt" };
 
     if (supportsACT) {
-      return [{ id: "uact", label: "uACT", tokenLabel: "ACT", value: "uact" }, UAKT];
+      return [{ id: "uact", label: "uACT", tokenLabel: "ACT", value: "uact" }];
     }
 
     return [UAKT, { id: "uusdc", label: "uUSDC", tokenLabel: "USDC", value: usdcDenom }];

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -1,6 +1,6 @@
 export const netConfigData = {
   mainnet: {
-    version: "v1.2.0",
+    version: "v2.0.1",
     faucetUrl: null,
     apiUrls: [
       "https://rest-akash.ecostake.com",


### PR DESCRIPTION
## Why

Fixes CON-118

AKT still appears as a selectable denomination option in the SDL builder token selector after the ACT migration. The network has been upgraded to support ACT, so AKT should no longer be offered as a deployment pricing option.

## What

Removed AKT from the `useSupportedDenoms` hook return value when ACT is supported — it now returns only `[UACT]` instead of `[UACT, UAKT]`. This is a temporary patch; a more elaborate implementation handling circuit breaker scenarios will follow in a separate branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed denomination support to return only ACT when ACT support is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->