### PR TITLE
fix(billing): treat partial ACT mint as success when AKT caps the burn

### DIFF
--- a/apps/api/src/billing/services/master-wallet-mint/master-wallet-mint.service.spec.ts
+++ b/apps/api/src/billing/services/master-wallet-mint/master-wallet-mint.service.spec.ts
@@ -48,7 +48,7 @@ describe(MasterWalletMintService.name, () => {
         balances: { uact: 5_000_000_000, uakt: 99_999_999_999 },
         aktPrice: 0.5
       });
-      mockBalancesOnce(chainSdk, { uact: 10_000_000_000, uakt: 89_799_999_999 });
+      mockBalancesOnce(chainSdk, { uact: 10_100_000_000, uakt: 89_799_999_999 });
 
       const result = await service.mintIfNeeded();
 
@@ -80,7 +80,7 @@ describe(MasterWalletMintService.name, () => {
         balances: { uact: 5_000_000_000, uakt: 99_999_999_999 },
         aktPrice: 0.5
       });
-      mockBalancesOnce(chainSdk, { uact: 10_000_000_000, uakt: 89_799_999_999 });
+      mockBalancesOnce(chainSdk, { uact: 10_100_000_000, uakt: 89_799_999_999 });
 
       const pendingRecord = createBmeLedgerRecord({ status: 1 });
       chainSdk.akash.bme.v1.getLedgerRecords
