### PR TITLE
fix(billing): propagate upstream status from tx-signer errors

### DIFF
--- a/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
@@ -1,6 +1,7 @@
 import type { BalanceHttpService } from "@akashnetwork/http-sdk";
 import type { EncodeObject } from "@cosmjs/proto-signing";
-import { BadRequest, PaymentRequired, ServiceUnavailable } from "http-errors";
+import { AxiosError, AxiosHeaders } from "axios";
+import { BadGateway, BadRequest, PaymentRequired, ServiceUnavailable } from "http-errors";
 import type { Mock } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
@@ -170,6 +171,59 @@ describe(ChainErrorService.name, () => {
       const appErr = await service.toAppError(err, encodeMessages);
       expect(appErr).toBeInstanceOf(PaymentRequired);
       expect(appErr.message).toBe("Insufficient balance");
+    });
+
+    it("returns 502 when cause is an AxiosError with 502 status", async () => {
+      const { service } = setup();
+      const axiosError = new AxiosError("Request failed", "ERR_BAD_RESPONSE", undefined, undefined, {
+        status: 502,
+        data: {},
+        statusText: "Bad Gateway",
+        headers: {},
+        config: { headers: new AxiosHeaders() }
+      });
+      const err = new Error("Bad status on response: 502", { cause: axiosError });
+
+      const appErr = await service.toAppError(err, encodeMessages);
+      expect(appErr).toBeInstanceOf(BadGateway);
+    });
+
+    it("returns upstream 5xx status from cause", async () => {
+      const { service } = setup();
+      const axiosError = new AxiosError("Request failed", "ERR_BAD_RESPONSE", undefined, undefined, {
+        status: 503,
+        data: {},
+        statusText: "Service Unavailable",
+        headers: {},
+        config: { headers: new AxiosHeaders() }
+      });
+      const err = new Error("Service unavailable", { cause: axiosError });
+
+      const appErr = await service.toAppError(err, encodeMessages);
+      expect(appErr).toBeInstanceOf(ServiceUnavailable);
+    });
+
+    it("returns original error when cause is an AxiosError with 4xx status", async () => {
+      const { service } = setup();
+      const axiosError = new AxiosError("Request failed", "ERR_BAD_REQUEST", undefined, undefined, {
+        status: 400,
+        data: {},
+        statusText: "Bad Request",
+        headers: {},
+        config: { headers: new AxiosHeaders() }
+      });
+      const err = new Error("Some upstream error", { cause: axiosError });
+
+      const appErr = await service.toAppError(err, encodeMessages);
+      expect(appErr).toBe(err);
+    });
+
+    it("returns original error when cause is not an AxiosError", async () => {
+      const { service } = setup();
+      const err = new Error("Unknown failure", { cause: new Error("some cause") });
+
+      const appErr = await service.toAppError(err, encodeMessages);
+      expect(appErr).toBe(err);
     });
   });
 

--- a/apps/api/src/billing/services/chain-error/chain-error.service.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.ts
@@ -1,5 +1,6 @@
 import { BalanceHttpService } from "@akashnetwork/http-sdk";
 import type { EncodeObject } from "@cosmjs/proto-signing";
+import axios from "axios";
 import createError from "http-errors";
 import { singleton } from "tsyringe";
 
@@ -81,6 +82,11 @@ export class ChainErrorService {
     const clue = clues.find(clue => error.message.toLowerCase().includes(clue.toLowerCase()));
 
     if (!clue) {
+      const upstreamStatus = this.getUpstreamStatusFromCause(error);
+      if (upstreamStatus) {
+        return createError(upstreamStatus, error.message, { originalError: error });
+      }
+
       return error;
     }
 
@@ -90,6 +96,16 @@ export class ChainErrorService {
     const prefixedMessage = messagePrefix ? `${messagePrefix}: ${message}` : message;
 
     return createError(code, prefixedMessage, { originalError: error });
+  }
+
+  private getUpstreamStatusFromCause(error: Error): number | undefined {
+    const { cause } = error;
+    if (!axios.isAxiosError(cause) || !cause.response) {
+      return undefined;
+    }
+
+    const status = cause.response.status;
+    return status >= 500 ? status : undefined;
   }
 
   public async isMasterWalletInsufficientFundsError(error: Error) {

--- a/apps/api/src/billing/services/external-signer-http-sdk/external-signer-http-sdk.service.ts
+++ b/apps/api/src/billing/services/external-signer-http-sdk/external-signer-http-sdk.service.ts
@@ -83,12 +83,12 @@ export class ExternalSignerHttpSdkService {
       if (axios.isAxiosError(error)) {
         const message = this.getErrorMessage(error.response?.data, error.message);
         this.logger.error({ event: "TX_SIGNER_REQUEST_FAILED", status: error.response?.status, message });
-        throw new Error(message);
+        throw new Error(message, { cause: error });
       }
 
       const message = error instanceof Error ? error.message : "Unknown error";
       this.logger.error({ event: "TX_SIGNER_REQUEST_FAILED", message });
-      throw new Error(message);
+      throw new Error(message, { cause: error });
     }
   }
 


### PR DESCRIPTION
## Why

When the tx-signer returns a 5xx error (e.g. 502), the API wraps it in a plain `Error` losing the status code. The error handler then defaults to 500, making it impossible to distinguish upstream failures from internal API errors.

## What

- `ExternalSignerHttpSdkService`: preserve the original `AxiosError` as `cause` when rethrowing
- `ChainErrorService`: extract upstream status from `error.cause` when no chain error clue matches — 5xx statuses are propagated as-is, 4xx are left unhandled
- Added 4 tests covering 502, 503, 4xx, and non-Axios cause scenarios

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test cases for error handling scenarios, validating upstream HTTP status code detection and error classification for gateway and service availability conditions.

* **Chores**
  * Enhanced error propagation in billing and signing services to preserve original error context throughout the system, improving error tracking and diagnostic capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->