### PR TITLE
feat(deployment): add v2 deployment settings API with implicit userId

### DIFF
--- a/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.spec.ts
+++ b/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.spec.ts
@@ -1,0 +1,125 @@
+import { faker } from "@faker-js/faker";
+import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { AuthService } from "@src/auth/services/auth.service";
+import type { DeploymentSettingService } from "@src/deployment/services/deployment-setting/deployment-setting.service";
+import { DeploymentSettingController } from "./deployment-setting.controller";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(DeploymentSettingController.name, () => {
+  describe("findOrCreateV2", () => {
+    it("uses provided userId", async () => {
+      const { controller, deploymentSettingService, setting } = setup();
+      const userId = faker.string.uuid();
+      const dseq = faker.string.numeric(6);
+      deploymentSettingService.findOrCreateByUserIdAndDseq.mockResolvedValue(setting);
+
+      const result = await controller.findOrCreateV2({ dseq, userId });
+
+      expect(result).toEqual({ data: setting });
+      expect(deploymentSettingService.findOrCreateByUserIdAndDseq).toHaveBeenCalledWith({ userId, dseq });
+    });
+
+    it("defaults userId to current user when not provided", async () => {
+      const { controller, deploymentSettingService, setting, user } = setup();
+      const dseq = faker.string.numeric(6);
+      deploymentSettingService.findOrCreateByUserIdAndDseq.mockResolvedValue(setting);
+
+      const result = await controller.findOrCreateV2({ dseq });
+
+      expect(result).toEqual({ data: setting });
+      expect(deploymentSettingService.findOrCreateByUserIdAndDseq).toHaveBeenCalledWith({ userId: user.id, dseq });
+    });
+
+    it("throws 404 when setting not found", async () => {
+      const { controller, deploymentSettingService } = setup();
+      deploymentSettingService.findOrCreateByUserIdAndDseq.mockResolvedValue(undefined);
+
+      await expect(() => controller.findOrCreateV2({ dseq: faker.string.numeric(6) })).rejects.toThrow("Deployment setting not found");
+    });
+  });
+
+  describe("createV2", () => {
+    it("uses provided userId", async () => {
+      const { controller, deploymentSettingService, setting } = setup();
+      const userId = faker.string.uuid();
+      const dseq = faker.string.numeric(6);
+      deploymentSettingService.create.mockResolvedValue(setting);
+
+      const result = await controller.createV2({ dseq, autoTopUpEnabled: true, userId });
+
+      expect(result).toEqual({ data: setting });
+      expect(deploymentSettingService.create).toHaveBeenCalledWith({ dseq, autoTopUpEnabled: true, userId });
+    });
+
+    it("defaults userId to current user when not provided", async () => {
+      const { controller, deploymentSettingService, setting, user } = setup();
+      const dseq = faker.string.numeric(6);
+      deploymentSettingService.create.mockResolvedValue(setting);
+
+      const result = await controller.createV2({ dseq, autoTopUpEnabled: false });
+
+      expect(result).toEqual({ data: setting });
+      expect(deploymentSettingService.create).toHaveBeenCalledWith({ dseq, autoTopUpEnabled: false, userId: user.id });
+    });
+  });
+
+  describe("upsertV2", () => {
+    it("uses provided userId", async () => {
+      const { controller, deploymentSettingService, setting } = setup();
+      const userId = faker.string.uuid();
+      const dseq = faker.string.numeric(6);
+      deploymentSettingService.upsert.mockResolvedValue(setting);
+
+      const result = await controller.upsertV2({ dseq, userId, autoTopUpEnabled: true });
+
+      expect(result).toEqual({ data: setting });
+      expect(deploymentSettingService.upsert).toHaveBeenCalledWith({ userId, dseq }, { autoTopUpEnabled: true });
+    });
+
+    it("defaults userId to current user when not provided", async () => {
+      const { controller, deploymentSettingService, setting, user } = setup();
+      const dseq = faker.string.numeric(6);
+      deploymentSettingService.upsert.mockResolvedValue(setting);
+
+      const result = await controller.upsertV2({ dseq, autoTopUpEnabled: false });
+
+      expect(result).toEqual({ data: setting });
+      expect(deploymentSettingService.upsert).toHaveBeenCalledWith({ userId: user.id, dseq }, { autoTopUpEnabled: false });
+    });
+
+    it("throws 404 when setting not found", async () => {
+      const { controller, deploymentSettingService } = setup();
+      deploymentSettingService.upsert.mockResolvedValue(undefined as never);
+
+      await expect(() => controller.upsertV2({ dseq: faker.string.numeric(6), autoTopUpEnabled: true })).rejects.toThrow("Deployment setting not found");
+    });
+  });
+
+  function setup() {
+    const user = createUser();
+    const deploymentSettingService = mock<DeploymentSettingService>();
+    const authService = mock<AuthService>({
+      currentUser: user
+    });
+    const controller = new DeploymentSettingController(deploymentSettingService, authService);
+    container.register(AuthService, { useValue: authService });
+
+    const setting = {
+      id: faker.string.uuid(),
+      userId: user.id,
+      dseq: faker.string.numeric(6),
+      autoTopUpEnabled: faker.datatype.boolean(),
+      closed: false,
+      estimatedTopUpAmount: faker.number.float({ min: 0, max: 100 }),
+      topUpFrequencyMs: faker.number.int({ min: 1000, max: 100000 }),
+      createdAt: faker.date.recent().toISOString(),
+      updatedAt: faker.date.recent().toISOString()
+    };
+
+    return { controller, deploymentSettingService, authService, user, setting };
+  }
+});

