### PR TITLE
fix(analytics): add dseq property to bids_received event

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
@@ -146,7 +146,8 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
     if (bids && bids.length > 0 && !bidsReceivedTracked.current) {
       bidsReceivedTracked.current = true;
       analyticsService.track("bids_received", {
-        numberOfBids: bids.length
+        numberOfBids: bids.length,
+        dseq
       });
     }
   }, [bids, analyticsService]);


### PR DESCRIPTION
## Why

Fixes CON-201

The `bids_received` Amplitude event lacks a `dseq` property, making it impossible to deduplicate fires per deployment or join with `create_deployment` events. The event can fire multiple times for the same deployment when the `CreateLease` component remounts, inflating funnel counts.

Adding `dseq` enables accurate per-deployment funnel analysis in Amplitude using the "holding constant" feature — needed to measure the impact of bid precheck (CON-186).

## What

Added `dseq` to the `bids_received` analytics event in `CreateLease.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced analytics tracking for bid requests by including deployment sequence information in collected data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->