### PR TITLE
chore: refactors gha related security

### DIFF
--- a/.github/actions/associated-pr/action.yml
+++ b/.github/actions/associated-pr/action.yml
@@ -10,6 +10,17 @@ inputs:
     description: GitHub user to Slack user mapping
     required: false
     default: "{}"
+  display-pr-details:
+    description: Whether to display associated PR details in the step summary
+    required: false
+    default: "false"
+  export-file-changes:
+    description: |
+      Newline-separated list of filenames to check for changes in the PR.
+      When provided, populates the `changes` output with the subset of these files
+      that were modified in the PR.
+    required: false
+    default: ""
 
 outputs:
   number:
@@ -31,11 +42,16 @@ outputs:
     description: The head repository full name of the PR
     value: ${{ steps.associated-pr.outputs.head_repo }}
   labels:
-    description: Comma-separated list of PR labels
+    description: JSON array of PR label names (use `fromJSON(...)` in expressions)
     value: ${{ steps.associated-pr.outputs.labels }}
   closed:
     description: Whether the PR is closed
     value: ${{ steps.associated-pr.outputs.closed }}
+  changes:
+    description: |
+      JSON array of filenames from `export-file-changes` that were modified in the PR.
+      Empty array when `export-file-changes` is not provided or no PR was found.
+    value: ${{ steps.associated-pr.outputs.changes }}
 
 runs:
   using: "composite"
@@ -73,9 +89,16 @@ runs:
       env:
         GH_USER_TO_SLACK_USER: ${{ inputs.gh-user-to-slack-user }}
         INPUT_SHA: ${{ steps.get-sha.outputs.sha }}
+        INPUT_EXPORT_FILE_CHANGES: ${{ inputs.export-file-changes }}
       with:
         script: | # js
           const commitSha = process.env.INPUT_SHA || context.sha;
