### PR TITLE
feat(log-collector): add watch-based pod discovery with polling fallback

### DIFF
--- a/apps/log-collector/README.md
+++ b/apps/log-collector/README.md
@@ -8,7 +8,7 @@ The Log Collector leverages internal Kubernetes access to discover and stream lo
 
 ## Features
 
-- **Automatic Pod Discovery**: Discovers all pods in the deployment namespace and automatically excludes itself
+- **Automatic Pod Discovery**: Discovers all pods in the deployment namespace using K8s Watch API (with polling fallback) and excludes pods from the same deployment
 - **Real-time Log Streaming**: Streams logs from all discovered pods with automatic reconnection on pod restarts
 - **File-based Output**: Writes raw logs to files organized by namespace and pod name
 - **Automatic Log Rotation**: Rotates log files when they reach configurable size limits
@@ -20,7 +20,7 @@ The Log Collector leverages internal Kubernetes access to discover and stream lo
 ## How It Works
 
 1. **Namespace Discovery**: The collector automatically detects the Kubernetes namespace it's deployed in
-2. **Pod Discovery**: Scans the namespace for all running pods (excluding pods from the same deployment), with optional label-based filtering via `POD_LABEL_SELECTOR`
+2. **Pod Discovery**: Uses the K8s Watch API for real-time pod lifecycle events (ADDED, MODIFIED, DELETED). Pods that become ready after creation are picked up via MODIFIED events. If watch is unavailable (e.g., RBAC lacks the `watch` verb), falls back to periodic polling. On non-403 watch failures, polls temporarily and retries watch every 30 seconds. Excludes pods from the same deployment, with optional label-based filtering via `POD_LABEL_SELECTOR`
 3. **Log Streaming**: Establishes log streams for each pod
 4. **File Output**: Writes collected logs to files for external processing
 5. **Log Rotation**: Automatically rotates log files when they reach the configured size limit, maintaining up to `LOG_MAX_ROTATED_FILES` rotated files
@@ -37,6 +37,8 @@ These are the environment variables you need to configure for production deploym
 | `LOG_MAX_FILE_SIZE_BYTES` | Max file size before rotation               | `10_485_760` (10MB) | `20_971_520` (20MB)                |
 | `LOG_MAX_ROTATED_FILES`   | Max number of rotated files                 | `5`                 | `10`                               |
 | `POD_LABEL_SELECTOR`      | Kubernetes label selector for pod discovery | unset (all pods)    | `"app=web,environment=production"` |
+| `POD_POLL_INTERVAL_MS`    | Interval between poll cycles (fallback mode) | `5000`              | `10000`                            |
+
 ### Log Collection Configuration
 
 **Note**: Output destinations are automatically configured at startup based on environment variables. No manual configuration files needed.

--- a/apps/log-collector/k8s/role.yaml
+++ b/apps/log-collector/k8s/role.yaml
@@ -5,7 +5,10 @@ metadata:
   name: tenant-pod-reader
 rules:
   - apiGroups: [""]
-    resources: ["pods", "pods/log"]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["events"]

--- a/apps/log-collector/k8s/target.deployment.yaml
+++ b/apps/log-collector/k8s/target.deployment.yaml
@@ -22,6 +22,7 @@ spec:
             - /bin/sh
             - -c
             - |
+              echo "$(date -u +%Y-%m-%dT%H:%M:%S).000Z [INFO] LOG TARGET STARTED <----------"
               while true; do
                 echo "$(date -u +%Y-%m-%dT%H:%M:%S).000Z [INFO] Dummy log message from pod dummy-logging-pod"
                 echo "$(date -u +%Y-%m-%dT%H:%M:%S).000Z [ERROR] This is a test error message"

--- a/apps/log-collector/src/lib/async-channel/async-channel.spec.ts
+++ b/apps/log-collector/src/lib/async-channel/async-channel.spec.ts
@@ -1,0 +1,89 @@
+import { AsyncChannel } from "./async-channel";
+
+describe(AsyncChannel.name, () => {
+  it("should deliver pushed values to async iterator", async () => {
+    const channel = new AsyncChannel<string>();
+
+    channel.push("a");
+    channel.push("b");
+    channel.close();
+
+    const results: string[] = [];
+    for await (const value of channel) {
+      results.push(value);
+    }
+
+    expect(results).toEqual(["a", "b"]);
+  });
+
+  it("should wait for push when iterator is ahead of producer", async () => {
+    const channel = new AsyncChannel<number>();
+
+    const promise = channel[Symbol.asyncIterator]().next();
+
+    channel.push(42);
+
+    const result = await promise;
+    expect(result).toEqual({ value: 42, done: false });
+  });
+
+  it("should return done when closed with no pending values", async () => {
+    const channel = new AsyncChannel<string>();
+
+    const promise = channel[Symbol.asyncIterator]().next();
+
+    channel.close();
+
+    const result = await promise;
+    expect(result.done).toBe(true);
+  });
+
+  it("should drain buffered values before signaling done", async () => {
+    const channel = new AsyncChannel<string>();
+
+    channel.push("first");
+    channel.push("second");
+    channel.close();
+
+    const iter = channel[Symbol.asyncIterator]();
+
+    expect(await iter.next()).toEqual({ value: "first", done: false });
+    expect(await iter.next()).toEqual({ value: "second", done: false });
+    expect((await iter.next()).done).toBe(true);
+  });
+
+  it("should ignore pushes after close", async () => {
+    const channel = new AsyncChannel<string>();
+
+    channel.push("before");
+    channel.close();
+    channel.push("after");
+
+    const results: string[] = [];
+    for await (const value of channel) {
+      results.push(value);
+    }
+
+    expect(results).toEqual(["before"]);
+  });
+
+  it("should work with yield* delegation", async () => {
+    const channel = new AsyncChannel<number>();
+
+    async function* consume(): AsyncGenerator<number> {
+      yield* channel;
+    }
+
+    const gen = consume();
+
+    channel.push(1);
+    channel.push(2);
+
+    expect(await gen.next()).toEqual({ value: 1, done: false });
+    expect(await gen.next()).toEqual({ value: 2, done: false });
+
+    channel.close();
+
+    expect((await gen.next()).done).toBe(true);
+  });
+});

--- a/apps/log-collector/src/lib/async-channel/async-channel.ts
+++ b/apps/log-collector/src/lib/async-channel/async-channel.ts
@@ -1,0 +1,72 @@
+/**
+ * Minimal async channel — bridges push-based callbacks to pull-based async iteration.
+ *
+ * Events pushed via `push()` are buffered until consumed. If a consumer is
+ * already waiting (via `next()`), the event is delivered immediately.
+ * Calling `close()` signals the end of the stream.
+ *
+ * Implements `AsyncIterable`, so it can be used with `for await` or `yield*`.
+ *
+ * @example
+ * ```typescript
+ * const channel = new AsyncChannel<string>();
+ *
+ * // Producer side (callback-based)
+ * someEmitter.on("data", (value) => channel.push(value));
+ * someEmitter.on("end", () => channel.close());
+ *
+ * // Consumer side (async iteration)
+ * for await (const value of channel) {
+ *   console.log(value);
+ * }
+ * ```
+ */
+export class AsyncChannel<T> {
+  private queue: T[] = [];
+
+  private waiting: ((result: IteratorResult<T>) => void) | null = null;
+
+  private done = false;
+
+  /** Enqueues a value. If a consumer is waiting, delivers it immediately. */
+  push(value: T): void {
+    if (this.done) return;
+
+    if (this.waiting) {
+      const resolve = this.waiting;
+      this.waiting = null;
+      resolve({ value, done: false });
+    } else {
+      this.queue.push(value);
+    }
+  }
+
+  /** Closes the channel. Any pending or future `next()` calls will return `done: true`. */
+  close(): void {
+    this.done = true;
+
+    if (this.waiting) {
+      const resolve = this.waiting;
+      this.waiting = null;
+      resolve({ value: undefined as T, done: true });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: () => {
+        if (this.queue.length > 0) {
+          return Promise.resolve({ value: this.queue.shift()!, done: false });
+        }
+
+        if (this.done) {
+          return Promise.resolve({ value: undefined as T, done: true });
+        }
+
+        return new Promise<IteratorResult<T>>(resolve => {
+          this.waiting = resolve;
+        });
+      }
+    };
+  }
+}

