### PR TITLE
feat(auth): add email verification code backend services

### DIFF
--- a/apps/api/drizzle/0029_fluffy_drax.sql
+++ b/apps/api/drizzle/0029_fluffy_drax.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS "email_verification_codes" (
+	"id" uuid PRIMARY KEY DEFAULT uuid_generate_v4() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"email" varchar(255) NOT NULL,
+	"code" varchar(64) NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "email_verification_codes" ADD CONSTRAINT "email_verification_codes_user_id_userSetting_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."userSetting"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "email_verification_codes_user_id_idx" ON "email_verification_codes" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "email_verification_codes_expires_at_idx" ON "email_verification_codes" USING btree ("expires_at");

--- a/apps/api/drizzle/0029_fluffy_drax.sql
+++ b/apps/api/drizzle/0029_fluffy_drax.sql
@@ -14,5 +14,4 @@ EXCEPTION
  WHEN duplicate_object THEN null;
 END $$;
 --> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "email_verification_codes_user_id_idx" ON "email_verification_codes" USING btree ("user_id");--> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "email_verification_codes_expires_at_idx" ON "email_verification_codes" USING btree ("expires_at");
+CREATE UNIQUE INDEX IF NOT EXISTS "email_verification_codes_user_id_idx" ON "email_verification_codes" USING btree ("user_id");

--- a/apps/api/drizzle/meta/0029_snapshot.json
+++ b/apps/api/drizzle/meta/0029_snapshot.json
@@ -1218,22 +1218,7 @@
               "nulls": "last"
             }
           ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "email_verification_codes_expires_at_idx": {
-          "name": "email_verification_codes_expires_at_idx",
-          "columns": [
-            {
-              "expression": "expires_at",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
+          "isUnique": true,
           "concurrently": false,
           "method": "btree",
           "with": {}

--- a/apps/api/drizzle/meta/0029_snapshot.json
+++ b/apps/api/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,1290 @@
+{
+  "id": "23f3ad91-3b5d-4930-9a49-628ecd8f138a",
+  "prevId": "84347453-dc3f-4b93-bc6b-b1b3ff4fc21b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      }
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      }
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      }
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      }
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      }
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_verification_codes_expires_at_idx": {
+          "name": "email_verification_codes_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1771591487804,
       "tag": "0028_right_red_ghost",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1771979737373,
+      "tag": "0029_fluffy_drax",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/auth/controllers/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/controllers/auth/auth.controller.spec.ts
@@ -1,0 +1,109 @@
+import { ResponseError } from "auth0";
+import { container as rootContainer } from "tsyringe";
+import { mock } from "vitest-mock-extended";
+
+import { AuthService } from "@src/auth/services/auth.service";
+import type { Auth0Service } from "@src/auth/services/auth0/auth0.service";
+import { AUTH0_DB_CONNECTION } from "@src/auth/services/auth0/auth0.service";
+import type { EmailVerificationCodeService } from "@src/auth/services/email-verification-code/email-verification-code.service";
+import type { UserService } from "@src/user/services/user/user.service";
+import { AuthController } from "./auth.controller";
+
+import { UserSeeder } from "@test/seeders/user.seeder";
+
+describe(AuthController.name, () => {
+  describe("signup", () => {
+    it("creates user via auth0 service", async () => {
+      const { controller, auth0Service } = setup();
+
+      auth0Service.createUser.mockResolvedValue(undefined);
+
+      await controller.signup({ email: "user@example.com", password: "StrongPassword123!" });
+
+      expect(auth0Service.createUser).toHaveBeenCalledWith({
+        email: "user@example.com",
+        password: "StrongPassword123!",
+        connection: AUTH0_DB_CONNECTION
+      });
+    });
+
+    it("throws http error when auth0 returns a non-409 error", async () => {
+      const { controller, auth0Service } = setup();
+
+      auth0Service.createUser.mockRejectedValue(
+        new ResponseError(400, JSON.stringify({ message: "PasswordStrengthError: Password is too weak" }), new Headers())
+      );
+
+      await expect(controller.signup({ email: "user@example.com", password: "weak" })).rejects.toThrow("PasswordStrengthError: Password is too weak");
+    });
+
+    it("converts 409 (user exists) to generic 422 error", async () => {
+      const { controller, auth0Service } = setup();
+
+      auth0Service.createUser.mockRejectedValue(new ResponseError(409, JSON.stringify({ message: "The user already exists." }), new Headers()));
+
+      await expect(controller.signup({ email: "user@example.com", password: "StrongPassword123!" })).rejects.toThrow(
+        "Unable to create account. Please try again or use a different email."
+      );
+    });
+
+    it("re-throws non-ResponseError errors", async () => {
+      const { controller, auth0Service } = setup();
+
+      auth0Service.createUser.mockRejectedValue(new Error("Network failure"));
+
+      await expect(controller.signup({ email: "user@example.com", password: "StrongPassword123!" })).rejects.toThrow("Network failure");
+    });
+  });
+
+  describe("sendVerificationCode", () => {
+    it("delegates to emailVerificationCodeService and wraps result in data", async () => {
+      const user = UserSeeder.create();
+      const codeSentAt = new Date().toISOString();
+      const { controller, emailVerificationCodeService } = setup({ user });
+
+      emailVerificationCodeService.sendCode.mockResolvedValue({ codeSentAt });
+
+      const result = await controller.sendVerificationCode();
+
+      expect(emailVerificationCodeService.sendCode).toHaveBeenCalledWith(user.id);
+      expect(result).toEqual({ data: { codeSentAt } });
+    });
+  });
+
+  describe("verifyEmailCode", () => {
+    it("delegates to emailVerificationCodeService with code", async () => {
+      const user = UserSeeder.create();
+      const { controller, emailVerificationCodeService } = setup({ user });
+
+      emailVerificationCodeService.verifyCode.mockResolvedValue(undefined);
+
+      await controller.verifyEmailCode({ data: { code: "123456" } });
+
+      expect(emailVerificationCodeService.verifyCode).toHaveBeenCalledWith(user.id, "123456");
+    });
+  });
+
+  function setup(
+    input: {
+      user?: ReturnType<typeof UserSeeder.create>;
+    } = {}
+  ) {
+    const user = input.user ?? UserSeeder.create();
+
+    rootContainer.register(AuthService, {
+      useValue: mock<AuthService>({
+        isAuthenticated: true,
+        currentUser: user
+      })
+    });
+
+    const auth0Service = mock<Auth0Service>();
+    const emailVerificationCodeService = mock<EmailVerificationCodeService>();
+    const userService = mock<UserService>();
+
+    const controller = new AuthController(rootContainer.resolve(AuthService), auth0Service, userService, emailVerificationCodeService);
+
+    return { controller, auth0Service, emailVerificationCodeService, userService };
+  }
+});

