### PR TITLE
chore(billing): schedule daily mint-act cron job

### DIFF
--- a/.helm/console-api-prod-mainnet-values.yaml
+++ b/.helm/console-api-prod-mainnet-values.yaml
@@ -40,6 +40,14 @@ jobs:
       - ./dist/instrumentation.js
       - ./dist/console.js
       - gpu-pricing-bot
+  - name: mint-act
+    schedule: "0 6 * * *" # 6:00 AM every day
+    command:
+      - node
+      - --require
+      - ./dist/instrumentation.js
+      - ./dist/console.js
+      - mint-act
 
 replicas: 3
 


### PR DESCRIPTION
## Why

Part of CON-120

The `mint-act` command was added in #3000 but not yet scheduled.

## What

Adds `mint-act` cron job to prod helm values, running daily at 6:00 AM UTC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new scheduled job to production configuration that runs daily at 6:00 AM UTC. No existing jobs were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->