### PR TITLE
fix(provider): prefer online provider when deduplicating by hostUri

### DIFF
--- a/apps/api/src/provider/services/provider/provider.service.spec.ts
+++ b/apps/api/src/provider/services/provider/provider.service.spec.ts
@@ -373,6 +373,43 @@ describe(ProviderService.name, () => {
     });
   });
 
+  describe("getProviderList", () => {
+    it("should prefer online provider when multiple providers share the same hostUri", async () => {
+      const { service, providerRepository, auditorsService, providerAttributesSchemaService } = setup();
+
+      const sharedHostUri = "https://provider.example.com:8443";
+      const offlineProvider = { ...createProviderWithAttributeSignatures(AUDITOR), hostUri: sharedHostUri, isOnline: false } as unknown as Provider;
+      const onlineProvider = { ...createProviderWithAttributeSignatures(AUDITOR), hostUri: sharedHostUri, isOnline: true } as unknown as Provider;
+
+      providerRepository.getWithAttributesAndAuditors.mockResolvedValue([offlineProvider, onlineProvider]);
+      providerRepository.getProviderWithNodes.mockResolvedValue([]);
+      auditorsService.getAuditors.mockResolvedValue([]);
+      providerAttributesSchemaService.getProviderAttributesSchema.mockResolvedValue(providerAttributeSchemaStub);
+
+      const result = await service.getProviderList();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].owner).toBe(onlineProvider.owner);
+    });
+
+    it("should deduplicate providers with the same hostUri", async () => {
+      const { service, providerRepository, auditorsService, providerAttributesSchemaService } = setup();
+
+      const sharedHostUri = "https://provider.example.com:8443";
+      const provider1 = { ...createProviderWithAttributeSignatures(AUDITOR), hostUri: sharedHostUri, isOnline: false } as unknown as Provider;
+      const provider2 = { ...createProviderWithAttributeSignatures(AUDITOR), hostUri: sharedHostUri, isOnline: false } as unknown as Provider;
+
+      providerRepository.getWithAttributesAndAuditors.mockResolvedValue([provider1, provider2]);
+      providerRepository.getProviderWithNodes.mockResolvedValue([]);
+      auditorsService.getAuditors.mockResolvedValue([]);
+      providerAttributesSchemaService.getProviderAttributesSchema.mockResolvedValue(providerAttributeSchemaStub);
+
+      const result = await service.getProviderList();
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
   describe("getProviderListByAddresses", () => {
     it("should return mapped providers for given addresses", async () => {
       const { service, providerRepository, auditorsService, providerAttributesSchemaService } = setup();

--- a/apps/api/src/provider/services/provider/provider.service.ts
+++ b/apps/api/src/provider/services/provider/provider.service.ts
@@ -148,14 +148,14 @@ export class ProviderService {
       offset += BATCH_SIZE;
     } while (batch.length === BATCH_SIZE);
 
-    const seenProviders = new Set<string>();
-    const distinctProviders: Provider[] = [];
+    const providerByHostUri = new Map<string, Provider>();
     await forEachInChunks(providersWithAttributesAndAuditors, provider => {
-      if (!seenProviders.has(provider.hostUri)) {
-        seenProviders.add(provider.hostUri);
-        distinctProviders.push(provider);
+      const existing = providerByHostUri.get(provider.hostUri);
+      if (!existing || (!existing.isOnline && provider.isOnline)) {
+        providerByHostUri.set(provider.hostUri, provider);
       }
     });
+    const distinctProviders = Array.from(providerByHostUri.values());
 
     const [auditors, providerAttributeSchema] = await Promise.all([
       this.auditorsService.getAuditors(),


### PR DESCRIPTION
## Why

Fixes CON-146

When multiple on-chain providers share the same `hostUri` (e.g. after a wallet migration), the provider list shows the oldest (offline) provider instead of the active online one. The old provider's wallet keys are lost so `MsgDeleteProvider` cannot clean up the stale record.

## What

Updated the `hostUri` dedup logic in `getProviderList` to prefer online providers over offline ones when resolving collisions. Previously it kept the first provider encountered (ordered by `createdHeight ASC`), ignoring online status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider deduplication now intelligently prioritizes online providers when multiple providers share the same host URI, improving provider selection reliability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->