--- a/apps/api/src/auth/controllers/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/controllers/auth/auth.controller.spec.ts
@@ -9,7 +9,7 @@ import type { EmailVerificationCodeService } from "@src/auth/services/email-veri
 import type { UserService } from "@src/user/services/user/user.service";
 import { AuthController } from "./auth.controller";
 
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 
 describe(AuthController.name, () => {
   describe("signup", () => {
@@ -58,7 +58,7 @@ describe(AuthController.name, () => {
 
   describe("sendVerificationCode", () => {
     it("delegates to emailVerificationCodeService and wraps result in data", async () => {
-      const user = UserSeeder.create();
+      const user = createUser();
       const codeSentAt = new Date().toISOString();
       const { controller, emailVerificationCodeService } = setup({ user });
 
@@ -73,7 +73,7 @@ describe(AuthController.name, () => {
 
   describe("verifyEmailCode", () => {
     it("delegates to emailVerificationCodeService with code", async () => {
-      const user = UserSeeder.create();
+      const user = createUser();
       const { controller, emailVerificationCodeService } = setup({ user });
 
       emailVerificationCodeService.verifyCode.mockResolvedValue(undefined);
@@ -86,10 +86,10 @@ describe(AuthController.name, () => {
 
   function setup(
     input: {
-      user?: ReturnType<typeof UserSeeder.create>;
+      user?: ReturnType<typeof createUser>;
     } = {}
   ) {
-    const user = input.user ?? UserSeeder.create();
+    const user = input.user ?? createUser();
 
     rootContainer.register(AuthService, {
       useValue: mock<AuthService>({

--- a/apps/api/src/auth/controllers/auth/auth.controller.ts
+++ b/apps/api/src/auth/controllers/auth/auth.controller.ts
@@ -1,9 +1,14 @@
+import { ResponseError } from "auth0";
+import assert from "http-assert";
 import { singleton } from "tsyringe";
 
 import type { SendVerificationEmailRequestInput } from "@src/auth";
 import { VerifyEmailRequest } from "@src/auth/http-schemas/verify-email.schema";
+import type { SignupInput } from "@src/auth/routes/signup/signup.router";
+import type { VerifyEmailCodeRequest } from "@src/auth/routes/verify-email-code/verify-email-code.router";
 import { AuthService, Protected } from "@src/auth/services/auth.service";
-import { Auth0Service } from "@src/auth/services/auth0/auth0.service";
+import { AUTH0_DB_CONNECTION, Auth0Service } from "@src/auth/services/auth0/auth0.service";
+import { EmailVerificationCodeService } from "@src/auth/services/email-verification-code/email-verification-code.service";
 import { UserService } from "@src/user/services/user/user.service";
 
 @singleton()
@@ -11,8 +16,29 @@ export class AuthController {
   constructor(
     private readonly authService: AuthService,
     private readonly auth0: Auth0Service,
-    private readonly userService: UserService
+    private readonly userService: UserService,
+    private readonly emailVerificationCodeService: EmailVerificationCodeService
   ) {}
+
+  async signup(input: SignupInput) {
+    try {
+      await this.auth0.createUser({
+        email: input.email,
+        password: input.password,
+        connection: AUTH0_DB_CONNECTION
+      });
+    } catch (error) {
+      if (error instanceof ResponseError) {
+        if (error.statusCode === 409) {
+          assert(false, 422, "Unable to create account. Please try again or use a different email.");
+        }
+        const body = JSON.parse(error.body);
+        assert(false, error.statusCode, body.message);
+      }
+
+      throw error;
+    }
+  }
 
   @Protected()
   async sendVerificationEmail({ data: { userId } }: SendVerificationEmailRequestInput) {
@@ -22,6 +48,22 @@ export class AuthController {
     if (currentUser?.userId) {
       await this.auth0.sendVerificationEmail(currentUser.userId);
     }
+  }
+
+  @Protected()
+  async sendVerificationCode() {
+    const { currentUser } = this.authService;
+
+    const result = await this.emailVerificationCodeService.sendCode(currentUser!.id);
+
+    return { data: result };
+  }
+
+  @Protected()
+  async verifyEmailCode({ data: { code } }: VerifyEmailCodeRequest) {
+    const { currentUser } = this.authService;
+
+    await this.emailVerificationCodeService.verifyCode(currentUser!.id, code);
   }
 
   async syncEmailVerified({ data: { email } }: VerifyEmailRequest) {

--- a/apps/api/src/auth/controllers/auth/auth.controller.ts
+++ b/apps/api/src/auth/controllers/auth/auth.controller.ts
@@ -1,5 +1,5 @@
 import { ResponseError } from "auth0";
-import assert from "http-assert";
+import createError from "http-errors";
 import { singleton } from "tsyringe";
 
 import type { SendVerificationEmailRequestInput } from "@src/auth";
@@ -30,13 +30,22 @@ export class AuthController {
     } catch (error) {
       if (error instanceof ResponseError) {
         if (error.statusCode === 409) {
-          assert(false, 422, "Unable to create account. Please try again or use a different email.");
+          throw createError(422, "Unable to create account. Please try again or use a different email.");
         }
-        const body = JSON.parse(error.body);
-        assert(false, error.statusCode, body.message);
+
+        throw createError(error.statusCode, this.extractAuth0Message(error));
       }
 
       throw error;
+    }
+  }
+
+  private extractAuth0Message(error: ResponseError): string {
+    try {
+      const body = JSON.parse(error.body);
+      return body.message || error.message;
+    } catch {
+      return error.message;
     }
   }
 

--- a/apps/api/src/auth/model-schemas/email-verification-code/email-verification-code.schema.ts
+++ b/apps/api/src/auth/model-schemas/email-verification-code/email-verification-code.schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { index, integer, pgTable, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
+import { integer, pgTable, timestamp, uniqueIndex, uuid, varchar } from "drizzle-orm/pg-core";
 
 import { Users } from "@src/user/model-schemas";
 
@@ -20,7 +20,6 @@ export const EmailVerificationCodes = pgTable(
     createdAt: timestamp("created_at").defaultNow().notNull()
   },
   table => ({
-    userIdIdx: index("email_verification_codes_user_id_idx").on(table.userId),
-    expiresAtIdx: index("email_verification_codes_expires_at_idx").on(table.expiresAt)
+    userIdIdx: uniqueIndex("email_verification_codes_user_id_idx").on(table.userId)
   })
 );

--- a/apps/api/src/auth/model-schemas/email-verification-code/email-verification-code.schema.ts
+++ b/apps/api/src/auth/model-schemas/email-verification-code/email-verification-code.schema.ts
@@ -1,0 +1,26 @@
+import { sql } from "drizzle-orm";
+import { index, integer, pgTable, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
+
+import { Users } from "@src/user/model-schemas";
+
+export const EmailVerificationCodes = pgTable(
+  "email_verification_codes",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .notNull()
+      .default(sql`uuid_generate_v4()`),
+    userId: uuid("user_id")
+      .references(() => Users.id, { onDelete: "cascade" })
+      .notNull(),
+    email: varchar("email", { length: 255 }).notNull(),
+    code: varchar("code", { length: 64 }).notNull(),
+    expiresAt: timestamp("expires_at").notNull(),
+    attempts: integer("attempts").default(0).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull()
+  },
+  table => ({
+    userIdIdx: index("email_verification_codes_user_id_idx").on(table.userId),
+    expiresAtIdx: index("email_verification_codes_expires_at_idx").on(table.expiresAt)
+  })
+);

--- a/apps/api/src/auth/model-schemas/index.ts
+++ b/apps/api/src/auth/model-schemas/index.ts
@@ -1,1 +1,2 @@
 export * from "./api-key/api-key.schema";
+export * from "./email-verification-code/email-verification-code.schema";

--- a/apps/api/src/auth/repositories/email-verification-code/email-verification-code.repository.ts
+++ b/apps/api/src/auth/repositories/email-verification-code/email-verification-code.repository.ts
@@ -1,0 +1,66 @@
+import { and, count, desc, eq, gt, sql } from "drizzle-orm";
+import { singleton } from "tsyringe";
+
+import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
+import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
+import { TxService } from "@src/core/services";
+
+type Table = ApiPgTables["EmailVerificationCodes"];
+export type EmailVerificationCodeInput = Partial<Table["$inferInsert"]>;
+export type EmailVerificationCodeDbOutput = Table["$inferSelect"];
+
+export type EmailVerificationCodeOutput = Omit<EmailVerificationCodeDbOutput, "expiresAt" | "createdAt"> & {
+  expiresAt: string;
+  createdAt: string;
+};
+
+@singleton()
+export class EmailVerificationCodeRepository extends BaseRepository<Table, EmailVerificationCodeInput, EmailVerificationCodeOutput> {
+  constructor(
+    @InjectPg() protected readonly pg: ApiPgDatabase,
+    @InjectPgTable("EmailVerificationCodes") protected readonly table: Table,
+    protected readonly txManager: TxService
+  ) {
+    super(pg, table, txManager, "EmailVerificationCode", "EmailVerificationCodes");
+  }
+
+  accessibleBy(...abilityParams: AbilityParams) {
+    return new EmailVerificationCodeRepository(this.pg, this.table, this.txManager).withAbility(...abilityParams) as this;
+  }
+
+  async findActiveByUserIdForUpdate(userId: string): Promise<EmailVerificationCodeOutput | undefined> {
+    const [result] = await this.cursor
+      .select()
+      .from(this.table)
+      .where(and(eq(this.table.userId, userId), gt(this.table.expiresAt, sql`now()`)))
+      .orderBy(desc(this.table.createdAt))
+      .limit(1)
+      .for("update");
+
+    return result ? this.toOutput(result) : undefined;
+  }
+
+  async countRecentByUserId(userId: string, since: Date): Promise<number> {
+    const [result] = await this.cursor
+      .select({ count: count() })
+      .from(this.table)
+      .where(and(eq(this.table.userId, userId), gt(this.table.createdAt, since)));
+
+    return result?.count ?? 0;
+  }
+
+  async incrementAttempts(id: string): Promise<void> {
+    await this.cursor
+      .update(this.table)
+      .set({ attempts: sql`${this.table.attempts} + 1` })
+      .where(eq(this.table.id, id));
+  }
+
+  protected toOutput(payload: EmailVerificationCodeDbOutput): EmailVerificationCodeOutput {
+    return {
+      ...payload,
+      expiresAt: payload.expiresAt.toISOString(),
+      createdAt: payload.createdAt.toISOString()
+    };
+  }
+}

--- a/apps/api/src/auth/repositories/email-verification-code/email-verification-code.repository.ts
+++ b/apps/api/src/auth/repositories/email-verification-code/email-verification-code.repository.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, gt, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
@@ -28,25 +28,41 @@ export class EmailVerificationCodeRepository extends BaseRepository<Table, Email
     return new EmailVerificationCodeRepository(this.pg, this.table, this.txManager).withAbility(...abilityParams) as this;
   }
 
-  async findActiveByUserIdForUpdate(userId: string): Promise<EmailVerificationCodeOutput | undefined> {
+  async upsert(data: { userId: string; email: string; code: string; expiresAt: Date }): Promise<EmailVerificationCodeOutput> {
     const [result] = await this.cursor
-      .select()
-      .from(this.table)
-      .where(and(eq(this.table.userId, userId), gt(this.table.expiresAt, sql`now()`)))
-      .orderBy(desc(this.table.createdAt))
-      .limit(1)
-      .for("update");
+      .insert(this.table)
+      .values({
+        userId: data.userId,
+        email: data.email,
+        code: data.code,
+        expiresAt: data.expiresAt,
+        attempts: 0
+      })
+      .onConflictDoUpdate({
+        target: this.table.userId,
+        set: {
+          email: data.email,
+          code: data.code,
+          expiresAt: data.expiresAt,
+          attempts: 0,
+          createdAt: sql`now()`
+        }
+      })
+      .returning();
+
+    return this.toOutput(result);
+  }
+
+  async findByUserId(userId: string): Promise<EmailVerificationCodeOutput | undefined> {
+    const [result] = await this.cursor.select().from(this.table).where(eq(this.table.userId, userId));
 
     return result ? this.toOutput(result) : undefined;
   }
 
-  async countRecentByUserId(userId: string, since: Date): Promise<number> {
-    const [result] = await this.cursor
-      .select({ count: count() })
-      .from(this.table)
-      .where(and(eq(this.table.userId, userId), gt(this.table.createdAt, since)));
+  async findByUserIdForUpdate(userId: string): Promise<EmailVerificationCodeOutput | undefined> {
+    const [result] = await this.cursor.select().from(this.table).where(eq(this.table.userId, userId)).for("update");
 
-    return result?.count ?? 0;
+    return result ? this.toOutput(result) : undefined;
   }
 
   async incrementAttempts(id: string): Promise<void> {

--- a/apps/api/src/auth/repositories/email-verification-code/email-verification-code.repository.ts
+++ b/apps/api/src/auth/repositories/email-verification-code/email-verification-code.repository.ts
@@ -65,6 +65,10 @@ export class EmailVerificationCodeRepository extends BaseRepository<Table, Email
     return result ? this.toOutput(result) : undefined;
   }
 
+  async deleteByUserId(userId: string): Promise<void> {
+    await this.cursor.delete(this.table).where(eq(this.table.userId, userId));
+  }
+
   async incrementAttempts(id: string): Promise<void> {
     await this.cursor
       .update(this.table)

--- a/apps/api/src/auth/routes/index.ts
+++ b/apps/api/src/auth/routes/index.ts
@@ -1,2 +1,5 @@
 export * from "./send-verification-email/send-verification-email.router";
+export * from "./send-verification-code/send-verification-code.router";
+export * from "./signup/signup.router";
+export * from "./verify-email-code/verify-email-code.router";
 export * from "./api-keys/api-keys.router";

--- a/apps/api/src/auth/routes/send-verification-code/send-verification-code.router.ts
+++ b/apps/api/src/auth/routes/send-verification-code/send-verification-code.router.ts
@@ -1,0 +1,33 @@
+import { SendVerificationCodeResponseSchema } from "@akashnetwork/http-sdk";
+import { container } from "tsyringe";
+
+import { AuthController } from "@src/auth/controllers/auth/auth.controller";
+import { createRoute } from "@src/core/lib/create-route/create-route";
+import { OpenApiHonoHandler } from "@src/core/services/open-api-hono-handler/open-api-hono-handler";
+import { SECURITY_BEARER } from "@src/core/services/openapi-docs/openapi-security";
+
+export const sendVerificationCodeRouter = new OpenApiHonoHandler();
+
+const route = createRoute({
+  method: "post",
+  path: "/v1/send-verification-code",
+  summary: "Sends a verification code to the authenticated user's email",
+  tags: ["Users"],
+  security: SECURITY_BEARER,
+  responses: {
+    200: {
+      description: "Returns the timestamp when the code was sent",
+      content: {
+        "application/json": {
+          schema: SendVerificationCodeResponseSchema
+        }
+      }
+    },
+    429: { description: "Too many requests" }
+  }
+});
+
+sendVerificationCodeRouter.openapi(route, async function sendVerificationCode(c) {
+  const result = await container.resolve(AuthController).sendVerificationCode();
+  return c.json(result, 200);
+});

--- a/apps/api/src/auth/routes/signup/signup.router.ts
+++ b/apps/api/src/auth/routes/signup/signup.router.ts
@@ -1,0 +1,44 @@
+import { container } from "tsyringe";
+import { z } from "zod";
+
+import { AuthController } from "@src/auth/controllers/auth/auth.controller";
+import { createRoute } from "@src/core/lib/create-route/create-route";
+import { OpenApiHonoHandler } from "@src/core/services/open-api-hono-handler/open-api-hono-handler";
+import { SECURITY_NONE } from "@src/core/services/openapi-docs/openapi-security";
+
+const signupInputSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8)
+});
+
+export type SignupInput = z.infer<typeof signupInputSchema>;
+
+const route = createRoute({
+  method: "post",
+  path: "/v1/auth/signup",
+  summary: "Creates a new user without sending a verification email",
+  tags: ["Auth"],
+  security: SECURITY_NONE,
+  request: {
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: signupInputSchema
+        }
+      }
+    }
+  },
+  responses: {
+    204: {
+      description: "User created successfully"
+    }
+  }
+});
+
+export const signupRouter = new OpenApiHonoHandler();
+
+signupRouter.openapi(route, async function signup(c) {
+  await container.resolve(AuthController).signup(c.req.valid("json"));
+  return c.body(null, 204);
+});

--- a/apps/api/src/auth/routes/verify-email-code/verify-email-code.router.ts
+++ b/apps/api/src/auth/routes/verify-email-code/verify-email-code.router.ts
@@ -1,0 +1,50 @@
+import { container } from "tsyringe";
+import { z } from "zod";
+
+import { AuthController } from "@src/auth/controllers/auth/auth.controller";
+import { createRoute } from "@src/core/lib/create-route/create-route";
+import { OpenApiHonoHandler } from "@src/core/services/open-api-hono-handler/open-api-hono-handler";
+import { SECURITY_BEARER } from "@src/core/services/openapi-docs/openapi-security";
+
+export const verifyEmailCodeRouter = new OpenApiHonoHandler();
+
+const VerifyEmailCodeRequestSchema = z.object({
+  data: z.object({
+    code: z
+      .string()
+      .length(6)
+      .regex(/^\d{6}$/, "Code must be exactly 6 digits")
+  })
+});
+
+export type VerifyEmailCodeRequest = z.infer<typeof VerifyEmailCodeRequestSchema>;
+
+const route = createRoute({
+  method: "post",
+  path: "/v1/verify-email-code",
+  summary: "Verifies the email using a 6-digit code",
+  tags: ["Users"],
+  security: SECURITY_BEARER,
+  request: {
+    body: {
+      required: true,
+      content: {
+        "application/json": {
+          schema: VerifyEmailCodeRequestSchema
+        }
+      }
+    }
+  },
+  responses: {
+    204: {
+      description: "Email verified successfully"
+    },
+    400: { description: "Invalid or expired code" },
+    429: { description: "Too many attempts" }
+  }
+});
+
+verifyEmailCodeRouter.openapi(route, async function verifyEmailCode(c) {
+  await container.resolve(AuthController).verifyEmailCode(c.req.valid("json"));
+  return c.body(null, 204);
+});

--- a/apps/api/src/auth/routes/verify-email-code/verify-email-code.router.ts
+++ b/apps/api/src/auth/routes/verify-email-code/verify-email-code.router.ts
@@ -10,10 +10,7 @@ export const verifyEmailCodeRouter = new OpenApiHonoHandler();
 
 const VerifyEmailCodeRequestSchema = z.object({
   data: z.object({
-    code: z
-      .string()
-      .length(6)
-      .regex(/^\d{6}$/, "Code must be exactly 6 digits")
+    code: z.string().regex(/^\d{6}$/, "Code must be exactly 6 digits")
   })
 });
 

--- a/apps/api/src/auth/services/auth0/auth0.service.spec.ts
+++ b/apps/api/src/auth/services/auth0/auth0.service.spec.ts
@@ -1,5 +1,7 @@
 import { faker } from "@faker-js/faker";
 import type { GetUsers200ResponseOneOfInner, ManagementClient } from "auth0";
+import type { Mock } from "vitest";
+import { vi } from "vitest";
 
 import { Auth0Service } from "./auth0.service";
 
@@ -8,7 +10,7 @@ import { createAuth0User } from "@test/seeders";
 describe(Auth0Service.name, () => {
   describe("createUser", () => {
     it("calls managementClient.users.create with verify_email false", async () => {
-      const create = jest.fn().mockResolvedValue({ data: {} });
+      const create = vi.fn().mockResolvedValue({ data: {} });
       const { auth0Service } = setup({ users: { create } });
 
       await auth0Service.createUser({
@@ -28,7 +30,7 @@ describe(Auth0Service.name, () => {
 
   describe("sendVerificationEmail", () => {
     it("calls managementClient.jobs.verifyEmail with user ID", async () => {
-      const verifyEmail = jest.fn().mockResolvedValue(undefined);
+      const verifyEmail = vi.fn().mockResolvedValue(undefined);
       const { auth0Service } = setup({ jobs: { verifyEmail } });
 
       await auth0Service.sendVerificationEmail("auth0|abc123");
@@ -39,7 +41,7 @@ describe(Auth0Service.name, () => {
 
   describe("markEmailVerified", () => {
     it("calls managementClient.users.update with email_verified true", async () => {
-      const update = jest.fn().mockResolvedValue(undefined);
+      const update = vi.fn().mockResolvedValue(undefined);
       const { auth0Service } = setup({ users: { update } });
 
       await auth0Service.markEmailVerified("auth0|xyz789");
@@ -56,7 +58,7 @@ describe(Auth0Service.name, () => {
         email_verified: true
       });
 
-      const mockGetByEmail = jest.fn().mockResolvedValue({ data: [mockUser] });
+      const mockGetByEmail = vi.fn().mockResolvedValue({ data: [mockUser] });
       const { auth0Service } = setup({ usersByEmail: { getByEmail: mockGetByEmail } });
 
       const result = await auth0Service.getUserByEmail(email);
@@ -68,7 +70,7 @@ describe(Auth0Service.name, () => {
     it("returns null when no user is found", async () => {
       const email = faker.internet.email();
 
-      const mockGetByEmail = jest.fn().mockResolvedValue({ data: [] });
+      const mockGetByEmail = vi.fn().mockResolvedValue({ data: [] });
       const { auth0Service } = setup({ usersByEmail: { getByEmail: mockGetByEmail } });
 
       const result = await auth0Service.getUserByEmail(email);
@@ -90,7 +92,7 @@ describe(Auth0Service.name, () => {
         })
       ];
 
-      const mockGetByEmail = jest.fn().mockResolvedValue({ data: mockUsers });
+      const mockGetByEmail = vi.fn().mockResolvedValue({ data: mockUsers });
       const { auth0Service } = setup({ usersByEmail: { getByEmail: mockGetByEmail } });
 
       const result = await auth0Service.getUserByEmail(email);
@@ -100,7 +102,7 @@ describe(Auth0Service.name, () => {
     });
 
     it("returns null for empty email string", async () => {
-      const mockGetByEmail = jest.fn().mockResolvedValue({ data: [] });
+      const mockGetByEmail = vi.fn().mockResolvedValue({ data: [] });
       const { auth0Service } = setup({ usersByEmail: { getByEmail: mockGetByEmail } });
 
       const result = await auth0Service.getUserByEmail("");
@@ -112,9 +114,9 @@ describe(Auth0Service.name, () => {
 
   function setup(
     input: {
-      jobs?: { verifyEmail: jest.Mock };
-      users?: { update?: jest.Mock; create?: jest.Mock };
-      usersByEmail?: { getByEmail: jest.Mock };
+      jobs?: { verifyEmail: Mock };
+      users?: { update?: Mock; create?: Mock };
+      usersByEmail?: { getByEmail: Mock };
     } = {}
   ) {
     const mockManagementClient = {

--- a/apps/api/src/auth/services/auth0/auth0.service.spec.ts
+++ b/apps/api/src/auth/services/auth0/auth0.service.spec.ts
@@ -1,24 +1,63 @@
 import { faker } from "@faker-js/faker";
 import type { GetUsers200ResponseOneOfInner, ManagementClient } from "auth0";
-import { mock } from "vitest-mock-extended";
 
-import type { AuthConfigService } from "@src/auth/services/auth-config/auth-config.service";
 import { Auth0Service } from "./auth0.service";
 
 import { createAuth0User } from "@test/seeders";
 
 describe(Auth0Service.name, () => {
+  describe("createUser", () => {
+    it("calls managementClient.users.create with verify_email false", async () => {
+      const create = jest.fn().mockResolvedValue({ data: {} });
+      const { auth0Service } = setup({ users: { create } });
+
+      await auth0Service.createUser({
+        email: "user@example.com",
+        password: "StrongPassword123!",
+        connection: "Username-Password-Authentication"
+      });
+
+      expect(create).toHaveBeenCalledWith({
+        email: "user@example.com",
+        password: "StrongPassword123!",
+        connection: "Username-Password-Authentication",
+        verify_email: false
+      });
+    });
+  });
+
+  describe("sendVerificationEmail", () => {
+    it("calls managementClient.jobs.verifyEmail with user ID", async () => {
+      const verifyEmail = jest.fn().mockResolvedValue(undefined);
+      const { auth0Service } = setup({ jobs: { verifyEmail } });
+
+      await auth0Service.sendVerificationEmail("auth0|abc123");
+
+      expect(verifyEmail).toHaveBeenCalledWith({ user_id: "auth0|abc123" });
+    });
+  });
+
+  describe("markEmailVerified", () => {
+    it("calls managementClient.users.update with email_verified true", async () => {
+      const update = jest.fn().mockResolvedValue(undefined);
+      const { auth0Service } = setup({ users: { update } });
+
+      await auth0Service.markEmailVerified("auth0|xyz789");
+
+      expect(update).toHaveBeenCalledWith({ id: "auth0|xyz789" }, { email_verified: true });
+    });
+  });
+
   describe("getUserByEmail", () => {
-    it("should return user when user is found", async () => {
+    it("returns user when user is found", async () => {
       const email = faker.internet.email();
       const mockUser: Partial<GetUsers200ResponseOneOfInner> = createAuth0User({
         email: email,
         email_verified: true
       });
 
-      const { auth0Service, mockGetByEmail } = setup({
-        mockUsers: [mockUser as GetUsers200ResponseOneOfInner]
-      });
+      const mockGetByEmail = jest.fn().mockResolvedValue({ data: [mockUser] });
+      const { auth0Service } = setup({ usersByEmail: { getByEmail: mockGetByEmail } });
 
       const result = await auth0Service.getUserByEmail(email);
 
@@ -26,12 +65,11 @@ describe(Auth0Service.name, () => {
       expect(mockGetByEmail).toHaveBeenCalledWith({ email });
     });
 
-    it("should return null when no user is found", async () => {
+    it("returns null when no user is found", async () => {
       const email = faker.internet.email();
 
-      const { auth0Service, mockGetByEmail } = setup({
-        mockUsers: []
-      });
+      const mockGetByEmail = jest.fn().mockResolvedValue({ data: [] });
+      const { auth0Service } = setup({ usersByEmail: { getByEmail: mockGetByEmail } });
 
       const result = await auth0Service.getUserByEmail(email);
 
@@ -39,7 +77,7 @@ describe(Auth0Service.name, () => {
       expect(mockGetByEmail).toHaveBeenCalledWith({ email });
     });
 
-    it("should return first user when multiple users are found", async () => {
+    it("returns first user when multiple users are found", async () => {
       const email = faker.internet.email();
       const mockUsers: Partial<GetUsers200ResponseOneOfInner>[] = [
         createAuth0User({
@@ -52,9 +90,8 @@ describe(Auth0Service.name, () => {
         })
       ];
 
-      const { auth0Service, mockGetByEmail } = setup({
-        mockUsers: mockUsers as GetUsers200ResponseOneOfInner[]
-      });
+      const mockGetByEmail = jest.fn().mockResolvedValue({ data: mockUsers });
+      const { auth0Service } = setup({ usersByEmail: { getByEmail: mockGetByEmail } });
 
       const result = await auth0Service.getUserByEmail(email);
 
@@ -62,52 +99,30 @@ describe(Auth0Service.name, () => {
       expect(mockGetByEmail).toHaveBeenCalledWith({ email });
     });
 
-    it("should handle empty email string", async () => {
-      const email = "";
+    it("returns null for empty email string", async () => {
+      const mockGetByEmail = jest.fn().mockResolvedValue({ data: [] });
+      const { auth0Service } = setup({ usersByEmail: { getByEmail: mockGetByEmail } });
 
-      const { auth0Service, mockGetByEmail } = setup({
-        mockUsers: []
-      });
-
-      const result = await auth0Service.getUserByEmail(email);
+      const result = await auth0Service.getUserByEmail("");
 
       expect(result).toBeNull();
       expect(mockGetByEmail).toHaveBeenCalledWith({ email: "" });
     });
-
-    function setup(input: { mockUsers?: GetUsers200ResponseOneOfInner[]; mockError?: Error }) {
-      const mockAuthConfig = mock<AuthConfigService>();
-      mockAuthConfig.get.mockImplementation((key: string) => {
-        const config = {
-          AUTH0_M2M_DOMAIN: "test-domain.auth0.com",
-          AUTH0_M2M_CLIENT_ID: "test-client-id",
-          AUTH0_M2M_SECRET: "test-client-secret"
-        };
-        return config[key as keyof typeof config];
-      });
-
-      const mockGetByEmail = jest.fn();
-      const mockManagementClient = {
-        usersByEmail: {
-          getByEmail: mockGetByEmail
-        }
-      } as unknown as ManagementClient;
-
-      if (input.mockError) {
-        mockGetByEmail.mockRejectedValue(input.mockError);
-      } else {
-        mockGetByEmail.mockResolvedValue({
-          data: input.mockUsers || []
-        });
-      }
-
-      const auth0Service = new Auth0Service(mockManagementClient);
-
-      return {
-        auth0Service,
-        mockGetByEmail,
-        mockManagementClient
-      };
-    }
   });
+
+  function setup(
+    input: {
+      jobs?: { verifyEmail: jest.Mock };
+      users?: { update?: jest.Mock; create?: jest.Mock };
+      usersByEmail?: { getByEmail: jest.Mock };
+    } = {}
+  ) {
+    const mockManagementClient = {
+      ...input
+    } as unknown as ManagementClient;
+
+    const auth0Service = new Auth0Service(mockManagementClient);
+
+    return { auth0Service, mockManagementClient };
+  }
 });

--- a/apps/api/src/auth/services/auth0/auth0.service.ts
+++ b/apps/api/src/auth/services/auth0/auth0.service.ts
@@ -1,12 +1,27 @@
 import { GetUsers200ResponseOneOfInner, ManagementClient } from "auth0";
 import { singleton } from "tsyringe";
 
+export const AUTH0_DB_CONNECTION = "Username-Password-Authentication";
+
 @singleton()
 export class Auth0Service {
   constructor(private readonly managementClient: ManagementClient) {}
 
+  async createUser(input: { email: string; password: string; connection: string }): Promise<void> {
+    await this.managementClient.users.create({
+      email: input.email,
+      password: input.password,
+      connection: input.connection,
+      verify_email: false
+    });
+  }
+
   async sendVerificationEmail(userId: string) {
     await this.managementClient.jobs.verifyEmail({ user_id: userId });
+  }
+
+  async markEmailVerified(userId: string) {
+    await this.managementClient.users.update({ id: userId }, { email_verified: true });
   }
 
   async getUserByEmail(email: string): Promise<GetUsers200ResponseOneOfInner | null> {

--- a/apps/api/src/auth/services/email-verification-code/email-verification-code.service.spec.ts
+++ b/apps/api/src/auth/services/email-verification-code/email-verification-code.service.spec.ts
@@ -24,12 +24,12 @@ describe(EmailVerificationCodeService.name, () => {
       const { service, emailVerificationCodeRepository, userRepository, notificationService } = setup();
 
       userRepository.findById.mockResolvedValue(user);
-      emailVerificationCodeRepository.countRecentByUserId.mockResolvedValue(0);
-      emailVerificationCodeRepository.create.mockResolvedValue(createdRecord);
+      emailVerificationCodeRepository.findByUserId.mockResolvedValue(undefined);
+      emailVerificationCodeRepository.upsert.mockResolvedValue(createdRecord);
 
       const result = await service.sendCode(user.id);
 
-      expect(emailVerificationCodeRepository.create).toHaveBeenCalledWith(
+      expect(emailVerificationCodeRepository.upsert).toHaveBeenCalledWith(
         expect.objectContaining({
           userId: user.id,
           email: user.email,
@@ -40,14 +40,37 @@ describe(EmailVerificationCodeService.name, () => {
       expect(result.codeSentAt).toBe(createdRecord.createdAt);
     });
 
-    it("throws 429 when rate limit exceeded", async () => {
+    it("upserts over an existing code outside cooldown", async () => {
       const user = createUser({ email: "test@example.com" });
+      const existingRecord = createVerificationCodeOutput({
+        userId: user.id,
+        expiresAt: new Date(Date.now() + 5 * 60 * 1000).toISOString()
+      });
+      const newRecord = createVerificationCodeOutput({ userId: user.id });
       const { service, emailVerificationCodeRepository, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue(user);
-      emailVerificationCodeRepository.countRecentByUserId.mockResolvedValue(5);
+      emailVerificationCodeRepository.findByUserId.mockResolvedValue(existingRecord);
+      emailVerificationCodeRepository.upsert.mockResolvedValue(newRecord);
 
-      await expect(service.sendCode(user.id)).rejects.toThrow();
+      const result = await service.sendCode(user.id);
+
+      expect(emailVerificationCodeRepository.upsert).toHaveBeenCalled();
+      expect(result.codeSentAt).toBe(newRecord.createdAt);
+    });
+
+    it("throws 429 when within cooldown window", async () => {
+      const user = createUser({ email: "test@example.com" });
+      const recentRecord = createVerificationCodeOutput({
+        userId: user.id,
+        expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString()
+      });
+      const { service, emailVerificationCodeRepository, userRepository } = setup();
+
+      userRepository.findById.mockResolvedValue(user);
+      emailVerificationCodeRepository.findByUserId.mockResolvedValue(recentRecord);
+
+      await expect(service.sendCode(user.id)).rejects.toThrow("Too many verification code requests");
     });
 
     it("throws 404 when user not found", async () => {
@@ -76,7 +99,7 @@ describe(EmailVerificationCodeService.name, () => {
       const { service, emailVerificationCodeRepository, userRepository, auth0Service } = setup();
 
       userRepository.findById.mockResolvedValue(user);
-      emailVerificationCodeRepository.findActiveByUserIdForUpdate.mockResolvedValue(record);
+      emailVerificationCodeRepository.findByUserIdForUpdate.mockResolvedValue(record);
 
       await service.verifyCode(user.id, code);
 
@@ -90,7 +113,7 @@ describe(EmailVerificationCodeService.name, () => {
       const { service, emailVerificationCodeRepository, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue(user);
-      emailVerificationCodeRepository.findActiveByUserIdForUpdate.mockResolvedValue(record);
+      emailVerificationCodeRepository.findByUserIdForUpdate.mockResolvedValue(record);
 
       await expect(service.verifyCode(user.id, "999999")).rejects.toThrow("Invalid verification code");
       expect(emailVerificationCodeRepository.incrementAttempts).toHaveBeenCalledWith(record.id);
@@ -102,22 +125,27 @@ describe(EmailVerificationCodeService.name, () => {
       const { service, emailVerificationCodeRepository, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue(user);
-      emailVerificationCodeRepository.findActiveByUserIdForUpdate.mockResolvedValue(record);
+      emailVerificationCodeRepository.findByUserIdForUpdate.mockResolvedValue(record);
 
       await expect(service.verifyCode(user.id, "123456")).rejects.toThrow();
       expect(emailVerificationCodeRepository.incrementAttempts).not.toHaveBeenCalled();
     });
 
-    it("throws and increments attempts for mismatched length code", async () => {
+    it("rejects when code is expired", async () => {
+      const code = "123456";
       const user = createUser({ userId: "auth0|123" });
-      const record = createVerificationCodeOutput({ userId: user.id, code: hashCode("123456"), attempts: 0 });
+      const record = createVerificationCodeOutput({
+        userId: user.id,
+        code: hashCode(code),
+        attempts: 0,
+        expiresAt: new Date(Date.now() - 1000).toISOString()
+      });
       const { service, emailVerificationCodeRepository, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue(user);
-      emailVerificationCodeRepository.findActiveByUserIdForUpdate.mockResolvedValue(record);
+      emailVerificationCodeRepository.findByUserIdForUpdate.mockResolvedValue(record);
 
-      await expect(service.verifyCode(user.id, "12345")).rejects.toThrow("Invalid verification code");
-      expect(emailVerificationCodeRepository.incrementAttempts).toHaveBeenCalledWith(record.id);
+      await expect(service.verifyCode(user.id, code)).rejects.toThrow("Verification code expired");
     });
 
     it("updates local DB even if Auth0 call fails", async () => {
@@ -127,7 +155,7 @@ describe(EmailVerificationCodeService.name, () => {
       const { service, emailVerificationCodeRepository, userRepository, auth0Service } = setup();
 
       userRepository.findById.mockResolvedValue(user);
-      emailVerificationCodeRepository.findActiveByUserIdForUpdate.mockResolvedValue(record);
+      emailVerificationCodeRepository.findByUserIdForUpdate.mockResolvedValue(record);
       auth0Service.markEmailVerified.mockRejectedValue(new Error("Auth0 unavailable"));
 
       await expect(service.verifyCode(user.id, code)).rejects.toThrow("Auth0 unavailable");
@@ -140,7 +168,7 @@ describe(EmailVerificationCodeService.name, () => {
       const { service, emailVerificationCodeRepository, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue(user);
-      emailVerificationCodeRepository.findActiveByUserIdForUpdate.mockResolvedValue(undefined);
+      emailVerificationCodeRepository.findByUserIdForUpdate.mockResolvedValue(undefined);
 
       await expect(service.verifyCode(user.id, "123456")).rejects.toThrow();
     });

--- a/apps/api/src/auth/services/email-verification-code/email-verification-code.service.spec.ts
+++ b/apps/api/src/auth/services/email-verification-code/email-verification-code.service.spec.ts
@@ -1,0 +1,192 @@
+import "@test/mocks/logger-service.mock";
+
+import { faker } from "@faker-js/faker";
+import { createHash } from "crypto";
+import { mock } from "vitest-mock-extended";
+
+import type {
+  EmailVerificationCodeOutput,
+  EmailVerificationCodeRepository
+} from "@src/auth/repositories/email-verification-code/email-verification-code.repository";
+import type { Auth0Service } from "@src/auth/services/auth0/auth0.service";
+import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { NotificationService } from "@src/notifications/services/notification/notification.service";
+import type { UserRepository } from "@src/user/repositories/user/user.repository";
+import { EmailVerificationCodeService } from "./email-verification-code.service";
+
+import { UserSeeder } from "@test/seeders/user.seeder";
+
+describe(EmailVerificationCodeService.name, () => {
+  describe("sendCode", () => {
+    it("creates a new code and sends notification", async () => {
+      const user = UserSeeder.create({ email: "test@example.com" });
+      const createdRecord = createVerificationCodeOutput({ userId: user.id });
+      const { service, emailVerificationCodeRepository, userRepository, notificationService } = setup();
+
+      userRepository.findById.mockResolvedValue(user);
+      emailVerificationCodeRepository.countRecentByUserId.mockResolvedValue(0);
+      emailVerificationCodeRepository.create.mockResolvedValue(createdRecord);
+
+      const result = await service.sendCode(user.id);
+
+      expect(emailVerificationCodeRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: user.id,
+          email: user.email,
+          code: expect.stringMatching(/^[a-f0-9]{64}$/)
+        })
+      );
+      expect(notificationService.createNotification).toHaveBeenCalled();
+      expect(result.codeSentAt).toBe(createdRecord.createdAt);
+    });
+
+    it("throws 429 when rate limit exceeded", async () => {
+      const user = UserSeeder.create({ email: "test@example.com" });
+      const { service, emailVerificationCodeRepository, userRepository } = setup();
+
+      userRepository.findById.mockResolvedValue(user);
+      emailVerificationCodeRepository.countRecentByUserId.mockResolvedValue(5);
+
+      await expect(service.sendCode(user.id)).rejects.toThrow();
+    });
+
+    it("throws 404 when user not found", async () => {
+      const { service, userRepository } = setup();
+
+      userRepository.findById.mockResolvedValue(undefined);
+
+      await expect(service.sendCode("nonexistent")).rejects.toThrow();
+    });
+
+    it("throws 400 when user has no email", async () => {
+      const user = UserSeeder.create({ email: null });
+      const { service, userRepository } = setup();
+
+      userRepository.findById.mockResolvedValue(user);
+
+      await expect(service.sendCode(user.id)).rejects.toThrow();
+    });
+  });
+
+  describe("verifyCode", () => {
+    it("verifies valid code and marks email as verified", async () => {
+      const code = "123456";
+      const user = UserSeeder.create({ userId: "auth0|123" });
+      const record = createVerificationCodeOutput({ userId: user.id, code: hashCode(code), attempts: 0 });
+      const { service, emailVerificationCodeRepository, userRepository, auth0Service } = setup();
+
+      userRepository.findById.mockResolvedValue(user);
+      emailVerificationCodeRepository.findActiveByUserIdForUpdate.mockResolvedValue(record);
+
+      await service.verifyCode(user.id, code);
+
+      expect(auth0Service.markEmailVerified).toHaveBeenCalledWith(user.userId);
+      expect(userRepository.updateById).toHaveBeenCalledWith(user.id, { emailVerified: true });
+    });
+
+    it("throws and increments attempts for invalid code", async () => {
+      const user = UserSeeder.create({ userId: "auth0|123" });
+      const record = createVerificationCodeOutput({ userId: user.id, code: hashCode("123456"), attempts: 0 });
+      const { service, emailVerificationCodeRepository, userRepository } = setup();
+
+      userRepository.findById.mockResolvedValue(user);
+      emailVerificationCodeRepository.findActiveByUserIdForUpdate.mockResolvedValue(record);
+
+      await expect(service.verifyCode(user.id, "999999")).rejects.toThrow("Invalid verification code");
+      expect(emailVerificationCodeRepository.incrementAttempts).toHaveBeenCalledWith(record.id);
+    });
+
+    it("rejects when max attempts exceeded", async () => {
+      const user = UserSeeder.create({ userId: "auth0|123" });
+      const record = createVerificationCodeOutput({ userId: user.id, code: hashCode("123456"), attempts: 5 });
+      const { service, emailVerificationCodeRepository, userRepository } = setup();
+
+      userRepository.findById.mockResolvedValue(user);
+      emailVerificationCodeRepository.findActiveByUserIdForUpdate.mockResolvedValue(record);
+
+      await expect(service.verifyCode(user.id, "123456")).rejects.toThrow();
+      expect(emailVerificationCodeRepository.incrementAttempts).not.toHaveBeenCalled();
+    });
+
+    it("throws and increments attempts for mismatched length code", async () => {
+      const user = UserSeeder.create({ userId: "auth0|123" });
+      const record = createVerificationCodeOutput({ userId: user.id, code: hashCode("123456"), attempts: 0 });
+      const { service, emailVerificationCodeRepository, userRepository } = setup();
+
+      userRepository.findById.mockResolvedValue(user);
+      emailVerificationCodeRepository.findActiveByUserIdForUpdate.mockResolvedValue(record);
+
+      await expect(service.verifyCode(user.id, "12345")).rejects.toThrow("Invalid verification code");
+      expect(emailVerificationCodeRepository.incrementAttempts).toHaveBeenCalledWith(record.id);
+    });
+
+    it("updates local DB even if Auth0 call fails", async () => {
+      const code = "123456";
+      const user = UserSeeder.create({ userId: "auth0|123" });
+      const record = createVerificationCodeOutput({ userId: user.id, code: hashCode(code), attempts: 0 });
+      const { service, emailVerificationCodeRepository, userRepository, auth0Service } = setup();
+
+      userRepository.findById.mockResolvedValue(user);
+      emailVerificationCodeRepository.findActiveByUserIdForUpdate.mockResolvedValue(record);
+      auth0Service.markEmailVerified.mockRejectedValue(new Error("Auth0 unavailable"));
+
+      await expect(service.verifyCode(user.id, code)).rejects.toThrow("Auth0 unavailable");
+
+      expect(userRepository.updateById).toHaveBeenCalledWith(user.id, { emailVerified: true });
+    });
+
+    it("rejects when no active code exists", async () => {
+      const user = UserSeeder.create({ userId: "auth0|123" });
+      const { service, emailVerificationCodeRepository, userRepository } = setup();
+
+      userRepository.findById.mockResolvedValue(user);
+      emailVerificationCodeRepository.findActiveByUserIdForUpdate.mockResolvedValue(undefined);
+
+      await expect(service.verifyCode(user.id, "123456")).rejects.toThrow();
+    });
+  });
+
+  function hashCode(code: string) {
+    return createHash("sha256").update(code).digest("hex");
+  }
+
+  function createVerificationCodeOutput(overrides: Partial<EmailVerificationCodeOutput> = {}): EmailVerificationCodeOutput {
+    return {
+      id: faker.string.uuid(),
+      userId: faker.string.uuid(),
+      email: faker.internet.email(),
+      code: hashCode(faker.string.numeric(6)),
+      expiresAt: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+      attempts: 0,
+      createdAt: new Date().toISOString(),
+      ...overrides
+    };
+  }
+
+  function setup(
+    input: {
+      emailVerificationCodeRepository?: EmailVerificationCodeRepository;
+      auth0Service?: Auth0Service;
+      notificationService?: NotificationService;
+      userRepository?: UserRepository;
+      logger?: LoggerService;
+    } = {}
+  ) {
+    const emailVerificationCodeRepository = input.emailVerificationCodeRepository ?? mock<EmailVerificationCodeRepository>();
+    const auth0Service = input.auth0Service ?? mock<Auth0Service>();
+    const notificationService = input.notificationService ?? mock<NotificationService>();
+    const userRepository = input.userRepository ?? mock<UserRepository>();
+    const logger = input.logger ?? mock<LoggerService>();
+
+    const service = new EmailVerificationCodeService(emailVerificationCodeRepository, auth0Service, notificationService, userRepository, logger);
+
+    return {
+      service,
+      emailVerificationCodeRepository,
+      auth0Service,
+      notificationService,
+      userRepository,
+      logger
+    };
+  }
+});

--- a/apps/api/src/auth/services/email-verification-code/email-verification-code.service.spec.ts
+++ b/apps/api/src/auth/services/email-verification-code/email-verification-code.service.spec.ts
@@ -9,10 +9,10 @@ import type {
   EmailVerificationCodeRepository
 } from "@src/auth/repositories/email-verification-code/email-verification-code.repository";
 import type { Auth0Service } from "@src/auth/services/auth0/auth0.service";
+import { EmailVerificationCodeService } from "@src/auth/services/email-verification-code/email-verification-code.service";
 import type { LoggerService } from "@src/core/providers/logging.provider";
 import type { NotificationService } from "@src/notifications/services/notification/notification.service";
 import type { UserRepository } from "@src/user/repositories/user/user.repository";
-import { EmailVerificationCodeService } from "./email-verification-code.service";
 
 import { createUser } from "@test/seeders/user.seeder";
 

--- a/apps/api/src/auth/services/email-verification-code/email-verification-code.service.spec.ts
+++ b/apps/api/src/auth/services/email-verification-code/email-verification-code.service.spec.ts
@@ -14,12 +14,12 @@ import type { NotificationService } from "@src/notifications/services/notificati
 import type { UserRepository } from "@src/user/repositories/user/user.repository";
 import { EmailVerificationCodeService } from "./email-verification-code.service";
 
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 
 describe(EmailVerificationCodeService.name, () => {
   describe("sendCode", () => {
     it("creates a new code and sends notification", async () => {
-      const user = UserSeeder.create({ email: "test@example.com" });
+      const user = createUser({ email: "test@example.com" });
       const createdRecord = createVerificationCodeOutput({ userId: user.id });
       const { service, emailVerificationCodeRepository, userRepository, notificationService } = setup();
 
@@ -41,7 +41,7 @@ describe(EmailVerificationCodeService.name, () => {
     });
 
     it("throws 429 when rate limit exceeded", async () => {
-      const user = UserSeeder.create({ email: "test@example.com" });
+      const user = createUser({ email: "test@example.com" });
       const { service, emailVerificationCodeRepository, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue(user);
@@ -59,7 +59,7 @@ describe(EmailVerificationCodeService.name, () => {
     });
 
     it("throws 400 when user has no email", async () => {
-      const user = UserSeeder.create({ email: null });
+      const user = createUser({ email: null });
       const { service, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue(user);
@@ -71,7 +71,7 @@ describe(EmailVerificationCodeService.name, () => {
   describe("verifyCode", () => {
     it("verifies valid code and marks email as verified", async () => {
       const code = "123456";
-      const user = UserSeeder.create({ userId: "auth0|123" });
+      const user = createUser({ userId: "auth0|123" });
       const record = createVerificationCodeOutput({ userId: user.id, code: hashCode(code), attempts: 0 });
       const { service, emailVerificationCodeRepository, userRepository, auth0Service } = setup();
 
@@ -85,7 +85,7 @@ describe(EmailVerificationCodeService.name, () => {
     });
 
     it("throws and increments attempts for invalid code", async () => {
-      const user = UserSeeder.create({ userId: "auth0|123" });
+      const user = createUser({ userId: "auth0|123" });
       const record = createVerificationCodeOutput({ userId: user.id, code: hashCode("123456"), attempts: 0 });
       const { service, emailVerificationCodeRepository, userRepository } = setup();
 
@@ -97,7 +97,7 @@ describe(EmailVerificationCodeService.name, () => {
     });
 
     it("rejects when max attempts exceeded", async () => {
-      const user = UserSeeder.create({ userId: "auth0|123" });
+      const user = createUser({ userId: "auth0|123" });
       const record = createVerificationCodeOutput({ userId: user.id, code: hashCode("123456"), attempts: 5 });
       const { service, emailVerificationCodeRepository, userRepository } = setup();
 
@@ -109,7 +109,7 @@ describe(EmailVerificationCodeService.name, () => {
     });
 
     it("throws and increments attempts for mismatched length code", async () => {
-      const user = UserSeeder.create({ userId: "auth0|123" });
+      const user = createUser({ userId: "auth0|123" });
       const record = createVerificationCodeOutput({ userId: user.id, code: hashCode("123456"), attempts: 0 });
       const { service, emailVerificationCodeRepository, userRepository } = setup();
 
@@ -122,7 +122,7 @@ describe(EmailVerificationCodeService.name, () => {
 
     it("updates local DB even if Auth0 call fails", async () => {
       const code = "123456";
-      const user = UserSeeder.create({ userId: "auth0|123" });
+      const user = createUser({ userId: "auth0|123" });
       const record = createVerificationCodeOutput({ userId: user.id, code: hashCode(code), attempts: 0 });
       const { service, emailVerificationCodeRepository, userRepository, auth0Service } = setup();
 
@@ -136,7 +136,7 @@ describe(EmailVerificationCodeService.name, () => {
     });
 
     it("rejects when no active code exists", async () => {
-      const user = UserSeeder.create({ userId: "auth0|123" });
+      const user = createUser({ userId: "auth0|123" });
       const { service, emailVerificationCodeRepository, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue(user);

--- a/apps/api/src/auth/services/email-verification-code/email-verification-code.service.spec.ts
+++ b/apps/api/src/auth/services/email-verification-code/email-verification-code.service.spec.ts
@@ -89,6 +89,20 @@ describe(EmailVerificationCodeService.name, () => {
 
       await expect(service.sendCode(user.id)).rejects.toThrow();
     });
+
+    it("deletes the code record when notification fails", async () => {
+      const user = createUser({ email: "test@example.com" });
+      const createdRecord = createVerificationCodeOutput({ userId: user.id });
+      const { service, emailVerificationCodeRepository, userRepository, notificationService } = setup();
+
+      userRepository.findById.mockResolvedValue(user);
+      emailVerificationCodeRepository.findByUserId.mockResolvedValue(undefined);
+      emailVerificationCodeRepository.upsert.mockResolvedValue(createdRecord);
+      notificationService.createNotification.mockRejectedValue(new Error("Notification service unavailable"));
+
+      await expect(service.sendCode(user.id)).rejects.toThrow("Notification service unavailable");
+      expect(emailVerificationCodeRepository.deleteByUserId).toHaveBeenCalledWith(user.id);
+    });
   });
 
   describe("verifyCode", () => {

--- a/apps/api/src/auth/services/email-verification-code/email-verification-code.service.ts
+++ b/apps/api/src/auth/services/email-verification-code/email-verification-code.service.ts
@@ -30,12 +30,13 @@ export class EmailVerificationCodeService {
   ) {}
 
   async sendCode(userInternalId: string): Promise<{ codeSentAt: string }> {
-    const user = await this.userRepository.findById(userInternalId);
+    const since = new Date(Date.now() - RATE_LIMIT_WINDOW_MS);
+    const [user, recentCount] = await Promise.all([
+      this.userRepository.findById(userInternalId),
+      this.emailVerificationCodeRepository.countRecentByUserId(userInternalId, since)
+    ]);
     assert(user, 404, "User not found");
     assert(user.email, 400, "User has no email address");
-
-    const since = new Date(Date.now() - RATE_LIMIT_WINDOW_MS);
-    const recentCount = await this.emailVerificationCodeRepository.countRecentByUserId(userInternalId, since);
     assert(recentCount < MAX_CODES_PER_WINDOW, 429, "Too many verification code requests. Please try again later.");
 
     const code = randomInt(100000, 1000000).toString();

--- a/apps/api/src/auth/services/email-verification-code/email-verification-code.service.ts
+++ b/apps/api/src/auth/services/email-verification-code/email-verification-code.service.ts
@@ -1,0 +1,90 @@
+import { createHash, randomInt, timingSafeEqual } from "crypto";
+import assert from "http-assert";
+import { singleton } from "tsyringe";
+
+import { EmailVerificationCodeRepository } from "@src/auth/repositories/email-verification-code/email-verification-code.repository";
+import { Auth0Service } from "@src/auth/services/auth0/auth0.service";
+import { WithTransaction } from "@src/core";
+import { LoggerService } from "@src/core/providers/logging.provider";
+import { NotificationService } from "@src/notifications/services/notification/notification.service";
+import { emailVerificationCodeNotification } from "@src/notifications/services/notification-templates/email-verification-code-notification";
+import { UserRepository } from "@src/user/repositories/user/user.repository";
+
+const CODE_EXPIRY_MS = 10 * 60 * 1000;
+const MAX_ATTEMPTS = 5;
+const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+const MAX_CODES_PER_WINDOW = 5;
+
+function hashCode(code: string): string {
+  return createHash("sha256").update(code).digest("hex");
+}
+
+@singleton()
+export class EmailVerificationCodeService {
+  constructor(
+    private readonly emailVerificationCodeRepository: EmailVerificationCodeRepository,
+    private readonly auth0Service: Auth0Service,
+    private readonly notificationService: NotificationService,
+    private readonly userRepository: UserRepository,
+    private readonly logger: LoggerService
+  ) {}
+
+  async sendCode(userInternalId: string): Promise<{ codeSentAt: string }> {
+    const user = await this.userRepository.findById(userInternalId);
+    assert(user, 404, "User not found");
+    assert(user.email, 400, "User has no email address");
+
+    const since = new Date(Date.now() - RATE_LIMIT_WINDOW_MS);
+    const recentCount = await this.emailVerificationCodeRepository.countRecentByUserId(userInternalId, since);
+    assert(recentCount < MAX_CODES_PER_WINDOW, 429, "Too many verification code requests. Please try again later.");
+
+    const code = randomInt(100000, 1000000).toString();
+    const expiresAt = new Date(Date.now() + CODE_EXPIRY_MS);
+
+    const record = await this.emailVerificationCodeRepository.create({
+      userId: userInternalId,
+      email: user.email,
+      code: hashCode(code),
+      expiresAt
+    });
+
+    await this.notificationService.createNotification(emailVerificationCodeNotification({ id: userInternalId, email: user.email }, { code }));
+
+    this.logger.info({ event: "VERIFICATION_CODE_SENT", userId: userInternalId });
+
+    return { codeSentAt: record.createdAt };
+  }
+
+  async verifyCode(userInternalId: string, code: string): Promise<void> {
+    const auth0UserId = await this.verifyCodeInTransaction(userInternalId, code);
+
+    await this.auth0Service.markEmailVerified(auth0UserId);
+
+    this.logger.info({ event: "EMAIL_VERIFIED_VIA_CODE", userId: userInternalId });
+  }
+
+  @WithTransaction()
+  private async verifyCodeInTransaction(userInternalId: string, code: string): Promise<string> {
+    const [user, record] = await Promise.all([
+      this.userRepository.findById(userInternalId),
+      this.emailVerificationCodeRepository.findActiveByUserIdForUpdate(userInternalId)
+    ]);
+    assert(user, 404, "User not found");
+    assert(user.userId, 400, "User has no Auth0 ID");
+    assert(record, 400, "No active verification code. Please request a new one.");
+    assert(record.attempts < MAX_ATTEMPTS, 429, "Too many attempts. Please request a new code.");
+
+    const codeBuffer = Buffer.from(hashCode(code));
+    const recordBuffer = Buffer.from(record.code);
+    const isCodeValid = codeBuffer.length === recordBuffer.length && timingSafeEqual(recordBuffer, codeBuffer);
+
+    if (!isCodeValid) {
+      await this.emailVerificationCodeRepository.incrementAttempts(record.id);
+      assert(false, 400, "Invalid verification code");
+    }
+
+    await this.userRepository.updateById(userInternalId, { emailVerified: true });
+
+    return user.userId;
+  }
+}

--- a/apps/api/src/auth/services/email-verification-code/email-verification-code.service.ts
+++ b/apps/api/src/auth/services/email-verification-code/email-verification-code.service.ts
@@ -1,4 +1,4 @@
-import { createHash, randomInt, timingSafeEqual } from "crypto";
+import { createHash, randomInt } from "crypto";
 import assert from "http-assert";
 import { singleton } from "tsyringe";
 
@@ -11,9 +11,8 @@ import { emailVerificationCodeNotification } from "@src/notifications/services/n
 import { UserRepository } from "@src/user/repositories/user/user.repository";
 
 const CODE_EXPIRY_MS = 10 * 60 * 1000;
+const COOLDOWN_MS = 60 * 1000;
 const MAX_ATTEMPTS = 5;
-const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
-const MAX_CODES_PER_WINDOW = 5;
 
 function hashCode(code: string): string {
   return createHash("sha256").update(code).digest("hex");
@@ -30,19 +29,20 @@ export class EmailVerificationCodeService {
   ) {}
 
   async sendCode(userInternalId: string): Promise<{ codeSentAt: string }> {
-    const since = new Date(Date.now() - RATE_LIMIT_WINDOW_MS);
-    const [user, recentCount] = await Promise.all([
-      this.userRepository.findById(userInternalId),
-      this.emailVerificationCodeRepository.countRecentByUserId(userInternalId, since)
-    ]);
+    const user = await this.userRepository.findById(userInternalId);
     assert(user, 404, "User not found");
     assert(user.email, 400, "User has no email address");
-    assert(recentCount < MAX_CODES_PER_WINDOW, 429, "Too many verification code requests. Please try again later.");
+
+    const existing = await this.emailVerificationCodeRepository.findByUserId(userInternalId);
+    if (existing) {
+      const isWithinCooldown = new Date(existing.expiresAt).getTime() > Date.now() + CODE_EXPIRY_MS - COOLDOWN_MS;
+      assert(!isWithinCooldown, 429, "Too many verification code requests. Please try again later.");
+    }
 
     const code = randomInt(100000, 1000000).toString();
     const expiresAt = new Date(Date.now() + CODE_EXPIRY_MS);
 
-    const record = await this.emailVerificationCodeRepository.create({
+    const record = await this.emailVerificationCodeRepository.upsert({
       userId: userInternalId,
       email: user.email,
       code: hashCode(code),
@@ -73,18 +73,15 @@ export class EmailVerificationCodeService {
   private async verifyCodeInTransaction(userInternalId: string, code: string): Promise<string> {
     const [user, record] = await Promise.all([
       this.userRepository.findById(userInternalId),
-      this.emailVerificationCodeRepository.findActiveByUserIdForUpdate(userInternalId)
+      this.emailVerificationCodeRepository.findByUserIdForUpdate(userInternalId)
     ]);
     assert(user, 404, "User not found");
     assert(user.userId, 400, "User has no Auth0 ID");
     assert(record, 400, "No active verification code. Please request a new one.");
+    assert(new Date(record.expiresAt) > new Date(), 400, "Verification code expired. Please request a new one.");
     assert(record.attempts < MAX_ATTEMPTS, 429, "Too many attempts. Please request a new code.");
 
-    const codeBuffer = Buffer.from(hashCode(code));
-    const recordBuffer = Buffer.from(record.code);
-    const isCodeValid = codeBuffer.length === recordBuffer.length && timingSafeEqual(recordBuffer, codeBuffer);
-
-    if (!isCodeValid) {
+    if (record.code !== hashCode(code)) {
       await this.emailVerificationCodeRepository.incrementAttempts(record.id);
       assert(false, 400, "Invalid verification code");
     }

--- a/apps/api/src/auth/services/email-verification-code/email-verification-code.service.ts
+++ b/apps/api/src/auth/services/email-verification-code/email-verification-code.service.ts
@@ -59,7 +59,12 @@ export class EmailVerificationCodeService {
   async verifyCode(userInternalId: string, code: string): Promise<void> {
     const auth0UserId = await this.verifyCodeInTransaction(userInternalId, code);
 
-    await this.auth0Service.markEmailVerified(auth0UserId);
+    try {
+      await this.auth0Service.markEmailVerified(auth0UserId);
+    } catch (error) {
+      this.logger.error({ event: "EMAIL_VERIFIED_MARK_AUTH0_FAILED", userId: userInternalId, auth0UserId, error });
+      throw error;
+    }
 
     this.logger.info({ event: "EMAIL_VERIFIED_VIA_CODE", userId: userInternalId });
   }

--- a/apps/api/src/auth/services/email-verification-code/email-verification-code.service.ts
+++ b/apps/api/src/auth/services/email-verification-code/email-verification-code.service.ts
@@ -49,7 +49,13 @@ export class EmailVerificationCodeService {
       expiresAt
     });
 
-    await this.notificationService.createNotification(emailVerificationCodeNotification({ id: userInternalId, email: user.email }, { code }));
+    try {
+      await this.notificationService.createNotification(emailVerificationCodeNotification({ id: userInternalId, email: user.email }, { code }));
+    } catch (error) {
+      await this.emailVerificationCodeRepository.deleteByUserId(userInternalId);
+      this.logger.error({ event: "VERIFICATION_CODE_NOTIFICATION_FAILED", userId: userInternalId, error });
+      throw error;
+    }
 
     this.logger.info({ event: "VERIFICATION_CODE_SENT", userId: userInternalId });
 

--- a/apps/api/src/notifications/services/notification-templates/email-verification-code-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/email-verification-code-notification.spec.ts
@@ -1,0 +1,16 @@
+import { emailVerificationCodeNotification } from "./email-verification-code-notification";
+
+describe(emailVerificationCodeNotification.name, () => {
+  it("returns notification with correct structure", () => {
+    const user = { id: "user-123", email: "test@example.com" };
+    const vars = { code: "123456" };
+
+    const result = emailVerificationCodeNotification(user, vars);
+
+    expect(result.notificationId).toMatch(/^emailVerificationCode\.user-123\.[0-9a-f-]{36}$/);
+    expect(result.payload.summary).toBe("Your verification code");
+    expect(result.payload.description).toContain("<strong>123456</strong>");
+    expect(result.payload.description).toContain("expires in 10 minutes");
+    expect(result.user).toEqual({ id: "user-123", email: "test@example.com" });
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/email-verification-code-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/email-verification-code-notification.ts
@@ -1,0 +1,19 @@
+import { randomUUID } from "crypto";
+
+import type { CreateNotificationInput } from "../notification/notification.service";
+
+export function emailVerificationCodeNotification(user: { id: string; email: string }, vars: { code: string }): CreateNotificationInput {
+  return {
+    notificationId: `emailVerificationCode.${user.id}.${randomUUID()}`,
+    payload: {
+      summary: "Your verification code",
+      description:
+        `Your email verification code is: <strong>${vars.code}</strong>. ` +
+        `This code expires in 10 minutes. If you did not request this code, please ignore this email.`
+    },
+    user: {
+      id: user.id,
+      email: user.email
+    }
+  };
+}

--- a/apps/api/src/rest-app.ts
+++ b/apps/api/src/rest-app.ts
@@ -32,7 +32,7 @@ import { legacyRouter } from "./routers/legacyRouter";
 import { web3IndexRouter } from "./routers/web3indexRouter";
 import { bytesToHumanReadableSize } from "./utils/files";
 import { addressRouter } from "./address";
-import { apiKeysRouter, sendVerificationEmailRouter } from "./auth";
+import { apiKeysRouter, sendVerificationCodeRouter, sendVerificationEmailRouter, signupRouter, verifyEmailCodeRouter } from "./auth";
 import {
   getBalancesRouter,
   getWalletListRouter,
@@ -123,6 +123,9 @@ const openApiHonoHandlers: OpenApiHonoHandler[] = [
   userSettingsRouter,
   userTemplatesRouter,
   sendVerificationEmailRouter,
+  sendVerificationCodeRouter,
+  signupRouter,
+  verifyEmailCodeRouter,
   verifyEmailRouter,
   deploymentSettingRouter,
   deploymentsRouter,

--- a/apps/api/src/user/services/user/user.service.integration.ts
+++ b/apps/api/src/user/services/user/user.service.integration.ts
@@ -4,6 +4,7 @@ import { container } from "tsyringe";
 import { mock } from "vitest-mock-extended";
 
 import type { Auth0Service } from "@src/auth/services/auth0/auth0.service";
+import type { EmailVerificationCodeService } from "@src/auth/services/email-verification-code/email-verification-code.service";
 import type { LoggerService } from "@src/core/providers/logging.provider";
 import type { AnalyticsService } from "@src/core/services/analytics/analytics.service";
 import type { NotificationService } from "@src/notifications/services/notification/notification.service";
@@ -343,7 +344,10 @@ describe(UserService.name, () => {
       mock<NotificationService>({
         createDefaultChannel: input?.createDefaultNotificationChannel ?? (() => Promise.resolve())
       }),
-      auth0Service
+      auth0Service,
+      mock<EmailVerificationCodeService>({
+        sendCode: jest.fn().mockResolvedValue({ codeSentAt: new Date().toISOString() })
+      })
     );
 
     return { service, analyticsService, logger, auth0Service, userRepository };

--- a/apps/api/src/user/services/user/user.service.integration.ts
+++ b/apps/api/src/user/services/user/user.service.integration.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 import type { GetUsers200ResponseOneOfInner } from "auth0";
 import { container } from "tsyringe";
+import { vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { Auth0Service } from "@src/auth/services/auth0/auth0.service";
@@ -15,7 +16,7 @@ import { UserService } from "./user.service";
 describe(UserService.name, () => {
   describe("registerUser", () => {
     it("registers a new user", async () => {
-      const createDefaultNotificationChannel = jest.fn(() => Promise.resolve());
+      const createDefaultNotificationChannel = vi.fn(() => Promise.resolve());
       const { service, analyticsService, logger } = setup({ createDefaultNotificationChannel });
 
       const input: RegisterUserInput = {
@@ -346,7 +347,7 @@ describe(UserService.name, () => {
       }),
       auth0Service,
       mock<EmailVerificationCodeService>({
-        sendCode: jest.fn().mockResolvedValue({ codeSentAt: new Date().toISOString() })
+        sendCode: vi.fn().mockResolvedValue({ codeSentAt: new Date().toISOString() })
       })
     );
 

--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -1,0 +1,86 @@
+import "@test/mocks/logger-service.mock";
+
+import { faker } from "@faker-js/faker";
+import { mock } from "vitest-mock-extended";
+
+import type { Auth0Service } from "@src/auth/services/auth0/auth0.service";
+import type { EmailVerificationCodeService } from "@src/auth/services/email-verification-code/email-verification-code.service";
+import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { AnalyticsService } from "@src/core/services/analytics/analytics.service";
+import type { NotificationService } from "@src/notifications/services/notification/notification.service";
+import type { UserRepository } from "@src/user/repositories/user/user.repository";
+import type { RegisterUserInput } from "./user.service";
+import { UserService } from "./user.service";
+
+import { UserSeeder } from "@test/seeders/user.seeder";
+
+describe(UserService.name, () => {
+  describe("registerUser", () => {
+    it("sends verification code when email is not verified", async () => {
+      const user = UserSeeder.create({ emailVerified: false, email: "test@example.com" });
+      const { service, emailVerificationCodeService, userRepository, notificationService } = setup();
+
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
+      notificationService.createDefaultChannel.mockResolvedValue(undefined);
+      emailVerificationCodeService.sendCode.mockResolvedValue({ codeSentAt: new Date().toISOString() });
+
+      await service.registerUser(createRegisterInput({ emailVerified: false }));
+
+      expect(emailVerificationCodeService.sendCode).toHaveBeenCalledWith(user.id);
+    });
+
+    it("does not send verification code when email is already verified", async () => {
+      const user = UserSeeder.create({ emailVerified: true, email: "test@example.com" });
+      const { service, emailVerificationCodeService, userRepository, notificationService } = setup();
+
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
+      notificationService.createDefaultChannel.mockResolvedValue(undefined);
+
+      await service.registerUser(createRegisterInput({ emailVerified: true }));
+
+      expect(emailVerificationCodeService.sendCode).not.toHaveBeenCalled();
+    });
+
+    it("logs error but does not throw when verification code send fails", async () => {
+      const user = UserSeeder.create({ emailVerified: false, email: "test@example.com" });
+      const { service, emailVerificationCodeService, userRepository, notificationService, logger } = setup();
+      const sendError = new Error("Send failed");
+
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
+      notificationService.createDefaultChannel.mockResolvedValue(undefined);
+      emailVerificationCodeService.sendCode.mockRejectedValue(sendError);
+
+      const result = await service.registerUser(createRegisterInput({ emailVerified: false }));
+
+      expect(result.id).toBe(user.id);
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "FAILED_TO_SEND_INITIAL_VERIFICATION_CODE", id: user.id, error: sendError }));
+    });
+  });
+
+  function setup() {
+    const userRepository = mock<UserRepository>();
+    const analyticsService = mock<AnalyticsService>();
+    const logger = mock<LoggerService>();
+    const notificationService = mock<NotificationService>();
+    const auth0Service = mock<Auth0Service>();
+    const emailVerificationCodeService = mock<EmailVerificationCodeService>();
+
+    const service = new UserService(userRepository, analyticsService, logger, notificationService, auth0Service, emailVerificationCodeService);
+
+    return { service, userRepository, analyticsService, logger, notificationService, auth0Service, emailVerificationCodeService };
+  }
+
+  function createRegisterInput(overrides: Partial<RegisterUserInput> = {}): RegisterUserInput {
+    return {
+      userId: faker.string.uuid(),
+      wantedUsername: faker.internet.userName(),
+      email: faker.internet.email(),
+      emailVerified: false,
+      subscribedToNewsletter: false,
+      ip: faker.internet.ip(),
+      userAgent: faker.internet.userAgent(),
+      fingerprint: faker.string.uuid(),
+      ...overrides
+    };
+  }
+});

--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -12,12 +12,12 @@ import type { UserRepository } from "@src/user/repositories/user/user.repository
 import type { RegisterUserInput } from "./user.service";
 import { UserService } from "./user.service";
 
-import { UserSeeder } from "@test/seeders/user.seeder";
+import { createUser } from "@test/seeders/user.seeder";
 
 describe(UserService.name, () => {
   describe("registerUser", () => {
     it("sends verification code when email is not verified", async () => {
-      const user = UserSeeder.create({ emailVerified: false, email: "test@example.com" });
+      const user = createUser({ emailVerified: false, email: "test@example.com" });
       const { service, emailVerificationCodeService, userRepository, notificationService } = setup();
 
       userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
@@ -30,7 +30,7 @@ describe(UserService.name, () => {
     });
 
     it("does not send verification code when email is already verified", async () => {
-      const user = UserSeeder.create({ emailVerified: true, email: "test@example.com" });
+      const user = createUser({ emailVerified: true, email: "test@example.com" });
       const { service, emailVerificationCodeService, userRepository, notificationService } = setup();
 
       userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
@@ -42,7 +42,7 @@ describe(UserService.name, () => {
     });
 
     it("logs error but does not throw when verification code send fails", async () => {
-      const user = UserSeeder.create({ emailVerified: false, email: "test@example.com" });
+      const user = createUser({ emailVerified: false, email: "test@example.com" });
       const { service, emailVerificationCodeService, userRepository, notificationService, logger } = setup();
       const sendError = new Error("Send failed");
 

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -15651,8 +15651,6 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                   "data": {
                     "properties": {
                       "code": {
-                        "maxLength": 6,
-                        "minLength": 6,
                         "pattern": "^\\d{6}$",
                         "type": "string",
                       },

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -2641,6 +2641,44 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
     },
+    "/v1/auth/signup": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "email": {
+                    "format": "email",
+                    "type": "string",
+                  },
+                  "password": {
+                    "minLength": 8,
+                    "type": "string",
+                  },
+                },
+                "required": [
+                  "email",
+                  "password",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "required": true,
+        },
+        "responses": {
+          "204": {
+            "description": "User created successfully",
+          },
+        },
+        "security": [],
+        "summary": "Creates a new user without sending a verification email",
+        "tags": [
+          "Auth",
+        ],
+      },
+    },
     "/v1/balances": {
       "get": {
         "parameters": [
@@ -12524,6 +12562,50 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
     },
+    "/v1/send-verification-code": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "properties": {
+                        "codeSentAt": {
+                          "type": "string",
+                        },
+                      },
+                      "required": [
+                        "codeSentAt",
+                      ],
+                      "type": "object",
+                    },
+                  },
+                  "required": [
+                    "data",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns the timestamp when the code was sent",
+          },
+          "429": {
+            "description": "Too many requests",
+          },
+        },
+        "security": [
+          {
+            "BearerAuth": [],
+          },
+        ],
+        "summary": "Sends a verification code to the authenticated user's email",
+        "tags": [
+          "Users",
+        ],
+      },
+    },
     "/v1/send-verification-email": {
       "post": {
         "requestBody": {
@@ -15554,6 +15636,59 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         },
         "security": [],
         "summary": "Checks if the email is verified",
+        "tags": [
+          "Users",
+        ],
+      },
+    },
+    "/v1/verify-email-code": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "data": {
+                    "properties": {
+                      "code": {
+                        "maxLength": 6,
+                        "minLength": 6,
+                        "pattern": "^\\d{6}$",
+                        "type": "string",
+                      },
+                    },
+                    "required": [
+                      "code",
+                    ],
+                    "type": "object",
+                  },
+                },
+                "required": [
+                  "data",
+                ],
+                "type": "object",
+              },
+            },
+          },
+          "required": true,
+        },
+        "responses": {
+          "204": {
+            "description": "Email verified successfully",
+          },
+          "400": {
+            "description": "Invalid or expired code",
+          },
+          "429": {
+            "description": "Too many attempts",
+          },
+        },
+        "security": [
+          {
+            "BearerAuth": [],
+          },
+        ],
+        "summary": "Verifies the email using a 6-digit code",
         "tags": [
           "Users",
         ],

--- a/apps/notifications/src/modules/notifications/services/email-sender/email-sender.service.ts
+++ b/apps/notifications/src/modules/notifications/services/email-sender/email-sender.service.ts
@@ -36,7 +36,7 @@ export class EmailSenderService {
       payload: {
         subject,
         content: sanitizeHtml(content, {
-          allowedTags: ["a"],
+          allowedTags: ["a", "strong"],
           allowedAttributes: {
             a: ["href"]
           }

--- a/packages/http-sdk/src/auth/auth-http.service.ts
+++ b/packages/http-sdk/src/auth/auth-http.service.ts
@@ -1,15 +1,24 @@
 import type { AxiosRequestConfig } from "axios";
 
 import { HttpService } from "../http/http.service";
-import type { VerifyEmailResponse } from "./auth-http.types";
+import type { SendVerificationCodeResponse, VerifyEmailResponse } from "./auth-http.types";
 
 export class AuthHttpService extends HttpService {
   constructor(config?: Pick<AxiosRequestConfig, "baseURL">) {
     super(config);
   }
 
+  /** @deprecated Use {@link sendVerificationCode} instead. This targets the legacy link-based verification endpoint. */
   async sendVerificationEmail(userId: string) {
     return this.post("/v1/send-verification-email", { data: { userId } });
+  }
+
+  async sendVerificationCode() {
+    return this.extractData(await this.post<SendVerificationCodeResponse>("/v1/send-verification-code"));
+  }
+
+  async verifyEmailCode(code: string) {
+    await this.post("/v1/verify-email-code", { data: { code } });
   }
 
   async verifyEmail(email: string) {

--- a/packages/http-sdk/src/auth/auth-http.types.ts
+++ b/packages/http-sdk/src/auth/auth-http.types.ts
@@ -7,3 +7,11 @@ export const VerifyEmailResponseSchema = z.object({
 });
 
 export type VerifyEmailResponse = z.infer<typeof VerifyEmailResponseSchema>;
+
+export const SendVerificationCodeResponseSchema = z.object({
+  data: z.object({
+    codeSentAt: z.string()
+  })
+});
+
+export type SendVerificationCodeResponse = z.infer<typeof SendVerificationCodeResponseSchema>;


### PR DESCRIPTION
## Why

Part of CON-197 — Replace Auth0's default email verification link with a 6-digit code flow.

This is **PR 1 of 2** — backend only. Split from #2824 to make review manageable.
PR 2 (frontend): #3052 (targets this branch).

## What

- DB migration: `email_verification_codes` table with unique index on `userId` (one row per user, upsert on new code)
- `EmailVerificationCodeRepository` with Drizzle ORM upsert and `SELECT ... FOR UPDATE`
- `EmailVerificationCodeService` with cooldown enforcement, code generation, and verification
- Three new routes: `POST /v1/send-verification-code`, `POST /v1/verify-email-code`, `POST /v1/signup`
- Auth0 service: `createUser` method for signup flow (409 sanitized to generic 422)
- `UserService`: sends verification code on registration
- Notification template for verification code emails
- Auth0 `markEmailVerified` call moved outside transaction
- HTTP SDK: `sendVerificationCode()` and `verifyEmailCode()` methods
- Unit, integration, and functional tests

### Auth0 Management API permissions

The management client needs these scopes on the **Auth0 Management API** (Dashboard → Applications → APIs → Auth0 Management API → Machine to Machine Applications):

| Scope | Used by |
|-------|---------|
| `read:users` | `users.get` |
| `update:users` | `users.update` (`markEmailVerified`) |
| `create:users` | `users.create` (`createUser` with `verify_email: false`) |

`verify_email: false` on `users.create` suppresses Auth0's built-in verification email for that specific call — needed because the tenant-wide email verification setting can't be toggled per-application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email verification with 6‑digit codes: send and verify endpoints, signup endpoint, and automatic initial code on new registrations.
  * Verification flow enforces cooldowns, attempt limits, and code expiry; notification includes emphasized code and expiry text.
  * Client SDK: methods to send a code and verify a code.

* **Tests**
  * New unit/integration tests covering signup and full verification send/verify flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->