### PR TITLE
feat(notifications): replace template helpers with unified formatBalance

### DIFF
--- a/apps/notifications/src/modules/alert/services/template/template.service.spec.ts
+++ b/apps/notifications/src/modules/alert/services/template/template.service.spec.ts
@@ -63,32 +63,27 @@ describe(TemplateService.name, () => {
     expect(new TemplateService().interpolate(template, context)).toBe("Env: ");
   });
 
-  describe("denomLabel helper", () => {
-    it("should map known denoms to token labels", () => {
-      const template = "{{denomLabel denom}}";
-      expect(setup().interpolate(template, { denom: "uakt" })).toBe("AKT");
-      expect(setup().interpolate(template, { denom: "uact" })).toBe("ACT");
+  describe("formatBalance helper", () => {
+    it("should convert, format, and label in one call", () => {
+      expect(setup().interpolate("{{formatBalance amount denom 2}}", { amount: 1_234_567_890, denom: "uakt" })).toBe("1,234.57 AKT");
     });
 
-    it("should return denom as-is if unknown", () => {
-      expect(setup().interpolate("{{denomLabel denom}}", { denom: "ufoo" })).toBe("ufoo");
-    });
-  });
-
-  describe("udenomToDenom helper", () => {
-    it("should convert micro-denomination to denom", () => {
-      const template = "{{udenomToDenom balance}}";
-      expect(setup().interpolate(template, { balance: 700_000 })).toBe("0.7");
+    it("should use default precision of 6", () => {
+      expect(setup().interpolate("{{formatBalance amount denom}}", { amount: 700_000, denom: "uact" })).toBe("0.7 ACT");
     });
 
-    it("should accept custom precision as second argument", () => {
-      expect(setup().interpolate("{{udenomToDenom balance 2}}", { balance: 1_234_567 })).toBe("1.23");
+    it("should pass through unknown denom", () => {
+      expect(setup().interpolate("{{formatBalance amount denom 2}}", { amount: 1_000_000, denom: "ufoo" })).toBe("1 ufoo");
+    });
+
+    it("should return empty string for non-numeric amount", () => {
+      expect(setup().interpolate("{{formatBalance amount denom}}", { amount: "abc", denom: "uakt" })).toBe("");
     });
   });
 
   describe("balance alert template", () => {
     const template =
-      '{{#if (eq alert.next.status "TRIGGERED")}}Balance dropped to {{udenomToDenom data.amount 2}} {{denomLabel data.denom}}, which is below the configured threshold{{else}}Balance recovered to {{udenomToDenom data.amount 2}} {{denomLabel data.denom}}, now above threshold{{/if}}';
+      '{{#if (eq alert.next.status "TRIGGERED")}}Balance dropped to {{formatBalance data.amount data.denom 2}}, which is below the configured threshold{{else}}Balance recovered to {{formatBalance data.amount data.denom 2}}, now above threshold{{/if}}';
 
     it("should render triggered alert", () => {
       const context = {

--- a/apps/notifications/src/modules/alert/services/template/template.service.ts
+++ b/apps/notifications/src/modules/alert/services/template/template.service.ts
@@ -10,15 +10,9 @@ const DENOM_LABELS: Record<string, string> = {
   uact: "ACT"
 };
 
-Handlebars.registerHelper("denomLabel", function (denom: unknown) {
-  if (typeof denom !== "string") {
-    return "";
-  }
+const numberFormatter = new Intl.NumberFormat("en-US");
 
-  return DENOM_LABELS[denom] ?? denom;
-});
-
-Handlebars.registerHelper("udenomToDenom", function (amount: unknown, precision?: unknown) {
+Handlebars.registerHelper("formatBalance", function (amount: unknown, denom: unknown, precision?: unknown) {
   const parsedAmount = typeof amount === "string" ? parseFloat(amount) : Number(amount);
 
   if (isNaN(parsedAmount)) {
@@ -27,8 +21,10 @@ Handlebars.registerHelper("udenomToDenom", function (amount: unknown, precision?
 
   const parsedPrecision = typeof precision === "number" ? precision : 6;
   const multiplier = Math.pow(10, parsedPrecision);
+  const converted = Math.round((parsedAmount / 1_000_000 + Number.EPSILON) * multiplier) / multiplier;
+  const label = typeof denom === "string" ? DENOM_LABELS[denom] ?? denom : "";
 
-  return String(Math.round((parsedAmount / 1_000_000 + Number.EPSILON) * multiplier) / multiplier);
+  return `${numberFormatter.format(converted)} ${label}`.trim();
 });
 
 @Injectable()


### PR DESCRIPTION
## Why

Simplifies notification template authoring by consolidating three separate helpers (`udenomToDenom`, `denomLabel`, `formatNumber`) into a single `formatBalance` helper that handles micro-denomination conversion, number formatting (via `Intl.NumberFormat`), and token labeling in one call.

## What

- Added `formatBalance` Handlebars helper that converts udenom amounts, formats with commas, and appends token label (e.g. `{{formatBalance data.amount data.denom 2}}` → `1,234.57 AKT`)
- Removed `udenomToDenom` and `denomLabel` helpers as `formatBalance` covers their use cases
- Updated tests accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved formatting of balance amounts in alert notifications. Balance displays now include thousands separators for better readability and consistent denom labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->