### PR TITLE
feat(onboarding): add email verification code UI

### DIFF
--- a/apps/api/src/auth/repositories/email-verification-code/email-verification-code.repository.ts
+++ b/apps/api/src/auth/repositories/email-verification-code/email-verification-code.repository.ts
@@ -59,12 +59,6 @@ export class EmailVerificationCodeRepository extends BaseRepository<Table, Email
     return result ? this.toOutput(result) : undefined;
   }
 
-  async findByUserIdForUpdate(userId: string): Promise<EmailVerificationCodeOutput | undefined> {
-    const [result] = await this.cursor.select().from(this.table).where(eq(this.table.userId, userId)).for("update");
-
-    return result ? this.toOutput(result) : undefined;
-  }
-
   async deleteByUserId(userId: string): Promise<void> {
     await this.cursor.delete(this.table).where(eq(this.table.userId, userId));
   }

--- a/apps/api/src/auth/services/email-verification-code/email-verification-code.service.spec.ts
+++ b/apps/api/src/auth/services/email-verification-code/email-verification-code.service.spec.ts
@@ -70,7 +70,7 @@ describe(EmailVerificationCodeService.name, () => {
       userRepository.findById.mockResolvedValue(user);
       emailVerificationCodeRepository.findByUserId.mockResolvedValue(recentRecord);
 
-      await expect(service.sendCode(user.id)).rejects.toThrow("Too many verification code requests");
+      await expect(service.sendCode(user.id)).rejects.toThrow("Please wait before requesting a new verification code");
     });
 
     it("throws 404 when user not found", async () => {
@@ -113,7 +113,7 @@ describe(EmailVerificationCodeService.name, () => {
       const { service, emailVerificationCodeRepository, userRepository, auth0Service } = setup();
 
       userRepository.findById.mockResolvedValue(user);
-      emailVerificationCodeRepository.findByUserIdForUpdate.mockResolvedValue(record);
+      emailVerificationCodeRepository.findByUserId.mockResolvedValue(record);
 
       await service.verifyCode(user.id, code);
 
@@ -127,7 +127,7 @@ describe(EmailVerificationCodeService.name, () => {
       const { service, emailVerificationCodeRepository, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue(user);
-      emailVerificationCodeRepository.findByUserIdForUpdate.mockResolvedValue(record);
+      emailVerificationCodeRepository.findByUserId.mockResolvedValue(record);
 
       await expect(service.verifyCode(user.id, "999999")).rejects.toThrow("Invalid verification code");
       expect(emailVerificationCodeRepository.incrementAttempts).toHaveBeenCalledWith(record.id);
@@ -139,7 +139,7 @@ describe(EmailVerificationCodeService.name, () => {
       const { service, emailVerificationCodeRepository, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue(user);
-      emailVerificationCodeRepository.findByUserIdForUpdate.mockResolvedValue(record);
+      emailVerificationCodeRepository.findByUserId.mockResolvedValue(record);
 
       await expect(service.verifyCode(user.id, "123456")).rejects.toThrow();
       expect(emailVerificationCodeRepository.incrementAttempts).not.toHaveBeenCalled();
@@ -157,7 +157,7 @@ describe(EmailVerificationCodeService.name, () => {
       const { service, emailVerificationCodeRepository, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue(user);
-      emailVerificationCodeRepository.findByUserIdForUpdate.mockResolvedValue(record);
+      emailVerificationCodeRepository.findByUserId.mockResolvedValue(record);
 
       await expect(service.verifyCode(user.id, code)).rejects.toThrow("Verification code expired");
     });
@@ -169,7 +169,7 @@ describe(EmailVerificationCodeService.name, () => {
       const { service, emailVerificationCodeRepository, userRepository, auth0Service } = setup();
 
       userRepository.findById.mockResolvedValue(user);
-      emailVerificationCodeRepository.findByUserIdForUpdate.mockResolvedValue(record);
+      emailVerificationCodeRepository.findByUserId.mockResolvedValue(record);
       auth0Service.markEmailVerified.mockRejectedValue(new Error("Auth0 unavailable"));
 
       await expect(service.verifyCode(user.id, code)).rejects.toThrow("Auth0 unavailable");
@@ -182,7 +182,7 @@ describe(EmailVerificationCodeService.name, () => {
       const { service, emailVerificationCodeRepository, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue(user);
-      emailVerificationCodeRepository.findByUserIdForUpdate.mockResolvedValue(undefined);
+      emailVerificationCodeRepository.findByUserId.mockResolvedValue(undefined);
 
       await expect(service.verifyCode(user.id, "123456")).rejects.toThrow();
     });

--- a/apps/api/src/auth/services/email-verification-code/email-verification-code.service.ts
+++ b/apps/api/src/auth/services/email-verification-code/email-verification-code.service.ts
@@ -4,7 +4,6 @@ import { singleton } from "tsyringe";
 
 import { EmailVerificationCodeRepository } from "@src/auth/repositories/email-verification-code/email-verification-code.repository";
 import { Auth0Service } from "@src/auth/services/auth0/auth0.service";
-import { WithTransaction } from "@src/core";
 import { LoggerService } from "@src/core/providers/logging.provider";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { emailVerificationCodeNotification } from "@src/notifications/services/notification-templates/email-verification-code-notification";
@@ -36,7 +35,7 @@ export class EmailVerificationCodeService {
     const existing = await this.emailVerificationCodeRepository.findByUserId(userInternalId);
     if (existing) {
       const isWithinCooldown = new Date(existing.expiresAt).getTime() > Date.now() + CODE_EXPIRY_MS - COOLDOWN_MS;
-      assert(!isWithinCooldown, 429, "Too many verification code requests. Please try again later.");
+      assert(!isWithinCooldown, 429, "Please wait before requesting a new verification code.");
     }
 
     const code = randomInt(100000, 1000000).toString();
@@ -63,24 +62,7 @@ export class EmailVerificationCodeService {
   }
 
   async verifyCode(userInternalId: string, code: string): Promise<void> {
-    const auth0UserId = await this.verifyCodeInTransaction(userInternalId, code);
-
-    try {
-      await this.auth0Service.markEmailVerified(auth0UserId);
-    } catch (error) {
-      this.logger.error({ event: "EMAIL_VERIFIED_MARK_AUTH0_FAILED", userId: userInternalId, auth0UserId, error });
-      throw error;
-    }
-
-    this.logger.info({ event: "EMAIL_VERIFIED_VIA_CODE", userId: userInternalId });
-  }
-
-  @WithTransaction()
-  private async verifyCodeInTransaction(userInternalId: string, code: string): Promise<string> {
-    const [user, record] = await Promise.all([
-      this.userRepository.findById(userInternalId),
-      this.emailVerificationCodeRepository.findByUserIdForUpdate(userInternalId)
-    ]);
+    const [user, record] = await Promise.all([this.userRepository.findById(userInternalId), this.emailVerificationCodeRepository.findByUserId(userInternalId)]);
     assert(user, 404, "User not found");
     assert(user.userId, 400, "User has no Auth0 ID");
     assert(record, 400, "No active verification code. Please request a new one.");
@@ -94,6 +76,13 @@ export class EmailVerificationCodeService {
 
     await this.userRepository.updateById(userInternalId, { emailVerified: true });
 
-    return user.userId;
+    try {
+      await this.auth0Service.markEmailVerified(user.userId);
+    } catch (error) {
+      this.logger.error({ event: "EMAIL_VERIFIED_MARK_AUTH0_FAILED", userId: userInternalId, auth0UserId: user.userId, error });
+      throw error;
+    }
+
+    this.logger.info({ event: "EMAIL_VERIFIED_VIA_CODE", userId: userInternalId });
   }
 }

--- a/apps/deploy-web/src/components/onboarding/OnboardingView/OnboardingView.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingView/OnboardingView.tsx
@@ -57,7 +57,7 @@ export const OnboardingView: FC<OnboardingViewProps> = ({
       ...steps[OnboardingStepIndex.EMAIL_VERIFICATION],
       component: (
         <d.EmailVerificationContainer onComplete={() => onStepChange(OnboardingStepIndex.PAYMENT_METHOD)}>
-          {props => <d.EmailVerificationStep {...props} />}
+          {({ sendCode, verifyCode }) => <d.EmailVerificationStep sendCode={sendCode} verifyCode={verifyCode} />}
         </d.EmailVerificationContainer>
       )
     },

--- a/apps/deploy-web/src/components/onboarding/VerifyEmailPage/VerifyEmailPage.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/VerifyEmailPage/VerifyEmailPage.spec.tsx
@@ -4,79 +4,72 @@ import { describe, expect, it, vi } from "vitest";
 
 import { VerifyEmailPage } from "./VerifyEmailPage";
 
-import { act, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 describe(VerifyEmailPage.name, () => {
-  it("calls verifyEmail with the email from search params", () => {
-    const { mockVerifyEmail } = setup({ email: "test@example.com" });
+  it("shows redirect loading text", () => {
+    const { restore } = setup();
 
-    expect(mockVerifyEmail).toHaveBeenCalledWith("test@example.com");
+    expect(screen.queryByText("Redirecting to email verification...")).toBeInTheDocument();
+    restore();
   });
 
-  it("does not call verifyEmail when email param is missing", () => {
-    const { mockVerifyEmail } = setup({ email: null });
+  it("sets onboarding step to EMAIL_VERIFICATION in localStorage", () => {
+    const { mockLocalStorage, restore } = setup();
 
-    expect(mockVerifyEmail).not.toHaveBeenCalled();
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith("onboardingStep", "2");
+    restore();
   });
 
-  it("shows loading text when verification is pending", () => {
-    setup({ email: "test@example.com", isPending: true });
+  it("redirects to onboarding page", () => {
+    const { getLocationHref, restore } = setup();
 
-    expect(screen.queryByText("Just a moment while we finish verifying your email.")).toBeInTheDocument();
+    expect(getLocationHref()).toBe("/signup?return-to=%2F");
+    restore();
   });
 
-  it("shows success message when email is verified", () => {
-    const { capturedOnSuccess } = setup({ email: "test@example.com" });
+  function setup(input: { onboardingUrl?: string } = {}) {
+    const originalLocalStorage = window.localStorage;
+    const originalLocation = window.location;
 
-    act(() => capturedOnSuccess?.(true));
+    const mockLocalStorage = {
+      setItem: vi.fn(),
+      getItem: vi.fn(),
+      removeItem: vi.fn()
+    };
+    Object.defineProperty(window, "localStorage", { value: mockLocalStorage, writable: true, configurable: true });
 
-    expect(screen.queryByTestId("CheckCircleIcon")).toBeInTheDocument();
-  });
-
-  it("shows error message when email verification fails", () => {
-    const { capturedOnError } = setup({ email: "test@example.com" });
-
-    act(() => capturedOnError?.());
-
-    expect(screen.queryByText("Your email was not verified. Please try again.")).toBeInTheDocument();
-  });
-
-  it("shows error message when isVerified is null", () => {
-    setup({ email: "test@example.com" });
-
-    expect(screen.queryByText("Your email was not verified. Please try again.")).toBeInTheDocument();
-  });
-
-  function setup(input: { email?: string | null; isPending?: boolean }) {
-    const mockVerifyEmail = vi.fn();
-    let capturedOnSuccess: ((isVerified: boolean) => void) | undefined;
-    let capturedOnError: (() => void) | undefined;
-
-    const mockUseVerifyEmail = vi.fn().mockImplementation((options: { onSuccess?: (v: boolean) => void; onError?: () => void }) => {
-      capturedOnSuccess = options.onSuccess;
-      capturedOnError = options.onError;
-      return { mutate: mockVerifyEmail, isPending: input.isPending || false };
-    });
-
-    const mockUseWhen = vi.fn().mockImplementation((condition: unknown, run: () => void) => {
-      if (condition) {
-        run();
-      }
+    let capturedHref = "";
+    Object.defineProperty(window, "location", {
+      value: {
+        get href() {
+          return capturedHref;
+        },
+        set href(val: string) {
+          capturedHref = val;
+        }
+      },
+      writable: true,
+      configurable: true
     });
 
     const dependencies = {
-      useSearchParams: vi.fn().mockReturnValue(new URLSearchParams(input.email ? `email=${input.email}` : "")),
-      useVerifyEmail: mockUseVerifyEmail,
-      useWhen: mockUseWhen,
       Layout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
       Loading: ({ text }: { text: string }) => <div>{text}</div>,
       UrlService: {
-        onboarding: vi.fn(() => "/signup")
+        onboarding: vi.fn(() => input.onboardingUrl ?? "/signup?return-to=%2F")
       }
     } as unknown as ComponentProps<typeof VerifyEmailPage>["dependencies"];
 
     render(<VerifyEmailPage dependencies={dependencies} />);
 
-    return { mockVerifyEmail, capturedOnSuccess, capturedOnError };
+    return {
+      mockLocalStorage,
+      getLocationHref: () => capturedHref,
+      restore: () => {
+        Object.defineProperty(window, "localStorage", { value: originalLocalStorage, writable: true, configurable: true });
+        Object.defineProperty(window, "location", { value: originalLocation, writable: true, configurable: true });
+      }
+    };
   }
 });

--- a/apps/deploy-web/src/components/onboarding/VerifyEmailPage/VerifyEmailPage.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/VerifyEmailPage/VerifyEmailPage.spec.tsx
@@ -8,68 +8,32 @@ import { render, screen } from "@testing-library/react";
 
 describe(VerifyEmailPage.name, () => {
   it("shows redirect loading text", () => {
-    const { restore } = setup();
+    setup();
 
     expect(screen.queryByText("Redirecting to email verification...")).toBeInTheDocument();
-    restore();
   });
 
-  it("sets onboarding step to EMAIL_VERIFICATION in localStorage", () => {
-    const { mockLocalStorage, restore } = setup();
+  it("redirects to onboarding with email verification step", () => {
+    const { redirect } = setup();
 
-    expect(mockLocalStorage.setItem).toHaveBeenCalledWith("onboardingStep", "2");
-    restore();
-  });
-
-  it("redirects to onboarding page", () => {
-    const { getLocationHref, restore } = setup();
-
-    expect(getLocationHref()).toBe("/signup?return-to=%2F");
-    restore();
+    expect(redirect).toHaveBeenCalledWith("/signup?return-to=%2F");
   });
 
   function setup(input: { onboardingUrl?: string } = {}) {
-    const originalLocalStorage = window.localStorage;
-    const originalLocation = window.location;
-
-    const mockLocalStorage = {
-      setItem: vi.fn(),
-      getItem: vi.fn(),
-      removeItem: vi.fn()
-    };
-    Object.defineProperty(window, "localStorage", { value: mockLocalStorage, writable: true, configurable: true });
-
-    let capturedHref = "";
-    Object.defineProperty(window, "location", {
-      value: {
-        get href() {
-          return capturedHref;
-        },
-        set href(val: string) {
-          capturedHref = val;
-        }
-      },
-      writable: true,
-      configurable: true
-    });
+    const redirect = vi.fn();
 
     const dependencies = {
       Layout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
       Loading: ({ text }: { text: string }) => <div>{text}</div>,
+      NextSeo: () => null,
       UrlService: {
         onboarding: vi.fn(() => input.onboardingUrl ?? "/signup?return-to=%2F")
-      }
+      },
+      redirect
     } as unknown as ComponentProps<typeof VerifyEmailPage>["dependencies"];
 
     render(<VerifyEmailPage dependencies={dependencies} />);
 
-    return {
-      mockLocalStorage,
-      getLocationHref: () => capturedHref,
-      restore: () => {
-        Object.defineProperty(window, "localStorage", { value: originalLocalStorage, writable: true, configurable: true });
-        Object.defineProperty(window, "location", { value: originalLocation, writable: true, configurable: true });
-      }
-    };
+    return { redirect };
   }
 });

--- a/apps/deploy-web/src/components/onboarding/VerifyEmailPage/VerifyEmailPage.tsx
+++ b/apps/deploy-web/src/components/onboarding/VerifyEmailPage/VerifyEmailPage.tsx
@@ -13,7 +13,7 @@ const DEPENDENCIES = {
   UrlService,
   redirect: (url: string) => {
     window.localStorage.setItem(ONBOARDING_STEP_KEY, OnboardingStepIndex.EMAIL_VERIFICATION.toString());
-    window.location.href = url;
+    window.location.replace(url);
   }
 };
 

--- a/apps/deploy-web/src/components/onboarding/VerifyEmailPage/VerifyEmailPage.tsx
+++ b/apps/deploy-web/src/components/onboarding/VerifyEmailPage/VerifyEmailPage.tsx
@@ -10,7 +10,11 @@ const DEPENDENCIES = {
   Layout,
   Loading,
   NextSeo,
-  UrlService
+  UrlService,
+  redirect: (url: string) => {
+    window.localStorage.setItem(ONBOARDING_STEP_KEY, OnboardingStepIndex.EMAIL_VERIFICATION.toString());
+    window.location.href = url;
+  }
 };
 
 type VerifyEmailPageProps = {
@@ -19,9 +23,8 @@ type VerifyEmailPageProps = {
 
 export function VerifyEmailPage({ dependencies: d = DEPENDENCIES }: VerifyEmailPageProps) {
   useEffect(() => {
-    window.localStorage.setItem(ONBOARDING_STEP_KEY, OnboardingStepIndex.EMAIL_VERIFICATION.toString());
-    window.location.href = d.UrlService.onboarding({ returnTo: "/" });
-  }, [d.UrlService]);
+    d.redirect(d.UrlService.onboarding({ returnTo: "/" }));
+  }, [d]);
 
   return (
     <d.Layout>

--- a/apps/deploy-web/src/components/onboarding/VerifyEmailPage/VerifyEmailPage.tsx
+++ b/apps/deploy-web/src/components/onboarding/VerifyEmailPage/VerifyEmailPage.tsx
@@ -1,24 +1,15 @@
-import React, { useCallback, useState } from "react";
-import { AutoButton } from "@akashnetwork/ui/components";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
-import { ArrowRight } from "iconoir-react";
-import { useSearchParams } from "next/navigation";
+import React, { useEffect } from "react";
 import { NextSeo } from "next-seo";
 
 import Layout, { Loading } from "@src/components/layout/Layout";
 import { OnboardingStepIndex } from "@src/components/onboarding/OnboardingContainer/OnboardingContainer";
-import { useWhen } from "@src/hooks/useWhen";
-import { useVerifyEmail } from "@src/queries/useVerifyEmailQuery";
 import { ONBOARDING_STEP_KEY } from "@src/services/storage/keys";
 import { UrlService } from "@src/utils/urlUtils";
 
 const DEPENDENCIES = {
-  useSearchParams,
-  useVerifyEmail,
-  useWhen,
   Layout,
   Loading,
+  NextSeo,
   UrlService
 };
 
@@ -26,68 +17,16 @@ type VerifyEmailPageProps = {
   dependencies?: typeof DEPENDENCIES;
 };
 
-type VerificationResultProps = {
-  isVerified: boolean;
-  dependencies: Pick<typeof DEPENDENCIES, "UrlService">;
-};
-
-function VerificationResult({ isVerified, dependencies: d }: VerificationResultProps) {
-  const gotoOnboarding = useCallback(() => {
-    window.localStorage?.setItem(ONBOARDING_STEP_KEY, OnboardingStepIndex.PAYMENT_METHOD.toString());
+export function VerifyEmailPage({ dependencies: d = DEPENDENCIES }: VerifyEmailPageProps) {
+  useEffect(() => {
+    window.localStorage.setItem(ONBOARDING_STEP_KEY, OnboardingStepIndex.EMAIL_VERIFICATION.toString());
     window.location.href = d.UrlService.onboarding({ returnTo: "/" });
   }, [d.UrlService]);
 
   return (
-    <div className="mt-10 text-center">
-      {isVerified ? (
-        <>
-          <CheckCircleIcon className="mb-2 h-16 w-16 text-green-500" />
-          <h5>
-            Your email was verified.
-            <br />
-            You can continue using the application.
-          </h5>
-          <AutoButton
-            onClick={gotoOnboarding}
-            text={
-              <>
-                Continue <ArrowRight className="ml-4" />
-              </>
-            }
-            timeout={5000}
-          />
-        </>
-      ) : (
-        <>
-          <ErrorOutlineIcon className="mb-2 h-16 w-16 text-red-500" />
-          <h5>Your email was not verified. Please try again.</h5>
-        </>
-      )}
-    </div>
-  );
-}
-
-export function VerifyEmailPage({ dependencies: d = DEPENDENCIES }: VerifyEmailPageProps) {
-  const email = d.useSearchParams().get("email");
-  const [isVerified, setIsVerified] = useState<boolean | null>(null);
-  const { mutate: verifyEmail, isPending: isVerifying } = d.useVerifyEmail({ onSuccess: setIsVerified, onError: () => setIsVerified(false) });
-
-  d.useWhen(email, () => {
-    if (email) {
-      verifyEmail(email);
-    }
-  });
-
-  return (
     <d.Layout>
-      <NextSeo title="Verifying your email" />
-      {isVerifying ? (
-        <d.Loading text="Just a moment while we finish verifying your email." />
-      ) : (
-        <>
-          <VerificationResult isVerified={isVerified === true} dependencies={d} />
-        </>
-      )}
+      <d.NextSeo title="Email Verification" />
+      <d.Loading text="Redirecting to email verification..." />
     </d.Layout>
   );
 }

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationContainer/EmailVerificationContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationContainer/EmailVerificationContainer.spec.tsx
@@ -5,122 +5,75 @@ import { EmailVerificationContainer } from "./EmailVerificationContainer";
 
 import { act, render } from "@testing-library/react";
 
-describe("EmailVerificationContainer", () => {
-  it("should render children with initial state", () => {
+describe(EmailVerificationContainer.name, () => {
+  it("renders children with sendCode and verifyCode functions", () => {
     const { child } = setup();
 
     expect(child).toHaveBeenCalledWith(
       expect.objectContaining({
-        isEmailVerified: false,
-        isResending: false,
-        isChecking: false,
-        onResendEmail: expect.any(Function),
-        onCheckVerification: expect.any(Function),
-        onContinue: expect.any(Function)
+        sendCode: expect.any(Function),
+        verifyCode: expect.any(Function)
       })
     );
   });
 
-  it("should handle resend email success", async () => {
-    const { child, mockSendVerificationEmail, mockEnqueueSnackbar } = setup();
-    mockSendVerificationEmail.mockResolvedValue(undefined);
-
-    const { onResendEmail } = child.mock.calls[0][0];
-    await act(async () => {
-      await onResendEmail();
-    });
-
-    expect(mockSendVerificationEmail).toHaveBeenCalledWith("test-user");
-    expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
-      expect.objectContaining({
-        props: expect.objectContaining({
-          title: "Verification email sent",
-          subTitle: "Please check your email and click the verification link",
-          iconVariant: "success"
-        })
-      }),
-      { variant: "success" }
-    );
-  });
-
-  it("should handle resend email error", async () => {
-    const { child, mockSendVerificationEmail, mockNotificator } = setup();
-    mockSendVerificationEmail.mockRejectedValue(new Error("Failed"));
-
-    const { onResendEmail } = child.mock.calls[0][0];
-    await act(async () => {
-      await onResendEmail();
-    });
-
-    expect(mockSendVerificationEmail).toHaveBeenCalledWith("test-user");
-    expect(mockNotificator.error).toHaveBeenCalledWith("Failed to send verification email. Please try again later");
-  });
-
-  it("should handle check verification success", async () => {
-    const { child, mockCheckSession, mockEnqueueSnackbar } = setup();
-    mockCheckSession.mockResolvedValue(undefined);
-
-    const { onCheckVerification } = child.mock.calls[0][0];
-    await act(async () => {
-      await onCheckVerification();
-    });
-
-    expect(mockCheckSession).toHaveBeenCalled();
-    expect(mockEnqueueSnackbar).toHaveBeenCalledWith(
-      expect.objectContaining({
-        props: expect.objectContaining({
-          title: "Verification status updated",
-          subTitle: "Your email verification status has been refreshed",
-          iconVariant: "success"
-        })
-      }),
-      { variant: "success" }
-    );
-  });
-
-  it("should handle check verification error", async () => {
-    const { child, mockCheckSession, mockNotificator } = setup();
-    mockCheckSession.mockRejectedValue(new Error("Failed"));
-
-    const { onCheckVerification } = child.mock.calls[0][0];
-    await act(async () => {
-      await onCheckVerification();
-    });
-
-    expect(mockCheckSession).toHaveBeenCalled();
-    expect(mockNotificator.error).toHaveBeenCalledWith("Failed to check verification. Please try again or refresh the page");
-  });
-
-  it("should call onComplete when email is verified", () => {
+  it("auto-advances when email is already verified", () => {
     const mockOnComplete = vi.fn();
-    const { child } = setup({
-      user: { id: "test-user", emailVerified: true },
-      onComplete: mockOnComplete
-    });
-
-    const { onContinue } = child.mock.calls[0][0];
-    onContinue();
+    setup({ user: { id: "test-user", emailVerified: true }, onComplete: mockOnComplete });
 
     expect(mockOnComplete).toHaveBeenCalled();
   });
 
-  it("should not call onComplete when email is not verified", () => {
-    const mockOnComplete = vi.fn();
-    const { child } = setup({
-      user: { id: "test-user", emailVerified: false },
-      onComplete: mockOnComplete
+  it("sendCode delegates to auth.sendVerificationCode", async () => {
+    const { child, mockSendVerificationCode } = setup();
+
+    mockSendVerificationCode.mockResolvedValue({});
+
+    const { sendCode } = child.mock.calls[child.mock.calls.length - 1][0];
+    await act(async () => {
+      await sendCode();
     });
 
-    const { onContinue } = child.mock.calls[0][0];
-    onContinue();
-
-    expect(mockOnComplete).not.toHaveBeenCalled();
+    expect(mockSendVerificationCode).toHaveBeenCalled();
   });
 
-  function setup(input: { user?: any; onComplete?: Mock } = {}) {
-    const mockSendVerificationEmail = vi.fn();
+  it("verifyCode delegates to auth.verifyEmailCode then calls checkSession", async () => {
+    const { child, mockVerifyEmailCode, mockCheckSession } = setup();
+    mockVerifyEmailCode.mockResolvedValue(undefined);
+    mockCheckSession.mockResolvedValue(undefined);
+
+    const { verifyCode } = child.mock.calls[0][0];
+    await act(async () => {
+      await verifyCode("123456");
+    });
+
+    expect(mockVerifyEmailCode).toHaveBeenCalledWith("123456");
+    expect(mockCheckSession).toHaveBeenCalled();
+  });
+
+  it("verifyCode propagates errors", async () => {
+    const { child, mockVerifyEmailCode } = setup();
+    mockVerifyEmailCode.mockRejectedValue(new Error("Invalid verification code"));
+
+    const { verifyCode } = child.mock.calls[0][0];
+    await expect(
+      act(async () => {
+        await verifyCode("000000");
+      })
+    ).rejects.toThrow("Invalid verification code");
+  });
+
+  it("tracks analytics on auto-advance", () => {
+    const mockOnComplete = vi.fn();
+    const { mockAnalyticsService } = setup({ user: { id: "test-user", emailVerified: true }, onComplete: mockOnComplete });
+
+    expect(mockAnalyticsService.track).toHaveBeenCalledWith("onboarding_email_verified", { category: "onboarding" });
+  });
+
+  function setup(input: { user?: { id: string; emailVerified: boolean }; onComplete?: Mock } = {}) {
+    const mockSendVerificationCode = vi.fn().mockResolvedValue({});
+    const mockVerifyEmailCode = vi.fn();
     const mockCheckSession = vi.fn();
-    const mockEnqueueSnackbar = vi.fn();
     const mockAnalyticsService = {
       track: vi.fn()
     };
@@ -130,30 +83,17 @@ describe("EmailVerificationContainer", () => {
       checkSession: mockCheckSession
     });
 
-    const mockUseSnackbar = vi.fn().mockReturnValue({
-      enqueueSnackbar: mockEnqueueSnackbar
-    });
-
     const mockUseServices = vi.fn().mockReturnValue({
       analyticsService: mockAnalyticsService,
       auth: {
-        sendVerificationEmail: mockSendVerificationEmail
+        sendVerificationCode: mockSendVerificationCode,
+        verifyEmailCode: mockVerifyEmailCode
       }
     });
 
-    const mockSnackbar = ({ title, subTitle, iconVariant }: any) => (
-      <div data-testid="snackbar" data-title={title} data-subtitle={subTitle} data-icon-variant={iconVariant} />
-    );
-
-    const mockNotificator = { success: vi.fn(), error: vi.fn() };
-    const mockUseNotificator = vi.fn().mockReturnValue(mockNotificator);
-
     const dependencies = {
       useCustomUser: mockUseCustomUser,
-      useSnackbar: mockUseSnackbar,
-      useServices: mockUseServices,
-      Snackbar: mockSnackbar,
-      useNotificator: mockUseNotificator
+      useServices: mockUseServices
     };
 
     const mockChildren = vi.fn().mockReturnValue(<div>Test</div>);
@@ -167,10 +107,9 @@ describe("EmailVerificationContainer", () => {
 
     return {
       child: mockChildren,
-      mockSendVerificationEmail,
+      mockSendVerificationCode,
+      mockVerifyEmailCode,
       mockCheckSession,
-      mockEnqueueSnackbar,
-      mockNotificator,
       mockAnalyticsService
     };
   }

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationContainer/EmailVerificationContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationContainer/EmailVerificationContainer.tsx
@@ -1,93 +1,49 @@
 "use client";
 import type { FC, ReactNode } from "react";
-import React, { useCallback, useState } from "react";
-import { Snackbar } from "@akashnetwork/ui/components";
-import { useSnackbar } from "notistack";
+import React, { useCallback, useEffect } from "react";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
-import { useNotificator } from "@src/hooks/useNotificator";
 
-const DEPENDENCIES = {
+export const DEPENDENCIES = {
   useCustomUser,
-  useSnackbar,
-  useServices,
-  Snackbar,
-  useNotificator
+  useServices
 };
 
 export type EmailVerificationContainerProps = {
-  children: (props: {
-    isEmailVerified: boolean;
-    isResending: boolean;
-    isChecking: boolean;
-    onResendEmail: () => void;
-    onCheckVerification: () => void;
-    onContinue: () => void;
-  }) => ReactNode;
+  children: (props: { sendCode: () => Promise<void>; verifyCode: (code: string) => Promise<void> }) => ReactNode;
   onComplete: () => void;
   dependencies?: typeof DEPENDENCIES;
 };
 
 export const EmailVerificationContainer: FC<EmailVerificationContainerProps> = ({ children, onComplete, dependencies: d = DEPENDENCIES }) => {
   const { user, checkSession } = d.useCustomUser();
-  const { enqueueSnackbar } = d.useSnackbar();
-  const notificator = d.useNotificator();
-  const [isResending, setIsResending] = useState(false);
-  const [isChecking, setIsChecking] = useState(false);
   const { analyticsService, auth } = d.useServices();
 
-  const isEmailVerified = !!user?.emailVerified;
+  const advance = useCallback(() => {
+    analyticsService.track("onboarding_email_verified", {
+      category: "onboarding"
+    });
+    onComplete();
+  }, [analyticsService, onComplete]);
 
-  const handleResendEmail = useCallback(async () => {
-    if (!user?.id) return;
-
-    setIsResending(true);
-    try {
-      await auth.sendVerificationEmail(user.id);
-      enqueueSnackbar(<d.Snackbar title="Verification email sent" subTitle="Please check your email and click the verification link" iconVariant="success" />, {
-        variant: "success"
-      });
-    } catch (error) {
-      notificator.error("Failed to send verification email. Please try again later");
-    } finally {
-      setIsResending(false);
+  useEffect(() => {
+    if (user?.emailVerified) {
+      advance();
     }
-  }, [user?.id, auth, enqueueSnackbar, d.Snackbar, notificator]);
+  }, [user?.emailVerified, advance]);
 
-  const handleCheckVerification = useCallback(async () => {
-    setIsChecking(true);
-    try {
+  const sendCode = useCallback(async () => {
+    await auth.sendVerificationCode();
+  }, [auth]);
+
+  const verifyCode = useCallback(
+    async (code: string) => {
+      await auth.verifyEmailCode(code);
       await checkSession();
-      enqueueSnackbar(<d.Snackbar title="Verification status updated" subTitle="Your email verification status has been refreshed" iconVariant="success" />, {
-        variant: "success"
-      });
-    } catch (error) {
-      notificator.error("Failed to check verification. Please try again or refresh the page");
-    } finally {
-      setIsChecking(false);
-    }
-  }, [checkSession, enqueueSnackbar, d.Snackbar, notificator]);
-
-  const handleContinue = useCallback(() => {
-    if (isEmailVerified) {
-      analyticsService.track("onboarding_email_verified", {
-        category: "onboarding"
-      });
-      onComplete();
-    }
-  }, [isEmailVerified, analyticsService, onComplete]);
-
-  return (
-    <>
-      {children({
-        isEmailVerified,
-        isResending,
-        isChecking,
-        onResendEmail: handleResendEmail,
-        onCheckVerification: handleCheckVerification,
-        onContinue: handleContinue
-      })}
-    </>
+    },
+    [auth, checkSession]
   );
+
+  return <>{children({ sendCode, verifyCode })}</>;
 };

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/EmailVerificationStep.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/EmailVerificationStep.spec.tsx
@@ -57,7 +57,7 @@ describe(EmailVerificationStep.name, () => {
   });
 
   it("shows error notification when resend fails", async () => {
-    const sendCode = vi.fn().mockRejectedValue(new Error("Network error"));
+    const sendCode = vi.fn().mockRejectedValue(new Error("Please wait before requesting a new verification code."));
     const { mockNotificator } = setup({ sendCode });
 
     const buttons = screen.queryAllByRole("button");
@@ -66,7 +66,7 @@ describe(EmailVerificationStep.name, () => {
       fireEvent.click(resendButton);
     });
 
-    expect(mockNotificator.error).toHaveBeenCalledWith("Failed to send verification code. Please try again later");
+    expect(mockNotificator.error).toHaveBeenCalledWith("Please wait before requesting a new verification code.");
   });
 
   it("starts cooldown after successful resend", async () => {

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/EmailVerificationStep.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/EmailVerificationStep.spec.tsx
@@ -1,0 +1,145 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { EmailVerificationStep } from "./EmailVerificationStep";
+
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(EmailVerificationStep.name, () => {
+  it("renders 6 digit inputs", () => {
+    setup();
+
+    const inputs = screen.queryAllByRole("textbox");
+    expect(inputs).toHaveLength(6);
+  });
+
+  it("renders verification title", () => {
+    setup();
+
+    expect(screen.queryByText("Email Verification")).toBeInTheDocument();
+  });
+
+  it("renders code prompt text", () => {
+    setup();
+
+    expect(screen.queryByText("We've sent a 6-digit verification code to your email address.")).toBeInTheDocument();
+  });
+
+  it("renders resend button as 'Resend Code' when idle", () => {
+    setup();
+
+    expect(screen.queryByText("Resend Code")).toBeInTheDocument();
+  });
+
+  it("calls sendCode when resend button is clicked", async () => {
+    const { sendCode } = setup();
+
+    const buttons = screen.queryAllByRole("button");
+    const resendButton = buttons.find(b => b.textContent?.includes("Resend Code"))!;
+    await act(async () => {
+      fireEvent.click(resendButton);
+    });
+
+    expect(sendCode).toHaveBeenCalled();
+  });
+
+  it("shows success notification after resend", async () => {
+    const { mockNotificator } = setup();
+
+    const buttons = screen.queryAllByRole("button");
+    const resendButton = buttons.find(b => b.textContent?.includes("Resend Code"))!;
+    await act(async () => {
+      fireEvent.click(resendButton);
+    });
+
+    expect(mockNotificator.success).toHaveBeenCalledWith("Verification code sent. Please check your email for the 6-digit code.");
+  });
+
+  it("shows error notification when resend fails", async () => {
+    const sendCode = vi.fn().mockRejectedValue(new Error("Network error"));
+    const { mockNotificator } = setup({ sendCode });
+
+    const buttons = screen.queryAllByRole("button");
+    const resendButton = buttons.find(b => b.textContent?.includes("Resend Code"))!;
+    await act(async () => {
+      fireEvent.click(resendButton);
+    });
+
+    expect(mockNotificator.error).toHaveBeenCalledWith("Failed to send verification code. Please try again later");
+  });
+
+  it("starts cooldown after successful resend", async () => {
+    setup();
+
+    const buttons = screen.queryAllByRole("button");
+    const resendButton = buttons.find(b => b.textContent?.includes("Resend Code"))!;
+    await act(async () => {
+      fireEvent.click(resendButton);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Resend Code (60s)")).toBeInTheDocument();
+    });
+  });
+
+  it("calls verifyCode when all 6 digits are entered", async () => {
+    const { verifyCode } = setup();
+
+    const inputs = screen.queryAllByRole("textbox");
+    const user = userEvent.setup();
+
+    for (let i = 0; i < 6; i++) {
+      await user.click(inputs[i]);
+      await user.keyboard((i + 1).toString());
+    }
+
+    expect(verifyCode).toHaveBeenCalledWith("123456");
+  });
+
+  it("calls verifyCode when OTP autofill injects all 6 digits into first input", async () => {
+    const { verifyCode } = setup();
+
+    const inputs = screen.queryAllByRole("textbox");
+    await act(async () => {
+      fireEvent.change(inputs[0], { target: { value: "654321" } });
+    });
+
+    expect(verifyCode).toHaveBeenCalledWith("654321");
+  });
+
+  it("shows error notification when verify fails", async () => {
+    const verifyCode = vi.fn().mockRejectedValue(new Error("Invalid verification code"));
+    const { mockNotificator } = setup({ verifyCode });
+
+    const inputs = screen.queryAllByRole("textbox");
+    await act(async () => {
+      fireEvent.change(inputs[0], { target: { value: "654321" } });
+    });
+
+    await waitFor(() => {
+      expect(mockNotificator.error).toHaveBeenCalledWith("Invalid verification code");
+    });
+  });
+
+  function setup(
+    input: {
+      sendCode?: () => Promise<void>;
+      verifyCode?: (code: string) => Promise<void>;
+    } = {}
+  ) {
+    const sendCode = input.sendCode ?? vi.fn().mockResolvedValue(undefined);
+    const verifyCode = input.verifyCode ?? vi.fn().mockResolvedValue(undefined);
+    const mockNotificator = { success: vi.fn(), error: vi.fn() };
+    const mockExtractErrorMessage = vi.fn((error: unknown) => (error instanceof Error ? error.message : "An error occurred. Please try again."));
+
+    const dependencies = {
+      useNotificator: () => mockNotificator,
+      extractErrorMessage: mockExtractErrorMessage
+    };
+
+    render(<EmailVerificationStep sendCode={sendCode} verifyCode={verifyCode} dependencies={dependencies} />);
+
+    return { sendCode, verifyCode, mockNotificator, mockExtractErrorMessage };
+  }
+});

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/EmailVerificationStep.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/EmailVerificationStep.tsx
@@ -29,38 +29,29 @@ export const EmailVerificationStep: React.FunctionComponent<EmailVerificationSte
   const [isResending, setIsResending] = useState(false);
   const [isVerifying, setIsVerifying] = useState(false);
   const [cooldownSeconds, setCooldownSeconds] = useState(0);
-  const cooldownRef = useRef(0);
-  const isSendingRef = useRef(false);
   const codeInputRef = useRef<VerificationCodeInputRef>(null);
 
   useEffect(() => {
     if (cooldownSeconds <= 0) return;
 
     const timer = setTimeout(() => {
-      const next = cooldownSeconds - 1;
-      cooldownRef.current = next;
-      setCooldownSeconds(next);
+      setCooldownSeconds(prev => prev - 1);
     }, 1000);
 
     return () => clearTimeout(timer);
   }, [cooldownSeconds]);
 
   const handleResendCode = useCallback(async () => {
-    if (isSendingRef.current || cooldownRef.current > 0) return;
-
-    isSendingRef.current = true;
     setIsResending(true);
     codeInputRef.current?.reset();
 
     try {
       await sendCode();
-      cooldownRef.current = COOLDOWN_DURATION;
       setCooldownSeconds(COOLDOWN_DURATION);
       notificator.success("Verification code sent. Please check your email for the 6-digit code.");
     } catch {
       notificator.error("Failed to send verification code. Please try again later");
     } finally {
-      isSendingRef.current = false;
       setIsResending(false);
     }
   }, [sendCode, notificator]);
@@ -79,7 +70,7 @@ export const EmailVerificationStep: React.FunctionComponent<EmailVerificationSte
         setIsVerifying(false);
       }
     },
-    [verifyCode, notificator, d]
+    [verifyCode, notificator, d.extractErrorMessage]
   );
 
   return (
@@ -102,12 +93,7 @@ export const EmailVerificationStep: React.FunctionComponent<EmailVerificationSte
           <p className="text-sm text-muted-foreground">Didn't receive the code? Check your spam folder or request a new one.</p>
 
           <Button onClick={handleResendCode} variant="outline" disabled={isResending || isVerifying || cooldownSeconds > 0} className="w-full">
-            {isVerifying ? (
-              <>
-                <Spinner size="small" className="mr-2" />
-                Verifying...
-              </>
-            ) : isResending ? (
+            {isResending ? (
               <>
                 <Spinner size="small" className="mr-2" />
                 Sending...

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/EmailVerificationStep.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/EmailVerificationStep.tsx
@@ -49,12 +49,12 @@ export const EmailVerificationStep: React.FunctionComponent<EmailVerificationSte
       await sendCode();
       setCooldownSeconds(COOLDOWN_DURATION);
       notificator.success("Verification code sent. Please check your email for the 6-digit code.");
-    } catch {
-      notificator.error("Failed to send verification code. Please try again later");
+    } catch (error) {
+      notificator.error(d.extractErrorMessage(error as AppError));
     } finally {
       setIsResending(false);
     }
-  }, [sendCode, notificator]);
+  }, [sendCode, notificator, d.extractErrorMessage]);
 
   const handleVerifyCode = useCallback(
     async (code: string) => {

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/EmailVerificationStep.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/EmailVerificationStep.tsx
@@ -1,52 +1,90 @@
 "use client";
-import React from "react";
-import { Alert, Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from "@akashnetwork/ui/components";
-import { Check, Mail, Refresh } from "iconoir-react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Spinner } from "@akashnetwork/ui/components";
+import { Mail, Refresh } from "iconoir-react";
 
 import { Title } from "@src/components/shared/Title";
+import { useNotificator } from "@src/hooks/useNotificator";
+import type { AppError } from "@src/types";
+import { extractErrorMessage } from "@src/utils/errorUtils";
+import type { VerificationCodeInputRef } from "./VerificationCodeInput";
+import { VerificationCodeInput } from "./VerificationCodeInput";
+
+const COOLDOWN_DURATION = 60;
+
+export const DEPENDENCIES = {
+  useNotificator,
+  extractErrorMessage
+};
 
 interface EmailVerificationStepProps {
-  isEmailVerified: boolean;
-  isResending: boolean;
-  isChecking: boolean;
-  onResendEmail: () => void;
-  onCheckVerification: () => void;
-  onContinue: () => void;
+  sendCode: () => Promise<void>;
+  verifyCode: (code: string) => Promise<void>;
+  dependencies?: typeof DEPENDENCIES;
 }
 
-export const EmailVerificationStep: React.FunctionComponent<EmailVerificationStepProps> = ({
-  isEmailVerified,
-  isResending,
-  isChecking,
-  onResendEmail,
-  onCheckVerification,
-  onContinue
-}) => {
+export const EmailVerificationStep: React.FunctionComponent<EmailVerificationStepProps> = ({ sendCode, verifyCode, dependencies: d = DEPENDENCIES }) => {
+  const notificator = d.useNotificator();
+
+  const [isResending, setIsResending] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [cooldownSeconds, setCooldownSeconds] = useState(0);
+  const cooldownRef = useRef(0);
+  const isSendingRef = useRef(false);
+  const codeInputRef = useRef<VerificationCodeInputRef>(null);
+
+  useEffect(() => {
+    if (cooldownSeconds <= 0) return;
+
+    const timer = setTimeout(() => {
+      const next = cooldownSeconds - 1;
+      cooldownRef.current = next;
+      setCooldownSeconds(next);
+    }, 1000);
+
+    return () => clearTimeout(timer);
+  }, [cooldownSeconds]);
+
+  const handleResendCode = useCallback(async () => {
+    if (isSendingRef.current || cooldownRef.current > 0) return;
+
+    isSendingRef.current = true;
+    setIsResending(true);
+    codeInputRef.current?.reset();
+
+    try {
+      await sendCode();
+      cooldownRef.current = COOLDOWN_DURATION;
+      setCooldownSeconds(COOLDOWN_DURATION);
+      notificator.success("Verification code sent. Please check your email for the 6-digit code.");
+    } catch {
+      notificator.error("Failed to send verification code. Please try again later");
+    } finally {
+      isSendingRef.current = false;
+      setIsResending(false);
+    }
+  }, [sendCode, notificator]);
+
+  const handleVerifyCode = useCallback(
+    async (code: string) => {
+      setIsVerifying(true);
+
+      try {
+        await verifyCode(code);
+        notificator.success("Your email has been successfully verified");
+      } catch (error) {
+        notificator.error(d.extractErrorMessage(error as AppError));
+        codeInputRef.current?.reset();
+      } finally {
+        setIsVerifying(false);
+      }
+    },
+    [verifyCode, notificator, d]
+  );
+
   return (
     <div className="mx-auto max-w-md space-y-6 text-center">
       <Title>Verify Your Email</Title>
-
-      {isEmailVerified ? (
-        <Alert className="mx-auto flex max-w-md flex-row items-center gap-2 text-left" variant="success">
-          <div className="rounded-full bg-card p-3">
-            <Check className="h-6 w-6" />
-          </div>
-          <div>
-            <h4 className="font-medium">Email Verified</h4>
-            <p className="text-sm">Your email has been successfully verified.</p>
-          </div>
-        </Alert>
-      ) : (
-        <Alert className="mx-auto flex max-w-md flex-row items-center gap-2 text-left" variant="warning">
-          <div className="rounded-full bg-card p-3">
-            <Mail className="h-4 w-4" />
-          </div>
-          <div>
-            <h4 className="font-medium">Email Verification Required</h4>
-            <p className="text-sm">Please verify your email address to continue.</p>
-          </div>
-        </Alert>
-      )}
 
       <Card className="mx-auto max-w-md">
         <CardHeader>
@@ -56,29 +94,31 @@ export const EmailVerificationStep: React.FunctionComponent<EmailVerificationSte
             </div>
           </div>
           <CardTitle>Email Verification</CardTitle>
-          <CardDescription>
-            {isEmailVerified ? "Your email has been verified successfully." : "We've sent a verification link to your email address."}
-          </CardDescription>
+          <CardDescription>We've sent a 6-digit verification code to your email address.</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          {!isEmailVerified ? (
-            <>
-              <p className="text-sm text-muted-foreground">Didn't receive the email? Check your spam folder or request a new verification email.</p>
-              <div className="flex gap-2">
-                <Button onClick={onResendEmail} variant="outline" disabled={isResending} className="flex-1">
-                  <Refresh className="mr-2 h-4 w-4" />
-                  {isResending ? "Sending..." : "Resend Email"}
-                </Button>
-                <Button onClick={onCheckVerification} disabled={isChecking} className="flex-1">
-                  {isChecking ? "Checking..." : "Check Verification"}
-                </Button>
-              </div>
-            </>
-          ) : (
-            <Button onClick={onContinue} className="w-full">
-              Continue
-            </Button>
-          )}
+          <VerificationCodeInput ref={codeInputRef} onComplete={handleVerifyCode} disabled={isVerifying} />
+
+          <p className="text-sm text-muted-foreground">Didn't receive the code? Check your spam folder or request a new one.</p>
+
+          <Button onClick={handleResendCode} variant="outline" disabled={isResending || isVerifying || cooldownSeconds > 0} className="w-full">
+            {isVerifying ? (
+              <>
+                <Spinner size="small" className="mr-2" />
+                Verifying...
+              </>
+            ) : isResending ? (
+              <>
+                <Spinner size="small" className="mr-2" />
+                Sending...
+              </>
+            ) : (
+              <>
+                <Refresh className="mr-2 h-4 w-4" />
+                {cooldownSeconds > 0 ? `Resend Code (${cooldownSeconds}s)` : "Resend Code"}
+              </>
+            )}
+          </Button>
         </CardContent>
       </Card>
     </div>

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/EmailVerificationStep.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/EmailVerificationStep.tsx
@@ -65,7 +65,7 @@ export const EmailVerificationStep: React.FunctionComponent<EmailVerificationSte
         notificator.success("Your email has been successfully verified");
       } catch (error) {
         notificator.error(d.extractErrorMessage(error as AppError));
-        codeInputRef.current?.reset();
+        setTimeout(() => codeInputRef.current?.reset(), 0);
       } finally {
         setIsVerifying(false);
       }

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/VerificationCodeInput.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/VerificationCodeInput.spec.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { VerificationCodeInputRef } from "./VerificationCodeInput";
+import { VerificationCodeInput } from "./VerificationCodeInput";
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(VerificationCodeInput.name, () => {
+  it("renders 6 digit inputs", () => {
+    setup();
+
+    const inputs = screen.queryAllByRole("textbox");
+    expect(inputs).toHaveLength(6);
+  });
+
+  it("renders inputs with correct aria labels", () => {
+    setup();
+
+    for (let i = 1; i <= 6; i++) {
+      expect(screen.queryByLabelText(`Verification code digit ${i}`)).toBeInTheDocument();
+    }
+  });
+
+  it("sets autoComplete='one-time-code' on first input only", () => {
+    setup();
+
+    const inputs = screen.queryAllByRole("textbox");
+    expect(inputs[0]).toHaveAttribute("autoComplete", "one-time-code");
+    expect(inputs[1]).toHaveAttribute("autoComplete", "off");
+  });
+
+  it("calls onComplete when all 6 digits are entered", async () => {
+    const { onComplete } = setup();
+    const user = userEvent.setup();
+
+    const inputs = screen.queryAllByRole("textbox");
+    for (let i = 0; i < 6; i++) {
+      await user.click(inputs[i]);
+      await user.keyboard((i + 1).toString());
+    }
+
+    expect(onComplete).toHaveBeenCalledWith("123456");
+  });
+
+  it("calls onComplete when OTP autofill injects all 6 digits into first input", async () => {
+    const { onComplete } = setup();
+
+    const inputs = screen.queryAllByRole("textbox");
+    await act(async () => {
+      fireEvent.change(inputs[0], { target: { value: "654321" } });
+    });
+
+    expect(onComplete).toHaveBeenCalledWith("654321");
+  });
+
+  it("does not call onComplete for non-numeric input", async () => {
+    const { onComplete } = setup();
+    const user = userEvent.setup();
+
+    const inputs = screen.queryAllByRole("textbox");
+    await user.click(inputs[0]);
+    await user.keyboard("abcdef");
+
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("disables all inputs when disabled prop is true", () => {
+    setup({ disabled: true });
+
+    const inputs = screen.queryAllByRole("textbox");
+    inputs.forEach(input => {
+      expect(input).toBeDisabled();
+    });
+  });
+
+  it("resets digits when reset is called via ref", async () => {
+    const ref = React.createRef<VerificationCodeInputRef>();
+    const { onComplete } = setup({ ref });
+
+    const inputs = screen.queryAllByRole("textbox");
+    await act(async () => {
+      fireEvent.change(inputs[0], { target: { value: "654321" } });
+    });
+
+    expect(onComplete).toHaveBeenCalledWith("654321");
+    onComplete.mockClear();
+
+    act(() => {
+      ref.current?.reset();
+    });
+
+    inputs.forEach(input => {
+      expect(input).toHaveValue("");
+    });
+  });
+
+  it("allows re-submitting the same code after reset", async () => {
+    const ref = React.createRef<VerificationCodeInputRef>();
+    const { onComplete } = setup({ ref });
+
+    const inputs = screen.queryAllByRole("textbox");
+    await act(async () => {
+      fireEvent.change(inputs[0], { target: { value: "654321" } });
+    });
+
+    expect(onComplete).toHaveBeenCalledWith("654321");
+    onComplete.mockClear();
+
+    act(() => {
+      ref.current?.reset();
+    });
+
+    await act(async () => {
+      fireEvent.change(inputs[0], { target: { value: "654321" } });
+    });
+
+    expect(onComplete).toHaveBeenCalledWith("654321");
+  });
+
+  function setup(input: { onComplete?: (code: string) => void; disabled?: boolean; ref?: React.Ref<VerificationCodeInputRef> } = {}) {
+    const onComplete = (input.onComplete as ReturnType<typeof vi.fn>) ?? vi.fn();
+
+    render(<VerificationCodeInput ref={input.ref ?? null} onComplete={onComplete} disabled={input.disabled} />);
+
+    return { onComplete };
+  }
+});

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/VerificationCodeInput.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/VerificationCodeInput.tsx
@@ -119,6 +119,7 @@ export const VerificationCodeInput = React.forwardRef<VerificationCodeInputRef, 
           autoComplete={index === 0 ? "one-time-code" : "off"}
           inputMode="numeric"
           value={digit}
+          onFocus={e => e.currentTarget.select()}
           onChange={e => handleDigitChange(index, e.target.value)}
           onKeyDown={e => handleKeyDown(index, e)}
           className="h-12 w-12"

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/VerificationCodeInput.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/VerificationCodeInput.tsx
@@ -1,0 +1,132 @@
+"use client";
+import React, { useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { Input } from "@akashnetwork/ui/components";
+
+const CODE_LENGTH = 6;
+
+export interface VerificationCodeInputRef {
+  reset: () => void;
+  focus: () => void;
+}
+
+interface VerificationCodeInputProps {
+  onComplete: (code: string) => void;
+  disabled?: boolean;
+}
+
+export const VerificationCodeInput = React.forwardRef<VerificationCodeInputRef, VerificationCodeInputProps>(({ onComplete, disabled = false }, ref) => {
+  const [digits, setDigits] = useState<string[]>(Array(CODE_LENGTH).fill(""));
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const submittedCodeRef = useRef<string | null>(null);
+
+  const reset = useCallback(() => {
+    setDigits(Array(CODE_LENGTH).fill(""));
+    submittedCodeRef.current = null;
+    inputRefs.current[0]?.focus();
+  }, []);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      reset,
+      focus: () => inputRefs.current[0]?.focus()
+    }),
+    [reset]
+  );
+
+  useEffect(() => {
+    const code = digits.join("");
+    if (code.length === CODE_LENGTH) {
+      if (submittedCodeRef.current !== code) {
+        submittedCodeRef.current = code;
+        onComplete(code);
+      }
+    } else {
+      submittedCodeRef.current = null;
+    }
+  }, [digits, onComplete]);
+
+  const handleDigitChange = useCallback(
+    (index: number, value: string) => {
+      if (!/^\d*$/.test(value) || disabled) return;
+
+      if (value.length > 1) {
+        const filled = value.slice(0, CODE_LENGTH - index);
+        setDigits(prev => {
+          const newDigits = [...prev];
+          for (let i = 0; i < filled.length; i++) {
+            newDigits[index + i] = filled[i];
+          }
+          return newDigits;
+        });
+        const nextIndex = index + filled.length;
+        if (nextIndex < CODE_LENGTH) {
+          inputRefs.current[nextIndex]?.focus();
+        }
+        return;
+      }
+
+      setDigits(prev => {
+        const newDigits = [...prev];
+        newDigits[index] = value;
+        return newDigits;
+      });
+      if (value && index < CODE_LENGTH - 1) {
+        inputRefs.current[index + 1]?.focus();
+      }
+    },
+    [disabled]
+  );
+
+  const handleKeyDown = useCallback((index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
+    const currentDigits = inputRefs.current[index]?.value ?? "";
+    if (e.key === "Backspace" && !currentDigits && index > 0) {
+      inputRefs.current[index - 1]?.focus();
+    }
+  }, []);
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      e.preventDefault();
+      if (disabled) return;
+
+      const pasted = e.clipboardData.getData("text").replace(/\D/g, "").slice(0, CODE_LENGTH);
+      if (!pasted) return;
+
+      const newDigits = Array(CODE_LENGTH).fill("");
+      for (let i = 0; i < CODE_LENGTH; i++) {
+        newDigits[i] = pasted[i] || "";
+      }
+      setDigits(newDigits);
+
+      if (pasted.length < CODE_LENGTH) {
+        inputRefs.current[pasted.length]?.focus();
+      }
+    },
+    [disabled]
+  );
+
+  return (
+    <div className="flex justify-center gap-2" onPaste={handlePaste}>
+      {digits.map((digit, index) => (
+        <Input
+          key={index}
+          ref={el => {
+            inputRefs.current[index] = el;
+          }}
+          type="text"
+          aria-label={`Verification code digit ${index + 1}`}
+          autoComplete={index === 0 ? "one-time-code" : "off"}
+          inputMode="numeric"
+          value={digit}
+          onChange={e => handleDigitChange(index, e.target.value)}
+          onKeyDown={e => handleKeyDown(index, e)}
+          className="h-12 w-12"
+          inputClassName="text-center text-lg font-semibold"
+          disabled={disabled}
+        />
+      ))}
+    </div>
+  );
+});
+VerificationCodeInput.displayName = "VerificationCodeInput";

--- a/apps/deploy-web/src/hooks/useEmailVerificationRequiredEventHandler.tsx
+++ b/apps/deploy-web/src/hooks/useEmailVerificationRequiredEventHandler.tsx
@@ -21,7 +21,7 @@ export const useEmailVerificationRequiredEventHandler = (): ((messageOtherwise: 
           message: messageOtherwise,
           actions: ({ close }) => [
             {
-              label: "Resend verification email",
+              label: "Send verification code",
               side: "left",
               size: "lg",
               onClick: () => {
@@ -31,17 +31,21 @@ export const useEmailVerificationRequiredEventHandler = (): ((messageOtherwise: 
                 }
 
                 auth
-                  .sendVerificationEmail(user.id)
+                  .sendVerificationCode()
                   .then(() => {
                     enqueueSnackbar(
-                      <Snackbar title="Email requested" subTitle="Please check your email and click a verification link" iconVariant="success" />,
+                      <Snackbar
+                        title="Verification code sent"
+                        subTitle="Please check your email for the 6-digit code and verify in the onboarding page"
+                        iconVariant="success"
+                      />,
                       {
                         variant: "success"
                       }
                     );
                   })
                   .catch(() => {
-                    enqueueSnackbar(<Snackbar title="Failed to request email" subTitle="Please try again later or contact support" iconVariant="error" />, {
+                    enqueueSnackbar(<Snackbar title="Failed to send code" subTitle="Please try again later or contact support" iconVariant="error" />, {
                       variant: "error"
                     });
                   })
@@ -54,6 +58,6 @@ export const useEmailVerificationRequiredEventHandler = (): ((messageOtherwise: 
 
       return user?.emailVerified ? handler : preventer;
     },
-    [user?.emailVerified, user?.id, requireAction, enqueueSnackbar]
+    [user?.emailVerified, user?.id, requireAction, enqueueSnackbar, auth, analyticsService]
   );
 };

--- a/apps/deploy-web/src/hooks/useEmailVerificationRequiredEventHandler.tsx
+++ b/apps/deploy-web/src/hooks/useEmailVerificationRequiredEventHandler.tsx
@@ -26,9 +26,6 @@ export const useEmailVerificationRequiredEventHandler = (): ((messageOtherwise: 
               size: "lg",
               onClick: () => {
                 analyticsService.track("resend_verification_email_btn_clk", "Amplitude");
-                if (!user?.id) {
-                  return;
-                }
 
                 auth
                   .sendVerificationCode()
@@ -58,6 +55,6 @@ export const useEmailVerificationRequiredEventHandler = (): ((messageOtherwise: 
 
       return user?.emailVerified ? handler : preventer;
     },
-    [user?.emailVerified, user?.id, requireAction, enqueueSnackbar, auth, analyticsService]
+    [user?.emailVerified, requireAction, enqueueSnackbar, auth, analyticsService]
   );
 };

--- a/apps/deploy-web/src/hooks/useEmailVerificationRequiredEventHandler.tsx
+++ b/apps/deploy-web/src/hooks/useEmailVerificationRequiredEventHandler.tsx
@@ -25,7 +25,7 @@ export const useEmailVerificationRequiredEventHandler = (): ((messageOtherwise: 
               side: "left",
               size: "lg",
               onClick: () => {
-                analyticsService.track("resend_verification_email_btn_clk", "Amplitude");
+                analyticsService.track("send_verification_code_btn_clk", "Amplitude");
 
                 auth
                   .sendVerificationCode()

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -74,7 +74,7 @@ export type AnalyticsEvent =
   | "delete_api_key"
   | "close_deposit_modal"
   | "buy_credits_btn_clk"
-  | "resend_verification_email_btn_clk"
+  | "send_verification_code_btn_clk"
   | "builder_mode_btn_clk"
   | "yml_mode_btn_clk"
   | "bid_selected"

--- a/apps/deploy-web/src/services/session/session.service.spec.ts
+++ b/apps/deploy-web/src/services/session/session.service.spec.ts
@@ -142,9 +142,9 @@ describe(SessionService.name, () => {
       const { service, consoleApiHttpClient, externalHttpClient } = setup();
 
       consoleApiHttpClient.post.mockResolvedValueOnce({
-        status: 409,
+        status: 422,
         data: {
-          message: "The user already exists."
+          message: "Unable to create account. Please try again or use a different email."
         },
         headers: {}
       });

--- a/apps/deploy-web/src/services/session/session.service.ts
+++ b/apps/deploy-web/src/services/session/session.service.ts
@@ -93,7 +93,7 @@ export class SessionService {
       }
     );
 
-    const isUserExists = signupResponse.status === 409;
+    const isUserExists = signupResponse.status === 422;
     if (signupResponse.status >= 400 && !isUserExists) {
       return Err({
         message: signupResponse.data?.message || "Signup failed",

--- a/packages/ui/components/custom/snackbar.tsx
+++ b/packages/ui/components/custom/snackbar.tsx
@@ -11,7 +11,6 @@ type Props = {
   subTitle?: string | ReactNode;
   iconVariant?: IconVariant;
   showLoading?: boolean;
-  children?: ReactNode;
   ["data-testid"]?: string;
 };
 
@@ -31,7 +30,7 @@ export const Snackbar: React.FunctionComponent<Props> = ({ title, subTitle, icon
         <h5 className="flex-grow text-lg font-semibold leading-4 tracking-tight">{title}</h5>
       </div>
 
-      {subTitle && <p className="break-words text-xs">{subTitle}</p>}
+      {subTitle && <div className="break-words text-xs">{subTitle}</div>}
     </div>
   );
 };


### PR DESCRIPTION
## Why

Part of CON-197 — Replace Auth0's default email verification link with a 6-digit code flow.

This is **PR 2 of 2** — frontend only. Split from #2824 to make review manageable.
Depends on PR 1 (backend): #3051

## What

- `VerificationCodeInput`: 6-digit OTP input with autofill support (extracted per review feedback)
- `EmailVerificationStep`: code entry UI with cooldown timer and resend
- `EmailVerificationContainer`: lean container orchestrating send/verify/resend (UI concerns moved to view per review feedback)
- `VerifyEmailPage`: updated to use new code-based verification
- `SessionService`: simplified to remove legacy verification logic
- `useEmailVerificationRequiredEventHandler`: updated for code-based flow
- Snackbar: fix DOM nesting warning
- Unit tests for all new and modified components

**13 files changed** (~670 additions, ~465 deletions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New 6-digit verification input with autofill/paste support, resend-code button with 60s cooldown, and explicit send/verify actions.
  * Verification auto-advances when confirmed and onboarding now shows a single redirect/loading state.

* **Bug Fixes**
  * Clarified signup and verification error messages and improved success/error toast behavior.

* **Other**
  * Analytics event and snackbar subtitle text updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->