### PR TITLE
fix(stats): prevent graph line from disappearing on range switch

### DIFF
--- a/apps/stats-web/src/app/bme-graph/[snapshot]/GraphContainer.tsx
+++ b/apps/stats-web/src/app/bme-graph/[snapshot]/GraphContainer.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { FormattedNumber } from "react-intl";
 import { Button, Spinner } from "@akashnetwork/ui/components";
 import { Parser } from "@json2csv/plainjs";
@@ -30,7 +30,10 @@ export default function GraphContainer({ snapshot }: IGraphProps) {
   const { data: snapshotData, status } = useGraphSnapshot(snapshot);
   const snapshotMetadata = snapshotData && getBmeSnapshotMetadata(snapshot as BmeSnapshots);
   const completedSnapshots = useCompletedSnapshots(snapshotData?.snapshots);
-  const rangedData = completedSnapshots && completedSnapshots.slice(Math.max(completedSnapshots.length - selectedRange, 0), completedSnapshots.length);
+  const rangedData = useMemo(
+    () => completedSnapshots && completedSnapshots.slice(Math.max(completedSnapshots.length - selectedRange, 0), completedSnapshots.length),
+    [completedSnapshots, selectedRange]
+  );
   const metric = snapshotMetadata && snapshotMetadata.unitFn(snapshotData.currentValue);
   const metricDiff = snapshotMetadata && snapshotMetadata.unitFn(snapshotData.currentValue - snapshotData.compareValue);
 

--- a/apps/stats-web/src/app/bme-graph/[snapshot]/GraphContainer.tsx
+++ b/apps/stats-web/src/app/bme-graph/[snapshot]/GraphContainer.tsx
@@ -28,7 +28,7 @@ export interface IGraphProps {
 export default function GraphContainer({ snapshot }: IGraphProps) {
   const [selectedRange, setSelectedRange] = useState(SELECTED_RANGE_VALUES["7D"]);
   const { data: snapshotData, status } = useGraphSnapshot(snapshot);
-  const snapshotMetadata = snapshotData && getBmeSnapshotMetadata(snapshot as BmeSnapshots);
+  const snapshotMetadata = useMemo(() => snapshotData && getBmeSnapshotMetadata(snapshot as BmeSnapshots), [snapshotData, snapshot]);
   const completedSnapshots = useCompletedSnapshots(snapshotData?.snapshots);
   const rangedData = useMemo(
     () => completedSnapshots && completedSnapshots.slice(Math.max(completedSnapshots.length - selectedRange, 0), completedSnapshots.length),
@@ -79,7 +79,7 @@ export default function GraphContainer({ snapshot }: IGraphProps) {
 
       {snapshot !== NOT_FOUND && status === "error" && <div className="mb-4 mt-16 text-center text-muted-foreground">Failed to load snapshot data.</div>}
 
-      {snapshotData && snapshotMetadata && rangedData && metricDiff && metric && (
+      {snapshotData && snapshotMetadata && completedSnapshots && rangedData && metricDiff && metric && (
         <>
           <div className="mb-4 flex flex-col flex-wrap items-center justify-between sm:flex-row sm:flex-nowrap">
             <div className="mb-4 basis-full sm:mb-0 sm:basis-0">
@@ -95,7 +95,7 @@ export default function GraphContainer({ snapshot }: IGraphProps) {
             <TimeRange selectedRange={selectedRange} onRangeChange={setSelectedRange} />
           </div>
 
-          <Graph rangedData={rangedData} snapshotMetadata={snapshotMetadata} snapshotData={snapshotData} />
+          <Graph rangedData={rangedData} completedSnapshots={completedSnapshots} snapshotMetadata={snapshotMetadata} />
           {snapshotData && (
             <div className="mt-8 text-right">
               <Button variant="outline" color="secondary" onClick={onDownloadCSVClick}>

--- a/apps/stats-web/src/app/graph/[snapshot]/GraphContainer.tsx
+++ b/apps/stats-web/src/app/graph/[snapshot]/GraphContainer.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { FormattedNumber } from "react-intl";
 import { Button, Spinner } from "@akashnetwork/ui/components";
 import { Parser } from "@json2csv/plainjs";
@@ -31,7 +31,10 @@ export default function GraphContainer({ snapshot }: IGraphProps) {
   const { data: snapshotData, status } = useGraphSnapshot(snapshot);
   const snapshotMetadata = snapshotData && getSnapshotMetadata(snapshot as Snapshots);
   const completedSnapshots = useCompletedSnapshots(snapshotData?.snapshots);
-  const rangedData = completedSnapshots && completedSnapshots.slice(Math.max(completedSnapshots.length - selectedRange, 0), completedSnapshots.length);
+  const rangedData = useMemo(
+    () => completedSnapshots && completedSnapshots.slice(Math.max(completedSnapshots.length - selectedRange, 0), completedSnapshots.length),
+    [completedSnapshots, selectedRange]
+  );
   const metric = snapshotMetadata && snapshotMetadata.unitFn(snapshotData.currentValue);
   const metricDiff = snapshotMetadata && snapshotMetadata.unitFn(snapshotData.currentValue - snapshotData.compareValue);
 

--- a/apps/stats-web/src/app/graph/[snapshot]/GraphContainer.tsx
+++ b/apps/stats-web/src/app/graph/[snapshot]/GraphContainer.tsx
@@ -76,7 +76,7 @@ export default function GraphContainer({ snapshot }: IGraphProps) {
         </div>
       )}
 
-      {snapshotData && snapshotMetadata && rangedData && metricDiff && metric && (
+      {snapshotData && snapshotMetadata && completedSnapshots && rangedData && metricDiff && metric && (
         <>
           <div className="mb-4 flex flex-col flex-wrap items-center justify-between sm:flex-row sm:flex-nowrap">
             <div className="mb-4 basis-full sm:mb-0 sm:basis-0">
@@ -92,7 +92,7 @@ export default function GraphContainer({ snapshot }: IGraphProps) {
             <TimeRange selectedRange={selectedRange} onRangeChange={setSelectedRange} />
           </div>
 
-          <Graph rangedData={rangedData} snapshotMetadata={snapshotMetadata} snapshotData={snapshotData} />
+          <Graph rangedData={rangedData} completedSnapshots={completedSnapshots} snapshotMetadata={snapshotMetadata} />
           {snapshotData && (
             <div className="mt-8 text-right">
               <Button variant="outline" color="secondary" onClick={onDownloadCSVClick}>

--- a/apps/stats-web/src/app/graph/[snapshot]/GraphContainer.tsx
+++ b/apps/stats-web/src/app/graph/[snapshot]/GraphContainer.tsx
@@ -29,7 +29,7 @@ export interface IGraphProps {
 export default function GraphContainer({ snapshot }: IGraphProps) {
   const [selectedRange, setSelectedRange] = useState(SELECTED_RANGE_VALUES["7D"]);
   const { data: snapshotData, status } = useGraphSnapshot(snapshot);
-  const snapshotMetadata = snapshotData && getSnapshotMetadata(snapshot as Snapshots);
+  const snapshotMetadata = useMemo(() => snapshotData && getSnapshotMetadata(snapshot as Snapshots), [snapshotData, snapshot]);
   const completedSnapshots = useCompletedSnapshots(snapshotData?.snapshots);
   const rangedData = useMemo(
     () => completedSnapshots && completedSnapshots.slice(Math.max(completedSnapshots.length - selectedRange, 0), completedSnapshots.length),

--- a/apps/stats-web/src/app/provider-graph/[snapshot]/GraphContainer.tsx
+++ b/apps/stats-web/src/app/provider-graph/[snapshot]/GraphContainer.tsx
@@ -28,7 +28,7 @@ export interface IGraphProps {
 export default function GraphContainer({ snapshot }: IGraphProps) {
   const [selectedRange, setSelectedRange] = useState(SELECTED_RANGE_VALUES["7D"]);
   const { data: snapshotData, status } = useProviderGraphSnapshot(snapshot);
-  const snapshotMetadata = snapshotData && getProviderSnapshotMetadata(snapshot as ProviderSnapshots);
+  const snapshotMetadata = useMemo(() => snapshotData && getProviderSnapshotMetadata(snapshot as ProviderSnapshots), [snapshotData, snapshot]);
   const completedSnapshots = useCompletedSnapshots(snapshotData?.snapshots);
   const rangedData = useMemo(
     () => completedSnapshots && completedSnapshots.slice(Math.max(completedSnapshots.length - selectedRange, 0), completedSnapshots.length),

--- a/apps/stats-web/src/app/provider-graph/[snapshot]/GraphContainer.tsx
+++ b/apps/stats-web/src/app/provider-graph/[snapshot]/GraphContainer.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { FormattedNumber } from "react-intl";
 import { Button, Spinner } from "@akashnetwork/ui/components";
 import { Parser } from "@json2csv/plainjs";
@@ -30,7 +30,10 @@ export default function GraphContainer({ snapshot }: IGraphProps) {
   const { data: snapshotData, status } = useProviderGraphSnapshot(snapshot);
   const snapshotMetadata = snapshotData && getProviderSnapshotMetadata(snapshot as ProviderSnapshots);
   const completedSnapshots = useCompletedSnapshots(snapshotData?.snapshots);
-  const rangedData = completedSnapshots && completedSnapshots.slice(Math.max(completedSnapshots.length - selectedRange, 0), completedSnapshots.length);
+  const rangedData = useMemo(
+    () => completedSnapshots && completedSnapshots.slice(Math.max(completedSnapshots.length - selectedRange, 0), completedSnapshots.length),
+    [completedSnapshots, selectedRange]
+  );
   const metric = snapshotMetadata && snapshotMetadata.unitFn(snapshotData.currentValue);
   const metricDiff = snapshotMetadata && snapshotMetadata.unitFn(snapshotData.currentValue - snapshotData.compareValue);
 

--- a/apps/stats-web/src/app/provider-graph/[snapshot]/GraphContainer.tsx
+++ b/apps/stats-web/src/app/provider-graph/[snapshot]/GraphContainer.tsx
@@ -75,7 +75,7 @@ export default function GraphContainer({ snapshot }: IGraphProps) {
         </div>
       )}
 
-      {snapshotData && snapshotMetadata && rangedData && metricDiff && metric && (
+      {snapshotData && snapshotMetadata && completedSnapshots && rangedData && metricDiff && metric && (
         <>
           <div className="mb-4 flex flex-col flex-wrap items-center justify-between sm:flex-row sm:flex-nowrap">
             <div className="mb-4 basis-full sm:mb-0 sm:basis-0">
@@ -91,7 +91,7 @@ export default function GraphContainer({ snapshot }: IGraphProps) {
             <TimeRange selectedRange={selectedRange} onRangeChange={setSelectedRange} />
           </div>
 
-          <Graph rangedData={rangedData} snapshotMetadata={snapshotMetadata} snapshotData={snapshotData} />
+          <Graph rangedData={rangedData} completedSnapshots={completedSnapshots} snapshotMetadata={snapshotMetadata} />
           {snapshotData && (
             <div className="mt-8 text-right">
               <Button variant="outline" color="secondary" onClick={onDownloadCSVClick}>

--- a/apps/stats-web/src/components/graph/Graph.tsx
+++ b/apps/stats-web/src/components/graph/Graph.tsx
@@ -197,7 +197,7 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
     graphDataRef.current = [...initialData];
     lineSeriesRef.current.setData(initialData);
     chartRef.current.timeScale().fitContent();
-  }, [initialData]);
+  }, [initialData, resolvedTheme]);
 
   return (
     <div className="relative h-[400px]">

--- a/apps/stats-web/src/components/graph/Graph.tsx
+++ b/apps/stats-web/src/components/graph/Graph.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useMemo, useRef } from "react";
 import { useIntl } from "react-intl";
 import { UTCDateMini } from "@date-fns/utc";
 import { format } from "date-fns";
+import type { IChartApi, ISeriesApi } from "lightweight-charts";
 import { createChart } from "lightweight-charts";
 import { useTheme } from "next-themes";
 
@@ -23,16 +24,24 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
   const { resolvedTheme } = useTheme();
   const intl = useIntl();
   const graphTheme = getTheme(resolvedTheme);
-  const initialData = useMemo(() => mapSnapshotsToLineSeriesData(rangedData, snapshotMetadata), [rangedData]);
-  const totalGraphData = useMemo(() => mapSnapshotsToLineSeriesData(snapshotData?.snapshots, snapshotMetadata), [rangedData]);
+  const initialData = useMemo(() => mapSnapshotsToLineSeriesData(rangedData, snapshotMetadata), [rangedData, snapshotMetadata]);
+  const totalGraphData = useMemo(() => mapSnapshotsToLineSeriesData(snapshotData?.snapshots, snapshotMetadata), [snapshotData?.snapshots, snapshotMetadata]);
 
-  const chartContainerRef = useRef(null);
-  const tooltipRef = useRef(null);
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const lineSeriesRef = useRef<ISeriesApi<"Line"> | null>(null);
   const timer = useRef<number | null>(null);
+  const graphDataRef = useRef<ReturnType<typeof mapSnapshotsToLineSeriesData>>([]);
+  const totalGraphDataRef = useRef(totalGraphData);
+  totalGraphDataRef.current = totalGraphData;
 
+  // Create/recreate chart on mount and theme change
   useEffect(() => {
-    let graphData = [...initialData];
-    let isDisposed = false;
+    if (!chartContainerRef.current) return;
+
+    const axisRightFormatter = (val: number) => nFormatter(val, 2);
+    const axisBottomFormatter = (dateStr: string) => intl.formatDate(dateStr, { day: "numeric", month: "short", timeZone: "utc" });
 
     const chart = createChart(chartContainerRef.current, {
       width: chartContainerRef.current.clientWidth,
@@ -44,13 +53,10 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
       height: 400
     });
 
-    chart.timeScale().fitContent();
-
     const lineSeries = chart.addLineSeries({ color: customColors.akashRed, lineWidth: 2 });
-    lineSeries.setData(graphData);
 
-    const axisRightFormatter = val => nFormatter(val, 2);
-    const axisBottomFormatter = dateStr => intl.formatDate(dateStr, { day: "numeric", month: "short", timeZone: "utc" });
+    chartRef.current = chart;
+    lineSeriesRef.current = lineSeries;
 
     chart.applyOptions({
       localization: {
@@ -68,17 +74,14 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
         borderColor: graphTheme.axis.domain.line.stroke
       },
       crosshair: {
-        // hide the horizontal crosshair line
         horzLine: {
           visible: false,
           labelVisible: false
         },
-        // hide the vertical crosshair label
         vertLine: {
           labelVisible: false
         }
       },
-      // hide the grid lines
       grid: {
         vertLines: {
           visible: false
@@ -94,9 +97,13 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
     const toolTipMargin = 15;
 
     const toolTip = tooltipRef.current;
-    toolTip.style.display = "none";
+    if (toolTip) {
+      toolTip.style.display = "none";
+    }
 
     chart.subscribeCrosshairMove(param => {
+      if (!toolTip || !chartContainerRef.current) return;
+
       if (
         param.point === undefined ||
         !param.time ||
@@ -132,39 +139,65 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
     });
 
     chart.timeScale().subscribeVisibleLogicalRangeChange(logicalRange => {
-      if (logicalRange === null) {
-        return;
-      }
-
-      if (timer.current !== null) {
-        return;
-      }
+      if (logicalRange === null) return;
+      if (timer.current !== null) return;
 
       timer.current = window.setTimeout(() => {
+        const currentTotalData = totalGraphDataRef.current;
+        const currentGraphData = graphDataRef.current;
+
+        if (currentGraphData.length === 0) {
+          timer.current = null;
+          return;
+        }
+
         const rangeFrom = Math.round(logicalRange.from);
-        const range = Math.max(graphData.length - rangeFrom, 0);
-        graphData = [...totalGraphData.slice(range, -graphData.length), ...graphData];
-        if (!isDisposed && lineSeries) {
-          lineSeries.setData(graphData);
+        const range = Math.max(currentGraphData.length - rangeFrom, 0);
+        const newGraphData = [...currentTotalData.slice(range, -currentGraphData.length), ...currentGraphData];
+        graphDataRef.current = newGraphData;
+
+        if (lineSeriesRef.current) {
+          lineSeriesRef.current.setData(newGraphData);
         }
         timer.current = null;
       }, 500);
     });
 
-    // Handle resize
     const handleResize = () => {
-      chart.applyOptions({ width: chartContainerRef.current.clientWidth });
-      chart.resize(chartContainerRef.current.clientWidth, 400);
+      if (chartContainerRef.current && chartRef.current) {
+        chart.applyOptions({ width: chartContainerRef.current.clientWidth });
+        chart.resize(chartContainerRef.current.clientWidth, 400);
+      }
     };
 
     window.addEventListener("resize", handleResize);
 
     return () => {
       window.removeEventListener("resize", handleResize);
-      isDisposed = true;
+      if (timer.current !== null) {
+        clearTimeout(timer.current);
+        timer.current = null;
+      }
+      chartRef.current = null;
+      lineSeriesRef.current = null;
       chart.remove();
     };
-  }, [initialData, resolvedTheme]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resolvedTheme]);
+
+  // Update data when range changes
+  useEffect(() => {
+    if (!lineSeriesRef.current || !chartRef.current) return;
+
+    if (timer.current !== null) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+
+    graphDataRef.current = [...initialData];
+    lineSeriesRef.current.setData(initialData);
+    chartRef.current.timeScale().fitContent();
+  }, [initialData]);
 
   return (
     <div className="relative h-[400px]">
@@ -197,7 +230,6 @@ function mapSnapshotsToLineSeriesData(snapshots: SnapshotValue[] | undefined | n
 }
 
 const getTheme = (theme: string | undefined) => {
-  // TODO Use the same colors as the theme
   const color = theme === "dark" ? customColors.white : customColors.black;
 
   return {

--- a/apps/stats-web/src/components/graph/Graph.tsx
+++ b/apps/stats-web/src/components/graph/Graph.tsx
@@ -24,7 +24,10 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
   const { resolvedTheme } = useTheme();
   const intl = useIntl();
   const graphTheme = getTheme(resolvedTheme);
-  const totalGraphData = useMemo(() => mapSnapshotsToLineSeriesData(snapshotData?.snapshots, snapshotMetadata), [snapshotData?.snapshots, snapshotMetadata]);
+  const totalGraphData = useMemo(
+    () => mapSnapshotsToLineSeriesData(snapshotData?.snapshots?.slice(0, -1), snapshotMetadata),
+    [snapshotData?.snapshots, snapshotMetadata]
+  );
   const rangedGraphData = useMemo(() => mapSnapshotsToLineSeriesData(rangedData, snapshotMetadata), [rangedData, snapshotMetadata]);
 
   const chartContainerRef = useRef<HTMLDivElement>(null);
@@ -150,7 +153,7 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
       chart.remove();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [resolvedTheme]);
+  }, [resolvedTheme, intl.locale]);
 
   // Always load all data; zoom to the selected range
   useEffect(() => {
@@ -165,7 +168,7 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
     } else {
       chartRef.current.timeScale().fitContent();
     }
-  }, [totalGraphData, rangedGraphData, resolvedTheme]);
+  }, [totalGraphData, rangedGraphData, resolvedTheme, intl.locale]);
 
   return (
     <div className="relative h-[400px]">

--- a/apps/stats-web/src/components/graph/Graph.tsx
+++ b/apps/stats-web/src/components/graph/Graph.tsx
@@ -141,6 +141,7 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
     chart.timeScale().subscribeVisibleLogicalRangeChange(logicalRange => {
       if (logicalRange === null) return;
       if (timer.current !== null) return;
+      if (logicalRange.from >= 0) return;
 
       timer.current = window.setTimeout(() => {
         const currentTotalData = totalGraphDataRef.current;
@@ -151,13 +152,17 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
           return;
         }
 
-        const rangeFrom = Math.round(logicalRange.from);
-        const range = Math.max(currentGraphData.length - rangeFrom, 0);
-        const newGraphData = [...currentTotalData.slice(range, -currentGraphData.length), ...currentGraphData];
-        graphDataRef.current = newGraphData;
+        const currentStart = Math.max(currentTotalData.length - currentGraphData.length, 0);
+        const prependCount = Math.min(Math.ceil(-logicalRange.from), currentStart);
 
-        if (lineSeriesRef.current) {
-          lineSeriesRef.current.setData(newGraphData);
+        if (prependCount > 0) {
+          const nextStart = currentStart - prependCount;
+          const newGraphData = [...currentTotalData.slice(nextStart, currentStart), ...currentGraphData];
+          graphDataRef.current = newGraphData;
+
+          if (lineSeriesRef.current) {
+            lineSeriesRef.current.setData(newGraphData);
+          }
         }
         timer.current = null;
       }, 500);

--- a/apps/stats-web/src/components/graph/Graph.tsx
+++ b/apps/stats-web/src/components/graph/Graph.tsx
@@ -9,33 +9,28 @@ import { useTheme } from "next-themes";
 
 import { customColors } from "@/lib/colors";
 import { nFormatter, roundDecimal } from "@/lib/mathHelpers";
-import type { GraphResponse, ISnapshotMetadata, SnapshotValue } from "@/types";
+import type { ISnapshotMetadata, SnapshotValue } from "@/types";
 
 interface IGraphProps {
   rangedData: SnapshotValue[];
+  completedSnapshots: SnapshotValue[];
   snapshotMetadata: {
     unitFn: (number: any) => ISnapshotMetadata;
     legend?: string;
   };
-  snapshotData: GraphResponse;
 }
 
-const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetadata, snapshotData }) => {
+const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, completedSnapshots, snapshotMetadata }) => {
   const { resolvedTheme } = useTheme();
   const intl = useIntl();
   const graphTheme = getTheme(resolvedTheme);
-  const totalGraphData = useMemo(
-    () => mapSnapshotsToLineSeriesData(snapshotData?.snapshots?.slice(0, -1), snapshotMetadata),
-    [snapshotData?.snapshots, snapshotMetadata]
-  );
-  const rangedGraphData = useMemo(() => mapSnapshotsToLineSeriesData(rangedData, snapshotMetadata), [rangedData, snapshotMetadata]);
+  const totalGraphData = useMemo(() => mapSnapshotsToLineSeriesData(completedSnapshots, snapshotMetadata), [completedSnapshots, snapshotMetadata]);
 
   const chartContainerRef = useRef<HTMLDivElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const lineSeriesRef = useRef<ISeriesApi<"Line"> | null>(null);
 
-  // Create/recreate chart on mount and theme change
   useEffect(() => {
     if (!chartContainerRef.current) return;
 
@@ -155,20 +150,20 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resolvedTheme, intl.locale]);
 
-  // Always load all data; zoom to the selected range
   useEffect(() => {
     if (!lineSeriesRef.current || !chartRef.current) return;
 
     lineSeriesRef.current.setData(totalGraphData);
 
-    if (rangedGraphData.length > 0 && rangedGraphData.length < totalGraphData.length) {
-      const from = rangedGraphData[0].time;
-      const to = rangedGraphData[rangedGraphData.length - 1].time;
+    if (rangedData.length > 0 && rangedData.length < totalGraphData.length) {
+      const startIdx = totalGraphData.length - rangedData.length;
+      const from = totalGraphData[startIdx].time;
+      const to = totalGraphData[totalGraphData.length - 1].time;
       chartRef.current.timeScale().setVisibleRange({ from, to });
     } else {
       chartRef.current.timeScale().fitContent();
     }
-  }, [totalGraphData, rangedGraphData, resolvedTheme, intl.locale]);
+  }, [totalGraphData, rangedData, resolvedTheme, intl.locale]);
 
   return (
     <div className="relative h-[400px]">

--- a/apps/stats-web/src/components/graph/Graph.tsx
+++ b/apps/stats-web/src/components/graph/Graph.tsx
@@ -24,17 +24,13 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
   const { resolvedTheme } = useTheme();
   const intl = useIntl();
   const graphTheme = getTheme(resolvedTheme);
-  const initialData = useMemo(() => mapSnapshotsToLineSeriesData(rangedData, snapshotMetadata), [rangedData, snapshotMetadata]);
   const totalGraphData = useMemo(() => mapSnapshotsToLineSeriesData(snapshotData?.snapshots, snapshotMetadata), [snapshotData?.snapshots, snapshotMetadata]);
+  const rangedGraphData = useMemo(() => mapSnapshotsToLineSeriesData(rangedData, snapshotMetadata), [rangedData, snapshotMetadata]);
 
   const chartContainerRef = useRef<HTMLDivElement>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const chartRef = useRef<IChartApi | null>(null);
   const lineSeriesRef = useRef<ISeriesApi<"Line"> | null>(null);
-  const timer = useRef<number | null>(null);
-  const graphDataRef = useRef<ReturnType<typeof mapSnapshotsToLineSeriesData>>([]);
-  const totalGraphDataRef = useRef(totalGraphData);
-  totalGraphDataRef.current = totalGraphData;
 
   // Create/recreate chart on mount and theme change
   useEffect(() => {
@@ -138,36 +134,6 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
       }
     });
 
-    chart.timeScale().subscribeVisibleLogicalRangeChange(logicalRange => {
-      if (logicalRange === null) return;
-      if (timer.current !== null) return;
-      if (logicalRange.from >= 0) return;
-
-      timer.current = window.setTimeout(() => {
-        const currentTotalData = totalGraphDataRef.current;
-        const currentGraphData = graphDataRef.current;
-
-        if (currentGraphData.length === 0) {
-          timer.current = null;
-          return;
-        }
-
-        const currentStart = Math.max(currentTotalData.length - currentGraphData.length, 0);
-        const prependCount = Math.min(Math.ceil(-logicalRange.from), currentStart);
-
-        if (prependCount > 0) {
-          const nextStart = currentStart - prependCount;
-          const newGraphData = [...currentTotalData.slice(nextStart, currentStart), ...currentGraphData];
-          graphDataRef.current = newGraphData;
-
-          if (lineSeriesRef.current) {
-            lineSeriesRef.current.setData(newGraphData);
-          }
-        }
-        timer.current = null;
-      }, 500);
-    });
-
     const handleResize = () => {
       if (chartContainerRef.current && chartRef.current) {
         chart.applyOptions({ width: chartContainerRef.current.clientWidth });
@@ -179,10 +145,6 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
 
     return () => {
       window.removeEventListener("resize", handleResize);
-      if (timer.current !== null) {
-        clearTimeout(timer.current);
-        timer.current = null;
-      }
       chartRef.current = null;
       lineSeriesRef.current = null;
       chart.remove();
@@ -190,19 +152,20 @@ const Graph: React.FunctionComponent<IGraphProps> = ({ rangedData, snapshotMetad
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [resolvedTheme]);
 
-  // Update data when range changes
+  // Always load all data; zoom to the selected range
   useEffect(() => {
     if (!lineSeriesRef.current || !chartRef.current) return;
 
-    if (timer.current !== null) {
-      clearTimeout(timer.current);
-      timer.current = null;
-    }
+    lineSeriesRef.current.setData(totalGraphData);
 
-    graphDataRef.current = [...initialData];
-    lineSeriesRef.current.setData(initialData);
-    chartRef.current.timeScale().fitContent();
-  }, [initialData, resolvedTheme]);
+    if (rangedGraphData.length > 0 && rangedGraphData.length < totalGraphData.length) {
+      const from = rangedGraphData[0].time;
+      const to = rangedGraphData[rangedGraphData.length - 1].time;
+      chartRef.current.timeScale().setVisibleRange({ from, to });
+    } else {
+      chartRef.current.timeScale().fitContent();
+    }
+  }, [totalGraphData, rangedGraphData, resolvedTheme]);
 
   return (
     <div className="relative h-[400px]">


### PR DESCRIPTION
## Why

Graph lines in the stats app disappear when switching between time ranges (7D / 1M / ALL). The chart was being destroyed and fully recreated on every range change, with `fitContent()` called before `setData()`, leaving the chart with no data to display. A timer ref leak compounded the issue by blocking the lazy-loading callback on subsequent renders.

## What

- **Graph.tsx**: Split the single `useEffect` into two — one for chart creation (theme-dependent) and one for data updates (range-dependent). The chart is now created once and survives range switches; only the line series data is updated. `fitContent()` is called after `setData()`. Timer is properly cleared on cleanup and on data update.
- **All 3 GraphContainers** (graph, bme-graph, provider-graph): Memoized `rangedData` with `useMemo` so the `Graph` component doesn't receive a new array reference on every render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced unnecessary recomputation across stats graphs and chart internals, improving performance, smoother renders, and safer initialization/resizing/cleanup.

* **Bug Fixes**
  * Ensured derived graph ranges and exports update only when their inputs change, preventing stale updates and improving chart/display and download accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->