### PR TITLE
fix: ensure that custodial wallet providers are not duplicated in modal

### DIFF
--- a/apps/deploy-web/src/components/layout/WalletStatus.tsx
+++ b/apps/deploy-web/src/components/layout/WalletStatus.tsx
@@ -89,11 +89,11 @@ export function WalletStatus() {
         )
       ) : (
         <div className="flex items-center space-x-2 rounded-md border bg-accent px-4 py-2">
-          <Skeleton className="h-4 w-4 rounded-full" />
-          <Skeleton className="h-4 w-20" />
+          <Skeleton className="h-4 w-4 rounded-full bg-muted-foreground/20" />
+          <Skeleton className="h-4 w-20 bg-muted-foreground/20" />
           <div className="text-muted-foreground">|</div>
-          <Skeleton className="h-4 w-16" />
-          <Skeleton className="h-4 w-4" />
+          <Skeleton className="h-4 w-16 bg-muted-foreground/20" />
+          <Skeleton className="h-4 w-4 bg-muted-foreground/20" />
         </div>
       )}
     </>

--- a/apps/deploy-web/src/context/CustomChainProvider/CustomChainProvider.spec.tsx
+++ b/apps/deploy-web/src/context/CustomChainProvider/CustomChainProvider.spec.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CustomChainProvider, DEPENDENCIES } from "./CustomChainProvider";
+
+import { render, screen } from "@testing-library/react";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe(CustomChainProvider.name, () => {
+  it("renders children", () => {
+    setup();
+
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  it("renders ModalWrapper", () => {
+    const { dependencies } = setup();
+
+    expect(dependencies.ModalWrapper).toHaveBeenCalled();
+  });
+
+  it("passes walletsRegistry to ChainStoreProvider", () => {
+    const { dependencies } = setup();
+
+    const call = vi.mocked(dependencies.ChainStoreProvider).mock.calls[0][0];
+    expect(call.walletsRegistry).toEqual([
+      { names: ["keplr-extension", "keplr-mobile"], loader: expect.any(Function) },
+      { names: ["leap-extension", "leap-mobile", "leap-metamask-cosmos-snap"], loader: expect.any(Function) },
+      { names: ["cosmostation-extension"], loader: expect.any(Function) },
+      { names: ["cosmos-extension-metamask"], loader: expect.any(Function) }
+    ]);
+  });
+
+  it("passes walletManagerOptions with chains and config to ChainStoreProvider", () => {
+    const { dependencies } = setup();
+
+    const call = vi.mocked(dependencies.ChainStoreProvider).mock.calls[0][0];
+    expect(call.walletManagerOptions).toEqual(
+      expect.objectContaining({
+        chains: expect.any(Array),
+        assetList: expect.any(Array),
+        sessionOptions: expect.objectContaining({ duration: 31_556_926_000 }),
+        walletConnectOptions: expect.objectContaining({
+          signClient: expect.objectContaining({ projectId: expect.any(String) })
+        }),
+        endpointOptions: expect.objectContaining({ isLazy: true }),
+        signerOptions: expect.objectContaining({
+          preferredSignType: expect.any(Function)
+        })
+      })
+    );
+  });
+
+  it("initializes ChainStoreInitializer with selected network chain name", () => {
+    const chainRegistryName = "akashnet-2";
+    const { dependencies } = setup({ chainRegistryName });
+
+    expect(dependencies.ChainStoreInitializer).toHaveBeenCalledWith(expect.objectContaining({ chainName: chainRegistryName }), expect.anything());
+  });
+
+  it("uses network from useServices to determine chain name", () => {
+    const chainRegistryName = "sandbox-chain";
+    const { dependencies } = setup({ chainRegistryName });
+
+    expect(dependencies.useServices).toHaveBeenCalled();
+    expect(dependencies.ChainStoreInitializer).toHaveBeenCalledWith(expect.objectContaining({ chainName: chainRegistryName }), expect.anything());
+  });
+
+  function setup(input?: { chainRegistryName?: string }) {
+    const useSelectedNetwork = vi.fn(() => ({
+      chainRegistryName: input?.chainRegistryName ?? "akashnet-2"
+    }));
+
+    const dependencies = MockComponents(DEPENDENCIES, {
+      useServices: vi.fn(() => ({
+        networkStore: { useSelectedNetwork }
+      })) as unknown as typeof DEPENDENCIES.useServices
+    });
+
+    render(
+      <CustomChainProvider dependencies={dependencies}>
+        <div data-testid="child" />
+      </CustomChainProvider>
+    );
+
+    return { dependencies, useSelectedNetwork };
+  }
+});

--- a/apps/deploy-web/src/context/CustomChainProvider/CustomChainProvider.tsx
+++ b/apps/deploy-web/src/context/CustomChainProvider/CustomChainProvider.tsx
@@ -1,28 +1,34 @@
 import { GasPrice } from "@cosmjs/stargate";
-import type { MainWalletBase } from "@cosmos-kit/core";
 
 import { assetLists, chains } from "@src/chains";
-import type { ChainStoreProviderProps } from "@src/lib/cosmos-kit-jotai";
+import type { ChainStoreProviderProps, WalletsRegistry } from "@src/lib/cosmos-kit-jotai";
 import { ChainStoreInitializer, ChainStoreProvider, CURRENT_WALLET_KEY, ModalWrapper } from "@src/lib/cosmos-kit-jotai";
 import { registry } from "@src/utils/customRegistry";
 import { useServices } from "../ServicesProvider";
 
 type Props = {
   children: React.ReactNode;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+export const DEPENDENCIES = {
+  ChainStoreProvider,
+  ModalWrapper,
+  ChainStoreInitializer,
+  useServices
 };
 
 /**
- * The order of keys is important here.
- * Wallets are rendered in the order they are specified in this registry
+ * The order of entries is important here.
+ * Wallets are rendered in the order they are specified in this registry.
+ * Each entry maps wallet names to a shared loader so each package is imported only once.
  */
-const WALLETS_PROVIDERS: Record<string, () => Promise<{ wallets: MainWalletBase[] }>> = {
-  "keplr-extension": () => import("@cosmos-kit/keplr"),
-  "leap-extension": () => import("@cosmos-kit/leap"),
-  "cosmostation-extension": () => import("@cosmos-kit/cosmostation-extension"),
-  "cosmos-extension-metamask": () => import("@cosmos-kit/cosmos-extension-metamask"),
-  "keplr-mobile": () => import("@cosmos-kit/keplr"),
-  "leap-mobile": () => import("@cosmos-kit/leap")
-};
+const WALLETS_PROVIDERS: WalletsRegistry = [
+  { names: ["keplr-extension", "keplr-mobile"], loader: () => import("@cosmos-kit/keplr") },
+  { names: ["leap-extension", "leap-mobile", "leap-metamask-cosmos-snap"], loader: () => import("@cosmos-kit/leap") },
+  { names: ["cosmostation-extension"], loader: () => import("@cosmos-kit/cosmostation-extension") },
+  { names: ["cosmos-extension-metamask"], loader: () => import("@cosmos-kit/cosmos-extension-metamask") }
+];
 
 const walletManagerOptions: ChainStoreProviderProps["walletManagerOptions"] = {
   chains,
@@ -55,19 +61,19 @@ const walletManagerOptions: ChainStoreProviderProps["walletManagerOptions"] = {
   }
 };
 
-export function CustomChainProvider({ children }: Props) {
+export function CustomChainProvider({ children, dependencies: d = DEPENDENCIES }: Props) {
   return (
-    <ChainStoreProvider walletsRegistry={WALLETS_PROVIDERS} walletManagerOptions={walletManagerOptions}>
-      <ModalWrapper />
-      <InitializeChainStoreForSelectedNetwork />
+    <d.ChainStoreProvider walletsRegistry={WALLETS_PROVIDERS} walletManagerOptions={walletManagerOptions}>
+      <d.ModalWrapper />
+      <InitializeChainStoreForSelectedNetwork dependencies={d} />
       {children}
-    </ChainStoreProvider>
+    </d.ChainStoreProvider>
   );
 }
 
-function InitializeChainStoreForSelectedNetwork() {
-  const { networkStore } = useServices();
+function InitializeChainStoreForSelectedNetwork({ dependencies: d = DEPENDENCIES }: Pick<Props, "dependencies">) {
+  const { networkStore } = d.useServices();
   const selectedNetwork = networkStore.useSelectedNetwork();
 
-  return <ChainStoreInitializer chainName={selectedNetwork.chainRegistryName} />;
+  return <d.ChainStoreInitializer chainName={selectedNetwork.chainRegistryName} />;
 }

--- a/apps/deploy-web/src/lib/cosmos-kit-jotai/components/WalletModal/WalletModal.spec.tsx
+++ b/apps/deploy-web/src/lib/cosmos-kit-jotai/components/WalletModal/WalletModal.spec.tsx
@@ -228,7 +228,7 @@ describe(WalletModal.name, () => {
 
     render(
       <JotaiProvider store={jotaiStore}>
-        <ChainStoreProvider walletsRegistry={{}} walletManagerOptions={{ chains: [], assetList: [] }}>
+        <ChainStoreProvider walletsRegistry={[]} walletManagerOptions={{ chains: [], assetList: [] }}>
           <MockChainStoreProvider selectedWalletName={input.selectedWalletName} onRenderChainStore={input.onRenderChainStore}>
             <WalletModal isOpen={input.isOpen} setOpen={input.setOpen ?? vi.fn()} walletRepo={walletRepo} />
           </MockChainStoreProvider>

--- a/apps/deploy-web/src/lib/cosmos-kit-jotai/hooks/useChain/useChain.spec.tsx
+++ b/apps/deploy-web/src/lib/cosmos-kit-jotai/hooks/useChain/useChain.spec.tsx
@@ -1,10 +1,10 @@
 import type { ReactNode } from "react";
-import type { MainWalletBase } from "@cosmos-kit/core";
 import { createStore, Provider as JotaiProvider } from "jotai";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { akash, akashAssetList } from "@src/chains/akash";
 import { ChainStoreProvider } from "../../context/ChainStoreProvider";
+import type { WalletsRegistry } from "../../store/ChainStore";
 import { CURRENT_WALLET_KEY } from "../../store/constants";
 import { useChain } from "./useChain";
 
@@ -147,13 +147,13 @@ describe(useChain.name, () => {
     });
   });
 
-  function setup(input?: { chainName?: string; walletsRegistry?: Record<string, () => Promise<{ wallets: MainWalletBase[] }>> }) {
+  function setup(input?: { chainName?: string; walletsRegistry?: WalletsRegistry }) {
     const chainName = input?.chainName ?? "akash";
     const store = createStore();
 
     const wrapper = ({ children }: { children: ReactNode }) => (
       <JotaiProvider store={store}>
-        <ChainStoreProvider walletsRegistry={input?.walletsRegistry ?? {}} walletManagerOptions={{ chains: [akash], assetList: [akashAssetList] }}>
+        <ChainStoreProvider walletsRegistry={input?.walletsRegistry ?? []} walletManagerOptions={{ chains: [akash], assetList: [akashAssetList] }}>
           {children}
         </ChainStoreProvider>
       </JotaiProvider>
@@ -163,8 +163,6 @@ describe(useChain.name, () => {
   }
 });
 
-function createKeplrRegistry(): Record<string, () => Promise<{ wallets: MainWalletBase[] }>> {
-  return {
-    "keplr-extension": () => import("@cosmos-kit/keplr")
-  };
+function createKeplrRegistry(): WalletsRegistry {
+  return [{ names: ["keplr-extension", "keplr-mobile"], loader: () => import("@cosmos-kit/keplr") }];
 }

--- a/apps/deploy-web/src/lib/cosmos-kit-jotai/index.ts
+++ b/apps/deploy-web/src/lib/cosmos-kit-jotai/index.ts
@@ -4,4 +4,5 @@ export { ModalWrapper } from "./components/ModalWrapper/ModalWrapper";
 export { WalletListView } from "./components/WalletModal/WalletListView";
 export { ChainStoreProvider, useChainStore, type ChainStoreProviderProps } from "./context/ChainStoreProvider";
 export { CURRENT_WALLET_KEY } from "./store/constants";
+export type { WalletsRegistry, WalletsRegistryEntry } from "./store/ChainStore";
 export { useManager, type ManagerContext } from "./hooks/useManager/useManager";

--- a/apps/deploy-web/src/lib/cosmos-kit-jotai/store/ChainStore.ts
+++ b/apps/deploy-web/src/lib/cosmos-kit-jotai/store/ChainStore.ts
@@ -165,17 +165,22 @@ export class ChainStore {
   }
 }
 
-type WalletsRegistry = Record<string, () => Promise<{ wallets: MainWalletBase[] }>>;
+export type WalletsRegistryEntry = {
+  names: string[];
+  loader: () => Promise<{ wallets: MainWalletBase[] }>;
+};
+export type WalletsRegistry = WalletsRegistryEntry[];
+
 async function loadWalletByName(registry: WalletsRegistry, name: string): Promise<MainWalletBase[]> {
-  const loader = registry[name];
-  if (!loader) {
+  const entry = registry.find(e => e.names.includes(name));
+  if (!entry) {
     throw new Error(`Unknown wallet: ${name}`);
   }
-  const { wallets } = await loader();
+  const { wallets } = await entry.loader();
   return wallets;
 }
 
 async function loadAllWallets(registry: WalletsRegistry): Promise<MainWalletBase[]> {
-  const wallets = await Promise.all(Object.keys(registry).map(name => loadWalletByName(registry, name)));
-  return wallets.flat();
+  const wallets = await Promise.all(registry.map(entry => entry.loader()));
+  return wallets.flatMap(({ wallets }) => wallets);
 }


### PR DESCRIPTION
## Why

User sees duplicated keplr and leap options when choosing web wallet provider. Introduced in https://github.com/akash-network/console/pull/3076

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved wallet-status loading visuals for a clearer skeleton display.

* **Refactor**
  * Modularized wallet provider loading into an ordered registry and made provider dependencies injectable for greater modularity.

* **Tests**
  * Updated test setups to match the new registry shape and added provider tests validating initialization and dependency wiring.

* **Chores**
  * Added type re-exports to expose the new registry types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->