### PR TITLE
fix(deployment): require state filter for offset-based pagination

### DIFF
--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
@@ -1,0 +1,84 @@
+import { MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { MsgCreateLease } from "@akashnetwork/chain-sdk/private-types/akash.v1beta5";
+import type { EncodeObject } from "@cosmjs/proto-signing";
+import { mock } from "vitest-mock-extended";
+
+import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import type { DeploymentReaderService } from "@src/deployment/services/deployment-reader/deployment-reader.service";
+import type { ProviderRepository } from "@src/provider/repositories/provider/provider.repository";
+import { TrialValidationService } from "./trial-validation.service";
+
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+describe(TrialValidationService.name, () => {
+  describe("validateTrialLimit", () => {
+    it("queries active deployments only when wallet is trialing and message is a deployment", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service, deploymentReaderService } = setup({ count: 0 });
+
+      await service.validateTrialLimit(createDeploymentMessage(), wallet);
+
+      expect(deploymentReaderService.listWithResources).toHaveBeenCalledWith({
+        address: wallet.address,
+        status: "active",
+        limit: 1
+      });
+    });
+
+    it("allows the deployment when active count is below the trial limit", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service } = setup({ count: 4 });
+
+      await expect(service.validateTrialLimit(createDeploymentMessage(), wallet)).resolves.toBeUndefined();
+    });
+
+    it("rejects with 402 when active count has reached the trial limit", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service } = setup({ count: 5 });
+
+      await expect(service.validateTrialLimit(createDeploymentMessage(), wallet)).rejects.toMatchObject({
+        status: 402,
+        message: "Trial limit reached. Add funds to your account to deploy more."
+      });
+    });
+
+    it("skips the check when wallet is not trialing", async () => {
+      const wallet = createUserWallet({ isTrialing: false });
+      const { service, deploymentReaderService } = setup({ count: 99 });
+
+      await service.validateTrialLimit(createDeploymentMessage(), wallet);
+
+      expect(deploymentReaderService.listWithResources).not.toHaveBeenCalled();
+    });
+
+    it("skips the check when message is not a deployment creation", async () => {
+      const wallet = createUserWallet({ isTrialing: true });
+      const { service, deploymentReaderService } = setup({ count: 99 });
+
+      const leaseMessage: EncodeObject = {
+        typeUrl: `/${MsgCreateLease.$type}`,
+        value: MsgCreateLease.fromPartial({})
+      };
+
+      await service.validateTrialLimit(leaseMessage, wallet);
+
+      expect(deploymentReaderService.listWithResources).not.toHaveBeenCalled();
+    });
+  });
+
+  function createDeploymentMessage(): EncodeObject {
+    return {
+      typeUrl: `/${MsgCreateDeployment.$type}`,
+      value: MsgCreateDeployment.fromPartial({})
+    };
+  }
+
+  function setup(input: { count: number }) {
+    const deploymentReaderService = mock<DeploymentReaderService>();
+    deploymentReaderService.listWithResources.mockResolvedValue({ count: input.count, results: [] });
+    const config = mock<BillingConfigService>();
+    const providerRepository = mock<ProviderRepository>();
+    const service = new TrialValidationService(deploymentReaderService, config, providerRepository);
+    return { service, deploymentReaderService, config, providerRepository };
+  }
+});

