### PR TITLE
chore: updates github action versions and pin them

### DIFF
--- a/.github/actions/associated-pr/action.yml
+++ b/.github/actions/associated-pr/action.yml
@@ -60,7 +60,7 @@ runs:
       id: get-sha
       env:
         INPUT_REF: ${{ inputs.ref }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       with:
         script: | # js
           if (!process.env.INPUT_REF) {
@@ -84,7 +84,7 @@ runs:
           core.info(`Using provided ref as sha: ${process.env.INPUT_REF}`);
           core.setOutput('sha', process.env.INPUT_REF);
 
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       id: associated-pr
       env:
         GH_USER_TO_SLACK_USER: ${{ inputs.gh-user-to-slack-user }}

--- a/.github/actions/console-web-ui-testing/action.yml
+++ b/.github/actions/console-web-ui-testing/action.yml
@@ -82,7 +82,7 @@ runs:
         TEST_WALLET_MNEMONIC: ${{ inputs.test-wallet-mnemonic }}
       run: |
         npx --yes tsx@4.20.6 apps/deploy-web/script/closeDeployments.ts
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       id: playwright-report
       if: ${{ !cancelled() }}
       with:

--- a/.github/actions/poll-check-status/action.yml
+++ b/.github/actions/poll-check-status/action.yml
@@ -28,7 +28,7 @@ runs:
   using: "composite"
   steps:
     - name: 'Poll check status'
-      uses: actions/github-script@v7
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
       env:
         CHECK_NAME: ${{ inputs.name }}
         CHECK_SHA: ${{ inputs.sha || github.sha }}

--- a/.github/actions/setup-app-deps/action.yml
+++ b/.github/actions/setup-app-deps/action.yml
@@ -15,13 +15,13 @@ runs:
   using: "composite"
   steps:
     - name: Setup Nodejs
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: "package.json"
 
     - name: Restore root node_modules cache
       if: inputs.setup-only-nodejs == 'false' && inputs.app != 'all'
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       id: cache
       with:
         path: |

--- a/.github/actions/slack-pending-deployment-approval/action.yml
+++ b/.github/actions/slack-pending-deployment-approval/action.yml
@@ -43,7 +43,7 @@ runs:
         gh-user-to-slack-user: ${{ inputs.gh-user-to-slack-user }}
         ref: ${{ inputs.app }}/v${{ inputs.new-version }}
     - name: Notify in Slack
-      uses: slackapi/slack-github-action@v2.0.0
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
         webhook-type: incoming-webhook
         webhook: ${{ inputs.slack-webhook-url }}

--- a/.github/actions/slack-tests-failed-notification/action.yml
+++ b/.github/actions/slack-tests-failed-notification/action.yml
@@ -29,7 +29,7 @@ runs:
         gh-user-to-slack-user: ${{ inputs.gh-user-to-slack-user }}
         ref: ${{ inputs.ref }}
     - name: Notify in Slack
-      uses: slackapi/slack-github-action@v2.0.0
+      uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
       with:
         webhook-type: incoming-webhook
         webhook: ${{ inputs.slack-webhook-url }}

--- a/.github/workflows/akash-templates-publisher.yml
+++ b/.github/workflows/akash-templates-publisher.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup-app-deps
         with:

--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -38,7 +38,7 @@ jobs:
       skip_reason: ${{ steps.decide.outputs.skip_reason }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github
       - name: Get associated PR
@@ -68,7 +68,7 @@ jobs:
 
       - name: Create check run
         id: create_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: | # js
             const sha = process.env.PARENT_WORKFLOW_HEAD_SHA;
@@ -99,7 +99,7 @@ jobs:
       pr_head_repo: ${{ steps.associated_pr.outputs.head_repo }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get associated PR
         id: associated_pr
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             .github
@@ -215,7 +215,7 @@ jobs:
             wait-for-check: true
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ env.PARENT_WORKFLOW_HEAD_SHA }}
       - name: Get associated PR
@@ -225,13 +225,13 @@ jobs:
           ref: ${{ env.PARENT_WORKFLOW_HEAD_SHA }}
       - name: Initialize CodeQL
         if: ${{ !contains(fromJSON(steps.associated_pr.outputs.labels), 'ignore-codeql-security') }}
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: ${{ matrix.language }}
           build-mode: none
       - name: Perform CodeQL Analysis
         if: ${{ !contains(fromJSON(steps.associated_pr.outputs.labels), 'ignore-codeql-security') }}
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           category: "/language:${{matrix.language}}"
           # Override GITHUB_SHA/REF (default branch under workflow_run) so the
@@ -306,7 +306,7 @@ jobs:
           emit_output "$conclusion" "$summary"
 
       - name: Complete check run
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           CHECK_RUN_ID: ${{ needs.create-check-run.outputs.check_run_id }}
           CONCLUSION: ${{ steps.final.outputs.conclusion }}

--- a/.github/workflows/all-ci.yml
+++ b/.github/workflows/all-ci.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.value }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: matrix
         run: |
           workspaces=$(find apps/* -type d -print0 -maxdepth 0 | xargs -0 -n1 basename | jq -R -s -c 'split("\n")[:-1]')

--- a/.github/workflows/all-deploy-testnet.yml
+++ b/.github/workflows/all-deploy-testnet.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Load kubeconfig
         id: op-load-secret
-        uses: 1password/load-secrets-action@v2
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
         with:
           export-env: true
         env:
@@ -25,7 +25,7 @@ jobs:
           TS_OAUTH_SECRET: ${{ vars.OP_TS_OAUTH_CLIENT_SECRET_URI }}
 
       - name: Tailscale
-        uses: tailscale/github-action@v3
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
         with:
           oauth-client-id: ${{ env.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ env.TS_OAUTH_SECRET }}

--- a/.github/workflows/all-release.yml
+++ b/.github/workflows/all-release.yml
@@ -25,7 +25,7 @@ jobs:
       backends: ${{ steps.matrix.outputs.backends }}
       nextjs: ${{ steps.matrix.outputs.nextjs }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Detect changed apps
         id: matrix
         env:

--- a/.github/workflows/auto-approval.yml
+++ b/.github/workflows/auto-approval.yml
@@ -17,7 +17,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             ./.github/actions
@@ -29,7 +29,7 @@ jobs:
       - name: Evaluate auto-approval criteria
         id: evaluate
         if: steps.associated-pr.outputs.number != '' && steps.associated-pr.outputs.closed != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PR_NUMBER: ${{ steps.associated-pr.outputs.number }}
           PR_TITLE: ${{ steps.associated-pr.outputs.title }}

--- a/.github/workflows/console-api-release.yml
+++ b/.github/workflows/console-api-release.yml
@@ -73,7 +73,7 @@ jobs:
     name: Test beta sandbox
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-e2e-tests
         env:
           TEST_API_BASE_URL: ${{ vars.CONSOLE_WEB_BETA_URL }}/api-sandbox

--- a/.github/workflows/console-web-release.yml
+++ b/.github/workflows/console-web-release.yml
@@ -52,7 +52,7 @@ jobs:
       - setup
       - deploy-beta
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/console-web-ui-testing
         with:
           ref: console-web/v${{ needs.setup.outputs.image_tag }}

--- a/.github/workflows/create-issue-branch.yml
+++ b/.github/workflows/create-issue-branch.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Create linked branch
         id: create
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: | # js
@@ -86,7 +86,7 @@ jobs:
       contents: write
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ needs.create-branch.outputs.branch_name }}
 
@@ -136,7 +136,7 @@ jobs:
           fi
 
       - name: Comment plan on issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: | # js

--- a/.github/workflows/diff-package-lock.yml
+++ b/.github/workflows/diff-package-lock.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: [self-hosted, akash]
     steps:
       - name: Checkout base commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.base.sha }}
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: package.json
       - name: Fetch PR head ref (no checkout)
@@ -52,7 +52,7 @@ jobs:
             echo "EOF" >> "$GITHUB_ENV"
           fi
       - name: Post package-lock.json comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/github-actions-lint.yml
+++ b/.github/workflows/github-actions-lint.yml
@@ -14,15 +14,13 @@ jobs:
   lint:
     runs-on: [self-hosted, akash]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: gh extension install https://github.com/cschleiden/gh-actionlint --pin v1.0.3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           gh actionlint \
-            -ignore 'description is required in metadata' \
-            -ignore 'input "[^"]+" is not defined in action "codecov/codecov-action@v5"' \
-            -ignore 'the runner of "[^"]+" action is too old'
+            -ignore 'description is required in metadata'
         env:
           SHELLCHECK_OPTS: >-
             -e SC2129 # exclude Consider using { cmd1; cmd2; } >> file instead of individual redirects

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: [self-hosted, akash]
     steps:
       - name: Apply PR size label
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: | # js
@@ -107,7 +107,7 @@ jobs:
               labels: [targetSizeLabel],
             });
       - name: Apply maintainer or trusted-contributor label
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: | # js

--- a/.github/workflows/local-packages-ci.yml
+++ b/.github/workflows/local-packages-ci.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup-app-deps
 
@@ -37,7 +37,11 @@ jobs:
       - name: Ensure there are no leftovers
         if: github.event_name == 'pull_request'
         run: |
-          npm run knip -- $(ls -d ./packages/*/ | sed 's|/$||' | xargs -I{} echo --workspace {})
+          workspace_args=()
+          for dir in ./packages/*/; do
+            workspace_args+=(--workspace "${dir%/}")
+          done
+          npm run knip -- "${workspace_args[@]}"
 
       - name: Type checking
         run: npm run validate:types -w ./packages --if-present

--- a/.github/workflows/log-collector-release.yml
+++ b/.github/workflows/log-collector-release.yml
@@ -24,10 +24,10 @@ jobs:
     if: needs.release.outputs.git_tag != ''
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/provider-proxy-release.yml
+++ b/.github/workflows/provider-proxy-release.yml
@@ -73,7 +73,7 @@ jobs:
     name: Test beta sandbox
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-e2e-tests
         env:
           SERVICE_BASE_URL: ${{ vars.CONSOLE_WEB_BETA_URL }}/provider-proxy-sandbox
@@ -97,7 +97,7 @@ jobs:
     name: Test beta mainnet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-e2e-tests
         env:
           SERVICE_BASE_URL: ${{ vars.CONSOLE_WEB_BETA_URL }}/provider-proxy-mainnet
@@ -155,7 +155,7 @@ jobs:
     name: Test prod sandbox
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-e2e-tests
         env:
           SERVICE_BASE_URL: ${{ vars.CONSOLE_WEB_URL }}/provider-proxy-sandbox

--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -63,10 +63,10 @@ jobs:
       base_image_tag: ${{ steps.determine.outputs.base_tag }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/reusable-create-github-release.yml
+++ b/.github/workflows/reusable-create-github-release.yml
@@ -29,16 +29,16 @@ jobs:
 
     steps:
       - name: Full history checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - name: Setup Nodejs
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: "package.json"
 
       - name: Restore Dependencies Cache
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         id: deps-cache
         with:
           path: |

--- a/.github/workflows/reusable-deploy-k8s.yml
+++ b/.github/workflows/reusable-deploy-k8s.yml
@@ -107,7 +107,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Display linked workflow run ID
         if: ${{ inputs.linked-workflow-run-id }}
@@ -157,11 +157,11 @@ jobs:
       needs.deployment-prerequisites.outputs.require_approval != 'true' || inputs.approve == 'true' || inputs.approve == true
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Load kubeconfig
         id: op-load-secret
-        uses: 1password/load-secrets-action@v2
+        uses: 1password/load-secrets-action@92467eb28f72e8255933372f1e0707c567ce2259 # v4.0.0
         with:
           export-env: true
         env:
@@ -171,7 +171,7 @@ jobs:
           TS_OAUTH_SECRET: ${{ vars.OP_TS_OAUTH_CLIENT_SECRET_URI }}
 
       - name: Tailscale
-        uses: tailscale/github-action@v3
+        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
         with:
           oauth-client-id: ${{ env.TS_OAUTH_CLIENT_ID }}
           oauth-secret: ${{ env.TS_OAUTH_SECRET }}
@@ -210,7 +210,7 @@ jobs:
           exit 1
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4.3.0
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
           version: "latest"
 

--- a/.github/workflows/reusable-deploy-setup.yml
+++ b/.github/workflows/reusable-deploy-setup.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Concurrency guard against old versions
         id: stale-guard
         if: ${{ steps.extract.outputs.image_tag != '' && inputs.cancel-if-stale }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const version = '${{ steps.extract.outputs.image_tag }}';

--- a/.github/workflows/reusable-release-app.yml
+++ b/.github/workflows/reusable-release-app.yml
@@ -56,7 +56,7 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github
       - name: Trigger deployment

--- a/.github/workflows/reusable-release-nextjs-app.yml
+++ b/.github/workflows/reusable-release-nextjs-app.yml
@@ -73,7 +73,7 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: .github
       - name: Trigger deployment

--- a/.github/workflows/reusable-should-validate.yml
+++ b/.github/workflows/reusable-should-validate.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/local-dependencies
         if: contains(inputs.path, 'apps/')
@@ -44,7 +44,7 @@ jobs:
           path: ${{ inputs.path }}
 
       - name: Check for changes
-        uses: dorny/paths-filter@v3.0.2
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: has_changes
         with:
           token: ${{ secrets.gh-token }}
@@ -56,7 +56,7 @@ jobs:
               - ".github/workflows/reusable-validate-app.yml"
               - ".github/workflows/reusable-validate-app-unsafe.yml"
             package_workflows: &package_workflows
-              - ".github/workflows/local-packages-validate.yml"
+              - ".github/workflows/local-packages-ci.yml"
             value:
               - "${{ inputs.path }}/**"
               - package-lock.json

--- a/.github/workflows/reusable-validate-app-unsafe.yml
+++ b/.github/workflows/reusable-validate-app-unsafe.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout UNTRUSTED fork
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.pr_head_ref || github.event.pull_request.head.ref }}
           repository: ${{ inputs.pr_head_repo || github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/reusable-validate-app.yml
+++ b/.github/workflows/reusable-validate-app.yml
@@ -30,7 +30,7 @@ jobs:
       TEST_SCRIPT_NAME: ${{ github.event_name == 'merge_group' && 'test' || 'test:cov' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: ./.github/actions/setup-app-deps
         with:
@@ -58,7 +58,7 @@ jobs:
         run: |
           npm run knip -- --workspace apps/${{ inputs.app }}
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         if: ${{ steps.tests_details.outputs.requires_env_setup == 'true' }}
 
       - name: Normalize branch name
@@ -88,8 +88,9 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && steps.tests_details.outputs.has_tests == 'true' && github.event_name != 'merge_group' }}
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
+          report_type: test_results
           files: ./junit.xml
           name: ${{ inputs.app }}-test-results
           flags: ${{ inputs.app }}
@@ -97,7 +98,7 @@ jobs:
 
       - name: Upload Test Coverage
         if: steps.tests_details.outputs.has_tests == 'true' && github.event_name != 'merge_group'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           fail_ci_if_error: true
           directory: ./apps/${{ inputs.app }}/coverage
@@ -110,7 +111,7 @@ jobs:
     if: needs.should-validate.outputs.has_changes == 'true'
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build the Docker image for API
         env:
           GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -129,7 +130,7 @@ jobs:
       checks: read
     steps:
       - name: Checkout gha
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             .github


### PR DESCRIPTION
## Why

GitHub has deprecated Node.js 20 as the runtime for GitHub Actions. Actions running on Node.js 20 will be forced to use Node.js 24 by default starting June 2nd, 2026, which may cause unexpected behavior in CI pipelines if action versions are not updated in time.

Additionally used [pinact](https://github.com/suzuki-shunsuke/pinact) to pin all gh versions to commit hash. This helps to prevent supply chain attacks when third party action tag version pointer is updated. For more details, check the real incident -> https://github.com/advisories/GHSA-mrrh-fwg8-r2c3

Ref: CON-242

## What

1. updates versions of gh actions
2. pins versions to prevent supply chain attacks
3. replaces codecov/test-results-action with codecov/codecov-action because the 1st one was deprecated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflow dependencies to pinned versions for improved consistency and reproducibility across builds.
  * Refactored workspace enumeration in local package validation workflows for enhanced reliability.

---

**Note:** This release contains primarily internal infrastructure and tooling updates that do not affect product functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->