### PR TITLE
feat(log-collector): add Akash deployment metadata to forwarded logs

### DIFF
--- a/apps/log-collector/fluent-bit/script/extract_metadata.lua
+++ b/apps/log-collector/fluent-bit/script/extract_metadata.lua
@@ -59,7 +59,29 @@ function extract_metadata(tag, timestamp, record)
 
     -- Set extracted metadata in the record for Datadog integration
     record["service"] = service
-    record["ddtags"]  = "pod_name:" .. pod_name .. ",service:" .. service
+
+    local tags = "pod_name:" .. pod_name .. ",service:" .. service
+
+    local akash_tags = {
+        { env = "AKASH_DEPLOYMENT_SEQUENCE", key = "deployment_sequence" },
+        { env = "AKASH_ORDER_SEQUENCE",      key = "order_sequence" },
+        { env = "AKASH_GROUP_SEQUENCE",       key = "group_sequence" },
+        { env = "AKASH_CLUSTER_PUBLIC_HOSTNAME", key = "cluster_hostname" }
+    }
+
+    for _, t in ipairs(akash_tags) do
+        local val = os.getenv(t.env)
+        if val and val ~= "" then
+            tags = tags .. "," .. t.key .. ":" .. val
+        end
+    end
+
+    record["ddtags"] = tags
+
+    local hostname = os.getenv("AKASH_CLUSTER_PUBLIC_HOSTNAME")
+    if hostname and hostname ~= "" then
+        record["hostname"] = hostname
+    end
 
     return 1, timestamp, record
 end


### PR DESCRIPTION
## Why

Fixes CON-222.

Forwarded logs only carry pod-level metadata (pod name, service). Users can't filter or group logs by Akash deployment, order, or provider in Datadog without cross-referencing external systems.

## What

- Enrich ddtags with `deployment_sequence`, `order_sequence`, `group_sequence`, and `cluster_hostname` from the corresponding `AKASH_*` environment variables (via the Lua metadata extraction script). Tags are silently skipped when the env var is unset, so non-Akash environments are unaffected.
- Set `dd_hostname` to `AKASH_CLUSTER_PUBLIC_HOSTNAME` so the provider hostname appears in Datadog's built-in Host filter.
<img width="1529" height="1183" alt="Screenshot 2026-04-16 at 10 23 07" src="https://github.com/user-attachments/assets/56c04fa5-591e-41a9-a60c-916def665483" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced log metadata: Tags now conditionally include environment-based values alongside pod and service information.
  * Automatic hostname field detection from system environment variables for improved log correlation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->