### PR TITLE
feat(log-collector): request events permission in SDL

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "^1.3.0",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+    "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+    "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/logging": "*",

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -354,7 +354,7 @@ export const ServiceSchema = z
     params: z
       .object({
         permissions: z.object({
-          read: z.array(z.enum(["deployment", "logs"]))
+          read: z.array(z.enum(["deployment", "logs", "events"]))
         })
       })
       .optional()

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
@@ -13,7 +13,7 @@ describe("sdlGenerator", () => {
 
       expect(parsed.services["web-log-collector"].params).toEqual({
         permissions: {
-          read: ["deployment", "logs"]
+          read: ["deployment", "logs", "events"]
         }
       });
     });

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
@@ -182,7 +182,7 @@ export const generateSdl = (services: ServiceType[], region?: string) => {
       sdl.services[service.title].params = {
         ...sdl.services[service.title].params,
         permissions: {
-          read: ["deployment", "logs"]
+          read: ["deployment", "logs", "events"]
         }
       };
     }

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "^1.3.0",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+    "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.0",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+    "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+    "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+    "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "^1.3.0",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+    "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+        "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -503,7 +503,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+        "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/logging": "*",
@@ -803,7 +803,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -825,7 +824,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -843,6 +841,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -860,6 +859,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -877,6 +877,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -894,6 +895,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -909,6 +911,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -926,6 +929,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -943,6 +947,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -960,6 +965,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -977,6 +983,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -994,6 +1001,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1011,6 +1019,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1028,6 +1037,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1045,6 +1055,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1062,6 +1073,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1079,6 +1091,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1096,6 +1109,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1113,6 +1127,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1130,6 +1145,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1147,6 +1163,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1164,6 +1181,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1181,6 +1199,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1198,6 +1217,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1215,6 +1235,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1735,7 +1756,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.57.1",
@@ -1749,7 +1771,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.57.1",
@@ -1763,7 +1786,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.57.1",
@@ -1777,7 +1801,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.35.0",
@@ -1804,7 +1829,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.35.0",
@@ -1857,7 +1883,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.57.1",
@@ -1871,7 +1898,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.35.0",
@@ -1911,7 +1939,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.35.0",
@@ -2198,7 +2227,6 @@
     "apps/deploy-web/node_modules/@stripe/stripe-js": {
       "version": "8.3.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.16"
       }
@@ -2324,6 +2352,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2363,6 +2392,7 @@
       "version": "6.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       },