+          const filesToTrack = (process.env.INPUT_EXPORT_FILE_CHANGES || '')
+            .split('\n')
+            .map(s => s.trim())
+            .filter(Boolean);
+          core.setOutput('changes', '[]');
+          core.setOutput('labels', '[]');
           let pr = context.payload.pull_request;
 
           if (!pr || pr.head?.sha !== commitSha) {
@@ -124,7 +147,7 @@ runs:
           core.setOutput('title', pr.title);
           core.setOutput('head_ref', pr.head.ref);
           core.setOutput('head_repo', pr.head.repo?.full_name || '');
-          core.setOutput('labels', (pr.labels || []).map(l => l.name).join(','));
+          core.setOutput('labels', JSON.stringify((pr.labels || []).map(l => l.name)));
           core.setOutput('closed', pr.closed_at ? 'true' : 'false');
 
           const author = pr.merged_by?.login || pr.user.login;
@@ -132,3 +155,25 @@ runs:
 
           const userMapping = JSON.parse(process.env.GH_USER_TO_SLACK_USER || '{}');
           core.setOutput('slack-user', userMapping[author] || "");
+
+          if (filesToTrack.length > 0) {
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+            const changedFilenames = new Set(files.map(f => f.filename));
+            const changes = filesToTrack.filter(f => changedFilenames.has(f));
+            core.setOutput('changes', JSON.stringify(changes));
+          }
+
+    - name: Display associated PR details
+      if: steps.associated-pr.outputs.number != '' && inputs.display-pr-details == 'true'
+      env:
+        PR_NUMBER: ${{ steps.associated-pr.outputs.number }}
+        PR_TITLE: ${{ steps.associated-pr.outputs.title }}
+      shell: bash
+      run: | # shell
+        pr_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
+        echo "### Associated PR" >> "$GITHUB_STEP_SUMMARY"
+        echo "[#${PR_NUMBER} - ${PR_TITLE}](${pr_url})" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/associated-pr/action.yml
+++ b/.github/actions/associated-pr/action.yml
@@ -99,33 +99,34 @@ runs:
             .filter(Boolean);
           core.setOutput('changes', '[]');
           core.setOutput('labels', '[]');
-          let pr = context.payload.pull_request;
 
-          if (!pr || pr.head?.sha !== commitSha) {
-            const maxRetries = 5;
-            const baseDelay = 2000;
+          let pr;
+          const maxRetries = 5;
+          const baseDelay = 2000;
 
-            // Retry logic to handle timing issues with GitHub API
-            // Sometimes the commit-PR association isn't immediately available after merge
-            for (let attempt = 0; attempt < maxRetries; attempt++) {
-              if (attempt > 0) {
-                // Exponential backoff: 2s, 4s, 8s, 16s, 32s
-                const delay = baseDelay * Math.pow(2, attempt - 1);
-                core.info(`PR not found, retrying in ${delay}ms (attempt ${attempt + 1}/${maxRetries})...`);
-                await new Promise(resolve => setTimeout(resolve, delay));
-              }
+          // Always fetch from the API rather than reading context.payload.pull_request:
+          // the webhook payload is frozen at event-fire time and does not reflect
+          // label/metadata changes made afterwards.
+          // Retry logic also handles timing issues where the commit-PR association
+          // isn't immediately available after merge.
+          for (let attempt = 0; attempt < maxRetries; attempt++) {
+            if (attempt > 0) {
+              // Exponential backoff: 2s, 4s, 8s, 16s, 32s
+              const delay = baseDelay * Math.pow(2, attempt - 1);
+              core.info(`PR not found, retrying in ${delay}ms (attempt ${attempt + 1}/${maxRetries})...`);
+              await new Promise(resolve => setTimeout(resolve, delay));
+            }
 
-              const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                commit_sha: commitSha,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              });
+            const response = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              commit_sha: commitSha,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
 
-              if (response.data && response.data.length > 0) {
-                pr = response.data[0];
-                core.info(`Found PR #${pr.number} on attempt ${attempt + 1}`);
-                break;
-              }
+            if (response.data && response.data.length > 0) {
+              pr = response.data[0];
+              core.info(`Found PR #${pr.number} on attempt ${attempt + 1}`);
+              break;
             }
           }
 

--- a/.github/actions/poll-check-status/action.yml
+++ b/.github/actions/poll-check-status/action.yml
@@ -37,7 +37,7 @@ runs:
         MAX_RETRIES: ${{ inputs.max_retries }}
         EXPECTED_CONCLUSIONS: ${{ inputs.expected_conclusions }}
       with:
-        script: |
+        script: | # js
           const checkName = process.env.CHECK_NAME;
           const sha = process.env.CHECK_SHA;
           const checkType = process.env.CHECK_TYPE;

--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -9,15 +9,25 @@ on:
   workflow_run:
     workflows: ["CI"]
     types: [completed]
+  # pull_request: # uncomment to test this workflow in PR
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.head_ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
   pull-requests: read
   checks: write # to create check run on related PR
+
+# Normalizes the parent-CI context into a single set of env vars so downstream
+# jobs don't need to branch on `github.event_name`. On `workflow_run` these come
+# from the triggering run; on `pull_request` (used for testing this workflow
+# in-place) they're synthesized from the PR payload.
+env:
+  PARENT_WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion || github.event.pull_request && 'success' }}
+  PARENT_WORKFLOW_EVENT: ${{ github.event.workflow_run.event || github.event_name }}
+  PARENT_WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha }}
 
 jobs:
   create-check-run:
