### PR TITLE
fix(managed-wallet): return 400 for invalid unit price chain errors

### DIFF
--- a/apps/tx-signer/src/services/chain-error/chain-error.service.spec.ts
+++ b/apps/tx-signer/src/services/chain-error/chain-error.service.spec.ts
@@ -67,6 +67,13 @@ describe(ChainErrorService.name, () => {
     expect(service.getChainErrorStatus("order not open")).toBe(400);
   });
 
+  it("returns 400 for invalid unit price error", () => {
+    const { service } = setup();
+    expect(
+      service.getChainErrorStatus("rpc error: code = Unknown desc = group dcloud: error: invalid unit price (10000000 > 50000000.000000000000000000uact fails)")
+    ).toBe(400);
+  });
+
   it("returns 402 for insufficient balance error", () => {
     const { service } = setup();
     expect(service.getChainErrorStatus("insufficient balance")).toBe(402);

--- a/apps/tx-signer/src/services/chain-error/chain-error.service.ts
+++ b/apps/tx-signer/src/services/chain-error/chain-error.service.ts
@@ -15,6 +15,7 @@ export class ChainErrorService {
     "invalid owner address": 400,
     "bid not open": 400,
     "order not open": 400,
+    "invalid unit price": 400,
     "insufficient balance": 402,
     "bad status on response: 502": 503,
     "bad status on response: 503": 503,


### PR DESCRIPTION
## Why

Deployments with unit prices below the chain's minimum are rejected during `simulate()`, but the error was surfacing as a 500 Internal Server Error. These are client errors (bad input) and should return 400.

Error example:
```
rpc error: code = Unknown desc = group dcloud: error: invalid unit price (10000000 > 50000000.000000000000000000uact fails)
```

## What

Add `"invalid unit price"` to the known chain error patterns in `ChainErrorService` so it maps to HTTP 400 instead of falling through to 500. Follows the exact same pattern as all other chain error mappings (e.g., `"insufficient funds"`, `"deposit too low"`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for invalid unit price scenarios with appropriate HTTP status code responses.

* **Tests**
  * Added test coverage for invalid unit price error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->