@@ -2632,6 +2662,7 @@
       "version": "7.3.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2713,7 +2744,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-android-arm64": {
       "version": "4.57.1",
@@ -2727,7 +2759,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.57.1",
@@ -2739,7 +2772,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.57.1",
@@ -2753,7 +2787,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.57.1",
@@ -2767,7 +2802,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.57.1",
@@ -2781,7 +2817,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.57.1",
@@ -2795,7 +2832,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.57.1",
@@ -2809,7 +2847,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.57.1",
@@ -2823,7 +2862,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.57.1",
@@ -2837,7 +2877,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.57.1",
@@ -2851,7 +2892,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.57.1",
@@ -2865,7 +2907,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.57.1",
@@ -2879,7 +2922,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.57.1",
@@ -2893,7 +2937,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.57.1",
@@ -2907,7 +2952,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.57.1",
@@ -2921,7 +2967,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.57.1",
@@ -2935,17 +2982,20 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/@types/estree": {
       "version": "1.0.8",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "apps/deploy-web/node_modules/vite/node_modules/rollup": {
       "version": "4.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -3036,7 +3086,6 @@
     "apps/deploy-web/node_modules/yaml": {
       "version": "2.8.2",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -3053,7 +3102,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+        "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
@@ -5051,6 +5100,7 @@
       "devDependencies": {
         "@akashnetwork/dev-config": "*",
         "@akashnetwork/releaser": "*",
+        "@dotenvx/dotenvx": "1.14.0",
         "@faker-js/faker": "^8.4.1",
         "@swc/core": "^1.11.10",
         "@types/node": "^22.13.11",
@@ -5087,7 +5137,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.0",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+        "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/logging": "*",
@@ -5342,7 +5392,6 @@
     "apps/notifications/node_modules/@opentelemetry/core": {
       "version": "2.4.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -6699,7 +6748,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+        "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -6854,7 +6903,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+        "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -8005,7 +8054,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "^1.3.0",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+        "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -8201,9 +8250,9 @@
       }
     },
     "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.29",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.29.tgz",
-      "integrity": "sha512-pu4UwCRl3NutXjXXdfDHO60Vm8H6sEsFyQkRcSN6cSkSJKOdLEJHA8dg2F0oVppMvx9ZWfsnsU2qEvwzhkCGfA==",
+      "version": "1.0.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.30.tgz",
+      "integrity": "sha512-T+CU6qfKFzLmlD2C0nkm6J76okNp9o0TAm9h8kKOpRGjM24k8XinDPIIUvivGIbNEM+uDTTMhoM089MyG1W3CQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.2.3",
@@ -8548,7 +8597,6 @@
       "resolved": "https://registry.npmjs.org/@amplitude/rrweb/-/rrweb-2.0.0-alpha.36.tgz",
       "integrity": "sha512-8vhPOk4fvszfxYZTk37EObW3n7uwEgO//funRSMt/QiBWtgQ8jhpFV9FcOAYdgde0Yw1uIM8oUbWZfy/XrexNw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@amplitude/rrdom": "^2.0.0-alpha.36",
         "@amplitude/rrweb-snapshot": "^2.0.0-alpha.36",
@@ -8823,7 +8871,6 @@
     "node_modules/@babel/core": {
       "version": "7.28.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -10388,8 +10435,7 @@
     "node_modules/@biomejs/wasm-nodejs": {
       "version": "1.9.4",
       "dev": true,
-      "license": "MIT OR Apache-2.0",
-      "peer": true
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@borewit/text-codec": {
       "version": "0.2.1",
@@ -10412,8 +10458,7 @@
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.9.0",
-      "license": "(Apache-2.0 AND BSD-3-Clause)",
-      "peer": true
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@casl/ability": {
       "version": "6.7.2",
@@ -10653,7 +10698,6 @@
       "version": "9.0.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -10895,7 +10939,6 @@
     "node_modules/@connectrpc/connect": {
       "version": "2.1.0",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.7.0"
       }
@@ -10914,7 +10957,6 @@
     "node_modules/@cosmjs/amino": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/crypto": "^0.32.4",
         "@cosmjs/encoding": "^0.32.4",
@@ -11006,7 +11048,6 @@
     "node_modules/@cosmjs/proto-signing": {
       "version": "0.36.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.36.2",
         "@cosmjs/crypto": "^0.36.2",
@@ -11115,7 +11156,6 @@
     "node_modules/@cosmjs/stargate": {
       "version": "0.36.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.36.2",
         "@cosmjs/encoding": "^0.36.2",
@@ -11307,7 +11347,6 @@
     "node_modules/@cosmos-kit/core/node_modules/@cosmjs/proto-signing": {
       "version": "0.32.4",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cosmjs/amino": "^0.32.4",
         "@cosmjs/crypto": "^0.32.4",
@@ -11745,7 +11784,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -11782,7 +11820,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11864,7 +11901,6 @@
     "node_modules/@dotenvx/dotenvx/node_modules/picomatch": {
       "version": "4.0.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11978,7 +12014,6 @@
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.2.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/memoize": "^0.8.1"
       }
@@ -11990,7 +12025,6 @@
     "node_modules/@emotion/react": {
       "version": "11.11.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -12028,7 +12062,6 @@
     "node_modules/@emotion/server": {
       "version": "11.11.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/utils": "^1.2.1",
         "html-tokenize": "^2.0.0",
@@ -12051,7 +12084,6 @@
     "node_modules/@emotion/styled": {
       "version": "11.11.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.11.0",
@@ -12792,6 +12824,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12825,6 +12858,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12858,6 +12892,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13153,7 +13188,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
         "npm": ">=6.14.13"
@@ -13300,7 +13334,6 @@
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -13509,7 +13542,6 @@
     "node_modules/@interchain-ui/react": {
       "version": "1.23.31",
       "license": "SEE LICENSE IN LICENSE",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.6.4",
         "@floating-ui/dom": "^1.6.7",
@@ -13965,7 +13997,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/expect": "^29.7.0",
@@ -14805,7 +14836,6 @@
     "node_modules/@mui/material": {
       "version": "5.15.20",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/base": "5.0.0-beta.40",
@@ -15049,7 +15079,6 @@
     "node_modules/@nestjs/common": {
       "version": "11.1.13",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -15160,7 +15189,6 @@
       "version": "11.1.13",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -15225,7 +15253,6 @@
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.13",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -15995,7 +16022,6 @@
     "node_modules/@octokit/core": {
       "version": "7.0.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -16216,7 +16242,6 @@
       "version": "11.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16"
       }
@@ -16430,7 +16455,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -16494,7 +16518,6 @@
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -16505,7 +16528,6 @@
     "node_modules/@opentelemetry/core": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -17139,7 +17161,6 @@
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.57.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -18839,7 +18860,6 @@
     "node_modules/@opentelemetry/resources": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -19077,7 +19097,6 @@
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "1.30.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -19167,7 +19186,6 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.38.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -22493,7 +22511,6 @@
       "version": "1.34.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@redocly/ajv": "^8.11.2",
         "@redocly/config": "^0.22.0",
@@ -22634,7 +22651,6 @@
     "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
       "version": "4.0.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -23173,6 +23189,7 @@
     "node_modules/@scure/starknet": {
       "version": "1.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "~1.7.0",
         "@noble/hashes": "~1.6.0"
@@ -23184,6 +23201,7 @@
     "node_modules/@scure/starknet/node_modules/@noble/curves": {
       "version": "1.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.6.0"
       },
@@ -23197,6 +23215,7 @@
     "node_modules/@scure/starknet/node_modules/@noble/curves/node_modules/@noble/hashes": {
       "version": "1.6.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -23207,6 +23226,7 @@
     "node_modules/@scure/starknet/node_modules/@noble/hashes": {
       "version": "1.6.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -23950,12 +23970,14 @@
     "node_modules/@starknet-io/starknet-types-07": {
       "name": "@starknet-io/types-js",
       "version": "0.7.10",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@starknet-io/starknet-types-08": {
       "name": "@starknet-io/types-js",
       "version": "0.8.4",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@streamparser/json": {
       "version": "0.0.20",
@@ -23990,7 +24012,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.19"
@@ -24028,7 +24049,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24045,7 +24065,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24062,7 +24081,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -24079,7 +24097,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24096,7 +24113,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24113,7 +24129,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24130,7 +24145,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24147,7 +24161,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24164,7 +24177,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24181,7 +24193,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -24198,7 +24209,6 @@
     "node_modules/@swc/helpers": {
       "version": "0.5.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
@@ -24229,7 +24239,6 @@
     "node_modules/@tanstack/query-core": {
       "version": "5.67.2",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -24238,7 +24247,6 @@
     "node_modules/@tanstack/react-query": {
       "version": "5.67.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.67.2"
       },
@@ -24306,7 +24314,6 @@
       "version": "10.4.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -24539,7 +24546,6 @@
       "version": "7.20.5",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -24760,6 +24766,7 @@
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -24768,6 +24775,7 @@
     "node_modules/@types/eslint-scope": {
       "version": "3.7.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -24987,7 +24995,6 @@
     "node_modules/@types/node": {
       "version": "22.15.30",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -25050,7 +25057,6 @@
     "node_modules/@types/react": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -25060,7 +25066,6 @@
     "node_modules/@types/react-dom": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -25234,8 +25239,7 @@
     },
     "node_modules/@types/validator": {
       "version": "13.11.10",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.5.13",
@@ -25818,7 +25822,6 @@
     "node_modules/@vanilla-extract/css": {
       "version": "1.17.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emotion/hash": "^0.9.0",
         "@vanilla-extract/private": "^1.0.6",
@@ -25841,7 +25844,6 @@
     "node_modules/@vanilla-extract/dynamic": {
       "version": "2.1.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vanilla-extract/private": "^1.0.6"
       }
@@ -26458,7 +26460,6 @@
     "node_modules/@walletconnect/types": {
       "version": "2.11.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -26702,6 +26703,7 @@
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -26709,19 +26711,23 @@
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.13.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -26730,11 +26736,13 @@
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.13.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -26745,6 +26753,7 @@
     "node_modules/@webassemblyjs/ieee754": {
       "version": "1.13.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -26752,17 +26761,20 @@
     "node_modules/@webassemblyjs/leb128": {
       "version": "1.13.2",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.13.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -26777,6 +26789,7 @@
     "node_modules/@webassemblyjs/wasm-gen": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -26788,6 +26801,7 @@
     "node_modules/@webassemblyjs/wasm-opt": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -26798,6 +26812,7 @@
     "node_modules/@webassemblyjs/wasm-parser": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -26810,6 +26825,7 @@
     "node_modules/@webassemblyjs/wast-printer": {
       "version": "1.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -26838,11 +26854,13 @@
     },
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -26852,6 +26870,7 @@
     "node_modules/abi-wan-kanabi": {
       "version": "2.2.4",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "ansicolors": "^0.3.2",
         "cardinal": "^2.1.1",
@@ -26865,6 +26884,7 @@
     "node_modules/abi-wan-kanabi/node_modules/fs-extra": {
       "version": "10.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -26934,7 +26954,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -26961,6 +26980,7 @@
     "node_modules/acorn-import-phases": {
       "version": "1.0.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -27014,7 +27034,6 @@
     "node_modules/ajv": {
       "version": "6.12.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -27074,7 +27093,6 @@
       "version": "4.1.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -27115,7 +27133,8 @@
     },
     "node_modules/ansicolors": {
       "version": "0.3.2",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
@@ -28049,7 +28068,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -28368,7 +28386,6 @@
     "node_modules/camelcase": {
       "version": "5.3.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -28401,6 +28418,7 @@
     "node_modules/cardinal": {
       "version": "2.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
@@ -28526,6 +28544,7 @@
     "node_modules/chrome-trace-event": {
       "version": "1.0.4",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -28925,7 +28944,6 @@
     "node_modules/commander": {
       "version": "12.1.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -29147,8 +29165,7 @@
     },
     "node_modules/cosmjs-types": {
       "version": "0.9.0",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/create-hash": {
       "version": "1.2.0",
@@ -29400,8 +29417,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/csv-stringify": {
       "version": "6.6.0",
@@ -29526,8 +29542,7 @@
     },
     "node_modules/d3-selection": {
       "version": "2.0.0",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/d3-shape": {
       "version": "3.2.0",
@@ -29712,7 +29727,6 @@
     "node_modules/date-fns": {
       "version": "2.30.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -30313,7 +30327,6 @@
     "node_modules/drizzle-orm": {
       "version": "0.31.2",
       "license": "Apache-2.0",
-      "peer": true,
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=3",
@@ -30873,7 +30886,6 @@
     "node_modules/eslint": {
       "version": "8.57.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -31144,7 +31156,6 @@
     "node_modules/eslint-plugin-import": {
       "version": "2.31.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -31176,7 +31187,6 @@
     "node_modules/eslint-plugin-import-x": {
       "version": "4.10.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@pkgr/core": "^0.2.0",
         "@types/doctrine": "^0.0.9",
@@ -32371,7 +32381,6 @@
     "node_modules/gel": {
       "version": "2.0.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@petamoriken/float16": "^3.8.7",
         "debug": "^4.3.4",
@@ -32622,7 +32631,8 @@
     },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/glob/node_modules/jackspeak": {
       "version": "3.4.3",
@@ -33193,7 +33203,6 @@
     "node_modules/hono": {
       "version": "4.6.12",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -33476,7 +33485,6 @@
     "node_modules/immer": {
       "version": "10.1.1",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
@@ -34385,7 +34393,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -35070,7 +35077,6 @@
     "node_modules/jiti": {
       "version": "1.21.3",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -35255,7 +35261,6 @@
     "node_modules/jsep": {
       "version": "1.4.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -35845,6 +35850,7 @@
     "node_modules/loader-runner": {
       "version": "4.3.1",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -36205,7 +36211,8 @@
     },
     "node_modules/lossless-json": {
       "version": "4.3.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lowlight": {
       "version": "2.9.0",
@@ -38504,7 +38511,6 @@
     "node_modules/monaco-editor": {
       "version": "0.55.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.2.7",
         "marked": "14.0.0"
@@ -38802,7 +38808,6 @@
     "node_modules/next": {
       "version": "14.2.35",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",
@@ -39553,6 +39558,7 @@
       "version": "8.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chalk": "^5.3.0",
         "cli-cursor": "^5.0.0",
@@ -39575,6 +39581,7 @@
       "version": "6.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -39586,6 +39593,7 @@
       "version": "5.4.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -39597,6 +39605,7 @@
       "version": "5.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "restore-cursor": "^5.0.0"
       },
@@ -39610,12 +39619,14 @@
     "node_modules/ora/node_modules/emoji-regex": {
       "version": "10.4.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ora/node_modules/onetime": {
       "version": "7.0.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mimic-function": "^5.0.0"
       },
@@ -39630,6 +39641,7 @@
       "version": "5.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "onetime": "^7.0.0",
         "signal-exit": "^4.1.0"
@@ -39645,6 +39657,7 @@
       "version": "4.1.0",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -39656,6 +39669,7 @@
       "version": "7.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
         "get-east-asian-width": "^1.0.0",
@@ -39672,6 +39686,7 @@
       "version": "7.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -39902,7 +39917,6 @@
     "node_modules/pg": {
       "version": "8.18.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.11.0",
@@ -40339,7 +40353,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -40477,7 +40490,6 @@
     "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -40561,7 +40573,6 @@
     "node_modules/prettier": {
       "version": "3.3.1",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -40741,7 +40752,6 @@
     "node_modules/prop-types": {
       "version": "15.8.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -41069,7 +41079,6 @@
     "node_modules/react": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -41178,7 +41187,6 @@
     "node_modules/react-dom": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -41218,7 +41226,6 @@
     "node_modules/react-hook-form": {
       "version": "7.52.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -41579,14 +41586,14 @@
     "node_modules/redeyed": {
       "version": "2.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esprima": "~4.0.0"
       }
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
@@ -42111,7 +42118,6 @@
     "node_modules/rollup": {
       "version": "2.79.2",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -42243,7 +42249,6 @@
     "node_modules/rxjs": {
       "version": "7.8.1",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -42374,7 +42379,6 @@
     "node_modules/schema-utils/node_modules/ajv": {
       "version": "8.17.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -43189,6 +43193,7 @@
     "node_modules/starknet/node_modules/@noble/curves": {
       "version": "1.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.6.0"
       },
@@ -43202,6 +43207,7 @@
     "node_modules/starknet/node_modules/@noble/hashes": {
       "version": "1.6.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -43212,6 +43218,7 @@
     "node_modules/starknet/node_modules/@scure/base": {
       "version": "1.2.1",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -43770,7 +43777,6 @@
     "node_modules/tailwindcss": {
       "version": "3.4.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -44288,7 +44294,6 @@
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -44567,7 +44572,8 @@
     },
     "node_modules/ts-mixer": {
       "version": "6.0.4",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -44575,7 +44581,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -45592,7 +45597,6 @@
     "node_modules/typescript": {
       "version": "5.8.3",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -45935,7 +45939,6 @@
     "node_modules/unleash-proxy-client": {
       "version": "3.7.6",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tiny-emitter": "^2.1.0",
         "uuid": "^9.0.1"
@@ -46527,7 +46530,6 @@
       "version": "4.0.18",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -47511,7 +47513,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -47574,7 +47575,6 @@
       "version": "7.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -47693,6 +47693,7 @@
     "node_modules/watchpack": {
       "version": "2.5.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -47837,15 +47838,18 @@
     },
     "node_modules/webpack/node_modules/@types/estree": {
       "version": "1.0.8",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webpack/node_modules/es-module-lexer": {
       "version": "2.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -47857,6 +47861,7 @@
     "node_modules/webpack/node_modules/estraverse": {
       "version": "4.3.0",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -48111,7 +48116,6 @@
     "node_modules/workbox-build/node_modules/ajv": {
       "version": "8.17.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -48373,7 +48377,6 @@
     "node_modules/ws": {
       "version": "8.18.2",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -48503,7 +48506,6 @@
     "node_modules/zod": {
       "version": "3.24.4",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -49501,7 +49503,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+        "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       }
@@ -49592,7 +49594,6 @@
     "packages/releaser/node_modules/conventional-commits-filter": {
       "version": "5.0.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -49600,7 +49601,6 @@
     "packages/releaser/node_modules/conventional-commits-parser": {
       "version": "6.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "meow": "^13.0.0"
       },

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.29",
+    "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   }


### PR DESCRIPTION
## Why

The log-collector's K8s events watch gets a 403 Forbidden on Akash providers because the SDL only requests `deployment` and `logs` read permissions. The `events` permission is missing, so the provider's RBAC doesn't grant access to the events API.

## What

- Add `"events"` to the SDL `permissions.read` array in the SDL generator and schema
- Bump `@akashnetwork/chain-sdk` to `^1.0.0-alpha.30` for events validation support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "events" permission in service read configurations.

* **Chores**
  * Updated chain SDK dependency to version 1.0.0-alpha.30 across all applications and packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->