### PR TITLE
refactor(onboarding): infer step from user state instead of localStorage

### DIFF
--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
@@ -14,24 +14,81 @@ import { OnboardingContainer, OnboardingStepIndex } from "./OnboardingContainer"
 import { act, render } from "@testing-library/react";
 
 describe("OnboardingContainer", () => {
-  it("should initialize with default state", () => {
+  it("should show loading state when user data is loading", () => {
+    const { child } = setup({ isUserLoading: true });
+
+    expect(child.mock.calls[0][0].isLoading).toBe(true);
+  });
+
+  it("should show loading state when wallet is loading", () => {
+    const { child } = setup({ wallet: { isWalletLoading: true } });
+
+    expect(child.mock.calls[0][0].isLoading).toBe(true);
+  });
+
+  it("should not be loading when all data is resolved", () => {
     const { child } = setup();
 
-    expect(child.mock.calls[0][0]).toEqual({
-      currentStep: OnboardingStepIndex.FREE_TRIAL,
-      steps: expect.arrayContaining([
+    expect(child.mock.calls[0][0].isLoading).toBe(false);
+  });
+
+  it("should infer FREE_TRIAL step when no user", () => {
+    const { child } = setup();
+
+    expect(child.mock.calls[0][0].currentStep).toBe(OnboardingStepIndex.FREE_TRIAL);
+  });
+
+  it("should infer EMAIL_VERIFICATION step when user exists but email not verified", () => {
+    const { child } = setup({
+      user: { userId: "user-1", emailVerified: false }
+    });
+
+    expect(child.mock.calls[0][0].currentStep).toBe(OnboardingStepIndex.EMAIL_VERIFICATION);
+  });
+
+  it("should infer PAYMENT_METHOD step when user has verified email but no managed wallet", () => {
+    const { child } = setup({
+      user: { userId: "user-1", emailVerified: true }
+    });
+
+    expect(child.mock.calls[0][0].currentStep).toBe(OnboardingStepIndex.PAYMENT_METHOD);
+  });
+
+  it("should infer WELCOME step when user has managed wallet", () => {
+    const { child } = setup({
+      user: { userId: "user-1", emailVerified: true },
+      wallet: { hasManagedWallet: true }
+    });
+
+    expect(child.mock.calls[0][0].currentStep).toBe(OnboardingStepIndex.WELCOME);
+  });
+
+  it("should derive completed steps from current step", () => {
+    const { child } = setup({
+      user: { userId: "user-1", emailVerified: true },
+      wallet: { hasManagedWallet: true }
+    });
+
+    const steps = child.mock.calls[0][0].steps;
+    expect(steps[OnboardingStepIndex.FREE_TRIAL].isCompleted).toBe(true);
+    expect(steps[OnboardingStepIndex.SIGNUP].isCompleted).toBe(true);
+    expect(steps[OnboardingStepIndex.EMAIL_VERIFICATION].isCompleted).toBe(true);
+    expect(steps[OnboardingStepIndex.PAYMENT_METHOD].isCompleted).toBe(true);
+    expect(steps[OnboardingStepIndex.WELCOME].isCompleted).toBe(false);
+  });
+
+  it("should have all step definitions", () => {
+    const { child } = setup();
+
+    expect(child.mock.calls[0][0].steps).toEqual(
+      expect.arrayContaining([
         expect.objectContaining({ id: "free-trial", title: "Free Trial" }),
         expect.objectContaining({ id: "signup", title: "Create Account" }),
         expect.objectContaining({ id: "email-verification", title: "Verify Email" }),
         expect.objectContaining({ id: "payment-method", title: "Payment Method" }),
         expect.objectContaining({ id: "welcome", title: "Welcome" })
-      ]),
-      onStepChange: expect.any(Function),
-      onStepComplete: expect.any(Function),
-      onStartTrial: expect.any(Function),
-      onPaymentMethodComplete: expect.any(Function),
-      onComplete: expect.any(Function)
-    });
+      ])
+    );
   });
 
   it("should track analytics when step changes", async () => {
@@ -80,24 +137,14 @@ describe("OnboardingContainer", () => {
     expect(mockRouter.push).toHaveBeenCalledWith("/login?tab=signup");
   });
 
-  it("should track analytics when payment method is completed", async () => {
-    const { child, mockAnalyticsService } = setup({
+  it("should stay on PAYMENT_METHOD until managed wallet is created", () => {
+    const { child } = setup({
+      user: { userId: "user-1", emailVerified: true },
       paymentMethods: [{ id: "1", type: "card" }]
     });
 
-    const { onPaymentMethodComplete } = child.mock.calls[0][0];
-    const initialStep = child.mock.calls[0][0].currentStep;
-
-    await act(async () => {
-      onPaymentMethodComplete();
-    });
-
-    expect(mockAnalyticsService.track).toHaveBeenCalledWith("onboarding_payment_method_added", {
-      category: "onboarding"
-    });
-
-    const currentStep = child.mock.calls[child.mock.calls.length - 1][0].currentStep;
-    expect(currentStep).toBe(initialStep);
+    // Even with payment methods, should stay on PAYMENT_METHOD without managed wallet
+    expect(child.mock.calls[0][0].currentStep).toBe(OnboardingStepIndex.PAYMENT_METHOD);
   });
 
   it("should redirect to deployment and connect managed wallet when onboarding is completed", async () => {
@@ -112,33 +159,18 @@ describe("OnboardingContainer", () => {
     expect(mockConnectManagedWallet).toHaveBeenCalled();
   });
 
-  it("should redirect to home when user has managed wallet and no saved step", async () => {
-    const { mockNavigateBack } = setup({
+  it("should show WELCOME step when user has managed wallet", () => {
+    const { child } = setup({
+      user: { userId: "user-1", emailVerified: true },
       wallet: { hasManagedWallet: true, isWalletLoading: false }
     });
 
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 10));
-    });
-
-    expect(mockNavigateBack).toHaveBeenCalled();
-  });
-
-  it("should not redirect when user has managed wallet but has saved step", async () => {
-    const { mockRouter } = setup({
-      wallet: { hasManagedWallet: true, isWalletLoading: false },
-      savedStep: "2"
-    });
-
-    await act(async () => {
-      await new Promise(resolve => setTimeout(resolve, 0));
-    });
-
-    expect(mockRouter.replace).not.toHaveBeenCalled();
+    expect(child.mock.calls[0][0].currentStep).toBe(OnboardingStepIndex.WELCOME);
   });
 
   it("should handle fromSignup URL parameter", async () => {
-    const { child, mockAnalyticsService } = setup({
+    const { mockAnalyticsService } = setup({
+      user: { userId: "user-1", emailVerified: false },
       windowLocation: {
         search: "?fromSignup=true",
         href: "http://localhost/onboarding?fromSignup=true",
@@ -156,9 +188,6 @@ describe("OnboardingContainer", () => {
     expect(mockAnalyticsService.track).toHaveBeenCalledWith("onboarding_account_created", {
       category: "onboarding"
     });
-
-    // The component should be on the EMAIL_VERIFICATION step after handling fromSignup
-    expect(child.mock.calls[child.mock.calls.length - 1][0].currentStep).toBe(OnboardingStepIndex.EMAIL_VERIFICATION);
   });
 
   it("replaces uakt with managed denom when completing onboarding", async () => {
@@ -233,19 +262,15 @@ describe("OnboardingContainer", () => {
   function setup(
     input: {
       paymentMethods?: Array<{ id: string; type: string }>;
-      user?: { emailVerified?: boolean; userId?: string };
+      user?: { emailVerified?: boolean; userId?: string; stripeCustomerId?: string };
       wallet?: { hasManagedWallet?: boolean; isWalletLoading?: boolean; isManaged?: boolean; denom?: string };
+      isUserLoading?: boolean;
+      isPaymentMethodsLoading?: boolean;
       windowLocation?: Partial<Location>;
       windowHistory?: Partial<History>;
-      savedStep?: string;
     } = {}
   ) {
     vi.clearAllMocks();
-
-    // Mock localStorage using jest-mock-extended
-    const mockLocalStorage = mock<Storage>({
-      getItem: vi.fn().mockReturnValue(input.savedStep || null)
-    });
 
     // Store original window objects
     let windowLocation = window.location;
@@ -302,8 +327,14 @@ describe("OnboardingContainer", () => {
       NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID: "sandbox"
     };
 
-    const mockUseUser = vi.fn().mockReturnValue(input.user || { emailVerified: false });
-    const mockUsePaymentMethodsQuery = vi.fn().mockReturnValue({ data: input.paymentMethods || [] });
+    const mockUseUser = vi.fn().mockReturnValue({
+      user: input.user,
+      isLoading: input.isUserLoading || false
+    });
+    const mockUsePaymentMethodsQuery = vi.fn().mockReturnValue({
+      data: input.paymentMethods || [],
+      isLoading: input.isPaymentMethodsLoading || false
+    });
     const mockUseChainParam = vi.fn().mockReturnValue({ minDeposit: { akt: 0.5, usdc: 5, act: 0.5 } });
     const mockDenomToUdenom = vi.fn().mockImplementation((amount: number) => amount * 1_000_000);
     const mockErrorHandler = mock<ErrorHandlerService>();
@@ -424,7 +455,6 @@ describe("OnboardingContainer", () => {
       useSnackbar: mockUseSnackbar,
       useNotificator: mockUseNotificator,
       useReturnTo: mockUseReturnTo,
-      localStorage: mockLocalStorage,
       deploymentData: mockDeploymentData,
       validateDeploymentData: mockValidateDeploymentData,
       appendAuditorRequirement: mockAppendAuditorRequirement,
@@ -451,10 +481,10 @@ describe("OnboardingContainer", () => {
       mockDenomToUdenom,
       mockUseServices,
       mockUseRouter,
+      mockUseWallet,
       mockConnectManagedWallet,
       mockNavigateBack,
       mockNavigateWithReturnTo,
-      mockLocalStorage,
       mockSignAndBroadcastTx,
       mockGenNewCertificateIfLocalIsInvalid,
       mockUpdateSelectedCertificate,
@@ -464,7 +494,6 @@ describe("OnboardingContainer", () => {
       mockValidateDeploymentData,
       mockAppendAuditorRequirement,
       mockTransactionMessageData,
-      mockUseWallet,
       mockSetSelectedNetworkId
     };
   }

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type { ReactNode } from "react";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { EncodeObject } from "@cosmjs/proto-signing";
 import { useRouter, useSearchParams } from "next/navigation";
 
@@ -13,7 +13,6 @@ import { useNotificator } from "@src/hooks/useNotificator";
 import { useReturnTo } from "@src/hooks/useReturnTo";
 import { useUser } from "@src/hooks/useUser";
 import { usePaymentMethodsQuery } from "@src/queries/usePaymentQueries";
-import { ONBOARDING_STEP_KEY } from "@src/services/storage/keys";
 import { RouteStep } from "@src/types/route-steps.type";
 import { deploymentData } from "@src/utils/deploymentData";
 import { appendAuditorRequirement, replaceSdlDenom } from "@src/utils/deploymentData/v1beta3";
@@ -33,6 +32,7 @@ export enum OnboardingStepIndex {
 
 export type OnboardingContainerProps = {
   children: (props: {
+    isLoading: boolean;
     currentStep: number;
     steps: OnboardingStep[];
     onStepChange: (step: number) => void;
@@ -54,7 +54,6 @@ const DEPENDENCIES = {
   useCertificate,
   useNotificator,
   useReturnTo,
-  localStorage: typeof window !== "undefined" ? window.localStorage : null,
   deploymentData,
   validateDeploymentData,
   appendAuditorRequirement,
@@ -65,15 +64,29 @@ const DEPENDENCIES = {
   denomToUdenom
 };
 
+function inferStep(user: { userId?: string; emailVerified?: boolean } | undefined, hasManagedWallet: boolean): OnboardingStepIndex {
+  if (!user?.userId) return OnboardingStepIndex.FREE_TRIAL;
+  if (!user.emailVerified) return OnboardingStepIndex.EMAIL_VERIFICATION;
+  if (!hasManagedWallet) return OnboardingStepIndex.PAYMENT_METHOD;
+  return OnboardingStepIndex.WELCOME;
+}
+
+function deriveCompletedSteps(step: OnboardingStepIndex): Set<OnboardingStepIndex> {
+  const completed = new Set<OnboardingStepIndex>();
+  const allSteps = [OnboardingStepIndex.FREE_TRIAL, OnboardingStepIndex.SIGNUP, OnboardingStepIndex.EMAIL_VERIFICATION, OnboardingStepIndex.PAYMENT_METHOD];
+  for (const s of allSteps) {
+    if (s < step) completed.add(s);
+  }
+  return completed;
+}
+
 export const OnboardingContainer: React.FunctionComponent<OnboardingContainerProps> = ({ children, dependencies: d = DEPENDENCIES }) => {
-  const [currentStep, setCurrentStep] = useState(OnboardingStepIndex.FREE_TRIAL);
-  const [completedSteps, setCompletedSteps] = useState<Set<OnboardingStepIndex>>(new Set());
   const [showSuccessAnimation, setShowSuccessAnimation] = useState(false);
 
   const router = d.useRouter();
   const searchParams = d.useSearchParams();
-  const { user } = d.useUser();
-  const { data: paymentMethods = [] } = d.usePaymentMethodsQuery({ enabled: !!user?.stripeCustomerId });
+  const { user, isLoading: isUserLoading } = d.useUser();
+  const { data: paymentMethods = [], isLoading: isPaymentMethodsLoading } = d.usePaymentMethodsQuery({ enabled: !!user?.stripeCustomerId });
   const { minDeposit } = d.useChainParam();
   const {
     analyticsService,
@@ -93,63 +106,65 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
   const notificator = d.useNotificator();
   const { navigateBack } = d.useReturnTo({ defaultReturnTo: "/" });
 
-  useEffect(() => {
-    const savedStep = d.localStorage?.getItem(ONBOARDING_STEP_KEY);
-    if (!wallet.isWalletLoading && wallet.hasManagedWallet && !savedStep) {
-      navigateBack();
-    }
-  }, [wallet.isWalletLoading, wallet.hasManagedWallet, d.localStorage, navigateBack]);
+  const isLoading = isUserLoading || wallet.isWalletLoading || (!!user?.stripeCustomerId && isPaymentMethodsLoading);
 
-  useEffect(() => {
-    const savedStep = d.localStorage?.getItem(ONBOARDING_STEP_KEY);
-    if (savedStep) {
-      const step = parseInt(savedStep, 10);
-      if (step >= 0 && step < Object.keys(OnboardingStepIndex).length / 2) {
-        setCurrentStep(step);
-      }
-    }
+  const currentStep = useMemo(() => {
+    if (isLoading) return OnboardingStepIndex.FREE_TRIAL;
+    return inferStep(user, wallet.hasManagedWallet);
+  }, [isLoading, user, wallet.hasManagedWallet]);
 
+  const completedSteps = useMemo(() => deriveCompletedSteps(currentStep), [currentStep]);
+
+  const fromSignupHandledRef = useRef(false);
+  useEffect(() => {
+    if (fromSignupHandledRef.current) return;
     const fromSignup = searchParams.get("fromSignup");
     if (fromSignup === "true") {
+      fromSignupHandledRef.current = true;
       analyticsService.track("onboarding_account_created", {
         category: "onboarding"
       });
-
-      setCompletedSteps(prev => new Set([...prev, OnboardingStepIndex.SIGNUP]));
-      setCurrentStep(OnboardingStepIndex.EMAIL_VERIFICATION);
-      d.localStorage?.setItem(ONBOARDING_STEP_KEY, OnboardingStepIndex.EMAIL_VERIFICATION.toString());
 
       const newUrl = new URL(windowLocation.href);
       newUrl.searchParams.delete("fromSignup");
       windowHistory.replaceState({}, "", newUrl.toString());
     }
-  }, [analyticsService, d.localStorage, searchParams, windowLocation, windowHistory]);
+  }, [analyticsService, searchParams, windowLocation, windowHistory]);
+
+  const prevStepRef = useRef<OnboardingStepIndex | null>(null);
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (prevStepRef.current === null) {
+      prevStepRef.current = currentStep;
+      return;
+    }
+
+    if (prevStepRef.current === OnboardingStepIndex.PAYMENT_METHOD && currentStep === OnboardingStepIndex.WELCOME) {
+      analyticsService.track("onboarding_payment_method_added", {
+        category: "onboarding"
+      });
+      analyticsService.track("onboarding_step_completed", {
+        category: "onboarding",
+        step: "payment_method",
+        step_index: OnboardingStepIndex.PAYMENT_METHOD
+      });
+      setShowSuccessAnimation(true);
+    }
+
+    prevStepRef.current = currentStep;
+  }, [isLoading, currentStep, analyticsService]);
 
   const handleStepChange = useCallback(
     (step: number) => {
-      if (step === OnboardingStepIndex.PAYMENT_METHOD && currentStep === OnboardingStepIndex.EMAIL_VERIFICATION) {
-        if (!user?.emailVerified) {
-          return;
-        }
-      }
-
-      if (step === OnboardingStepIndex.WELCOME && currentStep === OnboardingStepIndex.PAYMENT_METHOD) {
-        if (paymentMethods.length === 0) {
-          return;
-        }
-      }
-
       const stepNames = ["free_trial", "signup", "email_verification", "payment_method", "welcome"];
       analyticsService.track("onboarding_step_started", {
         category: "onboarding",
         step: stepNames[step],
         step_index: step
       });
-
-      setCurrentStep(step);
-      d.localStorage?.setItem(ONBOARDING_STEP_KEY, step.toString());
     },
-    [currentStep, user?.emailVerified, paymentMethods.length, analyticsService, d.localStorage]
+    [analyticsService]
   );
 
   const handleStepComplete = useCallback(
@@ -160,8 +175,6 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
         step: stepNames[step],
         step_index: step
       });
-
-      setCompletedSteps(prev => new Set([...prev, step]));
     },
     [analyticsService]
   );
@@ -179,10 +192,8 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
 
     if (user?.userId) {
       if (user.emailVerified) {
-        setCompletedSteps(prev => new Set([...prev, OnboardingStepIndex.SIGNUP, OnboardingStepIndex.EMAIL_VERIFICATION]));
         handleStepChange(OnboardingStepIndex.PAYMENT_METHOD);
       } else {
-        setCompletedSteps(prev => new Set([...prev, OnboardingStepIndex.SIGNUP]));
         handleStepChange(OnboardingStepIndex.EMAIL_VERIFICATION);
       }
     } else {
@@ -202,15 +213,9 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
   ]);
 
   const handlePaymentMethodComplete = useCallback(() => {
-    if (paymentMethods.length > 0) {
-      analyticsService.track("onboarding_payment_method_added", {
-        category: "onboarding"
-      });
-
-      handleStepComplete(OnboardingStepIndex.PAYMENT_METHOD);
-      setShowSuccessAnimation(true);
-    }
-  }, [paymentMethods.length, analyticsService, handleStepComplete]);
+    // Animation and analytics are handled by the step-transition effect
+    // This callback exists for PaymentMethodContainer's onComplete
+  }, []);
 
   const handleSuccessAnimationComplete = useCallback(() => {
     setShowSuccessAnimation(false);
@@ -220,7 +225,6 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
   const complete = useCallback(
     async (templateName?: string) => {
       if (!templateName) {
-        d.localStorage?.removeItem(ONBOARDING_STEP_KEY);
         navigateBack();
         return;
       }
@@ -313,7 +317,6 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
             dseq: dd.deploymentId.dseq
           });
 
-          d.localStorage?.removeItem(ONBOARDING_STEP_KEY);
           wallet.connectManagedWallet();
           router.push(urlService.newDeployment({ step: RouteStep.createLeases, dseq: dd.deploymentId.dseq }));
         }
@@ -383,6 +386,7 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
   return (
     <>
       {children({
+        isLoading,
         currentStep,
         steps,
         onStepChange: handleStepChange,

--- a/apps/deploy-web/src/components/onboarding/OnboardingView/OnboardingView.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingView/OnboardingView.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import React from "react";
-import { buttonVariants } from "@akashnetwork/ui/components";
+import { buttonVariants, Spinner } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import { LogOut } from "iconoir-react";
 
@@ -26,6 +26,7 @@ const DEPENDENCIES = {
 };
 
 export interface OnboardingViewProps {
+  isLoading: boolean;
   currentStep: number;
   steps: OnboardingStep[];
   onStepChange: (step: number) => void;
@@ -36,6 +37,7 @@ export interface OnboardingViewProps {
 }
 
 export const OnboardingView: FC<OnboardingViewProps> = ({
+  isLoading,
   currentStep,
   steps,
   onStepChange,
@@ -80,6 +82,15 @@ export const OnboardingView: FC<OnboardingViewProps> = ({
     });
     authService.logout();
   };
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[400px] flex-col items-center justify-center gap-4">
+        <Spinner size="large" />
+        <p className="text-sm text-muted-foreground">Preparing your onboarding...</p>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/apps/deploy-web/src/components/onboarding/VerifyEmailPage/VerifyEmailPage.tsx
+++ b/apps/deploy-web/src/components/onboarding/VerifyEmailPage/VerifyEmailPage.tsx
@@ -2,8 +2,6 @@ import React, { useEffect } from "react";
 import { NextSeo } from "next-seo";
 
 import Layout, { Loading } from "@src/components/layout/Layout";
-import { OnboardingStepIndex } from "@src/components/onboarding/OnboardingContainer/OnboardingContainer";
-import { ONBOARDING_STEP_KEY } from "@src/services/storage/keys";
 import { UrlService } from "@src/utils/urlUtils";
 
 const DEPENDENCIES = {
@@ -12,7 +10,6 @@ const DEPENDENCIES = {
   NextSeo,
   UrlService,
   redirect: (url: string) => {
-    window.localStorage.setItem(ONBOARDING_STEP_KEY, OnboardingStepIndex.EMAIL_VERIFICATION.toString());
     window.location.replace(url);
   }
 };

--- a/apps/deploy-web/src/services/auth/auth/auth.service.spec.ts
+++ b/apps/deploy-web/src/services/auth/auth/auth.service.spec.ts
@@ -2,7 +2,6 @@ import type { HttpClient } from "@akashnetwork/http-sdk";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import { ONBOARDING_STEP_KEY } from "@src/services/storage/keys";
 import type { AuthUrlService } from "./auth.service";
 import { AuthService } from "./auth.service";
 
@@ -30,15 +29,11 @@ describe(AuthService.name, () => {
   });
 
   describe("logout", () => {
-    it("clears localStorage items and redirects to logout URL", () => {
-      const { service, location, localStorage } = setup();
-
-      // Set up localStorage items
-      localStorage.setItem(ONBOARDING_STEP_KEY, "2");
+    it("redirects to logout URL", () => {
+      const { service, location } = setup();
 
       service.logout();
 
-      expect(localStorage.getItem(ONBOARDING_STEP_KEY)).toBeNull();
       expect(location.assign).toHaveBeenCalledWith(mockLogoutUrl);
     });
   });
@@ -59,8 +54,7 @@ describe(AuthService.name, () => {
       service,
       httpClient,
       urlService,
-      location,
-      localStorage
+      location
     };
   }
 });

--- a/apps/deploy-web/src/services/auth/auth/auth.service.ts
+++ b/apps/deploy-web/src/services/auth/auth/auth.service.ts
@@ -1,13 +1,10 @@
 import type { HttpClient } from "@akashnetwork/http-sdk";
 
-import { ONBOARDING_STEP_KEY } from "../../storage/keys";
-
 export class AuthService {
   constructor(
     private readonly urlService: AuthUrlService,
     private readonly internalApiHttpClient: HttpClient,
-    private readonly location = window.location,
-    private readonly localStorage = window.localStorage
+    private readonly location = window.location
   ) {}
 
   async loginViaOauth(options?: { returnTo?: string; connection?: string }): Promise<void> {
@@ -45,7 +42,6 @@ export class AuthService {
   }
 
   logout() {
-    this.localStorage.removeItem(ONBOARDING_STEP_KEY);
     this.location.assign(this.urlService.logout());
   }
 }

--- a/apps/deploy-web/src/services/storage/keys.ts
+++ b/apps/deploy-web/src/services/storage/keys.ts
@@ -1,1 +1,0 @@
-export const ONBOARDING_STEP_KEY = "onboardingStep";


### PR DESCRIPTION
## Why

Remove localStorage-based onboarding step persistence in favor of deriving the current step from actual user data (`userId`, `emailVerified`, `hasManagedWallet`). Stored state could go stale or diverge from reality, causing the stepper to land on the wrong step.

Stacked on #3052. Retarget to `main` once that merges.

## What

- Add `inferStep(user, hasManagedWallet)` + `deriveCompletedSteps(step)` helpers in `OnboardingContainer`
- Replace `useState` for current/completed steps with `useMemo` derivation
- Drop `localStorage` reads/writes from `OnboardingContainer`, `VerifyEmailPage`, and `AuthService.logout()`
- Delete `@src/services/storage/keys.ts` (no longer referenced)
- Add `isLoading` to onboarding children props; `OnboardingView` renders a spinner placeholder while data resolves
- Update tests: mock `useUser`/`usePaymentMethodsQuery` with proper `{data, isLoading}` shape, add coverage for each inferred-step branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a loading indicator that displays while your onboarding is being prepared.

* **Improvements**
  * Onboarding step progression is now more reliable and responsive. Steps automatically advance based on your current account state (email verification, wallet status) rather than relying on local storage, ensuring consistent behavior across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->