### PR TITLE
chore: sets actions/checkout ref for codeql

### DIFF
--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -216,6 +216,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ env.PARENT_WORKFLOW_HEAD_SHA }}
       - name: Get associated PR
         id: associated_pr
         uses: ./.github/actions/associated-pr
@@ -262,7 +264,8 @@ jobs:
           emit_output() {
             local conclusion="$1"
             local summary="$2"
-
+            local workflow_run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            summary="$summary"$'\n\n'"Managed in [this workflow run]($workflow_run_url)"
             {
               echo "conclusion=$conclusion"
               echo "summary<<SUMMARY_EOF"


### PR DESCRIPTION
## Why

codeql action doesn't create CodeQL check. probably because of the wrong association of scanning results with git commit

## What

setting `ref` value on actions/checkout in codeql job to ensure codeql inits in the correct repository state


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now checks out the exact PR head commit for automated scans, improving reliability and ensuring scans run against the intended code state for consistent results.
  * Scan/check-run summaries now include a direct link to the specific workflow run, making it easier to view execution context and trace findings back to the exact run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->