### PR TITLE
feat: add nodejs permissions model to api

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,7 +19,7 @@
     "format": "prettier --write ./*.{js,json} **/*.{ts,js,json}",
     "lint": "eslint .",
     "migration:gen": "drizzle-kit generate",
-    "prod": "node --require ./dist/instrumentation.js ./dist/server.js",
+    "prod": "node --permission --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --allow-fs-read=./drizzle/ --enable-source-maps --require ./dist/instrumentation.js ./dist/server.js",
     "start": "tsup --watch",
     "start:dev": "tsup src/server.ts --watch",
     "test": "vitest run --project=unit --project=functional --project=integration",

--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(async overrideOptions =>
     external: ["pino-pretty"],
     dts: false,
     plugins: [...(isProduction ? [copyDrizzlePlugin] : [])],
-    onSuccess: overrideOptions.watch && !isProduction ? "npm run prod" : undefined,
+    onSuccess: overrideOptions.watch && !isProduction ? "NODE_OPTIONS='--allow-worker' npm run prod" : undefined,
     ...overrideOptions
   })
 );

--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(async overrideOptions =>
     external: ["pino-pretty"],
     dts: false,
     plugins: [...(isProduction ? [copyDrizzlePlugin] : [])],
-    onSuccess: overrideOptions.watch && !isProduction ? "node --enable-source-maps dist/server.js" : undefined,
+    onSuccess: overrideOptions.watch && !isProduction ? "npm run prod" : undefined,
     ...overrideOptions
   })
 );


### PR DESCRIPTION
## Why

 This is part of a broader security hardening effort across all backend services, using the same pattern already established in provider-proxy.

Ref CON-235

## What

Adds the Node.js permissions model (`--permission`) to the API service, restricting filesystem and capability access at the runtime level. Running `npm run prod` in dev mode (via tsup `onSuccess`) ensures the permission model is validated early, preventing surprises in production.

### Permissions rationale (api)

| Capability | Allowed | Reason |
|-----------|---------|--------|
| FS read: `./dist/` | Yes | Compiled application code (includes template cache at `./dist/.data/`) |
| FS read: `./env/` | Yes | Environment variable files |
| FS read: `./node_modules/`, `../../node_modules/` | Yes | Runtime dependencies |
| FS read: `../../packages/env-loader/` | Yes | Shared env-loader package |
| FS read: `./drizzle/` | Yes | Drizzle ORM migration files read at startup |
| FS write | No | Template cache is written by a separate GHA workflow, not at runtime |
| Worker threads | No | Workers only used with `INTERFACE=all` (dev mode); production runs separate deployments with explicit `INTERFACE=rest` or `INTERFACE=background-jobs` |
| Child processes | No | Not used |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Hardened API runtime: tightened execution permissions and explicit filesystem allowlists to reduce runtime access to only required directories.
  * Improved developer build/watch flow: updated post-build startup to run with safer worker permissions, aligning dev startup with production security posture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->