### PR TITLE
feat(deployment): redesign deposit modal with ACT auto-mint support

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDepositModal/DeploymentDepositModal.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDepositModal/DeploymentDepositModal.spec.tsx
@@ -7,43 +7,180 @@ import { DeploymentDepositModal } from "./DeploymentDepositModal";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 describe(DeploymentDepositModal.name, () => {
-  it("shows ACT mint alert when denom is ACT and balance is 0", () => {
-    setup({ denom: UACT_DENOM, denomBalance: 0 });
+  describe("ACT deposit UI", () => {
+    it("renders radio presets for ACT denom", () => {
+      setup({ denom: UACT_DENOM, denomBalance: 100 });
 
-    expect(screen.getByText(/mint ACT tokens/)).toBeInTheDocument();
-    expect(screen.getByText("Go to Mint / Burn")).toBeInTheDocument();
+      expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+      expect(screen.getByLabelText("25")).toBeInTheDocument();
+      expect(screen.getByLabelText("50")).toBeInTheDocument();
+      expect(screen.getByLabelText("100")).toBeInTheDocument();
+    });
+
+    it("does not render radio presets for non-ACT denom", () => {
+      setup({ denom: UAKT_DENOM, denomBalance: 100 });
+
+      expect(screen.queryByRole("radiogroup")).not.toBeInTheDocument();
+    });
+
+    it("fills input when preset is selected", async () => {
+      setup({ denom: UACT_DENOM, denomBalance: 100 });
+
+      fireEvent.click(screen.getByLabelText("50"));
+
+      const input = await screen.findByPlaceholderText("Enter here");
+      expect(input).toHaveValue(50);
+    });
+
+    it("clears preset when custom amount is entered", () => {
+      setup({ denom: UACT_DENOM, denomBalance: 100 });
+
+      fireEvent.click(screen.getByLabelText("25"));
+      const input = screen.getByPlaceholderText("Enter here");
+      fireEvent.change(input, { target: { value: "42" } });
+
+      expect(screen.getByLabelText("25")).not.toBeChecked();
+    });
+
+    it("defaults to min amount and enables Continue", () => {
+      setup({ denom: UACT_DENOM, denomBalance: 100 });
+
+      const continueButton = screen.getByTestId("deposit-modal-continue-button");
+      expect(continueButton).not.toBeDisabled();
+    });
+
+    it("shows balance in red when balance < selected amount", () => {
+      setup({ denom: UACT_DENOM, denomBalance: 10 });
+
+      fireEvent.click(screen.getByLabelText("25"));
+
+      const balanceDisplay = screen.getByTestId("act-balance-display");
+      expect(balanceDisplay).toHaveClass("text-destructive");
+    });
+
+    it("shows balance in normal color when balance >= selected amount", () => {
+      setup({ denom: UACT_DENOM, denomBalance: 100 });
+
+      fireEvent.click(screen.getByLabelText("25"));
+
+      const balanceDisplay = screen.getByTestId("act-balance-display");
+      expect(balanceDisplay).toHaveClass("text-muted-foreground");
+    });
+
+    it("shows below-min message and disables Continue when amount < min", () => {
+      setup({ denom: UACT_DENOM, denomBalance: 100, denomMin: 10 });
+
+      const input = screen.getByPlaceholderText("Enter here");
+      fireEvent.change(input, { target: { value: "5" } });
+
+      expect(screen.getByTestId("act-balance-display")).toHaveTextContent("Minimum deposit amount is 10 ACT");
+      expect(screen.getByTestId("act-balance-display")).toHaveClass("text-destructive");
+      expect(screen.getByTestId("deposit-modal-continue-button")).toBeDisabled();
+    });
   });
 
-  it("shows ACT mint alert when denom is ACT and balance is less than amount", () => {
-    setup({ denom: UACT_DENOM, denomBalance: 5, denomMin: 10 });
+  describe("auto-mint", () => {
+    it("shows auto-mint notice when ACT balance insufficient but total sufficient", () => {
+      setup({ denom: UACT_DENOM, denomBalance: 10, balanceUAKT: 500_000_000 });
 
-    expect(screen.getByText(/mint ACT tokens/)).toBeInTheDocument();
+      fireEvent.click(screen.getByLabelText("25"));
+
+      expect(screen.getByTestId("act-auto-mint-notice")).toBeInTheDocument();
+      expect(screen.getByTestId("deposit-modal-continue-button")).not.toBeDisabled();
+    });
+
+    it("shows insufficient total balance alert and disables Continue when total too low", () => {
+      setup({ denom: UACT_DENOM, denomBalance: 5, balanceUAKT: 1_000_000 });
+
+      fireEvent.click(screen.getByLabelText("25"));
+
+      expect(screen.getByTestId("act-insufficient-total-balance")).toBeInTheDocument();
+      expect(screen.queryByTestId("act-auto-mint-notice")).not.toBeInTheDocument();
+      expect(screen.getByTestId("deposit-modal-continue-button")).toBeDisabled();
+    });
+
+    it("does not show any mint alert when ACT balance is sufficient", () => {
+      setup({ denom: UACT_DENOM, denomBalance: 100 });
+
+      fireEvent.click(screen.getByLabelText("25"));
+
+      expect(screen.queryByTestId("act-auto-mint-notice")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("act-insufficient-total-balance")).not.toBeInTheDocument();
+    });
   });
 
-  it("does not show ACT mint alert when denom is ACT and balance is sufficient", () => {
-    setup({ denom: UACT_DENOM, denomBalance: 100, denomMin: 5 });
+  describe("managed wallet", () => {
+    it("disables Continue when balance < selected amount", () => {
+      setup({ denom: UACT_DENOM, denomBalance: 10, isManaged: true });
 
-    expect(screen.queryByText(/mint ACT tokens/)).not.toBeInTheDocument();
+      fireEvent.click(screen.getByLabelText("$25"));
+
+      expect(screen.getByTestId("deposit-modal-continue-button")).toBeDisabled();
+    });
+
+    it("does not show mint alerts for managed wallet", () => {
+      setup({ denom: UACT_DENOM, denomBalance: 10, isManaged: true });
+
+      fireEvent.click(screen.getByLabelText("$25"));
+
+      expect(screen.queryByTestId("act-auto-mint-notice")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("act-insufficient-total-balance")).not.toBeInTheDocument();
+    });
+
+    it("shows $ labels instead of ACT", () => {
+      setup({ denom: UACT_DENOM, denomBalance: 100, isManaged: true });
+
+      expect(screen.getByText("Select the credits amount")).toBeInTheDocument();
+      expect(screen.getByLabelText("$25")).toBeInTheDocument();
+      expect(screen.getByLabelText("$50")).toBeInTheDocument();
+      expect(screen.getByLabelText("$100")).toBeInTheDocument();
+      expect(screen.getByTestId("act-balance-display")).toHaveTextContent("Current Balance: $100.00");
+    });
+
+    it("shows $ in below-min message", () => {
+      setup({ denom: UACT_DENOM, denomBalance: 100, denomMin: 10, isManaged: true });
+
+      const input = screen.getByPlaceholderText("Enter here");
+      fireEvent.change(input, { target: { value: "5" } });
+
+      expect(screen.getByTestId("act-balance-display")).toHaveTextContent("Minimum deposit amount is $10");
+    });
   });
 
-  it("does not show ACT mint alert when denom is not ACT", () => {
-    setup({ denom: UAKT_DENOM, denomBalance: 0 });
+  describe("submit", () => {
+    it("calls onSubmit with udenom amount when Continue is clicked", async () => {
+      const { onSubmit } = setup({ denom: UACT_DENOM, denomBalance: 100 });
 
-    expect(screen.queryByText(/mint ACT tokens/)).not.toBeInTheDocument();
+      fireEvent.click(screen.getByLabelText("25"));
+      fireEvent.click(screen.getByTestId("deposit-modal-continue-button"));
+
+      await vi.waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(25_000_000);
+      });
+    });
   });
 
-  it("navigates to mint-burn page and closes modal on CTA click", () => {
-    const { handleCancel, routerPush } = setup({ denom: UACT_DENOM, denomBalance: 0 });
+  describe("non-ACT denom", () => {
+    it("does not show ACT-specific UI", () => {
+      setup({ denom: UAKT_DENOM, denomBalance: 100 });
 
-    fireEvent.click(screen.getByText("Go to Mint / Burn"));
-
-    expect(handleCancel).toHaveBeenCalled();
-    expect(routerPush).toHaveBeenCalledWith("/mint-burn");
+      expect(screen.queryByRole("radiogroup")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("act-balance-display")).not.toBeInTheDocument();
+      expect(screen.queryByTestId("act-auto-mint-notice")).not.toBeInTheDocument();
+    });
   });
 
-  function setup(input: { denom: string; denomBalance: number; denomMin?: number }) {
-    const handleCancel = vi.fn();
-    const onDeploymentDeposit = vi.fn();
+  describe("subtitle", () => {
+    it("renders subtitle when provided", () => {
+      setup({ denom: UACT_DENOM, denomBalance: 100, subtitle: "Test subtitle text" });
+
+      expect(screen.getByText("Test subtitle text")).toBeInTheDocument();
+    });
+  });
+
+  function setup(input: { denom: string; denomBalance: number; denomMin?: number; isManaged?: boolean; balanceUAKT?: number; subtitle?: string }) {
+    const onCancel = vi.fn();
+    const onSubmit = vi.fn();
     const routerPush = vi.fn();
 
     const dependencies = {
@@ -51,11 +188,23 @@ describe(DeploymentDepositModal.name, () => {
         analyticsService: { track: vi.fn() },
         urlService: { mintBurn: () => "/mint-burn", billing: () => "/billing" }
       }),
-      useWallet: () => ({ isManaged: false }),
-      useWalletBalance: () => ({ balance: { balanceUAKT: 1000000 } }),
-      usePricing: () => ({ isLoaded: true, usdToAkt: (v: number) => v }),
+      useWallet: () => ({ isManaged: input.isManaged ?? false }),
+      useWalletBalance: () => ({
+        balance: {
+          balanceUAKT: input.balanceUAKT ?? 500_000_000,
+          balanceUACT: input.denomBalance * 1_000_000
+        }
+      }),
+      usePricing: () => ({ isLoaded: true, price: 1.0, usdToAkt: (v: number) => v }),
+      useMintACT: () => ({
+        mint: vi.fn(),
+        isLoading: false,
+        isSuccess: false,
+        error: null
+      }),
+      useBmeParams: () => ({ data: { minMintAct: 5 } }),
       useDenomData: () => ({
-        min: input.denomMin ?? 5,
+        min: input.denomMin ?? 0.5,
         max: input.denomBalance,
         balance: input.denomBalance,
         label: "ACT"
@@ -64,8 +213,8 @@ describe(DeploymentDepositModal.name, () => {
       useRouter: () => ({ push: routerPush })
     } as unknown as typeof DEPENDENCIES;
 
-    render(<DeploymentDepositModal denom={input.denom} handleCancel={handleCancel} onDeploymentDeposit={onDeploymentDeposit} dependencies={dependencies} />);
+    render(<DeploymentDepositModal denom={input.denom} onCancel={onCancel} onSubmit={onSubmit} subtitle={input.subtitle} dependencies={dependencies} />);
 
-    return { handleCancel, routerPush };
+    return { onCancel, routerPush, onSubmit };
   }
 });

--- a/apps/deploy-web/src/components/deployments/DeploymentDepositModal/DeploymentDepositModal.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDepositModal/DeploymentDepositModal.tsx
@@ -1,10 +1,12 @@
 "use client";
 import type { MouseEventHandler, ReactNode } from "react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import type { ActionButton } from "@akashnetwork/ui/components";
-import { Alert, Form, FormField, FormInput, Popup } from "@akashnetwork/ui/components";
+import { Alert, Form, FormField, FormInput, Popup, RadioGroup, RadioGroupItem } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { AlertTriangle } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { z } from "zod";
 
@@ -12,10 +14,13 @@ import { UACT_DENOM, UAKT_DENOM } from "@src/config/denom.config";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useAddFundsVerifiedLoginRequiredEventHandler } from "@src/hooks/useAddFundsVerifiedLoginRequiredEventHandler";
+import { useMintACT } from "@src/hooks/useMintACT/useMintACT";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useDenomData, useWalletBalance } from "@src/hooks/useWalletBalance";
+import { useBmeParams } from "@src/queries/useBmeQuery";
 import type { ServiceType } from "@src/types";
-import { denomToUdenom } from "@src/utils/mathHelpers";
+import { denomToUdenom, roundDecimal, udenomToDenom } from "@src/utils/mathHelpers";
+import { TransactionModal } from "../../layout/TransactionModal";
 import { LeaseSpecDetail } from "../../shared/LeaseSpecDetail";
 import { LinkTo } from "../../shared/LinkTo";
 
@@ -25,155 +30,235 @@ export const DEPENDENCIES = {
   useWalletBalance,
   usePricing,
   useDenomData,
+  useMintACT,
+  useBmeParams,
   useAddFundsVerifiedLoginRequiredEventHandler,
   useRouter
 };
 
 export type DeploymentDepositModalProps = {
-  infoText?: string | ReactNode;
+  subtitle?: string | ReactNode;
   disableMin?: boolean;
   denom: string;
-  onDeploymentDeposit: (deposit: number) => void;
-  handleCancel: () => void;
+  onSubmit: (deposit: number) => void;
+  onCancel: () => void;
   children?: ReactNode;
   title?: string;
   services?: ServiceType[];
   dependencies?: typeof DEPENDENCIES;
 };
 
+const DEPOSIT_PRESETS = [25, 50, 100] as const;
+
 const formSchema = z.object({
   amount: z.coerce
     .number({
       invalid_type_error: "Amount must be a number."
     })
-    .min(0.000001, { message: "Amount is required." })
+    .min(0, { message: "Amount is required." })
 });
 
 export const DeploymentDepositModal: React.FunctionComponent<DeploymentDepositModalProps> = ({
-  handleCancel,
-  onDeploymentDeposit,
+  onCancel,
+  onSubmit,
   disableMin,
   denom,
   title = "Deployment Deposit",
-  infoText = null,
+  subtitle = null,
   services = [],
   dependencies: d = DEPENDENCIES
 }) => {
   const { analyticsService, urlService } = d.useServices();
-  const formRef = useRef<HTMLFormElement>(null);
-  const [error, setError] = useState("");
   const { isManaged } = d.useWallet();
   const { balance: walletBalance } = d.useWalletBalance();
   const pricing = d.usePricing();
   const depositData = d.useDenomData(denom);
+  const { mint, isLoading: isMinting, isSuccess: isMintSuccess, error: mintError } = d.useMintACT();
+  const { data: bmeParams } = d.useBmeParams();
+  const whenLoggedInAndVerified = d.useAddFundsVerifiedLoginRequiredEventHandler();
+  const router = d.useRouter();
+  const formRef = useRef<HTMLFormElement>(null);
+  const onSubmitRef = useRef(onSubmit);
+  onSubmitRef.current = onSubmit;
+  const [selectedPreset, setSelectedPreset] = useState<string>("");
+  const [pendingDeposit, setPendingDeposit] = useState<number | null>(null);
   const form = useForm<z.infer<typeof formSchema>>({
-    defaultValues: {
-      amount: 0
-    },
+    defaultValues: { amount: 0 },
     resolver: zodResolver(formSchema)
   });
   const { handleSubmit, control, watch, setValue, clearErrors } = form;
   const { amount } = watch();
-  const whenLoggedInAndVerified = d.useAddFundsVerifiedLoginRequiredEventHandler();
-  const router = d.useRouter();
 
-  const closePopupAndGoToCheckoutIfPossible = (event: React.MouseEvent) => {
-    analyticsService.track("buy_credits_btn_clk", "Amplitude");
-    handleCancel();
+  const isACT = denom === UACT_DENOM;
+  const isBelowMin = !disableMin && depositData !== null && amount > 0 && amount < (depositData?.min ?? 0);
+  const isACTBalanceInsufficient = depositData !== null && amount > (depositData?.balance ?? 0);
+  const isTotalBalanceInsufficient = useMemo(() => {
+    if (isManaged || !isACT || !walletBalance || !pricing.price) return false;
 
-    whenLoggedInAndVerified(goToCheckout)(event);
-  };
+    const actBalance = udenomToDenom(walletBalance.balanceUACT);
+    if (amount <= actBalance) return false;
 
-  const goToCheckout = () => {
-    router.push(urlService.billing({ openPayment: true }));
-  };
+    const deficit = amount - actBalance;
+    const mintAmount = Math.max(deficit, bmeParams?.minMintAct ?? 0);
+    const aktCostForMint = (mintAmount / pricing.price) * 1.02;
+    const aktBalance = udenomToDenom(walletBalance.balanceUAKT);
 
-  useEffect(() => {
-    if (depositData && amount === 0 && !disableMin) {
-      setValue("amount", depositData?.min || 0);
-    }
-  }, [depositData, amount, disableMin, setValue]);
+    return aktCostForMint > aktBalance;
+  }, [isManaged, isACT, walletBalance, pricing.price, amount, bmeParams?.minMintAct]);
 
-  const onClose = () => {
-    analyticsService.track("close_deposit_modal", "Amplitude");
-    handleCancel();
-  };
+  const willAutoMint = !isManaged && isACT && isACTBalanceInsufficient && !isTotalBalanceInsufficient;
+  const isSubmitDisabled =
+    !amount || !walletBalance || isBelowMin || isMinting || (isACT && isManaged && isACTBalanceInsufficient) || isTotalBalanceInsufficient;
 
-  const onBalanceClick = () => {
+  useEffect(
+    function setMinAmount() {
+      if (depositData && amount === 0 && !disableMin) {
+        setValue("amount", depositData?.min || 0);
+      }
+    },
+    [depositData, amount, disableMin, setValue]
+  );
+
+  useEffect(
+    function submitAfterMint() {
+      if (pendingDeposit === null || isMinting) return;
+
+      if (isMintSuccess) {
+        onSubmitRef.current(pendingDeposit);
+      }
+
+      setPendingDeposit(null);
+    },
+    [pendingDeposit, isMintSuccess, isMinting]
+  );
+
+  const selectPreset = useCallback(
+    (value: string) => {
+      setSelectedPreset(value);
+      setValue("amount", Number(value));
+      clearErrors();
+    },
+    [setValue, clearErrors]
+  );
+
+  const clearPresetAndUpdateAmount = useCallback((e: React.ChangeEvent<HTMLInputElement>, fieldOnChange: (e: React.ChangeEvent<HTMLInputElement>) => void) => {
+    fieldOnChange(e);
+    setSelectedPreset("");
+  }, []);
+
+  const fillMaxAmount = useCallback(() => {
     clearErrors();
     setValue("amount", depositData?.max || 0);
-  };
+  }, [clearErrors, setValue, depositData?.max]);
 
-  const onDepositClick: MouseEventHandler = event => {
-    event.preventDefault();
-    formRef.current?.dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
-  };
+  const convertAndSubmitDeposit = useCallback(
+    ({ amount: submittedAmount }: z.infer<typeof formSchema>) => {
+      if (isSubmitDisabled) return;
 
-  const onSubmit = async ({ amount }: z.infer<typeof formSchema>) => {
-    setError("");
-    clearErrors();
-    const amountInDenom = (isManaged && denom === UAKT_DENOM ? pricing.usdToAkt(amount) : amount) || 0;
-    const deposit = denomToUdenom(amountInDenom);
+      const amountInDenom = roundDecimal((isManaged && denom === UAKT_DENOM ? pricing.usdToAkt(submittedAmount) : submittedAmount) || 0, 6);
+      const deposit = denomToUdenom(amountInDenom);
 
-    if (!disableMin && amount < (depositData?.min || 0)) {
-      setError(`Deposit amount must be greater or equal than ${depositData?.min}.`);
-      return;
-    }
+      if (willAutoMint) {
+        const deficit = deposit - denomToUdenom(depositData?.balance ?? 0);
+        if (deficit <= 0) {
+          onSubmit(deposit);
+          return;
+        }
+        setPendingDeposit(deposit);
+        mint(deficit);
+      } else {
+        onSubmit(deposit);
+      }
+    },
+    [isSubmitDisabled, isManaged, denom, pricing, onSubmit, willAutoMint, depositData?.balance, mint]
+  );
 
-    if (depositData && amount > depositData?.balance) {
-      setError(`You can't deposit more than you currently have in your balance. Current balance is: ${depositData?.balance} ${depositData?.label}.`);
-      return;
-    }
+  const submitForm: MouseEventHandler = useCallback(
+    event => {
+      event.preventDefault();
+      formRef.current?.dispatchEvent(new Event("submit", { cancelable: true, bubbles: true }));
+    },
+    [formRef]
+  );
 
-    onDeploymentDeposit(deposit);
-  };
+  const trackAndClose = useCallback(() => {
+    if (isMinting) return;
+    analyticsService.track("close_deposit_modal", "Amplitude");
+    onCancel();
+  }, [analyticsService, onCancel, isMinting]);
+
+  const navigateToCheckout = useCallback(() => {
+    router.push(urlService.billing({ openPayment: true }));
+  }, [router, urlService]);
+
+  const trackAndNavigateToCheckout = useCallback(
+    (event: React.MouseEvent) => {
+      analyticsService.track("buy_credits_btn_clk", "Amplitude");
+      onCancel();
+      whenLoggedInAndVerified(navigateToCheckout)(event);
+    },
+    [analyticsService, onCancel, whenLoggedInAndVerified, navigateToCheckout]
+  );
+
+  const actions = useMemo(
+    () =>
+      [
+        ...(isManaged
+          ? [
+              {
+                label: "Buy credits",
+                color: "primary",
+                variant: "ghost",
+                side: "left",
+                onClick: trackAndNavigateToCheckout,
+                "data-testid": "deposit-modal-buy-credits-button"
+              }
+            ]
+          : []),
+        {
+          label: "Cancel",
+          color: "primary",
+          variant: "outline",
+          side: "right",
+          disabled: isMinting,
+          onClick: trackAndClose
+        },
+        {
+          label: isMinting ? "Minting ACT..." : "Continue",
+          color: "secondary",
+          variant: "default",
+          side: "right",
+          disabled: isSubmitDisabled,
+          isLoading: isMinting,
+          onClick: submitForm,
+          "data-testid": "deposit-modal-continue-button"
+        }
+      ] as ActionButton[],
+    [isManaged, trackAndNavigateToCheckout, trackAndClose, isSubmitDisabled, isMinting, submitForm]
+  );
 
   return (
-    <Popup
-      fullWidth
-      open
-      variant="custom"
-      actions={
-        [
-          {
-            label: "Cancel",
-            color: "primary",
-            variant: "ghost",
-            side: "left",
-            onClick: onClose
-          },
-          ...(isManaged
-            ? [
-                {
-                  label: "Buy credits",
-                  color: "primary",
-                  variant: "ghost",
-                  side: "right",
-                  onClick: closePopupAndGoToCheckoutIfPossible,
-                  "data-testid": "deposit-modal-buy-credits-button"
-                }
-              ]
-            : []),
-          {
-            label: "Continue",
-            color: "secondary",
-            variant: "default",
-            side: "right",
-            disabled: !amount || !walletBalance,
-            onClick: onDepositClick,
-            "data-testid": "deposit-modal-continue-button"
-          }
-        ] as ActionButton[]
-      }
-      onClose={onClose}
-      enableCloseOnBackdropClick
-      title={title}
-    >
-      <div className="space-y-6">
-        {services.length > 0 && (
-          <div className="max-h-[300px] space-y-4 overflow-auto">
-            {services.map(service => {
-              return (
+    <>
+      <Popup
+        fullWidth
+        open
+        variant="custom"
+        actions={actions}
+        onClose={trackAndClose}
+        enableCloseOnBackdropClick={!isMinting}
+        title={
+          (title || subtitle) && (
+            <div className="flex flex-col gap-1.5">
+              {title && <span>{title}</span>}
+              {subtitle && <div className="text-sm font-normal text-muted-foreground">{subtitle}</div>}
+            </div>
+          )
+        }
+      >
+        <div className="space-y-4">
+          {services.length > 0 && (
+            <div className="max-h-[300px] space-y-4 overflow-auto">
+              {services.map(service => (
                 <Alert key={service.title}>
                   <div className="mb-2 break-all text-sm">
                     <span className="font-bold">{service.title}</span>:{service.image}
@@ -189,65 +274,125 @@ export const DeploymentDepositModal: React.FunctionComponent<DeploymentDepositMo
                     />
                   </div>
                 </Alert>
-              );
-            })}
-          </div>
-        )}
-
-        <Form {...form}>
-          <form onSubmit={handleSubmit(onSubmit)} ref={formRef}>
-            {infoText}
-
-            <div className="w-full">
-              <FormField
-                control={control}
-                name="amount"
-                render={({ field }) => {
-                  return (
-                    <FormInput
-                      {...field}
-                      type="number"
-                      label={
-                        <div className="mb-1 flex items-center justify-between">
-                          <span>Amount</span>
-                          <LinkTo onClick={() => onBalanceClick()} className="text-xs">
-                            Balance: {depositData?.balance} {depositData?.label}
-                          </LinkTo>
-                        </div>
-                      }
-                      autoFocus
-                      min={!disableMin ? depositData?.min : 0}
-                      step={0.000001}
-                      max={depositData?.max}
-                      startIcon={<div className="pl-2 text-xs">{depositData?.label}</div>}
-                    />
-                  );
-                }}
-              />
+              ))}
             </div>
+          )}
 
-            {!isManaged && denom === UACT_DENOM && depositData && (depositData.balance === 0 || depositData.balance < amount) && (
-              <Alert className="mt-4 text-sm">
-                To continue, mint ACT tokens.{" "}
-                <LinkTo
-                  onClick={() => {
-                    handleCancel();
-                    router.push(urlService.mintBurn());
-                  }}
-                >
-                  Go to Mint / Burn
-                </LinkTo>
-              </Alert>
-            )}
+          <Form {...form}>
+            <form onSubmit={handleSubmit(convertAndSubmitDeposit)} ref={formRef}>
+              {isACT ? (
+                <div className="w-full space-y-4">
+                  <div>
+                    <div className="mb-2 text-sm font-medium">{isManaged ? "Select the credits amount" : "Select amount of ACT"}</div>
+                    <RadioGroup value={selectedPreset} onValueChange={selectPreset} className="flex gap-3">
+                      {DEPOSIT_PRESETS.map(preset => (
+                        <label
+                          key={preset}
+                          className={cn(
+                            "flex flex-1 cursor-pointer items-center gap-3 rounded-lg border p-3",
+                            selectedPreset === String(preset) ? "border-primary bg-muted" : "border-border"
+                          )}
+                        >
+                          <RadioGroupItem value={String(preset)} />
+                          <span className="text-sm font-medium">{isManaged ? `$${preset}` : preset}</span>
+                        </label>
+                      ))}
+                    </RadioGroup>
+                  </div>
 
-            {error && (
-              <Alert variant="destructive" className="mt-4 text-sm">
-                {error}
-              </Alert>
-            )}
-          </form>
-        </Form>
-      </div>
-    </Popup>
+                  <FormField
+                    control={control}
+                    name="amount"
+                    render={({ field }) => (
+                      <FormInput
+                        {...field}
+                        type="number"
+                        label={
+                          <span>
+                            Or enter custom amount{" "}
+                            <span className="text-muted-foreground">(minimum {isManaged ? `$${depositData?.min ?? 0}` : `${depositData?.min ?? 0} ACT`})</span>
+                          </span>
+                        }
+                        placeholder="Enter here"
+                        min={0}
+                        step={0.000001}
+                        onChange={e => clearPresetAndUpdateAmount(e, field.onChange)}
+                      />
+                    )}
+                  />
+
+                  <div
+                    className={cn("text-sm", isACTBalanceInsufficient || isBelowMin ? "text-destructive" : "text-muted-foreground")}
+                    data-testid="act-balance-display"
+                  >
+                    {isBelowMin
+                      ? isManaged
+                        ? `Minimum deposit amount is $${depositData?.min}`
+                        : `Minimum deposit amount is ${depositData?.min} ACT`
+                      : isManaged
+                        ? `Current Balance: $${depositData?.balance?.toFixed(2)}`
+                        : `Current Balance: ${depositData?.balance?.toFixed(2)} ACT`}
+                  </div>
+
+                  {isTotalBalanceInsufficient && (
+                    <Alert className="bg-transparent px-4 py-3" data-testid="act-insufficient-total-balance">
+                      <div className="flex items-start gap-3 text-sm">
+                        <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                        <span className="text-muted-foreground">
+                          Your combined AKT and ACT balance is too low. Add AKT to your wallet to mint ACT for this deployment.
+                        </span>
+                      </div>
+                    </Alert>
+                  )}
+
+                  {willAutoMint && (
+                    <Alert className="bg-transparent px-4 py-3" data-testid="act-auto-mint-notice">
+                      <div className="flex items-start gap-3 text-sm">
+                        <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                        <span className="text-muted-foreground">Your balance is too low. We&apos;ll automatically mint ACT to cover this deployment.</span>
+                      </div>
+                    </Alert>
+                  )}
+
+                  {mintError && (
+                    <Alert variant="destructive" className="px-4 py-3 text-sm" data-testid="act-mint-error">
+                      {mintError}
+                    </Alert>
+                  )}
+                </div>
+              ) : (
+                <div className="w-full">
+                  <FormField
+                    control={control}
+                    name="amount"
+                    render={({ field }) => (
+                      <FormInput
+                        {...field}
+                        type="number"
+                        label={
+                          <div className="mb-1 flex items-center justify-between">
+                            <span>Amount</span>
+                            <LinkTo onClick={fillMaxAmount} className="text-xs">
+                              Balance: {depositData?.balance} {depositData?.label}
+                            </LinkTo>
+                          </div>
+                        }
+                        autoFocus
+                        min={!disableMin ? depositData?.min : 0}
+                        step={0.000001}
+                        max={depositData?.max}
+                        startIcon={<div className="pl-2 text-xs">{depositData?.label}</div>}
+                      />
+                    )}
+                  />
+                </div>
+              )}
+            </form>
+          </Form>
+        </div>
+      </Popup>
+
+      <TransactionModal state={isMinting ? "mintingACT" : undefined} />
+    </>
   );
 };

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.spec.tsx
@@ -286,6 +286,9 @@ describe(DeploymentDetailTopBar.name, () => {
         realTimeLeft: undefined,
         deploymentCost: 0
       })) as typeof DEPENDENCIES.useDeploymentMetrics,
+      useDepositDeployment: vi.fn(() => ({
+        deposit: vi.fn(() => Promise.resolve(true))
+      })) as unknown as typeof DEPENDENCIES.useDepositDeployment,
       useCurrencyFormatter: vi.fn(() => (value: number) => `$${value.toFixed(2)}`) as unknown as typeof DEPENDENCIES.useCurrencyFormatter,
       usePopup: vi.fn(() => ({
         confirm: vi.fn(() => Promise.resolve(true)),

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.tsx
@@ -18,6 +18,7 @@ import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useCurrencyFormatter } from "@src/hooks/useCurrencyFormatter/useCurrencyFormatter";
 import { useDeploymentMetrics } from "@src/hooks/useDeploymentMetrics";
+import { useDepositDeployment } from "@src/hooks/useDepositDeployment/useDepositDeployment";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { usePreviousRoute } from "@src/hooks/usePreviousRoute";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
@@ -42,6 +43,7 @@ export const DEPENDENCIES = {
   useLocalNotes,
   useWallet,
   useCurrencyFormatter,
+  useDepositDeployment,
   useDeploymentMetrics,
   useManagedDeploymentConfirm,
   usePreviousRoute,
@@ -123,27 +125,25 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
     router.push(url);
   };
 
-  const onDeploymentDeposit = async (deposit: number) => {
-    setIsDepositingDeployment(false);
-    const message = TransactionMessageData.getDepositDeploymentMsg(
-      address,
-      address,
-      deployment.dseq,
-      deposit,
-      deployment.escrowAccount.state.funds[0]?.denom || ""
-    );
-    const response = await wallet.signAndBroadcastTx([message]);
-    if (response) {
+  const { deposit: depositDeployment } = d.useDepositDeployment({
+    dseq: deployment.dseq,
+    denom: deployment.escrowAccount.state.funds[0]?.denom || "",
+    onSuccess: () => {
       loadDeploymentDetail();
-
       analyticsService.track("deployment_deposit", {
         category: "deployments",
         label: "Deposit deployment in deployment detail"
       });
     }
+  });
 
-    return response;
-  };
+  const onDeploymentDeposit = useCallback(
+    async (deposit: number) => {
+      setIsDepositingDeployment(false);
+      return depositDeployment(deposit);
+    },
+    [depositDeployment]
+  );
 
   const formatCurrency = useCurrencyFormatter();
   const setAutoTopUpEnabled = useCallback(
@@ -166,9 +166,8 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
             return;
           }
 
-          const isSuccess = await onDeploymentDeposit(deposit);
-
-          if (!isSuccess) {
+          const deposited = await onDeploymentDeposit(deposit);
+          if (!deposited) {
             return;
           }
         }
@@ -309,8 +308,8 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
         <d.DeploymentDepositModal
           denom={deployment.escrowAccount.state.funds[0]?.denom || ""}
           disableMin
-          handleCancel={() => setIsDepositingDeployment(false)}
-          onDeploymentDeposit={onDeploymentDeposit}
+          onCancel={() => setIsDepositingDeployment(false)}
+          onSubmit={onDeploymentDeposit}
         />
       )}
     </>

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -24,6 +24,7 @@ import { useRouter } from "next/navigation";
 import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
+import { useDepositDeployment } from "@src/hooks/useDepositDeployment/useDepositDeployment";
 import { useManagedDeploymentConfirm } from "@src/hooks/useManagedDeploymentConfirm";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { useRealTimeLeft } from "@src/hooks/useRealTimeLeft";
@@ -106,25 +107,21 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
     setOpen(false);
   };
 
-  const onDeploymentDeposit: DeploymentDepositModalProps["onDeploymentDeposit"] = async deposit => {
-    setIsDepositingDeployment(false);
-
-    const message = TransactionMessageData.getDepositDeploymentMsg(
-      address,
-      address,
-      deployment.dseq,
-      deposit,
-      deployment.escrowAccount.state.funds[0]?.denom || ""
-    );
-    const response = await signAndBroadcastTx([message]);
-    if (response) {
+  const { deposit: depositDeployment } = useDepositDeployment({
+    dseq: deployment.dseq,
+    denom: deployment.escrowAccount.state.funds[0]?.denom || "",
+    onSuccess: () => {
       refreshDeployments();
-
       analyticsService.track("deployment_deposit", {
         category: "deployments",
         label: "Deposit to deployment from list"
       });
     }
+  });
+
+  const onDeploymentDeposit: DeploymentDepositModalProps["onSubmit"] = deposit => {
+    setIsDepositingDeployment(false);
+    depositDeployment(deposit);
   };
 
   const onCloseDeployment = async () => {
@@ -365,8 +362,8 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
         <DeploymentDepositModal
           denom={deployment.escrowAccount.state.funds[0]?.denom || ""}
           disableMin
-          handleCancel={() => setIsDepositingDeployment(false)}
-          onDeploymentDeposit={onDeploymentDeposit}
+          onCancel={() => setIsDepositingDeployment(false)}
+          onSubmit={onDeploymentDeposit}
         />
       )}
     </>

--- a/apps/deploy-web/src/components/layout/TransactionModal.tsx
+++ b/apps/deploy-web/src/components/layout/TransactionModal.tsx
@@ -10,7 +10,8 @@ export type LoadingState =
   | "updatingDeployment"
   | "creatingLease"
   | "closingDeployment"
-  | "depositingDeployment";
+  | "depositingDeployment"
+  | "mintingACT";
 
 type Props = {
   state?: LoadingState;
@@ -26,10 +27,15 @@ const TITLES: Record<LoadingState, string> = {
   updatingDeployment: "Updating Deployment",
   creatingLease: "Creating Lease",
   closingDeployment: "Closing Deployment",
-  depositingDeployment: "Depositing Deployment"
+  depositingDeployment: "Depositing Deployment",
+  mintingACT: "Minting ACT"
 };
 
-const CRYPTO_STATES: LoadingState[] = ["waitingForApproval", "broadcasting"];
+const DESCRIPTIONS: Partial<Record<LoadingState, string>> = {
+  waitingForApproval: "APPROVE OR REJECT TX TO CONTINUE...",
+  broadcasting: "BROADCASTING TRANSACTION...",
+  mintingACT: "This should only take a moment"
+};
 
 export const TransactionModal: React.FunctionComponent<Props> = ({ state, onClose }) => {
   return state ? (
@@ -49,11 +55,7 @@ export const TransactionModal: React.FunctionComponent<Props> = ({ state, onClos
           <Spinner size="large" className="flex justify-center" />
         </div>
 
-        {CRYPTO_STATES.includes(state) && (
-          <div className="text-sm text-muted-foreground">
-            {state === "waitingForApproval" ? "APPROVE OR REJECT TX TO CONTINUE..." : "BROADCASTING TRANSACTION..."}
-          </div>
-        )}
+        {DESCRIPTIONS[state] && <div className="text-sm text-muted-foreground">{DESCRIPTIONS[state]}</div>}
       </div>
     </Popup>
   ) : null;

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.spec.tsx
@@ -168,8 +168,8 @@ describe(ManifestEdit.name, () => {
     await vi.waitFor(() => {
       expect(DeploymentDepositModal).toHaveBeenCalledWith(
         expect.objectContaining({
-          handleCancel: expect.any(Function),
-          onDeploymentDeposit: expect.any(Function),
+          onCancel: expect.any(Function),
+          onSubmit: expect.any(Function),
           denom: "uact",
           title: "Confirm deployment creation?"
         }),

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
@@ -449,23 +449,25 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
 
       {isDepositingDeployment && (
         <d.DeploymentDepositModal
-          handleCancel={() => setIsDepositingDeployment(false)}
-          onDeploymentDeposit={onDeploymentDeposit}
+          onCancel={() => setIsDepositingDeployment(false)}
+          onSubmit={onDeploymentDeposit}
           denom={sdlDenom}
           title="Confirm deployment creation?"
-          infoText={
-            <d.Alert className="mb-6 text-xs" variant="default">
+          subtitle={
+            <span>
               <d.DeploymentMinimumEscrowAlertText denom={sdlDenom} />
-              <d.LinkTo onClick={ev => handleDocClick(ev, "https://akash.network/docs/getting-started/intro-to-akash/payments/#escrow-accounts")}>
-                <strong>Learn more.</strong>
+              <d.LinkTo
+                onClick={ev => handleDocClick(ev, "https://akash.network/docs/getting-started/intro-to-akash/payments/#escrow-accounts")}
+                className="text-gray-500 no-underline hover:underline disabled:text-gray-300"
+              >
+                Learn more.
               </d.LinkTo>
-
               {isTrialing && (
-                <div className="mt-2">
+                <span className="mt-2 block">
                   <d.TrialDeploymentBadge />
-                </div>
+                </span>
               )}
-            </d.Alert>
+            </span>
           }
           services={services}
         />

--- a/apps/deploy-web/src/components/sdl/DeploymentMinimumEscrowAlertText.spec.tsx
+++ b/apps/deploy-web/src/components/sdl/DeploymentMinimumEscrowAlertText.spec.tsx
@@ -9,13 +9,13 @@ describe(DeploymentMinimumEscrowAlertText.name, () => {
   it("shows ACT dollar amount for managed wallet when act is supported", () => {
     setup({ isManaged: true, denom: "uact", minDeposit: { act: 10, akt: 5, usdc: 5 } });
 
-    expect(screen.getByText("$10")).toBeInTheDocument();
+    expect(screen.getByText("$10", { exact: false })).toBeInTheDocument();
   });
 
   it("shows ACT dollar amount for managed wallet with uakt denom", () => {
     setup({ isManaged: true, denom: "uakt", minDeposit: { act: 10, akt: 5, usdc: 5 } });
 
-    expect(screen.getByText("$10")).toBeInTheDocument();
+    expect(screen.getByText("$10", { exact: false })).toBeInTheDocument();
   });
 
   it("shows selected denom min deposit for self-custody wallet with uakt", () => {

--- a/apps/deploy-web/src/components/sdl/DeploymentMinimumEscrowAlertText.tsx
+++ b/apps/deploy-web/src/components/sdl/DeploymentMinimumEscrowAlertText.tsx
@@ -27,11 +27,7 @@ export const DeploymentMinimumEscrowAlertText: FC<{ denom: string; dependencies?
 
   if (isManaged) {
     const amount = minDeposit.act;
-    return (
-      <>
-        To create a deployment, you need to have at least <b>${amount}</b> in an escrow account.{" "}
-      </>
-    );
+    return <>To create a deployment, you need to have at least $${amount} in an escrow account. </>;
   }
 
   if (!readableDenom) {
@@ -43,9 +39,9 @@ export const DeploymentMinimumEscrowAlertText: FC<{ denom: string; dependencies?
   return (
     <>
       To create a deployment, you need to have at least{" "}
-      <b className="uppercase">
+      <span className="uppercase">
         {minDepositCurrent} {readableDenom}
-      </b>{" "}
+      </span>{" "}
       in an escrow account.{" "}
     </>
   );

--- a/apps/deploy-web/src/hooks/useDepositDeployment/useDepositDeployment.spec.ts
+++ b/apps/deploy-web/src/hooks/useDepositDeployment/useDepositDeployment.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DEPENDENCIES } from "./useDepositDeployment";
+import { useDepositDeployment } from "./useDepositDeployment";
+
+import { act, renderHook } from "@testing-library/react";
+
+describe(useDepositDeployment.name, () => {
+  it("broadcasts deposit message and calls onSuccess", async () => {
+    const signAndBroadcastTx = vi.fn().mockResolvedValue(true);
+    const onSuccess = vi.fn();
+    const { result } = setup({ signAndBroadcastTx, onSuccess });
+
+    await act(async () => {
+      await result.current.deposit(10_000_000);
+    });
+
+    expect(signAndBroadcastTx).toHaveBeenCalledOnce();
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  it("does not call onSuccess when tx fails", async () => {
+    const signAndBroadcastTx = vi.fn().mockResolvedValue(false);
+    const onSuccess = vi.fn();
+    const { result } = setup({ signAndBroadcastTx, onSuccess });
+
+    await act(async () => {
+      await result.current.deposit(10_000_000);
+    });
+
+    expect(signAndBroadcastTx).toHaveBeenCalledOnce();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  function setup(input?: { signAndBroadcastTx?: ReturnType<typeof vi.fn>; onSuccess?: ReturnType<typeof vi.fn> }) {
+    const signAndBroadcastTx = input?.signAndBroadcastTx ?? vi.fn().mockResolvedValue(true);
+
+    const { result } = renderHook(() =>
+      useDepositDeployment({
+        dseq: "123456",
+        denom: "uakt",
+        onSuccess: input?.onSuccess as (() => void) | undefined,
+        dependencies: {
+          useWallet: () =>
+            ({
+              address: "akash1abc",
+              signAndBroadcastTx
+            }) as unknown as ReturnType<typeof DEPENDENCIES.useWallet>
+        }
+      })
+    );
+
+    return { result, signAndBroadcastTx };
+  }
+});

--- a/apps/deploy-web/src/hooks/useDepositDeployment/useDepositDeployment.ts
+++ b/apps/deploy-web/src/hooks/useDepositDeployment/useDepositDeployment.ts
@@ -1,0 +1,35 @@
+import { useCallback } from "react";
+
+import { useWallet } from "@src/context/WalletProvider";
+import { TransactionMessageData } from "@src/utils/TransactionMessageData";
+
+export const DEPENDENCIES = {
+  useWallet
+};
+
+interface UseDepositDeploymentOptions {
+  dseq: string;
+  denom: string;
+  onSuccess?: () => void;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export function useDepositDeployment({ dseq, denom, onSuccess, dependencies: d = DEPENDENCIES }: UseDepositDeploymentOptions) {
+  const { address, signAndBroadcastTx } = d.useWallet();
+
+  const deposit = useCallback(
+    async (depositUdenom: number) => {
+      const message = TransactionMessageData.getDepositDeploymentMsg(address, address, dseq, depositUdenom, denom);
+      const success = await signAndBroadcastTx([message]);
+
+      if (success) {
+        onSuccess?.();
+      }
+
+      return success;
+    },
+    [address, dseq, denom, signAndBroadcastTx, onSuccess]
+  );
+
+  return { deposit };
+}

--- a/apps/deploy-web/src/hooks/useMintACT/useMintACT.spec.ts
+++ b/apps/deploy-web/src/hooks/useMintACT/useMintACT.spec.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DEPENDENCIES } from "./useMintACT";
+import { useMintACT } from "./useMintACT";
+
+import { act, renderHook } from "@testing-library/react";
+
+describe(useMintACT.name, () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns isLoading false, isSuccess false, and no error initially", () => {
+    const { result } = setup();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isSuccess).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets error when wallet is not connected", async () => {
+    const { result } = setup({ address: "" });
+
+    await act(async () => {
+      await result.current.mint(50_000_000);
+    });
+
+    expect(result.current.isSuccess).toBe(false);
+    expect(result.current.error).toBe("Wallet not connected or price unavailable");
+  });
+
+  it("sets error when price is unavailable", async () => {
+    const { result } = setup({ price: null });
+
+    await act(async () => {
+      await result.current.mint(50_000_000);
+    });
+
+    expect(result.current.isSuccess).toBe(false);
+    expect(result.current.error).toBe("Wallet not connected or price unavailable");
+  });
+
+  it("sets error when AKT balance is insufficient", async () => {
+    const { result } = setup({ balanceUAKT: 1_000 });
+
+    await act(async () => {
+      await result.current.mint(50_000_000);
+    });
+
+    expect(result.current.isSuccess).toBe(false);
+    expect(result.current.error).toBe("Insufficient AKT balance for minting");
+  });
+
+  it("broadcasts mint tx and sets isSuccess on success", async () => {
+    const signAndBroadcastTx = vi.fn().mockResolvedValue(true);
+    const waitForLedgerRecordsSettlement = vi.fn().mockResolvedValue(true);
+    const refetch = vi.fn();
+    const { result } = setup({ signAndBroadcastTx, waitForLedgerRecordsSettlement, refetch });
+
+    let mintPromise: Promise<void>;
+    await act(async () => {
+      mintPromise = result.current.mint(50_000_000);
+    });
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    await act(async () => mintPromise!);
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(signAndBroadcastTx).toHaveBeenCalledOnce();
+    expect(waitForLedgerRecordsSettlement).toHaveBeenCalled();
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it("sets error when tx broadcast fails", async () => {
+    const signAndBroadcastTx = vi.fn().mockResolvedValue(false);
+    const { result } = setup({ signAndBroadcastTx });
+
+    await act(async () => {
+      await result.current.mint(50_000_000);
+    });
+
+    expect(result.current.isSuccess).toBe(false);
+    expect(result.current.error).toBe("Mint transaction failed");
+  });
+
+  it("computes AKT to burn using price with slippage", async () => {
+    const signAndBroadcastTx = vi.fn().mockResolvedValue(true);
+    const waitForLedgerRecordsSettlement = vi.fn().mockResolvedValue(true);
+    const { result } = setup({ signAndBroadcastTx, waitForLedgerRecordsSettlement, price: 2.0 });
+
+    let mintPromise: Promise<void>;
+    await act(async () => {
+      mintPromise = result.current.mint(100_000_000);
+    });
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    await act(async () => mintPromise!);
+
+    const call = signAndBroadcastTx.mock.calls[0][0][0];
+    const amount = Number(call.value.coinsToBurn.amount);
+    // 100_000_000 / 2.0 * 1.02 = 51_000_000
+    expect(amount).toBe(51_000_000);
+  });
+
+  function setup(input?: {
+    address?: string;
+    price?: number | null;
+    balanceUAKT?: number;
+    signAndBroadcastTx?: ReturnType<typeof vi.fn>;
+    waitForLedgerRecordsSettlement?: ReturnType<typeof vi.fn>;
+    refetch?: ReturnType<typeof vi.fn>;
+  }) {
+    const signAndBroadcastTx = input?.signAndBroadcastTx ?? vi.fn().mockResolvedValue(true);
+    const waitForLedgerRecordsSettlement = input?.waitForLedgerRecordsSettlement ?? vi.fn().mockResolvedValue(true);
+    const refetch = input?.refetch ?? vi.fn();
+
+    const dependencies = {
+      useWallet: () =>
+        ({
+          address: input?.address ?? "akash1abc",
+          signAndBroadcastTx
+        }) as unknown as ReturnType<typeof DEPENDENCIES.useWallet>,
+      useServices: () =>
+        ({
+          bmeHttpService: { waitForLedgerRecordsSettlement },
+          errorHandler: { reportError: vi.fn() }
+        }) as unknown as ReturnType<typeof DEPENDENCIES.useServices>,
+      useWalletBalance: () =>
+        ({
+          balance: { balanceUAKT: input?.balanceUAKT ?? 500_000_000 },
+          refetch
+        }) as unknown as ReturnType<typeof DEPENDENCIES.useWalletBalance>,
+      usePricing: () =>
+        ({
+          price: input?.price === null ? undefined : input?.price ?? 2.0
+        }) as unknown as ReturnType<typeof DEPENDENCIES.usePricing>,
+      useBmeParams: () =>
+        ({
+          data: { minMintAct: 5 }
+        }) as unknown as ReturnType<typeof DEPENDENCIES.useBmeParams>
+    };
+
+    const { result } = renderHook(() => useMintACT({ dependencies }));
+
+    return { result, signAndBroadcastTx, waitForLedgerRecordsSettlement, refetch };
+  }
+});

--- a/apps/deploy-web/src/hooks/useMintACT/useMintACT.ts
+++ b/apps/deploy-web/src/hooks/useMintACT/useMintACT.ts
@@ -1,0 +1,120 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { UAKT_DENOM } from "@src/config/denom.config";
+import { useServices } from "@src/context/ServicesProvider";
+import { useWallet } from "@src/context/WalletProvider";
+import { usePricing } from "@src/hooks/usePricing/usePricing";
+import { useWalletBalance } from "@src/hooks/useWalletBalance";
+import { useBmeParams } from "@src/queries/useBmeQuery";
+import { denomToUdenom, roundDecimal } from "@src/utils/mathHelpers";
+import { TransactionMessageData } from "@src/utils/TransactionMessageData";
+
+const PRICE_SLIPPAGE_MULTIPLIER = 1.02;
+
+export const DEPENDENCIES = {
+  useWallet,
+  useServices,
+  useWalletBalance,
+  usePricing,
+  useBmeParams
+};
+
+interface UseMintACTInput {
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export interface UseMintACTReturn {
+  mint: (actAmountUdenom: number) => Promise<void>;
+  isLoading: boolean;
+  isSuccess: boolean;
+  error: string | null;
+}
+
+export function useMintACT({ dependencies: d = DEPENDENCIES }: UseMintACTInput = {}): UseMintACTReturn {
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { address, signAndBroadcastTx } = d.useWallet();
+  const { bmeHttpService, errorHandler } = d.useServices();
+  const { balance, refetch: refetchBalance } = d.useWalletBalance();
+  const { price } = d.usePricing();
+  const { data: bmeParams } = d.useBmeParams();
+  const abortController = useRef(new AbortController());
+
+  useEffect(() => {
+    const controller = abortController.current;
+    return () => {
+      controller.abort();
+    };
+  }, []);
+
+  const calculateAktToBurn = useCallback(
+    (actAmountUdenom: number): number | null => {
+      if (!price || price <= 0) {
+        setError("Wallet not connected or price unavailable");
+        return null;
+      }
+
+      let aktToBurnUdenom = Math.ceil((actAmountUdenom / price) * PRICE_SLIPPAGE_MULTIPLIER);
+
+      if (bmeParams?.minMintAct !== undefined) {
+        const minMintUakt = Math.ceil(denomToUdenom(roundDecimal(bmeParams.minMintAct / price, 6)) * PRICE_SLIPPAGE_MULTIPLIER);
+        aktToBurnUdenom = Math.max(aktToBurnUdenom, minMintUakt);
+      }
+
+      const aktBalanceUdenom = balance?.balanceUAKT ?? 0;
+      if (aktToBurnUdenom > aktBalanceUdenom) {
+        setError("Insufficient AKT balance for minting");
+        return null;
+      }
+
+      return aktToBurnUdenom;
+    },
+    [balance?.balanceUAKT, bmeParams?.minMintAct, price]
+  );
+
+  const mint = useCallback(
+    async (actAmountUdenom: number): Promise<void> => {
+      setError(null);
+      setIsSuccess(false);
+      setIsLoading(true);
+
+      try {
+        if (!address) {
+          setError("Wallet not connected or price unavailable");
+          return;
+        }
+
+        const aktToBurnUdenom = calculateAktToBurn(actAmountUdenom);
+        if (aktToBurnUdenom === null) {
+          return;
+        }
+
+        const msg = TransactionMessageData.getMintACTMsg(address, aktToBurnUdenom, UAKT_DENOM);
+        const txSuccess = await signAndBroadcastTx([msg]);
+
+        if (!txSuccess) {
+          setError("Mint transaction failed");
+          return;
+        }
+
+        const settled = await bmeHttpService.waitForLedgerRecordsSettlement(address, { signal: abortController.current.signal });
+        if (!settled) {
+          setError("Mint settlement timed out");
+          return;
+        }
+
+        refetchBalance();
+        setIsSuccess(true);
+      } catch (err) {
+        errorHandler.reportError({ error: err, tags: { context: "useMintACT" } });
+        setError("Something went wrong while minting. Please try again.");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [address, calculateAktToBurn, signAndBroadcastTx, bmeHttpService, refetchBalance, errorHandler]
+  );
+
+  return { mint, isLoading, isSuccess, error };
+}

--- a/packages/http-sdk/src/bme/bme-http.service.ts
+++ b/packages/http-sdk/src/bme/bme-http.service.ts
@@ -2,6 +2,9 @@ import { extractData } from "../http/http.service";
 import type { HttpClient } from "../utils/httpClient";
 import type { BmeLedgerFilters, BmeLedgerResponse, BmeParamsResponse } from "./types";
 
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_MAX_POLL_ATTEMPTS = 24;
+
 export class BmeHttpService {
   constructor(private readonly httpClient: HttpClient) {}
 
@@ -23,5 +26,25 @@ export class BmeHttpService {
 
     const query = params.toString();
     return extractData(await this.httpClient.get<BmeLedgerResponse>(`/akash/bme/v1/ledger${query ? `?${query}` : ""}`));
+  }
+
+  async waitForLedgerRecordsSettlement(address: string, options?: { pollIntervalMs?: number; maxAttempts?: number; signal?: AbortSignal }): Promise<boolean> {
+    const pollInterval = options?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    const maxAttempts = options?.maxAttempts ?? DEFAULT_MAX_POLL_ATTEMPTS;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (options?.signal?.aborted) return false;
+
+      const { records } = await this.getLedgerRecords({
+        source: address,
+        status: "ledger_record_status_pending"
+      });
+
+      if (records.length === 0) return true;
+
+      await new Promise(resolve => setTimeout(resolve, pollInterval));
+    }
+
+    return false;
   }
 }


### PR DESCRIPTION
## Why

Resolves CON-173

The deposit modal needed a redesign to support ACT deposits with auto-minting. Previously, users with insufficient ACT balance had to manually navigate to the Mint/Burn page before depositing. This change streamlines the flow by auto-minting ACT when the user's balance is insufficient.

## What

- **`useMintACT` hook** — encapsulates AKT→ACT minting: price calculation with slippage, min-mint enforcement, tx broadcast, settlement polling, balance refresh
- **`useDepositDeployment` hook** — thin wrapper for deposit-to-existing-deployment tx (build message, broadcast, call onSuccess)
- **`DeploymentDepositModal` redesign** — ACT-specific UI with radio presets (25/50/100), custom amount input, balance display, auto-mint orchestration when ACT balance is insufficient
- **`BmeHttpService.waitForLedgerRecordsSettlement`** — polling utility for mint settlement confirmation
- **`TransactionModal`** — added `mintingACT` state, refactored description display to use a map
- **`DeploymentMinimumEscrowAlertText`** — changed `<b>` to `<span>` for styling consistency
- Consumers (`DeploymentDetailTopBar`, `DeploymentListRow`, `ManifestEdit`) updated to use new hooks and modal API


https://github.com/user-attachments/assets/0aad3b01-17ef-420a-87f6-618b11b503fb


https://github.com/user-attachments/assets/7a1f41c0-29c1-4821-9564-23b13861ae29




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added preset amount options (25/50/100) and custom amount input for ACT deposits.
  * Implemented automatic minting to fulfill ACT requirements when balance is insufficient.
  * Enhanced deposit validation with minimum balance checks and clearer error messaging.
  * Improved transaction feedback with distinct status indicators during deposit and minting operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->