@@ -27,19 +37,29 @@ jobs:
       check_run_id: ${{ steps.create_check.outputs.check_run_id }}
       skip_reason: ${{ steps.decide.outputs.skip_reason }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github
+      - name: Get associated PR
+        id: associated_pr
+        uses: ./.github/actions/associated-pr
+        with:
+          ref: ${{ env.PARENT_WORKFLOW_HEAD_SHA }}
+          display-pr-details: 'true'
+
       - name: Decide whether to run scan
         id: decide
         run: | # shell
-          if [ "${{ github.event.workflow_run.conclusion }}" != "success" ]; then
+          if [ "${PARENT_WORKFLOW_CONCLUSION}" != "success" ]; then
             echo "run_scan=false" >> "$GITHUB_OUTPUT"
-            echo "skip_reason=Upstream CI conclusion is '${{ github.event.workflow_run.conclusion }}'" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=Upstream CI conclusion is '${PARENT_WORKFLOW_CONCLUSION}'" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # workflow_run.event is the triggering event of the upstream workflow (e.g. pull_request)
-          if [ "${{ github.event.workflow_run.event }}" != "pull_request" ]; then
+          if [ "${PARENT_WORKFLOW_EVENT}" != "pull_request" ]; then
             echo "run_scan=false" >> "$GITHUB_OUTPUT"
-            echo "skip_reason=Upstream CI was not triggered by pull_request (event=${{ github.event.workflow_run.event }})" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=Upstream CI was not triggered by pull_request (event=${PARENT_WORKFLOW_EVENT})" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -51,7 +71,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: | # js
-            const sha = context.payload.workflow_run.head_sha;
+            const sha = process.env.PARENT_WORKFLOW_HEAD_SHA;
             const workflowRunUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
             const res = await github.rest.checks.create({
               name: "security-scan",
@@ -59,6 +79,7 @@ jobs:
               repo: context.repo.repo,
               head_sha: sha,
               status: "in_progress",
+              details_url: workflowRunUrl,
               output: {
                 title: "Security scan",
                 summary: `Initializing... Managed in [this workflow run](${workflowRunUrl})`
@@ -73,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.value }}
-      should_run: ${{ !contains(fromJson(steps.associated_pr.outputs.labels), 'ignore-static-analyses') }}
+      should_run: ${{ !contains(fromJSON(steps.associated_pr.outputs.labels), 'ignore-static-analyses') }}
       pr_head_ref: ${{ steps.associated_pr.outputs.head_ref }}
       pr_head_repo: ${{ steps.associated_pr.outputs.head_repo }}
     steps:
@@ -84,11 +105,10 @@ jobs:
         id: associated_pr
         uses: ./.github/actions/associated-pr
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          display-pr-details: 'true'
+          ref: ${{ env.PARENT_WORKFLOW_HEAD_SHA }}
 
       - name: Build matrix from changed files
-        if: steps.associated_pr.outputs.labels != '' && steps.associated_pr.outputs.labels != '[]'
+        if: ${{ !contains(fromJSON(steps.associated_pr.outputs.labels), 'ignore-static-security-analysis') }}
         id: matrix
         env:
           GH_TOKEN: ${{ github.token }}
@@ -107,10 +127,12 @@ jobs:
           done
 
           if [ ${#changed_apps[@]} -eq 0 ]; then
+            echo "No changed apps detected, skipping static analyses"
             echo "value=" >> "$GITHUB_OUTPUT"
           else
             workspaces=$(printf '"%s",' "${changed_apps[@]}")
             workspaces="[${workspaces%,}]"
+            echo "Changed apps detected: ${changed_apps[*]}"
             echo 'value={"workspace":'"$workspaces"'}' >> "$GITHUB_OUTPUT"
           fi
 
@@ -118,7 +140,7 @@ jobs:
     needs: [setup-static-analyses]
     if: ${{ needs.setup-static-analyses.outputs.should_run == 'true' && needs.setup-static-analyses.outputs.matrix != '' }}
     strategy:
-      matrix: ${{ fromJson(needs.setup-static-analyses.outputs.matrix) }}
+      matrix: ${{ fromJSON(needs.setup-static-analyses.outputs.matrix) }}
       fail-fast: false
     uses: ./.github/workflows/reusable-validate-app-unsafe.yml
     secrets:
@@ -144,28 +166,27 @@ jobs:
         id: associated_pr
         uses: ./.github/actions/associated-pr
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          display-pr-details: 'true'
+          ref: ${{ env.PARENT_WORKFLOW_HEAD_SHA }}
           export-file-changes: package-lock.json
 
       - name: Check snyk status
         if: >-
-          contains(fromJson(steps.associated_pr.outputs.changes), 'package-lock.json')
-          && !contains(fromJson(steps.associated_pr.outputs.labels), 'ignore-apps-deps-scan')
+          contains(fromJSON(steps.associated_pr.outputs.changes), 'package-lock.json')
+          && !contains(fromJSON(steps.associated_pr.outputs.labels), 'ignore-apps-deps-scan')
         uses: ./.github/actions/poll-check-status
         with:
           name: "security/snyk (corysturtevant)"
-          sha: ${{ github.event.workflow_run.head_sha }}
+          sha: ${{ env.PARENT_WORKFLOW_HEAD_SHA }}
           check_type: status
 
       - name: Check socketio status
         if: >-
-          contains(fromJson(steps.associated_pr.outputs.changes), 'package-lock.json')
-          && !contains(fromJson(steps.associated_pr.outputs.labels), 'ignore-apps-deps-scan')
+          contains(fromJSON(steps.associated_pr.outputs.changes), 'package-lock.json')
+          && !contains(fromJSON(steps.associated_pr.outputs.labels), 'ignore-apps-deps-scan')
         uses: ./.github/actions/poll-check-status
         with:
           name: "Socket Security: Pull Request Alerts"
-          sha: ${{ github.event.workflow_run.head_sha }}
+          sha: ${{ env.PARENT_WORKFLOW_HEAD_SHA }}
 
   codeql-scan:
     if: needs.create-check-run.outputs.run_scan == 'true'
@@ -191,6 +212,7 @@ jobs:
         include:
           - language: actions
           - language: javascript-typescript
+            wait-for-check: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -198,19 +220,25 @@ jobs:
         id: associated_pr
         uses: ./.github/actions/associated-pr
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          display-pr-details: 'true'
+          ref: ${{ env.PARENT_WORKFLOW_HEAD_SHA }}
       - name: Initialize CodeQL
-        if: ${{ !contains(fromJson(steps.associated_pr.outputs.labels), 'ignore-codeql-scan') }}
+        if: ${{ !contains(fromJSON(steps.associated_pr.outputs.labels), 'ignore-codeql-security') }}
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
       - name: Perform CodeQL Analysis
-        if: ${{ !contains(fromJson(steps.associated_pr.outputs.labels), 'ignore-codeql-scan') }}
+        if: ${{ !contains(fromJSON(steps.associated_pr.outputs.labels), 'ignore-codeql-security') }}
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{matrix.language}}"
+      - name: Wait for CodeQL status
+        if: ${{ matrix.wait-for-check && !contains(fromJSON(steps.associated_pr.outputs.labels), 'ignore-codeql-security') }}
+        uses: ./.github/actions/poll-check-status
+        with:
+          name: "CodeQL"
+          sha: ${{ env.PARENT_WORKFLOW_HEAD_SHA }}
+          max_retries: 10
 
   finalize:
     runs-on: ubuntu-latest
@@ -222,7 +250,7 @@ jobs:
         env:
           RUN_SCAN: ${{ needs.create-check-run.outputs.run_scan }}
           SKIP_REASON: ${{ needs.create-check-run.outputs.skip_reason }}
-          RELATED_WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RELATED_WORKFLOW_CONCLUSION: ${{ env.PARENT_WORKFLOW_CONCLUSION }}
           STATIC_ANALYSES_RESULT: ${{ needs.static-analyses.result }}
           APPS_DEPS_SCAN_RESULT: ${{ needs.apps-deps-scan.result }}
           CODEQL_SCAN_RESULT: ${{ needs.codeql-scan.result }}
@@ -230,8 +258,7 @@ jobs:
           emit_output() {
             local conclusion="$1"
             local summary="$2"
-            local workflow_run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-            summary="$summary"$'\n\n'"Managed in [this workflow run]($workflow_run_url)"
+
             {
               echo "conclusion=$conclusion"
               echo "summary<<SUMMARY_EOF"
@@ -260,8 +287,8 @@ jobs:
           for scan in "${scans[@]}"; do
             label="${scan%%|*}"
             result="${scan#*|}"
-            if [[ "$result" == "success" ]]; then
-              details+=("$label: passed")
+            if [[ "$result" == "success" || "$result" == "skipped" ]]; then
+              details+=("$label: passed (result=$result)")
             else
               conclusion="failure"
               details+=("$label: failed (result=$result)")
@@ -279,8 +306,9 @@ jobs:
           SUMMARY: ${{ steps.final.outputs.summary }}
         with:
           script: | # js
-            const sha = context.payload.workflow_run.head_sha;
+            const sha = process.env.PARENT_WORKFLOW_HEAD_SHA;
             const checkRunId = Number(process.env.CHECK_RUN_ID);
+            const workflowRunUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
 
             await github.rest.checks.update({
               owner: context.repo.owner,
@@ -288,6 +316,7 @@ jobs:
               check_run_id: checkRunId,
               head_sha: sha,
               status: "completed",
+              details_url: workflowRunUrl,
               conclusion: process.env.CONCLUSION,
               output: {
                 title: "Security scan",

--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Decide whether to run scan
         id: decide
         run: | # shell
-          # If upstream CI failed, we must report failure (required check)
           if [ "${{ github.event.workflow_run.conclusion }}" != "success" ]; then
             echo "run_scan=false" >> "$GITHUB_OUTPUT"
             echo "skip_reason=Upstream CI conclusion is '${{ github.event.workflow_run.conclusion }}'" >> "$GITHUB_OUTPUT"
@@ -68,45 +67,13 @@ jobs:
 
             core.setOutput("check_run_id", String(res.data.id));
 
-      - name: Early-complete check as success when not running scan
-        if: ${{ steps.decide.outputs.run_scan != 'true' }}
-        uses: actions/github-script@v7
-        env:
-          CHECK_RUN_ID: ${{ steps.create_check.outputs.check_run_id }}
-          SKIP_REASON: ${{ steps.decide.outputs.skip_reason }}
-          RELATED_WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
-        with:
-          script: | # js
-            const sha = context.payload.workflow_run.head_sha;
-            const checkRunId = Number(process.env.CHECK_RUN_ID);
-            const conclusion = process.env.RELATED_WORKFLOW_CONCLUSION === 'success' ? 'success' : 'failure';
-            const summary = process.env.RELATED_WORKFLOW_CONCLUSION === 'success'
-              ? `Skipped (treated as pass)`
-              : `Blocked`;
-
-            await github.rest.checks.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              check_run_id: checkRunId,
-              head_sha: sha,
-              status: "completed",
-              conclusion,
-              output: {
-                title: "Security scan",
-                summary: `${summary}: ${process.env.SKIP_REASON}`
-              }
-            });
-
-  setup:
+  setup-static-analyses:
     needs: [create-check-run]
     if: ${{ needs.create-check-run.outputs.run_scan == 'true' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.value }}
-      should_run_static_analyses: ${{ steps.check_label.outputs.should_run_static_analyses }}
-      skip_reason_static_analyses: ${{ steps.check_label.outputs.skip_reason_static_analyses }}
-      should_run_deps_scan: ${{ steps.check_label.outputs.should_run_deps_scan }}
-      skip_reason_deps_scan: ${{ steps.check_label.outputs.skip_reason_deps_scan }}
+      should_run: ${{ !contains(fromJson(steps.associated_pr.outputs.labels), 'ignore-static-analyses') }}
       pr_head_ref: ${{ steps.associated_pr.outputs.head_ref }}
       pr_head_repo: ${{ steps.associated_pr.outputs.head_repo }}
     steps:
@@ -118,62 +85,10 @@ jobs:
         uses: ./.github/actions/associated-pr
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-
-      - name: Display associated PR details
-        if: steps.associated_pr.outputs.number != ''
-        env:
-          PR_NUMBER: ${{ steps.associated_pr.outputs.number }}
-          PR_TITLE: ${{ steps.associated_pr.outputs.title }}
-        run: | # shell
-          pr_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/pull/${PR_NUMBER}"
-          echo "### Associated PR" >> "$GITHUB_STEP_SUMMARY"
-          echo "[#${PR_NUMBER} - ${PR_TITLE}](${pr_url})" >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Check for skip labels
-        id: check_label
-        env:
-          PR_NUMBER: ${{ steps.associated_pr.outputs.number }}
-          PR_LABELS: ${{ steps.associated_pr.outputs.labels }}
-        uses: actions/github-script@v7
-        with:
-          script: | # js
-            const prNumber = process.env.PR_NUMBER;
-            const labels = (process.env.PR_LABELS || '').split(',').map(l => l.trim());
-
-            const checks = [
-              { output: 'static_analyses', ignoreLabel: 'ignore-static-security-analysis' },
-              { output: 'deps_scan', ignoreLabel: 'ignore-apps-deps-scan', run: requiredIfPackageLockChanged }
-            ];
-
-            for (const check of checks) {
-              if (!prNumber) {
-                core.setOutput(`should_run_${check.output}`, 'false');
-                core.setOutput(`skip_reason_${check.output}`, 'No PR found for commit');
-              } else if (labels.includes(check.ignoreLabel)) {
-                core.setOutput(`should_run_${check.output}`, 'false');
-                core.setOutput(`skip_reason_${check.output}`, `Label '${check.ignoreLabel}' is present`);
-              } else if (check.run) {
-                const result = await check.run();
-                core.setOutput(`should_run_${check.output}`, result.required ? 'true' : 'false');
-                core.setOutput(`skip_reason_${check.output}`, result.reason);
-              } else {
-                core.setOutput(`should_run_${check.output}`, 'true');
-                core.setOutput(`skip_reason_${check.output}`, '');
-              }
-            }
-
-            async function requiredIfPackageLockChanged() {
-              const files = await github.paginate(github.rest.pulls.listFiles, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: Number(prNumber),
-              });
-              const hasLockfileChange = files.some(f => f.filename === 'package-lock.json');
-              return { required: hasLockfileChange, reason: hasLockfileChange ? '' : 'package-lock.json not changed' };
-            }
+          display-pr-details: 'true'
 
       - name: Build matrix from changed files
-        if: steps.check_label.outputs.should_run_static_analyses == 'true'
+        if: steps.associated_pr.outputs.labels != '' && steps.associated_pr.outputs.labels != '[]'
         id: matrix
         env:
           GH_TOKEN: ${{ github.token }}
@@ -199,11 +114,11 @@ jobs:
             echo 'value={"workspace":'"$workspaces"'}' >> "$GITHUB_OUTPUT"
           fi
 
-  security-scan:
-    needs: [setup]
-    if: ${{ needs.setup.outputs.should_run_static_analyses == 'true' && needs.setup.outputs.matrix != '' }}
+  static-analyses:
+    needs: [setup-static-analyses]
+    if: ${{ needs.setup-static-analyses.outputs.should_run == 'true' && needs.setup-static-analyses.outputs.matrix != '' }}
     strategy:
-      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.setup-static-analyses.outputs.matrix) }}
       fail-fast: false
     uses: ./.github/workflows/reusable-validate-app-unsafe.yml
     secrets:
@@ -211,13 +126,12 @@ jobs:
       snyk-token: ${{ secrets.SNYK_TOKEN }}
     with:
       path: apps/${{ matrix.workspace }}
-      pr_head_ref: ${{ needs.setup.outputs.pr_head_ref }}
-      pr_head_repo: ${{ needs.setup.outputs.pr_head_repo }}
-      skip_change_detection: true
+      pr_head_ref: ${{ needs.setup-static-analyses.outputs.pr_head_ref }}
+      pr_head_repo: ${{ needs.setup-static-analyses.outputs.pr_head_repo }}
 
   apps-deps-scan:
-    needs: [setup]
-    if: ${{ needs.setup.outputs.should_run_deps_scan == 'true' }}
+    needs: [create-check-run]
+    if: needs.create-check-run.outputs.run_scan == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -226,7 +140,18 @@ jobs:
           sparse-checkout: |
             .github
 
+      - name: Get associated PR
+        id: associated_pr
+        uses: ./.github/actions/associated-pr
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          display-pr-details: 'true'
+          export-file-changes: package-lock.json
+
       - name: Check snyk status
+        if: >-
+          contains(fromJson(steps.associated_pr.outputs.changes), 'package-lock.json')
+          && !contains(fromJson(steps.associated_pr.outputs.labels), 'ignore-apps-deps-scan')
         uses: ./.github/actions/poll-check-status
         with:
           name: "security/snyk (corysturtevant)"
@@ -234,63 +159,117 @@ jobs:
           check_type: status
 
       - name: Check socketio status
+        if: >-
+          contains(fromJson(steps.associated_pr.outputs.changes), 'package-lock.json')
+          && !contains(fromJson(steps.associated_pr.outputs.labels), 'ignore-apps-deps-scan')
         uses: ./.github/actions/poll-check-status
         with:
           name: "Socket Security: Pull Request Alerts"
           sha: ${{ github.event.workflow_run.head_sha }}
 
+  codeql-scan:
+    if: needs.create-check-run.outputs.run_scan == 'true'
+    needs: [create-check-run]
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ubuntu-latest
+    permissions:
+      # required for all workflows
+      security-events: write
+      # required to fetch internal or private CodeQL packs
+      packages: read
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+          - language: javascript-typescript
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Get associated PR
+        id: associated_pr
+        uses: ./.github/actions/associated-pr
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          display-pr-details: 'true'
+      - name: Initialize CodeQL
+        if: ${{ !contains(fromJson(steps.associated_pr.outputs.labels), 'ignore-codeql-scan') }}
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+      - name: Perform CodeQL Analysis
+        if: ${{ !contains(fromJson(steps.associated_pr.outputs.labels), 'ignore-codeql-scan') }}
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"
+
   finalize:
     runs-on: ubuntu-latest
-    needs: [create-check-run, setup, security-scan, apps-deps-scan]
-    if: ${{ always() && needs.create-check-run.outputs.run_scan == 'true' }}
+    needs: [create-check-run, static-analyses, codeql-scan, apps-deps-scan]
+    if: ${{ always() && needs.create-check-run.result == 'success' }}
     steps:
       - name: Final conclusion and summary
         id: final
         env:
-          SHOULD_RUN_STATIC_ANALYSES: ${{ needs.setup.outputs.should_run_static_analyses }}
-          SKIP_REASON_STATIC_ANALYSES: ${{ needs.setup.outputs.skip_reason_static_analyses }}
-          SHOULD_RUN_DEPS_SCAN: ${{ needs.setup.outputs.should_run_deps_scan }}
-          SKIP_REASON_DEPS_SCAN: ${{ needs.setup.outputs.skip_reason_deps_scan }}
-          MATRIX: ${{ needs.setup.outputs.matrix }}
-          STATIC_ANALYZES_RESULT: ${{ needs.security-scan.result }}
-          APPS_DEPS_STATIC_ANALYZES_RESULT: ${{ needs.apps-deps-scan.result }}
+          RUN_SCAN: ${{ needs.create-check-run.outputs.run_scan }}
+          SKIP_REASON: ${{ needs.create-check-run.outputs.skip_reason }}
+          RELATED_WORKFLOW_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          STATIC_ANALYSES_RESULT: ${{ needs.static-analyses.result }}
+          APPS_DEPS_SCAN_RESULT: ${{ needs.apps-deps-scan.result }}
+          CODEQL_SCAN_RESULT: ${{ needs.codeql-scan.result }}
         run: | # shell
+          emit_output() {
+            local conclusion="$1"
+            local summary="$2"
+            local workflow_run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            summary="$summary"$'\n\n'"Managed in [this workflow run]($workflow_run_url)"
+            {
+              echo "conclusion=$conclusion"
+              echo "summary<<SUMMARY_EOF"
+              echo "$summary"
+              echo "SUMMARY_EOF"
+            } >> "$GITHUB_OUTPUT"
+          }
+
+          if [[ "$RUN_SCAN" != "true" ]]; then
+            if [[ "$RELATED_WORKFLOW_CONCLUSION" == "success" ]]; then
+              emit_output "success" "Skipped (treated as pass): $SKIP_REASON"
+            else
+              emit_output "failure" "Blocked: $SKIP_REASON"
+            fi
+            exit 0
+          fi
+
+          scans=(
+            "Static analysis|$STATIC_ANALYSES_RESULT"
+            "Apps deps scan|$APPS_DEPS_SCAN_RESULT"
+            "CodeQL scan|$CODEQL_SCAN_RESULT"
+          )
           conclusion="success"
           details=()
 
-          # Evaluate static analysis scan
-          if [[ "$SHOULD_RUN_STATIC_ANALYSES" != "true" ]]; then
-            details+=("Static analysis: skipped ($SKIP_REASON_STATIC_ANALYSES)")
-          elif [[ -z "$MATRIX" ]]; then
-            details+=("Static analysis: skipped (no apps changed in this PR)")
-          elif [[ "$STATIC_ANALYZES_RESULT" != "success" ]]; then
-            conclusion="failure"
-            details+=("Static analysis: failed (result=$STATIC_ANALYZES_RESULT)")
-          else
-            details+=("Static analysis: passed")
-          fi
+          for scan in "${scans[@]}"; do
+            label="${scan%%|*}"
+            result="${scan#*|}"
+            if [[ "$result" == "success" ]]; then
+              details+=("$label: passed")
+            else
+              conclusion="failure"
+              details+=("$label: failed (result=$result)")
+            fi
+          done
 
-          # Evaluate apps dependencies scan
-          if [[ "$SHOULD_RUN_DEPS_SCAN" != "true" ]]; then
-            details+=("Apps deps scan: skipped ($SKIP_REASON_DEPS_SCAN)")
-          elif [[ "$APPS_DEPS_STATIC_ANALYZES_RESULT" != "success" ]]; then
-            conclusion="failure"
-            details+=("Apps deps scan: failed (result=$APPS_DEPS_STATIC_ANALYZES_RESULT)")
-          else
-            details+=("Apps deps scan: passed")
-          fi
-
-          workflow_run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           summary=$(printf '%s\n' "${details[@]}")
-          summary="$summary"$'\n\n'"Managed in [this workflow run]($workflow_run_url)"
-
-          # Use delimiter syntax for multiline output
-          {
-            echo "conclusion=$conclusion"
-            echo "summary<<SUMMARY_EOF"
-            echo "$summary"
-            echo "SUMMARY_EOF"
-          } >> "$GITHUB_OUTPUT"
+          emit_output "$conclusion" "$summary"
 
       - name: Complete check run
         uses: actions/github-script@v7

--- a/.github/workflows/auto-approval.yml
+++ b/.github/workflows/auto-approval.yml
@@ -52,7 +52,7 @@ jobs:
               return;
             }
 
-            const labels = (process.env.PR_LABELS ?? "").split(",").filter(Boolean);
+            const labels = JSON.parse(process.env.PR_LABELS || "[]");
             core.info(`PR labels: ${labels.join(", ")}`);
 
             if (!labels.includes("experienced-contributor")) {

--- a/.github/workflows/reusable-validate-app-unsafe.yml
+++ b/.github/workflows/reusable-validate-app-unsafe.yml
@@ -20,11 +20,6 @@ on:
         description: "PR head repository full name (optional, defaults to github.event.pull_request.head.repo.full_name)"
         required: false
         type: string
-      skip_change_detection:
-        description: "Skip change detection and always run (useful when called from workflow_run context)"
-        required: false
-        type: boolean
-        default: false
     secrets:
       gh-token:
         description: "github token used to fetch changed files in PR"
@@ -38,21 +33,11 @@ permissions:
   pull-requests: read
 
 jobs:
-  should-validate-unsafe:
-    if: ${{ !inputs.skip_change_detection }}
-    uses: ./.github/workflows/reusable-should-validate.yml
-    secrets:
-      gh-token: ${{ secrets.gh-token }}
-    with:
-      path: ${{ inputs.path }}
-
   validate-unsafe:
-    needs: should-validate-unsafe
     runs-on: ubuntu-latest
-    if: always() && (inputs.skip_change_detection || needs.should-validate-unsafe.outputs.has_changes == 'true')
     steps:
-      - name: Checkout UNTRUSTED user's fork
-        uses: actions/checkout@v4
+      - name: Checkout UNTRUSTED fork
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.pr_head_ref || github.event.pull_request.head.ref }}
           repository: ${{ inputs.pr_head_repo || github.event.pull_request.head.repo.full_name }}


### PR DESCRIPTION
## Why

Refactor the security-scan workflow so each scan stands on its own and can be re-run on its own. 

## What

1. integrate CodeQL scans via gh actions
2. adds new label `ignore-codeql-security`
3. makes every security scan to be independent from `setup` job. This allows to re-run every scan separately, as a result "Re-run failed jobs" now should be supported after adding label on PR
4. enhances associated-pr action to export labels as JSON (easier to check with gha expressions) and expose changed-files (for example, to check that package-lock has been changed. simplifies checks)
5. removes early complete to unify and simplify path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export matched changed filenames and optional PR details to workflow summaries; PR labels output is now a JSON array and can be consumed as structured data.

* **Chores**
  * Added pull-request workflow trigger, normalized workflow context/env handling, reorganized CI jobs and gating, and added a CodeQL scan job.
  * Switched approval/label handling to JSON arrays and removed change-detection gating so a validation workflow runs unconditionally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->