### PR TITLE
fix(sdl): handle YAML parse errors as 400 instead of 500

### DIFF
--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -280,6 +280,15 @@ describe(SdlService.name, () => {
 
       expect(result.ok).toBeFalsy();
     });
+
+    it("returns error result with message for malformed YAML", () => {
+      const { result } = setup({ sdl: "key: value\n  bad_indent: true" });
+
+      expect(result).toMatchObject({
+        ok: false,
+        value: [expect.objectContaining({ message: expect.stringContaining("bad indentation") })]
+      });
+    });
   });
 
   function setup(input?: { sdl?: string; allowedAuditors?: string[]; deploymentGrantDenom?: string }) {

--- a/apps/api/src/deployment/services/sdl/sdl.service.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.ts
@@ -1,5 +1,6 @@
 import type { GenerateManifestResult, Manifest, NetworkId, SDLInput } from "@akashnetwork/chain-sdk";
 import { generateManifest, generateManifestVersion, yaml } from "@akashnetwork/chain-sdk";
+import { YAMLException } from "js-yaml";
 import { singleton } from "tsyringe";
 
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
@@ -15,7 +16,16 @@ export class SdlService {
   }
 
   generateManifest(rawSDL: string): GenerateManifestResult {
-    const potentiallyInvalidSDL = yaml.raw<SDLInput>(rawSDL);
+    let potentiallyInvalidSDL: SDLInput;
+
+    try {
+      potentiallyInvalidSDL = yaml.raw<SDLInput>(rawSDL);
+    } catch (error) {
+      if (error instanceof YAMLException) {
+        return { ok: false, value: [{ schemaPath: "", instancePath: "", keyword: "yaml", params: {}, message: error.message }] };
+      }
+      throw error;
+    }
     const deploymentGrantDenom = this.#config.DEPLOYMENT_GRANT_DENOM;
     const sdlPlacement =
       potentiallyInvalidSDL?.profiles?.placement && typeof potentiallyInvalidSDL?.profiles?.placement === "object"


### PR DESCRIPTION
## Why

Malformed YAML in user-submitted SDLs causes a `YAMLException` that bypasses the existing 400 error handling in `#parseManifest`, resulting in unhandled 500 errors in production.

## What

- Catch `YAMLException` specifically in `SdlService.generateManifest` and return it as an `{ ok: false }` error result
- Non-YAML errors are re-thrown to preserve existing 500 behavior for genuine bugs
- Added unit test for malformed YAML input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling to gracefully manage malformed YAML input, returning structured validation errors instead of throwing unhandled exceptions.

* **Tests**
  * Added test case validating proper error responses for invalid YAML formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->