--- a/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.ts
+++ b/apps/api/src/deployment/controllers/deployment-setting/deployment-setting.controller.ts
@@ -1,18 +1,27 @@
 import assert from "http-assert";
 import { singleton } from "tsyringe";
 
-import { Protected } from "@src/auth/services/auth.service";
+import { AuthService, Protected } from "@src/auth/services/auth.service";
 import {
   type CreateDeploymentSettingRequest,
+  type CreateDeploymentSettingV2Request,
   type DeploymentSettingResponse,
   type FindDeploymentSettingParams,
+  type FindDeploymentSettingV2Params,
+  type FindDeploymentSettingV2Query,
   type UpdateDeploymentSettingRequest
 } from "@src/deployment/http-schemas/deployment-setting.schema";
+
+type FindOrCreateV2Input = FindDeploymentSettingV2Params & FindDeploymentSettingV2Query;
+type UpsertV2Input = FindDeploymentSettingV2Params & FindDeploymentSettingV2Query & UpdateDeploymentSettingRequest["data"];
 import { DeploymentSettingService } from "@src/deployment/services/deployment-setting/deployment-setting.service";
 
 @singleton()
 export class DeploymentSettingController {
-  constructor(private readonly deploymentSettingService: DeploymentSettingService) {}
+  constructor(
+    private readonly deploymentSettingService: DeploymentSettingService,
+    private readonly authService: AuthService
+  ) {}
 
   @Protected([{ action: "read", subject: "DeploymentSetting" }])
   async findOrCreateByUserIdAndDseq(params: FindDeploymentSettingParams): Promise<DeploymentSettingResponse> {
@@ -30,6 +39,31 @@ export class DeploymentSettingController {
   @Protected([{ action: "update", subject: "DeploymentSetting" }])
   async upsert(params: FindDeploymentSettingParams, input: UpdateDeploymentSettingRequest["data"]): Promise<DeploymentSettingResponse> {
     const setting = await this.deploymentSettingService.upsert(params, input);
+    assert(setting, 404, "Deployment setting not found");
+    return { data: setting };
+  }
+
+  @Protected([{ action: "read", subject: "DeploymentSetting" }])
+  async findOrCreateV2(input: FindOrCreateV2Input): Promise<DeploymentSettingResponse> {
+    const userId = input.userId ?? this.authService.currentUser.id;
+    const setting = await this.deploymentSettingService.findOrCreateByUserIdAndDseq({ userId, dseq: input.dseq });
+    assert(setting, 404, "Deployment setting not found");
+    return { data: setting };
+  }
+
+  @Protected([{ action: "create", subject: "DeploymentSetting" }])
+  async createV2(input: CreateDeploymentSettingV2Request["data"]): Promise<DeploymentSettingResponse> {
+    const { userId: inputUserId, ...rest } = input;
+    const userId = inputUserId ?? this.authService.currentUser.id;
+    const setting = await this.deploymentSettingService.create({ ...rest, userId });
+    return { data: setting };
+  }
+
+  @Protected([{ action: "update", subject: "DeploymentSetting" }])
+  async upsertV2(input: UpsertV2Input): Promise<DeploymentSettingResponse> {
+    const { dseq, userId: inputUserId, ...rest } = input;
+    const userId = inputUserId ?? this.authService.currentUser.id;
+    const setting = await this.deploymentSettingService.upsert({ userId, dseq }, rest);
     assert(setting, 404, "Deployment setting not found");
     return { data: setting };
   }

--- a/apps/api/src/deployment/http-schemas/deployment-setting.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment-setting.schema.ts
@@ -48,8 +48,37 @@ export const FindDeploymentSettingParamsSchema = z.object({
   })
 });
 
+export const FindDeploymentSettingV2ParamsSchema = z.object({
+  dseq: DseqSchema.openapi({
+    description: "Deployment sequence number"
+  })
+});
+
+export const FindDeploymentSettingV2QuerySchema = z.object({
+  userId: z.string().uuid().optional().openapi({
+    description: "User ID. Defaults to the current authenticated user if not provided"
+  })
+});
+
+export const CreateDeploymentSettingV2RequestSchema = z.object({
+  data: z.object({
+    dseq: DseqSchema.openapi({
+      description: "Deployment sequence number"
+    }),
+    autoTopUpEnabled: z.boolean().default(false).openapi({
+      description: "Whether auto top-up is enabled for this deployment"
+    }),
+    userId: z.string().uuid().optional().openapi({
+      description: "User ID. Defaults to the current authenticated user if not provided"
+    })
+  })
+});
+
 export type DeploymentSetting = z.infer<typeof DeploymentSettingSchema>;
 export type DeploymentSettingResponse = z.infer<typeof DeploymentSettingResponseSchema>;
 export type CreateDeploymentSettingRequest = z.infer<typeof CreateDeploymentSettingRequestSchema>;
 export type UpdateDeploymentSettingRequest = z.infer<typeof UpdateDeploymentSettingRequestSchema>;
 export type FindDeploymentSettingParams = z.infer<typeof FindDeploymentSettingParamsSchema>;
+export type FindDeploymentSettingV2Params = z.infer<typeof FindDeploymentSettingV2ParamsSchema>;
+export type FindDeploymentSettingV2Query = z.infer<typeof FindDeploymentSettingV2QuerySchema>;
+export type CreateDeploymentSettingV2Request = z.infer<typeof CreateDeploymentSettingV2RequestSchema>;

--- a/apps/api/src/deployment/routes/deployment-setting/deployment-setting.router.ts
+++ b/apps/api/src/deployment/routes/deployment-setting/deployment-setting.router.ts
@@ -7,8 +7,11 @@ import { SECURITY_BEARER_OR_API_KEY } from "@src/core/services/openapi-docs/open
 import { DeploymentSettingController } from "@src/deployment/controllers/deployment-setting/deployment-setting.controller";
 import {
   CreateDeploymentSettingRequestSchema,
+  CreateDeploymentSettingV2RequestSchema,
   DeploymentSettingResponseSchema,
   FindDeploymentSettingParamsSchema,
+  FindDeploymentSettingV2ParamsSchema,
+  FindDeploymentSettingV2QuerySchema,
   UpdateDeploymentSettingRequestSchema
 } from "@src/deployment/http-schemas/deployment-setting.schema";
 
@@ -124,5 +127,117 @@ deploymentSettingRouter.openapi(patchRoute, async function routeUpdateDeployment
   const params = c.req.valid("param");
   const { data } = c.req.valid("json");
   const result = await container.resolve(DeploymentSettingController).upsert(params, data);
+  return c.json(result, 200);
+});
+
+const getRouteV2 = createRoute({
+  method: "get",
+  path: "/v2/deployment-settings/{dseq}",
+  summary: "Get deployment settings by dseq",
+  tags: ["Deployment Settings"],
+  security: SECURITY_BEARER_OR_API_KEY,
+  request: {
+    params: FindDeploymentSettingV2ParamsSchema,
+    query: FindDeploymentSettingV2QuerySchema
+  },
+  responses: {
+    200: {
+      description: "Returns deployment settings",
+      content: {
+        "application/json": {
+          schema: DeploymentSettingResponseSchema
+        }
+      }
+    },
+    404: {
+      description: "Deployment settings not found",
+      content: {
+        "application/json": {
+          schema: z.object({
+            message: z.string()
+          })
+        }
+      }
+    }
+  }
+});
+deploymentSettingRouter.openapi(getRouteV2, async function routeGetDeploymentSettingsV2(c) {
+  const result = await container.resolve(DeploymentSettingController).findOrCreateV2({ ...c.req.valid("param"), ...c.req.valid("query") });
+  return c.json(result, 200);
+});
+
+const postRouteV2 = createRoute({
+  method: "post",
+  path: "/v2/deployment-settings",
+  summary: "Create deployment settings",
+  tags: ["Deployment Settings"],
+  security: SECURITY_BEARER_OR_API_KEY,
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: CreateDeploymentSettingV2RequestSchema
+        }
+      }
+    }
+  },
+  responses: {
+    201: {
+      description: "Deployment settings created successfully",
+      content: {
+        "application/json": {
+          schema: DeploymentSettingResponseSchema
+        }
+      }
+    }
+  }
+});
+deploymentSettingRouter.openapi(postRouteV2, async function routeCreateDeploymentSettingsV2(c) {
+  const { data } = c.req.valid("json");
+  const result = await container.resolve(DeploymentSettingController).createV2(data);
+  return c.json(result, 201);
+});
+
+const patchRouteV2 = createRoute({
+  method: "patch",
+  path: "/v2/deployment-settings/{dseq}",
+  summary: "Update deployment settings",
+  tags: ["Deployment Settings"],
+  security: SECURITY_BEARER_OR_API_KEY,
+  request: {
+    params: FindDeploymentSettingV2ParamsSchema,
+    query: FindDeploymentSettingV2QuerySchema,
+    body: {
+      content: {
+        "application/json": {
+          schema: UpdateDeploymentSettingRequestSchema
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: "Deployment settings updated successfully",
+      content: {
+        "application/json": {
+          schema: DeploymentSettingResponseSchema
+        }
+      }
+    },
+    404: {
+      description: "Deployment settings not found",
+      content: {
+        "application/json": {
+          schema: z.object({
+            message: z.string()
+          })
+        }
+      }
+    }
+  }
+});
+deploymentSettingRouter.openapi(patchRouteV2, async function routeUpdateDeploymentSettingsV2(c) {
+  const { data } = c.req.valid("json");
+  const result = await container.resolve(DeploymentSettingController).upsertV2({ ...c.req.valid("param"), ...c.req.valid("query"), ...data });
   return c.json(result, 200);
 });

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -15915,6 +15915,375 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
     },
+    "/v2/deployment-settings": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "autoTopUpEnabled": {
+                        "default": false,
+                        "description": "Whether auto top-up is enabled for this deployment",
+                        "type": "boolean",
+                      },
+                      "dseq": {
+                        "description": "Deployment sequence number",
+                        "pattern": "^d+$",
+                        "type": "string",
+                      },
+                      "userId": {
+                        "description": "User ID. Defaults to the current authenticated user if not provided",
+                        "format": "uuid",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "dseq",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "autoTopUpEnabled": {
+                          "type": "boolean",
+                        },
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "dseq": {
+                          "pattern": "^d+$",
+                          "type": "string",
+                        },
+                        "estimatedTopUpAmount": {
+                          "type": "number",
+                        },
+                        "id": {
+                          "format": "uuid",
+                          "type": "string",
+                        },
+                        "topUpFrequencyMs": {
+                          "type": "number",
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "userId": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "userId",
+                        "dseq",
+                        "autoTopUpEnabled",
+                        "estimatedTopUpAmount",
+                        "topUpFrequencyMs",
+                        "createdAt",
+                        "updatedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Deployment settings created successfully",
+          },
+        },
+        "security": [
+          {
+            "BearerAuth": [],
+          },
+          {
+            "ApiKeyAuth": [],
+          },
+        ],
+        "summary": "Create deployment settings",
+        "tags": [
+          "Deployment Settings",
+        ],
+      },
+    },
+    "/v2/deployment-settings/{dseq}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dseq",
+            "required": true,
+            "schema": {
+              "description": "Deployment sequence number",
+              "pattern": "^d+$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "userId",
+            "required": false,
+            "schema": {
+              "description": "User ID. Defaults to the current authenticated user if not provided",
+              "format": "uuid",
+              "type": "string",
+            },
+          },
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "autoTopUpEnabled": {
+                          "type": "boolean",
+                        },
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "dseq": {
+                          "pattern": "^d+$",
+                          "type": "string",
+                        },
+                        "estimatedTopUpAmount": {
+                          "type": "number",
+                        },
+                        "id": {
+                          "format": "uuid",
+                          "type": "string",
+                        },
+                        "topUpFrequencyMs": {
+                          "type": "number",
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "userId": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "userId",
+                        "dseq",
+                        "autoTopUpEnabled",
+                        "estimatedTopUpAmount",
+                        "topUpFrequencyMs",
+                        "createdAt",
+                        "updatedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns deployment settings",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Deployment settings not found",
+          },
+        },
+        "security": [
+          {
+            "BearerAuth": [],
+          },
+          {
+            "ApiKeyAuth": [],
+          },
+        ],
+        "summary": "Get deployment settings by dseq",
+        "tags": [
+          "Deployment Settings",
+        ],
+      },
+      "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "dseq",
+            "required": true,
+            "schema": {
+              "description": "Deployment sequence number",
+              "pattern": "^d+$",
+              "type": "string",
+            },
+          },
+          {
+            "in": "query",
+            "name": "userId",
+            "required": false,
+            "schema": {
+              "description": "User ID. Defaults to the current authenticated user if not provided",
+              "format": "uuid",
+              "type": "string",
+            },
+          },
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "autoTopUpEnabled": {
+                        "description": "Whether auto top-up is enabled for this deployment",
+                        "type": "boolean",
+                      },
+                    },
+                    "required": [
+                      "autoTopUpEnabled",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "autoTopUpEnabled": {
+                          "type": "boolean",
+                        },
+                        "createdAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "dseq": {
+                          "pattern": "^d+$",
+                          "type": "string",
+                        },
+                        "estimatedTopUpAmount": {
+                          "type": "number",
+                        },
+                        "id": {
+                          "format": "uuid",
+                          "type": "string",
+                        },
+                        "topUpFrequencyMs": {
+                          "type": "number",
+                        },
+                        "updatedAt": {
+                          "format": "date-time",
+                          "type": "string",
+                        },
+                        "userId": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "id",
+                        "userId",
+                        "dseq",
+                        "autoTopUpEnabled",
+                        "estimatedTopUpAmount",
+                        "topUpFrequencyMs",
+                        "createdAt",
+                        "updatedAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Deployment settings updated successfully",
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "message",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Deployment settings not found",
+          },
+        },
+        "security": [
+          {
+            "BearerAuth": [],
+          },
+          {
+            "ApiKeyAuth": [],
+          },
+        ],
+        "summary": "Update deployment settings",
+        "tags": [
+          "Deployment Settings",
+        ],
+      },
+    },
   },
   "servers": [
     {

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.tsx
@@ -21,7 +21,6 @@ import { useDeploymentMetrics } from "@src/hooks/useDeploymentMetrics";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { usePreviousRoute } from "@src/hooks/usePreviousRoute";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
-import { useUser } from "@src/hooks/useUser";
 import { useDeploymentSettingQuery } from "@src/queries/deploymentSettingsQuery";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
 import { averageBlockTime } from "@src/utils/priceUtils";
@@ -47,7 +46,6 @@ export const DEPENDENCIES = {
   useManagedDeploymentConfirm,
   usePreviousRoute,
   usePricing,
-  useUser,
   useDeploymentSettingQuery,
   usePopup,
   useRouter
@@ -83,8 +81,7 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
   const deploymentName = getDeploymentName(deployment?.dseq);
   const previousRoute = d.usePreviousRoute();
   const { closeDeploymentConfirm } = d.useManagedDeploymentConfirm();
-  const { user } = d.useUser();
-  const deploymentSetting = d.useDeploymentSettingQuery({ userId: user?.id, dseq: deployment.dseq });
+  const deploymentSetting = d.useDeploymentSettingQuery({ dseq: deployment.dseq });
   const { realTimeLeft, deploymentCost } = d.useDeploymentMetrics({ deployment, leases });
   const { confirm } = d.usePopup();
 

--- a/apps/deploy-web/src/queries/deploymentSettingsQuery.spec.ts
+++ b/apps/deploy-web/src/queries/deploymentSettingsQuery.spec.ts
@@ -1,0 +1,138 @@
+import type { DeploymentSettingHttpService } from "@akashnetwork/http-sdk";
+import { faker } from "@faker-js/faker";
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ContextType as WalletProviderContextType } from "@src/context/WalletProvider/WalletProvider";
+import { USE_DEPLOYMENT_SETTING_DEPENDENCIES, useDeploymentSettingQuery } from "./deploymentSettingsQuery";
+
+import { act } from "@testing-library/react";
+import { buildWallet } from "@tests/seeders";
+import { setupQuery } from "@tests/unit/query-client";
+
+describe("useDeploymentSettingQuery", () => {
+  describe("query", () => {
+    it("fetches deployment setting by dseq when wallet is managed", async () => {
+      const dseq = faker.string.numeric(6);
+      const settingData = buildDeploymentSetting({ dseq });
+      const deploymentSettingService = mock<DeploymentSettingHttpService>({
+        findByDseq: vi.fn().mockResolvedValue(settingData)
+      });
+
+      const { result } = setup({ dseq, services: { deploymentSetting: () => deploymentSettingService } });
+
+      await vi.waitFor(() => {
+        expect(result.current.data).toEqual(settingData);
+      });
+      expect(deploymentSettingService.findByDseq).toHaveBeenCalledWith(dseq);
+    });
+
+    it("does not fetch when wallet is not managed", () => {
+      const dseq = faker.string.numeric(6);
+      const deploymentSettingService = mock<DeploymentSettingHttpService>();
+
+      const { result } = setup({
+        dseq,
+        wallet: buildWallet({ isManaged: false }),
+        services: { deploymentSetting: () => deploymentSettingService }
+      });
+
+      expect(result.current.data).toBeUndefined();
+      expect(deploymentSettingService.findByDseq).not.toHaveBeenCalled();
+    });
+
+    it("does not fetch when dseq is empty", () => {
+      const deploymentSettingService = mock<DeploymentSettingHttpService>();
+
+      const { result } = setup({
+        dseq: "",
+        services: { deploymentSetting: () => deploymentSettingService }
+      });
+
+      expect(result.current.data).toBeUndefined();
+      expect(deploymentSettingService.findByDseq).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("update", () => {
+    it("updates deployment setting and refreshes cache", async () => {
+      const dseq = faker.string.numeric(6);
+      const updatedSetting = buildDeploymentSetting({ dseq, autoTopUpEnabled: true });
+      const deploymentSettingService = mock<DeploymentSettingHttpService>({
+        findByDseq: vi.fn().mockResolvedValue(buildDeploymentSetting({ dseq })),
+        updateByDseq: vi.fn().mockResolvedValue(updatedSetting)
+      });
+      const queryClient = new QueryClient();
+
+      const { result } = setup({
+        dseq,
+        services: {
+          deploymentSetting: () => deploymentSettingService,
+          queryClient: () => queryClient
+        }
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.data).toBeDefined();
+      });
+
+      act(() => {
+        result.current.setAutoTopUpEnabled(true);
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.data?.autoTopUpEnabled).toBe(true);
+      });
+      expect(deploymentSettingService.updateByDseq).toHaveBeenCalledWith(dseq, { autoTopUpEnabled: true });
+    });
+
+    it("throws when wallet is not managed", async () => {
+      const dseq = faker.string.numeric(6);
+      const deploymentSettingService = mock<DeploymentSettingHttpService>();
+
+      const { result } = setup({
+        dseq,
+        wallet: buildWallet({ isManaged: false }),
+        services: { deploymentSetting: () => deploymentSettingService }
+      });
+
+      act(() => {
+        result.current.update(true);
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+      expect(deploymentSettingService.updateByDseq).not.toHaveBeenCalled();
+    });
+  });
+
+  function setup(input: { dseq: string; wallet?: WalletProviderContextType; services?: Record<string, () => unknown> }) {
+    const wallet = input.wallet ?? buildWallet({ isManaged: true });
+    const dependencies: typeof USE_DEPLOYMENT_SETTING_DEPENDENCIES = {
+      ...USE_DEPLOYMENT_SETTING_DEPENDENCIES,
+      useWallet: () => wallet
+    };
+
+    return setupQuery(() => useDeploymentSettingQuery({ dseq: input.dseq }, dependencies), {
+      services: {
+        deploymentSetting: () => mock<DeploymentSettingHttpService>(),
+        ...input.services
+      }
+    });
+  }
+});
+
+function buildDeploymentSetting(overrides: { dseq: string; autoTopUpEnabled?: boolean }) {
+  return {
+    id: faker.number.int(),
+    userId: faker.string.uuid(),
+    dseq: overrides.dseq,
+    autoTopUpEnabled: overrides.autoTopUpEnabled ?? false,
+    estimatedTopUpAmount: faker.number.float({ min: 0, max: 100 }),
+    topUpFrequencyMs: faker.number.int({ min: 1000, max: 100000 }),
+    createdAt: faker.date.recent().toISOString(),
+    updatedAt: faker.date.recent().toISOString()
+  };
+}

--- a/apps/deploy-web/src/queries/deploymentSettingsQuery.ts
+++ b/apps/deploy-web/src/queries/deploymentSettingsQuery.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { type FindDeploymentSettingParams, isHttpError } from "@akashnetwork/http-sdk";
+import { isHttpError } from "@akashnetwork/http-sdk";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { millisecondsInMinute } from "date-fns/constants";
 
@@ -7,22 +7,21 @@ import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { QueryKeys } from "./queryKeys";
 
-export function useDeploymentSettingQuery(params: Omit<FindDeploymentSettingParams, "userId"> & { userId?: string }) {
-  const wallet = useWallet();
-  const queryKey = useMemo(() => (params.userId ? QueryKeys.getDeploymentSettingKey(params.userId, params.dseq) : []), [params.userId, params.dseq]);
+export const USE_DEPLOYMENT_SETTING_DEPENDENCIES = { useWallet };
+
+export function useDeploymentSettingQuery(
+  params: { dseq: string },
+  dependencies: typeof USE_DEPLOYMENT_SETTING_DEPENDENCIES = USE_DEPLOYMENT_SETTING_DEPENDENCIES
+) {
+  const wallet = dependencies.useWallet();
+  const queryKey = useMemo(() => QueryKeys.getDeploymentSettingKey(params.dseq), [params.dseq]);
   const { deploymentSetting } = useServices();
   const queryClient = useQueryClient();
 
   const query = useQuery({
     queryKey,
-    queryFn: () => {
-      if (!params.userId) {
-        throw new Error("userId is required");
-      }
-
-      return deploymentSetting.findByUserIdAndDseq({ userId: params.userId, dseq: params.dseq });
-    },
-    enabled: !!params.userId && !!params.dseq && !!wallet.isManaged,
+    queryFn: () => deploymentSetting.findByDseq(params.dseq),
+    enabled: !!params.dseq && !!wallet.isManaged,
     staleTime: 5 * millisecondsInMinute,
     retry: (failureCount, error) => {
       if (isHttpError(error) && error.response?.status === 404) {
@@ -38,11 +37,7 @@ export function useDeploymentSettingQuery(params: Omit<FindDeploymentSettingPara
         throw new Error("Cannot update deployment setting for a custodial wallet");
       }
 
-      if (!params.userId) {
-        throw new Error("userId is required");
-      }
-
-      return deploymentSetting.update({ userId: params.userId, dseq: params.dseq }, { autoTopUpEnabled });
+      return deploymentSetting.updateByDseq(params.dseq, { autoTopUpEnabled });
     },
     onSuccess: data => {
       queryClient.setQueryData(queryKey, data);

--- a/apps/deploy-web/src/queries/queryKeys.ts
+++ b/apps/deploy-web/src/queries/queryKeys.ts
@@ -50,7 +50,7 @@ export class QueryKeys {
   static getBmeParamsKey = () => ["BME_PARAMS"];
   static getGpuModelsKey = () => ["GPU_MODELS"];
   static getTrialProvidersKey = () => ["TRIAL_PROVIDERS"];
-  static getDeploymentSettingKey = (userId: string, dseq: string) => ["DEPLOYMENT_SETTING", userId, dseq];
+  static getDeploymentSettingKey = (dseq: string) => ["DEPLOYMENT_SETTING", dseq];
   static getApiKeysKey = (userId: string) => ["API_KEYS", userId];
 
   // Remote deploy

--- a/packages/http-sdk/src/deployment-setting/deployment-setting-http.service.ts
+++ b/packages/http-sdk/src/deployment-setting/deployment-setting-http.service.ts
@@ -19,6 +19,11 @@ export interface CreateDeploymentSettingInput {
   autoTopUpEnabled: boolean;
 }
 
+export interface CreateDeploymentSettingV2Input {
+  dseq: string;
+  autoTopUpEnabled: boolean;
+}
+
 export interface UpdateDeploymentSettingInput {
   autoTopUpEnabled: boolean;
 }
@@ -43,5 +48,17 @@ export class DeploymentSettingHttpService extends ApiHttpService {
 
   async update(params: FindDeploymentSettingParams, input: UpdateDeploymentSettingInput): Promise<DeploymentSettingOutput> {
     return this.extractApiData(await this.patch<DeploymentSettingOutput>(`/v1/deployment-settings/${params.userId}/${params.dseq}`, { data: input }));
+  }
+
+  async findByDseq(dseq: string): Promise<DeploymentSettingOutput> {
+    return this.extractApiData(await this.get<DeploymentSettingOutput>(`/v2/deployment-settings/${dseq}`));
+  }
+
+  async createV2(input: CreateDeploymentSettingV2Input): Promise<DeploymentSettingOutput> {
+    return this.extractApiData(await this.post<DeploymentSettingOutput>("/v2/deployment-settings", { data: input }));
+  }
+
+  async updateByDseq(dseq: string, input: UpdateDeploymentSettingInput): Promise<DeploymentSettingOutput> {
+    return this.extractApiData(await this.patch<DeploymentSettingOutput>(`/v2/deployment-settings/${dseq}`, { data: input }));
   }
 }


### PR DESCRIPTION
## Why

The v1 deployment settings API requires `userId` in every request path (`/v1/deployment-settings/{userId}/{dseq}`), which is unnecessary for managed wallet API consumers who always operate on their own resources. This adds a v2 API that defaults `userId` to the authenticated user, simplifying the client interface.

## What

- Added v2 deployment settings endpoints (`GET/POST/PATCH /v2/deployment-settings/{dseq}`) where `userId` is an optional query param defaulting to the current authenticated user
- Added v2 methods to `DeploymentSettingHttpService` in `http-sdk`
- Updated `deploy-web` to use v2 endpoints, removing the `userId` requirement from `useDeploymentSettingQuery` and `DeploymentDetailTopBar`
- Added unit tests for the new v2 controller methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * V2 deployment-settings API (GET/POST/PATCH) by deployment sequence (dseq); omitting userId falls back to the authenticated user.
  * HTTP SDK adds V2 methods to get/create/update settings by dseq.

* **Refactor**
  * Client hooks, cache keys, and UI components simplified to use dseq only; explicit user context no longer required for deployment settings.

* **Tests**
  * New server and client test suites covering V2 endpoints and the updated hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->