### PR TITLE
test: waits for leap wallet to load before entering password

### DIFF
--- a/apps/deploy-web/tests/ui/fixture/wallet-setup.ts
+++ b/apps/deploy-web/tests/ui/fixture/wallet-setup.ts
@@ -136,6 +136,7 @@ export async function approveWalletOperation(popupPage: Page | null) {
 }
 
 export async function unlockWallet(page: Page) {
+  await page.waitForEvent("load", { timeout: 5_000 }).catch(() => {});
   await page.locator("input").fill(WALLET_PASSWORD);
   await page.getByRole("button", { name: /unlock wallet/i }).click();
 }


### PR DESCRIPTION
## Why

Sometimes Leap wallet doesn't accept the valid password, probably because playwright tries to enter it before wallet js loads

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved wallet unlock test reliability by enhancing page load handling in wallet setup test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->