### PR TITLE
fix: removes protobufjs dep since it is part of akash-api package

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -41,7 +41,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@akashnetwork/akash-api": "^1.3.0",
+    "@akashnetwork/akash-api": "1.4.3",
     "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
@@ -95,7 +95,6 @@
     "pg": "^8.12.0",
     "pg-boss": "^12.11.2",
     "postgres": "^3.4.4",
-    "protobufjs": "~6.11.2",
     "reflect-metadata": "^0.2.2",
     "semver": "^7.3.8",
     "sequelize": "^6.21.3",

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -28,7 +28,7 @@
     "validate:types": "tsc -p tsconfig.strict.json --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/akash-api": "^1.3.0",
+    "@akashnetwork/akash-api": "1.4.3",
     "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
@@ -50,7 +50,6 @@
     "node-fetch": "^2.6.1",
     "node-gzip": "^1.1.2",
     "pg": "^8.7.3",
-    "protobufjs": "~6.11.2",
     "reflect-metadata": "^0.1.13",
     "semver": "^7.6.0",
     "sequelize": "^6.28.0",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -21,7 +21,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/akash-api": "^1.3.0",
+    "@akashnetwork/akash-api": "1.4.3",
     "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
@@ -43,7 +43,6 @@
     "hono": "4.6.12",
     "http-errors": "^2.0.0",
     "lodash": "^4.17.21",
-    "protobufjs": "^6.11.4",
     "reflect-metadata": "^0.2.2",
     "ts-results": "^3.3.0",
     "tsyringe": "^4.10.0",

--- a/knip.json
+++ b/knip.json
@@ -38,7 +38,6 @@
       "ignore": [
         "test/seeders/balance.seeder.ts"
       ],
-      "ignoreDependencies": ["protobufjs"],
       "drizzle": false
     },
     "apps/deploy-web": {
@@ -57,7 +56,6 @@
     "apps/indexer": {
       "entry": ["drizzle.config.ts"],
       "project": ["src/**/*.ts"],
-      "ignoreDependencies": ["protobufjs"],
       "drizzle": false
     },
     "apps/notifications": {
@@ -74,7 +72,7 @@
     },
     "apps/tx-signer": {
       "project": ["src/**/*.ts", "test/**/*.ts"],
-      "ignoreDependencies": ["@akashnetwork/env-loader", "protobufjs"]
+      "ignoreDependencies": ["@akashnetwork/env-loader"]
     },
     "apps/provider-console": {
       "ignore": ["**/*"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
       "version": "3.32.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/akash-api": "^1.3.0",
+        "@akashnetwork/akash-api": "1.4.3",
         "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
@@ -93,7 +93,6 @@
         "pg": "^8.12.0",
         "pg-boss": "^12.11.2",
         "postgres": "^3.4.4",
-        "protobufjs": "~6.11.2",
         "reflect-metadata": "^0.2.2",
         "semver": "^7.3.8",
         "sequelize": "^6.21.3",
@@ -3137,7 +3136,7 @@
       "version": "1.25.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/akash-api": "^1.3.0",
+        "@akashnetwork/akash-api": "1.4.3",
         "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
@@ -3159,7 +3158,6 @@
         "node-fetch": "^2.6.1",
         "node-gzip": "^1.1.2",
         "pg": "^8.7.3",
-        "protobufjs": "~6.11.2",
         "reflect-metadata": "^0.1.13",
         "semver": "^7.6.0",
         "sequelize": "^6.28.0",
@@ -6990,7 +6988,7 @@
       "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/akash-api": "^1.3.0",
+        "@akashnetwork/akash-api": "1.4.3",
         "@akashnetwork/chain-sdk": "^1.0.0-alpha.30",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -7012,7 +7010,6 @@
         "hono": "4.6.12",
         "http-errors": "^2.0.0",
         "lodash": "^4.17.21",
-        "protobufjs": "^6.11.4",
         "reflect-metadata": "^0.2.2",
         "ts-results": "^3.3.0",
         "tsyringe": "^4.10.0",
@@ -7176,9 +7173,12 @@
       "license": "MIT"
     },
     "node_modules/@akashnetwork/akash-api": {
-      "version": "1.4.0",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/akash-api/-/akash-api-1.4.3.tgz",
+      "integrity": "sha512-nEDHYM6LzXGUYMBqZNAzYXRUg/+W/oKJaA00aP5TIqIDHxr4WGKzb1hSASwRC2nHPqL2MRwSYaG15gsLQaXegA==",
       "license": "Apache-2.0",
       "dependencies": {
+        "protobufjs": "~6.11.2",
         "rxjs": "^7.8.1"
       },
       "peerDependencies": {


### PR DESCRIPTION
## Why

Some apps have a direct dependency on protobufjs, even though they don’t use it explicitly. This dependency was added to compensate for its absence in the akash-api package. Since akash-api has been updated, protobufjs can now be removed from those apps.

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned @akashnetwork/akash-api to version 1.4.3 across affected packages for deterministic installs.
  * Removed direct protobufjs dependency declarations from application manifests.
  * Updated dependency-analysis configuration to reflect the reduced explicit dependency set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->