### PR TITLE
fix: fetch application version from rpc node

### DIFF
--- a/packages/net/scripts/generate.ts
+++ b/packages/net/scripts/generate.ts
@@ -25,6 +25,8 @@ const metaSchema = z.object({
   })
 });
 
+main().catch(console.error);
+
 async function main() {
   console.log(`Generate network configuration: ${networks.join(", ")}`);
   const config: Record<string, unknown> = {};
@@ -42,9 +44,10 @@ async function main() {
         }),
       fetchText(`${baseConfigUrl}/faucet-url.txt`).catch(() => null)
     ]);
+    const appVersion = meta?.apis?.rpc?.[0]?.address ? await getAppVersion(meta?.apis?.rpc[0]?.address) : null;
 
     const networkConfig = {
-      version: meta?.codebase?.recommended_version ?? null,
+      version: appVersion ?? meta?.codebase?.recommended_version ?? null,
       faucetUrl: faucetUrl?.trim() ?? null,
       apiUrls: meta?.apis?.rest?.map(({ address }) => address) ?? [],
       rpcUrls: meta?.apis?.rpc?.map(({ address }) => address) ?? []
@@ -70,13 +73,31 @@ function fetchText(url: string): Promise<string> {
   });
 }
 
-function fetchJson(url: string): Promise<unknown> {
+function fetchJson<T>(url: string): Promise<T> {
   return fetch(url).then(res => {
     if (!res.ok) {
       throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
     }
-    return res.json();
+    return res.json() as Promise<T>;
   });
 }
 
-main().catch(console.error);
+async function getAppVersion(rpcUrl: string): Promise<string | null> {
+  try {
+    const abciInfo = await fetchJson<{ result: AbciInfo }>(`${rpcUrl}/abci_info`);
+    if (!abciInfo.result.response.version) return null;
+    return `v${abciInfo.result.response.version}`;
+  } catch (error) {
+    console.error(`Failed to fetch app version from ${rpcUrl}:`, error);
+    return null;
+  }
+}
+
+interface AbciInfo {
+  response: {
+    data: string;
+    last_block_height: string;
+    last_block_app_hash: string;
+    version: string;
+  };
+}

--- a/packages/net/scripts/generate.ts
+++ b/packages/net/scripts/generate.ts
@@ -85,8 +85,9 @@ function fetchJson<T>(url: string): Promise<T> {
 async function getAppVersion(rpcUrl: string): Promise<string | null> {
   try {
     const abciInfo = await fetchJson<{ result: AbciInfo }>(`${rpcUrl}/abci_info`);
-    if (!abciInfo.result.response.version) return null;
-    return `v${abciInfo.result.response.version}`;
+    const version = abciInfo.result.response.version?.trim();
+    if (!version) return null;
+    return version.startsWith("v") ? version : `v${version}`;
   } catch (error) {
     console.error(`Failed to fetch app version from ${rpcUrl}:`, error);
     return null;

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -29,7 +29,7 @@ export const netConfigData = {
     ]
   },
   "sandbox-2": {
-    version: "v1.2.0",
+    version: "v2.0.0",
     faucetUrl: "http://faucet.sandbox-2.aksh.pw/",
     apiUrls: ["https://api.sandbox-2.aksh.pw:443"],
     rpcUrls: ["https://rpc.sandbox-2.aksh.pw:443"]


### PR DESCRIPTION
## Why

Sometimes version.txt and meta.json contain outdated version. The most reliable way to get version of chain node is to fetch it from the chain.

<img width="452" height="169" alt="Screenshot 2026-03-30 at 21 46 11" src="https://github.com/user-attachments/assets/25f79de5-3732-4ef3-86eb-8555599d19ff" />

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Network config generation now fetches application version directly from RPC endpoints with automatic fallback to the recommended version, and normalizes version format for consistency.
  * Improved runtime safety: single-entry execution, better error handling and logging for remote fetches, and safer JSON fetch/parsing to reduce runtime parsing issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->