### PR TITLE
feat(analytics): track log-collector adoption

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
@@ -14,6 +14,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useSnackbar } from "notistack";
 
 import { UACT_DENOM, UAKT_DENOM } from "@src/config/denom.config";
+import { LOG_COLLECTOR_IMAGE } from "@src/config/log-collector.config";
 import { useSdlBuilder } from "@src/context/SdlBuilderProvider/SdlBuilderProvider";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
@@ -296,6 +297,10 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
           category: "deployments",
           label: "Create deployment in wizard"
         });
+
+        if (sdl.includes(LOG_COLLECTOR_IMAGE)) {
+          analyticsService.track("log_collector_deployed", { category: "deployments" });
+        }
       } else {
         setIsCreatingDeployment(false);
       }

--- a/apps/deploy-web/src/components/sdl/LogCollectorControl/LogCollectorControl.tsx
+++ b/apps/deploy-web/src/components/sdl/LogCollectorControl/LogCollectorControl.tsx
@@ -22,6 +22,7 @@ import { DatadogEnvConfig } from "@src/components/sdl/DatadogEnvConfig/DatadogEn
 import { EphemeralStorageFormControl } from "@src/components/sdl/EphemeralStorageFormControl";
 import { MemoryFormControl } from "@src/components/sdl/MemoryFormControl";
 import { LOG_COLLECTOR_IMAGE } from "@src/config/log-collector.config";
+import { useServices } from "@src/context/ServicesProvider";
 import { useSdlEnv } from "@src/hooks/useSdlEnv/useSdlEnv";
 import { useThrottledEffect } from "@src/hooks/useThrottledEffect/useThrottledEffect";
 import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
@@ -36,6 +37,7 @@ type Props = {
   serviceIndex: number;
   dependencies?: {
     useSdlEnv: typeof useSdlEnv;
+    useServices: typeof useServices;
   };
 };
 
@@ -43,8 +45,9 @@ const logCollectorLabelSchema = z.object({
   POD_LABEL_SELECTOR: z.string()
 });
 
-export const LogCollectorControl: FC<Props> = ({ serviceIndex, dependencies: d = { useSdlEnv } }) => {
+export const LogCollectorControl: FC<Props> = ({ serviceIndex, dependencies: d = { useSdlEnv, useServices } }) => {
   const [isAdding, setIsAdding] = useState(false);
+  const { analyticsService } = d.useServices();
   const { watch, control } = useFormContext<SdlBuilderFormValuesType>();
   const { append, remove, update } = useFieldArray({ name: `services` });
   const allServices = watch(`services`);
@@ -136,7 +139,11 @@ export const LogCollectorControl: FC<Props> = ({ serviceIndex, dependencies: d =
       </div>
       <CheckboxWithLabel
         checked={isEnabled}
-        onCheckedChange={state => setIsEnabled(state === "indeterminate" ? false : state)}
+        onCheckedChange={state => {
+          const enabled = state === "indeterminate" ? false : state;
+          setIsEnabled(enabled);
+          analyticsService.track(enabled ? "log_collector_enabled" : "log_collector_disabled", { category: "deployments" });
+        }}
         className="ml-4"
         label="Enable log forwarding for this service"
       />{" "}

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -104,7 +104,10 @@ export type AnalyticsEvent =
   | "onboarding_email_verified"
   | "onboarding_payment_method_added"
   | "onboarding_completed"
-  | "onboarding_logout";
+  | "onboarding_logout"
+  | "log_collector_enabled"
+  | "log_collector_disabled"
+  | "log_collector_deployed";
 
 export type AnalyticsCategory =
   | "user"


### PR DESCRIPTION
## Why

Track adoption of the log-collector feature to understand how many users enable it and how many deployments actually ship with it.

## What

Add 3 analytics events:
- `log_collector_enabled` / `log_collector_disabled` — fired when toggling log forwarding in the SDL builder
- `log_collector_deployed` — fired when a deployment is successfully created with a log-collector service

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved system monitoring by adding analytics tracking for log collector deployment and state changes (enable/disable).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->