### PR TITLE
fix(log-collector): defer ESTABLISHED log until first event received

### DIFF
--- a/apps/log-collector/src/services/k8s-events-collector/k8s-events-collector.service.spec.ts
+++ b/apps/log-collector/src/services/k8s-events-collector/k8s-events-collector.service.spec.ts
@@ -43,6 +43,30 @@ describe(K8sEventsCollectorService.name, () => {
     expect(writeStream.write).toHaveBeenCalledWith(expect.stringContaining('"reason":"Scheduled"'));
   });
 
+  it("should log POD_EVENTS_WATCH_ESTABLISHED on first event received", async () => {
+    const podInfo = seedPodInfoTestData();
+    const { service, ac, loggerService } = setup({ podInfo });
+
+    const event = seedKubernetesEventTestData({ involvedObject: { kind: "Pod", name: podInfo.podName, namespace: podInfo.namespace } });
+
+    const startPromise = service.collectPodEvents();
+    await vi.waitFor(() => expect(watch.watch).toHaveBeenCalled());
+
+    expect(loggerService.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "POD_EVENTS_WATCH_ESTABLISHED" }));
+
+    fireEvent("ADDED", event);
+    await vi.waitFor(() => expect(loggerService.info).toHaveBeenCalledWith(expect.objectContaining({ event: "POD_EVENTS_WATCH_ESTABLISHED" })));
+
+    fireEvent("MODIFIED", event);
+
+    ac.abort();
+    endWatch();
+    await startPromise;
+
+    expect(loggerService.info).toHaveBeenCalledWith(expect.objectContaining({ event: "POD_EVENTS_WATCH_ESTABLISHED", podName: podInfo.podName }));
+    expect(loggerService.info).toHaveBeenCalledTimes(1);
+  });
+
   it("should only include curated fields in the JSON output", async () => {
     const podInfo = seedPodInfoTestData();
     const { service, ac, writeStream } = setup({ podInfo });
@@ -84,6 +108,7 @@ describe(K8sEventsCollectorService.name, () => {
     await startPromise;
 
     expect(loggerService.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "POD_EVENTS_WATCH_FORBIDDEN", podName: podInfo.podName }));
+    expect(loggerService.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "POD_EVENTS_WATCH_ESTABLISHED" }));
   });
 
   it("should reconnect when watch ends without error", async () => {

--- a/apps/log-collector/src/services/k8s-events-collector/k8s-events-collector.service.ts
+++ b/apps/log-collector/src/services/k8s-events-collector/k8s-events-collector.service.ts
@@ -51,31 +51,35 @@ export class K8sEventsCollectorService {
     let doneError: unknown;
     let currentResourceVersion = resourceVersion;
 
-    await this.watch
-      .watch(
-        path,
-        { fieldSelector, resourceVersion },
-        (phase: string, apiObj: CoreV1Event) => {
-          if (apiObj.metadata?.resourceVersion) {
-            currentResourceVersion = apiObj.metadata.resourceVersion;
-          }
-          channel.push({ phase, event: apiObj });
-        },
-        (err?: unknown) => {
-          doneError = err;
-          channel.close();
+    await this.watch.watch(
+      path,
+      { fieldSelector, resourceVersion },
+      (phase: string, apiObj: CoreV1Event) => {
+        if (apiObj.metadata?.resourceVersion) {
+          currentResourceVersion = apiObj.metadata.resourceVersion;
         }
-      )
-      .then(() => {
+        channel.push({ phase, event: apiObj });
+      },
+      (err?: unknown) => {
+        doneError = err;
+        channel.close();
+      }
+    );
+
+    let established = false;
+
+    for await (const { phase, event } of channel) {
+      if (this.signal.aborted) break;
+
+      if (!established) {
         this.loggerService.info({
           event: "POD_EVENTS_WATCH_ESTABLISHED",
           podName: this.podInfo.podName,
           namespace: this.podInfo.namespace
         });
-      });
+        established = true;
+      }
 
-    for await (const { phase, event } of channel) {
-      if (this.signal.aborted) break;
       writeStream.write(this.formatLine(phase, event));
     }
 


### PR DESCRIPTION
## Why

The log sequence `POD_EVENTS_WATCH_ESTABLISHED` → `POD_EVENTS_WATCH_FORBIDDEN` is confusing. The K8s client resolves the watch promise when the HTTP connection opens, before auth errors arrive — so "established" was logged even when the watch was immediately forbidden.

## What

- Moved `POD_EVENTS_WATCH_ESTABLISHED` log from the `watch.watch()` `.then()` callback to fire only when the first real K8s event is received through the channel
- On 403, only `POD_EVENTS_WATCH_FORBIDDEN` is now logged
- Added test coverage for the established log timing and the forbidden-only case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests to verify the event watch logs the "watch established" message exactly once across watch lifecycles and that it is not logged when the watch ends due to a forbidden (403) error.

* **Bug Fixes**
  * Adjusted watch startup behavior so the "watch established" log is emitted on first received event (once), improving accuracy of watch initialization reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->