--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.ts
@@ -26,6 +26,7 @@ export class TrialValidationService {
     if (userWallet.isTrialing && decoded.typeUrl === `/${MsgCreateDeployment.$type}`) {
       const deployments = await this.deploymentReaderService.listWithResources({
         address: userWallet.address!,
+        status: "active",
         limit: 1
       });
       assert(deployments.count < TRIAL_DEPLOYMENT_LIMIT, 402, "Trial limit reached. Add funds to your account to deploy more.");

--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -166,7 +166,7 @@ export const ListWithResourcesParamsSchema = z.object({
 });
 
 export const ListWithResourcesQuerySchema = z.object({
-  status: z.enum(["active", "closed"]).optional().openapi({
+  status: z.enum(["active", "closed"]).openapi({
     description: "Filter by status",
     example: "closed"
   }),

--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
@@ -78,6 +78,73 @@ describe(DeploymentReaderService.name, () => {
       expect(deploymentHttpService.findAll).toHaveBeenCalled();
       expect(fallbackDeploymentReaderService.findAll).toHaveBeenCalled();
     });
+
+    it("forwards pagination as flat skip/limit when falling back to database", async () => {
+      const deploymentList = createDeploymentListResponseSeed({}, 2);
+      const wallet = createUserWallet() as WalletInitialized;
+      const { service, deploymentHttpService, fallbackDeploymentReaderService } = setup({
+        wallet,
+        fallbackDeploymentList: deploymentList
+      });
+
+      deploymentHttpService.findAll.mockRejectedValue(createNetworkError("ECONNRESET"));
+      await service.list({ query: { userId: wallet.userId }, skip: 25, limit: 50 });
+
+      expect(fallbackDeploymentReaderService.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: wallet.address,
+          state: "active",
+          skip: 25,
+          limit: 50
+        })
+      );
+    });
+  });
+
+  describe("listWithResources", () => {
+    it("passes status as state with offset pagination when skip is provided", async () => {
+      const address = "akash1abc";
+      const { service, deploymentHttpService } = setup();
+
+      await service.listWithResources({ address, skip: 10, limit: 100, status: "active" });
+
+      expect(deploymentHttpService.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: address,
+          state: "active",
+          pagination: expect.objectContaining({ offset: 10 })
+        })
+      );
+    });
+
+    it("passes status as state with offset pagination when status is closed", async () => {
+      const address = "akash1abc";
+      const { service, deploymentHttpService } = setup();
+
+      await service.listWithResources({ address, skip: 0, limit: 50, status: "closed" });
+
+      expect(deploymentHttpService.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: address,
+          state: "closed",
+          pagination: expect.objectContaining({ offset: 0 })
+        })
+      );
+    });
+
+    it("passes status as state without offset when skip is not provided", async () => {
+      const address = "akash1abc";
+      const { service, deploymentHttpService } = setup();
+
+      await service.listWithResources({ address, status: "active" });
+
+      expect(deploymentHttpService.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: address,
+          state: "active"
+        })
+      );
+    });
   });
 
   function createNetworkError(code: string): AxiosError {

--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.ts
@@ -4,9 +4,9 @@ import {
   DeploymentHttpService,
   DeploymentInfo,
   DeploymentListResponse,
+  FindAllParams,
   LeaseHttpService,
   LeaseListParams,
-  PaginationParams,
   RestAkashLeaseListResponse
 } from "@akashnetwork/http-sdk";
 import { PromisePool } from "@supercharge/promise-pool";
@@ -111,8 +111,11 @@ export class DeploymentReaderService {
   }): Promise<{ deployments: ListDeploymentsItem[]; total: number; hasMore: boolean }> {
     const wallet = await this.walletReaderService.getWalletByUserId(query.userId);
     const { address: owner } = wallet;
-    const pagination = skip !== undefined || limit !== undefined ? { offset: skip, limit } : undefined;
-    const deploymentReponse = await this.getDeploymentsList({ owner, state: "active", pagination });
+    const deploymentReponse = await this.getDeploymentsList(
+      skip !== undefined
+        ? { owner, state: "active", pagination: { offset: skip, limit } }
+        : { owner, state: "active", pagination: limit !== undefined ? { limit } : undefined }
+    );
     const deployments = deploymentReponse.deployments;
     const total = parseInt(deploymentReponse.pagination.total, 10);
 
@@ -140,21 +143,17 @@ export class DeploymentReaderService {
     reverseSorting
   }: {
     address: string;
-    status?: "active" | "closed";
+    status: "active" | "closed";
     skip?: number;
     limit?: number;
     reverseSorting?: boolean;
   }) {
-    const response = await this.getDeploymentsList({
-      owner: address,
-      state: status,
-      pagination: {
-        offset: skip,
-        limit: limit,
-        reverse: reverseSorting,
-        countTotal: true
-      }
-    });
+    const basePagination = { limit, reverse: reverseSorting, countTotal: true as const };
+    const response = await this.getDeploymentsList(
+      skip === undefined
+        ? { owner: address, state: status, pagination: basePagination }
+        : { owner: address, state: status, pagination: { ...basePagination, offset: skip } }
+    );
     const leaseResponse = await this.leaseHttpService.list({ owner: address, state: "active" });
     const providers = response.deployments.length ? await this.providerService.getProviderList() : ([] as ProviderList[]);
     const providerMap = new Map(providers.map(p => [p.owner, p]));
@@ -332,12 +331,20 @@ export class DeploymentReaderService {
     }
   }
 
