### PR TITLE
feat: add nodejs permissions model to tx-signer

### DIFF
--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -12,7 +12,7 @@
     "dev-nodc": "npm run start",
     "format": "prettier --write ./*.{ts,js,json} **/*.{ts,js,json}",
     "lint": "eslint .",
-    "prod": "node --require ./dist/instrumentation.js ./dist/server.js",
+    "prod": "node --permission --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --enable-source-maps --require ./dist/instrumentation.js ./dist/server.js",
     "start": "tsup --watch",
     "start:dev": "tsup src/server.ts --watch",
     "test": "vitest run --project unit --project functional",

--- a/apps/tx-signer/tsup.config.ts
+++ b/apps/tx-signer/tsup.config.ts
@@ -18,7 +18,7 @@ export default defineConfig(async overrideOptions =>
     target: tsconfig.compilerOptions.target,
     tsconfig: "tsconfig.build.json",
     external: ["pino-pretty"],
-    onSuccess: overrideOptions.watch && !isProduction ? "node --enable-source-maps dist/server.js" : undefined,
+    onSuccess: overrideOptions.watch && !isProduction ? "npm run prod" : undefined,
     ...overrideOptions
   })
 );


### PR DESCRIPTION
## Why

This is part of a broader security hardening effort across all backend services, using the same pattern already established in provider-proxy.

Ref: CON-235

## What

Adds the Node.js permissions model (`--permission`) to the tx-signer service, restricting filesystem and capability access at the runtime level. 
Running `npm run prod` in dev mode (via tsup `onSuccess`) ensures the permission model is validated early, preventing surprises in production.

### Permissions rationale (tx-signer)

| Capability | Allowed | Reason |
|-----------|---------|--------|
| FS read: `./dist/` | Yes | Compiled application code |
| FS read: `./env/` | Yes | Environment variable files |
| FS read: `./node_modules/`, `../../node_modules/` | Yes | Runtime dependencies |
| FS read: `../../packages/env-loader/` | Yes | Shared env-loader package |
| FS write | No | Pure network service, no file writes |
| Worker threads | No | Single-threaded service |
| Child processes | No | Not used |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Hardened production startup by running the server in a stricter Node permission sandbox and granting only the minimal, explicit filesystem read access required at runtime.
  * Updated the local watch/build workflow to invoke the production start procedure after successful rebuilds, ensuring watch behavior mirrors production startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->