### PR TITLE
fix(managed-wallet): retries silently dropped fee grants after revoke+grant tx

### DIFF
--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.spec.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.spec.ts
@@ -7,6 +7,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { BillingConfig } from "@src/billing/providers";
 import type { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
+import type { LoggerService } from "@src/core/providers/logging.provider";
 import type { ManagedSignerService } from "../managed-signer/managed-signer.service";
 import type { RpcMessageService } from "../rpc-message-service/rpc-message.service";
 import { ManagedUserWalletService } from "./managed-user-wallet.service";
@@ -68,6 +69,73 @@ describe(ManagedUserWalletService.name, () => {
     });
   });
 
+  describe("fee grant silent-drop recovery", () => {
+    it("verifies the grant landed after a batched revoke+grant tx", async () => {
+      const { service, signer, rpcMessageService, authzHttpService, logger } = setup();
+      const wallet = { address: createAkashAddress(), isTrialing: false, createdAt: faker.date.past() };
+
+      authzHttpService.hasFeeAllowance.mockResolvedValueOnce(true).mockResolvedValueOnce(true);
+
+      await service.refillWalletFees(signer, wallet);
+
+      expect(authzHttpService.hasFeeAllowance).toHaveBeenCalledTimes(2);
+      expect(rpcMessageService.getRevokeAllowanceMsg).toHaveBeenCalledTimes(1);
+      expect(signer.executeFundingTx).toHaveBeenCalledTimes(1);
+      expect(logger.warn).not.toHaveBeenCalledWith(expect.objectContaining({ event: "FEE_GRANT_SILENTLY_DROPPED" }));
+      expect(logger.error).not.toHaveBeenCalledWith(expect.objectContaining({ event: "FEE_GRANT_REISSUE_FAILED" }));
+    });
+
+    it("re-issues the grant when the post-tx check reports it missing", async () => {
+      const { service, signer, rpcMessageService, authzHttpService, logger } = setup();
+      const wallet = { address: createAkashAddress(), isTrialing: false, createdAt: faker.date.past() };
+      const grantMsg = { typeUrl: "/fee-grant", value: {} } as unknown as EncodeObject;
+
+      rpcMessageService.getFeesAllowanceGrantMsg.mockReturnValue(grantMsg);
+      authzHttpService.hasFeeAllowance
+        .mockResolvedValueOnce(true) // pre-tx: prior allowance exists, revoke is batched
+        .mockResolvedValueOnce(false) // post-tx: grant silently dropped
+        .mockResolvedValueOnce(true); // post-retry: grant re-issued successfully
+
+      await service.refillWalletFees(signer, wallet);
+
+      expect(authzHttpService.hasFeeAllowance).toHaveBeenCalledTimes(3);
+      expect(signer.executeFundingTx).toHaveBeenCalledTimes(2);
+      expect(signer.executeFundingTx).toHaveBeenNthCalledWith(2, [grantMsg]);
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "FEE_GRANT_SILENTLY_DROPPED" }));
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.error).not.toHaveBeenCalledWith(expect.objectContaining({ event: "FEE_GRANT_REISSUE_FAILED" }));
+    });
+
+    it("throws BadGateway after the retry policy is exhausted", async () => {
+      const { service, signer, authzHttpService, logger } = setup();
+      const wallet = { address: createAkashAddress(), isTrialing: false, createdAt: faker.date.past() };
+
+      authzHttpService.hasFeeAllowance.mockResolvedValueOnce(true).mockResolvedValue(false);
+
+      await expect(service.refillWalletFees(signer, wallet)).rejects.toMatchObject({ status: 502 });
+
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "FEE_GRANT_SILENTLY_DROPPED" }));
+      expect(logger.warn).toHaveBeenCalledTimes(3);
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "FEE_GRANT_REISSUE_FAILED" }));
+      expect(logger.error).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips post-tx verification when no prior allowance existed", async () => {
+      const { service, signer, rpcMessageService, authzHttpService, logger } = setup();
+      const wallet = { address: createAkashAddress(), isTrialing: false, createdAt: faker.date.past() };
+
+      authzHttpService.hasFeeAllowance.mockResolvedValue(false);
+
+      await service.refillWalletFees(signer, wallet);
+
+      expect(authzHttpService.hasFeeAllowance).toHaveBeenCalledTimes(1);
+      expect(rpcMessageService.getRevokeAllowanceMsg).not.toHaveBeenCalled();
+      expect(signer.executeFundingTx).toHaveBeenCalledTimes(1);
+      expect(logger.warn).not.toHaveBeenCalled();
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+  });
+
   function setup() {
     const config: BillingConfig = {
       TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT: 500000,
@@ -81,14 +149,16 @@ describe(ManagedUserWalletService.name, () => {
     const rpcMessageService = mock<RpcMessageService>();
     const authzHttpService = mock<AuthzHttpService>();
     const signer = mock<ManagedSignerService>();
+    const logger = mock<LoggerService>();
 
     txManagerService.getFundingWalletAddress.mockResolvedValue(createAkashAddress());
     authzHttpService.hasFeeAllowance.mockResolvedValue(false);
     rpcMessageService.getFeesAllowanceGrantMsg.mockReturnValue({ typeUrl: "/fee-grant", value: {} } as unknown as EncodeObject);
+    rpcMessageService.getRevokeAllowanceMsg.mockReturnValue({ typeUrl: "/fee-revoke", value: {} } as unknown as EncodeObject);
     signer.executeFundingTx.mockResolvedValue({ code: 0, hash: "hash", rawLog: "[]" } as never);
 
-    const service = new ManagedUserWalletService(config, txManagerService, rpcMessageService, authzHttpService);
+    const service = new ManagedUserWalletService(config, txManagerService, rpcMessageService, authzHttpService, logger);
 
-    return { service, signer, config, txManagerService, rpcMessageService, authzHttpService };
+    return { service, signer, config, txManagerService, rpcMessageService, authzHttpService, logger };
   }
 });

--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
@@ -1,16 +1,18 @@
 import { AuthzHttpService } from "@akashnetwork/http-sdk";
-import { createOtelLogger } from "@akashnetwork/logging/otel";
 import { EncodeObject } from "@cosmjs/proto-signing";
+import { ConstantBackoff, handleWhenResult, type IPolicy, retry } from "cockatiel";
 import add from "date-fns/add";
 import addDays from "date-fns/addDays";
 import isAfter from "date-fns/isAfter";
 import subDays from "date-fns/subDays";
 import assert from "http-assert";
+import { BadGateway } from "http-errors";
 import { singleton } from "tsyringe";
 
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
 import type { UserWalletOutput } from "@src/billing/repositories";
 import { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
+import { LoggerService } from "@src/core/providers/logging.provider";
 import { Trace, withSpan } from "@src/core/services/tracing/tracing.service";
 import type { ManagedSignerService } from "../managed-signer/managed-signer.service";
 import { RpcMessageService, SpendingAuthorizationMsgOptions } from "../rpc-message-service/rpc-message.service";
@@ -30,13 +32,20 @@ interface SpendingAuthorizationOptions {
 
 @singleton()
 export class ManagedUserWalletService {
-  private readonly logger = createOtelLogger({ context: ManagedUserWalletService.name });
+  private readonly feeGrantVerifyPolicy: IPolicy = retry(
+    handleWhenResult(res => !res),
+    {
+      maxAttempts: 2,
+      backoff: new ConstantBackoff(0)
+    }
+  );
 
   constructor(
     @InjectBillingConfig() private readonly config: BillingConfig,
     private readonly txManagerService: TxManagerService,
     private readonly rpcMessageService: RpcMessageService,
-    private readonly authzHttpService: AuthzHttpService
+    private readonly authzHttpService: AuthzHttpService,
+    private readonly logger: LoggerService
   ) {}
 
   async createAndAuthorizeTrialSpending(signer: ManagedSignerService, { addressIndex }: { addressIndex: number }) {
@@ -124,8 +133,40 @@ export class ManagedUserWalletService {
 
       messages.push(this.rpcMessageService.getFeesAllowanceGrantMsg(options));
 
-      return await signer.executeFundingTx(messages);
+      const result = await signer.executeFundingTx(messages);
+
+      if (hasValidFeeAllowance) {
+        await this.ensureFeeAllowanceLanded(signer, options);
+      }
+
+      return result;
     });
+  }
+
+  private async ensureFeeAllowanceLanded(signer: ManagedSignerService, options: Omit<SpendingAuthorizationMsgOptions, "denom">) {
+    if (await this.authzHttpService.hasFeeAllowance(options.granter, options.grantee)) {
+      return;
+    }
+    const hasFeeAllowance = await this.feeGrantVerifyPolicy.execute(async () => {
+      this.logger.warn({
+        event: "FEE_GRANT_SILENTLY_DROPPED",
+        granter: options.granter,
+        grantee: options.grantee
+      });
+
+      await signer.executeFundingTx([this.rpcMessageService.getFeesAllowanceGrantMsg(options)]);
+
+      return await this.authzHttpService.hasFeeAllowance(options.granter, options.grantee);
+    });
+
+    if (!hasFeeAllowance) {
+      this.logger.error({
+        event: "FEE_GRANT_REISSUE_FAILED",
+        granter: options.granter,
+        grantee: options.grantee
+      });
+      throw new BadGateway();
+    }
   }
 
   private async authorizeDeploymentSpending(signer: ManagedSignerService, options: SpendingAuthorizationMsgOptions) {


### PR DESCRIPTION
## Why

Batched `MsgRevokeAllowance + MsgGrantAllowance` transactions intermittently succeed on-chain (code 0) but silently drop the grant — leaving managed wallets without fee authorization and blocking deployments.

Fixes CON-143

## What

`ManagedUserWalletService.authorizeFeeSpending` now verifies the grant landed after the batched tx and re-issues `MsgGrantAllowance` alone (with a bounded cockatiel retry — 3 total attempts, no backoff) when the post-tx check finds the grant missing. On exhaustion it logs `FEE_GRANT_REISSUE_FAILED` and surfaces a generic `BadGateway` (HTTP 502); each detected drop is logged as `FEE_GRANT_SILENTLY_DROPPED` for log-based alerting.

Verification is scope-gated to the batched revoke+grant path so pure initial grants are untouched. The retry re-issues only the grant message (no revoke) so the original race cannot recur.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic retry and verification for fee grants to reduce silent failures.
  * Improved error reporting and logging when fee-grant restoration fails; now surfaces a gateway error if recovery is exhausted.

* **Tests**
  * Expanded test coverage for fee-grant recovery scenarios, including successful recovery, retry-and-reissue, exhausted-retry failure, and cases with no prior allowance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->