### PR TITLE
fix(network): read faucet URL from meta.json with txt fallback

### DIFF
--- a/packages/net/scripts/generate.ts
+++ b/packages/net/scripts/generate.ts
@@ -22,7 +22,8 @@ const metaSchema = z.object({
   apis: z.object({
     rest: z.array(apiSchema),
     rpc: z.array(apiSchema)
-  })
+  }),
+  faucets: z.array(z.object({ url: z.string() })).optional()
 });
 
 main().catch(console.error);
@@ -59,9 +60,11 @@ async function main() {
     const firstRpcUrl = rpcUrls[0] ?? metaRpcUrls[0];
     const appVersion = firstRpcUrl ? await getAppVersion(firstRpcUrl) : null;
 
+    const metaFaucetUrl = meta?.faucets?.[0]?.url ?? null;
+
     const networkConfig = {
       version: appVersion ?? meta?.codebase?.recommended_version ?? null,
-      faucetUrl: faucetUrl?.trim() ?? null,
+      faucetUrl: faucetUrl?.trim() || metaFaucetUrl?.trim() || null,
       apiUrls,
       rpcUrls
     };

--- a/packages/net/scripts/generate.ts
+++ b/packages/net/scripts/generate.ts
@@ -61,10 +61,11 @@ async function main() {
     const appVersion = firstRpcUrl ? await getAppVersion(firstRpcUrl) : null;
 
     const metaFaucetUrl = meta?.faucets?.[0]?.url ?? null;
+    const resolvedFaucetUrl = faucetUrl !== null ? faucetUrl.trim() || null : metaFaucetUrl?.trim() || null;
 
     const networkConfig = {
       version: appVersion ?? meta?.codebase?.recommended_version ?? null,
-      faucetUrl: faucetUrl?.trim() || metaFaucetUrl?.trim() || null,
+      faucetUrl: resolvedFaucetUrl,
       apiUrls,
       rpcUrls
     };


### PR DESCRIPTION
## Why

The [akash-network/net#711](https://github.com/akash-network/net/pull/711) PR consolidates per-field `.txt` files (`api-nodes.txt`, `rpc-nodes.txt`, `faucet-url.txt`, etc.) into `meta.json`. Our generator already falls back to `meta.json` for API/RPC URLs via `fetchOptionalText` (404 → null → use meta), but the faucet URL was only read from `faucet-url.txt`.

After that upstream PR merges, `netConfig.getFaucetUrl("sandbox")` would return `null`, breaking sandbox E2E wallet funding in [`apps/deploy-web/tests/ui/fixture/wallet-setup.ts`](../blob/main/apps/deploy-web/tests/ui/fixture/wallet-setup.ts).

## What

- Extend `metaSchema` in [`packages/net/scripts/generate.ts`](../blob/main/packages/net/scripts/generate.ts) to parse the new `faucets: [{ url }]` field (optional — mainnet has no faucet).
- Prefer the `.txt` value when present, fall back to `meta.json`, so the generator works both before and after the upstream migration.

Verified by fetching `meta.json` from the PR's `meta` branch and running the updated schema:

```
[mainnet]   meta=200 txt=404 → faucetUrl=null                          ✓ (no faucet expected)
[sandbox-2] meta=200 txt=404 → faucetUrl=http://faucet.sandbox-2.aksh.pw/  ✓
```

## Test plan

- [x] `npm test -w packages/net` passes (4/4)
- [x] `npm run validate:types -w packages/net` passes
- [x] `npm run lint -w packages/net` passes
- [x] `npm run generate -w packages/net` against current net `main` produces identical `netConfigData.ts` (no regression today)
- [x] Simulated post-merge run against net `meta` branch correctly resolves sandbox faucet URL from `meta.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an optional faucet URL in network metadata.
  * Improved faucet URL resolution: prefers a configured file value when present (non-empty), otherwise falls back to metadata, otherwise remains unset — yielding more reliable network configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->