### PR TITLE
fix: ensure last_used_at is set in db for api-key and for user

### DIFF
--- a/apps/api/src/auth/repositories/api-key/api-key.repository.integration.ts
+++ b/apps/api/src/auth/repositories/api-key/api-key.repository.integration.ts
@@ -151,7 +151,7 @@ describe(ApiKeyRepository.name, () => {
       expect(after?.lastUsedAt).toBe(before?.lastUsedAt);
     });
 
-    it("does not update lastUsedAt when it is null", async () => {
+    it("updates lastUsedAt when it is null", async () => {
       const { apiKeyRepository, createTestUser } = setup();
       const user = await createTestUser();
 
@@ -165,7 +165,7 @@ describe(ApiKeyRepository.name, () => {
       await apiKeyRepository.markAsUsed(apiKey.id, 60);
 
       const updated = await apiKeyRepository.findById(apiKey.id);
-      expect(updated?.lastUsedAt).toBeNull();
+      expect(updated?.lastUsedAt).not.toBeNull();
     });
   });
 

--- a/apps/api/src/auth/repositories/api-key/api-key.repository.ts
+++ b/apps/api/src/auth/repositories/api-key/api-key.repository.ts
@@ -1,4 +1,4 @@
-import { eq, lt, ne, sql } from "drizzle-orm";
+import { eq, isNull, lt, ne, or, sql } from "drizzle-orm";
 import { and } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
@@ -44,7 +44,9 @@ export class ApiKeyRepository extends BaseRepository<Table, ApiKeyInput, ApiKeyO
     await this.cursor
       .update(this.table)
       .set({ lastUsedAt: sql`now()` })
-      .where(and(eq(this.table.id, id), lt(this.table.lastUsedAt, sql`now() - make_interval(secs => ${throttleTimeSeconds})`)));
+      .where(
+        and(eq(this.table.id, id), or(isNull(this.table.lastUsedAt), lt(this.table.lastUsedAt, sql`now() - make_interval(secs => ${throttleTimeSeconds})`)))
+      );
   }
 
   async updateHash(id: ApiKeyOutput["id"], hashedKey: string): Promise<void> {

--- a/apps/api/src/user/repositories/user/user.repository.integration.ts
+++ b/apps/api/src/user/repositories/user/user.repository.integration.ts
@@ -1,0 +1,112 @@
+import { faker } from "@faker-js/faker";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { UserRepository } from "./user.repository";
+
+describe(UserRepository.name, () => {
+  describe("markAsActive", () => {
+    it("updates lastActiveAt when last active longer ago than throttle", async () => {
+      const { userRepository, createTestUser } = setup();
+      const user = await createTestUser({ lastActiveAt: hoursAgo(1) });
+
+      await userRepository.markAsActive(user.id, { throttleTimeSeconds: 60 });
+
+      const updated = await userRepository.findById(user.id);
+      expect(new Date(updated!.lastActiveAt!).getTime()).toBeGreaterThan(new Date(user.lastActiveAt!).getTime());
+    });
+
+    it("does not update lastActiveAt when recently active", async () => {
+      const { userRepository, createTestUser } = setup();
+      const user = await createTestUser({ lastActiveAt: new Date() });
+
+      const before = await userRepository.findById(user.id);
+
+      await userRepository.markAsActive(user.id, { throttleTimeSeconds: 3600 });
+
+      const after = await userRepository.findById(user.id);
+      expect(after!.lastActiveAt).toEqual(before!.lastActiveAt);
+    });
+
+    it("updates lastActiveAt when it is null", async () => {
+      const { userRepository, createTestUser } = setup();
+      const user = await createTestUser({ lastActiveAt: null });
+
+      await userRepository.markAsActive(user.id, { throttleTimeSeconds: 60 });
+
+      const updated = await userRepository.findById(user.id);
+      expect(updated!.lastActiveAt).not.toBeNull();
+    });
+
+    it("updates lastIp when provided", async () => {
+      const { userRepository, createTestUser } = setup();
+      const user = await createTestUser({ lastActiveAt: hoursAgo(1) });
+      const ip = faker.internet.ip();
+
+      await userRepository.markAsActive(user.id, { throttleTimeSeconds: 60, ip });
+
+      const updated = await userRepository.findById(user.id);
+      expect(updated!.lastIp).toBe(ip);
+    });
+
+    it("updates lastFingerprint when provided", async () => {
+      const { userRepository, createTestUser } = setup();
+      const user = await createTestUser({ lastActiveAt: hoursAgo(1) });
+      const fingerprint = faker.string.alphanumeric(32);
+
+      await userRepository.markAsActive(user.id, { throttleTimeSeconds: 60, fingerprint });
+
+      const updated = await userRepository.findById(user.id);
+      expect(updated!.lastFingerprint).toBe(fingerprint);
+    });
+
+    it("does not update lastIp when not provided", async () => {
+      const { userRepository, createTestUser } = setup();
+      const existingIp = faker.internet.ip();
+      const user = await createTestUser({ lastActiveAt: hoursAgo(1), lastIp: existingIp });
+
+      await userRepository.markAsActive(user.id, { throttleTimeSeconds: 60 });
+
+      const updated = await userRepository.findById(user.id);
+      expect(updated!.lastIp).toBe(existingIp);
+    });
+  });
+
+  let cleanup: () => Promise<void>;
+  afterEach(async () => {
+    await cleanup?.();
+  });
+
+  function hoursAgo(hours: number): Date {
+    const date = new Date();
+    date.setHours(date.getHours() - hours);
+    return date;
+  }
+
+  function setup() {
+    const userRepository = container.resolve(UserRepository);
+    const createdUserIds: string[] = [];
+
+    cleanup = async () => {
+      if (createdUserIds.length > 0) {
+        await userRepository.deleteById(createdUserIds);
+      }
+    };
+
+    async function createTestUser(overrides: { lastActiveAt?: Date | null; lastIp?: string } = {}) {
+      const user = await userRepository.create({
+        id: faker.string.uuid(),
+        userId: faker.string.uuid(),
+        username: `testuser_${Date.now()}_${faker.string.alphanumeric(6)}`,
+        email: faker.internet.email(),
+        emailVerified: faker.datatype.boolean(),
+        subscribedToNewsletter: false,
+        ...overrides
+      });
+      createdUserIds.push(user.id);
+      return user;
+    }
+
+    return { userRepository, createTestUser };
+  }
+});

--- a/apps/api/src/user/repositories/user/user.repository.ts
+++ b/apps/api/src/user/repositories/user/user.repository.ts
@@ -1,4 +1,4 @@
-import { and, eq, lt, ne, SQL, sql } from "drizzle-orm";
+import { and, eq, isNull, lt, ne, or, SQL, sql } from "drizzle-orm";
 import { PgUpdateSetSource } from "drizzle-orm/pg-core";
 import { singleton } from "tsyringe";
 
@@ -66,7 +66,7 @@ export class UserRepository extends BaseRepository<ApiPgTables["Users"], UserInp
         and(
           // keep new line
           eq(this.table.id, id),
-          lt(this.table.lastActiveAt, sql`now() - make_interval(secs => ${options.throttleTimeSeconds})`)
+          or(isNull(this.table.lastActiveAt), lt(this.table.lastActiveAt, sql`now() - make_interval(secs => ${options.throttleTimeSeconds})`))
         )
       );
   }


### PR DESCRIPTION
## Why

some api keys don't have `last_used_at` field set in db. We don't have similar issue with users, probably because last_active_at is set during signup flow but applied the same fix to make code more resilient 

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API key tracking to properly record the first usage timestamp.
  * Fixed user activity tracking to properly record initial activity timestamp and related metadata (IP address, fingerprint) when previously unset.

* **Tests**
  * Added integration tests for user activity tracking to validate timestamp and metadata update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->