### PR TITLE
chore: sets permissions on gh workflows

### DIFF
--- a/.github/workflows/akash-templates-publisher.yml
+++ b/.github/workflows/akash-templates-publisher.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 15 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-deploy-templates:
     runs-on: [self-hosted, akash]

--- a/.github/workflows/all-deploy-testnet.yml
+++ b/.github/workflows/all-deploy-testnet.yml
@@ -3,6 +3,9 @@ name: Release next-sdk to sandbox
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   scale-down-services:
     runs-on: ubuntu-latest
@@ -84,6 +87,9 @@ jobs:
 
   deploy-console-api:
     name: Deploy to console-api sandbox
+    permissions:
+      contents: read
+      deployments: write
     uses: ./.github/workflows/reusable-deploy-k8s.yml
     secrets: inherit
     with:
@@ -96,6 +102,9 @@ jobs:
   deploy-notifications:
     needs: scale-down-services
     name: Deploy to beta sandbox
+    permissions:
+      contents: read
+      deployments: write
     uses: ./.github/workflows/reusable-deploy-k8s.yml
     secrets: inherit
     with:
@@ -106,6 +115,9 @@ jobs:
   deploy-console-web:
     needs: [ deploy-console-api, deploy-notifications]
     name: Deploy to beta sandbox
+    permissions:
+      contents: read
+      deployments: write
     uses: ./.github/workflows/reusable-deploy-k8s.yml
     secrets: inherit
     with:

--- a/.github/workflows/auto-approval.yml
+++ b/.github/workflows/auto-approval.yml
@@ -5,6 +5,10 @@ on:
     workflows: ["CI"]
     types: [completed]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check-whether-to-approve:
     if: github.event.workflow_run.conclusion == 'success'

--- a/.github/workflows/console-api-deploy-testnet.yml
+++ b/.github/workflows/console-api-deploy-testnet.yml
@@ -6,9 +6,15 @@ on:
       - main-sdk-next
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   should-deploy:
     name: Decide Whether to Deploy
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/reusable-should-validate.yml
     with:
       path: apps/console-api
@@ -30,6 +36,9 @@ jobs:
   deploy-beta-testnet:
     needs: build
     name: Deploy to beta sandbox
+    permissions:
+      contents: read
+      deployments: write
     uses: ./.github/workflows/reusable-deploy-k8s.yml
     secrets: inherit
     with:

--- a/.github/workflows/console-api-release.yml
+++ b/.github/workflows/console-api-release.yml
@@ -13,12 +13,18 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false # don't cancel deployments!
 
 jobs:
   setup:
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/reusable-deploy-setup.yml
     with:
       app: console-api

--- a/.github/workflows/console-web-deploy-testnet.yml
+++ b/.github/workflows/console-web-deploy-testnet.yml
@@ -6,9 +6,15 @@ on:
       - main-sdk-next
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   should-deploy:
     name: Decide Whether to Deploy
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/reusable-should-validate.yml
     with:
       path: apps/console-web
@@ -49,6 +55,9 @@ jobs:
     needs: [build-beta-testnet, build-beta]
     name: Deploy to Beta Testnet
     if: needs.build-beta-testnet.outputs.base_image_tag != ''
+    permissions:
+      contents: read
+      deployments: write
     uses: ./.github/workflows/reusable-deploy-k8s.yml
     secrets: inherit
     with:

--- a/.github/workflows/console-web-release.yml
+++ b/.github/workflows/console-web-release.yml
@@ -13,12 +13,18 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false # don't cancel deployments!
 
 jobs:
   setup:
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/reusable-deploy-setup.yml
     with:
       app: console-web

--- a/.github/workflows/create-issue-branch.yml
+++ b/.github/workflows/create-issue-branch.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  contents: write
+  issues: write
+
 jobs:
   create-branch:
     if: github.event.label.name == 'ready-for-dev'

