### PR TITLE
fix(provider): prefer newest provider when deduplicating by hostUri

### DIFF
--- a/apps/api/src/provider/services/provider/provider.service.spec.ts
+++ b/apps/api/src/provider/services/provider/provider.service.spec.ts
@@ -7,6 +7,7 @@ import { Ok } from "ts-results";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { cacheEngine } from "@src/caching/helpers";
 import { AUDITOR } from "@src/deployment/config/provider.config";
 import { createLeaseStatus } from "../../../../test/seeders/lease-status.seeder";
 import { createProviderSeed, createProviderWithAttributeSignatures } from "../../../../test/seeders/provider.seeder";
@@ -374,6 +375,10 @@ describe(ProviderService.name, () => {
   });
 
   describe("getProviderList", () => {
+    beforeEach(() => {
+      cacheEngine.clearAllKeyInCache();
+    });
+
     it("should prefer online provider when multiple providers share the same hostUri", async () => {
       const { service, providerRepository, auditorsService, providerAttributesSchemaService } = setup();
 
@@ -390,6 +395,34 @@ describe(ProviderService.name, () => {
 
       expect(result).toHaveLength(1);
       expect(result[0].owner).toBe(onlineProvider.owner);
+    });
+
+    it("should prefer newest provider when multiple online providers share the same hostUri", async () => {
+      const { service, providerRepository, auditorsService, providerAttributesSchemaService } = setup();
+
+      const sharedHostUri = "https://provider.example.com:8443";
+      const olderOnline = {
+        ...createProviderWithAttributeSignatures(AUDITOR),
+        hostUri: sharedHostUri,
+        isOnline: true,
+        createdHeight: 100
+      } as unknown as Provider;
+      const newerOnline = {
+        ...createProviderWithAttributeSignatures(AUDITOR),
+        hostUri: sharedHostUri,
+        isOnline: true,
+        createdHeight: 200
+      } as unknown as Provider;
+
+      providerRepository.getWithAttributesAndAuditors.mockResolvedValue([olderOnline, newerOnline]);
+      providerRepository.getProviderWithNodes.mockResolvedValue([]);
+      auditorsService.getAuditors.mockResolvedValue([]);
+      providerAttributesSchemaService.getProviderAttributesSchema.mockResolvedValue(providerAttributeSchemaStub);
+
+      const result = await service.getProviderList();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].owner).toBe(newerOnline.owner);
     });
 
     it("should deduplicate providers with the same hostUri", async () => {

--- a/apps/api/src/provider/services/provider/provider.service.ts
+++ b/apps/api/src/provider/services/provider/provider.service.ts
@@ -151,7 +151,11 @@ export class ProviderService {
     const providerByHostUri = new Map<string, Provider>();
     await forEachInChunks(providersWithAttributesAndAuditors, provider => {
       const existing = providerByHostUri.get(provider.hostUri);
-      if (!existing || (!existing.isOnline && provider.isOnline)) {
+      if (
+        !existing ||
+        (!existing.isOnline && provider.isOnline) ||
+        (existing.isOnline === provider.isOnline && provider.createdHeight > existing.createdHeight)
+      ) {
         providerByHostUri.set(provider.hostUri, provider);
       }
     });


### PR DESCRIPTION
## Why

Fixes CON-146

The previous fix (#3015) preferred online providers over offline ones when deduplicating by `hostUri`, but didn't handle the case where **multiple providers are all online**. In the `ouroboroz.tech` case, all three providers sharing the same `hostUri` are online, so the oldest one (lowest `createdHeight`) was still being surfaced instead of the active newest one.

## What

- Added `createdHeight` tiebreaker to the dedup logic: when providers share a `hostUri` and have the same online status, the newest one (highest `createdHeight`) wins
- Added test for the "all online, prefer newest" scenario
- Fixed pre-existing test isolation bug where `@Memoize` module-level cache leaked between `getProviderList` tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider deduplication logic to better handle scenarios where multiple providers share the same network address, now selecting the provider with the highest creation timestamp when all providers have matching availability status.
  * Enhanced the selection algorithm to ensure newer and compatible providers are consistently preferred during provider assignment and load-balancing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->