### PR TITLE
test(onboarding): add email verification strategy abstraction

### DIFF
--- a/.github/actions/console-web-ui-testing/action.yml
+++ b/.github/actions/console-web-ui-testing/action.yml
@@ -30,6 +30,13 @@ inputs:
   auth0-m2m-client-secret:
     description: Auth0 M2M client secret
     required: true
+  mailsac-api-key:
+    description: Mailsac API key for email verification
+    required: true
+  email-verification-strategy:
+    description: Email verification strategy (mailsac or auth0-ticket)
+    required: false
+    default: "mailsac"
 
 runs:
   using: "composite"
@@ -54,6 +61,8 @@ runs:
         AUTH0_M2M_DOMAIN: ${{ inputs.auth0-m2m-domain }}
         AUTH0_M2M_CLIENT_ID: ${{ inputs.auth0-m2m-client-id }}
         AUTH0_M2M_CLIENT_SECRET: ${{ inputs.auth0-m2m-client-secret }}
+        MAILSAC_API_KEY: ${{ inputs.mailsac-api-key }}
+        EMAIL_VERIFICATION_STRATEGY: ${{ inputs.email-verification-strategy }}
         USER_DATA_DIR: ${{ runner.temp }}/chrome-profile-${{ github.run_id }}-${{ github.run_attempt }}
         CI: "true"
       shell: bash

--- a/.github/workflows/console-web-release.yml
+++ b/.github/workflows/console-web-release.yml
@@ -64,6 +64,8 @@ jobs:
           auth0-m2m-domain: ${{ secrets.AUTH0_M2M_DOMAIN }}
           auth0-m2m-client-id: ${{ secrets.AUTH0_M2M_CLIENT_ID }}
           auth0-m2m-client-secret: ${{ secrets.AUTH0_M2M_CLIENT_SECRET }}
+          mailsac-api-key: ${{ secrets.MAILSAC_API_KEY }}
+          email-verification-strategy: ${{ vars.EMAIL_VERIFICATION_STRATEGY || 'mailsac' }}
 
   deploy-prod:
     permissions:

