### PR TITLE
feat(alert): show balance and threshold in deployment alert descriptions

### DIFF
--- a/apps/notifications/src/modules/alert/services/deployment-alert/deployment-alert.service.ts
+++ b/apps/notifications/src/modules/alert/services/deployment-alert/deployment-alert.service.ts
@@ -161,8 +161,8 @@ export class DeploymentAlertService {
       }),
       description: this.getTemplate({
         suspended: `Deployment was closed. Please visit ${consoleLink} to manage your deployment.`,
-        triggered: `Please visit ${consoleLink} to add more funds to your deployment before it is closed.`,
-        recovered: `Escrow account is above threshold. You'll be notified again next time your account threshold is hit. Please visit ${consoleLink} to manage your deployment`
+        triggered: `Current balance is {{formatBalance data.balance "uact" 2}}, which is below your configured threshold of {{formatBalance alert.next.conditions.value "uact" 2}}. Please visit ${consoleLink} to add more funds before it is closed.`,
+        recovered: `Current balance is {{formatBalance data.balance "uact" 2}}, now above your threshold of {{formatBalance alert.next.conditions.value "uact" 2}}. Please visit ${consoleLink} to manage your deployment.`
       })
     };
   }

--- a/apps/notifications/src/modules/alert/services/template/template.service.spec.ts
+++ b/apps/notifications/src/modules/alert/services/template/template.service.spec.ts
@@ -63,32 +63,27 @@ describe(TemplateService.name, () => {
     expect(new TemplateService().interpolate(template, context)).toBe("Env: ");
   });
 
-  describe("denomLabel helper", () => {
-    it("should map known denoms to token labels", () => {
-      const template = "{{denomLabel denom}}";
-      expect(setup().interpolate(template, { denom: "uakt" })).toBe("AKT");
-      expect(setup().interpolate(template, { denom: "uact" })).toBe("ACT");
+  describe("formatBalance helper", () => {
+    it("should convert, format, and label in one call", () => {
+      expect(setup().interpolate("{{formatBalance amount denom 2}}", { amount: 1_234_567_890, denom: "uakt" })).toBe("1,234.57 AKT");
     });
 
-    it("should return denom as-is if unknown", () => {
-      expect(setup().interpolate("{{denomLabel denom}}", { denom: "ufoo" })).toBe("ufoo");
-    });
-  });
-
-  describe("udenomToDenom helper", () => {
-    it("should convert micro-denomination to denom", () => {
-      const template = "{{udenomToDenom balance}}";
-      expect(setup().interpolate(template, { balance: 700_000 })).toBe("0.7");
+    it("should use default precision of 6", () => {
+      expect(setup().interpolate("{{formatBalance amount denom}}", { amount: 700_000, denom: "uact" })).toBe("0.7 ACT");
     });
 
-    it("should accept custom precision as second argument", () => {
-      expect(setup().interpolate("{{udenomToDenom balance 2}}", { balance: 1_234_567 })).toBe("1.23");
+    it("should pass through unknown denom", () => {
+      expect(setup().interpolate("{{formatBalance amount denom 2}}", { amount: 1_000_000, denom: "ufoo" })).toBe("1 ufoo");
+    });
+
+    it("should return empty string for non-numeric amount", () => {
+      expect(setup().interpolate("{{formatBalance amount denom}}", { amount: "abc", denom: "uakt" })).toBe("");
     });
   });
 
   describe("balance alert template", () => {
     const template =
-      '{{#if (eq alert.next.status "TRIGGERED")}}Balance dropped to {{udenomToDenom data.amount 2}} {{denomLabel data.denom}}, which is below the configured threshold{{else}}Balance recovered to {{udenomToDenom data.amount 2}} {{denomLabel data.denom}}, now above threshold{{/if}}';
+      '{{#if (eq alert.next.status "TRIGGERED")}}Balance dropped to {{formatBalance data.amount data.denom 2}}, which is below the configured threshold{{else}}Balance recovered to {{formatBalance data.amount data.denom 2}}, now above threshold{{/if}}';
 
     it("should render triggered alert", () => {
       const context = {

--- a/apps/notifications/src/modules/alert/services/template/template.service.ts
+++ b/apps/notifications/src/modules/alert/services/template/template.service.ts
@@ -10,15 +10,9 @@ const DENOM_LABELS: Record<string, string> = {
   uact: "ACT"
 };
 
-Handlebars.registerHelper("denomLabel", function (denom: unknown) {
-  if (typeof denom !== "string") {
-    return "";
-  }
+const numberFormatter = new Intl.NumberFormat("en-US");
 
-  return DENOM_LABELS[denom] ?? denom;
-});
-
-Handlebars.registerHelper("udenomToDenom", function (amount: unknown, precision?: unknown) {
+Handlebars.registerHelper("formatBalance", function (amount: unknown, denom: unknown, precision?: unknown) {
   const parsedAmount = typeof amount === "string" ? parseFloat(amount) : Number(amount);
 
   if (isNaN(parsedAmount)) {
@@ -27,8 +21,10 @@ Handlebars.registerHelper("udenomToDenom", function (amount: unknown, precision?
 
   const parsedPrecision = typeof precision === "number" ? precision : 6;
   const multiplier = Math.pow(10, parsedPrecision);
+  const converted = Math.round((parsedAmount / 1_000_000 + Number.EPSILON) * multiplier) / multiplier;
+  const label = typeof denom === "string" ? DENOM_LABELS[denom] ?? denom : "";
 
-  return String(Math.round((parsedAmount / 1_000_000 + Number.EPSILON) * multiplier) / multiplier);
+  return `${numberFormatter.format(converted)} ${label}`.trim();
 });
 
 @Injectable()


### PR DESCRIPTION
## Why

Deployment balance alert notifications had generic copy like "Please visit [link] to add more funds" without showing the actual balance or threshold values, making it hard for users to assess urgency.

## What

- Use `formatBalance` helper in deployment balance alert description templates to show current balance and configured threshold (e.g. "Current balance is 0.7 ACT, which is below your configured threshold of 5 ACT")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment alerts now display the current balance amount and configured threshold value in alert descriptions instead of generic text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->