--- a/apps/log-collector/src/providers/k8s-client.provider.ts
+++ b/apps/log-collector/src/providers/k8s-client.provider.ts
@@ -5,7 +5,7 @@
  * services. The KubeConfig is loaded from default sources (kubeconfig file, environment
  * variables, etc.) and used to create API clients.
  */
-import { CoreV1Api, KubeConfig, Log } from "@kubernetes/client-node";
+import { CoreV1Api, KubeConfig, Log, Watch } from "@kubernetes/client-node";
 import { container } from "tsyringe";
 
 // Register KubeConfig with default configuration
@@ -37,5 +37,13 @@ container.register(Log, {
   useFactory: c => {
     const kc = c.resolve(KubeConfig);
     return new Log(kc);
+  }
+});
+
+// Register Watch client using the configured KubeConfig
+container.register(Watch, {
+  useFactory: c => {
+    const kc = c.resolve(KubeConfig);
+    return new Watch(kc);
   }
 });

--- a/apps/log-collector/src/services/pod-discovery/pod-discovery.service.spec.ts
+++ b/apps/log-collector/src/services/pod-discovery/pod-discovery.service.spec.ts
@@ -1,9 +1,10 @@
 import { faker } from "@faker-js/faker";
-import type { Context, CoreV1Api, KubeConfig, V1Pod } from "@kubernetes/client-node";
+import type { Context, CoreV1Api, KubeConfig, V1Pod, Watch } from "@kubernetes/client-node";
 import { mock } from "jest-mock-extended";
 import { container } from "tsyringe";
 
 import { ConfigService } from "@src/services/config/config.service";
+import { ErrorHandlerService } from "@src/services/error-handler/error-handler.service";
 import { LoggerService } from "@src/services/logger/logger.service";
 import type { PodCallback } from "./pod-discovery.service";
 import { PodDiscoveryService } from "./pod-discovery.service";