--- a/apps/deploy-web/tests/ui/actions/auth.ts
+++ b/apps/deploy-web/tests/ui/actions/auth.ts
@@ -24,10 +24,6 @@ export async function signInViaUI(page: Page, input: { email: string; password: 
   await page.getByRole("button", { name: /log in/i }).click();
 }
 
-export function generateTestCredentials(): { email: string; password: string } {
-  const id = crypto.randomUUID().slice(0, 8);
-  return {
-    email: `e2e-${id}@test.akash.network`,
-    password: `E2e!${crypto.randomUUID()}`
-  };
+export function generateTestPassword(): string {
+  return `E2e!${crypto.randomUUID()}`;
 }

--- a/apps/deploy-web/tests/ui/fixture/managed-wallet-test.ts
+++ b/apps/deploy-web/tests/ui/fixture/managed-wallet-test.ts
@@ -1,13 +1,28 @@
 import { Auth0ManagementService } from "../services/auth0-management.service";
+import { createEmailVerificationStrategy, type EmailVerificationStrategy } from "../services/email-verification";
 import { test as baseTest } from "./base-test";
+import { testEnvConfig } from "./test-env.config";
 
 export { expect } from "./base-test";
 
 const auth0Management = new Auth0ManagementService();
+const emailVerificationStrategy = createEmailVerificationStrategy(auth0Management);
 
-export const test = baseTest.extend<{ auth0: Auth0ManagementService }>({
+export const test = baseTest.extend<{ auth0: Auth0ManagementService; emailVerification: EmailVerificationStrategy }>({
+  page: async ({ page }, use) => {
+    await page.route("**/api/auth/password-signup", (route, request) => {
+      route.continue({
+        headers: { ...request.headers(), "x-testing-client-token": testEnvConfig.E2E_TESTING_CLIENT_TOKEN }
+      });
+    });
+    await use(page);
+  },
   // eslint-disable-next-line no-empty-pattern
   auth0: async ({}, use) => {
     await use(auth0Management);
+  },
+  // eslint-disable-next-line no-empty-pattern
+  emailVerification: async ({}, use) => {
+    await use(emailVerificationStrategy);
   }
 });

--- a/apps/deploy-web/tests/ui/fixture/test-env.config.ts
+++ b/apps/deploy-web/tests/ui/fixture/test-env.config.ts
@@ -15,7 +15,9 @@ export const testEnvSchema = z.object({
   }),
   AUTH0_M2M_DOMAIN: z.string({ required_error: "Auth0 M2M domain for management API calls (e.g. 'your-tenant.us.auth0.com')" }).trim().min(1),
   AUTH0_M2M_CLIENT_ID: z.string({ required_error: "Auth0 M2M client ID for management API" }).trim().min(1),
-  AUTH0_M2M_CLIENT_SECRET: z.string({ required_error: "Auth0 M2M client secret for management API" }).min(1)
+  AUTH0_M2M_CLIENT_SECRET: z.string({ required_error: "Auth0 M2M client secret for management API" }).trim().min(1),
+  MAILSAC_API_KEY: z.string({ required_error: "Mailsac API key for email verification" }).trim().min(1),
+  EMAIL_VERIFICATION_STRATEGY: z.enum(["mailsac", "auth0-ticket"]).default("mailsac")
 });
 
 export const testEnvConfig = testEnvSchema.parse({
@@ -25,7 +27,9 @@ export const testEnvConfig = testEnvSchema.parse({
   E2E_TESTING_CLIENT_TOKEN: process.env.E2E_TESTING_CLIENT_TOKEN,
   AUTH0_M2M_DOMAIN: process.env.AUTH0_M2M_DOMAIN,
   AUTH0_M2M_CLIENT_ID: process.env.AUTH0_M2M_CLIENT_ID,
-  AUTH0_M2M_CLIENT_SECRET: process.env.AUTH0_M2M_CLIENT_SECRET
+  AUTH0_M2M_CLIENT_SECRET: process.env.AUTH0_M2M_CLIENT_SECRET,
+  MAILSAC_API_KEY: process.env.MAILSAC_API_KEY,
+  EMAIL_VERIFICATION_STRATEGY: process.env.EMAIL_VERIFICATION_STRATEGY
 });
 
 export const PROVIDERS_WHITELIST = {

--- a/apps/deploy-web/tests/ui/managed-wallet-onboarding.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-onboarding.spec.ts
@@ -1,6 +1,5 @@
-import { generateTestCredentials, signUpViaUI } from "./actions/auth";
+import { generateTestPassword, signUpViaUI } from "./actions/auth";
 import { expect, test } from "./fixture/managed-wallet-test";
-import { testEnvConfig } from "./fixture/test-env.config";
 import { HomePage } from "./pages/HomePage";
 import { OnboardingPage } from "./pages/OnboardingPage";
 
@@ -14,10 +13,11 @@ test.describe("Managed wallet onboarding", () => {
     }
   });
 
-  test("completes free trial start, signup, and email verification", async ({ page, auth0 }) => {
+  test("completes free trial start, signup, and email verification", async ({ page, auth0, emailVerification }) => {
     test.setTimeout(2 * 60 * 1000);
 
-    const { email, password } = generateTestCredentials();
+    const email = emailVerification.generateEmail();
+    const password = generateTestPassword();
     const homePage = new HomePage(page);
     const onboardingPage = new OnboardingPage(page);
 
@@ -40,18 +40,12 @@ test.describe("Managed wallet onboarding", () => {
       await expect(onboardingPage.getCheckVerificationButton()).toBeVisible({ timeout: 15_000 });
     });
 
-    await test.step("verify email via Auth0 verification link", async () => {
+    await test.step("verify email via verification link", async () => {
       const auth0User = await auth0.getUserByEmail(email);
       expect(auth0User).toBeTruthy();
       testUserId = auth0User!.user_id;
 
-      const verifyEmailUrl = `${testEnvConfig.BASE_URL}/user/verify-email?email=${encodeURIComponent(email)}`;
-      const verificationUrl = await auth0.createEmailVerificationTicket(testUserId!, verifyEmailUrl);
-
-      const verificationPage = await page.context().newPage();
-      await verificationPage.goto(verificationUrl);
-      await verificationPage.getByText("Your email was verified").waitFor({ timeout: 15_000 });
-      await verificationPage.close();
+      await emailVerification.verify({ context: page.context(), email, userId: testUserId! });
     });
 
     await test.step("confirm email verification on onboarding page", async () => {

--- a/apps/deploy-web/tests/ui/services/email-verification/auth0-ticket.strategy.ts
+++ b/apps/deploy-web/tests/ui/services/email-verification/auth0-ticket.strategy.ts
@@ -1,0 +1,26 @@
+import type { BrowserContext } from "@playwright/test";
+
+import { testEnvConfig } from "../../fixture/test-env.config";
+import type { Auth0ManagementService } from "../auth0-management.service";
+import type { EmailVerificationStrategy } from "./email-verification.strategy";
+
+export class Auth0TicketVerificationStrategy implements EmailVerificationStrategy {
+  constructor(private readonly auth0: Auth0ManagementService) {}
+
+  generateEmail(): string {
+    return `e2e-${crypto.randomUUID().slice(0, 8)}@test.akash.network`;
+  }
+
+  async verify(input: { context: BrowserContext; email: string; userId: string }): Promise<void> {
+    const verifyEmailUrl = `${testEnvConfig.BASE_URL}/user/verify-email?email=${encodeURIComponent(input.email)}`;
+    const ticketUrl = await this.auth0.createEmailVerificationTicket(input.userId, verifyEmailUrl);
+
+    const page = await input.context.newPage();
+    try {
+      await page.goto(ticketUrl);
+      await page.getByText("Your email was verified").waitFor({ timeout: 15_000 });
+    } finally {
+      await page.close();
+    }
+  }
+}

--- a/apps/deploy-web/tests/ui/services/email-verification/email-verification.strategy.ts
+++ b/apps/deploy-web/tests/ui/services/email-verification/email-verification.strategy.ts
@@ -1,0 +1,6 @@
+import type { BrowserContext } from "@playwright/test";
+
+export interface EmailVerificationStrategy {
+  generateEmail(): string;
+  verify(input: { context: BrowserContext; email: string; userId: string }): Promise<void>;
+}

--- a/apps/deploy-web/tests/ui/services/email-verification/index.ts
+++ b/apps/deploy-web/tests/ui/services/email-verification/index.ts
@@ -1,0 +1,15 @@
+import { testEnvConfig } from "../../fixture/test-env.config";
+import type { Auth0ManagementService } from "../auth0-management.service";
+import { Auth0TicketVerificationStrategy } from "./auth0-ticket.strategy";
+import type { EmailVerificationStrategy } from "./email-verification.strategy";
+import { MailsacVerificationStrategy } from "./mailsac.strategy";
+
+export type { EmailVerificationStrategy } from "./email-verification.strategy";
+
+export function createEmailVerificationStrategy(auth0: Auth0ManagementService): EmailVerificationStrategy {
+  if (testEnvConfig.EMAIL_VERIFICATION_STRATEGY === "auth0-ticket") {
+    return new Auth0TicketVerificationStrategy(auth0);
+  }
+
+  return new MailsacVerificationStrategy(testEnvConfig.MAILSAC_API_KEY);
+}

--- a/apps/deploy-web/tests/ui/services/email-verification/mailsac.strategy.ts
+++ b/apps/deploy-web/tests/ui/services/email-verification/mailsac.strategy.ts
@@ -1,0 +1,89 @@
+import type { BrowserContext, Page } from "@playwright/test";
+
+import { testEnvConfig } from "../../fixture/test-env.config";
+import type { EmailVerificationStrategy } from "./email-verification.strategy";
+
+export class MailsacVerificationStrategy implements EmailVerificationStrategy {
+  private readonly baseUrl = "https://mailsac.com/api";
+
+  constructor(private readonly apiKey: string) {}
+
+  generateEmail(): string {
+    return `e2e-${crypto.randomUUID().slice(0, 8)}@mailsac.com`;
+  }
+
+  async verify(input: { context: BrowserContext; email: string; userId: string }): Promise<void> {
+    const verificationLink = await this.pollForVerificationLink(input.email);
+
+    const page = await input.context.newPage();
+    try {
+      await page.goto(verificationLink, { waitUntil: "commit" });
+      await page.waitForURL(/success=true/, { timeout: 15_000 });
+
+      if (this.auth0RedirectedToRemoteDeployment(page)) {
+        await this.syncVerificationViaLocalApp(page, input.email);
+      }
+
+      await page.getByText("Your email was verified").waitFor({ timeout: 30_000 });
+    } finally {
+      await page.close();
+    }
+  }
+
+  private auth0RedirectedToRemoteDeployment(page: Page): boolean {
+    return !page.url().startsWith(testEnvConfig.BASE_URL);
+  }
+
+  private async syncVerificationViaLocalApp(page: Page, email: string): Promise<void> {
+    const verifyEmailUrl = `${testEnvConfig.BASE_URL}/user/verify-email?email=${encodeURIComponent(email)}`;
+    await page.goto(verifyEmailUrl);
+  }
+
+  private async pollForVerificationLink(email: string): Promise<string> {
+    const maxAttempts = 30;
+    const pollIntervalMs = 2_000;
+
+    const errors: Error[] = [];
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        const messages = await this.fetchMessages(email);
+
+        const verificationMessage = messages.find(m => m.subject?.toLowerCase().includes("verify") || m.subject?.toLowerCase().includes("verification"));
+
+        if (verificationMessage) {
+          const message = await this.fetchMessage(email, verificationMessage._id);
+          const links: string[] = message.links ?? [];
+          const link = links.find(l => l.includes("email-verification"));
+          if (link) return link;
+        }
+      } catch (error) {
+        errors.push(error instanceof Error ? error : new Error(String(error)));
+      }
+
+      await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+    }
+
+    throw new AggregateError(errors, `Verification email not received at ${email} within ${(maxAttempts * pollIntervalMs) / 1_000}s`);
+  }
+
+  private async fetchMessages(email: string) {
+    return this.fetch<Array<{ _id: string; subject?: string }>>(`${this.baseUrl}/addresses/${email}/messages`);
+  }
+
+  private async fetchMessage(email: string, messageId: string) {
+    return this.fetch<{ links?: string[] }>(`${this.baseUrl}/addresses/${email}/messages/${messageId}`);
+  }
+
+  private async fetch<T>(path: string): Promise<T> {
+    const response = await fetch(path, {
+      headers: { "Mailsac-Key": this.apiKey }
+    });
+
+    if (!response.ok) {
+      throw new Error(`Mailsac get message failed (${response.status}): ${await response.text()}`);
+    }
+
+    return response.json();
+  }
+}


### PR DESCRIPTION
## Why

Part of CON-152

Email verification in E2E tests was hardcoded to the Auth0 Management API ticket approach. This adds a strategy abstraction so verification can also be done via real email delivery (Mailsac), which tests the actual user-facing flow.

## What

- `EmailVerificationStrategy` interface with `generateEmail()` and `verify()` methods
- `Auth0TicketVerificationStrategy` — existing approach using Auth0 Management API tickets
- `MailsacVerificationStrategy` — polls Mailsac API for the verification email, extracts the link, navigates to it
- Factory selects strategy based on `MAILSAC_API_KEY` env var presence
- Test updated to use strategy via Playwright fixture

### New optional env var
- `MAILSAC_API_KEY` — when set, uses Mailsac instead of Auth0 tickets for email verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added flexible email verification with selectable strategies (Mailsac and Auth0 ticket).
  * Extended test fixtures to provide email verification and updated tests to use the new flow.
  * Simplified credential handling: test helpers now generate passwords only; emails are produced by verification strategies.
  * Added validation for MAILSAC API key and selection of verification strategy in test configuration.

* **Chores**
  * Added MAILSAC API key and email-verification-strategy inputs for CI/test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->