-  private async getDeploymentsList(params: { owner: string; state?: "active" | "closed"; pagination?: PaginationParams }): Promise<DeploymentListResponse> {
+  private async getDeploymentsList(params: FindAllParams): Promise<DeploymentListResponse> {
     try {
       return await this.deploymentHttpService.findAll(params);
     } catch (error) {
       if (this.shouldFallbackToDatabase(error)) {
-        return await this.fallbackDeploymentReaderService.findAll(params);
+        return await this.fallbackDeploymentReaderService.findAll({
+          owner: params.owner,
+          state: params.state,
+          skip: params.pagination?.offset,
+          limit: params.pagination?.limit,
+          key: params.pagination?.key,
+          countTotal: params.pagination?.countTotal,
+          reverse: params.pagination?.reverse
+        });
       }
 
       throw error;

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -1824,7 +1824,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
           {
             "in": "query",
             "name": "status",
-            "required": false,
+            "required": true,
             "schema": {
               "description": "Filter by status",
               "enum": [

--- a/apps/api/test/functional/addresses.spec.ts
+++ b/apps/api/test/functional/addresses.spec.ts
@@ -164,7 +164,7 @@ describe("Addresses API", () => {
     it("returns paginated deployments for an address", async () => {
       const { address } = await setup();
 
-      const response = await app.request(`/v1/addresses/${address}/deployments/0/10`);
+      const response = await app.request(`/v1/addresses/${address}/deployments/0/10?status=active`);
 
       expect(response.status).toBe(200);
       const result = (await response.json()) as ListWithResourcesResponse;
@@ -198,6 +198,14 @@ describe("Addresses API", () => {
       const { address } = await setup();
 
       const response = await app.request(`/v1/addresses/${address}/deployments/0/invalid`);
+
+      expect(response.status).toBe(400);
+    });
+
+    it("returns 400 when status is missing", async () => {
+      const { address } = await setup();
+
+      const response = await app.request(`/v1/addresses/${address}/deployments/0/10`);
 
       expect(response.status).toBe(400);
     });
@@ -381,7 +389,7 @@ describe("Addresses API", () => {
     nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
       .persist()
       .get(
-        `/akash/deployment/${deploymentVersion}/deployments/list?filters.owner=${address}&pagination.limit=10&pagination.offset=0&pagination.count_total=true&pagination.reverse=false`
+        `/akash/deployment/${deploymentVersion}/deployments/list?filters.owner=${address}&filters.state=active&pagination.limit=10&pagination.offset=0&pagination.count_total=true&pagination.reverse=false`
       )
       .reply(200, {
         deployments: [

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -157,7 +157,7 @@ describe("Deployments API", () => {
     nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
       .persist()
       .get(
-        `/akash/deployment/${deploymentVersion}/deployments/list?filters.owner=${address}&pagination.offset=0&pagination.limit=1&pagination.count_total=true&pagination.reverse=false`
+        `/akash/deployment/${deploymentVersion}/deployments/list?filters.owner=${address}&pagination.limit=1&pagination.offset=0&pagination.count_total=true&pagination.reverse=false&filters.state=active`
       )
       .reply(200, {
         deployments: [defaultDeploymentInfo],
@@ -874,7 +874,7 @@ describe("Deployments API", () => {
       const { userApiKeySecret, wallets } = await mockUser();
       await setupDeploymentInfoMock(wallets, dseq);
 
-      const response = await app.request(`/v1/addresses/${wallets[0].address}/deployments/0/1`, {
+      const response = await app.request(`/v1/addresses/${wallets[0].address}/deployments/0/1?status=active`, {
         method: "GET",
         headers: new Headers({ "Content-Type": "application/json", "x-api-key": userApiKeySecret })
       });

--- a/apps/stats-web/src/app/addresses/[address]/deployments/AddressDeployments.tsx
+++ b/apps/stats-web/src/app/addresses/[address]/deployments/AddressDeployments.tsx
@@ -15,7 +15,7 @@ interface IProps {
 export function AddressDeployments({ address }: IProps) {
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(10);
-  const [statusFilter, setStatusFilter] = useState("*");
+  const [statusFilter, setStatusFilter] = useState("active");
   const [isSortingReversed, setIsSortingReversed] = useState(true);
   const { data: deploymentsResult, isLoading } = useAddressDeployments(address, page * pageSize, pageSize, isSortingReversed, { status: statusFilter });
   const pageCount = deploymentsResult?.count ? Math.ceil((deploymentsResult.count || 0) / pageSize) : undefined;
@@ -29,17 +29,17 @@ export function AddressDeployments({ address }: IProps) {
   };
 
   const onColumnFiltersChange = (columnFilters: ColumnFiltersState) => {
-    const statusFilter = (columnFilters.find(filter => filter.id === "status")?.value as string) || "*";
+    const statusFilter = (columnFilters.find(filter => filter.id === "status")?.value as string) || "active";
     setStatusFilter(statusFilter);
   };
 
   return (
     <Card>
       <CardContent className="pt-6">
-        {deploymentsResult?.results.length === 0 && statusFilter === "*" ? (
+        {deploymentsResult?.results.length === 0 && statusFilter === "active" ? (
           <div className="flex items-center p-4">
             <SearchX size="1rem" />
-            &nbsp;This address has no deployments
+            &nbsp;This address has no active deployments
           </div>
         ) : (
           <DataTable

--- a/packages/http-sdk/src/deployment/deployment-http.service.spec.ts
+++ b/packages/http-sdk/src/deployment/deployment-http.service.spec.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { HttpClient } from "../utils/httpClient";
+import { DeploymentHttpService } from "./deployment-http.service";
+
+describe(DeploymentHttpService.name, () => {
+  describe("findAll", () => {
+    it("includes filters.state when offset pagination is used", async () => {
+      const { service, httpClient } = setup();
+
+      await service.findAll({
+        owner: "akash1abc",
+        state: "active",
+        pagination: { offset: 10, limit: 100 }
+      });
+
+      expect(httpClient.get).toHaveBeenCalledWith(
+        "/akash/deployment/v1beta4/deployments/list",
+        expect.objectContaining({
+          params: expect.objectContaining({
+            "filters.owner": "akash1abc",
+            "filters.state": "active",
+            "pagination.offset": 10,
+            "pagination.limit": 100
+          })
+        })
+      );
+    });
+
+    it("does not include filters.state when state is not provided and key pagination is used", async () => {
+      const { service, httpClient } = setup();
+
+      await service.findAll({
+        owner: "akash1abc",
+        pagination: { key: "some-key", limit: 100 }
+      });
+
+      expect(httpClient.get).toHaveBeenCalledWith(
+        "/akash/deployment/v1beta4/deployments/list",
+        expect.objectContaining({
+          params: expect.objectContaining({
+            "filters.owner": "akash1abc",
+            "pagination.key": "some-key",
+            "pagination.limit": 100
+          })
+        })
+      );
+      const params = httpClient.get.mock.calls[0][1].params;
+      expect(params["filters.state"]).toBeUndefined();
+    });
+
+    it("does not include filters.state when no pagination is provided", async () => {
+      const { service, httpClient } = setup();
+
+      httpClient.getUri.mockReturnValue("http://test/akash/deployment/v1beta4/deployments/list?filters.owner=akash1abc");
+      httpClient.get.mockResolvedValue({
+        data: { deployments: [], pagination: { next_key: null, total: "0" } }
+      });
+
+      await service.findAll({ owner: "akash1abc" });
+
+      const uri = httpClient.getUri.mock.calls[0][0].url;
+      expect(uri).not.toContain("filters.state");
+    });
+
+    it("includes filters.state=closed when offset pagination is used with closed state", async () => {
+      const { service, httpClient } = setup();
+
+      await service.findAll({
+        owner: "akash1abc",
+        state: "closed",
+        pagination: { offset: 0, limit: 50 }
+      });
+
+      const params = httpClient.get.mock.calls[0][1].params;
+      expect(params["filters.state"]).toBe("closed");
+      expect(params["pagination.offset"]).toBe(0);
+    });
+
+    it("sets count_total to true when offset is used", async () => {
+      const { service, httpClient } = setup();
+
+      await service.findAll({
+        owner: "akash1abc",
+        state: "active",
+        pagination: { offset: 5, limit: 10 }
+      });
+
+      const params = httpClient.get.mock.calls[0][1].params;
+      expect(params["pagination.count_total"]).toBe(true);
+    });
+
+    it("uses key-based pagination when key is provided", async () => {
+      const { service, httpClient } = setup();
+
+      await service.findAll({
+        owner: "akash1abc",
+        pagination: { key: "next-page-key", limit: 100 }
+      });
+
+      const params = httpClient.get.mock.calls[0][1].params;
+      expect(params["pagination.key"]).toBe("next-page-key");
+      expect(params["pagination.offset"]).toBeUndefined();
+    });
+  });
+
+  function setup() {
+    const emptyResponse = { data: { deployments: [], pagination: { next_key: null, total: "0" } } };
+    const httpClient = {
+      get: vi.fn().mockResolvedValue(emptyResponse),
+      getUri: vi.fn().mockReturnValue("http://test")
+    } as unknown as HttpClient & { get: ReturnType<typeof vi.fn>; getUri: ReturnType<typeof vi.fn> };
+    const service = new DeploymentHttpService(httpClient);
+    return { service, httpClient };
+  }
+});

--- a/packages/http-sdk/src/deployment/deployment-http.service.ts
+++ b/packages/http-sdk/src/deployment/deployment-http.service.ts
@@ -136,6 +136,16 @@ export interface PaginationParams {
   reverse?: boolean;
 }
 
+/**
+ * Akash blockchain requires `filters.state` when `pagination.offset` is used.
+ * This type enforces that constraint at compile time:
+ * - Without pagination or with key-based pagination: `state` is optional
+ * - With offset-based pagination: `state` is required
+ */
+export type FindAllParams =
+  | { owner: string; state?: "active" | "closed"; pagination?: PaginationParams & { offset?: undefined } }
+  | { owner: string; state: "active" | "closed"; pagination: PaginationParams & { offset: number } };
+
 export class DeploymentHttpService {
   constructor(private readonly httpClient: HttpClient) {}
 
@@ -153,13 +163,15 @@ export class DeploymentHttpService {
   }
 
   /**
-   * Load deployments for an owner with optional pagination
-   * @param owner Owner address
-   * @param state Optional state filter
-   * @param pagination Optional pagination parameters
+   * Load deployments for an owner with optional pagination.
+   * Note: The Akash blockchain requires `state` when offset-based pagination is used.
+   * This constraint is enforced by the {@link FindAllParams} type.
+   * @param input.owner Owner address
+   * @param input.state Optional state filter (required when using offset pagination)
+   * @param input.pagination Optional pagination parameters
    * @returns Paginated response with deployments
    */
-  public async findAll(input: { owner: string; state?: "active" | "closed"; pagination?: PaginationParams }): Promise<DeploymentListResponse> {
+  public async findAll(input: FindAllParams): Promise<DeploymentListResponse> {
     const { owner, state, pagination } = input;
     const baseUrl = this.httpClient.getUri({
       url: `/akash/deployment/v1beta4/deployments/list?filters.owner=${owner}${state ? `&filters.state=${state}` : ""}`


### PR DESCRIPTION
## Why

The Akash blockchain endpoint `/akash/deployment/v1beta4/deployments/list` rejects requests that use `pagination.offset` without `filters.state`, returning a 400 error:

> invalid request parameters. if offset is set, filter.state must be provided

The `listWithResources` route (`/v1/addresses/:address/deployments/:skip/:limit`) always provides `skip` (offset) as a path param but `status` was an optional query param, so requests without `status` were failing.

## What

**BREAKING CHANGE**: The `status` query parameter is now **required** on `GET /v1/addresses/{address}/deployments/{skip}/{limit}`. Requests without `?status=active` or `?status=closed` will return 400.

- Made `status` required in the `ListWithResourcesQuerySchema` (OpenAPI)
- Made `status` required in `DeploymentReaderService.listWithResources` signature, removing the silent `"active"` default
- Added `FindAllParams` union type in `packages/http-sdk` that enforces `state` is required when `pagination.offset` is set — catches violations at compile time
- Updated `list` method to branch on `skip` for type narrowing
- Updated stats-web `AddressDeployments` to default the status filter to `"active"` instead of `"*"` so it always sends a valid status
- Updated empty state message to say "no active deployments"
- Added unit tests for `DeploymentHttpService.findAll` and `DeploymentReaderService.listWithResources`
- Added functional test for missing status returning 400

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced deployment filtering to require explicit status selection in API calls
  * Updated default deployment view to display active deployments
  * Refined trial deployment limit calculation to count only active deployments
  * Improved pagination handling for better consistency across deployment list queries

* **Bug Fixes**
  * Fixed validation to properly enforce status parameter requirements in deployment endpoints
<!-- end of auto-generated comment: release notes by coderabbit.ai -->