### PR TITLE
fix: allow indexer to read/write nested folders in data/ folder

### DIFF
--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -23,7 +23,7 @@
     "lint": "eslint .",
     "migration:exec": "drizzle-kit migrate",
     "migration:pull": "drizzle-kit pull",
-    "prod": "node --permission --allow-addons --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --allow-fs-read=./data/ --allow-fs-write=./data/ --max-old-space-size=8192 --enable-source-maps --require ./dist/instrumentation.js ./dist/index.js",
+    "prod": "node --permission --allow-addons --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --allow-fs-read='./data/*' --allow-fs-write='./data/*' --max-old-space-size=8192 --enable-source-maps --require ./dist/instrumentation.js ./dist/index.js",
     "start": "tsup --watch",
     "validate:types": "tsc -p tsconfig.strict.json --noEmit && echo"
   },


### PR DESCRIPTION
## Why

It appears that nodejs permissions model requires to specify `*` for nested dynamically created folders (https://nodejs.org/api/permissions.html)

<img width="1138" height="100" alt="Screenshot 2026-04-22 at 13 23 17" src="https://github.com/user-attachments/assets/2481baa5-1346-4b85-90dd-327cd81c0e91" />

So, when directory doesn't exist (dynamically created in code), wildcard is not automatically added and that's why we need to add it manually


## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production build script's filesystem permissions configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->