### PR TITLE
fix(deployment): guard xterm renderer race condition

### DIFF
--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -73,6 +73,8 @@
     "@tanstack/react-table": "^8.20.6",
     "@textea/json-viewer": "^3.0.0",
     "@unleash/nextjs": "^1.6.2",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "auth0": "^4.3.1",
     "axios": "^1.7.2",
     "chain-registry": "^1.69.31",
@@ -130,8 +132,6 @@
     "tss-react": "^4.8.5",
     "use-state-with-callback": "^3.0.2",
     "usehooks-ts": "^2.9.1",
-    "xterm": "^5.3.0",
-    "xterm-addon-fit": "^0.7.0",
     "yaml": "^2.8.2",
     "zod": "^3.22.4"
   },

--- a/apps/deploy-web/src/chains/index.ts
+++ b/apps/deploy-web/src/chains/index.ts
@@ -1,6 +1,9 @@
+import type { Chain } from "@chain-registry/types";
+
 import { akash, akashAssetList } from "./akash";
 import { akashSandbox, akashSandboxAssetList } from "./akash-sandbox";
 import { akashTestnet, akashTestnetAssetList } from "./akash-testnet";
 
 export { akash, akashSandbox, akashTestnet, akashAssetList, akashSandboxAssetList, akashTestnetAssetList };
-export const assetLists = [akashAssetList, akashSandboxAssetList, akashTestnetAssetList];
+export const chains: Chain[] = [akash, akashSandbox, akashTestnet].filter((c): c is Chain => c !== null);
+export const assetLists = [akashAssetList, akashSandboxAssetList, ...(akashTestnet ? [akashTestnetAssetList] : [])];

--- a/apps/deploy-web/src/context/CustomChainProvider/CustomChainProvider.tsx
+++ b/apps/deploy-web/src/context/CustomChainProvider/CustomChainProvider.tsx
@@ -14,7 +14,7 @@ import { ChainProvider, DefaultModal, useChain } from "@cosmos-kit/react";
 import { useAtom } from "jotai";
 import { useSnackbar } from "notistack";
 
-import { akash, akashSandbox, akashTestnet, assetLists } from "@src/chains";
+import { assetLists, chains } from "@src/chains";
 import networkStore from "@src/store/networkStore";
 import walletStore from "@src/store/walletStore";
 import { registry } from "@src/utils/customRegistry";
