### PR TITLE
feat(billing): add Stripe free trial abuse prevention metadata

### DIFF
--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -111,6 +111,50 @@ describe(StripeController.name, () => {
     });
   });
 
+  describe("createSetupIntent", () => {
+    it("passes isFreeTrial true when user wallet is trialing", async () => {
+      const { controller, stripe, userWalletRepository, user } = setup();
+      const clientSecret = faker.string.alphanumeric(32);
+
+      userWalletRepository.findOneByUserId.mockResolvedValue({ isTrialing: true } as any);
+      stripe.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
+      stripe.createSetupIntent.mockResolvedValue({ client_secret: clientSecret } as any);
+
+      const result = await controller.createSetupIntent();
+
+      expect(stripe.createSetupIntent).toHaveBeenCalledWith(user.stripeCustomerId, { isFreeTrial: true });
+      expect(result).toEqual({ data: { clientSecret } });
+    });
+
+    it("passes isFreeTrial false when user wallet is not trialing", async () => {
+      const { controller, stripe, userWalletRepository, user } = setup();
+      const clientSecret = faker.string.alphanumeric(32);
+
+      userWalletRepository.findOneByUserId.mockResolvedValue({ isTrialing: false } as any);
+      stripe.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
+      stripe.createSetupIntent.mockResolvedValue({ client_secret: clientSecret } as any);
+
+      const result = await controller.createSetupIntent();
+
+      expect(stripe.createSetupIntent).toHaveBeenCalledWith(user.stripeCustomerId, { isFreeTrial: false });
+      expect(result).toEqual({ data: { clientSecret } });
+    });
+
+    it("defaults isFreeTrial to true when no wallet exists", async () => {
+      const { controller, stripe, userWalletRepository, user } = setup();
+      const clientSecret = faker.string.alphanumeric(32);
+
+      userWalletRepository.findOneByUserId.mockResolvedValue(undefined);
+      stripe.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
+      stripe.createSetupIntent.mockResolvedValue({ client_secret: clientSecret } as any);
+
+      const result = await controller.createSetupIntent();
+
+      expect(stripe.createSetupIntent).toHaveBeenCalledWith(user.stripeCustomerId, { isFreeTrial: true });
+      expect(result).toEqual({ data: { clientSecret } });
+    });
+  });
+
   describe("applyCoupon", () => {
     it("returns transactionId and transactionStatus on successful coupon", async () => {
       const { controller, stripe, user } = setup();

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -4,7 +4,7 @@ import { container } from "tsyringe";
 import { mock } from "vitest-mock-extended";
 
 import { AuthService } from "@src/auth/services/auth.service";
-import type { UserWalletRepository } from "@src/billing/repositories";
+import type { UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
 import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
 import type { StripeService } from "@src/billing/services/stripe/stripe.service";
 import type { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
@@ -116,9 +116,9 @@ describe(StripeController.name, () => {
       const { controller, stripe, userWalletRepository, user } = setup();
       const clientSecret = faker.string.alphanumeric(32);
 
-      userWalletRepository.findOneByUserId.mockResolvedValue({ isTrialing: true } as any);
+      userWalletRepository.findOneByUserId.mockResolvedValue(mock<UserWalletOutput>({ isTrialing: true }));
       stripe.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
-      stripe.createSetupIntent.mockResolvedValue({ client_secret: clientSecret } as any);
+      stripe.createSetupIntent.mockResolvedValue(mock<Stripe.SetupIntent>({ client_secret: clientSecret }));
 
       const result = await controller.createSetupIntent();
 
@@ -130,9 +130,9 @@ describe(StripeController.name, () => {
       const { controller, stripe, userWalletRepository, user } = setup();
       const clientSecret = faker.string.alphanumeric(32);
 
-      userWalletRepository.findOneByUserId.mockResolvedValue({ isTrialing: false } as any);
+      userWalletRepository.findOneByUserId.mockResolvedValue(mock<UserWalletOutput>({ isTrialing: false }));
       stripe.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
-      stripe.createSetupIntent.mockResolvedValue({ client_secret: clientSecret } as any);
+      stripe.createSetupIntent.mockResolvedValue(mock<Stripe.SetupIntent>({ client_secret: clientSecret }));
 
       const result = await controller.createSetupIntent();
 
@@ -146,7 +146,7 @@ describe(StripeController.name, () => {
 
       userWalletRepository.findOneByUserId.mockResolvedValue(undefined);
       stripe.getStripeCustomerId.mockResolvedValue(user.stripeCustomerId!);
-      stripe.createSetupIntent.mockResolvedValue({ client_secret: clientSecret } as any);
+      stripe.createSetupIntent.mockResolvedValue(mock<Stripe.SetupIntent>({ client_secret: clientSecret }));
 
       const result = await controller.createSetupIntent();
 

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -42,7 +42,7 @@ export class StripeController {
 
     const stripeCustomerId = await this.stripe.getStripeCustomerId(currentUser);
     const userWallet = await this.userWalletRepository.findOneByUserId(currentUser.id);
-    const isFreeTrial = userWallet?.isTrialing ?? false;
+    const isFreeTrial = userWallet?.isTrialing ?? true;
 
     const setupIntent = await this.stripe.createSetupIntent(stripeCustomerId, { isFreeTrial });
     return { data: { clientSecret: setupIntent.client_secret } };

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -41,8 +41,10 @@ export class StripeController {
     const { currentUser } = this.authService;
 
     const stripeCustomerId = await this.stripe.getStripeCustomerId(currentUser);
+    const userWallet = await this.userWalletRepository.findOneByUserId(currentUser.id);
+    const isFreeTrial = userWallet?.isTrialing ?? false;
 
-    const setupIntent = await this.stripe.createSetupIntent(stripeCustomerId);
+    const setupIntent = await this.stripe.createSetupIntent(stripeCustomerId, { isFreeTrial });
     return { data: { clientSecret: setupIntent.client_secret } };
   }
 

--- a/apps/api/src/billing/services/stripe/stripe.service.spec.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.spec.ts
@@ -770,16 +770,31 @@ describe(StripeService.name, () => {
   });
 
   describe("createSetupIntent", () => {
-    it("creates setup intent with correct parameters", async () => {
+    it("creates setup intent with correct parameters when not a free trial", async () => {
       const { service } = setup();
       const stripeData = StripeSeederCreate();
       jest.spyOn(service.setupIntents, "create").mockResolvedValue(stripeData.setupIntent);
 
-      const result = await service.createSetupIntent(TEST_CONSTANTS.CUSTOMER_ID);
+      const result = await service.createSetupIntent(TEST_CONSTANTS.CUSTOMER_ID, { isFreeTrial: false });
       expect(service.setupIntents.create).toHaveBeenCalledWith({
         customer: TEST_CONSTANTS.CUSTOMER_ID,
         usage: "off_session",
         payment_method_types: ["card", "link"]
+      });
+      expect(result).toEqual(stripeData.setupIntent);
+    });
+
+    it("creates setup intent with free trial metadata when user is trialing", async () => {
+      const { service } = setup();
+      const stripeData = StripeSeederCreate();
+      jest.spyOn(service.setupIntents, "create").mockResolvedValue(stripeData.setupIntent);
+
+      const result = await service.createSetupIntent(TEST_CONSTANTS.CUSTOMER_ID, { isFreeTrial: true });
+      expect(service.setupIntents.create).toHaveBeenCalledWith({
+        customer: TEST_CONSTANTS.CUSTOMER_ID,
+        usage: "off_session",
+        payment_method_types: ["card", "link"],
+        metadata: { is_free_trial: "true" }
       });
       expect(result).toEqual(stripeData.setupIntent);
     });

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -51,11 +51,12 @@ export class StripeService extends Stripe {
     });
   }
 
-  async createSetupIntent(customerId: string) {
+  async createSetupIntent(customerId: string, { isFreeTrial }: { isFreeTrial: boolean }) {
     return await this.setupIntents.create({
       customer: customerId,
       usage: "off_session",
-      payment_method_types: ["card", "link"]
+      payment_method_types: ["card", "link"],
+      ...(isFreeTrial && { metadata: { is_free_trial: "true" } })
     });
   }
 


### PR DESCRIPTION
## Why

Integrate Stripe's Free Trial Abuse Prevention feature. This enables Stripe Radar to identify and block abusive free trial signups by flagging SetupIntents created during a trial with `is_free_trial: "true"` metadata.

## What

- `StripeService.createSetupIntent` now accepts an `{ isFreeTrial }` option and conditionally includes `metadata: { is_free_trial: "true" }` on the Stripe SetupIntent
- `StripeController.createSetupIntent` looks up the user's wallet to determine if they are currently trialing, then passes that flag to the service
- Updated existing unit test and added a new test case covering the free trial metadata path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payment method setup now includes whether the user is on a free trial when creating a setup intent.
* **Behavior Change**
  * Users without a wallet record are treated as on a free trial by default.
* **Tests**
  * Added tests for free-trial, non-free-trial, and missing-wallet scenarios validating the setup intent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->