### PR TITLE
fix(analytics): add dseq property to deployment lifecycle events

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
@@ -190,7 +190,8 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
 
       analyticsService.track("send_manifest", {
         category: "deployments",
-        label: "Send manifest after creating lease"
+        label: "Send manifest after creating lease",
+        dseq
       });
 
       if (!localDeploymentData || !localDeploymentData.manifest) {
@@ -322,7 +323,8 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
 
       analyticsService.track("create_lease", {
         category: "deployments",
-        label: "Create lease"
+        label: "Create lease",
+        dseq
       });
 
       if (newLocalCert) {

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
@@ -291,7 +291,8 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
 
         analyticsService.track("create_deployment", {
           category: "deployments",
-          label: "Create deployment in wizard"
+          label: "Create deployment in wizard",
+          dseq: dd.deploymentId.dseq
         });
 
         if (sdl.includes(LOG_COLLECTOR_IMAGE)) {


### PR DESCRIPTION
## Why

Fixes CON-218

Per-deployment funnel tracking in Amplitude requires `dseq` on all deployment lifecycle events. Currently `bids_received` has `dseq` (added in #3047), but `create_deployment`, `create_lease`, and `send_manifest` do not — making it impossible to build a per-deployment funnel or deduplicate events by deployment.

Without this, the TOTALS funnel inflates `bids_received` by ~14% (component remounts fire the event multiple times per dseq), and we cannot compute accurate per-deployment zero-bid rates. Verified baseline: zero-bid rate is ~8.4% per-dseq vs 10.7% using inflated TOTALS.

## What

Added `dseq` property to three analytics events where it was already in scope but not passed:

- `create_deployment` in `ManifestEdit.tsx` (wizard flow) — `dd.deploymentId.dseq`
- `create_lease` in `CreateLease.tsx` — component-level `dseq` variable
- `send_manifest` in `CreateLease.tsx` — component-level `dseq` variable

Note: `create_deployment` in `OnboardingContainer.tsx` already includes `dseq`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics tracking across deployment workflows. Deployment identifiers are now included in tracked events for manifest submission, lease creation, and deployment finalization to provide improved visibility into deployment operations and usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->