### PR TITLE
fix(billing): add missing ThreeDSecurePopup to PaymentPopup

### DIFF
--- a/apps/api/src/billing/services/stripe/stripe.service.spec.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.spec.ts
@@ -79,10 +79,7 @@ describe(StripeService.name, () => {
         amount: 10000,
         currency: mockPaymentParams.currency,
         confirm: mockPaymentParams.confirm,
-        automatic_payment_methods: {
-          enabled: true,
-          allow_redirects: "never"
-        },
+        payment_method_types: ["card", "link"],
         metadata: {
           internal_transaction_id: "test-transaction-id"
         }

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -212,10 +212,7 @@ export class StripeService extends Stripe {
           ...params.metadata,
           internal_transaction_id: transaction.id
         },
-        automatic_payment_methods: {
-          enabled: true,
-          allow_redirects: "never"
-        }
+        payment_method_types: ["card", "link"]
       }
     ];
 

--- a/apps/deploy-web/src/components/billing-usage/PaymentPopup/PaymentPopup.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentPopup/PaymentPopup.spec.tsx
@@ -117,6 +117,11 @@ const MockSelectItem = ({ children, value }: any) => (
   </div>
 );
 
+const MockThreeDSecurePopup = ({ isOpen, clientSecret }: any) => {
+  if (!isOpen) return null;
+  return <div data-testid="three-d-secure-popup" data-client-secret={clientSecret} />;
+};
+
 describe(PaymentPopup.name, () => {
   describe("Rendering", () => {
     it("renders popup when open is true", () => {
@@ -591,6 +596,47 @@ describe(PaymentPopup.name, () => {
       expect(mockSetShowPaymentSuccess).toHaveBeenCalledWith({ amount: "100", show: true });
       expect(mockOnClose).toHaveBeenCalled();
     });
+
+    it("renders ThreeDSecurePopup when 3DS data is present and open", () => {
+      setup({
+        open: true,
+        threeDSecureIsOpen: true,
+        threeDSData: {
+          clientSecret: "secret_abc",
+          paymentIntentId: "pi_abc",
+          paymentMethodId: "pm_abc"
+        }
+      });
+
+      const popup = screen.getByTestId("three-d-secure-popup");
+      expect(popup).toBeInTheDocument();
+      expect(popup).toHaveAttribute("data-client-secret", "secret_abc");
+    });
+
+    it("does not render ThreeDSecurePopup when 3DS data is null", () => {
+      setup({
+        open: true,
+        threeDSecureIsOpen: false,
+        threeDSData: null
+      });
+
+      expect(screen.queryByTestId("three-d-secure-popup")).not.toBeInTheDocument();
+    });
+
+    it("hides PaymentPopup when 3DS popup is open", () => {
+      setup({
+        open: true,
+        threeDSecureIsOpen: true,
+        threeDSData: {
+          clientSecret: "secret_abc",
+          paymentIntentId: "pi_abc",
+          paymentMethodId: "pm_abc"
+        }
+      });
+
+      expect(screen.queryByTestId("popup")).not.toBeInTheDocument();
+      expect(screen.getByTestId("three-d-secure-popup")).toBeInTheDocument();
+    });
   });
 
   describe("Error Handling", () => {
@@ -821,6 +867,8 @@ function setup(
     isPolling?: boolean;
     pollForPayment?: Mock;
     start3DSecure?: Mock;
+    threeDSecureIsOpen?: boolean;
+    threeDSData?: { clientSecret: string; paymentIntentId: string; paymentMethodId: string } | null;
     stripeErrorResponse?: any;
     mockUse3DSecure?: Mock;
     paymentMethods?: any[];
@@ -910,10 +958,18 @@ function setup(
 
   const mockZodResolver = vi.fn((schema: any) => schema);
 
+  const mockHandle3DSSuccess = vi.fn();
+  const mockHandle3DSError = vi.fn();
+
   const mockUse3DSecure =
     input.mockUse3DSecure ||
     vi.fn().mockReturnValue({
-      start3DSecure: mockStart3DSecure
+      start3DSecure: mockStart3DSecure,
+      isOpen: input.threeDSecureIsOpen ?? false,
+      threeDSData: input.threeDSData ?? null,
+      handle3DSSuccess: mockHandle3DSSuccess,
+      handle3DSError: mockHandle3DSError,
+      isLoading: false
     });
 
   const mockErrorHandler = {
@@ -943,6 +999,7 @@ function setup(
     Xmark: MockXmark,
     Snackbar: MockSnackbar,
     Link: MockLink,
+    ThreeDSecurePopup: MockThreeDSecurePopup,
     useForm: mockUseForm,
     zodResolver: mockZodResolver,
     useSnackbar: vi.fn(() => ({ enqueueSnackbar: mockEnqueueSnackbar })),

--- a/apps/deploy-web/src/components/billing-usage/PaymentPopup/PaymentPopup.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentPopup/PaymentPopup.spec.tsx
@@ -117,11 +117,6 @@ const MockSelectItem = ({ children, value }: any) => (
   </div>
 );
 
-const MockThreeDSecurePopup = ({ isOpen, clientSecret }: any) => {
-  if (!isOpen) return null;
-  return <div data-testid="three-d-secure-popup" data-client-secret={clientSecret} />;
-};
-
 describe(PaymentPopup.name, () => {
   describe("Rendering", () => {
     it("renders popup when open is true", () => {
@@ -616,7 +611,7 @@ describe(PaymentPopup.name, () => {
     it("does not render ThreeDSecurePopup when 3DS data is null", () => {
       setup({
         open: true,
-        threeDSecureIsOpen: false,
+        threeDSecureIsOpen: true,
         threeDSData: null
       });
 
@@ -1066,3 +1061,8 @@ function setup(
     mockErrorHandler
   };
 }
+
+const MockThreeDSecurePopup = ({ isOpen, clientSecret }: { isOpen: boolean; clientSecret: string }) => {
+  if (!isOpen) return null;
+  return <div data-testid="three-d-secure-popup" data-client-secret={clientSecret} />;
+};

--- a/apps/deploy-web/src/components/billing-usage/PaymentPopup/PaymentPopup.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentPopup/PaymentPopup.tsx
@@ -30,6 +30,7 @@ import { useSnackbar } from "notistack";
 import { z } from "zod";
 
 import { getPaymentMethodDisplay } from "@src/components/shared/PaymentMethodCard/PaymentMethodCard";
+import { ThreeDSecurePopup } from "@src/components/shared/PaymentMethodForm/ThreeDSecurePopup";
 import { usePaymentPolling } from "@src/context/PaymentPollingProvider";
 import { useServices } from "@src/context/ServicesProvider";
 import { use3DSecure } from "@src/hooks/use3DSecure";
@@ -71,7 +72,8 @@ export const DEPENDENCIES = {
   usePaymentMethodsQuery,
   handleCouponError,
   handleStripeError,
-  useServices
+  useServices,
+  ThreeDSecurePopup
 };
 
 const MINIMUM_PAYMENT_AMOUNT = 20;
@@ -245,143 +247,160 @@ export const PaymentPopup: React.FC<PaymentPopupProps> = ({
   const disabled = isProcessing || !selectedMethodId;
 
   return (
-    <d.Popup
-      open={open}
-      onClose={onClose}
-      title="Add Funds"
-      variant="custom"
-      actions={[
-        {
-          label: "Cancel",
-          variant: "ghost",
-          onClick: onClose,
-          side: "right"
-        }
-      ]}
-    >
-      <div className="space-y-6">
-        <d.Card>
-          <d.CardHeader>
-            <d.CardTitle className="text-lg">Add credits</d.CardTitle>
-          </d.CardHeader>
-          <d.CardContent className="space-y-4">
-            <div>
-              <d.Label>Payment Method</d.Label>
-              {isLoadingPaymentMethods ? (
-                <d.Skeleton className="mt-1 h-10 w-full" />
-              ) : (
-                <>
-                  <d.Select value={selectedMethodId ?? ""} onValueChange={setSelectedMethodId}>
-                    <d.SelectTrigger>
-                      <d.SelectValue placeholder="Select a payment method" />
-                    </d.SelectTrigger>
-                    <d.SelectContent>
-                      {paymentMethods?.map(method => (
-                        <d.SelectItem key={method.id} value={method.id}>
-                          {getPaymentMethodDisplay(method).label}
-                        </d.SelectItem>
-                      ))}
-                    </d.SelectContent>
-                  </d.Select>
-                  {!paymentMethods?.length && (
-                    <d.Alert className="mt-2">
-                      <p className="text-sm">No payment methods available.</p>
-                      <d.Link href={urlService.paymentMethods()} className="mt-1 inline-block text-sm font-medium text-primary underline">
-                        Add a payment method
-                      </d.Link>
-                    </d.Alert>
-                  )}
-                </>
-              )}
-            </div>
-
-            <d.Form {...paymentForm}>
-              <form onSubmit={paymentForm.handleSubmit(onPayment)} className="space-y-4">
-                <d.FormField
-                  control={paymentForm.control}
-                  name="amount"
-                  render={({ field }) => (
-                    <d.FormInput
-                      {...field}
-                      type="number"
-                      min="0"
-                      step="0.01"
-                      placeholder="0.00"
-                      label="Amount (USD)"
-                      autoFocus
-                      onChange={e => {
-                        field.onChange(e);
-                        clearError();
-                      }}
-                    />
-                  )}
-                />
-
-                <d.LoadingButton loading={isProcessing} className="w-full" type="submit" disabled={disabled}>
-                  {isConfirmingPayment || isPolling ? (
-                    "Processing..."
-                  ) : (
-                    <>
-                      Pay <d.FormattedNumber value={amount || 0} style="currency" currency="USD" />
-                    </>
-                  )}
-                </d.LoadingButton>
-              </form>
-            </d.Form>
-
-            {error && (
-              <div className="mx-auto mt-6 max-w-md">
-                <d.Alert variant="destructive" className="mb-4">
-                  <p className="font-medium">Payment Error</p>
-                  <p className="text-sm">{error}</p>
-                  {errorAction && (
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      <strong>Suggestion:</strong> {errorAction}
-                    </p>
-                  )}
-                  <d.Button onClick={clearError} variant="default" size="sm" className="mt-2">
-                    <d.Xmark className="mr-2 h-4 w-4" />
-                    Clear Error
-                  </d.Button>
-                </d.Alert>
+    <>
+      <d.Popup
+        open={open && !threeDSecure.isOpen}
+        onClose={onClose}
+        title="Add Funds"
+        variant="custom"
+        actions={[
+          {
+            label: "Cancel",
+            variant: "ghost",
+            onClick: onClose,
+            side: "right"
+          }
+        ]}
+      >
+        <div className="space-y-6">
+          <d.Card>
+            <d.CardHeader>
+              <d.CardTitle className="text-lg">Add credits</d.CardTitle>
+            </d.CardHeader>
+            <d.CardContent className="space-y-4">
+              <div>
+                <d.Label>Payment Method</d.Label>
+                {isLoadingPaymentMethods ? (
+                  <d.Skeleton className="mt-1 h-10 w-full" />
+                ) : (
+                  <>
+                    <d.Select value={selectedMethodId ?? ""} onValueChange={setSelectedMethodId}>
+                      <d.SelectTrigger>
+                        <d.SelectValue placeholder="Select a payment method" />
+                      </d.SelectTrigger>
+                      <d.SelectContent>
+                        {paymentMethods?.map(method => (
+                          <d.SelectItem key={method.id} value={method.id}>
+                            {getPaymentMethodDisplay(method).label}
+                          </d.SelectItem>
+                        ))}
+                      </d.SelectContent>
+                    </d.Select>
+                    {!paymentMethods?.length && (
+                      <d.Alert className="mt-2">
+                        <p className="text-sm">No payment methods available.</p>
+                        <d.Link href={urlService.paymentMethods()} className="mt-1 inline-block text-sm font-medium text-primary underline">
+                          Add a payment method
+                        </d.Link>
+                      </d.Alert>
+                    )}
+                  </>
+                )}
               </div>
-            )}
-          </d.CardContent>
-        </d.Card>
 
-        <d.Card>
-          <d.CardHeader>
-            <d.CardTitle className="text-lg">Have a coupon code?</d.CardTitle>
-            <d.CardDescription>Enter your coupon code to claim credits</d.CardDescription>
-          </d.CardHeader>
-          <d.CardContent className="space-y-4">
-            <d.Form {...couponForm}>
-              <form onSubmit={couponForm.handleSubmit(onClaimCoupon)} className="space-y-4">
-                <d.FormField
-                  control={couponForm.control}
-                  name="coupon"
-                  render={({ field }) => (
-                    <d.FormInput
-                      {...field}
-                      type="text"
-                      placeholder="Enter coupon code"
-                      label="Coupon Code"
-                      onChange={e => {
-                        field.onChange(e);
-                        clearError();
-                      }}
-                    />
-                  )}
-                />
+              <d.Form {...paymentForm}>
+                <form onSubmit={paymentForm.handleSubmit(onPayment)} className="space-y-4">
+                  <d.FormField
+                    control={paymentForm.control}
+                    name="amount"
+                    render={({ field }) => (
+                      <d.FormInput
+                        {...field}
+                        type="number"
+                        min="0"
+                        step="0.01"
+                        placeholder="0.00"
+                        label="Amount (USD)"
+                        autoFocus
+                        onChange={e => {
+                          field.onChange(e);
+                          clearError();
+                        }}
+                      />
+                    )}
+                  />
 
-                <d.LoadingButton className="w-full" loading={isApplyingCoupon} type="submit">
-                  Claim coupon
-                </d.LoadingButton>
-              </form>
-            </d.Form>
-          </d.CardContent>
-        </d.Card>
-      </div>
-    </d.Popup>
+                  <d.LoadingButton loading={isProcessing} className="w-full" type="submit" disabled={disabled}>
+                    {isConfirmingPayment || isPolling ? (
+                      "Processing..."
+                    ) : (
+                      <>
+                        Pay <d.FormattedNumber value={amount || 0} style="currency" currency="USD" />
+                      </>
+                    )}
+                  </d.LoadingButton>
+                </form>
+              </d.Form>
+
+              {error && (
+                <div className="mx-auto mt-6 max-w-md">
+                  <d.Alert variant="destructive" className="mb-4">
+                    <p className="font-medium">Payment Error</p>
+                    <p className="text-sm">{error}</p>
+                    {errorAction && (
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        <strong>Suggestion:</strong> {errorAction}
+                      </p>
+                    )}
+                    <d.Button onClick={clearError} variant="default" size="sm" className="mt-2">
+                      <d.Xmark className="mr-2 h-4 w-4" />
+                      Clear Error
+                    </d.Button>
+                  </d.Alert>
+                </div>
+              )}
+            </d.CardContent>
+          </d.Card>
+
+          <d.Card>
+            <d.CardHeader>
+              <d.CardTitle className="text-lg">Have a coupon code?</d.CardTitle>
+              <d.CardDescription>Enter your coupon code to claim credits</d.CardDescription>
+            </d.CardHeader>
+            <d.CardContent className="space-y-4">
+              <d.Form {...couponForm}>
+                <form onSubmit={couponForm.handleSubmit(onClaimCoupon)} className="space-y-4">
+                  <d.FormField
+                    control={couponForm.control}
+                    name="coupon"
+                    render={({ field }) => (
+                      <d.FormInput
+                        {...field}
+                        type="text"
+                        placeholder="Enter coupon code"
+                        label="Coupon Code"
+                        onChange={e => {
+                          field.onChange(e);
+                          clearError();
+                        }}
+                      />
+                    )}
+                  />
+
+                  <d.LoadingButton className="w-full" loading={isApplyingCoupon} type="submit">
+                    Claim coupon
+                  </d.LoadingButton>
+                </form>
+              </d.Form>
+            </d.CardContent>
+          </d.Card>
+        </div>
+      </d.Popup>
+
+      {threeDSecure.threeDSData?.clientSecret && (
+        <d.ThreeDSecurePopup
+          isOpen={threeDSecure.isOpen}
+          onSuccess={threeDSecure.handle3DSSuccess}
+          onError={threeDSecure.handle3DSError}
+          clientSecret={threeDSecure.threeDSData.clientSecret}
+          paymentIntentId={threeDSecure.threeDSData.paymentIntentId}
+          paymentMethodId={threeDSecure.threeDSData.paymentMethodId}
+          title="Payment Authentication"
+          description="Your bank requires additional verification for this payment."
+          successMessage="Payment authenticated successfully!"
+          errorMessage="Please try again or use a different payment method."
+        />
+      )}
+    </>
   );
 };

--- a/apps/deploy-web/src/components/shared/PaymentMethodForm/ThreeDSecureModal.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodForm/ThreeDSecureModal.tsx
@@ -122,8 +122,13 @@ const ThreeDSecureForm: React.FC<Omit<ThreeDSecureModalProps, "isOpen" | "onClos
     authenticationInProgress.current = true;
 
     try {
-      const result = await stripe.confirmCardPayment(clientSecret, {
-        payment_method: paymentMethodId
+      const result = await stripe.confirmPayment({
+        clientSecret,
+        confirmParams: {
+          payment_method: paymentMethodId,
+          return_url: window.location.href
+        },
+        redirect: "if_required"
       });
       console.log("3D Secure authentication result:", result);
       processAuthenticationResult(result);


### PR DESCRIPTION
## Why

Fixes [CON-162](https://linear.app/akash-network/issue/CON-162/3d-secure-payment-authentication-broken-on-billing-page)

When the `/payment` page was removed in favor of `/billing` (#2846), the `ThreeDSecurePopup` component was not carried over to the new `PaymentPopup`. The `use3DSecure` hook was wired up and `start3DSecure()` is called correctly, but the popup that performs the Stripe 3D Secure authentication never rendered — causing silent payment failures for cards requiring 3DS verification (e.g., certain EU cards).

## What

- Import and render `ThreeDSecurePopup` in `PaymentPopup` component
- Add it to `DEPENDENCIES` for testability
- Add two tests verifying the popup renders when 3DS data is present and does not render when absent
- Expand the `use3DSecure` mock in tests to return the full hook interface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 3D Secure authentication flow to the payment popup; when 3DS is active the main payment UI is hidden and a dedicated 3DS dialog appears with success/error handling.
  * Payment intents now explicitly include additional payment method types (e.g., card and link).

* **Behavioral Change**
  * Updated 3DS confirmation to support conditional redirects and an explicit return URL during authentication.

* **Tests**
  * Added rendering tests verifying 3DS dialog visibility and that the main payment popup is hidden during 3DS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->