### PR TITLE
feat(notifications): add udenomToDenom and denomLabel template helpers

### DIFF
--- a/apps/notifications/src/modules/alert/services/template/template.service.spec.ts
+++ b/apps/notifications/src/modules/alert/services/template/template.service.spec.ts
@@ -62,4 +62,52 @@ describe(TemplateService.name, () => {
     const context = {};
     expect(new TemplateService().interpolate(template, context)).toBe("Env: ");
   });
+
+  describe("denomLabel helper", () => {
+    it("should map known denoms to token labels", () => {
+      const template = "{{denomLabel denom}}";
+      expect(setup().interpolate(template, { denom: "uakt" })).toBe("AKT");
+      expect(setup().interpolate(template, { denom: "uact" })).toBe("ACT");
+    });
+
+    it("should return denom as-is if unknown", () => {
+      expect(setup().interpolate("{{denomLabel denom}}", { denom: "ufoo" })).toBe("ufoo");
+    });
+  });
+
+  describe("udenomToDenom helper", () => {
+    it("should convert micro-denomination to denom", () => {
+      const template = "{{udenomToDenom balance}}";
+      expect(setup().interpolate(template, { balance: 700_000 })).toBe("0.7");
+    });
+
+    it("should accept custom precision as second argument", () => {
+      expect(setup().interpolate("{{udenomToDenom balance 2}}", { balance: 1_234_567 })).toBe("1.23");
+    });
+  });
+
+  describe("balance alert template", () => {
+    const template =
+      '{{#if (eq alert.next.status "TRIGGERED")}}Balance dropped to {{udenomToDenom data.amount 2}} {{denomLabel data.denom}}, which is below the configured threshold{{else}}Balance recovered to {{udenomToDenom data.amount 2}} {{denomLabel data.denom}}, now above threshold{{/if}}';
+
+    it("should render triggered alert", () => {
+      const context = {
+        alert: { next: { status: "TRIGGERED" } },
+        data: { amount: 700_000, denom: "uakt" }
+      };
+      expect(setup().interpolate(template, context)).toBe("Balance dropped to 0.7 AKT, which is below the configured threshold");
+    });
+
+    it("should render recovered alert", () => {
+      const context = {
+        alert: { next: { status: "OK" } },
+        data: { amount: 5_000_000, denom: "uact" }
+      };
+      expect(setup().interpolate(template, context)).toBe("Balance recovered to 5 ACT, now above threshold");
+    });
+  });
+
+  function setup() {
+    return new TemplateService();
+  }
 });

--- a/apps/notifications/src/modules/alert/services/template/template.service.ts
+++ b/apps/notifications/src/modules/alert/services/template/template.service.ts
@@ -5,6 +5,32 @@ Handlebars.registerHelper("eq", function (a, b) {
   return a === b;
 });
 
+const DENOM_LABELS: Record<string, string> = {
+  uakt: "AKT",
+  uact: "ACT"
+};
+
+Handlebars.registerHelper("denomLabel", function (denom: unknown) {
+  if (typeof denom !== "string") {
+    return "";
+  }
+
+  return DENOM_LABELS[denom] ?? denom;
+});
+
+Handlebars.registerHelper("udenomToDenom", function (amount: unknown, precision?: unknown) {
+  const parsedAmount = typeof amount === "string" ? parseFloat(amount) : Number(amount);
+
+  if (isNaN(parsedAmount)) {
+    return "";
+  }
+
+  const parsedPrecision = typeof precision === "number" ? precision : 6;
+  const multiplier = Math.pow(10, parsedPrecision);
+
+  return String(Math.round((parsedAmount / 1_000_000 + Number.EPSILON) * multiplier) / multiplier);
+});
+
 @Injectable()
 export class TemplateService {
   interpolate(template: string, context: object): string {


### PR DESCRIPTION
## Why

Notification templates currently display raw micro-denomination amounts (e.g. `700000 uakt`) which are not user-friendly. We need Handlebars helpers to format these values into human-readable token amounts.

## What

- Add `udenomToDenom` Handlebars helper that converts micro-denomination amounts to human-readable values (e.g. `700000` → `0.7`) with configurable precision (default 6)
- Add `denomLabel` Handlebars helper that maps denom identifiers to token labels (`uakt` → `AKT`, `uact` → `ACT`)
- Add tests for both helpers including an integration test with a realistic balance alert template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Denomination label formatting in alert templates (e.g., micro-denoms like uakt show as AKT).
  * Amount conversion helper that displays micro-denominations as human-friendly values with configurable decimal precision.

* **Tests**
  * Expanded unit coverage for label mapping and amount conversion.
  * Added end-to-end template test covering conditional alert rendering (triggered vs recovered).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->