--- a/.github/workflows/github-actions-lint.yml
+++ b/.github/workflows/github-actions-lint.yml
@@ -7,6 +7,9 @@ on:
       - .github/actions/**
       - .github/workflows/**
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: [self-hosted, akash]

--- a/.github/workflows/indexer-deploy-testnet.yml
+++ b/.github/workflows/indexer-deploy-testnet.yml
@@ -6,9 +6,15 @@ on:
       - main-sdk-next
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   should-deploy:
     name: Decide Whether to Deploy
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/reusable-should-validate.yml
     with:
       path: apps/indexer
@@ -30,6 +36,9 @@ jobs:
   deploy-beta-testnet:
     needs: build
     name: Deploy testnet to beta
+    permissions:
+      contents: read
+      deployments: write
     uses: ./.github/workflows/reusable-deploy-k8s.yml
     secrets: inherit
     with:

--- a/.github/workflows/indexer-release.yml
+++ b/.github/workflows/indexer-release.yml
@@ -13,12 +13,18 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false # don't cancel deployments!
 
 jobs:
   setup:
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/reusable-deploy-setup.yml
     with:
       app: indexer

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   label:
     permissions:

--- a/.github/workflows/log-collector-release.yml
+++ b/.github/workflows/log-collector-release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
   release:
     name: Create Release

--- a/.github/workflows/notifications-deploy-testnet.yml
+++ b/.github/workflows/notifications-deploy-testnet.yml
@@ -6,9 +6,15 @@ on:
       - main-sdk-next
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   should-deploy:
     name: Decide Whether to Deploy
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/reusable-should-validate.yml
     with:
       path: apps/notifications
@@ -31,6 +37,9 @@ jobs:
   deploy-beta:
     needs: build
     name: Deploy to beta sandbox
+    permissions:
+      contents: read
+      deployments: write
     uses: ./.github/workflows/reusable-deploy-k8s.yml
     secrets: inherit
     with:

--- a/.github/workflows/notifications-release.yml
+++ b/.github/workflows/notifications-release.yml
@@ -13,12 +13,18 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false # don't cancel deployments!
 
 jobs:
   setup:
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/reusable-deploy-setup.yml
     with:
       app: notifications

--- a/.github/workflows/provider-proxy-release.yml
+++ b/.github/workflows/provider-proxy-release.yml
@@ -13,12 +13,18 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false # don't cancel deployments!
 
 jobs:
   setup:
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/reusable-deploy-setup.yml
     with:
       app: provider-proxy

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -50,7 +50,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ inputs.tag }}
 
 permissions:
-  contents: write
+  contents: read
   packages: write
 
 jobs:

--- a/.github/workflows/reusable-deploy-k8s.yml
+++ b/.github/workflows/reusable-deploy-k8s.yml
@@ -89,6 +89,9 @@ on:
         description: >-
           Whether to require manual approval before proceeding with the deployment.
 
+permissions:
+  contents: read
+
 # 1 pending + 1 in-progress workflows
 concurrency:
   group: deploy-${{ inputs.app }}-${{ inputs.environment }}-${{ inputs.chain || 'NA' }}

--- a/.github/workflows/reusable-release-app.yml
+++ b/.github/workflows/reusable-release-app.yml
@@ -23,6 +23,9 @@ on:
         description: "The Docker image tag"
         value: ${{ jobs.build.outputs.image_tag }}
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Create Release

--- a/.github/workflows/reusable-release-nextjs-app.yml
+++ b/.github/workflows/reusable-release-nextjs-app.yml
@@ -26,6 +26,9 @@ on:
         description: "The prod Docker image tag"
         value: ${{ jobs.build-prod.outputs.image_tag }}
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Create Release

--- a/.github/workflows/reusable-should-validate.yml
+++ b/.github/workflows/reusable-should-validate.yml
@@ -18,6 +18,10 @@ on:
         description: "Whether app has PR level changes"
         value: ${{ jobs.should-validate.outputs.has_changes }}
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.path }}
   cancel-in-progress: true
@@ -31,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: ./.github/actions/local-dependencies
         if: contains(inputs.path, 'apps/')

--- a/.github/workflows/reusable-validate-app-unsafe.yml
+++ b/.github/workflows/reusable-validate-app-unsafe.yml
@@ -33,6 +33,10 @@ on:
         description: "snyk token used to test code for security issues"
         required: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   should-validate-unsafe:
     if: ${{ !inputs.skip_change_detection }}

--- a/.github/workflows/reusable-validate-app.yml
+++ b/.github/workflows/reusable-validate-app.yml
@@ -14,6 +14,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   should-validate:

--- a/.github/workflows/stats-web-release.yml
+++ b/.github/workflows/stats-web-release.yml
@@ -13,12 +13,18 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false # don't cancel deployments!
 
 jobs:
   setup:
+    permissions:
+      contents: read
+      actions: read
     uses: ./.github/workflows/reusable-deploy-setup.yml
     with:
       app: stats-web

--- a/.github/workflows/tx-signer-release.yml
+++ b/.github/workflows/tx-signer-release.yml
@@ -13,6 +13,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false # don't cancel deployments!
@@ -20,6 +23,9 @@ concurrency:
 jobs:
   setup:
     uses: ./.github/workflows/reusable-deploy-setup.yml
+    permissions:
+      contents: read
+      actions: read
     with:
       app: tx-signer
       image_tag: ${{ inputs.image_tag || github.ref_name }}


### PR DESCRIPTION
## Why

To make workflows work in scope of permissions they need. This increases safety and reduces blast radius for security attacks on our CI

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized and added explicit workflow-level GitHub Actions permissions across CI/CD workflows to set clearer default token scopes (mostly read-only). Job-level permission overrides were preserved where deployments or actions require elevated scopes. No changes to runtime behavior, deployment logic, or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->