@@ -48,7 +49,7 @@ describe(PodDiscoveryService.name, () => {
 
     k8sClient.listNamespacedPod.mockResolvedValue({ items: podsRaw });
 
-    const result = await podDiscoveryService.discoverPodsInNamespace();
+    const { pods: result } = await podDiscoveryService.discoverPodsInNamespace();
 
     expect(result).toHaveLength(2);
     expect(result[0].podName).toBe("web-78d5c9c5b-hxqxs");
@@ -58,17 +59,9 @@ describe(PodDiscoveryService.name, () => {
     expect(result.find(pod => pod.podName === "log-collector-c5f7d6bc5-d8nrl")).toBeUndefined();
     expect(result.find(pod => pod.podName === "log-collector-xyz789-abc123")).toBeUndefined();
 
-    expect(k8sClient.listNamespacedPod).toHaveBeenCalledWith({
-      namespace,
-      labelSelector: undefined
-    });
-
-    expect(loggerService.info).toHaveBeenCalledWith({
-      event: "POD_DISCOVERY_STARTED",
-      namespace
-    });
-
-    expect(loggerService.info).toHaveBeenCalledWith({
+    expect(k8sClient.listNamespacedPod).toHaveBeenCalledWith({ namespace, labelSelector: undefined });
+    expect(loggerService.debug).toHaveBeenCalledWith({ event: "POD_DISCOVERY_STARTED", namespace });
+    expect(loggerService.debug).toHaveBeenCalledWith({
       event: "POD_DISCOVERY_COMPLETED",
       namespace,
       totalPods: 5,
@@ -80,9 +73,7 @@ describe(PodDiscoveryService.name, () => {
 
   it("should filter out pods that are not ready", async () => {
     const namespace = faker.internet.domainWord();
-    const { podDiscoveryService, k8sClient } = setup({
-      KUBERNETES_NAMESPACE_OVERRIDE: namespace
-    });
+    const { podDiscoveryService, k8sClient } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: namespace });
 
     const podsRaw = [
       seedKubernetesPodTestData({
@@ -104,7 +95,7 @@ describe(PodDiscoveryService.name, () => {
 
     k8sClient.listNamespacedPod.mockResolvedValue({ items: podsRaw });
 
-    const result = await podDiscoveryService.discoverPodsInNamespace();
+    const { pods: result } = await podDiscoveryService.discoverPodsInNamespace();
 
     expect(result).toHaveLength(1);
     expect(result[0].podName).toBe("ready-pod");
@@ -112,18 +103,12 @@ describe(PodDiscoveryService.name, () => {
 
   it("should use namespace override when provided", async () => {
     const overrideNamespace = faker.internet.domainWord();
-    const { podDiscoveryService, k8sClient } = setup({
-      KUBERNETES_NAMESPACE_OVERRIDE: overrideNamespace
-    });
+    const { podDiscoveryService, k8sClient } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: overrideNamespace });
 
     k8sClient.listNamespacedPod.mockResolvedValue({ items: [] });
-
     await podDiscoveryService.discoverPodsInNamespace();
 
-    expect(k8sClient.listNamespacedPod).toHaveBeenCalledWith({
-      namespace: overrideNamespace,
-      labelSelector: undefined
-    });
+    expect(k8sClient.listNamespacedPod).toHaveBeenCalledWith({ namespace: overrideNamespace, labelSelector: undefined });
   });
 
   it("should get namespace from kubeconfig when no override provided", async () => {
@@ -142,18 +127,12 @@ describe(PodDiscoveryService.name, () => {
 
     await podDiscoveryService.discoverPodsInNamespace();
 
-    expect(kubeConfig.getCurrentContext).toHaveBeenCalled();
-    expect(kubeConfig.getContextObject).toHaveBeenCalledWith(currentContext);
-    expect(k8sClient.listNamespacedPod).toHaveBeenCalledWith({
-      namespace: kubeconfigNamespace,
-      labelSelector: undefined
-    });
+    expect(k8sClient.listNamespacedPod).toHaveBeenCalledWith({ namespace: kubeconfigNamespace, labelSelector: undefined });
   });
 
   it("should throw error when kubeconfig context not found", async () => {
     const { podDiscoveryService, kubeConfig } = setup();
     const currentContext = faker.internet.domainWord();
-
     kubeConfig.getCurrentContext.mockReturnValue(currentContext);
     kubeConfig.getContextObject.mockReturnValue(null);
 
@@ -163,287 +142,334 @@ describe(PodDiscoveryService.name, () => {
   it("should throw error when kubeconfig context has no namespace", async () => {
     const { podDiscoveryService, kubeConfig } = setup();
     const currentContext = faker.internet.domainWord();
-
     kubeConfig.getCurrentContext.mockReturnValue(currentContext);
-    kubeConfig.getContextObject.mockReturnValue({
-      name: currentContext,
-      cluster: faker.internet.domainWord(),
-      user: faker.internet.domainWord(),
-      namespace: undefined
-    } as Context);
+    kubeConfig.getContextObject.mockReturnValue({ name: currentContext, cluster: "c", user: "u", namespace: undefined } as Context);
 
-    await expect(podDiscoveryService.discoverPodsInNamespace()).rejects.toThrow(
-      `No namespace provided in k8s context: ${currentContext}. Please set namespace in context or provide KUBERNETES_NAMESPACE_OVERRIDE`
-    );
+    await expect(podDiscoveryService.discoverPodsInNamespace()).rejects.toThrow("No namespace provided");
   });
 
   it("should handle empty pod list", async () => {
     const namespace = faker.internet.domainWord();
-    const { podDiscoveryService, k8sClient, loggerService } = setup({
-      KUBERNETES_NAMESPACE_OVERRIDE: namespace
-    });
-    const currentPodName = "log-collector-6bdb59678c-w9jww";
+    const { podDiscoveryService, k8sClient, loggerService } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: namespace });
 
     k8sClient.listNamespacedPod.mockResolvedValue({ items: [] });
-
-    const result = await podDiscoveryService.discoverPodsInNamespace();
+    const { pods: result } = await podDiscoveryService.discoverPodsInNamespace();
 
     expect(result).toHaveLength(0);
-    expect(loggerService.info).toHaveBeenCalledWith({
-      event: "POD_DISCOVERY_COMPLETED",
-      namespace,
-      totalPods: 0,
-      readyPods: 0,
-      targetPods: 0,
-      currentPodName
-    });
+    expect(loggerService.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "POD_DISCOVERY_COMPLETED", targetPods: 0 }));
   });
 
   it("should handle pod names with insufficient parts for deployment extraction", async () => {
     const namespace = faker.internet.domainWord();
-    const { podDiscoveryService, k8sClient, loggerService } = setup({
-      KUBERNETES_NAMESPACE_OVERRIDE: namespace,
-      HOSTNAME: "simple-pod" // Only 2 parts, not enough for deployment extraction
+    const { podDiscoveryService, k8sClient } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: namespace, HOSTNAME: "simple-pod" });
+
+    k8sClient.listNamespacedPod.mockResolvedValue({
+      items: [
+        seedKubernetesPodTestData({
+          metadata: { name: "simple-pod", namespace },
+          spec: { containers: [{ name: "app" }] },
+          status: { phase: "Running", conditions: [{ type: "Ready", status: "True" }] }
+        }),
+        seedKubernetesPodTestData({
+          metadata: { name: "other-pod", namespace },
+          spec: { containers: [{ name: "nginx" }] },
+          status: { phase: "Running", conditions: [{ type: "Ready", status: "True" }] }
+        })
+      ]
     });
-    const podsRaw = [
-      seedKubernetesPodTestData({
-        metadata: { name: "simple-pod", namespace },
-        spec: { containers: [{ name: "app" }] },
-        status: { phase: "Running", conditions: [{ type: "Ready", status: "True" }] }
-      }),
-      seedKubernetesPodTestData({
-        metadata: { name: "other-pod", namespace },
-        spec: { containers: [{ name: "nginx" }] },
-        status: { phase: "Running", conditions: [{ type: "Ready", status: "True" }] }
-      })
-    ];
 
-    k8sClient.listNamespacedPod.mockResolvedValue({ items: podsRaw });
-
-    const result = await podDiscoveryService.discoverPodsInNamespace();
-
-    // Current pod excluded by exact name match even when deployment name can't be extracted
+    const { pods: result } = await podDiscoveryService.discoverPodsInNamespace();
     expect(result).toHaveLength(1);
     expect(result[0].podName).toBe("other-pod");
-
-    expect(loggerService.info).toHaveBeenCalledWith({
-      event: "POD_DISCOVERY_COMPLETED",
-      namespace,
-      totalPods: 2,
-      readyPods: 2,
-      targetPods: 1,
-      currentPodName: "simple-pod"
-    });
   });
 
   it("should map pod to PodInfo correctly", async () => {
     const namespace = faker.internet.domainWord();
-    const { podDiscoveryService, k8sClient } = setup({
-      KUBERNETES_NAMESPACE_OVERRIDE: namespace
-    });
+    const { podDiscoveryService, k8sClient } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: namespace });
     const podName = faker.internet.domainWord();
     const podRaw = seedKubernetesPodTestData({
-      metadata: {
-        name: podName,
-        namespace,
-        labels: { app: faker.internet.domainWord(), version: faker.system.semver() },
-        annotations: { "kubernetes.io/created-by": faker.internet.domainWord() }
-      },
-      spec: {
-        containers: [{ name: faker.internet.domainWord() }, { name: faker.internet.domainWord() }],
-        nodeName: faker.internet.domainWord()
-      },
-      status: {
-        phase: faker.helpers.arrayElement(["Running", "Pending", "Succeeded", "Failed", "Unknown"]),
-        podIP: faker.internet.ip(),
-        conditions: [{ type: "Ready", status: "True" }]
-      }
+      metadata: { name: podName, namespace, labels: { app: "web" }, annotations: { note: "test" } },
+      spec: { containers: [{ name: "app" }, { name: "sidecar" }], nodeName: "node-1" },
+      status: { phase: "Running", podIP: "10.0.0.1", conditions: [{ type: "Ready", status: "True" }] }
     });
 
     k8sClient.listNamespacedPod.mockResolvedValue({ items: [podRaw] });
-
-    const result = await podDiscoveryService.discoverPodsInNamespace();
+    const { pods: result } = await podDiscoveryService.discoverPodsInNamespace();
 
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual({
       podName,
       namespace,
-      status: podRaw.status?.phase,
-      podIP: podRaw.status?.podIP,
-      nodeName: podRaw.spec?.nodeName,
-      labels: podRaw.metadata?.labels,
-      annotations: podRaw.metadata?.annotations,
-      containerNames: podRaw.spec?.containers.map(c => c.name)
+      status: "Running",
+      podIP: "10.0.0.1",
+      nodeName: "node-1",
+      labels: { app: "web" },
+      annotations: { note: "test" },
+      containerNames: ["app", "sidecar"]
     });
   });
 
   it("should handle pods with missing metadata gracefully", async () => {
     const namespace = faker.internet.domainWord();
-    const { podDiscoveryService, k8sClient } = setup({
-      KUBERNETES_NAMESPACE_OVERRIDE: namespace
-    });
+    const { podDiscoveryService, k8sClient } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: namespace });
     const podName = faker.internet.domainWord();
     const podRaw = seedKubernetesPodTestData({
-      metadata: {
-        name: podName,
-        namespace,
-        labels: undefined,
-        annotations: undefined
-      },
-      spec: {
-        containers: [{ name: faker.internet.domainWord() }],
-        nodeName: undefined
-      },
-      status: {
-        phase: undefined,
-        podIP: undefined,
-        conditions: [{ type: "Ready", status: "True" }]
-      }
+      metadata: { name: podName, namespace, labels: undefined, annotations: undefined },
+      spec: { containers: [{ name: "app" }], nodeName: undefined },
+      status: { phase: undefined, podIP: undefined, conditions: [{ type: "Ready", status: "True" }] }
     });
 
     k8sClient.listNamespacedPod.mockResolvedValue({ items: [podRaw] });
+    const { pods: result } = await podDiscoveryService.discoverPodsInNamespace();
 
-    const result = await podDiscoveryService.discoverPodsInNamespace();
-
-    expect(result).toHaveLength(1);
-    expect(result[0]).toEqual({
-      podName,
-      namespace,
-      status: undefined,
-      podIP: undefined,
-      nodeName: undefined,
-      labels: {},
-      annotations: {},
-      containerNames: [podRaw.spec?.containers[0].name]
-    });
+    expect(result[0]).toEqual(expect.objectContaining({ podName, labels: {}, annotations: {} }));
   });
 
   it("should handle pods with missing container spec", async () => {
     const namespace = faker.internet.domainWord();
-    const { podDiscoveryService, k8sClient } = setup({
-      KUBERNETES_NAMESPACE_OVERRIDE: namespace
-    });
-    const podName = faker.internet.domainWord();
-    const podRaw: V1Pod = {
-      metadata: { name: podName },
-      spec: undefined,
-      status: { conditions: [{ type: "Ready", status: "True" }] }
-    };
+    const { podDiscoveryService, k8sClient } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: namespace });
+    const podRaw: V1Pod = { metadata: { name: faker.internet.domainWord() }, spec: undefined, status: { conditions: [{ type: "Ready", status: "True" }] } };
 
     k8sClient.listNamespacedPod.mockResolvedValue({ items: [podRaw] });
+    const { pods: result } = await podDiscoveryService.discoverPodsInNamespace();
 
-    const result = await podDiscoveryService.discoverPodsInNamespace();
-
-    expect(result).toHaveLength(1);
     expect(result[0].containerNames).toEqual([]);
-  });
-
-  it("should log debug information for kubeconfig context", async () => {
-    const { podDiscoveryService, kubeConfig, k8sClient } = setup();
-    const currentContext = faker.internet.domainWord();
-    const kubeconfigNamespace = faker.internet.domainWord();
-
-    kubeConfig.getCurrentContext.mockReturnValue(currentContext);
-    kubeConfig.getContextObject.mockReturnValue({
-      name: currentContext,
-      cluster: faker.internet.domainWord(),
-      user: faker.internet.domainWord(),
-      namespace: kubeconfigNamespace
-    } as Context);
-    k8sClient.listNamespacedPod.mockResolvedValue({ items: [] });
-
-    await podDiscoveryService.discoverPodsInNamespace();
-
-    expect(kubeConfig.getCurrentContext).toHaveBeenCalled();
-    expect(kubeConfig.getContextObject).toHaveBeenCalledWith(currentContext);
-  });
-
-  it("should log namespace source when using kubeconfig", async () => {
-    const { podDiscoveryService, kubeConfig, k8sClient, loggerService } = setup();
-    const kubeconfigNamespace = faker.internet.domainWord();
-    const currentContext = faker.internet.domainWord();
-
-    kubeConfig.getCurrentContext.mockReturnValue(currentContext);
-    kubeConfig.getContextObject.mockReturnValue({
-      name: currentContext,
-      cluster: faker.internet.domainWord(),
-      user: faker.internet.domainWord(),
-      namespace: kubeconfigNamespace
-    } as Context);
-    k8sClient.listNamespacedPod.mockResolvedValue({ items: [] });
-
-    await podDiscoveryService.discoverPodsInNamespace();
-
-    expect(loggerService.info).toHaveBeenCalledWith({
-      event: "NAMESPACE_RESOLVED",
-      namespace: kubeconfigNamespace,
-      source: "kubeconfig"
-    });
   });
 
   it("should use label selector when POD_LABEL_SELECTOR is configured", async () => {
     const namespace = faker.internet.domainWord();
-    const labelSelector = "app=web,environment=production";
-    const { podDiscoveryService, k8sClient } = setup({
-      KUBERNETES_NAMESPACE_OVERRIDE: namespace,
-      POD_LABEL_SELECTOR: labelSelector
-    });
+    const labelSelector = "app=web";
+    const { podDiscoveryService, k8sClient } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: namespace, POD_LABEL_SELECTOR: labelSelector });
 
     k8sClient.listNamespacedPod.mockResolvedValue({ items: [] });
-
     await podDiscoveryService.discoverPodsInNamespace();
 
-    expect(k8sClient.listNamespacedPod).toHaveBeenCalledWith({
-      namespace,
-      labelSelector
+    expect(k8sClient.listNamespacedPod).toHaveBeenCalledWith({ namespace, labelSelector });
+  });
+
+  describe("watchPods — K8s Watch", () => {
+    it("should track initially discovered pods and start K8s watch", async () => {
+      const namespace = faker.internet.domainWord();
+      const { podDiscoveryService, k8sClient, watch } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: namespace });
+
+      const pod = seedKubernetesPodTestData({
+        metadata: { name: "pod-1", namespace },
+        spec: { containers: [{ name: "app" }] },
+        status: { phase: "Running", conditions: [{ type: "Ready", status: "True" }] }
+      });
+
+      k8sClient.listNamespacedPod.mockResolvedValue({ items: [pod] });
+      watch.watch.mockResolvedValue(new AbortController());
+
+      const callback = jest.fn();
+      podDiscoveryService.watchPods(callback).catch(() => {});
+      await flushPromises();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(expect.objectContaining({ podName: "pod-1" }), expect.any(AbortSignal));
+      expect(watch.watch).toHaveBeenCalledWith(`/api/v1/namespaces/${namespace}/pods`, expect.any(Object), expect.any(Function), expect.any(Function));
+    });
+
+    it("should track new ready pod on ADDED watch event", async () => {
+      const namespace = faker.internet.domainWord();
+      const { podDiscoveryService, k8sClient, watch } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: namespace });
+
+      k8sClient.listNamespacedPod.mockResolvedValue({ items: [] });
+
+      let eventCb: (phase: string, apiObj: V1Pod) => void = () => {};
+      watch.watch.mockImplementation(async (_path, _params, cb) => {
+        eventCb = cb;
+        return new AbortController();
+      });
+
+      const callback = jest.fn();
+      podDiscoveryService.watchPods(callback).catch(() => {});
+      await flushPromises();
+
+      eventCb(
+        "ADDED",
+        seedKubernetesPodTestData({
+          metadata: { name: "new-pod", namespace },
+          spec: { containers: [{ name: "app" }] },
+          status: { conditions: [{ type: "Ready", status: "True" }] }
+        })
+      );
+      await flushPromises();
+
+      expect(callback).toHaveBeenCalledWith(expect.objectContaining({ podName: "new-pod" }), expect.any(AbortSignal));
+    });
+
+    it("should skip ADDED events for not-ready pods", async () => {
+      const namespace = faker.internet.domainWord();
+      const { podDiscoveryService, k8sClient, watch } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: namespace });
+
+      k8sClient.listNamespacedPod.mockResolvedValue({ items: [] });
+
+      let eventCb: (phase: string, apiObj: V1Pod) => void = () => {};
+      watch.watch.mockImplementation(async (_path, _params, cb) => {
+        eventCb = cb;
+        return new AbortController();
+      });
+
+      const callback = jest.fn();
+      podDiscoveryService.watchPods(callback).catch(() => {});
+      await flushPromises();
+
+      eventCb(
+        "ADDED",
+        seedKubernetesPodTestData({
+          metadata: { name: "not-ready", namespace },
+          spec: { containers: [{ name: "app" }] },
+          status: { conditions: [{ type: "Ready", status: "False" }] }
+        })
+      );
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("should abort signal on DELETED watch event", async () => {
+      const namespace = faker.internet.domainWord();
+      const { podDiscoveryService, k8sClient, watch, loggerService } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: namespace });
+
+      const pod = seedKubernetesPodTestData({
+        metadata: { name: "web-abc", namespace },
+        spec: { containers: [{ name: "app" }] },
+        status: { phase: "Running", conditions: [{ type: "Ready", status: "True" }] }
+      });
+      k8sClient.listNamespacedPod.mockResolvedValue({ items: [pod] });
+
+      let eventCb: (phase: string, apiObj: V1Pod) => void = () => {};
+      watch.watch.mockImplementation(async (_path, _params, cb) => {
+        eventCb = cb;
+        return new AbortController();
+      });
+
+      let capturedSignal: AbortSignal | undefined;
+      const callback: PodCallback = jest.fn((_p, signal) => {
+        capturedSignal = signal;
+      });
+
+      podDiscoveryService.watchPods(callback).catch(() => {});
+      await flushPromises();
+
+      expect(capturedSignal!.aborted).toBe(false);
+      eventCb("DELETED", pod);
+      await flushPromises();
+      expect(capturedSignal!.aborted).toBe(true);
+      expect(loggerService.info).toHaveBeenCalledWith(expect.objectContaining({ event: "POD_DELETED", podName: "web-abc" }));
+    });
+
+    it("should skip already-tracked pods", async () => {
+      const namespace = faker.internet.domainWord();
+      const { podDiscoveryService, k8sClient, watch } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: namespace });
+
+      const pod = seedKubernetesPodTestData({
+        metadata: { name: "pod-1", namespace },
+        spec: { containers: [{ name: "app" }] },
+        status: { phase: "Running", conditions: [{ type: "Ready", status: "True" }] }
+      });
+      k8sClient.listNamespacedPod.mockResolvedValue({ items: [pod, pod] });
+      watch.watch.mockResolvedValue(new AbortController());
+
+      const callback = jest.fn();
+      podDiscoveryService.watchPods(callback).catch(() => {});
+      await flushPromises();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("should filter same-deployment pods in watch events", async () => {
+      const namespace = faker.internet.domainWord();
+      const { podDiscoveryService, k8sClient, watch } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: namespace });
+
+      k8sClient.listNamespacedPod.mockResolvedValue({ items: [] });
+
+      let eventCb: (phase: string, apiObj: V1Pod) => void = () => {};
+      watch.watch.mockImplementation(async (_path, _params, cb) => {
+        eventCb = cb;
+        return new AbortController();
+      });
+
+      const callback = jest.fn();
+      podDiscoveryService.watchPods(callback).catch(() => {});
+      await flushPromises();
+
+      eventCb(
+        "ADDED",
+        seedKubernetesPodTestData({
+          metadata: { name: "log-collector-abc123-def456", namespace },
+          spec: { containers: [{ name: "c" }] },
+          status: { conditions: [{ type: "Ready", status: "True" }] }
+        })
+      );
+
+      expect(callback).not.toHaveBeenCalled();
     });
   });
 
-  describe("watchPods", () => {
-    it("should call callback for each initially discovered pod", async () => {
+  describe("watchPods — fallback to polling", () => {
+    it("should fall back to polling permanently on 403", async () => {
       const namespace = faker.internet.domainWord();
-      const { podDiscoveryService, k8sClient } = setup({
-        KUBERNETES_NAMESPACE_OVERRIDE: namespace
+      const { podDiscoveryService, k8sClient, watch, loggerService } = setup({
+        KUBERNETES_NAMESPACE_OVERRIDE: namespace,
+        POD_POLL_INTERVAL_MS: "100"
       });
 
-      const pod1 = seedKubernetesPodTestData({
-        metadata: { name: "pod-1", namespace },
-        spec: { containers: [{ name: "app" }] },
-        status: { phase: "Running", conditions: [{ type: "Ready", status: "True" }] }
-      });
-      const pod2 = seedKubernetesPodTestData({
-        metadata: { name: "pod-2", namespace },
-        spec: { containers: [{ name: "app" }] },
-        status: { phase: "Running", conditions: [{ type: "Ready", status: "True" }] }
+      k8sClient.listNamespacedPod.mockResolvedValue({ items: [] });
+
+      let doneCb: (err?: unknown) => void = () => {};
+      watch.watch.mockImplementation(async (_path, _params, _cb, done) => {
+        doneCb = done;
+        return new AbortController();
       });
 
-      let callCount = 0;
-      k8sClient.listNamespacedPod.mockImplementation(async () => {
-        callCount++;
-        if (callCount === 1) {
-          return { items: [pod1, pod2] };
-        }
-        // Never resolves on second call to stop the polling loop
-        return new Promise(() => {});
-      });
-
-      const callback = jest.fn();
-      const watchPromise = podDiscoveryService.watchPods(callback);
-
+      podDiscoveryService.watchPods(jest.fn()).catch(() => {});
       await flushPromises();
 
-      expect(callback).toHaveBeenCalledTimes(2);
-      expect(callback).toHaveBeenCalledWith(expect.objectContaining({ podName: "pod-1" }), expect.any(AbortSignal));
-      expect(callback).toHaveBeenCalledWith(expect.objectContaining({ podName: "pod-2" }), expect.any(AbortSignal));
+      doneCb(Object.assign(new Error("Forbidden"), { statusCode: 403 }));
+      await flushPromises();
 
-      void watchPromise.catch(() => {});
+      expect(loggerService.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "POD_WATCH_FORBIDDEN" }));
+      // Now polling — it will call listNamespacedPod after interval
     });
 
-    it("should detect new pods on subsequent polls and call callback", async () => {
+    it("should fall back to polling then retry watch on non-403 failure", async () => {
       const namespace = faker.internet.domainWord();
-      const { podDiscoveryService, k8sClient, loggerService } = setup({
+      const { podDiscoveryService, k8sClient, watch, loggerService } = setup({
         KUBERNETES_NAMESPACE_OVERRIDE: namespace,
         POD_POLL_INTERVAL_MS: "100"
+      });
+
+      k8sClient.listNamespacedPod.mockResolvedValue({ items: [] });
+
+      let watchCallCount = 0;
+      watch.watch.mockImplementation(async () => {
+        watchCallCount++;
+        throw new Error("connection refused");
+      });
+
+      podDiscoveryService.watchPods(jest.fn()).catch(() => {});
+
+      // First watch attempt fails immediately, falls back to polling
+      await waitFor(() => {
+        expect(loggerService.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "POD_WATCH_FAILED_FALLBACK_TO_POLLING" }));
+      });
+
+      // After WATCH_RETRY_INTERVAL_MS (30s), watch is retried
+      await waitFor(() => expect(watchCallCount).toBeGreaterThanOrEqual(2), 35000);
+    }, 40000);
+
+    it("should detect new pods on polling", async () => {
+      const namespace = faker.internet.domainWord();
+      const { podDiscoveryService, k8sClient, watch } = setup({
+        KUBERNETES_NAMESPACE_OVERRIDE: namespace,
+        POD_POLL_INTERVAL_MS: "100"
+      });
+
+      let doneCb: (err?: unknown) => void = () => {};
+      watch.watch.mockImplementation(async (_path, _params, _cb, done) => {
+        doneCb = done;
+        return new AbortController();
       });
 
       const pod1 = seedKubernetesPodTestData({
@@ -460,31 +486,32 @@ describe(PodDiscoveryService.name, () => {
       let callCount = 0;
       k8sClient.listNamespacedPod.mockImplementation(async () => {
         callCount++;
-        if (callCount <= 1) {
-          return { items: [pod1] };
-        }
-        if (callCount === 2) {
-          return { items: [pod1, pod2] };
-        }
+        if (callCount <= 1) return { items: [pod1] };
+        if (callCount === 2) return { items: [pod1, pod2] };
         return new Promise(() => {});
       });
 
       const callback = jest.fn();
-      const watchPromise = podDiscoveryService.watchPods(callback);
+      podDiscoveryService.watchPods(callback).catch(() => {});
+      await flushPromises();
+
+      doneCb(Object.assign(new Error("Forbidden"), { statusCode: 403 }));
 
       await waitFor(() => expect(callback).toHaveBeenCalledTimes(2));
-
       expect(callback).toHaveBeenLastCalledWith(expect.objectContaining({ podName: "pod-2" }), expect.any(AbortSignal));
-      expect(loggerService.info).toHaveBeenCalledWith(expect.objectContaining({ event: "POD_READY", podName: "pod-2" }));
-
-      void watchPromise.catch(() => {});
     });
 
-    it("should abort signal for removed pods on subsequent polls", async () => {
+    it("should abort signal for removed pods on polling", async () => {
       const namespace = faker.internet.domainWord();
-      const { podDiscoveryService, k8sClient, loggerService } = setup({
+      const { podDiscoveryService, k8sClient, watch, loggerService } = setup({
         KUBERNETES_NAMESPACE_OVERRIDE: namespace,
         POD_POLL_INTERVAL_MS: "100"
+      });
+
+      let doneCb: (err?: unknown) => void = () => {};
+      watch.watch.mockImplementation(async (_path, _params, _cb, done) => {
+        doneCb = done;
+        return new AbortController();
       });
 
       const pod1 = seedKubernetesPodTestData({
@@ -501,71 +528,72 @@ describe(PodDiscoveryService.name, () => {
       let callCount = 0;
       k8sClient.listNamespacedPod.mockImplementation(async () => {
         callCount++;
-        if (callCount === 1) {
-          return { items: [pod1, pod2] };
-        }
-        if (callCount === 2) {
-          return { items: [pod1] }; // pod2 is gone
-        }
+        if (callCount === 1) return { items: [pod1, pod2] };
+        if (callCount === 2) return { items: [pod1] };
         return new Promise(() => {});
       });
 
       const signals: AbortSignal[] = [];
-      const callback: PodCallback = jest.fn((_podInfo, signal) => {
+      const callback: PodCallback = jest.fn((_p, signal) => {
         signals.push(signal);
       });
-      const watchPromise = podDiscoveryService.watchPods(callback);
+
+      podDiscoveryService.watchPods(callback).catch(() => {});
+      await flushPromises();
+
+      doneCb(Object.assign(new Error("Forbidden"), { statusCode: 403 }));
 
       await waitFor(() => expect(signals).toHaveLength(2));
-      expect(signals[1].aborted).toBe(false);
-
       await waitFor(() => expect(signals[1].aborted).toBe(true));
-
       expect(loggerService.info).toHaveBeenCalledWith(expect.objectContaining({ event: "POD_DELETED", podName: "pod-2" }));
-
-      void watchPromise.catch(() => {});
     });
 
-    it("throws AggregateError after 3 consecutive poll failures", async () => {
+    it("should throw AggregateError after 3 consecutive poll failures including watch errors", async () => {
       const namespace = faker.internet.domainWord();
-      const { podDiscoveryService, k8sClient, loggerService } = setup({
+      const { podDiscoveryService, k8sClient, watch } = setup({
         KUBERNETES_NAMESPACE_OVERRIDE: namespace,
         POD_POLL_INTERVAL_MS: "100"
+      });
+
+      let doneCb: (err?: unknown) => void = () => {};
+      watch.watch.mockImplementation(async (_path, _params, _cb, done) => {
+        doneCb = done;
+        return new AbortController();
+      });
+
+      let callCount = 0;
+      k8sClient.listNamespacedPod.mockImplementation(async () => {
+        callCount++;
+        if (callCount === 1) return { items: [] };
+        throw new Error("K8s API unavailable");
+      });
+
+      const promise = podDiscoveryService.watchPods(jest.fn());
+      await flushPromises();
+
+      doneCb(Object.assign(new Error("Forbidden"), { statusCode: 403 }));
+
+      await expect(promise).rejects.toThrow("Pod polling failed 3 times consecutively");
+    });
+
+    it("should reset consecutive error count on successful poll", async () => {
+      const namespace = faker.internet.domainWord();
+      const { podDiscoveryService, k8sClient, watch, loggerService } = setup({
+        KUBERNETES_NAMESPACE_OVERRIDE: namespace,
+        POD_POLL_INTERVAL_MS: "100"
+      });
+
+      let doneCb: (err?: unknown) => void = () => {};
+      watch.watch.mockImplementation(async (_path, _params, _cb, done) => {
+        doneCb = done;
+        return new AbortController();
       });
 
       const pollError = new Error("K8s API unavailable");
       let callCount = 0;
       k8sClient.listNamespacedPod.mockImplementation(async () => {
         callCount++;
-        if (callCount === 1) {
-          return { items: [] };
-        }
-        throw pollError;
-      });
-
-      const callback = jest.fn();
-
-      await expect(podDiscoveryService.watchPods(callback)).rejects.toThrow("Pod polling failed 3 times consecutively");
-
-      expect(loggerService.error).toHaveBeenCalledTimes(3);
-      expect(loggerService.error).toHaveBeenCalledWith(expect.objectContaining({ event: "POD_POLL_ERROR", consecutiveFailures: 3 }));
-    });
-
-    it("resets consecutive error count on successful poll", async () => {
-      const namespace = faker.internet.domainWord();
-      const { podDiscoveryService, k8sClient, loggerService } = setup({
-        KUBERNETES_NAMESPACE_OVERRIDE: namespace,
-        POD_POLL_INTERVAL_MS: "100"
-      });
-
-      const pollError = new Error("K8s API unavailable");
-      let callCount = 0;
-      k8sClient.listNamespacedPod.mockImplementation(async () => {
-        callCount++;
-        if (callCount === 1) {
-          return { items: [] };
-        }
-        // Fail twice, succeed, fail twice, succeed, fail 3 times
+        if (callCount === 1) return { items: [] };
         if (callCount <= 3) throw pollError;
         if (callCount === 4) return { items: [] };
         if (callCount <= 6) throw pollError;
@@ -573,11 +601,12 @@ describe(PodDiscoveryService.name, () => {
         throw pollError;
       });
 
-      const callback = jest.fn();
+      const promise = podDiscoveryService.watchPods(jest.fn());
+      await flushPromises();
 
-      await expect(podDiscoveryService.watchPods(callback)).rejects.toThrow("Pod polling failed 3 times consecutively");
+      doneCb(Object.assign(new Error("Forbidden"), { statusCode: 403 }));
 
-      // 2 + 2 + 3 = 7 errors total, but only 3 consecutive at the end
+      await expect(promise).rejects.toThrow("Pod polling failed 3 times consecutively");
       expect(loggerService.error).toHaveBeenCalledTimes(7);
     });
   });
@@ -587,6 +616,8 @@ describe(PodDiscoveryService.name, () => {
 
     const k8sClient = mock<CoreV1Api>();
     const kubeConfig = mock<KubeConfig>();
+    const watch = mock<Watch>();
+    const errorHandlerService = new ErrorHandlerService();
 
     const testEnv = {
       HOSTNAME: "log-collector-6bdb59678c-w9jww",
@@ -599,20 +630,16 @@ describe(PodDiscoveryService.name, () => {
     const config = new ConfigService(testEnv);
     const loggerService = mockProvider(LoggerService);
 
-    const podDiscoveryService = new PodDiscoveryService(k8sClient, kubeConfig, config, loggerService);
+    const podDiscoveryService = new PodDiscoveryService(k8sClient, kubeConfig, config, loggerService, errorHandlerService, watch);
 
-    return {
-      podDiscoveryService,
-      k8sClient,
-      kubeConfig,
-      config,
-      loggerService
-    };
+    return { podDiscoveryService, k8sClient, kubeConfig, config, loggerService, watch, errorHandlerService };
   }
 });
 
-function flushPromises(): Promise<void> {
-  return new Promise(resolve => setImmediate(resolve));
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
 }
 
 async function waitFor(assertion: () => void, timeout = 2000, interval = 10): Promise<void> {

--- a/apps/log-collector/src/services/pod-discovery/pod-discovery.service.ts
+++ b/apps/log-collector/src/services/pod-discovery/pod-discovery.service.ts
@@ -1,8 +1,10 @@
-import { CoreV1Api, KubeConfig, V1Pod } from "@kubernetes/client-node";
+import { CoreV1Api, KubeConfig, V1Pod, Watch } from "@kubernetes/client-node";
 import { setTimeout as delay } from "timers/promises";
 import { singleton } from "tsyringe";
 
+import { AsyncChannel } from "@src/lib/async-channel/async-channel";
 import { ConfigService } from "@src/services/config/config.service";
+import { ErrorHandlerService } from "@src/services/error-handler/error-handler.service";
 import { LoggerService } from "@src/services/logger/logger.service";
 
 /**
@@ -29,6 +31,9 @@ export interface PodInfo {
 
 export type PodCallback = (podInfo: PodInfo, signal: AbortSignal) => void;
 
+/** A pod lifecycle event yielded by the event stream generators. */
+type PodEvent = { type: "added"; podInfo: PodInfo } | { type: "deleted"; podName: string };
+
 /**
  * Discovers Kubernetes pods in the current namespace for log collection
  *
@@ -38,7 +43,17 @@ export type PodCallback = (podInfo: PodInfo, signal: AbortSignal) => void;
  * - Mapping Kubernetes pod objects to simplified PodInfo structures
  * - Determining the current namespace from kubeconfig or environment
  * - Providing pod metadata needed for log collection
- * - Polling for pod changes and notifying via callbacks
+ * - Watching for pod changes via K8s Watch API with polling fallback
+ *
+ * The watch → fallback → retry logic is expressed as composable generators:
+ *
+ *   podEventStream()           — orchestrator: try watch, fall back, retry
+ *     ├── watchEvents()        — yields pod events from K8s Watch API
+ *     └── pollEvents(signal?)  — yields pod events from periodic listing
+ *
+ * The service consumes `for await (const event of podEventStream())` and
+ * manages tracking state. This cleanly separates event production (generators)
+ * from event consumption (trackPod/untrackPod).
  *
  * The service supports namespace override via environment variables
  * and automatically excludes the current pod from discovery to prevent
@@ -46,6 +61,10 @@ export type PodCallback = (podInfo: PodInfo, signal: AbortSignal) => void;
  */
 @singleton()
 export class PodDiscoveryService {
+  private readonly WATCH_RETRY_INTERVAL_MS = 30_000;
+
+  private readonly MAX_POLL_FAILURES = 3;
+
   private readonly controllers = new Map<string, { ac: AbortController; podInfo: PodInfo }>();
 
   private namespace?: string;
@@ -57,12 +76,16 @@ export class PodDiscoveryService {
    * @param kubeConfig - Kubernetes configuration for context and namespace
    * @param config - Service for accessing configuration values
    * @param loggerService - Service for logging application events
+   * @param errorHandlerService - Service for classifying errors (e.g. 403 detection)
+   * @param watch - Kubernetes Watch client for real-time pod events
    */
   constructor(
     private readonly k8sClient: CoreV1Api,
     private readonly kubeConfig: KubeConfig,
     private readonly config: ConfigService,
-    private readonly loggerService: LoggerService
+    private readonly loggerService: LoggerService,
+    private readonly errorHandlerService: ErrorHandlerService,
+    private readonly watch: Watch
   ) {
     this.loggerService.setContext(PodDiscoveryService.name);
   }
@@ -70,103 +93,261 @@ export class PodDiscoveryService {
   /**
    * Watches for pod changes and invokes callback for each discovered pod.
    *
-   * Performs an initial discovery, then enters a polling loop to detect
-   * pod additions and removals. The returned promise stays pending
-   * indefinitely (same contract as the future watch-based implementation).
+   * Performs an initial discovery, then consumes the pod event stream to track
+   * lifecycle changes. Never resolves under normal operation.
    *
    * @param callback - Called for each discovered pod with an AbortSignal that fires when the pod disappears
    */
   async watchPods(callback: PodCallback): Promise<void> {
-    const pods = await this.discoverPodsInNamespace();
+    const { pods, resourceVersion } = await this.discoverPodsInNamespace();
 
     for (const pod of pods) {
       this.trackPod(pod, callback);
     }
 
-    await this.startPodWatch(callback);
+    for await (const event of this.podEventStream(resourceVersion)) {
+      if (event.type === "added") {
+        this.trackPod(event.podInfo, callback);
+      } else {
+        this.untrackPod(event.podName);
+      }
+    }
   }
 
+  // ---------------------------------------------------------------------------
+  // Event stream generators
+  // ---------------------------------------------------------------------------
+
   /**
-   * Enters a polling loop that periodically re-lists pods and reconciles
-   * additions/removals against the tracked set. Never resolves normally.
+   * Top-level orchestrator generator.
+   * - Tries K8s watch. If it connects and later ends, reconnects immediately.
+   * - On 403, yields from permanent polling.
+   * - On other errors, yields from timed polling, then retries watch.
    *
-   * @param callback - Forwarded to trackPod for newly discovered pods
+   * Threads resourceVersion from initial list → watch → polling → next watch
+   * to avoid missing events between transitions. Resets accumulated watch
+   * errors after a successful watch connection.
+   *
+   * @param initialResourceVersion - resourceVersion from the initial pod list, used for the first watch
    */
-  private async startPodWatch(callback: PodCallback): Promise<void> {
-    const pollInterval = this.config.get("POD_POLL_INTERVAL_MS");
-    const ALWAYS_TRUE_TO_RUN_INDEFINITELY = true;
-    const consecutiveErrors: Error[] = [];
-    while (ALWAYS_TRUE_TO_RUN_INDEFINITELY) {
-      await delay(pollInterval);
+  private async *podEventStream(initialResourceVersion?: string): AsyncGenerator<PodEvent> {
+    const watchErrors: Error[] = [];
+    let resourceVersion = initialResourceVersion;
 
+    const ALWAYS_RETRY = true;
+    while (ALWAYS_RETRY) {
       try {
-        const currentPods = await this.discoverPodsInNamespace();
-        const currentPodNames = new Set(currentPods.map(p => p.podName));
-
-        for (const pod of currentPods) {
-          if (!this.controllers.has(pod.podName)) {
-            this.trackPod(pod, callback);
-          }
-        }
-
-        for (const [podName, { podInfo }] of this.controllers) {
-          if (!currentPodNames.has(podName)) {
-            this.untrackPod(podInfo);
-          }
-        }
-
-        consecutiveErrors.length = 0;
+        yield* this.watchEvents(resourceVersion);
+        watchErrors.length = 0;
       } catch (error) {
-        consecutiveErrors.push(error instanceof Error ? error : new Error(String(error)));
-        this.loggerService.error({ event: "POD_POLL_ERROR", error, consecutiveFailures: consecutiveErrors.length });
+        if (this.errorHandlerService.isForbidden(error)) {
+          this.loggerService.warn({
+            event: "POD_WATCH_FORBIDDEN",
+            message: 'Pod watch is forbidden. Ensure the SDL includes permissions: { read: ["logs", "events"] }'
+          });
+          yield* this.pollEvents();
+          return;
+        }
 
-        if (consecutiveErrors.length >= 3) {
-          throw new AggregateError(consecutiveErrors, `Pod polling failed ${consecutiveErrors.length} times consecutively`);
+        watchErrors.push(error instanceof Error ? error : new Error(String(error)));
+        this.loggerService.warn({ event: "POD_WATCH_FAILED_FALLBACK_TO_POLLING", error });
+
+        try {
+          resourceVersion = yield* this.timedPollEvents(this.WATCH_RETRY_INTERVAL_MS);
+        } catch (pollError) {
+          if (pollError instanceof AggregateError && watchErrors.length > 0) {
+            throw new AggregateError([...watchErrors, ...pollError.errors], pollError.message);
+          }
+          throw pollError;
         }
       }
     }
   }
 
   /**
+   * Yields pod events from the K8s Watch API until the watch stream ends.
+   * Throws on 403 or if the watch setup itself fails.
+   *
+   * @param resourceVersion - If provided, watch starts after this version to avoid replaying known events
+   */
+  private async *watchEvents(resourceVersion?: string): AsyncGenerator<PodEvent> {
+    const namespace = this.getCurrentNamespace();
+    const labelSelector = this.config.get("POD_LABEL_SELECTOR");
+    const path = `/api/v1/namespaces/${namespace}/pods`;
+    const channel = new AsyncChannel<PodEvent>();
+
+    let doneError: unknown;
+    let isDone = false;
+
+    await this.watch
+      .watch(
+        path,
+        { labelSelector, resourceVersion },
+        (phase: string, apiObj: V1Pod) => {
+          if (phase === "DELETED") {
+            const podName = apiObj.metadata?.name;
+            if (podName && this.controllers.has(podName)) {
+              channel.push({ type: "deleted", podName });
+            }
+            return;
+          }
+
+          const podInfo = this.processPod(apiObj);
+          if (!podInfo) return;
+
+          if ((phase === "ADDED" || phase === "MODIFIED") && !this.controllers.has(podInfo.podName)) {
+            channel.push({ type: "added", podInfo });
+          }
+        },
+        (err?: unknown) => {
+          isDone = true;
+          doneError = err;
+          channel.close();
+        }
+      )
+      .then(() => {
+        if (!isDone) {
+          this.loggerService.info({ event: "POD_WATCH_ESTABLISHED", path, labelSelector });
+        }
+      });
+
+    yield* channel;
+
+    if (doneError) {
+      throw doneError;
+    }
+
+    this.loggerService.info({ event: "POD_WATCH_ENDED", namespace });
+  }
+
+  /**
+   * Yields pod events from periodic polling. Polls immediately on entry,
+   * then waits pollInterval between cycles. Runs indefinitely until
+   * MAX_POLL_FAILURES consecutive errors (throws AggregateError).
+   * Returns gracefully when the optional signal is aborted.
+   *
+   * @param signal - Optional AbortSignal to stop polling (used for timed watch retries)
+   * @returns The latest resourceVersion from the last successful list, for resuming watch
+   */
+  private async *pollEvents(signal?: AbortSignal): AsyncGenerator<PodEvent, string | undefined> {
+    const pollInterval = this.config.get("POD_POLL_INTERVAL_MS");
+    const consecutiveErrors: Error[] = [];
+    let lastResourceVersion: string | undefined;
+
+    this.loggerService.info({ event: "POLLING_STARTED", pollInterval });
+
+    try {
+      while (!signal?.aborted) {
+        try {
+          const { pods: currentPods, resourceVersion } = await this.discoverPodsInNamespace();
+          lastResourceVersion = resourceVersion;
+          yield* this.reconcilePolledPods(currentPods);
+          consecutiveErrors.length = 0;
+        } catch (error) {
+          consecutiveErrors.push(error instanceof Error ? error : new Error(String(error)));
+          this.loggerService.error({ event: "POD_POLL_ERROR", error, consecutiveFailures: consecutiveErrors.length });
+
+          if (consecutiveErrors.length >= this.MAX_POLL_FAILURES) {
+            throw new AggregateError(consecutiveErrors, `Pod polling failed ${consecutiveErrors.length} times consecutively`);
+          }
+        }
+
+        try {
+          await delay(pollInterval, null, { signal });
+        } catch {
+          return lastResourceVersion;
+        }
+      }
+    } finally {
+      this.loggerService.info({ event: "POLLING_STOPPED" });
+    }
+
+    return lastResourceVersion;
+  }
+
+  /** Polls for a fixed duration, then returns the latest resourceVersion so the caller can resume watch. */
+  private async *timedPollEvents(durationMs: number): AsyncGenerator<PodEvent, string | undefined> {
+    const ac = new AbortController();
+    const timeout = setTimeout(() => ac.abort(), durationMs);
+
+    try {
+      return yield* this.pollEvents(ac.signal);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /** Diffs polled pods against tracked state, yielding add/delete events. */
+  private *reconcilePolledPods(currentPods: PodInfo[]): Generator<PodEvent> {
+    const currentPodNames = new Set(currentPods.map(p => p.podName));
+
+    for (const pod of currentPods) {
+      if (!this.controllers.has(pod.podName)) {
+        yield { type: "added", podInfo: pod };
+      }
+    }
+
+    for (const podName of this.controllers.keys()) {
+      if (!currentPodNames.has(podName)) {
+        yield { type: "deleted", podName };
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pod discovery & filtering
+  // ---------------------------------------------------------------------------
+
+  /**
    * Discovers all pods in the current namespace, excluding the current pod
    *
-   * @returns Promise that resolves to an array of PodInfo objects for discovered pods
+   * @returns Promise that resolves to discovered pods and the list's resourceVersion
    * @throws Error if namespace cannot be determined or Kubernetes API calls fail
    */
-  async discoverPodsInNamespace(): Promise<PodInfo[]> {
+  async discoverPodsInNamespace(): Promise<{ pods: PodInfo[]; resourceVersion?: string }> {
     const namespace = this.getCurrentNamespace();
 
-    this.loggerService.info({ event: "POD_DISCOVERY_STARTED", namespace });
+    this.loggerService.debug({ event: "POD_DISCOVERY_STARTED", namespace });
 
-    const { items: podsRaw } = await this.k8sClient.listNamespacedPod({
+    const response = await this.k8sClient.listNamespacedPod({
       namespace,
       labelSelector: this.config.get("POD_LABEL_SELECTOR")
     });
 
+    const resourceVersion = response.metadata?.resourceVersion;
     const currentPodName = this.config.get("HOSTNAME");
-    const pods = podsRaw.filter(pod => this.isPodReady(pod)).map(pod => this.mapPodToInfo(pod, namespace));
+    const pods = response.items.filter(pod => this.isPodReady(pod)).map(pod => this.mapPodToInfo(pod, namespace));
 
     const targetPods = this.filterOutPodsFromSameDeployment(pods, currentPodName);
 
-    this.loggerService.info({
+    this.loggerService.debug({
       event: "POD_DISCOVERY_COMPLETED",
       namespace,
-      totalPods: podsRaw.length,
+      totalPods: response.items.length,
       readyPods: pods.length,
       targetPods: targetPods.length,
       currentPodName
     });
 
-    return targetPods;
+    return { pods: targetPods, resourceVersion };
   }
+
+  // ---------------------------------------------------------------------------
+  // Pod tracking
+  // ---------------------------------------------------------------------------
 
   /**
    * Starts tracking a pod by creating an AbortController and invoking the callback.
+   * Skips if the pod is already tracked (deduplication guard for watch events).
    *
    * @param podInfo - The pod to track
    * @param callback - Called with the pod info and an AbortSignal tied to this pod's lifecycle
    */
   private trackPod(podInfo: PodInfo, callback: PodCallback): void {
+    if (this.controllers.has(podInfo.podName)) {
+      return;
+    }
+
     const ac = new AbortController();
     this.controllers.set(podInfo.podName, { ac, podInfo });
     this.loggerService.info({
@@ -180,19 +361,45 @@ export class PodDiscoveryService {
   /**
    * Stops tracking a pod by aborting its signal and removing it from the map.
    *
-   * @param podInfo - The pod to untrack
+   * @param podName - Name of the pod to untrack
    */
-  private untrackPod(podInfo: PodInfo): void {
-    const entry = this.controllers.get(podInfo.podName);
+  private untrackPod(podName: string): void {
+    const entry = this.controllers.get(podName);
     if (entry) {
       this.loggerService.info({
         event: "POD_DELETED",
-        podName: podInfo.podName,
-        namespace: podInfo.namespace
+        podName: entry.podInfo.podName,
+        namespace: entry.podInfo.namespace
       });
       entry.ac.abort();
-      this.controllers.delete(podInfo.podName);
+      this.controllers.delete(podName);
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pod filtering utilities
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Filters a raw V1Pod through readiness and same-deployment checks.
+   *
+   * @param pod - Raw Kubernetes pod object
+   * @returns PodInfo if the pod should be tracked, null otherwise
+   */
+  private processPod(pod: V1Pod): PodInfo | null {
+    if (!this.isPodReady(pod)) {
+      return null;
+    }
+
+    const namespace = this.getCurrentNamespace();
+    const podInfo = this.mapPodToInfo(pod, namespace);
+    const currentPodName = this.config.get("HOSTNAME");
+
+    if (podInfo.podName === currentPodName || this.isPodFromSameDeployment(podInfo.podName, currentPodName)) {
+      return null;
+    }
+
+    return podInfo;
   }
 
   /**
@@ -231,6 +438,10 @@ export class PodDiscoveryService {
   private filterOutPodsFromSameDeployment(pods: PodInfo[], currentPodName: string): PodInfo[] {
     return pods.filter(pod => pod.podName !== currentPodName && !this.isPodFromSameDeployment(pod.podName, currentPodName));
   }
+
+  // ---------------------------------------------------------------------------
+  // Namespace resolution
+  // ---------------------------------------------------------------------------
 
   /**
    * Determines the current namespace for pod discovery


### PR DESCRIPTION
## Why

The log-collector uses polling to detect pod additions and removals, which adds latency and unnecessary API load. The K8s Watch API provides real-time events but may not be available in all RBAC configurations.

## What

Adds K8s Watch-based pod discovery as the primary mechanism, with automatic fallback to polling when watch is unavailable.

**Watch behavior:**
- Watch works → use it for real-time ADDED/MODIFIED/DELETED events, no polling
- Watch fails 403 → fall back to polling permanently (RBAC missing `watch` verb)
- Watch fails other → poll for 30s, retry watch, repeat indefinitely
- Watch ends normally (server timeout) → reconnect immediately

**Implementation:**
- Uses AsyncGenerators to compose the watch/poll/retry flow declaratively
- `podEventStream()` orchestrates: try watch → fallback → retry — visible in ~15 lines
- `AsyncChannel` bridges K8s Watch push-based callbacks to pull-based async iteration (generic utility in `src/lib/`)
- DELETED events bypass readiness checks (deleted pods aren't ready)

**Infrastructure:**
- Register `Watch` client in `k8s-client.provider.ts`
- Add `watch` verb to RBAC `role.yaml`

**Testing:**
- Manually verified all flows on local K8s cluster:
  - Flow 1: Watch detects pod additions (ADDED) and removals (DELETED) in real-time
  - Flow 3: 403 triggers permanent polling with `POD_WATCH_FORBIDDEN` warning
- Unit tests: 66 passing across 8 suites (including 6 AsyncChannel tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pod discovery now uses an async event stream driven by Kubernetes Watch with automatic polling fallback and improved deduplication/tracking.
  * Added an AsyncChannel utility for async producer-consumer event streaming.

* **Chores**
  * Separated pod and pod-log RBAC permissions.
  * Improved startup diagnostic logging.

* **Tests**
  * Expanded pod discovery tests and added AsyncChannel tests covering watch/polling behaviors and edge cases.

* **Documentation**
  * Updated README to document watch/poll fallback and a POD_POLL_INTERVAL_MS setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->