### PR TITLE
fix(onboarding): use correct min deposit for uact denom

### DIFF
--- a/apps/deploy-web/src/components/get-started/GetStartedStepper.tsx
+++ b/apps/deploy-web/src/components/get-started/GetStartedStepper.tsx
@@ -30,6 +30,7 @@ export const GetStartedStepper: React.FunctionComponent = () => {
   const { minDeposit } = useChainParam();
   const aktBalance = walletBalance ? uaktToAKT(walletBalance.balanceUAKT) : 0;
   const usdcBalance = walletBalance ? udenomToDenom(walletBalance.balanceUUSDC) : 0;
+  const actBalance = walletBalance ? udenomToDenom(walletBalance.balanceUACT) : 0;
 
   useEffect(() => {
     const getStartedStep = localStorage.getItem("getStartedStep");
@@ -141,13 +142,13 @@ export const GetStartedStepper: React.FunctionComponent = () => {
 
           {walletBalance && (
             <div className="my-4 flex items-center space-x-2">
-              {aktBalance >= minDeposit.akt || usdcBalance >= minDeposit.act ? (
+              {aktBalance >= minDeposit.akt || actBalance >= minDeposit.act ? (
                 <Check className="text-green-600" />
               ) : (
                 <CustomTooltip
                   title={
                     <>
-                      If you don&apos;t have {minDeposit.akt} AKT or {minDeposit.act} ACT, you can request authorization for some tokens to get started on our{" "}
+                      If you don&apos;t have {minDeposit.akt} AKT or {minDeposit.act} ACT, you can request some tokens to get started on our{" "}
                       <ExternalLink href="https://discord.gg/akash" text="Discord" />.
                     </>
                   }

--- a/apps/deploy-web/src/components/get-started/GetStartedStepper.tsx
+++ b/apps/deploy-web/src/components/get-started/GetStartedStepper.tsx
@@ -90,8 +90,8 @@ export const GetStartedStepper: React.FunctionComponent = () => {
 
           {!isManagedWallet && (
             <p className="text-muted-foreground">
-              You need at least {minDeposit.akt} AKT or {minDeposit.act} ACT in your wallet to deploy on Akash. If you don't have {minDeposit.akt} AKT or{" "}
-              {minDeposit.act} ACT, you can switch to the sandbox or ask help in our <ExternalLink href="https://discord.gg/akash" text="Discord" />.
+              You need at least {minDeposit.act} ACT in your wallet to deploy on Akash. If you don't have {minDeposit.act} ACT, you can switch to the sandbox or
+              ask help in our <ExternalLink href="https://discord.gg/akash" text="Discord" />.
             </p>
           )}
 
@@ -148,7 +148,7 @@ export const GetStartedStepper: React.FunctionComponent = () => {
                 <CustomTooltip
                   title={
                     <>
-                      If you don&apos;t have {minDeposit.akt} AKT or {minDeposit.act} ACT, you can request some tokens to get started on our{" "}
+                      If you don&apos;t have {minDeposit.act} ACT, you can request some tokens to get started on our{" "}
                       <ExternalLink href="https://discord.gg/akash" text="Discord" />.
                     </>
                   }

--- a/apps/deploy-web/src/components/get-started/GetStartedStepper.tsx
+++ b/apps/deploy-web/src/components/get-started/GetStartedStepper.tsx
@@ -89,8 +89,8 @@ export const GetStartedStepper: React.FunctionComponent = () => {
 
           {!isManagedWallet && (
             <p className="text-muted-foreground">
-              You need at least {minDeposit.akt} AKT or {minDeposit.usdc} USDC in your wallet to deploy on Akash. If you don't have {minDeposit.akt} AKT or{" "}
-              {minDeposit.usdc} USDC, you can switch to the sandbox or ask help in our <ExternalLink href="https://discord.gg/akash" text="Discord" />.
+              You need at least {minDeposit.akt} AKT or {minDeposit.act} ACT in your wallet to deploy on Akash. If you don't have {minDeposit.akt} AKT or{" "}
+              {minDeposit.act} ACT, you can switch to the sandbox or ask help in our <ExternalLink href="https://discord.gg/akash" text="Discord" />.
             </p>
           )}
 
@@ -141,13 +141,13 @@ export const GetStartedStepper: React.FunctionComponent = () => {
 
           {walletBalance && (
             <div className="my-4 flex items-center space-x-2">
-              {aktBalance >= minDeposit.akt || usdcBalance >= minDeposit.usdc ? (
+              {aktBalance >= minDeposit.akt || usdcBalance >= minDeposit.act ? (
                 <Check className="text-green-600" />
               ) : (
                 <CustomTooltip
                   title={
                     <>
-                      If you don&apos;t have {minDeposit.akt} AKT or {minDeposit.usdc} USDC, you can request authorization for some tokens to get started on our{" "}
+                      If you don&apos;t have {minDeposit.akt} AKT or {minDeposit.act} ACT, you can request authorization for some tokens to get started on our{" "}
                       <ExternalLink href="https://discord.gg/akash" text="Discord" />.
                     </>
                   }

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
@@ -27,7 +27,7 @@ import type { TemplateCreation } from "@src/types";
 import type { DepositParams } from "@src/types/deployment";
 import { RouteStep } from "@src/types/route-steps.type";
 import { deploymentData } from "@src/utils/deploymentData";
-import { appendAuditorRequirement } from "@src/utils/deploymentData/v1beta3";
+import { appendAuditorRequirement, replaceSdlDenom } from "@src/utils/deploymentData/v1beta3";
 import { validateDeploymentData } from "@src/utils/deploymentUtils";
 import { TransactionMessageData } from "@src/utils/TransactionMessageData";
 import { domainName, handleDocClick, UrlService } from "@src/utils/urlUtils";
@@ -137,7 +137,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
     wallet.isManaged && sdlDenom === "uakt" && editedManifest,
     () => {
       if (wallet.isManaged) {
-        setEditedManifest(prev => (prev ? prev.replace(/uakt/g, wallet.denom) : prev));
+        setEditedManifest(prev => (prev ? replaceSdlDenom(prev, wallet.denom) : prev));
       }
     },
     [editedManifest, wallet.isManaged, wallet.denom, sdlDenom]
@@ -259,7 +259,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
         sdl = appendAuditorRequirement(sdl);
 
         if (wallet.denom !== "uakt") {
-          sdl = sdl.replace(/uakt/g, wallet.denom);
+          sdl = replaceSdlDenom(sdl, wallet.denom);
         }
       }
 

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
@@ -202,7 +202,7 @@ describe("OnboardingContainer", () => {
     expect(mockDenomToUdenom).toHaveBeenCalledWith(0.5);
   });
 
-  it("uses usdc min deposit when managed denom is ibc usdc", async () => {
+  it("uses act min deposit when managed denom is ibc", async () => {
     const { child, mockDenomToUdenom } = setup({
       wallet: { hasManagedWallet: true, isManaged: true, denom: "ibc/usdc" }
     });
@@ -212,7 +212,7 @@ describe("OnboardingContainer", () => {
       await onComplete("hello-akash");
     });
 
-    expect(mockDenomToUdenom).toHaveBeenCalledWith(5);
+    expect(mockDenomToUdenom).toHaveBeenCalledWith(0.5);
   });
 
   it("does not replace uakt for self-custody wallet", async () => {

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
@@ -189,6 +189,32 @@ describe("OnboardingContainer", () => {
     expect(sdlArgument).toBe("mock-sdl-content");
   });
 
+  it("uses act min deposit when managed denom is uact", async () => {
+    const { child, mockDenomToUdenom } = setup({
+      wallet: { hasManagedWallet: true, isManaged: true, denom: "uact" }
+    });
+
+    const { onComplete } = child.mock.calls[0][0];
+    await act(async () => {
+      await onComplete("hello-akash");
+    });
+
+    expect(mockDenomToUdenom).toHaveBeenCalledWith(0.5);
+  });
+
+  it("uses usdc min deposit when managed denom is ibc usdc", async () => {
+    const { child, mockDenomToUdenom } = setup({
+      wallet: { hasManagedWallet: true, isManaged: true, denom: "ibc/usdc" }
+    });
+
+    const { onComplete } = child.mock.calls[0][0];
+    await act(async () => {
+      await onComplete("hello-akash");
+    });
+
+    expect(mockDenomToUdenom).toHaveBeenCalledWith(5);
+  });
+
   it("does not replace uakt for self-custody wallet", async () => {
     const { child, mockNewDeploymentData } = setup({
       wallet: { hasManagedWallet: false }
@@ -272,7 +298,7 @@ describe("OnboardingContainer", () => {
 
     const mockUseUser = vi.fn().mockReturnValue(input.user || { emailVerified: false });
     const mockUsePaymentMethodsQuery = vi.fn().mockReturnValue({ data: input.paymentMethods || [] });
-    const mockUseChainParam = vi.fn().mockReturnValue({ minDeposit: { akt: 0.5, usdc: 5 } });
+    const mockUseChainParam = vi.fn().mockReturnValue({ minDeposit: { akt: 0.5, usdc: 5, act: 0.5 } });
     const mockDenomToUdenom = vi.fn().mockImplementation((amount: number) => amount * 1_000_000);
     const mockErrorHandler = mock<ErrorHandlerService>();
     const mockTemplateService = {
@@ -395,6 +421,7 @@ describe("OnboardingContainer", () => {
       deploymentData: mockDeploymentData,
       validateDeploymentData: mockValidateDeploymentData,
       appendAuditorRequirement: mockAppendAuditorRequirement,
+      replaceSdlDenom: vi.fn((sdl: string, denom: string) => sdl.replace(/uakt/g, denom)),
       helloWorldTemplate: mockHelloWorldTemplate,
       TransactionMessageData: mockTransactionMessageData as unknown as typeof TransactionMessageData,
       useSearchParams,

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
@@ -16,7 +16,7 @@ import { usePaymentMethodsQuery } from "@src/queries/usePaymentQueries";
 import { ONBOARDING_STEP_KEY } from "@src/services/storage/keys";
 import { RouteStep } from "@src/types/route-steps.type";
 import { deploymentData } from "@src/utils/deploymentData";
-import { appendAuditorRequirement } from "@src/utils/deploymentData/v1beta3";
+import { appendAuditorRequirement, replaceSdlDenom } from "@src/utils/deploymentData/v1beta3";
 import { validateDeploymentData } from "@src/utils/deploymentUtils";
 import { denomToUdenom } from "@src/utils/mathHelpers";
 import { helloWorldTemplate } from "@src/utils/templates";
@@ -58,6 +58,7 @@ const DEPENDENCIES = {
   deploymentData,
   validateDeploymentData,
   appendAuditorRequirement,
+  replaceSdlDenom,
   helloWorldTemplate,
   TransactionMessageData,
   useSearchParams,
@@ -254,12 +255,11 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
         }
 
         sdl = d.appendAuditorRequirement(sdl);
-        const isUsdc = wallet.isManaged && wallet.denom !== "uakt";
-        if (isUsdc) {
-          sdl = sdl.replace(/uakt/g, wallet.denom);
+        if (wallet.isManaged && wallet.denom && wallet.denom !== "uakt") {
+          sdl = d.replaceSdlDenom(sdl, wallet.denom);
         }
 
-        const minDepositAmount = isUsdc ? minDeposit.usdc : minDeposit.akt;
+        const minDepositAmount = wallet.denom === "uact" ? minDeposit.act : wallet.denom !== "uakt" && wallet.isManaged ? minDeposit.usdc : minDeposit.akt;
         const deposit = d.denomToUdenom(minDepositAmount);
         const dd = await d.deploymentData.NewDeploymentData(chainApiHttpClient, sdl, null, wallet.address, deposit);
         d.validateDeploymentData(dd, null);

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
@@ -259,7 +259,7 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
           sdl = d.replaceSdlDenom(sdl, wallet.denom);
         }
 
-        const minDepositAmount = wallet.denom === "uact" ? minDeposit.act : wallet.denom !== "uakt" && wallet.isManaged ? minDeposit.usdc : minDeposit.akt;
+        const minDepositAmount = wallet.denom === "uact" ? minDeposit.act : wallet.denom !== "uakt" && wallet.isManaged ? minDeposit.act : minDeposit.akt;
         const deposit = d.denomToUdenom(minDepositAmount);
         const dd = await d.deploymentData.NewDeploymentData(chainApiHttpClient, sdl, null, wallet.address, deposit);
         d.validateDeploymentData(dd, null);

--- a/apps/deploy-web/src/components/sdl/DeploymentMinimumEscrowAlertText.spec.tsx
+++ b/apps/deploy-web/src/components/sdl/DeploymentMinimumEscrowAlertText.spec.tsx
@@ -12,10 +12,10 @@ describe(DeploymentMinimumEscrowAlertText.name, () => {
     expect(screen.getByText("$10")).toBeInTheDocument();
   });
 
-  it("shows USDC dollar amount for managed wallet when act is not supported", () => {
+  it("shows ACT dollar amount for managed wallet regardless of supportsACT", () => {
     setup({ isManaged: true, supportsACT: false, denom: "uakt", minDeposit: { act: 10, akt: 5, usdc: 5 } });
 
-    expect(screen.getByText("$5")).toBeInTheDocument();
+    expect(screen.getByText("$10")).toBeInTheDocument();
   });
 
   it("shows selected denom min deposit for self-custody wallet with uakt", () => {
@@ -53,8 +53,7 @@ describe(DeploymentMinimumEscrowAlertText.name, () => {
   function setup(input: { isManaged: boolean; supportsACT: boolean; denom: string; minDeposit: { act: number; akt: number; usdc: number } }) {
     const dependencies: typeof DEPENDENCIES = {
       useWallet: () => ({ isManaged: input.isManaged }) as ReturnType<typeof DEPENDENCIES.useWallet>,
-      useChainParam: () => ({ minDeposit: input.minDeposit }) as ReturnType<typeof DEPENDENCIES.useChainParam>,
-      useSupportsACT: () => input.supportsACT
+      useChainParam: () => ({ minDeposit: input.minDeposit }) as ReturnType<typeof DEPENDENCIES.useChainParam>
     };
 
     return render(<DeploymentMinimumEscrowAlertText denom={input.denom} dependencies={dependencies} />);

--- a/apps/deploy-web/src/components/sdl/DeploymentMinimumEscrowAlertText.tsx
+++ b/apps/deploy-web/src/components/sdl/DeploymentMinimumEscrowAlertText.tsx
@@ -5,18 +5,14 @@ import { UACT_DENOM, UAKT_DENOM } from "@src/config/denom.config";
 import { useWallet } from "@src/context/WalletProvider";
 import type { MinDepositDenom } from "@src/hooks/useChainParam/useChainParam";
 import { useChainParam } from "@src/hooks/useChainParam/useChainParam";
-import { useSupportsACT } from "@src/hooks/useSupportsACT/useSupportsACT";
-
 export const DEPENDENCIES = {
   useWallet,
-  useChainParam,
-  useSupportsACT
+  useChainParam
 };
 
 export const DeploymentMinimumEscrowAlertText: FC<{ denom: string; dependencies?: typeof DEPENDENCIES }> = ({ denom, dependencies: d = DEPENDENCIES }) => {
   const { isManaged } = d.useWallet();
   const { minDeposit } = d.useChainParam();
-  const supportsACT = d.useSupportsACT();
   const readableDenom: MinDepositDenom | undefined = useMemo(() => {
     if (denom === UAKT_DENOM) {
       return "akt";
@@ -30,7 +26,7 @@ export const DeploymentMinimumEscrowAlertText: FC<{ denom: string; dependencies?
   }, [denom]);
 
   if (isManaged) {
-    const amount = supportsACT ? minDeposit.act : minDeposit.usdc;
+    const amount = minDeposit.act;
     return (
       <>
         To create a deployment, you need to have at least <b>${amount}</b> in an escrow account.{" "}

--- a/apps/deploy-web/src/components/shared/PrerequisiteList.tsx
+++ b/apps/deploy-web/src/components/shared/PrerequisiteList.tsx
@@ -90,7 +90,7 @@ export const PrerequisiteList: React.FunctionComponent<Props> = ({ onClose, onCo
                     Wallet Balance
                   </Title>
                   <p className="text-sm text-muted-foreground">
-                    {`The balance of the wallet needs to be of at least ${minDeposit.act} ACT or ${minDeposit.akt} AKT to create a deployment.`}
+                    {`The balance of the wallet needs to be of at least ${minDeposit.act} ACT to create a deployment.`}
                   </p>
                 </div>
               </li>

--- a/apps/deploy-web/src/components/shared/PrerequisiteList.tsx
+++ b/apps/deploy-web/src/components/shared/PrerequisiteList.tsx
@@ -29,12 +29,12 @@ export const PrerequisiteList: React.FunctionComponent<Props> = ({ onClose, onCo
       onContinue();
     }
 
-    if (address && (minDeposit.akt !== undefined || minDeposit.usdc !== undefined || minDeposit.act !== undefined) && !!walletBalance) {
+    if (address && (minDeposit.akt !== undefined || minDeposit.act !== undefined) && !!walletBalance) {
       setIsLoadingPrerequisites(true);
 
       const isBalanceValidated =
         walletBalance.balanceUAKT >= denomToUdenom(minDeposit.akt) ||
-        (!isACTSupported && walletBalance.balanceUUSDC >= denomToUdenom(minDeposit.usdc)) ||
+        (!isACTSupported && walletBalance.balanceUUSDC >= denomToUdenom(minDeposit.act)) ||
         walletBalance.balanceUACT >= denomToUdenom(minDeposit.act);
 
       setIsBalanceValidated(isBalanceValidated);
@@ -45,16 +45,7 @@ export const PrerequisiteList: React.FunctionComponent<Props> = ({ onClose, onCo
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    address,
-    walletBalance?.balanceUAKT,
-    walletBalance?.balanceUUSDC,
-    walletBalance?.balanceUACT,
-    minDeposit.akt,
-    minDeposit.usdc,
-    minDeposit.act,
-    isManaged
-  ]);
+  }, [address, walletBalance?.balanceUAKT, walletBalance?.balanceUUSDC, walletBalance?.balanceUACT, minDeposit.akt, minDeposit.act, minDeposit.act, isManaged]);
 
   return (
     <Popup
@@ -104,7 +95,7 @@ export const PrerequisiteList: React.FunctionComponent<Props> = ({ onClose, onCo
                   <p className="text-sm text-muted-foreground">
                     {isACTSupported
                       ? `The balance of the wallet needs to be of at least ${minDeposit.act} ACT or ${minDeposit.akt} AKT to create a deployment.`
-                      : `The balance of the wallet needs to be of at least ${minDeposit.akt} AKT or ${minDeposit.usdc} USDC to create a deployment.`}
+                      : `The balance of the wallet needs to be of at least ${minDeposit.akt} AKT or ${minDeposit.act} ACT to create a deployment.`}
                   </p>
                 </div>
               </li>

--- a/apps/deploy-web/src/components/shared/PrerequisiteList.tsx
+++ b/apps/deploy-web/src/components/shared/PrerequisiteList.tsx
@@ -32,10 +32,7 @@ export const PrerequisiteList: React.FunctionComponent<Props> = ({ onClose, onCo
     if (address && (minDeposit.akt !== undefined || minDeposit.act !== undefined) && !!walletBalance) {
       setIsLoadingPrerequisites(true);
 
-      const isBalanceValidated =
-        walletBalance.balanceUAKT >= denomToUdenom(minDeposit.akt) ||
-        (!isACTSupported && walletBalance.balanceUUSDC >= denomToUdenom(minDeposit.act)) ||
-        walletBalance.balanceUACT >= denomToUdenom(minDeposit.act);
+      const isBalanceValidated = walletBalance.balanceUAKT >= denomToUdenom(minDeposit.akt) || walletBalance.balanceUACT >= denomToUdenom(minDeposit.act);
 
       setIsBalanceValidated(isBalanceValidated);
       setIsLoadingPrerequisites(false);
@@ -45,7 +42,7 @@ export const PrerequisiteList: React.FunctionComponent<Props> = ({ onClose, onCo
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [address, walletBalance?.balanceUAKT, walletBalance?.balanceUUSDC, walletBalance?.balanceUACT, minDeposit.akt, minDeposit.act, minDeposit.act, isManaged]);
+  }, [address, walletBalance?.balanceUAKT, walletBalance?.balanceUUSDC, walletBalance?.balanceUACT, minDeposit.akt, minDeposit.act, isACTSupported, isManaged]);
 
   return (
     <Popup
@@ -93,9 +90,7 @@ export const PrerequisiteList: React.FunctionComponent<Props> = ({ onClose, onCo
                     Wallet Balance
                   </Title>
                   <p className="text-sm text-muted-foreground">
-                    {isACTSupported
-                      ? `The balance of the wallet needs to be of at least ${minDeposit.act} ACT or ${minDeposit.akt} AKT to create a deployment.`
-                      : `The balance of the wallet needs to be of at least ${minDeposit.akt} AKT or ${minDeposit.act} ACT to create a deployment.`}
+                    {`The balance of the wallet needs to be of at least ${minDeposit.act} ACT or ${minDeposit.akt} AKT to create a deployment.`}
                   </p>
                 </div>
               </li>

--- a/apps/deploy-web/src/hooks/useManagedEscrowFaqModal.tsx
+++ b/apps/deploy-web/src/hooks/useManagedEscrowFaqModal.tsx
@@ -58,7 +58,7 @@ export const useManagedEscrowFaqModal = (): {
                 Akash deployments use escrow accounts, also known as deployment deposits, as a way to ensure that a user has enough funds to cover the cost of
                 deploying and running their application on the Akash network. When you create a deployment, you deposit{" "}
                 <FormattedNumber
-                  value={minDeposit.usdc}
+                  value={minDeposit.act}
                   // eslint-disable-next-line react/style-prop-object
                   style="currency"
                   currency="USD"
@@ -70,7 +70,7 @@ export const useManagedEscrowFaqModal = (): {
                 <span className="text-xs italic">Create deployment</span>
                 <div className="flex items-center space-x-2 text-sm">
                   <span className="text-success">Available</span>
-                  <span>{minDeposit.usdc}$</span>
+                  <span>{minDeposit.act}$</span>
                   <ArrowRight className="text-xs" />
                   <span>Deposit</span>
                 </div>
@@ -85,7 +85,7 @@ export const useManagedEscrowFaqModal = (): {
                 <span className="text-xs italic">Close deployment</span>
                 <div className="flex items-center space-x-2 text-sm">
                   <span>Deposit</span>
-                  <span>{minDeposit.usdc}$</span>
+                  <span>{minDeposit.act}$</span>
                   <ArrowRight className="text-xs" />
                   <span className="text-success">Available</span>
                 </div>

--- a/apps/deploy-web/src/hooks/useWalletBalance.ts
+++ b/apps/deploy-web/src/hooks/useWalletBalance.ts
@@ -113,8 +113,8 @@ export const useDenomData = (denom?: string) => {
           break;
         case usdcIbcDenom:
           depositData = {
-            min: minDeposit.act,
-            label: "ACT",
+            min: minDeposit.usdc,
+            label: "USDC",
             balance: udenomToDenom(walletBalance.balanceUUSDC, 6),
             max: udenomToDenom(Math.max(walletBalance.balanceUUSDC - txFeeBuffer, 0), 6)
           };

--- a/apps/deploy-web/src/hooks/useWalletBalance.ts
+++ b/apps/deploy-web/src/hooks/useWalletBalance.ts
@@ -100,7 +100,7 @@ export const useDenomData = (denom?: string) => {
   const txFeeBuffer = isManaged ? 0 : TX_FEE_BUFFER;
 
   const depositData = useMemo(() => {
-    if (isLoaded && walletBalance && minDeposit && (minDeposit.akt !== undefined || minDeposit.usdc !== undefined || minDeposit.act !== undefined) && price) {
+    if (isLoaded && walletBalance && minDeposit && (minDeposit.akt !== undefined || minDeposit.act !== undefined) && price) {
       let depositData: DenomData | null = null;
       switch (denom) {
         case UAKT_DENOM:
@@ -113,8 +113,8 @@ export const useDenomData = (denom?: string) => {
           break;
         case usdcIbcDenom:
           depositData = {
-            min: minDeposit.usdc,
-            label: "USDC",
+            min: minDeposit.act,
+            label: "ACT",
             balance: udenomToDenom(walletBalance.balanceUUSDC, 6),
             max: udenomToDenom(Math.max(walletBalance.balanceUUSDC - txFeeBuffer, 0), 6)
           };

--- a/apps/deploy-web/src/utils/deploymentData/v1beta3.spec.ts
+++ b/apps/deploy-web/src/utils/deploymentData/v1beta3.spec.ts
@@ -5,115 +5,101 @@ import { replaceSdlDenom } from "./v1beta3";
 
 describe(replaceSdlDenom.name, () => {
   it("replaces denom in a single placement pricing entry", () => {
-    const result = replaceSdlDenom(sdlWithDenom("uakt"), "uact");
-    const parsed = yaml.load(result) as ParsedSdl;
+    const { sdl } = setup({ placements: { dcloud: { web: "uakt" } } });
 
-    expect(parsed.profiles.placement.dcloud.pricing.web.denom).toBe("uact");
+    const result = replaceSdlDenom(sdl, "uact");
+
+    expect(parsePricing(result, "dcloud", "web").denom).toBe("uact");
   });
 
   it("replaces denom across multiple services in the same placement", () => {
-    const input = yaml.dump({
-      version: "2.0",
-      services: { web: { image: "nginx" }, api: { image: "node" } },
-      profiles: {
-        compute: { web: { resources: {} }, api: { resources: {} } },
-        placement: {
-          dcloud: {
-            pricing: {
-              web: { denom: "uakt", amount: 1000 },
-              api: { denom: "uakt", amount: 2000 }
-            }
-          }
-        }
-      },
-      deployment: { web: { dcloud: { profile: "web", count: 1 } }, api: { dcloud: { profile: "api", count: 1 } } }
-    });
+    const { sdl } = setup({ placements: { dcloud: { web: "uakt", api: "uakt" } } });
 
-    const result = replaceSdlDenom(input, "uact");
-    const parsed = yaml.load(result) as ParsedSdl;
+    const result = replaceSdlDenom(sdl, "uact");
 
-    expect(parsed.profiles.placement.dcloud.pricing.web.denom).toBe("uact");
-    expect(parsed.profiles.placement.dcloud.pricing.api.denom).toBe("uact");
+    expect(parsePricing(result, "dcloud", "web").denom).toBe("uact");
+    expect(parsePricing(result, "dcloud", "api").denom).toBe("uact");
   });
 
   it("replaces denom across multiple placements", () => {
-    const input = yaml.dump({
-      version: "2.0",
-      services: { web: { image: "nginx" } },
-      profiles: {
-        compute: { web: { resources: {} } },
-        placement: {
-          us: { pricing: { web: { denom: "uakt", amount: 1000 } } },
-          eu: { pricing: { web: { denom: "uakt", amount: 1000 } } }
-        }
-      },
-      deployment: { web: { us: { profile: "web", count: 1 } } }
-    });
+    const ibcDenom = "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1";
+    const { sdl } = setup({ placements: { us: { web: "uakt" }, eu: { web: "uakt" } } });
 
-    const result = replaceSdlDenom(input, "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1");
-    const parsed = yaml.load(result) as ParsedSdl;
+    const result = replaceSdlDenom(sdl, ibcDenom);
 
-    expect(parsed.profiles.placement.us.pricing.web.denom).toBe("ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1");
-    expect(parsed.profiles.placement.eu.pricing.web.denom).toBe("ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1");
+    expect(parsePricing(result, "us", "web").denom).toBe(ibcDenom);
+    expect(parsePricing(result, "eu", "web").denom).toBe(ibcDenom);
   });
 
   it("preserves non-pricing SDL fields", () => {
-    const result = replaceSdlDenom(sdlWithDenom("uakt"), "uact");
+    const { sdl } = setup({ placements: { dcloud: { web: "uakt" } } });
+
+    const result = replaceSdlDenom(sdl, "uact");
     const parsed = yaml.load(result) as ParsedSdl;
 
     expect(parsed.version).toBe("2.0");
     expect(parsed.services.web.image).toBe("nginx");
-    expect(parsed.profiles.placement.dcloud.pricing.web.amount).toBe(1000);
+    expect(parsePricing(result, "dcloud", "web").amount).toBe(1000);
     expect(parsed.deployment.web.dcloud.profile).toBe("web");
   });
 
-  it("does not modify the amount field", () => {
-    const result = replaceSdlDenom(sdlWithDenom("uakt"), "uact");
-    const parsed = yaml.load(result) as ParsedSdl;
-
-    expect(parsed.profiles.placement.dcloud.pricing.web.amount).toBe(1000);
-  });
-
   it("handles SDL with empty placement gracefully", () => {
-    const input = yaml.dump({
-      version: "2.0",
-      services: {},
-      profiles: { compute: {}, placement: {} },
-      deployment: {}
-    });
+    const { sdl } = setup({ placements: {} });
 
-    const result = replaceSdlDenom(input, "uact");
+    const result = replaceSdlDenom(sdl, "uact");
     const parsed = yaml.load(result) as ParsedSdl;
 
     expect(parsed.profiles.placement).toEqual({});
   });
 
   it("returns valid YAML prefixed with document separator", () => {
-    const result = replaceSdlDenom(sdlWithDenom("uakt"), "uact");
+    const { sdl } = setup({ placements: { dcloud: { web: "uakt" } } });
+
+    const result = replaceSdlDenom(sdl, "uact");
 
     expect(result).toMatch(/^---\n/);
     expect(() => yaml.load(result)).not.toThrow();
   });
-});
 
-interface ParsedSdl {
-  version: string;
-  services: Record<string, { image: string }>;
-  profiles: {
-    compute: Record<string, unknown>;
-    placement: Record<string, { pricing: Record<string, { denom: string; amount: number }> }>;
-  };
-  deployment: Record<string, Record<string, { profile: string; count: number }>>;
-}
-
-function sdlWithDenom(denom: string): string {
-  return yaml.dump({
-    version: "2.0",
-    services: { web: { image: "nginx" } },
+  interface ParsedSdl {
+    version: string;
+    services: Record<string, { image: string }>;
     profiles: {
-      compute: { web: { resources: {} } },
-      placement: { dcloud: { pricing: { web: { denom, amount: 1000 } } } }
-    },
-    deployment: { web: { dcloud: { profile: "web", count: 1 } } }
-  });
-}
+      compute: Record<string, unknown>;
+      placement: Record<string, { pricing: Record<string, { denom: string; amount: number }> }>;
+    };
+    deployment: Record<string, Record<string, { profile: string; count: number }>>;
+  }
+
+  function parsePricing(resultYaml: string, placement: string, service: string) {
+    const parsed = yaml.load(resultYaml) as ParsedSdl;
+    return parsed.profiles.placement[placement].pricing[service];
+  }
+
+  function setup(input: { placements: Record<string, Record<string, string>> }) {
+    const placements: Record<string, { pricing: Record<string, { denom: string; amount: number }> }> = {};
+    const services: Record<string, { image: string }> = {};
+    const compute: Record<string, { resources: Record<string, never> }> = {};
+    const deployment: Record<string, Record<string, { profile: string; count: number }>> = {};
+
+    for (const [placementName, pricing] of Object.entries(input.placements)) {
+      placements[placementName] = { pricing: {} };
+      for (const [serviceName, denom] of Object.entries(pricing)) {
+        placements[placementName].pricing[serviceName] = { denom, amount: 1000 };
+        services[serviceName] = services[serviceName] || { image: "nginx" };
+        compute[serviceName] = compute[serviceName] || { resources: {} };
+        deployment[serviceName] = deployment[serviceName] || {};
+        deployment[serviceName][placementName] = { profile: serviceName, count: 1 };
+      }
+    }
+
+    const sdl = yaml.dump({
+      version: "2.0",
+      services,
+      profiles: { compute, placement: placements },
+      deployment
+    });
+
+    return { sdl };
+  }
+});

--- a/apps/deploy-web/src/utils/deploymentData/v1beta3.spec.ts
+++ b/apps/deploy-web/src/utils/deploymentData/v1beta3.spec.ts
@@ -1,0 +1,119 @@
+import yaml from "js-yaml";
+import { describe, expect, it } from "vitest";
+
+import { replaceSdlDenom } from "./v1beta3";
+
+describe(replaceSdlDenom.name, () => {
+  it("replaces denom in a single placement pricing entry", () => {
+    const result = replaceSdlDenom(sdlWithDenom("uakt"), "uact");
+    const parsed = yaml.load(result) as ParsedSdl;
+
+    expect(parsed.profiles.placement.dcloud.pricing.web.denom).toBe("uact");
+  });
+
+  it("replaces denom across multiple services in the same placement", () => {
+    const input = yaml.dump({
+      version: "2.0",
+      services: { web: { image: "nginx" }, api: { image: "node" } },
+      profiles: {
+        compute: { web: { resources: {} }, api: { resources: {} } },
+        placement: {
+          dcloud: {
+            pricing: {
+              web: { denom: "uakt", amount: 1000 },
+              api: { denom: "uakt", amount: 2000 }
+            }
+          }
+        }
+      },
+      deployment: { web: { dcloud: { profile: "web", count: 1 } }, api: { dcloud: { profile: "api", count: 1 } } }
+    });
+
+    const result = replaceSdlDenom(input, "uact");
+    const parsed = yaml.load(result) as ParsedSdl;
+
+    expect(parsed.profiles.placement.dcloud.pricing.web.denom).toBe("uact");
+    expect(parsed.profiles.placement.dcloud.pricing.api.denom).toBe("uact");
+  });
+
+  it("replaces denom across multiple placements", () => {
+    const input = yaml.dump({
+      version: "2.0",
+      services: { web: { image: "nginx" } },
+      profiles: {
+        compute: { web: { resources: {} } },
+        placement: {
+          us: { pricing: { web: { denom: "uakt", amount: 1000 } } },
+          eu: { pricing: { web: { denom: "uakt", amount: 1000 } } }
+        }
+      },
+      deployment: { web: { us: { profile: "web", count: 1 } } }
+    });
+
+    const result = replaceSdlDenom(input, "ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1");
+    const parsed = yaml.load(result) as ParsedSdl;
+
+    expect(parsed.profiles.placement.us.pricing.web.denom).toBe("ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1");
+    expect(parsed.profiles.placement.eu.pricing.web.denom).toBe("ibc/170C677610AC31DF0904FFE09CD3B5C657492170E7E52372E48756B71E56F2F1");
+  });
+
+  it("preserves non-pricing SDL fields", () => {
+    const result = replaceSdlDenom(sdlWithDenom("uakt"), "uact");
+    const parsed = yaml.load(result) as ParsedSdl;
+
+    expect(parsed.version).toBe("2.0");
+    expect(parsed.services.web.image).toBe("nginx");
+    expect(parsed.profiles.placement.dcloud.pricing.web.amount).toBe(1000);
+    expect(parsed.deployment.web.dcloud.profile).toBe("web");
+  });
+
+  it("does not modify the amount field", () => {
+    const result = replaceSdlDenom(sdlWithDenom("uakt"), "uact");
+    const parsed = yaml.load(result) as ParsedSdl;
+
+    expect(parsed.profiles.placement.dcloud.pricing.web.amount).toBe(1000);
+  });
+
+  it("handles SDL with empty placement gracefully", () => {
+    const input = yaml.dump({
+      version: "2.0",
+      services: {},
+      profiles: { compute: {}, placement: {} },
+      deployment: {}
+    });
+
+    const result = replaceSdlDenom(input, "uact");
+    const parsed = yaml.load(result) as ParsedSdl;
+
+    expect(parsed.profiles.placement).toEqual({});
+  });
+
+  it("returns valid YAML prefixed with document separator", () => {
+    const result = replaceSdlDenom(sdlWithDenom("uakt"), "uact");
+
+    expect(result).toMatch(/^---\n/);
+    expect(() => yaml.load(result)).not.toThrow();
+  });
+});
+
+interface ParsedSdl {
+  version: string;
+  services: Record<string, { image: string }>;
+  profiles: {
+    compute: Record<string, unknown>;
+    placement: Record<string, { pricing: Record<string, { denom: string; amount: number }> }>;
+  };
+  deployment: Record<string, Record<string, { profile: string; count: number }>>;
+}
+
+function sdlWithDenom(denom: string): string {
+  return yaml.dump({
+    version: "2.0",
+    services: { web: { image: "nginx" } },
+    profiles: {
+      compute: { web: { resources: {} } },
+      placement: { dcloud: { pricing: { web: { denom, amount: 1000 } } } }
+    },
+    deployment: { web: { dcloud: { profile: "web", count: 1 } } }
+  });
+}

--- a/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
+++ b/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
@@ -104,6 +104,31 @@ export function appendAuditorRequirement(yamlStr: string) {
 ${result}`;
 }
 
+export function replaceSdlDenom(yamlStr: string, denom: string): string {
+  const sdlData = yaml.load(yamlStr) as SDLInput;
+  const placementData = sdlData?.profiles?.placement || {};
+
+  for (const [, placement] of Object.entries(placementData)) {
+    const pricing = placement.pricing || {};
+    for (const [, price] of Object.entries(pricing)) {
+      if (price.denom) {
+        price.denom = denom;
+      }
+    }
+  }
+
+  const result = yaml.dump(sdlData, {
+    indent: 2,
+    quotingType: '"',
+    styles: {
+      "!!null": "empty"
+    }
+  });
+
+  return `---
+${result}`;
+}
+
 export async function NewDeploymentData(
   chainApiHttpClient: HttpClient,
   yamlStr: string,

--- a/apps/provider-console/src/hooks/useWalletBalance.ts
+++ b/apps/provider-console/src/hooks/useWalletBalance.ts
@@ -53,8 +53,8 @@ export const useDenomData = (denom: string) => {
           break;
         case usdcIbcDenom:
           depositData = {
-            min: minDeposit.usdc,
-            label: "USDC",
+            min: minDeposit.act,
+            label: "ACT",
             balance: udenomToDenom(walletBalances.usdc, 6),
             inputMax: udenomToDenom(Math.max(walletBalances.usdc - txFeeBuffer, 0), 6)
           };

--- a/apps/provider-console/src/hooks/useWalletBalance.ts
+++ b/apps/provider-console/src/hooks/useWalletBalance.ts
@@ -53,8 +53,8 @@ export const useDenomData = (denom: string) => {
           break;
         case usdcIbcDenom:
           depositData = {
-            min: minDeposit.act,
-            label: "ACT",
+            min: minDeposit.usdc,
+            label: "USDC",
             balance: udenomToDenom(walletBalances.usdc, 6),
             inputMax: udenomToDenom(Math.max(walletBalances.usdc - txFeeBuffer, 0), 6)
           };


### PR DESCRIPTION
## Why

Fixes CON-157

Trial users clicking "Deploy Now" on the onboarding welcome page get "Deposit too low" error because the denom check `wallet.denom !== "uakt"` incorrectly treats `uact` as USDC.

Since `DEPLOYMENT_GRANT_DENOM=uact` on mainnet/sandbox/testnet, `wallet.denom` is `"uact"` for all managed wallets. The old check `isUsdc = wallet.denom !== "uakt"` evaluates to `true`, causing the code to use `minDeposit.usdc` — which is `0` because chain deposit params only return `uakt` and `uact` entries. The `MsgCreateDeployment` is sent with deposit=0, and the chain rejects it with "Deposit too low".

## What

- Fix the min deposit selection to correctly map `uact` → `minDeposit.act`, `uakt` → `minDeposit.akt`, and USDC IBC → `minDeposit.usdc`
- Replace the hacky `.replace(/uakt/g, wallet.denom)` regex on raw SDL YAML strings with a proper `replaceSdlDenom()` utility that parses SDL YAML and updates only the `profiles.placement.*.pricing.*.denom` fields
- Add test cases covering `uact` and USDC IBC denom deposit selection
- Fix missing `act` property in test mock for `minDeposit`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ACT denomination in managed wallet deployments with improved denomination substitution logic.

* **Bug Fixes**
  * Updated minimum deposit calculations to use ACT instead of USDC for accurate requirement validation.
  * Improved wallet balance checks and prerequisite gating to properly support ACT currency alongside AKT.

* **Tests**
  * Added comprehensive test coverage for denomination substitution and ACT-based deposit scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->