### PR TITLE
Security: Usage history and spending statistics are publicly accessible

### DIFF
--- a/apps/api/src/billing/routes/usage/usage.router.ts
+++ b/apps/api/src/billing/routes/usage/usage.router.ts
@@ -4,14 +4,13 @@ import { UsageController } from "@src/billing/controllers/usage/usage.controller
 import { GetUsageHistoryQuerySchema, UsageHistoryResponseSchema, UsageHistoryStatsResponseSchema } from "@src/billing/http-schemas/usage.schema";
 import { createRoute } from "@src/core/lib/create-route/create-route";
 import { OpenApiHonoHandler } from "@src/core/services/open-api-hono-handler/open-api-hono-handler";
-import { SECURITY_NONE } from "@src/core/services/openapi-docs/openapi-security";
 
 const getUsageHistoryRoute = createRoute({
   method: "get",
   path: "/v1/usage/history",
   summary: "Get historical data of billing and usage for a wallet address.",
   tags: ["Billing"],
-  security: SECURITY_NONE,
+  security: [{ bearerAuth: [] }],
 
   request: {
     query: GetUsageHistoryQuerySchema
@@ -36,7 +35,7 @@ const getUsageHistoryStatsRoute = createRoute({
   path: "/v1/usage/history/stats",
   summary: "Get historical usage stats for a wallet address.",
   tags: ["Billing"],
-  security: SECURITY_NONE,
+  security: [{ bearerAuth: [] }],
   request: {
     query: GetUsageHistoryQuerySchema
   },


### PR DESCRIPTION
## Summary

Security: Usage history and spending statistics are publicly accessible

## Problem

**Severity**: `Medium` | **File**: `apps/api/src/billing/routes/usage/usage.router.ts:L12`

Both usage routes (`/v1/usage/history` and `/v1/usage/history/stats`) are configured with `SECURITY_NONE`. These endpoints expose billing/usage-derived information for any provided wallet address, which can reveal sensitive behavioral and financial metadata at scale (profiling users, competitors, or high-value accounts).

## Solution

Require authentication and authorization tied to the requesting user/wallet owner. If public analytics are intended, provide only coarse/aggregated data and remove per-address detailed outputs.

## Changes

- `apps/api/src/billing/routes/usage/usage.router.ts` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation for usage endpoints to explicitly indicate bearer token authentication is required, improving clarity on endpoint security requirements for API consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->