### PR TITLE
test(onboarding): add mailsac-code email verification strategy

### DIFF
--- a/apps/deploy-web/tests/ui/fixture/test-env.config.ts
+++ b/apps/deploy-web/tests/ui/fixture/test-env.config.ts
@@ -17,7 +17,7 @@ export const testEnvSchema = z.object({
   AUTH0_M2M_CLIENT_ID: z.string({ required_error: "Auth0 M2M client ID for management API" }).trim().min(1),
   AUTH0_M2M_CLIENT_SECRET: z.string({ required_error: "Auth0 M2M client secret for management API" }).trim().min(1),
   MAILSAC_API_KEY: z.string({ required_error: "Mailsac API key for email verification" }).trim().min(1),
-  EMAIL_VERIFICATION_STRATEGY: z.enum(["mailsac", "auth0-ticket"]).default("mailsac")
+  EMAIL_VERIFICATION_STRATEGY: z.enum(["mailsac", "mailsac-code", "auth0-ticket"]).default("mailsac")
 });
 
 export const testEnvConfig = testEnvSchema.parse({

--- a/apps/deploy-web/tests/ui/services/email-verification/index.ts
+++ b/apps/deploy-web/tests/ui/services/email-verification/index.ts
@@ -3,12 +3,17 @@ import type { Auth0ManagementService } from "../auth0-management.service";
 import { Auth0TicketVerificationStrategy } from "./auth0-ticket.strategy";
 import type { EmailVerificationStrategy } from "./email-verification.strategy";
 import { MailsacVerificationStrategy } from "./mailsac.strategy";
+import { MailsacCodeVerificationStrategy } from "./mailsac-code.strategy";
 
 export type { EmailVerificationStrategy } from "./email-verification.strategy";
 
 export function createEmailVerificationStrategy(auth0: Auth0ManagementService): EmailVerificationStrategy {
   if (testEnvConfig.EMAIL_VERIFICATION_STRATEGY === "auth0-ticket") {
     return new Auth0TicketVerificationStrategy(auth0);
+  }
+
+  if (testEnvConfig.EMAIL_VERIFICATION_STRATEGY === "mailsac-code") {
+    return new MailsacCodeVerificationStrategy(testEnvConfig.MAILSAC_API_KEY);
   }
 
   return new MailsacVerificationStrategy(testEnvConfig.MAILSAC_API_KEY);

--- a/apps/deploy-web/tests/ui/services/email-verification/mailsac-code.strategy.ts
+++ b/apps/deploy-web/tests/ui/services/email-verification/mailsac-code.strategy.ts
@@ -1,0 +1,81 @@
+import type { BrowserContext } from "@playwright/test";
+
+import type { EmailVerificationStrategy } from "./email-verification.strategy";
+
+export class MailsacCodeVerificationStrategy implements EmailVerificationStrategy {
+  private readonly baseUrl = "https://mailsac.com/api";
+
+  constructor(private readonly apiKey: string) {}
+
+  generateEmail(): string {
+    return `e2e-${crypto.randomUUID().slice(0, 8)}@mailsac.com`;
+  }
+
+  async verify(input: { context: BrowserContext; email: string; userId: string }): Promise<void> {
+    const code = await this.pollForVerificationCode(input.email);
+    const pages = input.context.pages();
+
+    if (pages.length === 0) {
+      throw new Error("No browser pages available to enter verification code");
+    }
+
+    const page = pages[0];
+    const firstDigitInput = page.getByLabel("Verification code digit 1");
+    await firstDigitInput.click();
+    await page.keyboard.type(code);
+  }
+
+  private async pollForVerificationCode(email: string): Promise<string> {
+    const maxAttempts = 30;
+    const pollIntervalMs = 2_000;
+    const errors: Error[] = [];
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      try {
+        const messages = await this.fetchMessages(email);
+
+        const verificationMessage = messages.find(m => m.subject?.toLowerCase().includes("verif") || m.subject?.toLowerCase().includes("code"));
+
+        if (verificationMessage) {
+          const body = await this.fetchMessageBody(email, verificationMessage._id);
+          const match = body.match(/\b(\d{6})\b/);
+          if (match) return match[1];
+        }
+      } catch (error) {
+        errors.push(error instanceof Error ? error : new Error(String(error)));
+      }
+
+      await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+    }
+
+    throw new AggregateError(errors, `Verification code email not received at ${email} within ${(maxAttempts * pollIntervalMs) / 1_000}s`);
+  }
+
+  private async fetchMessages(email: string) {
+    return this.fetch<Array<{ _id: string; subject?: string }>>(`${this.baseUrl}/addresses/${email}/messages`);
+  }
+
+  private async fetchMessageBody(email: string, messageId: string): Promise<string> {
+    const response = await fetch(`${this.baseUrl}/text/${email}/${messageId}`, {
+      headers: { "Mailsac-Key": this.apiKey }
+    });
+
+    if (!response.ok) {
+      throw new Error(`Mailsac body fetch failed (${response.status}): ${await response.text()}`);
+    }
+
+    return response.text();
+  }
+
+  private async fetch<T>(path: string): Promise<T> {
+    const response = await fetch(path, {
+      headers: { "Mailsac-Key": this.apiKey }
+    });
+
+    if (!response.ok) {
+      throw new Error(`Mailsac request failed (${response.status}): ${await response.text()}`);
+    }
+
+    return response.json();
+  }
+}


### PR DESCRIPTION
## Why

Part of CON-152

Prepares E2E test infrastructure for the upcoming code-based email verification flow (PR #3052). The current strategies only support link-based verification.

## What

- Add `MailsacCodeVerificationStrategy` — polls Mailsac for the verification code email, extracts the 6-digit code from the plain text body via `/text/` API endpoint, and enters it in the UI via `page.keyboard.type()`
- Register `mailsac-code` option in the strategy factory and env config schema
- Activated via `EMAIL_VERIFICATION_STRATEGY=mailsac-code` env var; existing strategies unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "mailsac-code" email verification option — tests can now generate a mailsac-based alias, poll for verification messages, extract a 6-digit code, and enter it into the verification UI, alongside existing "mailsac" and "auth0-ticket" methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->