### PR TITLE
fix(deployment): update Help from Expert sidebar link

### DIFF
--- a/apps/deploy-web/src/components/layout/Sidebar.tsx
+++ b/apps/deploy-web/src/components/layout/Sidebar.tsx
@@ -227,7 +227,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
           {
             title: "Help from Expert",
             icon: props => <HeadsetHelp {...props} />,
-            url: "https://share.hsforms.com/29tSLilX9Qye5Rxrlsz7WPwsaima",
+            url: "https://akash.network/gpus-on-demand/",
             activeRoutes: [],
             target: "_blank",
             isNew: true


### PR DESCRIPTION
## Why

Update the "Help from Expert" sidebar link to point to the new GPUs on Demand page as requested by Denis.

## What

- Changed the sidebar link from the old HubSpot form (`https://share.hsforms.com/29tSLilX9Qye5Rxrlsz7WPwsaima`) to `https://akash.network/gpus-on-demand/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the "Help from Expert" sidebar link to point to https://akash.network/gpus-on-demand/.
  * Link behavior unchanged — it remains marked as a new resource and continues to open in a separate browser tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->