### PR TITLE
fix(log-collector): prevent stale-resourceVersion reconnect loop

### DIFF
--- a/apps/log-collector/src/services/k8s-events-collector/k8s-events-collector.service.spec.ts
+++ b/apps/log-collector/src/services/k8s-events-collector/k8s-events-collector.service.spec.ts
@@ -12,7 +12,7 @@ import { seedPodInfoTestData } from "@test/seeders/pod-info.seeder";
 describe(K8sEventsCollectorService.name, () => {
   it("should watch events filtered by pod name and write formatted lines", async () => {
     const podInfo = seedPodInfoTestData();
-    const { service, ac, watch, writeStream } = setup({ podInfo });
+    const { service, ac, watch, writeStream, fireEvent, endWatch } = setup({ podInfo });
 
     const event = seedKubernetesEventTestData({
       involvedObject: { kind: "Pod", name: podInfo.podName, namespace: podInfo.namespace },
@@ -45,7 +45,7 @@ describe(K8sEventsCollectorService.name, () => {
 
   it("should log POD_EVENTS_WATCH_ESTABLISHED on first event received", async () => {
     const podInfo = seedPodInfoTestData();
-    const { service, ac, loggerService } = setup({ podInfo });
+    const { service, ac, watch, loggerService, fireEvent, endWatch } = setup({ podInfo });
 
     const event = seedKubernetesEventTestData({ involvedObject: { kind: "Pod", name: podInfo.podName, namespace: podInfo.namespace } });
 
@@ -69,7 +69,7 @@ describe(K8sEventsCollectorService.name, () => {
 
   it("should only include curated fields in the JSON output", async () => {
     const podInfo = seedPodInfoTestData();
-    const { service, ac, writeStream } = setup({ podInfo });
+    const { service, ac, watch, writeStream, fireEvent, endWatch } = setup({ podInfo });
 
     const event = seedKubernetesEventTestData({
       metadata: { resourceVersion: "200", uid: "some-uid", name: "event-name", creationTimestamp: new Date() },
@@ -96,7 +96,7 @@ describe(K8sEventsCollectorService.name, () => {
 
   it("should log POD_EVENTS_WATCH_FORBIDDEN and return on 403 error", async () => {
     const podInfo = seedPodInfoTestData();
-    const { service, loggerService, errorHandlerService } = setup({ podInfo });
+    const { service, watch, loggerService, errorHandlerService, endWatch } = setup({ podInfo });
 
     const forbiddenError = Object.assign(new Error("Forbidden"), { statusCode: 403 });
     errorHandlerService.isForbidden.mockReturnValue(true);
@@ -112,8 +112,7 @@ describe(K8sEventsCollectorService.name, () => {
   });
 
   it("should reconnect when watch ends without error", async () => {
-    const podInfo = seedPodInfoTestData();
-    const { service, ac } = setup({ podInfo });
+    const { service, ac, watch, endWatch } = setup();
 
     const startPromise = service.collectPodEvents();
     await vi.waitFor(() => expect(watch.watch).toHaveBeenCalledTimes(1));
@@ -126,26 +125,95 @@ describe(K8sEventsCollectorService.name, () => {
     await startPromise;
   });
 
-  it("should pass resourceVersion from last event on reconnect", async () => {
-    const podInfo = seedPodInfoTestData();
-    const { service, ac } = setup({ podInfo });
-
-    const event = seedKubernetesEventTestData({ metadata: { resourceVersion: "456" } });
+  it("passes the last-seen resourceVersion on normal reconnect to avoid duplicates", async () => {
+    const { service, ac, watch, fireEvent, endWatch, watchResourceVersionAt } = setup();
 
     const startPromise = service.collectPodEvents();
     await vi.waitFor(() => expect(watch.watch).toHaveBeenCalledTimes(1));
 
-    fireEvent("ADDED", event);
+    fireEvent("ADDED", seedKubernetesEventTestData({ metadata: { resourceVersion: "456" } }));
+    endWatch();
+    await vi.waitFor(() => expect(watch.watch).toHaveBeenCalledTimes(2));
+
+    expect(watchResourceVersionAt(1)).toBe("456");
+
+    ac.abort();
+    endWatch();
+    await startPromise;
+  });
+
+  it("does not write ERROR phase events to the output stream", async () => {
+    const { service, ac, watch, writeStream, fireEvent, endWatch, STATUS_TOO_OLD_RESOURCE_VERSION } = setup();
+    const normalEvent = seedKubernetesEventTestData({ reason: "Scheduled", lastTimestamp: "2025-06-15T10:30:00.000Z" as unknown as Date });
+
+    const startPromise = service.collectPodEvents();
+    await vi.waitFor(() => expect(watch.watch).toHaveBeenCalledTimes(1));
+
+    fireEvent("ERROR", STATUS_TOO_OLD_RESOURCE_VERSION);
+    fireEvent("ADDED", normalEvent);
+    await vi.waitFor(() => expect(writeStream.write).toHaveBeenCalled());
+
+    ac.abort();
+    endWatch();
+    await startPromise;
+
+    expect(writeStream.write).toHaveBeenCalledTimes(1);
+    expect(writeStream.write).toHaveBeenCalledWith(expect.stringContaining('"phase":"ADDED"'));
+  });
+
+  it("skips duplicate events on reconnect by uid:resourceVersion", async () => {
+    const { service, ac, watch, writeStream, fireEvent, endWatch } = setup();
+
+    const event1 = seedKubernetesEventTestData({
+      metadata: { uid: "uid-1", resourceVersion: "100" },
+      reason: "Scheduled",
+      lastTimestamp: "2025-06-15T10:30:00.000Z" as unknown as Date
+    });
+    const event2 = seedKubernetesEventTestData({
+      metadata: { uid: "uid-2", resourceVersion: "101" },
+      reason: "Started",
+      lastTimestamp: "2025-06-15T10:30:01.000Z" as unknown as Date
+    });
+
+    const startPromise = service.collectPodEvents();
+    await vi.waitFor(() => expect(watch.watch).toHaveBeenCalledTimes(1));
+
+    fireEvent("ADDED", event1);
+    fireEvent("ADDED", event2);
+    await vi.waitFor(() => expect(writeStream.write).toHaveBeenCalledTimes(2));
 
     endWatch();
     await vi.waitFor(() => expect(watch.watch).toHaveBeenCalledTimes(2));
 
-    expect(watch.watch).toHaveBeenLastCalledWith(
-      expect.any(String),
-      expect.objectContaining({ resourceVersion: "456" }),
-      expect.any(Function),
-      expect.any(Function)
-    );
+    fireEvent("ADDED", event1);
+    fireEvent("ADDED", event2);
+    const event3 = seedKubernetesEventTestData({
+      metadata: { uid: "uid-3", resourceVersion: "200" },
+      reason: "Pulled",
+      lastTimestamp: "2025-06-15T10:31:00.000Z" as unknown as Date
+    });
+    fireEvent("ADDED", event3);
+    await vi.waitFor(() => expect(writeStream.write).toHaveBeenCalledTimes(3));
+
+    ac.abort();
+    endWatch();
+    await startPromise;
+
+    expect(writeStream.write).toHaveBeenCalledTimes(3);
+  });
+
+  it("reconnects without a resourceVersion after an ERROR phase event", async () => {
+    const { service, ac, watch, fireEvent, endWatch, watchResourceVersionAt, STATUS_TOO_OLD_RESOURCE_VERSION } = setup();
+
+    const startPromise = service.collectPodEvents();
+    await vi.waitFor(() => expect(watch.watch).toHaveBeenCalledTimes(1));
+
+    fireEvent("ADDED", seedKubernetesEventTestData({ metadata: { resourceVersion: "111" } }));
+    fireEvent("ERROR", STATUS_TOO_OLD_RESOURCE_VERSION);
+    endWatch();
+    await vi.waitFor(() => expect(watch.watch).toHaveBeenCalledTimes(2));
+
+    expect(watchResourceVersionAt(1)).toBeUndefined();
 
     ac.abort();
     endWatch();
@@ -154,7 +222,7 @@ describe(K8sEventsCollectorService.name, () => {
 
   it("should throw on non-403 watch error", async () => {
     const podInfo = seedPodInfoTestData();
-    const { service, errorHandlerService } = setup({ podInfo });
+    const { service, watch, errorHandlerService, endWatch } = setup({ podInfo });
 
     const watchError = new Error("connection refused");
     errorHandlerService.isForbidden.mockReturnValue(false);
@@ -169,7 +237,7 @@ describe(K8sEventsCollectorService.name, () => {
 
   it("should stop when signal is aborted", async () => {
     const podInfo = seedPodInfoTestData();
-    const { service, ac } = setup({ podInfo });
+    const { service, ac, watch, endWatch } = setup({ podInfo });
 
     const startPromise = service.collectPodEvents();
     await vi.waitFor(() => expect(watch.watch).toHaveBeenCalled());
@@ -181,23 +249,16 @@ describe(K8sEventsCollectorService.name, () => {
     expect(watch.watch).toHaveBeenCalledTimes(1);
   });
 
-  let watch: ReturnType<typeof mock<Watch>>;
-  let eventCb: (phase: string, apiObj: CoreV1Event) => void;
-  let doneCb: (err?: unknown) => void;
-  const fireEvent = (phase: string, event: CoreV1Event) => eventCb(phase, event);
-  const endWatch = (err?: unknown) => doneCb(err);
-
   function setup(input: { podInfo?: ReturnType<typeof seedPodInfoTestData> } = {}) {
     const podInfo = input.podInfo ?? seedPodInfoTestData();
     const ac = new AbortController();
 
-    watch = mock<Watch>();
-    eventCb = () => {};
-    doneCb = () => {};
+    const watch = mock<Watch>();
+    const handlers: { eventCb?: (phase: string, apiObj: CoreV1Event) => void; doneCb?: (err?: unknown) => void } = {};
 
     watch.watch.mockImplementation(async (_path, _params, cb, done) => {
-      eventCb = cb;
-      doneCb = done;
+      handlers.eventCb = cb;
+      handlers.doneCb = done;
       return new AbortController();
     });
 
@@ -213,6 +274,24 @@ describe(K8sEventsCollectorService.name, () => {
 
     const service = new K8sEventsCollectorService(podInfo, fileDestination, watch, loggerService, errorHandlerService, ac.signal);
 
-    return { service, ac, watch, loggerService, errorHandlerService, fileDestination, writeStream };
+    return {
+      service,
+      ac,
+      watch,
+      loggerService,
+      errorHandlerService,
+      fileDestination,
+      writeStream,
+      fireEvent: (phase: string, event: CoreV1Event) => handlers.eventCb?.(phase, event),
+      endWatch: (err?: unknown) => handlers.doneCb?.(err),
+      watchResourceVersionAt: (callIndex: number) => (watch.watch.mock.calls[callIndex]?.[1] as { resourceVersion?: string } | undefined)?.resourceVersion,
+      STATUS_TOO_OLD_RESOURCE_VERSION: {
+        kind: "Status",
+        status: "Failure",
+        message: "too old resource version: 12345",
+        reason: "Expired",
+        code: 410
+      } as unknown as CoreV1Event
+    };
   }
 });

--- a/apps/log-collector/src/services/k8s-events-collector/k8s-events-collector.service.ts
+++ b/apps/log-collector/src/services/k8s-events-collector/k8s-events-collector.service.ts
@@ -8,6 +8,10 @@ import type { LoggerService } from "@src/services/logger/logger.service";
 import type { PodInfo } from "@src/services/pod-discovery/pod-discovery.service";
 
 export class K8sEventsCollectorService {
+  private lastWrittenTimestamp?: string;
+
+  private writtenEventKeys = new Set<string>();
+
   constructor(
     private readonly podInfo: PodInfo,
     private readonly fileDestination: FileDestinationService,
@@ -55,6 +59,10 @@ export class K8sEventsCollectorService {
       path,
       { fieldSelector, resourceVersion },
       (phase: string, apiObj: CoreV1Event) => {
+        if (phase === "ERROR") {
+          currentResourceVersion = undefined;
+          return;
+        }
         if (apiObj.metadata?.resourceVersion) {
           currentResourceVersion = apiObj.metadata.resourceVersion;
         }
@@ -80,6 +88,10 @@ export class K8sEventsCollectorService {
         established = true;
       }
 
+      if (this.isDuplicateEvent(event)) {
+        continue;
+      }
+
       writeStream.write(this.formatLine(phase, event));
     }
 
@@ -88,6 +100,29 @@ export class K8sEventsCollectorService {
     }
 
     return currentResourceVersion;
+  }
+
+  private isDuplicateEvent(event: CoreV1Event): boolean {
+    const uid = event.metadata?.uid;
+    const rv = event.metadata?.resourceVersion;
+    if (!uid || !rv) return false;
+
+    const timestamp = String(event.lastTimestamp ?? event.eventTime ?? "");
+
+    if (this.lastWrittenTimestamp && timestamp < this.lastWrittenTimestamp) {
+      return true;
+    }
+
+    if (timestamp !== this.lastWrittenTimestamp) {
+      this.writtenEventKeys.clear();
+      this.lastWrittenTimestamp = timestamp;
+    }
+
+    const key = `${uid}:${rv}`;
+    if (this.writtenEventKeys.has(key)) return true;
+
+    this.writtenEventKeys.add(key);
+    return false;
   }
 
   private formatLine(phase: string, event: CoreV1Event): string {

--- a/apps/log-collector/src/services/pod-discovery/pod-discovery.service.spec.ts
+++ b/apps/log-collector/src/services/pod-discovery/pod-discovery.service.spec.ts
@@ -65,7 +65,6 @@ describe(PodDiscoveryService.name, () => {
       event: "POD_DISCOVERY_COMPLETED",
       namespace,
       totalPods: 5,
-      readyPods: 5,
       targetPods: 2,
       currentPodName
     });
@@ -407,6 +406,144 @@ describe(PodDiscoveryService.name, () => {
     });
   });
 
+  describe("watchPods — clean watch end reconnect", () => {
+    it("re-lists and reconnects with a fresh resourceVersion after a clean watch end", async () => {
+      const namespace = faker.internet.domainWord();
+      const { podDiscoveryService, captureWatchHandlers, mockListsSequence } = setup({ KUBERNETES_NAMESPACE_OVERRIDE: namespace });
+      const watch = captureWatchHandlers();
+      mockListsSequence([{ resourceVersion: "rv-1" }, { resourceVersion: "rv-2" }]);
+
+      podDiscoveryService.watchPods(vi.fn()).catch(() => {});
+      await vi.waitFor(() => expect(watch.resourceVersionAt(0)).toBe("rv-1"));
+
+      watch.endWatchCleanly();
+
+      await vi.waitFor(() => expect(watch.resourceVersionAt(1)).toBe("rv-2"));
+    });
+
+    it("tracks new pods discovered when re-listing after a clean watch end", async () => {
+      const namespace = faker.internet.domainWord();
+      const { podDiscoveryService, captureWatchHandlers, mockListsSequence, readyPod } = setup({
+        KUBERNETES_NAMESPACE_OVERRIDE: namespace
+      });
+      const watch = captureWatchHandlers();
+      const pod1 = readyPod({ name: "pod-1", namespace });
+      const pod2 = readyPod({ name: "pod-2", namespace });
+      mockListsSequence([{ items: [pod1] }, { items: [pod1, pod2] }]);
+
+      const callback = vi.fn();
+      podDiscoveryService.watchPods(callback).catch(() => {});
+      await vi.waitFor(() => expect(callback).toHaveBeenCalledTimes(1));
+
+      watch.endWatchCleanly();
+
+      await vi.waitFor(() => expect(callback).toHaveBeenCalledTimes(2));
+      expect(callback).toHaveBeenLastCalledWith(expect.objectContaining({ podName: "pod-2" }), expect.any(AbortSignal));
+    });
+
+    it("aborts signals for pods missing on the re-list after a clean watch end", async () => {
+      const namespace = faker.internet.domainWord();
+      const { podDiscoveryService, loggerService, captureWatchHandlers, mockListsSequence, readyPod } = setup({
+        KUBERNETES_NAMESPACE_OVERRIDE: namespace
+      });
+      const watch = captureWatchHandlers();
+      const pod1 = readyPod({ name: "pod-1", namespace });
+      const pod2 = readyPod({ name: "pod-2", namespace });
+      mockListsSequence([{ items: [pod1, pod2] }, { items: [pod1] }]);
+
+      const signals: AbortSignal[] = [];
+      const callback: PodCallback = vi.fn((_p, signal) => signals.push(signal));
+
+      podDiscoveryService.watchPods(callback).catch(() => {});
+      await vi.waitFor(() => expect(signals).toHaveLength(2));
+
+      watch.endWatchCleanly();
+
+      await vi.waitFor(() => expect(signals[1].aborted).toBe(true));
+      expect(loggerService.info).toHaveBeenCalledWith(expect.objectContaining({ event: "POD_DELETED", podName: "pod-2" }));
+    });
+
+    it("falls back to polling when the server emits an ERROR watch event", async () => {
+      const originalTimeout = AbortSignal.timeout;
+      AbortSignal.timeout = (ms: number) => originalTimeout(Math.min(ms, 200));
+
+      try {
+        const namespace = faker.internet.domainWord();
+        const { podDiscoveryService, k8sClient, loggerService, captureWatchHandlers, STATUS_TOO_OLD_RESOURCE_VERSION } = setup({
+          KUBERNETES_NAMESPACE_OVERRIDE: namespace,
+          POD_POLL_INTERVAL_MS: "100"
+        });
+        const watch = captureWatchHandlers();
+        k8sClient.listNamespacedPod.mockResolvedValue({ items: [] });
+
+        podDiscoveryService.watchPods(vi.fn()).catch(() => {});
+        await flushPromises();
+
+        watch.fireEvent("ERROR", STATUS_TOO_OLD_RESOURCE_VERSION);
+
+        await vi.waitFor(() => {
+          expect(loggerService.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "POD_WATCH_FAILED_FALLBACK_TO_POLLING" }));
+        });
+      } finally {
+        AbortSignal.timeout = originalTimeout;
+      }
+    });
+
+    it("still falls back to polling when an ERROR event is followed by a clean stream close", async () => {
+      const originalTimeout = AbortSignal.timeout;
+      AbortSignal.timeout = (ms: number) => originalTimeout(Math.min(ms, 200));
+
+      try {
+        const namespace = faker.internet.domainWord();
+        const { podDiscoveryService, k8sClient, loggerService, captureWatchHandlers, STATUS_TOO_OLD_RESOURCE_VERSION } = setup({
+          KUBERNETES_NAMESPACE_OVERRIDE: namespace,
+          POD_POLL_INTERVAL_MS: "100"
+        });
+        const watch = captureWatchHandlers();
+        k8sClient.listNamespacedPod.mockResolvedValue({ items: [] });
+
+        podDiscoveryService.watchPods(vi.fn()).catch(() => {});
+        await flushPromises();
+
+        watch.fireEvent("ERROR", STATUS_TOO_OLD_RESOURCE_VERSION);
+        watch.endWatchCleanly();
+
+        await vi.waitFor(() => {
+          expect(loggerService.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "POD_WATCH_FAILED_FALLBACK_TO_POLLING" }));
+        });
+      } finally {
+        AbortSignal.timeout = originalTimeout;
+      }
+    });
+
+    it("keeps tracking a pod that becomes not-ready between watches", async () => {
+      const namespace = faker.internet.domainWord();
+      const { podDiscoveryService, k8sClient, captureWatchHandlers, mockListsSequence, readyPod, loggerService } = setup({
+        KUBERNETES_NAMESPACE_OVERRIDE: namespace
+      });
+      const watch = captureWatchHandlers();
+      const podReady = readyPod({ name: "pod-1", namespace });
+      const podSameButNotReady: V1Pod = {
+        ...podReady,
+        status: { ...podReady.status, conditions: [{ type: "Ready", status: "False" }] }
+      };
+      mockListsSequence([{ items: [podReady] }, { items: [podSameButNotReady] }]);
+
+      const signals: AbortSignal[] = [];
+      const callback: PodCallback = vi.fn((_p, signal) => signals.push(signal));
+
+      podDiscoveryService.watchPods(callback).catch(() => {});
+      await vi.waitFor(() => expect(signals).toHaveLength(1));
+
+      watch.endWatchCleanly();
+
+      await vi.waitFor(() => expect(k8sClient.listNamespacedPod).toHaveBeenCalledTimes(2));
+      await flushPromises();
+      expect(signals[0].aborted).toBe(false);
+      expect(loggerService.info).not.toHaveBeenCalledWith(expect.objectContaining({ event: "POD_DELETED", podName: "pod-1" }));
+    });
+  });
+
   describe("watchPods — fallback to polling", () => {
     it("should fall back to polling permanently on 403", async () => {
       const namespace = faker.internet.domainWord();
@@ -639,7 +776,54 @@ describe(PodDiscoveryService.name, () => {
 
     const podDiscoveryService = new PodDiscoveryService(k8sClient, kubeConfig, config, loggerService, errorHandlerService, watch);
 
-    return { podDiscoveryService, k8sClient, kubeConfig, config, loggerService, watch, errorHandlerService };
+    const handlers: { eventCb?: (phase: string, obj: unknown) => void; doneCb?: (err?: unknown) => void } = {};
+    const captureWatchHandlers = () => {
+      watch.watch.mockImplementation(async (_path, _params, cb, done) => {
+        handlers.eventCb = cb as (phase: string, obj: unknown) => void;
+        handlers.doneCb = done;
+        return new AbortController();
+      });
+      return {
+        fireEvent: (phase: string, obj: unknown) => handlers.eventCb?.(phase, obj),
+        endWatchCleanly: () => handlers.doneCb?.(),
+        resourceVersionAt: (callIndex: number) => (watch.watch.mock.calls[callIndex]?.[1] as { resourceVersion?: string } | undefined)?.resourceVersion
+      };
+    };
+
+    const mockListsSequence = (responses: Array<{ items?: V1Pod[]; resourceVersion?: string }>) => {
+      let call = 0;
+      k8sClient.listNamespacedPod.mockImplementation(async () => {
+        const response = responses[Math.min(call++, responses.length - 1)];
+        return { items: response.items ?? [], metadata: { resourceVersion: response.resourceVersion } };
+      });
+    };
+
+    const readyPod = (params: { name: string; namespace: string }): V1Pod =>
+      seedKubernetesPodTestData({
+        metadata: { name: params.name, namespace: params.namespace },
+        spec: { containers: [{ name: "app" }] },
+        status: { phase: "Running", conditions: [{ type: "Ready", status: "True" }] }
+      });
+
+    return {
+      podDiscoveryService,
+      k8sClient,
+      kubeConfig,
+      config,
+      loggerService,
+      watch,
+      errorHandlerService,
+      captureWatchHandlers,
+      mockListsSequence,
+      readyPod,
+      STATUS_TOO_OLD_RESOURCE_VERSION: {
+        kind: "Status",
+        status: "Failure",
+        message: "too old resource version: 12345",
+        reason: "Expired",
+        code: 410
+      }
+    };
   }
 });
 

--- a/apps/log-collector/src/services/pod-discovery/pod-discovery.service.ts
+++ b/apps/log-collector/src/services/pod-discovery/pod-discovery.service.ts
@@ -114,18 +114,16 @@ export class PodDiscoveryService {
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // Event stream generators
-  // ---------------------------------------------------------------------------
-
   /**
    * Top-level orchestrator generator.
-   * - Tries K8s watch. If it connects and later ends, reconnects immediately.
+   * - Tries K8s watch. On clean end, re-lists to anchor a fresh resourceVersion
+   *   before reconnecting (canonical ListAndWatch pattern — avoids tight-loop
+   *   reconnects with a stale resourceVersion the server has already evicted).
    * - On 403, yields from permanent polling.
    * - On other errors, yields from timed polling, then retries watch.
    *
-   * Threads resourceVersion from initial list → watch → polling → next watch
-   * to avoid missing events between transitions. Resets accumulated watch
+   * Threads resourceVersion from initial list → watch → re-list/polling → next
+   * watch to avoid missing events between transitions. Resets accumulated watch
    * errors after a successful watch connection.
    *
    * @param initialResourceVersion - resourceVersion from the initial pod list, used for the first watch
@@ -139,6 +137,9 @@ export class PodDiscoveryService {
       try {
         yield* this.watchEvents(resourceVersion);
         watchErrors.length = 0;
+        const listing = await this.listPodsRaw();
+        yield* this.reconcileTrackedPods(listing.pods);
+        resourceVersion = listing.resourceVersion;
       } catch (error) {
         if (this.errorHandlerService.isForbidden(error)) {
           this.loggerService.warn({
@@ -184,6 +185,13 @@ export class PodDiscoveryService {
         path,
         { labelSelector, resourceVersion },
         (phase: string, apiObj: V1Pod) => {
+          if (phase === "ERROR") {
+            isDone = true;
+            doneError = new Error((apiObj as unknown as { message?: string }).message || "Pod watch terminated by server");
+            channel.close();
+            return;
+          }
+
           if (phase === "DELETED") {
             const podName = apiObj.metadata?.name;
             if (podName && this.controllers.has(podName)) {
@@ -200,6 +208,7 @@ export class PodDiscoveryService {
           }
         },
         (err?: unknown) => {
+          if (isDone) return;
           isDone = true;
           doneError = err;
           channel.close();
@@ -239,9 +248,9 @@ export class PodDiscoveryService {
     try {
       while (!signal?.aborted) {
         try {
-          const { pods: currentPods, resourceVersion } = await this.discoverPodsInNamespace();
-          lastResourceVersion = resourceVersion;
-          yield* this.reconcilePolledPods(currentPods);
+          const listing = await this.listPodsRaw();
+          lastResourceVersion = listing.resourceVersion;
+          yield* this.reconcileTrackedPods(listing.pods);
           consecutiveErrors.length = 0;
         } catch (error) {
           consecutiveErrors.push(error instanceof Error ? error : new Error(String(error)));
@@ -265,27 +274,6 @@ export class PodDiscoveryService {
     return lastResourceVersion;
   }
 
-  /** Diffs polled pods against tracked state, yielding add/delete events. */
-  private *reconcilePolledPods(currentPods: PodInfo[]): Generator<PodEvent> {
-    const currentPodNames = new Set(currentPods.map(p => p.podName));
-
-    for (const pod of currentPods) {
-      if (!this.controllers.has(pod.podName)) {
-        yield { type: "added", podInfo: pod };
-      }
-    }
-
-    for (const podName of this.controllers.keys()) {
-      if (!currentPodNames.has(podName)) {
-        yield { type: "deleted", podName };
-      }
-    }
-  }
-
-  // ---------------------------------------------------------------------------
-  // Pod discovery & filtering
-  // ---------------------------------------------------------------------------
-
   /**
    * Discovers all pods in the current namespace, excluding the current pod
    *
@@ -294,35 +282,62 @@ export class PodDiscoveryService {
    */
   async discoverPodsInNamespace(): Promise<{ pods: PodInfo[]; resourceVersion?: string }> {
     const namespace = this.getCurrentNamespace();
-
     this.loggerService.debug({ event: "POD_DISCOVERY_STARTED", namespace });
 
-    const response = await this.k8sClient.listNamespacedPod({
-      namespace,
-      labelSelector: this.config.get("POD_LABEL_SELECTOR")
-    });
-
-    const resourceVersion = response.metadata?.resourceVersion;
-    const currentPodName = this.config.get("HOSTNAME");
-    const pods = response.items.filter(pod => this.isPodReady(pod)).map(pod => this.mapPodToInfo(pod, namespace));
-
-    const targetPods = this.filterOutPodsFromSameDeployment(pods, currentPodName);
+    const { pods, totalPods, resourceVersion } = await this.listPodsRaw();
+    const targetPods = pods.filter(pod => this.isPodReady(pod)).map(pod => this.mapPodToInfo(pod, namespace));
 
     this.loggerService.debug({
       event: "POD_DISCOVERY_COMPLETED",
       namespace,
-      totalPods: response.items.length,
-      readyPods: pods.length,
+      totalPods,
       targetPods: targetPods.length,
-      currentPodName
+      currentPodName: this.config.get("HOSTNAME")
     });
 
     return { pods: targetPods, resourceVersion };
   }
 
-  // ---------------------------------------------------------------------------
-  // Pod tracking
-  // ---------------------------------------------------------------------------
+  private async listPodsRaw() {
+    const namespace = this.getCurrentNamespace();
+    const response = await this.k8sClient.listNamespacedPod({
+      namespace,
+      labelSelector: this.config.get("POD_LABEL_SELECTOR")
+    });
+    const currentPodName = this.config.get("HOSTNAME");
+
+    return {
+      pods: response.items.filter(pod => pod.metadata?.name && !this.isPodFromSameDeployment(pod.metadata.name, currentPodName)),
+      totalPods: response.items.length,
+      resourceVersion: response.metadata?.resourceVersion
+    };
+  }
+
+  /**
+   * Reconciles the tracked pod set against a fresh pod listing.
+   *
+   * Additions are driven by ready pods only, but deletions are checked
+   * against every pod present in the namespace — a pod that is still there
+   * but transiently `Ready=False` must keep its existing stream, matching
+   * the watch behavior that only untracks on a real `DELETED` event.
+   */
+  private *reconcileTrackedPods(pods: V1Pod[]): Generator<PodEvent> {
+    const namespace = this.getCurrentNamespace();
+    const existingPodNames = new Set(pods.map(pod => pod.metadata?.name).filter(Boolean));
+    const readyPods = pods.filter(pod => this.isPodReady(pod)).map(pod => this.mapPodToInfo(pod, namespace));
+
+    for (const pod of readyPods) {
+      if (!this.controllers.has(pod.podName)) {
+        yield { type: "added", podInfo: pod };
+      }
+    }
+
+    for (const podName of this.controllers.keys()) {
+      if (!existingPodNames.has(podName)) {
+        yield { type: "deleted", podName };
+      }
+    }
+  }
 
   /**
    * Starts tracking a pod by creating an AbortController and invoking the callback.
@@ -364,10 +379,6 @@ export class PodDiscoveryService {
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // Pod filtering utilities
-  // ---------------------------------------------------------------------------
-
   /**
    * Filters a raw V1Pod through readiness and same-deployment checks.
    *
@@ -405,6 +416,8 @@ export class PodDiscoveryService {
    * @returns true if the pod belongs to the same deployment
    */
   private isPodFromSameDeployment(podName: string, currentPodName: string): boolean {
+    if (podName === currentPodName) return true;
+
     const currentParts = currentPodName.split("-");
     if (currentParts.length < 3) return false;
     const currentDeployment = currentParts.slice(0, -2).join("-");
@@ -415,21 +428,6 @@ export class PodDiscoveryService {
 
     return podDeployment === currentDeployment;
   }
-
-  /**
-   * Filters out all pods from the same deployment as the current pod.
-   *
-   * @param pods - Array of discovered pods
-   * @param currentPodName - Name of the current pod
-   * @returns Array of pods excluding all pods from the same deployment
-   */
-  private filterOutPodsFromSameDeployment(pods: PodInfo[], currentPodName: string): PodInfo[] {
-    return pods.filter(pod => pod.podName !== currentPodName && !this.isPodFromSameDeployment(pod.podName, currentPodName));
-  }
-
-  // ---------------------------------------------------------------------------
-  // Namespace resolution
-  // ---------------------------------------------------------------------------
 
   /**
    * Determines the current namespace for pod discovery


### PR DESCRIPTION
## Why

Fixes CON-211.

Log-collector entered a tight reconnect loop with the Kubernetes API on idle deployments, flooding the user-visible log stream with thousands of watch-reconnection entries (~107k observed on a single instance in production) and drowning out actual workload logs.

Root cause: after a clean watch termination, the next watch was re-issued with the previous `resourceVersion`. Once the server had evicted that version, it rejected the watch via an `ERROR` watch event (the library delivers these as events, not as stream errors), the stream closed cleanly, and the reconnect happened again with the same stale version — indefinitely.

## What

- **Pod discovery:** on every clean watch end, re-list pods to anchor a fresh `resourceVersion` before reconnecting (canonical ListAndWatch). `ERROR` phase events are surfaced as watch failures, routing them into the existing polling-fallback path. The done-callback is guarded so a subsequent `done(null)` from the library can't overwrite a captured ERROR. Shared `listPodsRaw` + `reconcileTrackedPods` eliminate duplication between the watch-reconnect and polling paths, and fix polling's pre-existing issue of deleting transiently-not-ready pods.
- **K8s events collector:** restored `resourceVersion` threading between watches (avoids duplicate events on normal reconnect), with `ERROR` phase clearing the RV so the next reconnect starts fresh instead of looping. Added `uid:resourceVersion` dedup to skip replayed events on fresh reconnects.
- Tests added for both: re-list/reconcile on clean end, new/removed pods across the gap, ERROR-event handling, ERROR+clean-close sequence, transient not-ready preservation, event dedup across reconnects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate Kubernetes events from being written across watch/reconnect cycles.
  * Ensure watcher ERROR events clear stored resourceVersion so reconnects don’t resume from stale state.
  * Corrected pod-state handling so ready→not-ready transitions aren’t misclassified as deletions.

* **Improvements**
  * Re-listing after watch end to reconcile state and use fresh resourceVersion for subsequent watches.
  * In-memory deduplication of event writes and pruning of stale dedupe state.
  * More robust reconciliation and polling behavior for pod discovery.

* **Tests**
  * Expanded and refactored test harness; added tests for reconnects, error handling, deduplication, and clean-watch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->