### PR TITLE
feat: add nodejs permissions model to notifications

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -17,7 +17,7 @@
     "migration:gen": "drizzle-kit generate",
     "migration:init": "node script/init-db.js",
     "preprod": "npm run migration:exec:prod",
-    "prod": "node --require @opentelemetry/auto-instrumentations-node/register dist/main.js",
+    "prod": "node --permission --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --enable-source-maps --require @opentelemetry/auto-instrumentations-node/register ./dist/main.js",
     "sdk:gen:http": "npm run sdk:gen:swagger && rimraf ../../packages/react-query-sdk/src/notifications && openapi-qraft --plugin tanstack-query-react --plugin openapi-typescript ./swagger/swagger.json -o ../../packages/react-query-sdk/src/notifications",
     "sdk:gen:swagger": "rimraf ./swagger && npm run build && INTERFACE=swagger-gen node dist/main.js",
     "start": "node dist/main.js",

--- a/apps/notifications/src/interfaces/alert-events/alert-events.module.ts
+++ b/apps/notifications/src/interfaces/alert-events/alert-events.module.ts
@@ -8,7 +8,7 @@ import { ChainEventsHandler } from "@src/interfaces/alert-events/handlers/chain-
 import { AlertModule } from "@src/modules/alert/alert.module";
 
 @Module({
-  imports: [BrokerModule, AlertModule, CommonModule, ConfigModule.forRoot({ isGlobal: true })],
+  imports: [BrokerModule, AlertModule, CommonModule, ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true })],
   providers: [ChainEventsHandler],
   controllers: [WorkerHealthzController]
 })

--- a/apps/notifications/src/interfaces/chain-events/chain-events.module.ts
+++ b/apps/notifications/src/interfaces/chain-events/chain-events.module.ts
@@ -7,7 +7,7 @@ import { HealthzController } from "@src/interfaces/chain-events/controllers/heal
 import { ChainModule } from "@src/modules/chain/chain.module";
 
 @Module({
-  imports: [CommonModule, ChainModule, BrokerModule, ConfigModule.forRoot({ isGlobal: true })],
+  imports: [CommonModule, ChainModule, BrokerModule, ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true })],
   controllers: [HealthzController]
 })
 export default class ChainEventsModule {}

--- a/apps/notifications/src/interfaces/notifications-events/notifications-events.module.ts
+++ b/apps/notifications/src/interfaces/notifications-events/notifications-events.module.ts
@@ -8,7 +8,7 @@ import { NotificationHandler } from "@src/interfaces/notifications-events/handle
 import { NotificationsModule } from "@src/modules/notifications/notifications.module";
 
 @Module({
-  imports: [CommonModule, NotificationsModule, BrokerModule, ConfigModule.forRoot({ isGlobal: true })],
+  imports: [CommonModule, NotificationsModule, BrokerModule, ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true })],
   providers: [NotificationHandler],
   controllers: [WorkerHealthzController]
 })

--- a/apps/notifications/src/interfaces/rest/rest.module.ts
+++ b/apps/notifications/src/interfaces/rest/rest.module.ts
@@ -18,7 +18,7 @@ import { HttpResultInterceptor } from "./interceptors/http-result/http-result.in
 import { AuthService } from "./services/auth/auth.service";
 
 @Module({
-  imports: [CommonModule, AlertModule, NotificationsModule, BrokerModule, ConfigModule.forRoot({ isGlobal: true })],
+  imports: [CommonModule, AlertModule, NotificationsModule, BrokerModule, ConfigModule.forRoot({ isGlobal: true, ignoreEnvFile: true })],
   providers: [
     { provide: APP_INTERCEPTOR, useClass: ZodSerializerInterceptor },
     { provide: APP_INTERCEPTOR, useClass: HttpResultInterceptor },

--- a/apps/notifications/tsup.config.ts
+++ b/apps/notifications/tsup.config.ts
@@ -7,6 +7,8 @@ import { defineConfig, type Options } from "tsup";
 import packageJson from "./package.json";
 import tsconfig from "./tsconfig.build.json";
 
+const isProduction = process.env.NODE_ENV === "production";
+
 type Plugin = Required<Options>["plugins"][number];
 
 const copyDrizzleConfigPlugin: Plugin = {
@@ -40,7 +42,7 @@ export default defineConfig(async overrideOptions =>
         }
       }
     } as Options["swc"],
-    onSuccess: overrideOptions.watch ? "node --enable-source-maps dist/main.js" : undefined,
+    onSuccess: overrideOptions.watch && !isProduction ? "npm run prod" : undefined,
     ...overrideOptions
   })
 );


### PR DESCRIPTION
## Why

This is part of a broader security hardening effort across all backend services, using the same pattern already established in provider-proxy.

Ref CON-235

## What

Adds the Node.js permissions model (`--permission`) to the notifications service, restricting filesystem and capability access at the runtime level.  Running `npm run prod` in dev mode (via tsup `onSuccess`) ensures the permission model is validated early, preventing surprises in production.

### Permissions rationale (notifications)

| Capability | Allowed | Reason |
|-----------|---------|--------|
| FS read: `./dist/` | Yes | Compiled application code |
| FS read: `./env/` | Yes | Environment variable files |
| FS read: `./node_modules/`, `../../node_modules/` | Yes | Runtime dependencies (includes OTel auto-instrumentation) |
| FS read: `../../packages/env-loader/` | Yes | Shared env-loader package |
| FS write | No | No runtime file writes (swagger generation is build-time only) |
| Worker threads | No | NestJS single-process service |
| Child processes | No | Not used |

Note: Drizzle migrations run via `preprod` lifecycle hook (separate process), unaffected by `--permission` on the `prod` script.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Applied stricter runtime permission restrictions to limit file-read access in production.
  * Adjusted build/startup behavior so development-only tasks run only in non-production modes.
  * Enabled source maps for improved debugging and kept observability auto-instrumentation active for monitoring.
  * Configured modules to ignore local environment files at runtime to rely on external env provisioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->