### PR TITLE
fix: upgrades nodejs version to latest lts

### DIFF
--- a/.github/workflows/diff-package-lock.yml
+++ b/.github/workflows/diff-package-lock.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "24"
+          node-version-file: package.json
       - name: Fetch PR head ref (no checkout)
         run: |
           git fetch origin pull/${{ github.event.pull_request.number }}/head

--- a/apps/log-collector/Dockerfile
+++ b/apps/log-collector/Dockerfile
@@ -2,7 +2,7 @@
 # ----------- BUILDER STAGE ----------
 # Multi-stage build to optimize final image size
 # This stage compiles TypeScript and installs all dependencies
-FROM node:24.13.0-slim AS builder
+FROM node:24.14.1-slim AS builder
 
 # Install bash for better shell scripting support
 RUN apt-get update && apt-get install -y bash
@@ -23,7 +23,7 @@ RUN npm run build -w apps/log-collector
 # ----------- PRODUCTION STAGE ----------
 # Final production image with minimal dependencies
 # Contains only runtime requirements and compiled application
-FROM node:24.13.0-slim AS production
+FROM node:24.14.1-slim AS production
 
 # Install system dependencies and Fluent Bit
 # - bash: Shell scripting support

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,8 @@
         "vitest": "^4.0.18"
       },
       "engines": {
-        "node": "^24.13.0",
-        "npm": "^11.6.2"
+        "node": "^24.14.1",
+        "npm": "^11.11.0"
       }
     },
     "apps/api": {
@@ -804,7 +804,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -826,7 +825,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -844,6 +842,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -861,6 +860,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -878,6 +878,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -895,6 +896,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -910,6 +912,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -927,6 +930,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -944,6 +948,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -961,6 +966,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -978,6 +984,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -995,6 +1002,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1012,6 +1020,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1029,6 +1038,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1046,6 +1056,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1063,6 +1074,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1080,6 +1092,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1097,6 +1110,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1114,6 +1128,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1131,6 +1146,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1148,6 +1164,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1165,6 +1182,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1182,6 +1200,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1199,6 +1218,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1216,6 +1236,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1736,7 +1757,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.57.1",
@@ -1750,7 +1772,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.57.1",
@@ -1764,7 +1787,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.57.1",
@@ -1778,7 +1802,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.35.0",
@@ -1805,7 +1830,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.35.0",
@@ -1858,7 +1884,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.57.1",
@@ -1872,7 +1899,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.35.0",
@@ -1912,7 +1940,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.35.0",
@@ -2199,7 +2228,6 @@
     "apps/deploy-web/node_modules/@stripe/stripe-js": {
       "version": "8.3.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.16"
       }
@@ -2325,6 +2353,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2364,6 +2393,7 @@
       "version": "6.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -2633,6 +2663,7 @@
       "version": "7.3.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2714,7 +2745,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-android-arm64": {
       "version": "4.57.1",
@@ -2728,7 +2760,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.57.1",
@@ -2740,7 +2773,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.57.1",
@@ -2754,7 +2788,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.57.1",
@@ -2768,7 +2803,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.57.1",
@@ -2782,7 +2818,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.57.1",
@@ -2796,7 +2833,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.57.1",
@@ -2810,7 +2848,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.57.1",
@@ -2824,7 +2863,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.57.1",
@@ -2838,7 +2878,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.57.1",
@@ -2852,7 +2893,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.57.1",
@@ -2866,7 +2908,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.57.1",
@@ -2880,7 +2923,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.57.1",
@@ -2894,7 +2938,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.57.1",
@@ -2908,7 +2953,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.57.1",
@@ -2922,7 +2968,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.57.1",
@@ -2936,17 +2983,20 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@types/estree": {
       "version": "1.0.8",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/rollup": {
       "version": "4.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -3037,7 +3087,6 @@
     "apps/deploy-web/node_modules/yaml": {
       "version": "2.8.2",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -5367,7 +5416,6 @@
     "apps/notifications/node_modules/@opentelemetry/core": {
       "version": "2.4.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -8588,7 +8636,6 @@
       "resolved": "https://registry.npmjs.org/@amplitude/rrweb/-/rrweb-2.0.0-alpha.36.tgz",
       "integrity": "sha512-8vhPOk4fvszfxYZTk37EObW3n7uwEgO//funRSMt/QiBWtgQ8jhpFV9FcOAYdgde0Yw1uIM8oUbWZfy/XrexNw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@amplitude/rrdom": "^2.0.0-alpha.36",
         "@amplitude/rrweb-snapshot": "^2.0.0-alpha.36",
@@ -8863,7 +8910,6 @@
     "node_modules/@babel/core": {
       "version": "7.28.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -10428,8 +10474,7 @@
     "node_modules/@biomejs/wasm-nodejs": {
       "version": "1.9.4",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@borewit/text-codec": {
       "version": "0.2.1",
@@ -10452,8 +10497,7 @@
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.9.0",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@casl/ability": {
       "version": "6.7.2",
@@ -10693,7 +10737,6 @@
       "version": "9.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -10935,7 +10978,6 @@
     "node_modules/@connectrpc/connect": {
       "version": "2.1.0",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -10954,7 +10996,6 @@
     "node_modules/@cosmjs/amino": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
@@ -11046,7 +11087,6 @@
     "node_modules/@cosmjs/proto-signing": {
       "version": "0.36.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.36.2",
         "@cosmjs/crypto": "^0.36.2",
@@ -11155,7 +11195,6 @@
     "node_modules/@cosmjs/stargate": {
       "version": "0.36.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.36.2",
         "@cosmjs/encoding": "^0.36.2",
@@ -11347,7 +11386,6 @@
     "node_modules/@cosmos-kit/core/node_modules/@cosmjs/proto-signing": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -11785,7 +11823,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -11822,7 +11859,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11904,7 +11940,6 @@
     "node_modules/@dotenvx/dotenvx/node_modules/picomatch": {
       "version": "4.0.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12018,7 +12053,6 @@
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -12030,7 +12064,6 @@
     "node_modules/@emotion/react": {
       "version": "11.11.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -12068,7 +12101,6 @@
     "node_modules/@emotion/server": {
       "version": "11.11.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/utils": "^1.2.1",
         "html-tokenize": "^2.0.0",
@@ -12091,7 +12123,6 @@
     "node_modules/@emotion/styled": {
       "version": "11.11.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -12832,6 +12863,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12865,6 +12897,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12898,6 +12931,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13193,7 +13227,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=6.14.13"
@@ -13340,7 +13373,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -13549,7 +13581,6 @@
     "node_modules/@interchain-ui/react": {
       "version": "1.23.31",
       "license": "SEE LICENSE IN LICENSE",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.6.4",
         "@floating-ui/dom": "^1.6.7",
@@ -14005,7 +14036,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -14845,7 +14875,6 @@
     "node_modules/@mui/material": {
       "version": "5.15.20",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/base": "5.0.0-beta.40",
@@ -15089,7 +15118,6 @@
     "node_modules/@nestjs/common": {
       "version": "11.1.13",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -15200,7 +15228,6 @@
       "version": "11.1.13",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -15265,7 +15292,6 @@
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.13",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -16035,7 +16061,6 @@
     "node_modules/@octokit/core": {
       "version": "7.0.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -16256,7 +16281,6 @@
       "version": "11.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -16470,7 +16494,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -16534,7 +16557,6 @@
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -16545,7 +16567,6 @@
     "node_modules/@opentelemetry/core": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -17179,7 +17200,6 @@
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.57.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -18879,7 +18899,6 @@
     "node_modules/@opentelemetry/resources": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -19117,7 +19136,6 @@
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -19207,7 +19225,6 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.38.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -22533,7 +22550,6 @@
       "version": "1.34.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redocly/ajv": "^8.11.2",
         "@redocly/config": "^0.22.0",
@@ -22674,7 +22690,6 @@
     "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
       "version": "4.0.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23213,6 +23228,7 @@
     "node_modules/@scure/starknet": {
       "version": "1.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "~1.7.0",
         "@noble/hashes": "~1.6.0"
@@ -23224,6 +23240,7 @@
     "node_modules/@scure/starknet/node_modules/@noble/curves": {
       "version": "1.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.6.0"
       },
@@ -23237,6 +23254,7 @@
     "node_modules/@scure/starknet/node_modules/@noble/curves/node_modules/@noble/hashes": {
       "version": "1.6.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -23247,6 +23265,7 @@
     "node_modules/@scure/starknet/node_modules/@noble/hashes": {
       "version": "1.6.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -23990,12 +24009,14 @@
     "node_modules/@starknet-io/starknet-types-07": {
       "name": "@starknet-io/types-js",
       "version": "0.7.10",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@starknet-io/starknet-types-08": {
       "name": "@starknet-io/types-js",
       "version": "0.8.4",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@streamparser/json": {
       "version": "0.0.20",
@@ -24030,7 +24051,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.19"
@@ -24068,7 +24088,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24085,7 +24104,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24102,7 +24120,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -24119,7 +24136,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24136,7 +24152,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24153,7 +24168,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24170,7 +24184,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24187,7 +24200,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24204,7 +24216,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24221,7 +24232,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24238,7 +24248,6 @@
     "node_modules/@swc/helpers": {
       "version": "0.5.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
@@ -24269,7 +24278,6 @@
     "node_modules/@tanstack/query-core": {
       "version": "5.67.2",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -24278,7 +24286,6 @@
     "node_modules/@tanstack/react-query": {
       "version": "5.67.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.67.2"
       },
@@ -24346,7 +24353,6 @@
       "version": "10.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -24579,7 +24585,6 @@
       "version": "7.20.5",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -24800,6 +24805,7 @@
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -24808,6 +24814,7 @@
     "node_modules/@types/eslint-scope": {
       "version": "3.7.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -25027,7 +25034,6 @@
     "node_modules/@types/node": {
       "version": "22.15.30",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -25098,7 +25104,6 @@
     "node_modules/@types/react": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -25108,7 +25113,6 @@
     "node_modules/@types/react-dom": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -25282,8 +25286,7 @@
     },
     "node_modules/@types/validator": {
       "version": "13.11.10",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.5.13",
@@ -25866,7 +25869,6 @@
     "node_modules/@vanilla-extract/css": {
       "version": "1.17.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@vanilla-extract/private": "^1.0.6",
@@ -25889,7 +25891,6 @@
     "node_modules/@vanilla-extract/dynamic": {
       "version": "2.1.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vanilla-extract/private": "^1.0.6"
       }
@@ -26506,7 +26507,6 @@
     "node_modules/@walletconnect/types": {
       "version": "2.11.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -26750,6 +26750,7 @@
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -26757,19 +26758,23 @@
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.13.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -26778,11 +26783,13 @@
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.13.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -26793,6 +26800,7 @@
     "node_modules/@webassemblyjs/ieee754": {
       "version": "1.13.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -26800,17 +26808,20 @@
     "node_modules/@webassemblyjs/leb128": {
       "version": "1.13.2",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.13.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -26825,6 +26836,7 @@
     "node_modules/@webassemblyjs/wasm-gen": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -26836,6 +26848,7 @@
     "node_modules/@webassemblyjs/wasm-opt": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -26846,6 +26859,7 @@
     "node_modules/@webassemblyjs/wasm-parser": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -26858,6 +26872,7 @@
     "node_modules/@webassemblyjs/wast-printer": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -26871,11 +26886,13 @@
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -26885,6 +26902,7 @@
     "node_modules/abi-wan-kanabi": {
       "version": "2.2.4",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ansicolors": "^0.3.2",
         "cardinal": "^2.1.1",
@@ -26898,6 +26916,7 @@
     "node_modules/abi-wan-kanabi/node_modules/fs-extra": {
       "version": "10.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -26967,7 +26986,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -26994,6 +27012,7 @@
     "node_modules/acorn-import-phases": {
       "version": "1.0.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -27047,7 +27066,6 @@
     "node_modules/ajv": {
       "version": "6.12.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -27107,7 +27125,6 @@
       "version": "4.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -27148,7 +27165,8 @@
     },
     "node_modules/ansicolors": {
       "version": "0.3.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
@@ -28082,7 +28100,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -28401,7 +28418,6 @@
     "node_modules/camelcase": {
       "version": "5.3.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -28434,6 +28450,7 @@
     "node_modules/cardinal": {
       "version": "2.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
@@ -28559,6 +28576,7 @@
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -28958,7 +28976,6 @@
     "node_modules/commander": {
       "version": "12.1.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -29180,8 +29197,7 @@
     },
     "node_modules/cosmjs-types": {
       "version": "0.9.0",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
@@ -29433,8 +29449,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/csv-stringify": {
       "version": "6.6.0",
@@ -29559,8 +29574,7 @@
     },
     "node_modules/d3-selection": {
       "version": "2.0.0",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
@@ -29745,7 +29759,6 @@
     "node_modules/date-fns": {
       "version": "2.30.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -30346,7 +30359,6 @@
     "node_modules/drizzle-orm": {
       "version": "0.31.2",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=3",
@@ -30906,7 +30918,6 @@
     "node_modules/eslint": {
       "version": "8.57.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -31177,7 +31188,6 @@
     "node_modules/eslint-plugin-import": {
       "version": "2.31.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -31209,7 +31219,6 @@
     "node_modules/eslint-plugin-import-x": {
       "version": "4.10.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pkgr/core": "^0.2.0",
         "@types/doctrine": "^0.0.9",
@@ -32404,7 +32413,6 @@
     "node_modules/gel": {
       "version": "2.0.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@petamoriken/float16": "^3.8.7",
         "debug": "^4.3.4",
@@ -32655,7 +32663,8 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/glob/node_modules/jackspeak": {
       "version": "3.4.3",
@@ -33226,7 +33235,6 @@
     "node_modules/hono": {
       "version": "4.6.12",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -33509,7 +33517,6 @@
     "node_modules/immer": {
       "version": "10.1.1",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -34418,7 +34425,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -35103,7 +35109,6 @@
     "node_modules/jiti": {
       "version": "1.21.3",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -35288,7 +35293,6 @@
     "node_modules/jsep": {
       "version": "1.4.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -35878,6 +35882,7 @@
     "node_modules/loader-runner": {
       "version": "4.3.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -36238,7 +36243,8 @@
     },
     "node_modules/lossless-json": {
       "version": "4.3.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lowlight": {
       "version": "2.9.0",
@@ -38537,7 +38543,6 @@
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -38835,7 +38840,6 @@
     "node_modules/next": {
       "version": "14.2.35",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
@@ -39586,6 +39590,7 @@
       "version": "8.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "cli-cursor": "^5.0.0",
@@ -39608,6 +39613,7 @@
       "version": "6.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -39619,6 +39625,7 @@
       "version": "5.4.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -39630,6 +39637,7 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "restore-cursor": "^5.0.0"
       },
@@ -39643,12 +39651,14 @@
     "node_modules/ora/node_modules/emoji-regex": {
       "version": "10.4.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ora/node_modules/onetime": {
       "version": "7.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-function": "^5.0.0"
       },
@@ -39663,6 +39673,7 @@
       "version": "5.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "onetime": "^7.0.0",
         "signal-exit": "^4.1.0"
@@ -39678,6 +39689,7 @@
       "version": "4.1.0",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -39689,6 +39701,7 @@
       "version": "7.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -39705,6 +39718,7 @@
       "version": "7.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -39935,7 +39949,6 @@
     "node_modules/pg": {
       "version": "8.18.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -40372,7 +40385,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -40510,7 +40522,6 @@
     "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -40594,7 +40605,6 @@
     "node_modules/prettier": {
       "version": "3.3.1",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -40774,7 +40784,6 @@
     "node_modules/prop-types": {
       "version": "15.8.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -41102,7 +41111,6 @@
     "node_modules/react": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -41211,7 +41219,6 @@
     "node_modules/react-dom": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -41251,7 +41258,6 @@
     "node_modules/react-hook-form": {
       "version": "7.52.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -41612,14 +41618,14 @@
     "node_modules/redeyed": {
       "version": "2.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esprima": "~4.0.0"
       }
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
@@ -42144,7 +42150,6 @@
     "node_modules/rollup": {
       "version": "2.79.2",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -42276,7 +42281,6 @@
     "node_modules/rxjs": {
       "version": "7.8.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -42407,7 +42411,6 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "8.17.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -43222,6 +43225,7 @@
     "node_modules/starknet/node_modules/@noble/curves": {
       "version": "1.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.6.0"
       },
@@ -43235,6 +43239,7 @@
     "node_modules/starknet/node_modules/@noble/hashes": {
       "version": "1.6.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -43245,6 +43250,7 @@
     "node_modules/starknet/node_modules/@scure/base": {
       "version": "1.2.1",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -43803,7 +43809,6 @@
     "node_modules/tailwindcss": {
       "version": "3.4.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -44321,7 +44326,6 @@
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -44600,7 +44604,8 @@
     },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -44608,7 +44613,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -45625,7 +45629,6 @@
     "node_modules/typescript": {
       "version": "5.8.3",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -45968,7 +45971,6 @@
     "node_modules/unleash-proxy-client": {
       "version": "3.7.6",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tiny-emitter": "^2.1.0",
         "uuid": "^9.0.1"
@@ -46558,7 +46560,6 @@
       "version": "4.0.18",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -47542,7 +47543,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -47605,7 +47605,6 @@
       "version": "7.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -47724,6 +47723,7 @@
     "node_modules/watchpack": {
       "version": "2.5.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -47868,15 +47868,18 @@
     },
     "node_modules/webpack/node_modules/@types/estree": {
       "version": "1.0.8",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webpack/node_modules/es-module-lexer": {
       "version": "2.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -47888,6 +47891,7 @@
     "node_modules/webpack/node_modules/estraverse": {
       "version": "4.3.0",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -48142,7 +48146,6 @@
     "node_modules/workbox-build/node_modules/ajv": {
       "version": "8.17.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -48404,7 +48407,6 @@
     "node_modules/ws": {
       "version": "8.18.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -48462,8 +48464,7 @@
     },
     "node_modules/xterm": {
       "version": "5.3.0",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/xterm-addon-fit": {
       "version": "0.7.0",
@@ -48546,7 +48547,6 @@
     "node_modules/zod": {
       "version": "3.24.4",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -49635,7 +49635,6 @@
     "packages/releaser/node_modules/conventional-commits-filter": {
       "version": "5.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -49643,7 +49642,6 @@
     "packages/releaser/node_modules/conventional-commits-parser": {
       "version": "6.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "meow": "^13.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -78,14 +78,14 @@
     "turbo": "^2.3.3",
     "vitest": "^4.0.18"
   },
-  "packageManager": "npm@11.6.2",
+  "packageManager": "npm@11.11.0",
   "engines": {
-    "node": "^24.13.0",
-    "npm": "^11.6.2"
+    "node": "^24.14.1",
+    "npm": "^11.11.0"
   },
   "volta": {
-    "node": "24.13.0",
-    "npm": "11.6.2"
+    "node": "24.14.1",
+    "npm": "11.11.0"
   },
   "trustedDependencies": [
     "esbuild@0.27.2",

--- a/packages/docker/Dockerfile.nextjs
+++ b/packages/docker/Dockerfile.nextjs
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.20
 
-FROM node:24.13.0-alpine AS base
+FROM node:24.14.1-alpine AS base
 
 ARG CI
 ENV CI $CI

--- a/packages/docker/Dockerfile.node
+++ b/packages/docker/Dockerfile.node
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.20
 
-FROM node:24.13.0-alpine AS base
+FROM node:24.14.1-alpine AS base
 
 # see https://r1ch.net/blog/node-v20-aggregateeerror-etimedout-happy-eyeballs and https://github.com/nodejs/node/issues/54359
 ARG NODE_OPTIONS="--no-network-family-autoselection --enable-source-maps"


### PR DESCRIPTION
## Why

Security release of Nodejs -> https://nodejs.org/en/blog/vulnerability/march-2026-security-releases

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime to 24.14.1 and npm to 11.11.0 across the project
  * Updated package metadata to require Node 24.14.1 and npm 11.11.0
  * Updated Docker base images to use Node.js 24.14.1
  * Workflow now derives Node.js version dynamically from project configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->