### PR TITLE
test(onboarding): align E2E with email verification code UI

### DIFF
--- a/.github/actions/console-web-ui-testing/action.yml
+++ b/.github/actions/console-web-ui-testing/action.yml
@@ -34,9 +34,9 @@ inputs:
     description: Mailsac API key for email verification
     required: true
   email-verification-strategy:
-    description: Email verification strategy (mailsac or auth0-ticket)
+    description: Email verification strategy (mailsac-code, mailsac, or auth0-ticket)
     required: false
-    default: "mailsac"
+    default: "mailsac-code"
   test-user-email:
     description: Pre-registered test user email for authenticated tests
     required: false

--- a/.github/workflows/console-web-release.yml
+++ b/.github/workflows/console-web-release.yml
@@ -65,7 +65,7 @@ jobs:
           auth0-m2m-client-id: ${{ secrets.AUTH0_M2M_CLIENT_ID }}
           auth0-m2m-client-secret: ${{ secrets.AUTH0_M2M_CLIENT_SECRET }}
           mailsac-api-key: ${{ secrets.MAILSAC_API_KEY }}
-          email-verification-strategy: ${{ vars.EMAIL_VERIFICATION_STRATEGY || 'mailsac' }}
+          email-verification-strategy: ${{ vars.EMAIL_VERIFICATION_STRATEGY || 'mailsac-code' }}
           test-user-email: ${{ secrets.CONSOLE_WEB_E2E_TEST_USER_EMAIL }}
           test-user-password: ${{ secrets.CONSOLE_WEB_E2E_TEST_USER_PASSWORD }}
 

--- a/apps/deploy-web/tests/ui/fixture/test-env.config.ts
+++ b/apps/deploy-web/tests/ui/fixture/test-env.config.ts
@@ -17,7 +17,7 @@ export const testEnvSchema = z.object({
   AUTH0_M2M_CLIENT_ID: z.string({ required_error: "Auth0 M2M client ID for management API" }).trim().min(1),
   AUTH0_M2M_CLIENT_SECRET: z.string({ required_error: "Auth0 M2M client secret for management API" }).trim().min(1),
   MAILSAC_API_KEY: z.string({ required_error: "Mailsac API key for email verification" }).trim().min(1),
-  EMAIL_VERIFICATION_STRATEGY: z.enum(["mailsac", "mailsac-code", "auth0-ticket"]).default("mailsac"),
+  EMAIL_VERIFICATION_STRATEGY: z.enum(["mailsac", "mailsac-code", "auth0-ticket"]).default("mailsac-code"),
   TEST_USER_EMAIL: z.string().optional(),
   TEST_USER_PASSWORD: z.string().optional()
 });

--- a/apps/deploy-web/tests/ui/managed-wallet-onboarding.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-onboarding.spec.ts
@@ -39,21 +39,15 @@ test.describe("Managed wallet onboarding", () => {
 
     await test.step("arrive at email verification step", async () => {
       await onboardingPage.waitForPage();
-      await expect(onboardingPage.getCheckVerificationButton()).toBeVisible({ timeout: 15_000 });
+      await expect(onboardingPage.getFirstVerificationCodeDigit()).toBeVisible({ timeout: 15_000 });
     });
 
-    await test.step("verify email via verification link", async () => {
+    await test.step("verify email via verification code", async () => {
       const auth0User = await auth0.getUserByEmail(email);
       expect(auth0User).toBeTruthy();
       testUserId = auth0User!.user_id;
 
       await emailVerification.verify({ context: page.context(), email, userId: testUserId! });
-    });
-
-    await test.step("confirm email verification on onboarding page", async () => {
-      await onboardingPage.getCheckVerificationButton().click();
-      await expect(onboardingPage.getEmailVerifiedAlert()).toBeVisible({ timeout: 15_000 });
-      await onboardingPage.getContinueButton().click();
     });
 
     await test.step("add payment method via Stripe", async () => {

--- a/apps/deploy-web/tests/ui/pages/OnboardingPage.ts
+++ b/apps/deploy-web/tests/ui/pages/OnboardingPage.ts
@@ -11,16 +11,8 @@ export class OnboardingPage {
     await this.page.getByRole("button", { name: /start free trial/i }).click();
   }
 
-  getEmailVerifiedAlert() {
-    return this.page.getByText("Email Verified");
-  }
-
-  getCheckVerificationButton() {
-    return this.page.getByRole("button", { name: /check verification/i });
-  }
-
-  getContinueButton() {
-    return this.page.getByRole("button", { name: /^continue$/i });
+  getFirstVerificationCodeDigit() {
+    return this.page.getByLabel("Verification code digit 1");
   }
 
   async fillStripeAddress(input: { name: string; line1: string; city: string; state: string; zip: string }) {


### PR DESCRIPTION
## Why

The beta E2E run that follows a console-web release ([failed job](https://github.com/akash-network/console/actions/runs/24733330119/job/72353619751)) broke after #3052 replaced the link-based email verification UI with the 6-digit code input. The onboarding spec still waited for the removed **Check Verification** button.

## What

- Swap the onboarding spec's locator from the removed `Check Verification` button to the first code-input digit.
- Drop the now-redundant *confirm email verification* step — `EmailVerificationContainer` auto-advances once `user.emailVerified` flips after `verifyCode` + `checkSession`, and the next step's `Add Payment Method` assertion already gates progress.
- Update `OnboardingPage` to expose `getFirstVerificationCodeDigit()` and remove the old alert/button/continue helpers.
- Default `email-verification-strategy` (composite action + beta release workflow) to `mailsac-code`. The link-based `mailsac` flow is no longer supported by the frontend (`/user/verify-email` now just redirects to onboarding). If the `EMAIL_VERIFICATION_STRATEGY` repo variable is set, it should be updated/unset to use the new default.

### Not addressed here

- `managed-wallet-credits.spec.ts` also failed in the same run (`dialog.getByRole("option").first()` times out because the payment-method combobox is empty). That looks like a data/flake issue on the beta test user, not caused by #3052 — happy to tackle it separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated email verification test flow to validate entry of the verification code (OTP) instead of interacting with a verification-link/button.

* **Chores**
  * Changed the default email verification strategy in CI and test environments to "mailsac-code".
  * Updated the email-verification strategy options to include "mailsac-code", "mailsac", and "auth0-ticket".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->