### PR TITLE
fix: enables lazy initialization for network configuration

### DIFF
--- a/apps/deploy-web/src/pages/api/blockchain-config.ts
+++ b/apps/deploy-web/src/pages/api/blockchain-config.ts
@@ -3,6 +3,7 @@ import { netConfig } from "@akashnetwork/net";
 import { z } from "zod";
 
 import { defineApiHandler } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
+import type { AppServices } from "@src/services/app-di-container/server-di-container.service";
 
 export default defineApiHandler({
   route: "/api/blockchain-config",
@@ -12,33 +13,48 @@ export default defineApiHandler({
     })
   }),
   async handler({ query, res, services }) {
-    const config = {
-      mainnet: [
+    const allNetworksConfig = createNetworksConfig(services.privateConfig);
+    let networkConfig: Array<ReturnType<typeof nodeWithId>>;
+    try {
+      networkConfig = allNetworksConfig[query.network];
+    } catch (error) {
+      res.status(422).json({ error: `Unable to fetch ${query.network} blockchain network config. Does this network exist?` });
+      return;
+    }
+
+    res.status(200).json(networkConfig);
+  }
+});
+
+function createNetworksConfig(privateConfig: Pick<AppServices["privateConfig"], "DEFAULT_REST_API_NODE_URL_MAINNET" | "DEFAULT_RPC_NODE_URL_MAINNET">) {
+  const networks = {
+    get mainnet() {
+      return [
         nodeWithId({
-          api: services.privateConfig.DEFAULT_REST_API_NODE_URL_MAINNET ?? netConfig.getBaseAPIUrl("mainnet"),
-          rpc: services.privateConfig.DEFAULT_RPC_NODE_URL_MAINNET ?? netConfig.getBaseRpcUrl("mainnet")
+          api: privateConfig.DEFAULT_REST_API_NODE_URL_MAINNET ?? netConfig.getBaseAPIUrl("mainnet"),
+          rpc: privateConfig.DEFAULT_RPC_NODE_URL_MAINNET ?? netConfig.getBaseRpcUrl("mainnet")
         })
-      ],
-      sandbox: [
+      ];
+    },
+    get sandbox() {
+      return [
         nodeWithId({
           api: netConfig.getBaseAPIUrl("sandbox"),
           rpc: netConfig.getBaseRpcUrl("sandbox")
         })
-      ],
-      testnet: [
+      ];
+    },
+    get testnet() {
+      return [
         nodeWithId({
           api: netConfig.getBaseAPIUrl("testnet"),
           rpc: netConfig.getBaseRpcUrl("testnet")
         })
-      ]
-    };
-    const data = config[query.network]?.map(node => {
-      node.id = new URL(node.api).hostname;
-      return node;
-    });
-    res.status(200).json(data);
-  }
-});
+      ];
+    }
+  };
+  return networks;
+}
 
 function nodeWithId(node: { api: string; rpc: string }) {
   return {


### PR DESCRIPTION
## Why

testnet configuration may be sometimes available and sometimes unavailable. That's why `/blockchain-config` should be tolerant to its absence

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for blockchain network configuration requests. The API now returns clear error messages when requesting non-existent networks instead of failing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->