### PR TITLE
test(onboarding): E2E managed wallet onboarding flow

### DIFF
--- a/.github/actions/console-web-ui-testing/action.yml
+++ b/.github/actions/console-web-ui-testing/action.yml
@@ -21,6 +21,15 @@ inputs:
   testing-client-token:
     description: E2E testing client token which allows to bypass captcha verification
     required: true
+  auth0-m2m-domain:
+    description: Auth0 M2M domain for management API calls
+    required: true
+  auth0-m2m-client-id:
+    description: Auth0 M2M client ID
+    required: true
+  auth0-m2m-client-secret:
+    description: Auth0 M2M client secret
+    required: true
 
 runs:
   using: "composite"
@@ -42,6 +51,9 @@ runs:
         TEST_WALLET_MNEMONIC: ${{ inputs.test-wallet-mnemonic }}
         BASE_URL: ${{ inputs.url }}
         E2E_TESTING_CLIENT_TOKEN: ${{ inputs.testing-client-token }}
+        AUTH0_M2M_DOMAIN: ${{ inputs.auth0-m2m-domain }}
+        AUTH0_M2M_CLIENT_ID: ${{ inputs.auth0-m2m-client-id }}
+        AUTH0_M2M_CLIENT_SECRET: ${{ inputs.auth0-m2m-client-secret }}
         USER_DATA_DIR: ${{ runner.temp }}/chrome-profile-${{ github.run_id }}-${{ github.run_attempt }}
         CI: "true"
       shell: bash

--- a/.github/workflows/console-web-release.yml
+++ b/.github/workflows/console-web-release.yml
@@ -61,6 +61,9 @@ jobs:
           test-wallet-mnemonic: ${{ secrets.CONSOLE_WEB_E2E_TEST_WALLET_MNEMONIC }}
           gh-user-to-slack-user: ${{ vars.GH_USER_TO_SLACK_USER }}
           testing-client-token: ${{ secrets.CONSOLE_WEB_E2E_TESTING_CLIENT_TOKEN_BETA }}
+          auth0-m2m-domain: ${{ secrets.AUTH0_M2M_DOMAIN }}
+          auth0-m2m-client-id: ${{ secrets.AUTH0_M2M_CLIENT_ID }}
+          auth0-m2m-client-secret: ${{ secrets.AUTH0_M2M_CLIENT_SECRET }}
 
   deploy-prod:
     permissions:

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -146,6 +146,7 @@
     "@typescript-eslint/eslint-plugin": "^7.12.0",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/coverage-v8": "^4.0.0",
+    "auth0": "^4.16.0",
     "autoprefixer": "^10.4.16",
     "copy-webpack-plugin": "^13.0.1",
     "eslint": "^8.57.0",

--- a/apps/deploy-web/playwright.config.ts
+++ b/apps/deploy-web/playwright.config.ts
@@ -4,6 +4,7 @@ import path from "path";
 
 import { getUserAgent } from "./tests/ui/fixture/base-test"; // for process.env types
 
