### PR TITLE
feat(network): disable testnet in network selector

### DIFF
--- a/packages/network-store/src/network.config.ts
+++ b/packages/network-store/src/network.config.ts
@@ -21,22 +21,6 @@ export const getInitialNetworksConfig = ({ apiBaseUrl }: { apiBaseUrl: string })
     version: netConfig.getVersion(MAINNET_ID)
   },
   {
-    id: TESTNET_ID,
-    title: "BME Testnet",
-    description: "Testnet of the BME feature.",
-    nodesUrl: `${apiBaseUrl}/blockchain-config?network=testnet`,
-    chainId: "testnet-8",
-    chainRegistryName: "akash-testnet",
-    rpcEndpoint: "",
-    enabled: true,
-    deploymentVersion: "v1beta4",
-    marketVersion: "v1beta5",
-    escrowVersion: "v1",
-    certVersion: "v1",
-    providerVersion: "v1beta4",
-    version: null
-  },
-  {
     id: SANDBOX_ID,
     title: "Sandbox",
     description: "Sandbox of the mainnet version.",
@@ -51,5 +35,21 @@ export const getInitialNetworksConfig = ({ apiBaseUrl }: { apiBaseUrl: string })
     escrowVersion: "v1",
     certVersion: "v1",
     providerVersion: "v1beta4"
+  },
+  {
+    id: TESTNET_ID,
+    title: "Testnet",
+    description: "Testnet of the BME feature.",
+    nodesUrl: `${apiBaseUrl}/blockchain-config?network=testnet`,
+    chainId: "testnet-8",
+    chainRegistryName: "akash-testnet",
+    rpcEndpoint: "",
+    enabled: false,
+    deploymentVersion: "v1beta4",
+    marketVersion: "v1beta5",
+    escrowVersion: "v1",
+    certVersion: "v1",
+    providerVersion: "v1beta4",
+    version: null
   }
 ];


### PR DESCRIPTION
## Why

Disable the testnet network option in the network selector as BME has been upgraded to mainnet.

## What

- Set `enabled: false` for the testnet entry in `packages/network-store/src/network.config.ts`
<img width="684" height="574" alt="image" src="https://github.com/user-attachments/assets/9aed849b-ccad-464e-93c7-948facdce960" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Testnet configuration updated: disabled by default and renamed to "Testnet" (previously "BME Testnet" and enabled)
  * Network list ordering adjusted to place Testnet after the Sandbox network
<!-- end of auto-generated comment: release notes by coderabbit.ai -->