### PR TITLE
fix(user): resolve enqueueSnackbar crash on API keys page

### DIFF
--- a/apps/deploy-web/src/components/api-keys/ApiKeysPage/ApiKeysPage.spec.tsx
+++ b/apps/deploy-web/src/components/api-keys/ApiKeysPage/ApiKeysPage.spec.tsx
@@ -148,7 +148,7 @@ describe(ApiKeysPage.name, () => {
     setup({
       dependencies: {
         useDeleteApiKey,
-        enqueueSnackbar
+        useSnackbar: () => ({ enqueueSnackbar, closeSnackbar: vi.fn() }) as unknown as ReturnType<typeof DEPENDENCIES.useSnackbar>
       }
     });
 
@@ -191,7 +191,7 @@ describe(ApiKeysPage.name, () => {
             ...MockComponents(DEPENDENCIES),
             useUserApiKeys,
             useDeleteApiKey,
-            enqueueSnackbar: vi.fn(),
+            useSnackbar: () => ({ enqueueSnackbar: vi.fn(), closeSnackbar: vi.fn() }) as unknown as ReturnType<typeof DEPENDENCIES.useSnackbar>,
             ...input.dependencies
           }}
         />

--- a/apps/deploy-web/src/components/api-keys/ApiKeysPage/ApiKeysPage.tsx
+++ b/apps/deploy-web/src/components/api-keys/ApiKeysPage/ApiKeysPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { ApiKeyResponse } from "@akashnetwork/http-sdk";
 import { NextSeo } from "next-seo";
-import { enqueueSnackbar } from "notistack";
+import { useSnackbar } from "notistack";
 
 import { ApiKeyList } from "@src/components/api-keys/ApiKeyList";
 import Layout from "@src/components/layout/Layout";
@@ -14,7 +14,7 @@ export const DEPENDENCIES = {
   ApiKeyList,
   useUserApiKeys,
   useDeleteApiKey,
-  enqueueSnackbar
+  useSnackbar
 };
 
 interface Props {
@@ -23,11 +23,12 @@ interface Props {
 
 export function ApiKeysPage({ dependencies: d = DEPENDENCIES }: Props = {}) {
   const { analyticsService } = useServices();
+  const { enqueueSnackbar } = d.useSnackbar();
   const [apiKeyToDelete, setApiKeyToDelete] = useState<ApiKeyResponse | null>(null);
   const { data: apiKeys, isLoading: isLoadingApiKeys } = d.useUserApiKeys();
   const { mutate: deleteApiKey, isPending: isDeleting } = d.useDeleteApiKey(apiKeyToDelete?.id ?? "", () => {
     setApiKeyToDelete(null);
-    d.enqueueSnackbar("API Key deleted successfully", {
+    enqueueSnackbar("API Key deleted successfully", {
       variant: "success"
     });
   });

--- a/apps/deploy-web/src/components/settings/CertificateDisplay.tsx
+++ b/apps/deploy-web/src/components/settings/CertificateDisplay.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { MdAutorenew, MdGetApp } from "react-icons/md";
 import { Button, CustomTooltip, DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, Snackbar, Spinner } from "@akashnetwork/ui/components";
 import { BinMinusIn, Check, MoreHoriz, PlusCircle, Refresh, WarningTriangle } from "iconoir-react";
-import { enqueueSnackbar } from "notistack";
+import { useSnackbar } from "notistack";
 
 import { FormPaper } from "@src/components/sdl/FormPaper";
 import { CustomDropdownLinkItem } from "@src/components/shared/CustomDropdownLinkItem";
@@ -24,6 +24,7 @@ export function CertificateDisplay() {
     regenerateCertificate,
     revokeCertificate
   } = useCertificate();
+  const { enqueueSnackbar } = useSnackbar();
   const { address } = useWallet();
 
   const onRegenerateCert = () => {


### PR DESCRIPTION
## Why

Fixes CON-149

Deleting an API key on `/user/api-keys` crashes with `TypeError: enqueueSnackbar is not a function` (32 events, 18 users in Sentry).

The standalone `enqueueSnackbar` export from notistack is a module-level `var` that starts as `undefined` and only gets assigned when `SnackbarProvider` constructs. Storing it in the `DEPENDENCIES` object at module-load time captured that `undefined` value, so the delete success callback always called `undefined(...)`.

## What

- Replaced the standalone `enqueueSnackbar` import with the `useSnackbar` hook in `DEPENDENCIES`, matching the pattern used by other components (`MintBurnPage`, `PaymentPollingProvider`, etc.)
- The hook reads from React context at render time, guaranteeing `enqueueSnackbar` is always available
- Updated tests to mock `useSnackbar` instead of `enqueueSnackbar`
- Also fixed a pre-existing `packages/net` type error where `testnet-bme` was hardcoded in `NetConfig.ts` but excluded from generated config (upstream meta.json returns 404)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated internal notification system wiring for API key and certificate management components to use an improved dependency structure.

* **Tests**
  * Updated test suite to align with refactored notification system wiring while maintaining verification of notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->