### PR TITLE
test(onboarding): add E2E credit purchase test for managed wallet

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.tsx
@@ -174,7 +174,7 @@ export const AccountOverview: React.FunctionComponent<{ dependencies?: typeof DE
             </d.CardHeader>
             <d.CardContent>
               <div className="flex flex-col gap-1">
-                <p className="text-2xl font-bold leading-none">
+                <p className="text-2xl font-bold leading-none" aria-label="Available balance amount">
                   {walletBalance && <d.FormattedNumber value={walletBalance.totalDeploymentGrantsUSD} style="currency" currency="USD" />}
                 </p>
                 <p className="text-sm text-muted-foreground">

--- a/apps/deploy-web/tests/ui/managed-wallet-credits.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-credits.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "./fixture/authenticated-test";
+import { AuthPage } from "./pages/AuthPage";
+import { BillingPage } from "./pages/BillingPage";
+import { HomePage } from "./pages/HomePage";
+
+test.describe("Managed wallet credits", () => {
+  test("purchases credits via Add Funds", async ({ page, login }) => {
+    test.setTimeout(2 * 60 * 1000);
+
+    const homePage = new HomePage(page);
+    const authPage = new AuthPage(page);
+    const billingPage = new BillingPage(page);
+
+    await test.step("login", async () => {
+      await homePage.goto();
+      await homePage.openSignIn();
+      await authPage.waitForPage();
+      await login();
+    });
+
+    await test.step("navigate to billing via Add Funds", async () => {
+      await homePage.getAddFundsLink().click();
+      await billingPage.waitForPage();
+    });
+
+    const balanceBefore = await test.step("read initial balance", async () => {
+      await expect(billingPage.getAvailableBalance()).toBeVisible({ timeout: 15_000 });
+      const text = await billingPage.getAvailableBalance().textContent();
+      return parseBalance(text);
+    });
+
+    await test.step("submit payment", async () => {
+      const dialog = page.getByRole("dialog", { name: "Add Funds" });
+      await expect(dialog.getByText("Add credits")).toBeVisible({ timeout: 10_000 });
+
+      await dialog.getByRole("combobox").click();
+      await dialog.getByRole("option").first().click();
+
+      await dialog.getByRole("spinbutton", { name: /amount/i }).fill("20");
+      await billingPage.getPayButton().click();
+    });
+
+    await test.step("verify payment success", async () => {
+      await expect(page.getByText("Payment Successful!")).toBeVisible({ timeout: 60_000 });
+    });
+
+    await test.step("verify balance increased", async () => {
+      await expect(async () => {
+        const text = await billingPage.getAvailableBalance().textContent();
+        const balanceAfter = parseBalance(text);
+        expect(balanceAfter).toBeGreaterThanOrEqual(balanceBefore + 20);
+      }).toPass({ timeout: 30_000, intervals: [2_000] });
+    });
+  });
+});
+
+function parseBalance(raw: string | null): number {
+  const normalized = (raw ?? "").replace(/[^\d.-]/g, "");
+  const value = Number.parseFloat(normalized);
+
+  if (!Number.isFinite(value)) {
+    throw new Error(`Unable to parse balance from "${raw}"`);
+  }
+
+  return value;
+}

--- a/apps/deploy-web/tests/ui/pages/BillingPage.ts
+++ b/apps/deploy-web/tests/ui/pages/BillingPage.ts
@@ -1,0 +1,17 @@
+import type { Page } from "@playwright/test";
+
+export class BillingPage {
+  constructor(readonly page: Page) {}
+
+  async waitForPage() {
+    await this.page.waitForURL(/\/billing/);
+  }
+
+  getAvailableBalance() {
+    return this.page.locator('[aria-label="Available balance amount"]');
+  }
+
+  getPayButton() {
+    return this.page.getByRole("button", { name: /^pay \$/i });
+  }
+}

--- a/apps/deploy-web/tests/ui/pages/HomePage.ts
+++ b/apps/deploy-web/tests/ui/pages/HomePage.ts
@@ -17,4 +17,8 @@ export class HomePage {
     await this.page.getByRole("button", { name: /account menu/i }).hover();
     await this.page.getByText("Sign in").click();
   }
+
+  getAddFundsLink() {
+    return this.page.getByRole("link", { name: /add funds/i });
+  }
 }


### PR DESCRIPTION
## Why

Part of CON-154

No E2E coverage exists for the credit purchase flow, which is the primary monetization path for managed wallet users.

## What

- Add `managed-wallet-credits.spec.ts` covering: login → Add Funds → select payment method → enter amount → pay → verify balance increased
- Add `BillingPage` page object with `waitForPage()`, `getAvailableBalance()`, `getPayButton()`
- Add `HomePage.getAddFundsLink()` for navigating to billing via the home page
- Add `aria-label="Available balance amount"` to `AccountOverview` balance element for testability

Depends on #3081


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support for the Available Balance display by adding an explicit accessible label.

* **Tests**
  * Added end-to-end UI tests for the managed wallet credits flow: sign-in, add funds dialog, payment confirmation, and balance verification.
  * Added supporting UI page objects and locators to enable reliable, maintainable test interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->