### PR TITLE
feat: enable node.js permission model for provider-proxy

### DIFF
--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -8,11 +8,11 @@
   "scripts": {
     "build": "NODE_ENV=production tsup && tsc -p tsconfig.build.json",
     "build:container": "dc build provider-proxy",
-    "dev": "tsup src/server.ts --watch",
+    "dev": "tsup --watch",
     "dev:inspect": "NODE_OPTIONS=\"--inspect\" npm run dev",
     "format": "prettier --write ./*.{ts,js,json} **/*.{ts,js,json}",
     "lint": "eslint .",
-    "prod": "node --require ./dist/instrumentation ./dist/server.js",
+    "prod": "node --permission --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --enable-source-maps --require ./dist/instrumentation.js ./dist/server.js",
     "start": "tsup --watch",
     "test": "vitest run --project unit --project functional",
     "test:cov": "vitest run --project unit --project functional --coverage",

--- a/apps/provider-proxy/tsup.config.ts
+++ b/apps/provider-proxy/tsup.config.ts
@@ -21,7 +21,7 @@ export default defineConfig(async overrideOptions =>
     tsconfig: "tsconfig.build.json",
     external: ["pino-pretty"],
     dts: false,
-    onSuccess: overrideOptions.watch && !isProduction ? "node --enable-source-maps dist/server.js" : undefined,
+    onSuccess: overrideOptions.watch && !isProduction ? "npm run prod" : undefined,
     ...overrideOptions
   })
 );


### PR DESCRIPTION
## Why

Ref https://github.com/akash-network/console/issues/1550

Enable the Node.js Permission Model (`--permission`) on provider-proxy to restrict filesystem access at runtime. This is a defense-in-depth security measure that prevents the process from reading or writing files outside explicitly allowed paths, and
blocks spawning child processes, worker threads, and loading native addons.

## What

- Updated the `prod` script in `apps/provider-proxy/package.json` to run with `--permission` and minimal `--allow-fs-read` paths
(`./dist/`, `./env/`, `./node_modules/`, `../../node_modules/`, `../../packages/env-loader/`)
- No write, worker, child-process, or addon permissions are granted — provider-proxy only needs read access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified the development watch command to rely on the build tool's default entry handling while preserving watch behavior.
  * Production start now runs in a stricter Node sandbox with explicit read permissions and source maps enabled for better diagnostics.
  * Watch-mode builds now invoke the updated production start command automatically after successful builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->