### PR TITLE
feat: add nodejs permissions model to indexer

### DIFF
--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint .",
     "migration:exec": "drizzle-kit migrate",
     "migration:pull": "drizzle-kit pull",
-    "prod": "node --max-old-space-size=8192 --require ./dist/instrumentation.js ./dist/index.js",
+    "prod": "node --permission --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --allow-fs-read=./data/ --allow-fs-write=./data/ --max-old-space-size=8192 --enable-source-maps --require ./dist/instrumentation.js ./dist/index.js",
     "start": "tsup --watch",
     "validate:types": "tsc -p tsconfig.strict.json --noEmit && echo"
   },

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint .",
     "migration:exec": "drizzle-kit migrate",
     "migration:pull": "drizzle-kit pull",
-    "prod": "node --permission --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --allow-fs-read=./data/ --allow-fs-write=./data/ --max-old-space-size=8192 --enable-source-maps --require ./dist/instrumentation.js ./dist/index.js",
+    "prod": "node --permission --allow-addons --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --allow-fs-read=./data/ --allow-fs-write=./data/ --max-old-space-size=8192 --enable-source-maps --require ./dist/instrumentation.js ./dist/index.js",
     "start": "tsup --watch",
     "validate:types": "tsc -p tsconfig.strict.json --noEmit && echo"
   },

--- a/apps/indexer/tsup.config.ts
+++ b/apps/indexer/tsup.config.ts
@@ -17,7 +17,7 @@ export default defineConfig(async overrideOptions =>
     external: ["pino-pretty"],
     dts: false,
     plugins: [...(isProduction ? [copyDrizzlePlugin] : [])],
-    onSuccess: overrideOptions.watch && !isProduction ? "node --enable-source-maps dist/index.js" : undefined,
+    onSuccess: overrideOptions.watch && !isProduction ? "npm run prod" : undefined,
     ...overrideOptions
   })
 );

--- a/packages/docker/Dockerfile.node
+++ b/packages/docker/Dockerfile.node
@@ -8,6 +8,8 @@ ARG GITHUB_PAT
 ARG WORKSPACE
 ENV WORKSPACE $WORKSPACE
 ENV HUSKY 0
+# tells node-gyp-build the libc flavor so it skips existsSync('/etc/alpine-release'), which fails under --permission
+ENV LIBC musl
 
 WORKDIR /app
 


### PR DESCRIPTION
## Why

This is part of a broader security hardening effort across all backend services, using the same pattern already established in provider-proxy.

Ref: CON-235

## What

Adds the Node.js permissions model (`--permission`) to the indexer service, restricting filesystem and capability access at the runtime level. 
Running `npm run prod` in dev mode (via tsup `onSuccess`) ensures the permission model is validated early, preventing surprises in production.

### Permissions rationale (indexer)

| Capability | Allowed | Reason |
|-----------|---------|--------|
| FS read: `./dist/` | Yes | Compiled application code |
| FS read: `./env/` | Yes | Environment variable files |
| FS read: `./node_modules/`, `../../node_modules/` | Yes | Runtime dependencies |
| FS read: `../../packages/env-loader/` | Yes | Shared env-loader package |
| FS read: `./data/` | Yes | LevelDB block cache, genesis files, node status |
| FS write: `./data/` | Yes | LevelDB writes, genesis file downloads, node status persistence |
| Worker threads | No | Single-threaded indexer |
| Child processes | No | Not used |

Note: `--max-old-space-size=8192` retained for large blockchain cache operations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added runtime security controls with a filesystem allowlist and a restricted write path for production launches.
  * Enabled source-map support for improved debugging.
  * Adjusted build tooling to run the production startup after successful watch builds.

* **Bug Fixes**
  * Set container libc flavor to musl to avoid native build failures under tightened permission modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->