### PR TITLE
feat(log-collector): improve log forwarding UI clarity in SDL builder

### DIFF
--- a/apps/deploy-web/src/components/sdl/DatadogEnvConfig/DatadogEnvConfig.tsx
+++ b/apps/deploy-web/src/components/sdl/DatadogEnvConfig/DatadogEnvConfig.tsx
@@ -29,7 +29,7 @@ export const DatadogEnvConfig: FC<Props> = ({ serviceIndex, dependencies: d = { 
           type="text"
           label="Regional URL"
           className="w-full"
-          placeholder="Example: app.datadoghq.com"
+          placeholder="Example: datadoghq.eu"
           error={!!env.errors.DD_SITE}
         />
         {env.errors.DD_SITE && <p className="mt-2 text-xs font-medium text-destructive">{env.errors.DD_SITE}</p>}
@@ -40,9 +40,9 @@ export const DatadogEnvConfig: FC<Props> = ({ serviceIndex, dependencies: d = { 
           value={env.values.DD_API_KEY}
           onChange={e => env.setValue("DD_API_KEY", e.target.value)}
           type="password"
-          label="API Key"
+          label="Provider API"
           className="w-full"
-          placeholder="Paste your API key here"
+          placeholder="Paste the API key from your provider here"
           error={!!env.errors.DD_API_KEY}
         />
         {env.errors.DD_API_KEY && <p className="mt-2 text-xs font-medium text-destructive">{env.errors.DD_API_KEY}</p>}

--- a/apps/deploy-web/src/components/sdl/LogCollectorControl/LogCollectorControl.tsx
+++ b/apps/deploy-web/src/components/sdl/LogCollectorControl/LogCollectorControl.tsx
@@ -148,16 +148,16 @@ export const LogCollectorControl: FC<Props> = ({ serviceIndex, dependencies: d =
         label="Enable log forwarding for this service"
       />{" "}
       {!isAdding && logCollectorService && (
-        <div>
-          <div>
-            <FormLabel htmlFor="provider" className="mb-2 mt-4 flex items-center">
-              Provider
-              <CustomTooltip title={<>We are actively working on adding support for more providers.</>}>
-                <InfoCircle className="ml-2 text-xs text-muted-foreground" />
-              </CustomTooltip>
-            </FormLabel>
+        <div className="mt-4 flex flex-col gap-4">
+          <div className="rounded-xl border border-border bg-card p-4">
+            <FormLabel className="mb-1">Log Provider Info</FormLabel>
+            <p className="mb-4 text-sm text-muted-foreground">
+              We currently only offer support for <strong>Datadog</strong> but will be adding other options in the future.
+            </p>
+
+            <FormLabel htmlFor="provider">Provider Selection</FormLabel>
             <Select value="DATADOG" disabled>
-              <SelectTrigger id="provider">
+              <SelectTrigger id="provider" className="mt-2">
                 <SelectValue placeholder="Select Provider" />
               </SelectTrigger>
               <SelectContent>
@@ -166,20 +166,25 @@ export const LogCollectorControl: FC<Props> = ({ serviceIndex, dependencies: d =
                 </SelectGroup>
               </SelectContent>
             </Select>
+
+            <div className="ml-10">
+              <DatadogEnvConfig serviceIndex={logCollectorServiceIndex} />
+            </div>
           </div>
 
-          <DatadogEnvConfig serviceIndex={logCollectorServiceIndex} />
+          <div className="rounded-xl border border-border bg-card p-4">
+            <FormLabel className="mb-1">Resources</FormLabel>
+            <p className="mb-4 text-sm text-muted-foreground">This runs as a separate service alongside the main deployment for log collection.</p>
 
-          <div className="mt-4">
             <CpuFormControl control={control} currentService={logCollectorService} serviceIndex={logCollectorServiceIndex} />
-          </div>
 
-          <div className="mt-4">
-            <MemoryFormControl control={control} serviceIndex={logCollectorServiceIndex} />
-          </div>
+            <div className="mt-4">
+              <MemoryFormControl control={control} serviceIndex={logCollectorServiceIndex} />
+            </div>
 
-          <div className="mt-4">
-            <EphemeralStorageFormControl services={allServices} control={control} serviceIndex={logCollectorServiceIndex} />
+            <div className="mt-4">
+              <EphemeralStorageFormControl services={allServices} control={control} serviceIndex={logCollectorServiceIndex} />
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Why

Fixes CON-206

Internal testing surfaced confusion around the Log Forwarding form in the SDL Builder:
- Users didn't understand that Regional URL and API Key are Datadog-specific fields
- It wasn't clear where to get the API key or what to enter
- The resource controls (CPU/Memory/Storage) weren't understood as being for a separate log collector service running alongside the main deployment

## What

- Grouped provider selection, Regional URL, and Provider API into a "Log Provider Info" card with description explaining Datadog-only support
- Indented Regional URL and Provider API under the provider dropdown to visually associate them as sub-attributes
- Grouped CPU, Memory, and Ephemeral Storage into a "Resources" card with description clarifying it runs as a separate service
- Updated labels and placeholder text to be more descriptive

Figma: https://www.figma.com/design/mGKwgSZIQIiYObm9iS4w8U/Console---Ready-for-dev?node-id=995-4970&m=dev
<img width="661" height="858" alt="image" src="https://github.com/user-attachments/assets/e0f59a8a-5207-4f00-91ac-cb1bf212750e" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI/UX Improvements**
  * Updated Datadog site endpoint placeholder text for clarity
  * Refined API key input labels and helper text
  * Reorganized log collector configuration interface with card-based layout structure
  * Added informational section indicating Datadog as the currently supported provider option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->