### PR TITLE
fix(ci): pass vars context as explicit input to composite action

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: "Slack webhook URL for failure notifications"
     required: false
     default: ""
+  gh-user-to-slack-user:
+    description: "JSON mapping of GitHub usernames to Slack user IDs"
+    required: false
+    default: "{}"
 
 runs:
   using: composite
@@ -40,5 +44,5 @@ runs:
         ref: ${{ inputs.app }}/v${{ inputs.app-version }}
         url: ${{ inputs.app-url }}
         slack-webhook-url: ${{ inputs.slack-webhook-url }}
-        gh-user-to-slack-user: ${{ vars.GH_USER_TO_SLACK_USER }}
+        gh-user-to-slack-user: ${{ inputs.gh-user-to-slack-user }}
         message-title: "Console ${{ inputs.app }} E2E tests failed on ${{ inputs.environment == 'prod' && 'production' || inputs.environment }} ${{ inputs.chain }}"

--- a/.github/workflows/console-api-release.yml
+++ b/.github/workflows/console-api-release.yml
@@ -79,6 +79,7 @@ jobs:
           environment: staging
           chain: sandbox
           slack-webhook-url: ${{ secrets.FAILED_E2E_TESTS_SLACK_WEBHOOK_URL }}
+          gh-user-to-slack-user: ${{ vars.GH_USER_TO_SLACK_USER }}
 
   deploy-prod-mainnet:
     permissions:

--- a/.github/workflows/provider-proxy-release.yml
+++ b/.github/workflows/provider-proxy-release.yml
@@ -79,6 +79,7 @@ jobs:
           environment: staging
           chain: sandbox
           slack-webhook-url: ${{ secrets.FAILED_E2E_TESTS_SLACK_WEBHOOK_URL }}
+          gh-user-to-slack-user: ${{ vars.GH_USER_TO_SLACK_USER }}
 
   test-beta-mainnet:
     permissions:
@@ -102,6 +103,7 @@ jobs:
           environment: staging
           chain: mainnet
           slack-webhook-url: ${{ secrets.FAILED_E2E_TESTS_SLACK_WEBHOOK_URL }}
+          gh-user-to-slack-user: ${{ vars.GH_USER_TO_SLACK_USER }}
 
   deploy-prod-mainnet:
     permissions:
@@ -159,3 +161,4 @@ jobs:
           environment: prod
           chain: sandbox
           slack-webhook-url: ${{ secrets.FAILED_E2E_TESTS_SLACK_WEBHOOK_URL }}
+          gh-user-to-slack-user: ${{ vars.GH_USER_TO_SLACK_USER }}


### PR DESCRIPTION
## Why

Runner v2.333.0 ([actions/runner#4279](https://github.com/actions/runner/pull/4279)) fixed a bug where `allowCaseFunction` was passed positionally into the `allowUnknownKeywords` parameter in `ExpressionParser.CreateTree`. This accidentally made the parser accept any named-value — including `vars` — in composite action templates. With the fix, `vars` is correctly rejected in composite actions, breaking our `run-e2e-tests` action.

## What

- Added `gh-user-to-slack-user` input to the `run-e2e-tests` composite action
- Changed `vars.GH_USER_TO_SLACK_USER` → `inputs.gh-user-to-slack-user` in the composite action
- Pass `vars.GH_USER_TO_SLACK_USER` as an explicit input from all calling workflows (`console-api-release`, `provider-proxy-release`)