### PR TITLE
refactor(dx): replace axios with native fetch in http-sdk

### DIFF
--- a/packages/http-sdk/package.json
+++ b/packages/http-sdk/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@akashnetwork/logging": "*",
-    "axios": "^1.7.2",
     "cockatiel": "^3.2.1",
     "date-fns": "^4.1.0",
     "lodash": "^4.17.21",

--- a/packages/http-sdk/src/api-http/api-http.service.ts
+++ b/packages/http-sdk/src/api-http/api-http.service.ts
@@ -1,29 +1,31 @@
-import type { AxiosRequestConfig, AxiosResponse } from "axios";
-
 import { HttpService } from "../http/http.service";
+import type { HttpRequestConfig, HttpResponse } from "../http/http.types";
 
 export interface ApiOutput<T> {
   data: T;
 }
 
 export class ApiHttpService extends HttpService {
-  constructor(config?: AxiosRequestConfig) {
+  constructor(config?: Pick<HttpRequestConfig, "baseURL" | "headers" | "timeout">) {
     super(config);
   }
 
-  post<T = any, R = AxiosResponse<ApiOutput<T>>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R> {
-    return super.post(url, data, config);
+  // @ts-expect-error - Narrowing response type for API services that wrap responses in ApiOutput<T>
+  post<T = any>(url: string, data?: unknown, config?: HttpRequestConfig): Promise<HttpResponse<ApiOutput<T>>> {
+    return super.post(url, data, config) as Promise<HttpResponse<ApiOutput<T>>>;
   }
 
-  patch<T = any, R = AxiosResponse<ApiOutput<T>>, D = any>(url: string, data?: D, config?: AxiosRequestConfig<D>): Promise<R> {
-    return super.patch(url, data, config);
+  // @ts-expect-error - Narrowing response type for API services that wrap responses in ApiOutput<T>
+  patch<T = any>(url: string, data?: unknown, config?: HttpRequestConfig): Promise<HttpResponse<ApiOutput<T>>> {
+    return super.patch(url, data, config) as Promise<HttpResponse<ApiOutput<T>>>;
   }
 
-  get<T = any, R = AxiosResponse<ApiOutput<T>>, D = any>(url: string, config?: AxiosRequestConfig<D>): Promise<R> {
-    return super.get(url, config);
+  // @ts-expect-error - Narrowing response type for API services that wrap responses in ApiOutput<T>
+  get<T = any>(url: string, config?: HttpRequestConfig): Promise<HttpResponse<ApiOutput<T>>> {
+    return super.get(url, config) as Promise<HttpResponse<ApiOutput<T>>>;
   }
 
-  protected extractApiData<T = unknown>(response: AxiosResponse<ApiOutput<T>>): ApiOutput<T>["data"] {
+  protected extractApiData<T = unknown>(response: HttpResponse<ApiOutput<T>>): ApiOutput<T>["data"] {
     return this.extractData(response).data;
   }
 }

--- a/packages/http-sdk/src/auth/auth-http.service.ts
+++ b/packages/http-sdk/src/auth/auth-http.service.ts
@@ -1,10 +1,9 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { HttpService } from "../http/http.service";
+import type { HttpRequestConfig } from "../http/http.types";
 import type { VerifyEmailResponse } from "./auth-http.types";
 
 export class AuthHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
+  constructor(config?: Pick<HttpRequestConfig, "baseURL">) {
     super(config);
   }
 

--- a/packages/http-sdk/src/balance/balance-http.service.ts
+++ b/packages/http-sdk/src/balance/balance-http.service.ts
@@ -1,6 +1,5 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { HttpService } from "../http/http.service";
+import type { HttpRequestConfig } from "../http/http.types";
 import type { Denom } from "../types/denom.type";
 
 export interface RawBalance {
@@ -18,7 +17,7 @@ interface BalanceResponse {
 }
 
 export class BalanceHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
+  constructor(config?: Pick<HttpRequestConfig, "baseURL">) {
     super(config);
   }
 

--- a/packages/http-sdk/src/bid/bid-http.service.ts
+++ b/packages/http-sdk/src/bid/bid-http.service.ts
@@ -1,6 +1,5 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { HttpService } from "../http/http.service";
+import type { HttpRequestConfig } from "../http/http.types";
 
 type Attribute = {
   key: string;
@@ -100,7 +99,7 @@ type RestAkashBidListResponse = {
 };
 
 export class BidHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
+  constructor(config?: Pick<HttpRequestConfig, "baseURL">) {
     super(config);
   }
 

--- a/packages/http-sdk/src/certificates/certificates.service.ts
+++ b/packages/http-sdk/src/certificates/certificates.service.ts
@@ -1,5 +1,4 @@
-import type { AxiosInstance } from "axios";
-
+import type { HttpClient } from "../utils/httpClient";
 import { getAllItems } from "../utils/pagination.utils";
 
 export type RestApiCertificatesResponseType = {
@@ -20,7 +19,7 @@ export type RestApiCertificate = {
 };
 
 export class CertificatesService {
-  constructor(private readonly axios: AxiosInstance) {}
+  constructor(private readonly httpClient: HttpClient) {}
 
   async getCertificates(params: GetCertificatesParams): Promise<RestApiCertificatesResponseType> {
     const queryParams: Record<string, string | number> = {
@@ -32,7 +31,7 @@ export class CertificatesService {
     if (params["pagination.key"]) queryParams["pagination.key"] = params["pagination.key"];
     if (params["pagination.count_total"]) queryParams["pagination.count_total"] = params["pagination.count_total"];
 
-    const response = await this.axios.get<RestApiCertificatesResponseType>("/akash/cert/v1/certificates/list", { params: queryParams });
+    const response = await this.httpClient.get<RestApiCertificatesResponseType>("/akash/cert/v1/certificates/list", { params: queryParams });
     return response.data;
   }
 

--- a/packages/http-sdk/src/deployment-setting/deployment-setting-http.service.ts
+++ b/packages/http-sdk/src/deployment-setting/deployment-setting-http.service.ts
@@ -1,6 +1,5 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { ApiHttpService } from "../api-http/api-http.service";
+import type { HttpRequestConfig } from "../http/http.types";
 
 export interface DeploymentSettingOutput {
   id: number;
@@ -34,7 +33,7 @@ export interface FindDeploymentSettingParams {
 }
 
 export class DeploymentSettingHttpService extends ApiHttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
+  constructor(config?: Pick<HttpRequestConfig, "baseURL">) {
     super(config);
   }
 

--- a/packages/http-sdk/src/git-hub/git-hub-http.service.ts
+++ b/packages/http-sdk/src/git-hub/git-hub-http.service.ts
@@ -1,6 +1,5 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { HttpService } from "../http/http.service";
+import type { HttpRequestConfig } from "../http/http.types";
 
 type ProviderAttributeSchemaDetailValue = { key: string; description: string; value?: string };
 
@@ -47,7 +46,7 @@ export class GitHubHttpService extends HttpService {
   private readonly repository = "console";
   private readonly branch = "main";
 
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
+  constructor(config?: Pick<HttpRequestConfig, "baseURL">) {
     super(config);
   }
 

--- a/packages/http-sdk/src/http/execute-fetch.ts
+++ b/packages/http-sdk/src/http/execute-fetch.ts
@@ -1,0 +1,77 @@
+import type { HttpAdapter, HttpResponse } from "./http.types";
+import { HttpError } from "./http-error";
+
+export const executeFetch: HttpAdapter = async config => {
+  let signal = config.signal;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let timeoutController: AbortController | undefined;
+
+  if (config.timeout) {
+    timeoutController = new AbortController();
+    timeoutId = setTimeout(() => timeoutController!.abort(), config.timeout);
+    signal = config.signal ? AbortSignal.any([config.signal, timeoutController.signal]) : timeoutController.signal;
+  }
+
+  try {
+    let body: BodyInit | undefined;
+    if (config.data !== undefined && config.method !== "GET" && config.method !== "HEAD") {
+      body = typeof config.data === "string" ? config.data : JSON.stringify(config.data);
+    }
+
+    const response = await fetch(config.url, {
+      method: config.method,
+      headers: config.headers,
+      body,
+      signal,
+      credentials: config.withCredentials ? "include" : undefined
+    });
+
+    const data = await parseResponseBody(response, config.responseType);
+    const headers = parseResponseHeaders(response.headers);
+
+    const httpResponse: HttpResponse = { data, status: response.status, statusText: response.statusText, headers, config };
+
+    const validate = config.validateStatus ?? (s => s >= 200 && s < 300);
+    if (!validate(response.status)) {
+      throw new HttpError(`Request failed with status code ${response.status}`, String(response.status), config, httpResponse);
+    }
+
+    return httpResponse;
+  } catch (error) {
+    if (error instanceof HttpError) throw error;
+
+    let code = "ERR_NETWORK";
+    if (error instanceof DOMException && error.name === "AbortError") {
+      code = timeoutController?.signal.aborted ? "ECONNABORTED" : "ERR_CANCELED";
+    } else if (error instanceof Error && "code" in error && typeof error.code === "string") {
+      code = error.code;
+    }
+
+    throw new HttpError(error instanceof Error ? error.message : "Network Error", code, config);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+};
+
+async function parseResponseBody(response: Response, responseType?: string): Promise<unknown> {
+  if (responseType === "blob") return response.blob();
+  if (responseType === "text") return response.text();
+  if (responseType === "arraybuffer") return response.arrayBuffer();
+
+  const text = await response.text();
+  if (!text) return undefined;
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function parseResponseHeaders(headers: Headers): Record<string, string> {
+  const result: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    result[key] = value;
+  });
+  return result;
+}

--- a/packages/http-sdk/src/http/http-error.ts
+++ b/packages/http-sdk/src/http/http-error.ts
@@ -1,0 +1,17 @@
+import type { HttpRequestConfig, HttpResponse } from "./http.types";
+
+export class HttpError<T = unknown> extends Error {
+  readonly response?: HttpResponse<T>;
+  readonly config?: HttpRequestConfig;
+  readonly code?: string;
+  readonly status?: number;
+
+  constructor(message: string, code?: string, config?: HttpRequestConfig, response?: HttpResponse<T>) {
+    super(message);
+    this.name = "HttpError";
+    this.code = code;
+    this.config = config;
+    this.response = response;
+    this.status = response?.status;
+  }
+}

--- a/packages/http-sdk/src/http/http.service.ts
+++ b/packages/http-sdk/src/http/http.service.ts
@@ -1,19 +1,88 @@
-import axios, { Axios, type AxiosRequestConfig, type AxiosResponse } from "axios";
+import { executeFetch } from "./execute-fetch";
+import type { HttpRequestConfig, HttpResponse } from "./http.types";
 
-export class HttpService extends Axios {
-  constructor(config?: AxiosRequestConfig) {
-    const { headers, ...defaults } = axios.defaults;
-    super({
-      ...defaults,
-      ...config
-    });
+export class HttpService {
+  private readonly baseURL?: string;
+  private readonly defaultHeaders: Record<string, string>;
+  private readonly defaultTimeout?: number;
+
+  constructor(config?: Pick<HttpRequestConfig, "baseURL" | "headers" | "timeout">) {
+    this.baseURL = config?.baseURL;
+    this.defaultHeaders = config?.headers ?? {};
+    this.defaultTimeout = config?.timeout;
   }
 
-  protected extractData<T = unknown>(response: AxiosResponse<T>): AxiosResponse<T>["data"] {
+  get<T = unknown>(url: string, config?: HttpRequestConfig): Promise<HttpResponse<T>> {
+    return this.request<T>({ ...config, url, method: "GET" });
+  }
+
+  post<T = unknown>(url: string, data?: unknown, config?: HttpRequestConfig): Promise<HttpResponse<T>> {
+    return this.request<T>({ ...config, url, method: "POST", data });
+  }
+
+  put<T = unknown>(url: string, data?: unknown, config?: HttpRequestConfig): Promise<HttpResponse<T>> {
+    return this.request<T>({ ...config, url, method: "PUT", data });
+  }
+
+  patch<T = unknown>(url: string, data?: unknown, config?: HttpRequestConfig): Promise<HttpResponse<T>> {
+    return this.request<T>({ ...config, url, method: "PATCH", data });
+  }
+
+  delete<T = unknown>(url: string, config?: HttpRequestConfig): Promise<HttpResponse<T>> {
+    return this.request<T>({ ...config, url, method: "DELETE" });
+  }
+
+  getUri(config: { url: string }): string {
+    return buildUrl(config.url, this.baseURL);
+  }
+
+  protected extractData<T = unknown>(response: HttpResponse<T>): T {
     return extractData(response);
+  }
+
+  private async request<T>(config: HttpRequestConfig): Promise<HttpResponse<T>> {
+    const baseURL = config.baseURL ?? this.baseURL;
+    const headers: Record<string, string> = { ...this.defaultHeaders, ...config.headers };
+    const url = buildUrl(config.url ?? "", baseURL, config.params);
+
+    if (config.data !== undefined && typeof config.data !== "string" && config.method !== "GET" && config.method !== "HEAD") {
+      headers["Content-Type"] ??= "application/json";
+    }
+
+    return executeFetch({
+      ...config,
+      method: config.method!,
+      url,
+      headers,
+      timeout: config.timeout ?? this.defaultTimeout
+    }) as Promise<HttpResponse<T>>;
   }
 }
 
-export function extractData<T = unknown>(response: AxiosResponse<T>): T {
+export function extractData<T = unknown>(response: HttpResponse<T>): T {
   return response.data;
+}
+
+export function buildUrl(path: string, baseURL?: string, params?: Record<string, unknown>): string {
+  let url: string;
+
+  if (baseURL && !path.startsWith("http://") && !path.startsWith("https://")) {
+    const base = baseURL.endsWith("/") ? baseURL.slice(0, -1) : baseURL;
+    url = path.startsWith("/") ? `${base}${path}` : `${base}/${path}`;
+  } else {
+    url = path;
+  }
+
+  if (params) {
+    const entries = Object.entries(params).filter(([, v]) => v !== undefined && v !== null);
+    if (entries.length > 0) {
+      const searchParams = new URLSearchParams();
+      for (const [key, value] of entries) {
+        searchParams.set(key, String(value));
+      }
+      url += (url.includes("?") ? "&" : "?") + searchParams.toString();
+    }
+  }
+
+  return url;
 }

--- a/packages/http-sdk/src/http/http.types.ts
+++ b/packages/http-sdk/src/http/http.types.ts
@@ -1,0 +1,23 @@
+export interface HttpRequestConfig {
+  baseURL?: string;
+  url?: string;
+  method?: string;
+  headers?: Record<string, string>;
+  params?: Record<string, unknown>;
+  data?: unknown;
+  timeout?: number;
+  signal?: AbortSignal;
+  withCredentials?: boolean;
+  responseType?: "json" | "blob" | "text" | "arraybuffer";
+  validateStatus?: (status: number) => boolean;
+}
+
+export interface HttpResponse<T = unknown> {
+  data: T;
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  config: HttpRequestConfig;
+}
+
+export type HttpAdapter = (config: HttpRequestConfig & { method: string; url: string; headers: Record<string, string> }) => Promise<HttpResponse>;

--- a/packages/http-sdk/src/index.ts
+++ b/packages/http-sdk/src/index.ts
@@ -1,3 +1,5 @@
+export * from "./http/http.types";
+export * from "./http/http-error";
 export * from "./http/http.service";
 export * from "./authz/authz-http.service";
 export * from "./api-http/api-http.service";

--- a/packages/http-sdk/src/provider/provider-http.service.ts
+++ b/packages/http-sdk/src/provider/provider-http.service.ts
@@ -1,10 +1,9 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { HttpService } from "../http/http.service";
+import type { HttpRequestConfig } from "../http/http.types";
 import type { GetProviderResponse } from "./types";
 
 export class ProviderHttpService extends HttpService {
-  constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
+  constructor(config?: Pick<HttpRequestConfig, "baseURL">) {
     super(config);
   }
 

--- a/packages/http-sdk/src/stripe/stripe.service.ts
+++ b/packages/http-sdk/src/stripe/stripe.service.ts
@@ -1,6 +1,5 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { ApiHttpService } from "../api-http/api-http.service";
+import type { HttpRequestConfig } from "../http/http.types";
 import type {
   ConfirmPaymentParams,
   ConfirmPaymentResponse,
@@ -17,11 +16,11 @@ import type {
 } from "./stripe.types";
 
 export class StripeService extends ApiHttpService {
-  constructor(config?: AxiosRequestConfig) {
+  constructor(config?: HttpRequestConfig) {
     super(config);
   }
 
-  async createSetupIntent(config?: AxiosRequestConfig): Promise<SetupIntentResponse> {
+  async createSetupIntent(config?: HttpRequestConfig): Promise<SetupIntentResponse> {
     return this.extractApiData(await this.post("/v1/stripe/payment-methods/setup", {}, config));
   }
 
@@ -90,14 +89,11 @@ export class StripeService extends ApiHttpService {
 
     const url = `/v1/stripe/transactions/export?${queryParams}`;
 
-    return this.extractData(
-      await this.get(url, {
-        responseType: "blob"
-      })
-    );
+    // Blob endpoints don't return ApiOutput<T> - use extractData with cast
+    return this.extractData(await this.get(url, { responseType: "blob" })) as any;
   }
 
-  async findPrices(config?: AxiosRequestConfig): Promise<StripePrice[]> {
+  async findPrices(config?: HttpRequestConfig): Promise<StripePrice[]> {
     return this.extractApiData(await this.get("/v1/stripe/prices", config));
   }
 }

--- a/packages/http-sdk/src/tx-http/tx-http.service.ts
+++ b/packages/http-sdk/src/tx-http/tx-http.service.ts
@@ -1,8 +1,8 @@
 import type { EncodeObject, Registry } from "@cosmjs/proto-signing";
 import type { DeliverTxResponse } from "@cosmjs/stargate";
-import type { AxiosRequestConfig } from "axios";
 
 import { ApiHttpService } from "../api-http/api-http.service";
+import type { HttpRequestConfig } from "../http/http.types";
 
 export interface TxInput {
   userId: string;
@@ -14,7 +14,7 @@ export type TxOutput = Pick<DeliverTxResponse, "code" | "transactionHash" | "raw
 export class TxHttpService extends ApiHttpService {
   constructor(
     private readonly registry: Registry,
-    config?: AxiosRequestConfig
+    config?: HttpRequestConfig
   ) {
     super(config);
   }

--- a/packages/http-sdk/src/usage/usage-http.service.ts
+++ b/packages/http-sdk/src/usage/usage-http.service.ts
@@ -1,7 +1,7 @@
-import type { AxiosRequestConfig } from "axios";
 import { format } from "date-fns";
 
 import { HttpService } from "../http/http.service";
+import type { HttpRequestConfig } from "../http/http.types";
 import type { UsageHistory, UsageHistoryStats } from "./usage.types";
 
 type UsageParams = {
@@ -11,7 +11,7 @@ type UsageParams = {
 };
 
 export class UsageHttpService extends HttpService {
-  constructor(config?: AxiosRequestConfig) {
+  constructor(config?: HttpRequestConfig) {
     super(config);
   }
 

--- a/packages/http-sdk/src/utils/createFetchAdapter/createFetchAdapter.spec.ts
+++ b/packages/http-sdk/src/utils/createFetchAdapter/createFetchAdapter.spec.ts
@@ -1,10 +1,25 @@
-import type { InternalAxiosRequestConfig } from "axios";
-import { AxiosError, AxiosHeaders } from "axios";
 import { BrokenCircuitError } from "cockatiel";
 import { setTimeout as wait } from "timers/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { HttpAdapter, HttpResponse } from "../../http/http.types";
+import { HttpError } from "../../http/http-error";
 import { createFetchAdapter } from "./createFetchAdapter";
+
+function makeConfig(overrides: Partial<Parameters<HttpAdapter>[0]> = {}): Parameters<HttpAdapter>[0] {
+  return { method: "GET", url: "/test", headers: {}, ...overrides };
+}
+
+function makeHttpError(status: number, config: Parameters<HttpAdapter>[0], responseHeaders: Record<string, string> = {}): HttpError {
+  const response: HttpResponse = {
+    data: {},
+    status,
+    statusText: "test",
+    headers: responseHeaders,
+    config
+  };
+  return new HttpError("test", String(status), config, response);
+}
 
 describe(createFetchAdapter.name, () => {
   beforeEach(() => {
@@ -19,28 +34,16 @@ describe(createFetchAdapter.name, () => {
     it("retries request 3 times if it fails with 5xx", async () => {
       const adapter = vi
         .fn()
-        .mockImplementationOnce(async (config: InternalAxiosRequestConfig) => {
-          throw new AxiosError(
-            "test",
-            "500",
-            config,
-            {},
-            {
-              status: 500,
-              statusText: "test",
-              headers: {},
-              data: {},
-              config
-            }
-          );
+        .mockImplementationOnce(async (config: Parameters<HttpAdapter>[0]) => {
+          throw makeHttpError(500, config);
         })
-        .mockImplementation(async () => ({ status: 200, data: "test" }));
+        .mockImplementation(async () => ({ status: 200, data: "test", statusText: "OK", headers: {}, config: {} }));
 
       const fetch = createFetchAdapter({
         adapter
       });
 
-      const [result] = await Promise.all([fetch({ method: "GET", url: "/test", headers: new AxiosHeaders() }), vi.runAllTimersAsync()]);
+      const [result] = await Promise.all([fetch(makeConfig()), vi.runAllTimersAsync()]);
 
       expect(adapter).toHaveBeenCalledTimes(2);
       expect(result.data).toEqual("test");
@@ -49,58 +52,31 @@ describe(createFetchAdapter.name, () => {
     it("retries request 3 times if it fails with 429", async () => {
       const adapter = vi
         .fn()
-        .mockImplementationOnce(async (config: InternalAxiosRequestConfig) => {
-          throw new AxiosError(
-            "test",
-            "500",
-            config,
-            {},
-            {
-              status: 429,
-              statusText: "test",
-              headers: {},
-              data: {},
-              config
-            }
-          );
+        .mockImplementationOnce(async (config: Parameters<HttpAdapter>[0]) => {
+          throw makeHttpError(429, config);
         })
-        .mockImplementation(async () => ({ status: 200, data: "test" }));
+        .mockImplementation(async () => ({ status: 200, data: "test", statusText: "OK", headers: {}, config: {} }));
 
       const fetch = createFetchAdapter({
         adapter
       });
 
-      const [result] = await Promise.all([fetch({ method: "GET", url: "/test", headers: new AxiosHeaders() }), vi.runAllTimersAsync()]);
+      const [result] = await Promise.all([fetch(makeConfig()), vi.runAllTimersAsync()]);
 
       expect(adapter).toHaveBeenCalledTimes(2);
       expect(result.data).toEqual("test");
     });
 
     it("does not retry request if it fails with 400", async () => {
-      const adapter = vi.fn().mockImplementationOnce(async (config: InternalAxiosRequestConfig) => {
-        throw new AxiosError(
-          "test",
-          "500",
-          config,
-          {},
-          {
-            status: 400,
-            statusText: "test",
-            headers: {},
-            data: {},
-            config
-          }
-        );
+      const adapter = vi.fn().mockImplementationOnce(async (config: Parameters<HttpAdapter>[0]) => {
+        throw makeHttpError(400, config);
       });
 
       const fetch = createFetchAdapter({
         adapter
       });
 
-      const [result] = await Promise.all([
-        fetch({ method: "GET", url: "/test", headers: new AxiosHeaders() }).catch(error => error as AxiosError),
-        vi.runAllTimersAsync()
-      ]);
+      const [result] = await Promise.all([fetch(makeConfig()).catch(error => error as HttpError), vi.runAllTimersAsync()]);
 
       expect(adapter).toHaveBeenCalledTimes(1);
       expect(result.status).toEqual(400);
@@ -109,29 +85,17 @@ describe(createFetchAdapter.name, () => {
     it("respects numeric retry-after header", async () => {
       const adapter = vi
         .fn()
-        .mockImplementationOnce(async (config: InternalAxiosRequestConfig) => {
-          throw new AxiosError(
-            "test",
-            "500",
-            config,
-            {},
-            {
-              status: 500,
-              statusText: "test",
-              headers: { "retry-after": "60" },
-              data: {},
-              config
-            }
-          );
+        .mockImplementationOnce(async (config: Parameters<HttpAdapter>[0]) => {
+          throw makeHttpError(500, config, { "retry-after": "60" });
         })
-        .mockImplementation(async () => ({ status: 200, data: "test" }));
+        .mockImplementation(async () => ({ status: 200, data: "test", statusText: "OK", headers: {}, config: {} }));
 
       const fetch = createFetchAdapter({
         adapter
       });
 
       const start = Date.now();
-      const [result] = await Promise.all([fetch({ method: "GET", url: "/test", headers: new AxiosHeaders() }), vi.runAllTimersAsync()]);
+      const [result] = await Promise.all([fetch(makeConfig()), vi.runAllTimersAsync()]);
 
       expect(adapter).toHaveBeenCalledTimes(2);
       expect(Date.now() - start).toBeGreaterThanOrEqual(60 * 1000);
@@ -141,29 +105,17 @@ describe(createFetchAdapter.name, () => {
     it("respects date retry-after header", async () => {
       const adapter = vi
         .fn()
-        .mockImplementationOnce(async (config: InternalAxiosRequestConfig) => {
-          throw new AxiosError(
-            "test",
-            "500",
-            config,
-            {},
-            {
-              status: 500,
-              statusText: "test",
-              headers: { "retry-after": new Date(Date.now() + 60 * 1000).toUTCString() },
-              data: {},
-              config
-            }
-          );
+        .mockImplementationOnce(async (config: Parameters<HttpAdapter>[0]) => {
+          throw makeHttpError(500, config, { "retry-after": new Date(Date.now() + 60 * 1000).toUTCString() });
         })
-        .mockImplementation(async () => ({ status: 200, data: "test" }));
+        .mockImplementation(async () => ({ status: 200, data: "test", statusText: "OK", headers: {}, config: {} }));
 
       const fetch = createFetchAdapter({
         adapter
       });
 
       const start = Date.now();
-      const [result] = await Promise.all([fetch({ method: "GET", url: "/test", headers: new AxiosHeaders() }), vi.runAllTimersAsync()]);
+      const [result] = await Promise.all([fetch(makeConfig()), vi.runAllTimersAsync()]);
 
       expect(adapter).toHaveBeenCalledTimes(2);
       expect(Date.now() - start).toBeGreaterThanOrEqual(60 * 1000);
@@ -173,20 +125,8 @@ describe(createFetchAdapter.name, () => {
 
   describe("circuit breaker", () => {
     it("opens the circuit breaker if it fails 3 times", async () => {
-      const adapter = vi.fn().mockImplementation(async (config: InternalAxiosRequestConfig) => {
-        throw new AxiosError(
-          "test",
-          "500",
-          config,
-          {},
-          {
-            status: 500,
-            statusText: "test",
-            headers: {},
-            data: {},
-            config
-          }
-        );
+      const adapter = vi.fn().mockImplementation(async (config: Parameters<HttpAdapter>[0]) => {
+        throw makeHttpError(500, config);
       });
 
       const fetch = createFetchAdapter({
@@ -196,27 +136,15 @@ describe(createFetchAdapter.name, () => {
         }
       });
 
-      await Promise.all([fetch({ method: "GET", url: "/test", headers: new AxiosHeaders() }).catch(error => error as AxiosError), vi.runAllTimersAsync()]);
+      await Promise.all([fetch(makeConfig()).catch(error => error as HttpError), vi.runAllTimersAsync()]);
 
-      await expect(fetch({ method: "GET", url: "/test", headers: new AxiosHeaders() })).rejects.toThrow(BrokenCircuitError);
+      await expect(fetch(makeConfig())).rejects.toThrow(BrokenCircuitError);
       expect(adapter).toHaveBeenCalledTimes(4);
     });
 
     it("closes the circuit breaker after halfOpenAfter it succeeds", async () => {
-      const adapter = vi.fn().mockImplementation(async (config: InternalAxiosRequestConfig) => {
-        throw new AxiosError(
-          "test",
-          "500",
-          config,
-          {},
-          {
-            status: 500,
-            statusText: "test",
-            headers: {},
-            data: {},
-            config
-          }
-        );
+      const adapter = vi.fn().mockImplementation(async (config: Parameters<HttpAdapter>[0]) => {
+        throw makeHttpError(500, config);
       });
 
       const fetch = createFetchAdapter({
@@ -226,45 +154,33 @@ describe(createFetchAdapter.name, () => {
         }
       });
 
-      await Promise.all([fetch({ method: "GET", url: "/test", headers: new AxiosHeaders() }).catch(error => error as AxiosError), vi.runAllTimersAsync()]);
+      await Promise.all([fetch(makeConfig()).catch(error => error as HttpError), vi.runAllTimersAsync()]);
 
-      await expect(fetch({ method: "GET", url: "/test", headers: new AxiosHeaders() })).rejects.toThrow(BrokenCircuitError);
+      await expect(fetch(makeConfig())).rejects.toThrow(BrokenCircuitError);
 
-      adapter.mockImplementationOnce(async () => ({ status: 200, data: "test" }));
+      adapter.mockImplementationOnce(async () => ({ status: 200, data: "test", statusText: "OK", headers: {}, config: {} }));
       vi.advanceTimersByTime(30 * 1000);
 
-      expect(await fetch({ method: "GET", url: "/test", headers: new AxiosHeaders() })).toEqual({ status: 200, data: "test" });
+      expect(await fetch(makeConfig())).toEqual({ status: 200, data: "test", statusText: "OK", headers: {}, config: {} });
     });
 
     it("calls onSuccess callback when request succeeds", async () => {
-      const adapter = vi.fn().mockImplementation(async () => ({ status: 200, data: "test" }));
+      const adapter = vi.fn().mockImplementation(async () => ({ status: 200, data: "test", statusText: "OK", headers: {}, config: {} }));
       const onSuccess = vi.fn();
       const fetch = createFetchAdapter({
         adapter,
         onSuccess
       });
 
-      await fetch({ method: "GET", url: "/test", headers: new AxiosHeaders() });
+      await fetch(makeConfig());
 
       expect(adapter).toHaveBeenCalledTimes(1);
       expect(onSuccess).toHaveBeenCalledTimes(1);
     });
 
     it("calls onFailure callback when request finally fails", async () => {
-      const adapter = vi.fn().mockImplementation(async (config: InternalAxiosRequestConfig) => {
-        throw new AxiosError(
-          "test",
-          "500",
-          config,
-          {},
-          {
-            status: 500,
-            statusText: "test",
-            headers: {},
-            data: {},
-            config
-          }
-        );
+      const adapter = vi.fn().mockImplementation(async (config: Parameters<HttpAdapter>[0]) => {
+        throw makeHttpError(500, config);
       });
       const onFailure = vi.fn();
       const fetch = createFetchAdapter({
@@ -272,7 +188,7 @@ describe(createFetchAdapter.name, () => {
         onFailure
       });
 
-      await Promise.all([fetch({ method: "GET", url: "/test", headers: new AxiosHeaders() }).catch(error => error as AxiosError), vi.runAllTimersAsync()]);
+      await Promise.all([fetch(makeConfig()).catch(error => error as HttpError), vi.runAllTimersAsync()]);
 
       expect(adapter).toHaveBeenCalledTimes(4);
       expect(onFailure).toHaveBeenCalledTimes(1);
@@ -282,22 +198,10 @@ describe(createFetchAdapter.name, () => {
   describe("abortPendingWhenOneFail", () => {
     it("aborts all pending requests when one request fails with matching condition", async () => {
       let i = 0;
-      const adapter = vi.fn().mockImplementation(async (config: InternalAxiosRequestConfig) => {
+      const adapter = vi.fn().mockImplementation(async (config: Parameters<HttpAdapter>[0]) => {
         await wait(i * 100, undefined, { signal: config.signal as AbortSignal });
         i += 2;
-        throw new AxiosError(
-          "Unauthorized",
-          "401",
-          config,
-          {},
-          {
-            status: 401,
-            statusText: "Unauthorized",
-            headers: {},
-            data: {},
-            config
-          }
-        );
+        throw makeHttpError(401, config);
       });
 
       const fetch = createFetchAdapter({
@@ -306,8 +210,8 @@ describe(createFetchAdapter.name, () => {
         retries: 1
       });
 
-      const failingRequest = fetch({ method: "GET", url: "/failing", headers: new AxiosHeaders() });
-      const pendingRequest = fetch({ method: "GET", url: "/pending", headers: new AxiosHeaders() });
+      const failingRequest = fetch(makeConfig({ url: "/failing" }));
+      const pendingRequest = fetch(makeConfig({ url: "/pending" }));
 
       const [pendingResult, failingResult] = await Promise.allSettled([pendingRequest, failingRequest]);
 
@@ -322,24 +226,12 @@ describe(createFetchAdapter.name, () => {
 
     it("allows new requests after abort", async () => {
       let callCount = 0;
-      const adapter = vi.fn().mockImplementation(async (config: InternalAxiosRequestConfig) => {
+      const adapter = vi.fn().mockImplementation(async (config: Parameters<HttpAdapter>[0]) => {
         callCount++;
         if (callCount === 1) {
-          throw new AxiosError(
-            "Unauthorized",
-            "401",
-            config,
-            {},
-            {
-              status: 401,
-              statusText: "Unauthorized",
-              headers: {},
-              data: {},
-              config
-            }
-          );
+          throw makeHttpError(401, config);
         }
-        return { status: 200, data: "success" };
+        return { status: 200, data: "success", statusText: "OK", headers: {}, config: {} };
       });
 
       const fetch = createFetchAdapter({
@@ -348,30 +240,18 @@ describe(createFetchAdapter.name, () => {
         retries: 1
       });
 
-      await expect(fetch({ method: "GET", url: "/first", headers: new AxiosHeaders() })).rejects.toThrow();
+      await expect(fetch(makeConfig({ url: "/first" }))).rejects.toThrow();
 
-      const result = await fetch({ method: "GET", url: "/second", headers: new AxiosHeaders() });
+      const result = await fetch(makeConfig({ url: "/second" }));
       expect(result.data).toBe("success");
     });
 
     it("does not abort requests when condition does not match", async () => {
-      const adapter = vi.fn().mockImplementation(async (config: InternalAxiosRequestConfig) => {
+      const adapter = vi.fn().mockImplementation(async (config: Parameters<HttpAdapter>[0]) => {
         if (config.url === "/failing") {
-          throw new AxiosError(
-            "Bad Request",
-            "400",
-            config,
-            {},
-            {
-              status: 400,
-              statusText: "Bad Request",
-              headers: {},
-              data: {},
-              config
-            }
-          );
+          throw makeHttpError(400, config);
         }
-        return { status: 200, data: "success" };
+        return { status: 200, data: "success", statusText: "OK", headers: {}, config: {} };
       });
 
       const fetch = createFetchAdapter({
@@ -380,18 +260,18 @@ describe(createFetchAdapter.name, () => {
         retries: 1
       });
 
-      const failingPromise = fetch({ method: "GET", url: "/failing", headers: new AxiosHeaders() }).catch((error: AxiosError) => error);
-      const successPromise = fetch({ method: "GET", url: "/success", headers: new AxiosHeaders() });
+      const failingPromise = fetch(makeConfig({ url: "/failing" })).catch((error: HttpError) => error);
+      const successPromise = fetch(makeConfig({ url: "/success" }));
 
       const [failingResult, successResult] = await Promise.all([failingPromise, successPromise]);
 
-      expect((failingResult as AxiosError).response?.status).toBe(400);
+      expect((failingResult as HttpError).response?.status).toBe(400);
       expect(successResult.data).toBe("success");
     });
 
     it("preserves existing signal when provided", async () => {
       const externalAbortController = new AbortController();
-      const adapter = vi.fn().mockImplementation(async () => ({ status: 200, data: "success" }));
+      const adapter = vi.fn().mockImplementation(async () => ({ status: 200, data: "success", statusText: "OK", headers: {}, config: {} }));
 
       const fetch = createFetchAdapter({
         adapter,
@@ -399,7 +279,7 @@ describe(createFetchAdapter.name, () => {
         retries: 1
       });
 
-      await fetch({ method: "GET", url: "/test", headers: new AxiosHeaders(), signal: externalAbortController.signal });
+      await fetch(makeConfig({ signal: externalAbortController.signal }));
 
       expect(adapter).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -407,7 +287,7 @@ describe(createFetchAdapter.name, () => {
         })
       );
 
-      const passedConfig = adapter.mock.calls[0][0] as InternalAxiosRequestConfig;
+      const passedConfig = adapter.mock.calls[0][0] as Parameters<HttpAdapter>[0];
       expect(passedConfig.signal).not.toBe(externalAbortController.signal);
     });
   });

--- a/packages/http-sdk/src/utils/createFetchAdapter/createFetchAdapter.ts
+++ b/packages/http-sdk/src/utils/createFetchAdapter/createFetchAdapter.ts
@@ -1,7 +1,9 @@
-import type { AxiosAdapter, AxiosError, AxiosResponse, InternalAxiosRequestConfig } from "axios";
-import axios from "axios";
 import type { IBreaker, ICircuitBreakerOptions, IPolicy } from "cockatiel";
 import { circuitBreaker, ConsecutiveBreaker, ConstantBackoff, handleAll, handleWhen, IterableBackoff, retry, wrap } from "cockatiel";
+
+import { executeFetch } from "../../http/execute-fetch";
+import type { HttpAdapter, HttpRequestConfig, HttpResponse } from "../../http/http.types";
+import { HttpError } from "../../http/http-error";
 
 export interface FetchAdapterOptions {
   retries?: number;
@@ -10,14 +12,14 @@ export interface FetchAdapterOptions {
     breaker?: IBreaker;
     halfOpenAfter?: ICircuitBreakerOptions["halfOpenAfter"];
   };
-  adapter?: AxiosAdapter;
-  onFailure?: (error: unknown, requestConfig: InternalAxiosRequestConfig) => AxiosResponse | Promise<AxiosResponse> | undefined | null | void;
+  adapter?: HttpAdapter;
+  onFailure?: (error: unknown, requestConfig: HttpRequestConfig) => HttpResponse | Promise<HttpResponse> | undefined | null | void;
   onSuccess?: () => void;
-  abortPendingWhenOneFail?: (response: AxiosResponse) => boolean;
+  abortPendingWhenOneFail?: (response: HttpResponse) => boolean;
 }
 
 const EXTRA_RETRY_AFTER_DELAY = 10 * 1000;
-export function createFetchAdapter(options: FetchAdapterOptions = {}): AxiosAdapter {
+export function createFetchAdapter(options: FetchAdapterOptions = {}): HttpAdapter {
   const handleNetworkOrIdempotentError = handleWhen(error => isNetworkOrIdempotentRequestError(error));
   const policies: IPolicy[] = [];
 
@@ -38,7 +40,7 @@ export function createFetchAdapter(options: FetchAdapterOptions = {}): AxiosAdap
       maxAttempts: options.retries ?? 3,
       backoff: {
         next: context => {
-          if (!("error" in context.result) || !axios.isAxiosError(context.result.error)) return noBackoff.next();
+          if (!("error" in context.result) || !(context.result.error instanceof HttpError)) return noBackoff.next();
 
           const retryAfterHeader = context.result.error.response?.headers["retry-after"];
           if (!retryAfterHeader) return retryBackoffFallback.next(context);
@@ -62,23 +64,23 @@ export function createFetchAdapter(options: FetchAdapterOptions = {}): AxiosAdap
     fetchPolicy.onSuccess(options.onSuccess);
   }
 
-  const fetchAdapter = options.adapter ?? axios.getAdapter("fetch");
-  const axiosAdapter = async (config: InternalAxiosRequestConfig) => {
+  const fetchAdapter = options.adapter ?? executeFetch;
+  const wrappedAdapter: HttpAdapter = async config => {
     return fetchPolicy
-      .execute(() => fetchAdapter(config), config.signal as AbortSignal)
+      .execute(() => fetchAdapter(config), config.signal)
       .catch(error => {
         const result = options.onFailure?.(error, config);
         return result ? result : Promise.reject(error);
       });
   };
 
-  return options.abortPendingWhenOneFail ? abortableAdapter(axiosAdapter, options.abortPendingWhenOneFail) : axiosAdapter;
+  return options.abortPendingWhenOneFail ? abortableAdapter(wrappedAdapter, options.abortPendingWhenOneFail) : wrappedAdapter;
 }
 
 export function isNetworkOrIdempotentRequestError(error: unknown): boolean {
-  const isNetworkError = error && !axios.isAxiosError(error) && error instanceof Error && "code" in error && error.code;
-  if (isNetworkError) return isRetriableError(error);
-  return axios.isAxiosError(error) && isIdempotentRequestError(error);
+  if (error instanceof HttpError) return isIdempotentRequestError(error);
+  if (error instanceof Error && "code" in error) return isRetriableError(error as ErrorWithCode);
+  return false;
 }
 
 type ErrorWithCode = Error & { code: unknown };
@@ -88,7 +90,7 @@ export function isRetriableError(error: ErrorWithCode): boolean {
 }
 
 const IDEMPOTENT_HTTP_METHODS = ["get", "head", "options", "delete", "put"];
-function isIdempotentRequestError(error: AxiosError): boolean {
+function isIdempotentRequestError(error: HttpError): boolean {
   if (!error.config?.method) return false;
   return (
     IDEMPOTENT_HTTP_METHODS.includes(error.config.method.toLowerCase()) &&
@@ -97,17 +99,13 @@ function isIdempotentRequestError(error: AxiosError): boolean {
   );
 }
 
-function abortableAdapter(defaultAdapter: AxiosAdapter, abortWhen: (response: AxiosResponse) => boolean): AxiosAdapter {
+function abortableAdapter(defaultAdapter: HttpAdapter, abortWhen: (response: HttpResponse) => boolean): HttpAdapter {
   let adapterLevelAbortController = new AbortController();
-  return async (requestConfig: InternalAxiosRequestConfig) => {
-    if (requestConfig.signal) {
-      requestConfig.signal = AbortSignal.any([requestConfig.signal as AbortSignal, adapterLevelAbortController.signal]);
-    } else {
-      requestConfig.signal = adapterLevelAbortController.signal;
-    }
-    return defaultAdapter(requestConfig).catch(error => {
-      if (error.response && abortWhen(error.response)) {
-        // abort all requests sent by this adapter
+  return async requestConfig => {
+    const signal = requestConfig.signal ? AbortSignal.any([requestConfig.signal, adapterLevelAbortController.signal]) : adapterLevelAbortController.signal;
+
+    return defaultAdapter({ ...requestConfig, signal }).catch(error => {
+      if (error instanceof HttpError && error.response && abortWhen(error.response)) {
         adapterLevelAbortController.abort();
         adapterLevelAbortController = new AbortController();
       }

--- a/packages/http-sdk/src/utils/httpClient.ts
+++ b/packages/http-sdk/src/utils/httpClient.ts
@@ -37,10 +37,6 @@ export function createHttpClient(fullConfig: HttpClientOptions = {}): HttpClient
     const resolvedUrl = buildUrl(url, reqConfig?.baseURL ?? baseURL, reqConfig?.params);
     const headers: Record<string, string> = { ...defaultHeaders, ...reqConfig?.headers };
 
-    if (data !== undefined && typeof data !== "string" && method !== "GET" && method !== "HEAD") {
-      headers["Content-Type"] ??= "application/json";
-    }
-
     return resilientAdapter({
       ...reqConfig,
       method,

--- a/packages/http-sdk/src/utils/httpClient.ts
+++ b/packages/http-sdk/src/utils/httpClient.ts
@@ -1,31 +1,63 @@
-import type { AxiosAdapter, AxiosInstance, AxiosResponse, CreateAxiosDefaults } from "axios";
-import axios from "axios";
-
+import { buildUrl } from "../http/http.service";
+import type { HttpRequestConfig, HttpResponse } from "../http/http.types";
 import { createFetchAdapter } from "./createFetchAdapter/createFetchAdapter";
 
+export interface HttpClient {
+  get<T = unknown>(url: string, config?: HttpRequestConfig): Promise<HttpResponse<T>>;
+  post<T = unknown>(url: string, data?: unknown, config?: HttpRequestConfig): Promise<HttpResponse<T>>;
+  put<T = unknown>(url: string, data?: unknown, config?: HttpRequestConfig): Promise<HttpResponse<T>>;
+  patch<T = unknown>(url: string, data?: unknown, config?: HttpRequestConfig): Promise<HttpResponse<T>>;
+  delete<T = unknown>(url: string, config?: HttpRequestConfig): Promise<HttpResponse<T>>;
+  getUri(config: { url: string }): string;
+}
+
+export interface HttpClientOptions {
+  baseURL?: string;
+  headers?: Record<string, string>;
+  timeout?: number;
+  withCredentials?: boolean;
+  abortPendingWhenOneFail?: (response: HttpResponse) => boolean;
+}
+
 export function createHttpClient(fullConfig: HttpClientOptions = {}): HttpClient {
-  const { abortPendingWhenOneFail, adapter, ...config } = fullConfig;
-  const customAdapter = createFetchAdapter({
+  const { abortPendingWhenOneFail, ...config } = fullConfig;
+  const resilientAdapter = createFetchAdapter({
     retries: 3,
-    adapter: typeof adapter === "function" ? adapter : axios.getAdapter(adapter || "fetch"),
     abortPendingWhenOneFail
   });
 
-  const instance = axios.create({
-    ...config,
-    adapter: customAdapter,
-    headers: {
-      "Content-Type": "application/json",
-      ...config?.headers
+  const baseURL = config.baseURL;
+  const defaultHeaders: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...config.headers
+  };
+  const defaultTimeout = config.timeout;
+
+  function makeRequest<T>(method: string, url: string, data?: unknown, reqConfig?: HttpRequestConfig): Promise<HttpResponse<T>> {
+    const resolvedUrl = buildUrl(url, reqConfig?.baseURL ?? baseURL, reqConfig?.params);
+    const headers: Record<string, string> = { ...defaultHeaders, ...reqConfig?.headers };
+
+    if (data !== undefined && typeof data !== "string" && method !== "GET" && method !== "HEAD") {
+      headers["Content-Type"] ??= "application/json";
     }
-  });
 
-  return instance;
+    return resilientAdapter({
+      ...reqConfig,
+      method,
+      url: resolvedUrl,
+      headers,
+      data,
+      timeout: reqConfig?.timeout ?? defaultTimeout,
+      withCredentials: reqConfig?.withCredentials ?? config.withCredentials
+    }) as Promise<HttpResponse<T>>;
+  }
+
+  return {
+    get: <T = unknown>(url: string, reqConfig?: HttpRequestConfig) => makeRequest<T>("GET", url, undefined, reqConfig),
+    post: <T = unknown>(url: string, data?: unknown, reqConfig?: HttpRequestConfig) => makeRequest<T>("POST", url, data, reqConfig),
+    put: <T = unknown>(url: string, data?: unknown, reqConfig?: HttpRequestConfig) => makeRequest<T>("PUT", url, data, reqConfig),
+    patch: <T = unknown>(url: string, data?: unknown, reqConfig?: HttpRequestConfig) => makeRequest<T>("PATCH", url, data, reqConfig),
+    delete: <T = unknown>(url: string, reqConfig?: HttpRequestConfig) => makeRequest<T>("DELETE", url, undefined, reqConfig),
+    getUri: (uriConfig: { url: string }) => buildUrl(uriConfig.url, baseURL)
+  };
 }
-
-export type HttpClient = AxiosInstance;
-export type HttpClientOptions = Omit<CreateAxiosDefaults, "adapter"> & {
-  /** @default 'fetch' */
-  adapter?: "fetch" | "xhr" | "http" | AxiosAdapter;
-  abortPendingWhenOneFail?: (response: AxiosResponse) => boolean;
-};

--- a/packages/http-sdk/src/utils/isHttpError.ts
+++ b/packages/http-sdk/src/utils/isHttpError.ts
@@ -1,5 +1,5 @@
-import { AxiosError } from "axios";
+import { HttpError } from "../http/http-error";
 
-export function isHttpError<T = any>(error: unknown): error is AxiosError<T> {
-  return !!error && error instanceof AxiosError;
+export function isHttpError<T = any>(error: unknown): error is HttpError<T> {
+  return error instanceof HttpError;
 }

--- a/packages/http-sdk/src/wallet-settings/wallet-settings-http.service.ts
+++ b/packages/http-sdk/src/wallet-settings/wallet-settings-http.service.ts
@@ -1,12 +1,11 @@
-import type { AxiosRequestConfig } from "axios";
-
 import { ApiHttpService } from "../api-http/api-http.service";
+import type { HttpRequestConfig } from "../http/http.types";
 import type { UpdateWalletSettingsParams, WalletSettings } from "./wallet-settings.types";
 
 export type { UpdateWalletSettingsParams, WalletSettings };
 
 export class WalletSettingsHttpService extends ApiHttpService {
-  constructor(config?: AxiosRequestConfig) {
+  constructor(config?: HttpRequestConfig) {
     super(config);
   }
 


### PR DESCRIPTION
## Why

Fixes CON-166

http-sdk is the shared HTTP client layer used by all frontend and backend apps. Removing axios from it first unblocks axios removal from all downstream consumers.

## What

- Replaced axios with native `fetch` API across the entire http-sdk package (22 files)
- Created new types: `HttpRequestConfig`, `HttpResponse`, `HttpAdapter`, `HttpError` to replace axios equivalents
- Rewrote `HttpService` base class to use native fetch instead of extending Axios
- Rewrote `createHttpClient` to return a fetch-based `HttpClient` interface
- Rewrote `createFetchAdapter` retry/circuit-breaker logic without axios dependency
- Updated `isHttpError` to use the new `HttpError` class
- Updated all domain services (auth, balance, bid, deployment, stripe, etc.) to use new types
- Removed `axios` from `package.json` dependencies
- All existing tests pass without regression

**BREAKING CHANGE:** `HttpClient` type is now a custom interface instead of `AxiosInstance`. Downstream apps that directly reference axios types from http-sdk will need to migrate to the new `HttpRequestConfig`, `HttpResponse`, and `HttpError` types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced new HTTP error type and response interfaces for improved error handling.
  * Added new fetch-based HTTP adapter for request processing.

* **Refactor**
  * Updated HTTP service constructors and method signatures across the SDK for consistency.
  * Modified HTTP client implementation with updated configuration and response types.

* **Tests**
  * Updated test utilities to align with new HTTP abstractions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->