### PR TITLE
test(onboarding): add E2E API key management test for managed wallet

### DIFF
--- a/apps/deploy-web/tests/ui/managed-wallet-api-keys.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-api-keys.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "./fixture/authenticated-test";
+import { ApiKeysPage } from "./pages/ApiKeysPage";
+import { AuthPage } from "./pages/AuthPage";
+import { HomePage } from "./pages/HomePage";
+
+test.describe("Managed wallet API keys", () => {
+  const keyName = `e2e-test-${Date.now()}`;
+
+  test("creates and deletes an API key", async ({ page, login }) => {
+    const homePage = new HomePage(page);
+    const authPage = new AuthPage(page);
+    const apiKeysPage = new ApiKeysPage(page);
+
+    await test.step("login", async () => {
+      await homePage.goto();
+      await homePage.openSignIn();
+      await authPage.waitForPage();
+      await login();
+    });
+
+    await test.step("navigate to API keys via account menu", async () => {
+      await page.getByRole("button", { name: /account menu/i }).hover();
+      await page.getByText("API Keys").click();
+      await apiKeysPage.waitForPage();
+    });
+
+    await test.step("create API key", async () => {
+      await apiKeysPage.createKey(keyName);
+      await expect(apiKeysPage.getSaveKeyDialog()).toBeVisible({ timeout: 10_000 });
+      await apiKeysPage.dismissSaveDialog();
+    });
+
+    await test.step("verify key appears in list", async () => {
+      await expect(apiKeysPage.getKeyRow(keyName)).toBeVisible({ timeout: 10_000 });
+    });
+
+    await test.step("delete API key", async () => {
+      await apiKeysPage.deleteKey(keyName);
+    });
+
+    await test.step("verify key is removed", async () => {
+      await expect(apiKeysPage.getKeyRow(keyName)).toBeHidden({ timeout: 10_000 });
+    });
+  });
+});

--- a/apps/deploy-web/tests/ui/pages/ApiKeysPage.ts
+++ b/apps/deploy-web/tests/ui/pages/ApiKeysPage.ts
@@ -1,0 +1,33 @@
+import type { Page } from "@playwright/test";
+
+export class ApiKeysPage {
+  constructor(readonly page: Page) {}
+
+  async waitForPage() {
+    await this.page.waitForURL(/\/user\/api-keys/);
+  }
+
+  async createKey(name: string) {
+    await this.page.getByRole("button", { name: /create key/i }).click();
+    const dialog = this.page.getByRole("dialog");
+    await dialog.getByLabel("Name").fill(name);
+    await dialog.getByRole("button", { name: /create key/i }).click();
+  }
+
+  getSaveKeyDialog() {
+    return this.page.getByRole("dialog", { name: /save your key/i });
+  }
+
+  async dismissSaveDialog() {
+    await this.getSaveKeyDialog().getByRole("button", { name: /done/i }).click();
+  }
+
+  getKeyRow(name: string) {
+    return this.page.getByRole("row").filter({ hasText: name });
+  }
+
+  async deleteKey(name: string) {
+    await this.getKeyRow(name).getByRole("button").click();
+    await this.page.getByRole("button", { name: /confirm/i }).click();
+  }
+}


### PR DESCRIPTION
## Why

Part of CON-156

API key management (create, view, delete) has no E2E coverage for managed wallet users.

## What

- Add `managed-wallet-api-keys.spec.ts` covering full API key lifecycle: login → navigate to API Keys via account menu → create key → verify save dialog → dismiss → verify key in list → delete → confirm → verify removed
- Add `ApiKeysPage` page object with `createKey()`, `getSaveKeyDialog()`, `dismissSaveDialog()`, `getKeyRow()`, `deleteKey()`

Depends on #3099