+dotenv.config({ path: path.resolve(__dirname, "env/.env.test.local") });
 dotenv.config({ path: path.resolve(__dirname, "env/.env.test") });
 
 /**

--- a/apps/deploy-web/tests/ui/actions/auth.ts
+++ b/apps/deploy-web/tests/ui/actions/auth.ts
@@ -1,0 +1,33 @@
+import type { Page } from "@playwright/test";
+
+export async function signUpViaUI(page: Page, input: { email: string; password: string }) {
+  const signUpTab = page.getByRole("tab", { name: /sign up/i });
+
+  if (await signUpTab.isVisible()) {
+    await signUpTab.click();
+  }
+
+  await page.getByLabel("Email").fill(input.email);
+  await page.getByLabel("Password").fill(input.password);
+  await page.getByRole("checkbox").check();
+  await page.getByRole("button", { name: /sign up/i }).click();
+}
+
+export async function signInViaUI(page: Page, input: { email: string; password: string }) {
+  const logInTab = page.getByRole("tab", { name: /log in/i });
+  if (await logInTab.isVisible()) {
+    await logInTab.click();
+  }
+
+  await page.getByLabel("Email").fill(input.email);
+  await page.getByLabel("Password").fill(input.password);
+  await page.getByRole("button", { name: /log in/i }).click();
+}
+
+export function generateTestCredentials(): { email: string; password: string } {
+  const id = crypto.randomUUID().slice(0, 8);
+  return {
+    email: `e2e-${id}@test.akash.network`,
+    password: `E2e!${crypto.randomUUID()}`
+  };
+}

--- a/apps/deploy-web/tests/ui/fixture/managed-wallet-test.ts
+++ b/apps/deploy-web/tests/ui/fixture/managed-wallet-test.ts
@@ -1,0 +1,13 @@
+import { Auth0ManagementService } from "../services/auth0-management.service";
+import { test as baseTest } from "./base-test";
+
+export { expect } from "./base-test";
+
+const auth0Management = new Auth0ManagementService();
+
+export const test = baseTest.extend<{ auth0: Auth0ManagementService }>({
+  // eslint-disable-next-line no-empty-pattern
+  auth0: async ({}, use) => {
+    await use(auth0Management);
+  }
+});

--- a/apps/deploy-web/tests/ui/fixture/test-env.config.ts
+++ b/apps/deploy-web/tests/ui/fixture/test-env.config.ts
@@ -12,14 +12,20 @@ export const testEnvSchema = z.object({
   USER_DATA_DIR: z.string().default(path.join(tmpdir(), "akash-console-web-ui-tests", crypto.randomUUID())),
   E2E_TESTING_CLIENT_TOKEN: z.string({
     required_error: "This token is used to adjust configuration of the app for e2e testing. Can be any random string but should match the one used by app."
-  })
+  }),
+  AUTH0_M2M_DOMAIN: z.string({ required_error: "Auth0 M2M domain for management API calls (e.g. 'your-tenant.us.auth0.com')" }).trim().min(1),
+  AUTH0_M2M_CLIENT_ID: z.string({ required_error: "Auth0 M2M client ID for management API" }).trim().min(1),
+  AUTH0_M2M_CLIENT_SECRET: z.string({ required_error: "Auth0 M2M client secret for management API" }).min(1)
 });
 
 export const testEnvConfig = testEnvSchema.parse({
   BASE_URL: process.env.BASE_URL,
   TEST_WALLET_MNEMONIC: process.env.TEST_WALLET_MNEMONIC,
   USER_DATA_DIR: process.env.USER_DATA_DIR,
-  E2E_TESTING_CLIENT_TOKEN: process.env.E2E_TESTING_CLIENT_TOKEN
+  E2E_TESTING_CLIENT_TOKEN: process.env.E2E_TESTING_CLIENT_TOKEN,
+  AUTH0_M2M_DOMAIN: process.env.AUTH0_M2M_DOMAIN,
+  AUTH0_M2M_CLIENT_ID: process.env.AUTH0_M2M_CLIENT_ID,
+  AUTH0_M2M_CLIENT_SECRET: process.env.AUTH0_M2M_CLIENT_SECRET
 });
 
 export const PROVIDERS_WHITELIST = {

--- a/apps/deploy-web/tests/ui/managed-wallet-onboarding.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-onboarding.spec.ts
@@ -1,0 +1,63 @@
+import { generateTestCredentials, signUpViaUI } from "./actions/auth";
+import { expect, test } from "./fixture/managed-wallet-test";
+import { testEnvConfig } from "./fixture/test-env.config";
+import { HomePage } from "./pages/HomePage";
+import { OnboardingPage } from "./pages/OnboardingPage";
+
+test.describe("Managed wallet onboarding", () => {
+  let testUserId: string | undefined;
+
+  test.afterEach(async ({ auth0 }) => {
+    if (testUserId) {
+      await auth0.deleteUser(testUserId).catch(() => {});
+      testUserId = undefined;
+    }
+  });
+
+  test("completes free trial start, signup, and email verification", async ({ page, auth0 }) => {
+    test.setTimeout(2 * 60 * 1000);
+
+    const { email, password } = generateTestCredentials();
+    const homePage = new HomePage(page);
+    const onboardingPage = new OnboardingPage(page);
+
+    await test.step("start trial from home page", async () => {
+      await homePage.goto();
+      await homePage.startTrial();
+    });
+
+    await test.step("begin free trial onboarding", async () => {
+      await onboardingPage.startFreeTrial();
+    });
+
+    await test.step("sign up with email and password", async () => {
+      await page.waitForURL(/\/login.*tab=signup/);
+      await signUpViaUI(page, { email, password });
+    });
+
+    await test.step("arrive at email verification step", async () => {
+      await page.waitForURL(/\/signup/);
+      await expect(onboardingPage.getCheckVerificationButton()).toBeVisible({ timeout: 15_000 });
+    });
+
+    await test.step("verify email via Auth0 verification link", async () => {
+      const auth0User = await auth0.getUserByEmail(email);
+      expect(auth0User).toBeTruthy();
+      testUserId = auth0User!.user_id;
+
+      const verifyEmailUrl = `${testEnvConfig.BASE_URL}/user/verify-email?email=${encodeURIComponent(email)}`;
+      const verificationUrl = await auth0.createEmailVerificationTicket(testUserId!, verifyEmailUrl);
+
+      const verificationPage = await page.context().newPage();
+      await verificationPage.goto(verificationUrl);
+      await verificationPage.getByText("Your email was verified").waitFor({ timeout: 15_000 });
+      await verificationPage.close();
+    });
+
+    await test.step("confirm email verification on onboarding page", async () => {
+      await onboardingPage.getCheckVerificationButton().click();
+      await expect(onboardingPage.getEmailVerifiedAlert()).toBeVisible({ timeout: 15_000 });
+      await onboardingPage.getContinueButton().click();
+    });
+  });
+});

--- a/apps/deploy-web/tests/ui/pages/HomePage.ts
+++ b/apps/deploy-web/tests/ui/pages/HomePage.ts
@@ -1,0 +1,15 @@
+import type { Page } from "@playwright/test";
+
+import { testEnvConfig } from "../fixture/test-env.config";
+
+export class HomePage {
+  constructor(readonly page: Page) {}
+
+  async goto() {
+    await this.page.goto(testEnvConfig.BASE_URL);
+  }
+
+  async startTrial() {
+    await this.page.getByRole("button", { name: /start trial/i }).click();
+  }
+}

--- a/apps/deploy-web/tests/ui/pages/OnboardingPage.ts
+++ b/apps/deploy-web/tests/ui/pages/OnboardingPage.ts
@@ -1,0 +1,21 @@
+import type { Page } from "@playwright/test";
+
+export class OnboardingPage {
+  constructor(readonly page: Page) {}
+
+  async startFreeTrial() {
+    await this.page.getByRole("button", { name: /start free trial/i }).click();
+  }
+
+  getEmailVerifiedAlert() {
+    return this.page.getByText("Email Verified");
+  }
+
+  getCheckVerificationButton() {
+    return this.page.getByRole("button", { name: /check verification/i });
+  }
+
+  getContinueButton() {
+    return this.page.getByRole("button", { name: /^continue$/i });
+  }
+}

--- a/apps/deploy-web/tests/ui/services/auth0-management.service.ts
+++ b/apps/deploy-web/tests/ui/services/auth0-management.service.ts
@@ -1,0 +1,28 @@
+import { ManagementClient } from "auth0";
+
+import { testEnvConfig } from "../fixture/test-env.config";
+
+export class Auth0ManagementService {
+  private readonly managementClient = new ManagementClient({
+    domain: testEnvConfig.AUTH0_M2M_DOMAIN,
+    clientId: testEnvConfig.AUTH0_M2M_CLIENT_ID,
+    clientSecret: testEnvConfig.AUTH0_M2M_CLIENT_SECRET
+  });
+
+  async createEmailVerificationTicket(userId: string, resultUrl: string): Promise<string> {
+    const { data } = await this.managementClient.tickets.verifyEmail({
+      user_id: userId,
+      result_url: resultUrl
+    });
+    return data.ticket;
+  }
+
+  async deleteUser(userId: string): Promise<void> {
+    await this.managementClient.users.delete({ id: userId });
+  }
+
+  async getUserByEmail(email: string): Promise<{ user_id: string } | null> {
+    const { data: users } = await this.managementClient.usersByEmail.getByEmail({ email });
+    return users.length > 0 ? users[0] : null;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -618,6 +618,7 @@
         "@typescript-eslint/eslint-plugin": "^7.12.0",
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/coverage-v8": "^4.0.0",
+        "auth0": "^4.16.0",
         "autoprefixer": "^10.4.16",
         "copy-webpack-plugin": "^13.0.1",
         "eslint": "^8.57.0",


### PR DESCRIPTION
## Why

Part of CON-152

The managed wallet onboarding funnel (home page → free trial → signup → email verification) has no automated test coverage.

## What

- Add Playwright E2E test covering managed wallet onboarding through email verification
- Reusable auth helpers (`signUpViaUI`, `signInViaUI`, `generateTestCredentials`) for future tests
- Auth0 Management API service for E2E (email verification tickets, user cleanup)
- `HomePage` and `OnboardingPage` page objects
- GHA workflow updated to pass Auth0 M2M secrets
- `playwright.config.ts` loads `env/.env.test.local` for local test credentials

### Required GitHub secrets
- `AUTH0_M2M_DOMAIN`
- `AUTH0_M2M_CLIENT_ID`
- `AUTH0_M2M_CLIENT_SECRET`

### Required Auth0 M2M permissions
- `read:users`
- `delete:users`
- `create:user_tickets`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests covering managed wallet onboarding, signup, sign-in, and email verification flows.
  * Test infrastructure now supports Auth0 machine-to-machine credentials for verification and cleanup.

* **New Features**
  * Automated UI interactions and pages for starting trials and onboarding to validate user-facing signup and verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->