### PR TITLE
fix(bid): use uakt denom for transaction fees in GPU bids creator

### DIFF
--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.spec.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.spec.ts
@@ -40,7 +40,7 @@ vi.mock("@cosmjs/stargate", async importOriginal => {
     SigningStargateClient: {
       connectWithSigner: vi.fn().mockImplementation(() => Promise.resolve(mockSigningClient))
     },
-    calculateFee: vi.fn().mockReturnValue({ amount: [{ denom: "uact", amount: "2500" }], gas: "100000" })
+    calculateFee: vi.fn().mockReturnValue({ amount: [{ denom: "uakt", amount: "2500" }], gas: "100000" })
   };
 });
 

--- a/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
+++ b/apps/api/src/deployment/services/gpu-bids-creator/gpu-bids-creator.service.ts
@@ -68,7 +68,7 @@ export class GpuBidsCreatorService {
   private async signAndBroadcast(address: string, client: SigningStargateClient, messages: readonly EncodeObject[]) {
     const simulation = await client.simulate(address, messages, "");
 
-    const fee = calculateFee(Math.round(simulation * 1.35), `${this.config.get("AVERAGE_GAS_PRICE")}uact`);
+    const fee = calculateFee(Math.round(simulation * 1.35), `${this.config.get("AVERAGE_GAS_PRICE")}uakt`);
 
     const txRaw = await client.sign(address, messages, fee, "");
 


### PR DESCRIPTION
## Why

The GPU bids creator bot was using `uact` as the denom for transaction fees (gas), which is incorrect. Transaction fees on the Akash chain must use `uakt`, while deployment deposits correctly use `uact`.

## What

- Changed the gas price denom from `uact` to `uakt` in `signAndBroadcast`
- Updated the corresponding `calculateFee` mock in the spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the fee denomination used in GPU bid transaction processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->