@@ -127,7 +127,108 @@ describe(MasterWalletMintService.name, () => {
       const result = await service.mintIfNeeded();
 
       expect(result.err).toBe(true);
-      expect(result.val).toBe("ACT balance still below target after mint");
+      expect(result.val).toBe("ACT balance still below expected after mint");
+    });
+
+    it("should fail when AKT price is invalid", async () => {
+      const { service, denomExchangeService } = setup({
+        targetActBalance: 10_000_000_000,
+        balances: { uact: 5_000_000_000, uakt: 99_999_999_999 }
+      });
+      denomExchangeService.getExchangeRateToUSD.mockResolvedValue(createDenomExchangeRate({ price: 0 }));
+
+      const result = await service.mintIfNeeded();
+
+      expect(result.err).toBe(true);
+      expect(result.val).toBe("Invalid AKT price: 0");
+    });
+
+    it("should fail when mint transaction returns a non-zero code", async () => {
+      const { service, txManagerService } = setup({
+        targetActBalance: 10_000_000_000,
+        balances: { uact: 5_000_000_000, uakt: 99_999_999_999 },
+        aktPrice: 0.5
+      });
+      txManagerService.signAndBroadcastWithFundingWallet.mockResolvedValue({ code: 11, hash: "FAIL", rawLog: "insufficient funds" });
+
+      const result = await service.mintIfNeeded();
+
+      expect(result.err).toBe(true);
+      expect(result.val).toBe("Transaction failed with code 11: insufficient funds");
+    });
+
+    it("should cap burn amount and scale expected ACT when AKT partially covers the mint", async () => {
+      const { service, chainSdk, rpcMessageService, masterAddress } = setup({
+        targetActBalance: 10_000_000_000,
+        balances: { uact: 5_000_000_000, uakt: 5_200_000_000 },
+        aktPrice: 0.5
+      });
+      mockBalancesOnce(chainSdk, { uact: 7_500_000_000, uakt: 0 });
+
+      const result = await service.mintIfNeeded();
+
+      expect(result).toEqual(Ok.EMPTY);
+      // available = 5_200_000_000 - 100_000_000 reserve = 5_100_000_000 (< 10_200_000_000 requested)
+      // expected ACT = floor(5_100_000_000 * 0.5 / 1.02) = 2_500_000_000
+      // expectedActBalance = 5_000_000_000 + 2_500_000_000 = 7_500_000_000
+      expect(rpcMessageService.getMintACTMsg).toHaveBeenCalledWith({
+        owner: masterAddress,
+        amount: 5_100_000_000
+      });
+    });
+
+    it("should bump mint amount to the BME minimum when deficit is smaller", async () => {
+      const { service, chainSdk, rpcMessageService, masterAddress } = setup({
+        targetActBalance: 10_000_000_000,
+        balances: { uact: 9_999_000_000, uakt: 99_999_999_999 },
+        aktPrice: 0.5
+      });
+      mockBalancesOnce(chainSdk, { uact: 10_009_000_000, uakt: 0 });
+
+      const result = await service.mintIfNeeded();
+
+      expect(result).toEqual(Ok.EMPTY);
+      // deficit = 1_000_000 uact, BME minMintUact = 10_000_000
+      // aktToBurn = ceil(10_000_000 / 0.5 * 1.02) = 20_400_000
+      expect(rpcMessageService.getMintACTMsg).toHaveBeenCalledWith({
+        owner: masterAddress,
+        amount: 20_400_000
+      });
+    });
+
+    it("should fall back to default minimum mint when uact denom is absent from BME params", async () => {
+      const { service, bmeHttpService, chainSdk, rpcMessageService, masterAddress } = setup({
+        targetActBalance: 10_000_000_000,
+        balances: { uact: 9_999_000_000, uakt: 99_999_999_999 },
+        aktPrice: 0.5
+      });
+      bmeHttpService.getParams.mockResolvedValue({ params: { min_mint: [{ denom: "uother", amount: "500000" }] } });
+      mockBalancesOnce(chainSdk, { uact: 10_009_000_000, uakt: 0 });
+
+      const result = await service.mintIfNeeded();
+
+      expect(result).toEqual(Ok.EMPTY);
+      // fallback minMintUact = 10_000_000; aktToBurn = ceil(10_000_000 / 0.5 * 1.02) = 20_400_000
+      expect(rpcMessageService.getMintACTMsg).toHaveBeenCalledWith({
+        owner: masterAddress,
+        amount: 20_400_000
+      });
+    });
+
+    it("should keep polling until ACT balance reaches expected after mint", async () => {
+      const { service, chainSdk } = setup({
+        targetActBalance: 10_000_000_000,
+        balances: { uact: 5_000_000_000, uakt: 99_999_999_999 },
+        aktPrice: 0.5
+      });
+      mockBalancesOnce(chainSdk, { uact: 5_000_000_000, uakt: 89_799_999_999 });
+      mockBalancesOnce(chainSdk, { uact: 10_100_000_000, uakt: 89_799_999_999 });
+
+      const result = await service.mintIfNeeded();
+
+      expect(result).toEqual(Ok.EMPTY);
+      // 1 initial fetch + 2 verification polls
+      expect(chainSdk.cosmos.bank.v1beta1.getAllBalances).toHaveBeenCalledTimes(3);
     });
 
     it("should skip broadcasting when dry-run is enabled", async () => {

--- a/apps/api/src/billing/services/master-wallet-mint/master-wallet-mint.service.ts
+++ b/apps/api/src/billing/services/master-wallet-mint/master-wallet-mint.service.ts
@@ -42,7 +42,8 @@ export class MasterWalletMintService {
   async mintIfNeeded(options?: DryRunOptions): Promise<Result<void, string>> {
     const address = await this.txManagerService.getFundingWalletAddress();
     const balances = await this.fetchWalletBalances(address);
-    const deficit = this.billingConfigService.get("MASTER_WALLET_TARGET_ACT_BALANCE") - this.findBalance(balances, "uact");
+    const currentUactBalance = this.findBalance(balances, "uact");
+    const deficit = this.billingConfigService.get("MASTER_WALLET_TARGET_ACT_BALANCE") - currentUactBalance;
 
     if (deficit <= 0) {
       this.logger.info({ event: "MASTER_WALLET_MINT_SKIPPED", deficit });
@@ -55,14 +56,15 @@ export class MasterWalletMintService {
       return calculation;
     }
 
-    const aktToBurn = calculation.val;
+    const aktToBurn = calculation.val.akt;
+    const expectedActBalance = currentUactBalance + calculation.val.act;
 
     if (options?.dryRun) {
-      this.logger.info({ event: "MASTER_WALLET_MINT_DRY_RUN", deficit, aktToBurn });
+      this.logger.info({ event: "MASTER_WALLET_MINT_DRY_RUN", deficit, aktToBurn, expectedActToMint: calculation.val.act, expectedActBalance });
       return Ok.EMPTY;
     }
 
-    return this.executeMint(address, aktToBurn);
+    return this.executeMint(address, aktToBurn, expectedActBalance);
   }
 
   private async fetchWalletBalances(address: string): Promise<Balances> {
@@ -73,7 +75,7 @@ export class MasterWalletMintService {
   /**
    * Computes the final AKT amount to burn: applies oracle price with slippage, enforces BME min mint, and caps to available AKT minus reserve.
    */
-  private async calculateAktToBurn(actDeficit: number, balances: Balances): Promise<Result<number, string>> {
+  private async calculateAktToBurn(actDeficit: number, balances: Balances): Promise<Result<{ akt: number; act: number }, string>> {
     const [{ price }, minMintUact] = await Promise.all([this.denomExchangeService.getExchangeRateToUSD("akt"), this.getMinMintAmount()]);
 
     if (!price || price <= 0) {
@@ -84,7 +86,16 @@ export class MasterWalletMintService {
     const minAktToBurn = Math.ceil((minMintUact / price) * this.PRICE_SLIPPAGE_MULTIPLIER);
     const aktToBurn = Math.ceil((Math.max(actDeficit, minMintUact) / price) * this.PRICE_SLIPPAGE_MULTIPLIER);
 
-    return this.capToAvailableAkt(balances, aktToBurn, minAktToBurn);
+    const capped = this.capToAvailableAkt(balances, aktToBurn, minAktToBurn);
+
+    if (capped.err) {
+      return capped;
+    }
+
+    return Ok({
+      akt: capped.val,
+      act: Math.floor((capped.val * price) / this.PRICE_SLIPPAGE_MULTIPLIER)
+    });
   }
 
   private async getMinMintAmount(): Promise<number> {
@@ -122,12 +133,12 @@ export class MasterWalletMintService {
   }
 
   /**
-   * Broadcasts MsgMintACT, waits for ledger settlement, and verifies ACT balance meets target.
+   * Broadcasts MsgMintACT, waits for ledger settlement, and verifies ACT balance reaches the expected post-mint value.
    */
-  private async executeMint(address: string, aktToBurn: number): Promise<Result<void, string>> {
+  private async executeMint(address: string, aktToBurn: number, expectedActBalance: number): Promise<Result<void, string>> {
     const message = this.rpcMessageService.getMintACTMsg({ owner: address, amount: aktToBurn });
 
-    this.logger.info({ event: "MASTER_WALLET_MINT_STARTED", aktToBurn, address });
+    this.logger.info({ event: "MASTER_WALLET_MINT_STARTED", aktToBurn, expectedActBalance, address });
     const tx = await this.txManagerService.signAndBroadcastWithFundingWallet([message as EncodeObject]);
 
     if (tx.code !== 0) {
@@ -142,7 +153,7 @@ export class MasterWalletMintService {
       return settlement;
     }
 
-    return this.verifyBalanceAboveTarget(address);
+    return this.verifyMintedBalance(address, aktToBurn, expectedActBalance);
   }
 
   /** Polls BME ledger until no pending records remain for this address. */
@@ -163,28 +174,41 @@ export class MasterWalletMintService {
     return Err("Ledger polling timed out waiting for mint settlement");
   }
 
-  /** Polls ACT balance until it meets the configured target, retrying up to 3 minutes. */
-  private async verifyBalanceAboveTarget(address: string): Promise<Result<void, string>> {
-    const target = this.billingConfigService.get("MASTER_WALLET_TARGET_ACT_BALANCE");
+  /**
+   * Polls the wallet's ACT balance until it reaches the expected post-mint value, retrying up to 3 minutes.
+   * @param address - Master wallet address to query balances for.
+   * @param aktBurned - AKT amount burned in the mint tx, included in the failure log for context.
+   * @param expectedActBalance - Minimum ACT balance (in uact) expected after the mint settles.
+   * @returns Ok when balance reaches the threshold, Err if still below expected after all retries.
+   */
+  private async verifyMintedBalance(address: string, aktBurned: number, expectedActBalance: number): Promise<Result<void, string>> {
+    let actBalance = 0;
 
     for (let attempt = 0; attempt < this.MAX_BALANCE_CHECK_ATTEMPTS; attempt++) {
       const balances = await this.fetchWalletBalances(address);
-      const actBalance = this.findBalance(balances, "uact");
+      actBalance = this.findBalance(balances, "uact");
 
-      if (actBalance >= target) {
-        this.logger.info({ event: "MASTER_WALLET_MINT_CONFIRMED", address, actBalance, target });
+      if (actBalance >= expectedActBalance) {
+        this.logger.info({ event: "MASTER_WALLET_MINT_CONFIRMED", address, actBalance, expectedActBalance });
         return Ok.EMPTY;
       }
 
-      this.logger.debug({ event: "MASTER_WALLET_MINT_BALANCE_PENDING", actBalance, target, attempt });
+      this.logger.debug({ event: "MASTER_WALLET_MINT_BALANCE_PENDING", actBalance, expectedActBalance, attempt });
       await this.timerService.delay(this.BALANCE_CHECK_INTERVAL_MS);
     }
 
-    this.logger.error({ event: "MASTER_WALLET_MINT_FAILED", message: "ACT balance still below target after mint" });
-    return Err("ACT balance still below target after mint");
+    this.logger.error({
+      event: "MASTER_WALLET_MINT_FAILED",
+      message: "ACT balance still below expected after mint",
+      actBalance,
+      aktBurned,
+      expectedActBalance
+    });
+
+    return Err("ACT balance still below expected after mint");
   }
 
-  private findBalance(balances: Balances, denom: string): number {
+  private findBalance(balances: Balances, denom: "uact" | "uakt"): number {
     return parseFloat(balances.find(b => b.denom === denom)?.amount || "0");
   }
 }


### PR DESCRIPTION
## Why

Fixes CON-219.

The master wallet ACT mint job was being reported as failed whenever the resulting balance fell short of the configured target. When the funding wallet's AKT supply couldn't cover a full top-up, the job intentionally minted what it could — but the verification step still tripped on the absolute target and we got a failed-job alert despite the mint behaving correctly.

A separate, clearly-worded alert wired to the existing `MASTER_WALLET_MINT_CAPPED` warning will be added so we still know when the master wallet is running low on AKT and needs refilling — without conflating that signal with real failures.

## What

- Verification now checks against the expected post-mint balance derived from the AKT actually burned (scaled down when capped), so a capped mint is treated as success.
- Enriched `MASTER_WALLET_MINT_FAILED` log with `actBalance`, `aktBurned`, and `expectedActBalance` so real failures are diagnosable at a glance.
- Added test coverage for previously untested branches: invalid AKT price, transaction failure, capped mint with proportional ACT scaling, BME minimum mint floor, BME denom fallback, and balance-poll retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable on-chain minting: post-mint balances are now validated against expected outcomes to reduce false negatives and handle price/slippage edge cases.

* **Chores**
  * Improved minting error handling and diagnostics with clearer failure messages and additional verification logging.

* **Tests**
  * Added negative-path and polling tests to ensure robust handling of price errors, partial coverage, minimum-mint fallbacks, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->