### PR TITLE
chore: provides ref and sha for codeql action

### DIFF
--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -232,6 +232,10 @@ jobs:
         uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{matrix.language}}"
+          # Override GITHUB_SHA/REF (default branch under workflow_run) so the
+          # "CodeQL" check lands on the PR head. Ignored for fork PRs.
+          sha: ${{ env.PARENT_WORKFLOW_HEAD_SHA }}
+          ref: refs/pull/${{ steps.associated_pr.outputs.number }}/head
       - name: Wait for CodeQL status
         if: ${{ matrix.wait-for-check && !contains(fromJSON(steps.associated_pr.outputs.labels), 'ignore-codeql-security') }}
         uses: ./.github/actions/poll-check-status


### PR DESCRIPTION
## Why

Otherwise github doesn't create CodeQL check run on PR

## What

provides ref and sha for codeql action


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD configuration to improve code quality verification in pull request checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->