@@ -26,7 +26,7 @@ type Props = {
 export function CustomChainProvider({ children }: Props) {
   return (
     <ChainProvider
-      chains={[akash, akashSandbox, akashTestnet]}
+      chains={chains}
       assetLists={assetLists}
       wallets={[...keplr, ...leap, ...cosmostation, ...metamask]}
       walletModal={ModalWrapper}
@@ -46,9 +46,7 @@ export function CustomChainProvider({ children }: Props) {
       endpointOptions={{
         isLazy: true,
         endpoints: {
-          akash: { rest: [], rpc: [] },
-          "akash-sandbox": { rest: [], rpc: [] },
-          "akash-testnet": { rest: [], rpc: [] }
+          ...Object.fromEntries(chains.map(c => [c.chain_name, { rest: [], rpc: [] }]))
         }
       }}
       signerOptions={{

--- a/apps/deploy-web/src/lib/XTerm/XTerm.spec.tsx
+++ b/apps/deploy-web/src/lib/XTerm/XTerm.spec.tsx
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DEPENDENCIES } from "./XTerm";
+import XTerm, { getTheme } from "./XTerm";
+
+import { render } from "@testing-library/react";
+
+describe("getTheme", () => {
+  it("returns dark theme colors when resolvedTheme is dark", () => {
+    const theme = getTheme("dark");
+
+    expect(theme).toEqual({
+      background: "#1e1e1e",
+      foreground: "white",
+      cursor: "white",
+      cursorAccent: "#1e1e1e",
+      selectionBackground: "white",
+      selectionForeground: "black",
+      selectionInactiveBackground: "white"
+    });
+  });
+
+  it("returns light theme colors when resolvedTheme is light", () => {
+    const theme = getTheme("light");
+
+    expect(theme).toEqual({
+      background: "white",
+      foreground: "black",
+      cursor: "black",
+      cursorAccent: "white",
+      selectionBackground: "black",
+      selectionForeground: "white",
+      selectionInactiveBackground: "black"
+    });
+  });
+
+  it("returns light theme colors when resolvedTheme is undefined", () => {
+    const theme = getTheme(undefined);
+
+    expect(theme.background).toBe("white");
+    expect(theme.foreground).toBe("black");
+  });
+});
+
+describe("XTerm", () => {
+  it("creates terminal and opens it on mount", () => {
+    const { mockTerminal, mockFitAddon } = setup();
+
+    expect(mockTerminal.open).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+    expect(mockTerminal.loadAddon).toHaveBeenCalledWith(mockFitAddon);
+    expect(mockFitAddon.fit).toHaveBeenCalled();
+    expect(mockTerminal.attachCustomKeyEventHandler).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it("loads additional addons when provided", () => {
+    const addon = { activate: vi.fn(), dispose: vi.fn() };
+    const { mockTerminal } = setup({ addons: [addon] });
+
+    expect(mockTerminal.loadAddon).toHaveBeenCalledWith(addon);
+  });
+
+  it("disposes terminal and fit addon on unmount", () => {
+    const { unmount, mockTerminal, mockFitAddon } = setup();
+
+    unmount();
+
+    expect(mockFitAddon.dispose).toHaveBeenCalled();
+    expect(mockTerminal.dispose).toHaveBeenCalled();
+  });
+
+  it("updates theme when resolvedTheme changes", () => {
+    const { mockTerminal } = setup({ resolvedTheme: "dark" });
+
+    expect(mockTerminal.options.theme).toEqual(getTheme("dark"));
+  });
+
+  it("handles fit failure gracefully", () => {
+    const mockFitAddonInstance = createMockFitAddon();
+    mockFitAddonInstance.fit.mockImplementation(() => {
+      throw new Error("Renderer not attached");
+    });
+
+    expect(() => setup({ mockFitAddon: mockFitAddonInstance })).not.toThrow();
+  });
+
+  describe("key event handler", () => {
+    it("delegates to customKeyEventHandler when provided", () => {
+      const customHandler = vi.fn().mockReturnValue(false);
+      const { getKeyHandler } = setup({ customKeyEventHandler: customHandler });
+      const handler = getKeyHandler();
+
+      const event = new KeyboardEvent("keydown", { code: "KeyA" });
+      const result = handler(event);
+
+      expect(customHandler).toHaveBeenCalledWith(event);
+      expect(result).toBe(false);
+    });
+
+    it("copies selection on Ctrl+C when text is selected", () => {
+      const { getKeyHandler, mockTerminal, copyTextToClipboardMock } = setup();
+      mockTerminal.getSelection.mockReturnValue("selected text");
+      const handler = getKeyHandler();
+
+      const event = new KeyboardEvent("keydown", { code: "KeyC", ctrlKey: true });
+      const result = handler(event);
+
+      expect(copyTextToClipboardMock).toHaveBeenCalledWith("selected text");
+      expect(result).toBe(false);
+    });
+
+    it("returns true for unhandled key events", () => {
+      const { getKeyHandler } = setup();
+      const handler = getKeyHandler();
+
+      const event = new KeyboardEvent("keydown", { code: "KeyA" });
+      const result = handler(event);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  function createMockTerminal() {
+    return {
+      attachCustomKeyEventHandler: vi.fn(),
+      loadAddon: vi.fn(),
+      open: vi.fn(),
+      dispose: vi.fn(),
+      write: vi.fn(),
+      clear: vi.fn(),
+      reset: vi.fn(),
+      focus: vi.fn(),
+      getSelection: vi.fn().mockReturnValue(""),
+      onBinary: vi.fn(() => ({ dispose: vi.fn() })),
+      onCursorMove: vi.fn(() => ({ dispose: vi.fn() })),
+      onData: vi.fn(() => ({ dispose: vi.fn() })),
+      onKey: vi.fn(() => ({ dispose: vi.fn() })),
+      onLineFeed: vi.fn(() => ({ dispose: vi.fn() })),
+      onScroll: vi.fn(() => ({ dispose: vi.fn() })),
+      onSelectionChange: vi.fn(() => ({ dispose: vi.fn() })),
+      onRender: vi.fn(() => ({ dispose: vi.fn() })),
+      onResize: vi.fn(() => ({ dispose: vi.fn() })),
+      onTitleChange: vi.fn(() => ({ dispose: vi.fn() })),
+      options: {} as Record<string, unknown>
+    };
+  }
+
+  function createMockFitAddon() {
+    return {
+      fit: vi.fn(),
+      dispose: vi.fn(),
+      activate: vi.fn()
+    };
+  }
+
+  function setup(input?: {
+    resolvedTheme?: string;
+    addons?: Array<{ activate: ReturnType<typeof vi.fn>; dispose: ReturnType<typeof vi.fn> }>;
+    customKeyEventHandler?: (event: KeyboardEvent) => boolean;
+    mockFitAddon?: ReturnType<typeof createMockFitAddon>;
+  }) {
+    const mockTerminal = createMockTerminal();
+    const mockFitAddon = input?.mockFitAddon ?? createMockFitAddon();
+    const copyTextToClipboardMock = vi.fn();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const MockTerminal = vi.fn(function (this: any) {
+      Object.assign(this, mockTerminal);
+      return mockTerminal;
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const MockFitAddon = vi.fn(function (this: any) {
+      Object.assign(this, mockFitAddon);
+      return mockFitAddon;
+    });
+    const useThemeMock = () => ({ resolvedTheme: input?.resolvedTheme ?? "dark" });
+
+    const result = render(
+      <XTerm
+        dependencies={{
+          Terminal: MockTerminal as unknown as typeof DEPENDENCIES.Terminal,
+          FitAddon: MockFitAddon as unknown as typeof DEPENDENCIES.FitAddon,
+          useTheme: useThemeMock as unknown as typeof DEPENDENCIES.useTheme,
+          copyTextToClipboard: copyTextToClipboardMock
+        }}
+        addons={input?.addons as never}
+        customKeyEventHandler={input?.customKeyEventHandler}
+      />
+    );
+
+    const getKeyHandler = () => {
+      return mockTerminal.attachCustomKeyEventHandler.mock.calls[0][0] as (event: KeyboardEvent) => boolean;
+    };
+
+    return { ...result, mockTerminal, mockFitAddon, MockTerminal, MockFitAddon, copyTextToClipboardMock, getKeyHandler };
+  }
+});

--- a/apps/deploy-web/src/lib/XTerm/XTerm.spec.tsx
+++ b/apps/deploy-web/src/lib/XTerm/XTerm.spec.tsx
@@ -69,9 +69,25 @@ describe("XTerm", () => {
   });
 
   it("updates theme when resolvedTheme changes", () => {
-    const { mockTerminal } = setup({ resolvedTheme: "dark" });
+    let currentTheme = "dark";
+    const useThemeMock = () => ({ resolvedTheme: currentTheme });
+    const { mockTerminal, rerender, MockTerminal, MockFitAddon, copyTextToClipboardMock } = setup({ useThemeMock });
 
     expect(mockTerminal.options.theme).toEqual(getTheme("dark"));
+
+    currentTheme = "light";
+    rerender(
+      <XTerm
+        dependencies={{
+          Terminal: MockTerminal as unknown as typeof DEPENDENCIES.Terminal,
+          FitAddon: MockFitAddon as unknown as typeof DEPENDENCIES.FitAddon,
+          useTheme: useThemeMock as unknown as typeof DEPENDENCIES.useTheme,
+          copyTextToClipboard: copyTextToClipboardMock
+        }}
+      />
+    );
+
+    expect(mockTerminal.options.theme).toEqual(getTheme("light"));
   });
 
   it("handles fit failure gracefully", () => {
@@ -94,6 +110,33 @@ describe("XTerm", () => {
 
       expect(customHandler).toHaveBeenCalledWith(event);
       expect(result).toBe(false);
+    });
+
+    it("uses latest customKeyEventHandler via ref after rerender", () => {
+      const firstHandler = vi.fn().mockReturnValue(true);
+      const secondHandler = vi.fn().mockReturnValue(false);
+      const { getKeyHandler, rerender, MockTerminal, MockFitAddon, copyTextToClipboardMock, useThemeMock } = setup({
+        customKeyEventHandler: firstHandler
+      });
+
+      rerender(
+        <XTerm
+          dependencies={{
+            Terminal: MockTerminal as unknown as typeof DEPENDENCIES.Terminal,
+            FitAddon: MockFitAddon as unknown as typeof DEPENDENCIES.FitAddon,
+            useTheme: useThemeMock as unknown as typeof DEPENDENCIES.useTheme,
+            copyTextToClipboard: copyTextToClipboardMock
+          }}
+          customKeyEventHandler={secondHandler}
+        />
+      );
+
+      const handler = getKeyHandler();
+      const event = new KeyboardEvent("keydown", { code: "KeyA" });
+      handler(event);
+
+      expect(secondHandler).toHaveBeenCalledWith(event);
+      expect(firstHandler).not.toHaveBeenCalled();
     });
 
     it("copies selection on Ctrl+C when text is selected", () => {
@@ -157,6 +200,7 @@ describe("XTerm", () => {
     addons?: Array<{ activate: ReturnType<typeof vi.fn>; dispose: ReturnType<typeof vi.fn> }>;
     customKeyEventHandler?: (event: KeyboardEvent) => boolean;
     mockFitAddon?: ReturnType<typeof createMockFitAddon>;
+    useThemeMock?: () => { resolvedTheme: string };
   }) {
     const mockTerminal = createMockTerminal();
     const mockFitAddon = input?.mockFitAddon ?? createMockFitAddon();
@@ -172,7 +216,7 @@ describe("XTerm", () => {
       Object.assign(this, mockFitAddon);
       return mockFitAddon;
     });
-    const useThemeMock = () => ({ resolvedTheme: input?.resolvedTheme ?? "dark" });
+    const useThemeMock = input?.useThemeMock ?? (() => ({ resolvedTheme: input?.resolvedTheme ?? "dark" }));
 
     const result = render(
       <XTerm
@@ -191,6 +235,6 @@ describe("XTerm", () => {
       return mockTerminal.attachCustomKeyEventHandler.mock.calls[0][0] as (event: KeyboardEvent) => boolean;
     };
 
-    return { ...result, mockTerminal, mockFitAddon, MockTerminal, MockFitAddon, copyTextToClipboardMock, getKeyHandler };
+    return { ...result, mockTerminal, mockFitAddon, MockTerminal, MockFitAddon, copyTextToClipboardMock, useThemeMock, getKeyHandler };
   }
 });

--- a/apps/deploy-web/src/lib/XTerm/XTerm.tsx
+++ b/apps/deploy-web/src/lib/XTerm/XTerm.tsx
@@ -1,14 +1,14 @@
 "use client";
-import "xterm/css/xterm.css";
+import "@xterm/xterm/css/xterm.css";
 
 import type { Ref } from "react";
 import { useEffect, useRef } from "react";
 import React from "react";
 import { cn } from "@akashnetwork/ui/utils";
+import { FitAddon } from "@xterm/addon-fit";
+import type { IDisposable, ITerminalAddon, ITerminalOptions } from "@xterm/xterm";
+import { Terminal } from "@xterm/xterm";
 import { useTheme } from "next-themes";
-import type { IDisposable, ITerminalAddon, ITerminalOptions } from "xterm";
-import { Terminal } from "xterm";
-import { FitAddon } from "xterm-addon-fit";
 
 import { copyTextToClipboard } from "@src/utils/copyClipboard";
 
@@ -127,14 +127,9 @@ export type XTermRefType = {
 
 const XTerm: React.FunctionComponent<IProps> = props => {
   const { resolvedTheme } = useTheme();
-  /**
-   * The ref for the containing element.
-   */
   const terminalEleRef = useRef<HTMLDivElement | null>(null);
-  /**
-   * XTerm.js Terminal object.
-   */
   const terminalRef = useRef<Terminal | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
 
   React.useImperativeHandle(props.customRef, () => ({
     write: (data: string | Uint8Array, callback?: () => void) => terminalRef.current?.write(data, callback),
@@ -142,29 +137,18 @@ const XTerm: React.FunctionComponent<IProps> = props => {
     clear: () => terminalRef.current?.clear(),
     reset: () => terminalRef.current?.reset(),
     focus: () => terminalRef.current?.focus()
-    // TODO more commands
   }));
 
   useEffect(() => {
     if (!terminalEleRef.current) return;
 
-    // Setup the XTerm terminal.
-    terminalRef.current = new Terminal({
+    const terminal = new Terminal({
       ...props.options,
-      theme: {
-        background: resolvedTheme === "dark" ? "#1e1e1e" : "white",
-        foreground: resolvedTheme === "dark" ? "white" : "black",
-        cursor: resolvedTheme === "dark" ? "white" : "black",
-        cursorAccent: resolvedTheme === "dark" ? "#1e1e1e" : "white",
-        selectionBackground: resolvedTheme === "dark" ? "white" : "black",
-        selectionForeground: resolvedTheme === "dark" ? "black" : "white",
-        selectionInactiveBackground: resolvedTheme === "dark" ? "white" : "black"
-      },
+      theme: getTheme(resolvedTheme),
       cursorBlink: true
     });
 
-    terminalRef.current.attachCustomKeyEventHandler((keyEvent: KeyboardEvent) => {
-      // Handle pasting with ctrl or cmd + v
+    terminal.attachCustomKeyEventHandler((keyEvent: KeyboardEvent) => {
       if ((keyEvent.ctrlKey || keyEvent.metaKey) && keyEvent.code === "KeyV" && keyEvent.type === "keydown") {
         if (props.onTerminalPaste) {
           navigator.clipboard.readText().then(
@@ -176,54 +160,64 @@ const XTerm: React.FunctionComponent<IProps> = props => {
         }
       }
 
-      // Handle pasting with ctrl or cmd + c
       if ((keyEvent.ctrlKey || keyEvent.metaKey) && keyEvent.code === "KeyC" && keyEvent.type === "keydown") {
-        const selection = terminalRef.current?.getSelection();
+        const selection = terminal.getSelection();
         if (selection) {
           copyTextToClipboard(selection);
           return false;
         }
       }
+
+      if (props.customKeyEventHandler) {
+        return props.customKeyEventHandler(keyEvent);
+      }
+
       return true;
     });
 
     const fitAddon = new FitAddon();
-    terminalRef.current.loadAddon(fitAddon);
+    terminal.loadAddon(fitAddon);
+    fitAddonRef.current = fitAddon;
 
-    // Load addons if the prop exists.
     if (props.addons) {
       props.addons.forEach(addon => {
-        terminalRef.current?.loadAddon(addon);
+        terminal.loadAddon(addon);
       });
     }
 
-    // Add Custom Key Event Handler
-    if (props.customKeyEventHandler) {
-      terminalRef.current.attachCustomKeyEventHandler(props.customKeyEventHandler);
-    }
-
-    // Open terminal
-    terminalRef.current.open(terminalEleRef.current);
+    terminal.open(terminalEleRef.current);
+    terminalRef.current = terminal;
 
     try {
       fitAddon.fit();
     } catch {
       // Fit can fail if the renderer is not yet attached due to a race condition
       // in xterm.js (Viewport._innerRefresh accesses renderer dimensions).
-      // This is safe to ignore — the terminal will render correctly on the next resize.
     }
 
+    const resizeObserver = new ResizeObserver(() => {
+      try {
+        fitAddon.fit();
+      } catch {
+        // Terminal may be mid-disposal during a resize callback.
+      }
+    });
+    resizeObserver.observe(terminalEleRef.current);
+
     return () => {
-      // Dispose the fit addon first to prevent it from triggering a resize
-      // after the terminal renderer has been torn down.
+      resizeObserver.disconnect();
       fitAddon.dispose();
-      terminalRef.current?.dispose();
-      // Null out the ref so that any in-flight async calls (e.g. shell
-      // messages arriving after unmount) become no-ops via the optional
-      // chaining in the imperative handle.
+      fitAddonRef.current = null;
+      terminal.dispose();
       terminalRef.current = null;
     };
   }, []);
+
+  useEffect(() => {
+    if (terminalRef.current) {
+      terminalRef.current.options.theme = getTheme(resolvedTheme);
+    }
+  }, [resolvedTheme]);
 
   useEffect(() => disposable(props.onBinary && terminalRef.current?.onBinary(props.onBinary)), [props.onBinary]);
   useEffect(() => disposable(props.onCursorMove && terminalRef.current?.onCursorMove(props.onCursorMove)), [props.onCursorMove]);
@@ -236,13 +230,7 @@ const XTerm: React.FunctionComponent<IProps> = props => {
   useEffect(() => disposable(props.onResize && terminalRef.current?.onResize(props.onResize)), [props.onResize]);
   useEffect(() => disposable(props.onTitleChange && terminalRef.current?.onTitleChange(props.onTitleChange)), [props.onTitleChange]);
 
-  return (
-    <div
-      // sx={{ height: "100%", "& .terminal": { height: "100%" } }}
-      className={cn(props.className, "h-full [&>.terminal]:h-full")}
-      ref={terminalEleRef}
-    />
-  );
+  return <div className={cn(props.className, "h-full [&>.terminal]:h-full")} ref={terminalEleRef} />;
 };
 
 export default XTerm;
@@ -250,4 +238,17 @@ export default XTerm;
 function disposable(value: IDisposable | undefined) {
   if (!value) return;
   return () => value.dispose();
+}
+
+function getTheme(resolvedTheme: string | undefined) {
+  const isDark = resolvedTheme === "dark";
+  return {
+    background: isDark ? "#1e1e1e" : "white",
+    foreground: isDark ? "white" : "black",
+    cursor: isDark ? "white" : "black",
+    cursorAccent: isDark ? "#1e1e1e" : "white",
+    selectionBackground: isDark ? "white" : "black",
+    selectionForeground: isDark ? "black" : "white",
+    selectionInactiveBackground: isDark ? "white" : "black"
+  };
 }

--- a/apps/deploy-web/src/lib/XTerm/XTerm.tsx
+++ b/apps/deploy-web/src/lib/XTerm/XTerm.tsx
@@ -12,6 +12,8 @@ import { useTheme } from "next-themes";
 
 import { copyTextToClipboard } from "@src/utils/copyClipboard";
 
+export const DEPENDENCIES = { Terminal, FitAddon, useTheme, copyTextToClipboard };
+
 export interface IProps {
   /**
    * Class name to add to the terminal container.
@@ -125,7 +127,8 @@ export type XTermRefType = {
   focus: () => void;
 };
 
-const XTerm: React.FunctionComponent<IProps> = props => {
+const XTerm: React.FunctionComponent<IProps & { dependencies?: typeof DEPENDENCIES }> = props => {
+  const { Terminal, FitAddon, useTheme, copyTextToClipboard } = props.dependencies ?? DEPENDENCIES;
   const { resolvedTheme } = useTheme();
   const terminalEleRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<Terminal | null>(null);
@@ -240,7 +243,7 @@ function disposable(value: IDisposable | undefined) {
   return () => value.dispose();
 }
 
-function getTheme(resolvedTheme: string | undefined) {
+export function getTheme(resolvedTheme: string | undefined) {
   const isDark = resolvedTheme === "dark";
   return {
     background: isDark ? "#1e1e1e" : "white",

--- a/apps/deploy-web/src/lib/XTerm/XTerm.tsx
+++ b/apps/deploy-web/src/lib/XTerm/XTerm.tsx
@@ -146,6 +146,8 @@ const XTerm: React.FunctionComponent<IProps> = props => {
   }));
 
   useEffect(() => {
+    if (!terminalEleRef.current) return;
+
     // Setup the XTerm terminal.
     terminalRef.current = new Terminal({
       ...props.options,
@@ -201,13 +203,25 @@ const XTerm: React.FunctionComponent<IProps> = props => {
     }
 
     // Open terminal
-    terminalRef.current.open(terminalEleRef.current as HTMLDivElement);
+    terminalRef.current.open(terminalEleRef.current);
 
-    fitAddon.fit();
+    try {
+      fitAddon.fit();
+    } catch {
+      // Fit can fail if the renderer is not yet attached due to a race condition
+      // in xterm.js (Viewport._innerRefresh accesses renderer dimensions).
+      // This is safe to ignore — the terminal will render correctly on the next resize.
+    }
 
     return () => {
-      // When the component unmounts dispose of the terminal and all of its listeners.
+      // Dispose the fit addon first to prevent it from triggering a resize
+      // after the terminal renderer has been torn down.
+      fitAddon.dispose();
       terminalRef.current?.dispose();
+      // Null out the ref so that any in-flight async calls (e.g. shell
+      // messages arriving after unmount) become no-ops via the optional
+      // chaining in the imperative handle.
+      terminalRef.current = null;
     };
   }, []);
 

--- a/apps/deploy-web/src/lib/XTerm/XTerm.tsx
+++ b/apps/deploy-web/src/lib/XTerm/XTerm.tsx
@@ -4,6 +4,7 @@ import "@xterm/xterm/css/xterm.css";
 import type { Ref } from "react";
 import { useEffect, useRef } from "react";
 import React from "react";
+import { LoggerService } from "@akashnetwork/logging";
 import { cn } from "@akashnetwork/ui/utils";
 import { FitAddon } from "@xterm/addon-fit";
 import type { IDisposable, ITerminalAddon, ITerminalOptions } from "@xterm/xterm";
@@ -11,6 +12,8 @@ import { Terminal } from "@xterm/xterm";
 import { useTheme } from "next-themes";
 
 import { copyTextToClipboard } from "@src/utils/copyClipboard";
+
+const logger = LoggerService.forContext("XTerm");
 
 export const DEPENDENCIES = { Terminal, FitAddon, useTheme, copyTextToClipboard };
 
@@ -133,6 +136,16 @@ const XTerm: React.FunctionComponent<IProps & { dependencies?: typeof DEPENDENCI
   const terminalEleRef = useRef<HTMLDivElement | null>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
+  const onTerminalPasteRef = useRef(props.onTerminalPaste);
+  const customKeyEventHandlerRef = useRef(props.customKeyEventHandler);
+
+  useEffect(() => {
+    onTerminalPasteRef.current = props.onTerminalPaste;
+  }, [props.onTerminalPaste]);
+
+  useEffect(() => {
+    customKeyEventHandlerRef.current = props.customKeyEventHandler;
+  }, [props.customKeyEventHandler]);
 
   React.useImperativeHandle(props.customRef, () => ({
     write: (data: string | Uint8Array, callback?: () => void) => terminalRef.current?.write(data, callback),
@@ -153,11 +166,11 @@ const XTerm: React.FunctionComponent<IProps & { dependencies?: typeof DEPENDENCI
 
     terminal.attachCustomKeyEventHandler((keyEvent: KeyboardEvent) => {
       if ((keyEvent.ctrlKey || keyEvent.metaKey) && keyEvent.code === "KeyV" && keyEvent.type === "keydown") {
-        if (props.onTerminalPaste) {
+        if (onTerminalPasteRef.current) {
           navigator.clipboard.readText().then(
-            value => props.onTerminalPaste && props.onTerminalPaste(value),
+            value => onTerminalPasteRef.current?.(value),
             err => {
-              console.error("Async: Could not read text from clipboard: ", err);
+              logger.error({ event: "CLIPBOARD_READ_FAILED", error: err });
             }
           );
         }
@@ -171,8 +184,8 @@ const XTerm: React.FunctionComponent<IProps & { dependencies?: typeof DEPENDENCI
         }
       }
 
-      if (props.customKeyEventHandler) {
-        return props.customKeyEventHandler(keyEvent);
+      if (customKeyEventHandlerRef.current) {
+        return customKeyEventHandlerRef.current(keyEvent);
       }
 
       return true;

--- a/apps/deploy-web/tests/unit/__mocks__/xterm-addon-fit.ts
+++ b/apps/deploy-web/tests/unit/__mocks__/xterm-addon-fit.ts
@@ -1,0 +1,5 @@
+export class FitAddon {
+  activate() {}
+  fit() {}
+  dispose() {}
+}

--- a/apps/deploy-web/tests/unit/__mocks__/xterm.ts
+++ b/apps/deploy-web/tests/unit/__mocks__/xterm.ts
@@ -1,0 +1,44 @@
+export class Terminal {
+  options = {};
+  open() {}
+  dispose() {}
+  write() {}
+  clear() {}
+  reset() {}
+  focus() {}
+  loadAddon() {}
+  attachCustomKeyEventHandler() {}
+  getSelection() {
+    return "";
+  }
+  onBinary() {
+    return { dispose() {} };
+  }
+  onCursorMove() {
+    return { dispose() {} };
+  }
+  onData() {
+    return { dispose() {} };
+  }
+  onKey() {
+    return { dispose() {} };
+  }
+  onLineFeed() {
+    return { dispose() {} };
+  }
+  onScroll() {
+    return { dispose() {} };
+  }
+  onSelectionChange() {
+    return { dispose() {} };
+  }
+  onRender() {
+    return { dispose() {} };
+  }
+  onResize() {
+    return { dispose() {} };
+  }
+  onTitleChange() {
+    return { dispose() {} };
+  }
+}

--- a/apps/deploy-web/vitest.config.ts
+++ b/apps/deploy-web/vitest.config.ts
@@ -38,7 +38,10 @@ export default defineConfig({
           alias: {
             ...commonAlias,
             "@interchain-ui/react/styles": path.resolve("./tests/unit/__mocks__/style.ts"),
-            "@interchain-ui/react/globalStyles": path.resolve("./tests/unit/__mocks__/style.ts")
+            "@interchain-ui/react/globalStyles": path.resolve("./tests/unit/__mocks__/style.ts"),
+            "@xterm/xterm/css/xterm.css": path.resolve("./tests/unit/__mocks__/style.ts"),
+            "@xterm/xterm": path.resolve("./tests/unit/__mocks__/xterm.ts"),
+            "@xterm/addon-fit": path.resolve("./tests/unit/__mocks__/xterm-addon-fit.ts")
           }
         }
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -550,6 +550,8 @@
         "@tanstack/react-table": "^8.20.6",
         "@textea/json-viewer": "^3.0.0",
         "@unleash/nextjs": "^1.6.2",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "auth0": "^4.3.1",
         "axios": "^1.7.2",
         "chain-registry": "^1.69.31",
@@ -607,8 +609,6 @@
         "tss-react": "^4.8.5",
         "use-state-with-callback": "^3.0.2",
         "usehooks-ts": "^2.9.1",
-        "xterm": "^5.3.0",
-        "xterm-addon-fit": "^0.7.0",
         "yaml": "^2.8.2",
         "zod": "^3.22.4"
       },
@@ -26868,6 +26868,21 @@
       "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
       "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
       "license": "MIT"
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
+      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -48475,18 +48475,6 @@
       "version": "0.4.0",
       "license": "MIT"
     },
-    "node_modules/xterm": {
-      "version": "5.3.0",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/xterm-addon-fit": {
-      "version": "0.7.0",
-      "license": "MIT",
-      "peerDependencies": {
-        "xterm": "^5.0.0"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "license": "ISC",

--- a/packages/net/src/NetConfig/NetConfig.ts
+++ b/packages/net/src/NetConfig/NetConfig.ts
@@ -7,10 +7,6 @@ export class NetConfig {
     sandbox: "sandbox-2"
   };
 
-  isSupported(network: string): boolean {
-    return this.networkMap[network] !== undefined || network in netConfigData;
-  }
-
   mapped(network: string): SupportedChainNetworks {
     if (this.networkMap[network]) {
       return this.networkMap[network];

--- a/packages/net/src/NetConfig/NetConfig.ts
+++ b/packages/net/src/NetConfig/NetConfig.ts
@@ -7,6 +7,10 @@ export class NetConfig {
     sandbox: "sandbox-2"
   };
 
+  isSupported(network: string): boolean {
+    return this.networkMap[network] !== undefined || network in netConfigData;
+  }
+
   mapped(network: string): SupportedChainNetworks {
     if (this.networkMap[network]) {
       return this.networkMap[network];


### PR DESCRIPTION
## Why

Fixes CON-150

The deployment terminal view crashes with `TypeError: can't access property "dimensions", this._renderer.value is undefined` — an xterm.js race condition where the renderer is accessed before initialization or after disposal. This affects 43 users (145 events) across all browsers on `/deployments/[dseq]`.

The root cause: when a user navigates away from the deployment page, `terminal.dispose()` tears down the renderer, but in-flight async shell messages can still arrive and call `write()` on the disposed terminal. The write triggers an internal `Viewport._innerRefresh()` which accesses the now-undefined renderer dimensions.

## What

**Package upgrade:**
- Migrate from deprecated `xterm`/`xterm-addon-fit` to `@xterm/xterm` 6.0.0 and `@xterm/addon-fit` 0.11.0

**Race condition fix** (CON-150):
- Null out `terminalRef` after disposal so in-flight async callbacks become no-ops via the imperative handle's optional chaining
- Dispose FitAddon before terminal to prevent post-teardown resize events
- Wrap `fitAddon.fit()` in try-catch for the edge case where the renderer isn't attached yet

**Terminal improvements:**
- Add `ResizeObserver` so the terminal refits when the container/window resizes
- React to dark/light mode changes via a dedicated `useEffect` on `resolvedTheme`
- Unify custom key event handling into a single `attachCustomKeyEventHandler` that chains the built-in copy/paste handler with the optional `props.customKeyEventHandler`
- Extract `getTheme()` helper to reduce duplication

Also cherry-picks network fix commits from #3003 (`ae82e6db`, `a759a5ab`) to handle unsupported networks gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal initialization and cleanup with proper resource disposal
  * Enhanced theme switching that now dynamically updates when system theme changes

* **Chores**
  * Updated xterm dependencies to latest versions (v6.0.0 and addon-fit v0.11.0)
  * Improved chain configuration handling for better network support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->