### PR TITLE
feat(alert): add E2E deployment alerts test and fix threshold rounding

### DIFF
--- a/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.tsx
@@ -12,7 +12,7 @@ import { useNotificator } from "@src/hooks/useNotificator";
 import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useWhen } from "@src/hooks/useWhen";
 import type { DeploymentDto } from "@src/types/deployment";
-import { ceilDecimal, denomToUdenom, udenomToDenom } from "@src/utils/mathHelpers";
+import { ceilDecimal, denomToUdenom, roundDecimal, udenomToDenom } from "@src/utils/mathHelpers";
 
 type DeploymentAlertsInput = components["schemas"]["DeploymentAlertCreateInput"]["data"];
 export type DeploymentAlertsOutput = components["schemas"]["DeploymentAlertsResponse"]["data"];
@@ -115,7 +115,7 @@ export const DeploymentAlertsContainer: FC<Props> = ({ children, deployment, dep
         return merge({}, data?.data, {
           alerts: {
             deploymentBalance: {
-              threshold: ceilDecimal(value * price)
+              threshold: roundDecimal(value * price, 6)
             }
           }
         });

--- a/apps/deploy-web/src/components/deployments/DeploymentBalanceAlert/DeploymentBalanceAlert.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentBalanceAlert/DeploymentBalanceAlert.tsx
@@ -18,10 +18,12 @@ export const DeploymentBalanceAlert: FC<Props> = ({ disabled }) => {
 
   return (
     <Fieldset
-      aria-label="Escrow Balance alert"
+      aria-labelledby="escrow-balance-alert-title"
       label={
         <div className="flex items-center justify-between">
-          <p className="mr-3 text-xl font-bold">Escrow Balance</p>
+          <p id="escrow-balance-alert-title" className="mr-3 text-xl font-bold">
+            Escrow Balance
+          </p>
           <FormField
             control={control}
             name="deploymentBalance.enabled"

--- a/apps/deploy-web/src/components/deployments/DeploymentBalanceAlert/DeploymentBalanceAlert.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentBalanceAlert/DeploymentBalanceAlert.tsx
@@ -18,6 +18,7 @@ export const DeploymentBalanceAlert: FC<Props> = ({ disabled }) => {
 
   return (
     <Fieldset
+      aria-label="Escrow Balance alert"
       label={
         <div className="flex items-center justify-between">
           <p className="mr-3 text-xl font-bold">Escrow Balance</p>

--- a/apps/deploy-web/src/components/deployments/DeploymentCloseAlert/DeploymentCloseAlert.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentCloseAlert/DeploymentCloseAlert.tsx
@@ -13,6 +13,7 @@ export const DeploymentCloseAlert: FC<{ disabled?: boolean }> = ({ disabled }) =
 
   return (
     <Fieldset
+      aria-label="Deployment Close alert"
       label={
         <div className="flex items-center justify-between">
           <p className="mr-3 text-xl font-bold">Deployment Close</p>

--- a/apps/deploy-web/src/components/deployments/DeploymentCloseAlert/DeploymentCloseAlert.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentCloseAlert/DeploymentCloseAlert.tsx
@@ -13,10 +13,12 @@ export const DeploymentCloseAlert: FC<{ disabled?: boolean }> = ({ disabled }) =
 
   return (
     <Fieldset
-      aria-label="Deployment Close alert"
+      aria-labelledby="deployment-close-alert-title"
       label={
         <div className="flex items-center justify-between">
-          <p className="mr-3 text-xl font-bold">Deployment Close</p>
+          <p id="deployment-close-alert-title" className="mr-3 text-xl font-bold">
+            Deployment Close
+          </p>
           <FormField
             control={control}
             name="deploymentClosed.enabled"

--- a/apps/deploy-web/src/components/shared/Fieldset.tsx
+++ b/apps/deploy-web/src/components/shared/Fieldset.tsx
@@ -7,12 +7,12 @@ type Props = {
   subLabel?: string;
   className?: string;
   children: React.ReactNode;
-  "aria-label"?: string;
+  "aria-labelledby"?: string;
 };
 
-export const Fieldset: React.FunctionComponent<Props> = ({ label, subLabel, className = "", children, "aria-label": ariaLabel }) => {
+export const Fieldset: React.FunctionComponent<Props> = ({ label, subLabel, className = "", children, "aria-labelledby": ariaLabelledBy }) => {
   return (
-    <Card className={className} aria-label={ariaLabel}>
+    <Card className={className} aria-labelledby={ariaLabelledBy}>
       <CardHeader>
         {label}
         {subLabel && <p className="text-gray-400">{subLabel}</p>}

--- a/apps/deploy-web/src/components/shared/Fieldset.tsx
+++ b/apps/deploy-web/src/components/shared/Fieldset.tsx
@@ -7,11 +7,12 @@ type Props = {
   subLabel?: string;
   className?: string;
   children: React.ReactNode;
+  "aria-label"?: string;
 };
 
-export const Fieldset: React.FunctionComponent<Props> = ({ label, subLabel, className = "", children }) => {
+export const Fieldset: React.FunctionComponent<Props> = ({ label, subLabel, className = "", children, "aria-label": ariaLabel }) => {
   return (
-    <Card className={className}>
+    <Card className={className} aria-label={ariaLabel}>
       <CardHeader>
         {label}
         {subLabel && <p className="text-gray-400">{subLabel}</p>}

--- a/apps/deploy-web/tests/ui/actions/deploy.ts
+++ b/apps/deploy-web/tests/ui/actions/deploy.ts
@@ -1,0 +1,60 @@
+import type { Page } from "@playwright/test";
+
+import type { BillingPage } from "../pages/BillingPage";
+import type { DeployPage } from "../pages/DeployPage";
+import type { Sidebar } from "../pages/Sidebar";
+
+export interface CreateManagedDeploymentCallbacks {
+  onDepositDisabled?: () => Promise<void>;
+  onPaymentSuccess?: () => Promise<void>;
+  onDepositEnabled?: () => Promise<void>;
+  onLeaseValidated?: () => Promise<void>;
+}
+
+export async function createManagedDeployment(
+  page: Page,
+  input: {
+    sidebar: Sidebar;
+    deployPage: DeployPage;
+    billingPage: BillingPage;
+    templateName: string;
+  },
+  callbacks?: CreateManagedDeploymentCallbacks
+) {
+  const { sidebar, deployPage, billingPage, templateName } = input;
+
+  const openTemplate = async () => {
+    await sidebar.openDeploy();
+    await deployPage.selectTemplate(templateName);
+    await page.getByLabel("SDL editor").waitFor({ state: "visible", timeout: 15_000 });
+  };
+
+  await openTemplate();
+
+  let depositDialog = await deployPage.openDepositDialog();
+  let continueButton = depositDialog.getByRole("button", { name: /^continue$/i });
+
+  const isDisabled = await continueButton.isDisabled();
+
+  if (isDisabled) {
+    await callbacks?.onDepositDisabled?.();
+
+    await depositDialog.getByRole("button", { name: /buy credits/i }).click();
+    await billingPage.waitForPage();
+    await billingPage.submitPayment("20");
+
+    await callbacks?.onPaymentSuccess?.();
+
+    await openTemplate();
+    depositDialog = await deployPage.openDepositDialog();
+    continueButton = depositDialog.getByRole("button", { name: /^continue$/i });
+  }
+
+  await callbacks?.onDepositEnabled?.();
+  await continueButton.click();
+
+  await deployPage.createLease();
+  await deployPage.validateLease();
+
+  await callbacks?.onLeaseValidated?.();
+}

--- a/apps/deploy-web/tests/ui/managed-wallet-alerts.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-alerts.spec.ts
@@ -1,0 +1,115 @@
+import { createManagedDeployment } from "./actions/deploy";
+import { expect, test } from "./fixture/authenticated-test";
+import { AlertsPage } from "./pages/AlertsPage";
+import { AuthPage } from "./pages/AuthPage";
+import { BillingPage } from "./pages/BillingPage";
+import { DeploymentAlertsForm } from "./pages/DeploymentAlertsForm";
+import { DeployPage } from "./pages/DeployPage";
+import { HomePage } from "./pages/HomePage";
+import { Sidebar } from "./pages/Sidebar";
+
+test.describe("Managed wallet alerts", () => {
+  test("configures deployment alerts and verifies on alerts page", async ({ context, page, login }) => {
+    test.setTimeout(4 * 60 * 1000);
+
+    const homePage = new HomePage(page);
+    const authPage = new AuthPage(page);
+    const sidebar = new Sidebar(page);
+    const alertsPage = new AlertsPage(page);
+    const alertsForm = new DeploymentAlertsForm(page);
+    const billingPage = new BillingPage(page);
+    const deployPage = new DeployPage(context, page, { walletType: "api" });
+
+    await test.step("login", async () => {
+      await homePage.goto();
+      await homePage.openSignIn();
+      await authPage.waitForPage();
+      await login();
+    });
+
+    let dseq: string;
+
+    await test.step("deploy hello-world", async () => {
+      await createManagedDeployment(
+        page,
+        { sidebar, deployPage, billingPage, templateName: "Hello World" },
+        {
+          onPaymentSuccess: async () => {
+            await expect(page.getByText("Payment Successful!")).toBeVisible({ timeout: 60_000 });
+            await expect(page.getByText("Payment Successful!")).toBeHidden({ timeout: 30_000 });
+          },
+          onDepositEnabled: async () => {
+            await expect(deployPage.page.getByRole("button", { name: /^continue$/i })).toBeEnabled({ timeout: 30_000 });
+          }
+        }
+      );
+
+      const match = page.url().match(/deployments\/(\d+)/);
+      if (!match) throw new Error(`Could not extract DSEQ from URL: ${page.url()}`);
+      dseq = match[1];
+    });
+
+    await test.step("open deployment alerts tab", async () => {
+      await deployPage.openTab("Alerts");
+      await expect(page.getByText("Configure Alerts")).toBeVisible({ timeout: 10_000 });
+    });
+
+    await test.step("verify escrow balance alert is enabled by default", async () => {
+      await expect(alertsForm.getEscrowEnabledToggle()).toBeChecked();
+      await expect(alertsForm.getEscrowThresholdInput()).toBeVisible();
+      await expect(alertsForm.getEscrowChannelSelect()).toBeVisible();
+    });
+
+    await test.step("verify deployment close alert is enabled by default", async () => {
+      await expect(alertsForm.getCloseEnabledToggle()).toBeChecked();
+      await expect(alertsForm.getCloseChannelSelect()).toBeVisible();
+    });
+
+    await test.step("update escrow threshold and save", async () => {
+      const originalValue = await alertsForm.getEscrowThresholdInput().inputValue();
+      const newThreshold = Math.max(0.01, parseFloat(originalValue) * 0.5).toFixed(3);
+
+      await alertsForm.setEscrowThreshold(newThreshold);
+      await alertsForm.saveChanges();
+
+      await expect(alertsForm.getEscrowThresholdInput()).toHaveValue(newThreshold);
+    });
+
+    await test.step("disable escrow balance alert and save", async () => {
+      await alertsForm.getEscrowEnabledToggle().click();
+      await expect(alertsForm.getEscrowEnabledToggle()).not.toBeChecked();
+      await alertsForm.saveChanges();
+    });
+
+    await test.step("re-enable escrow balance alert and save", async () => {
+      await alertsForm.getEscrowEnabledToggle().click();
+      await expect(alertsForm.getEscrowEnabledToggle()).toBeChecked();
+      await alertsForm.saveChanges();
+    });
+
+    await test.step("verify alerts on global alerts page", async () => {
+      await sidebar.openAlerts();
+      await alertsPage.waitForPage();
+      await alertsPage.openAlertsTab();
+      await expect(alertsPage.getAlertRow(0)).toBeVisible({ timeout: 10_000 });
+    });
+
+    await test.step("toggle alert from alerts list", async () => {
+      const firstAlertRow = alertsPage.getAlertRow(0);
+      const toggle = alertsPage.getAlertToggle(firstAlertRow);
+
+      await toggle.click();
+      await expect(toggle).not.toBeChecked({ timeout: 5_000 });
+
+      await toggle.click();
+      await expect(toggle).toBeChecked({ timeout: 5_000 });
+    });
+
+    await test.step("close deployment", async () => {
+      await page.getByRole("row").filter({ hasText: dseq }).getByRole("link").first().click();
+      await deployPage.closeDeployment();
+      await expect(page.getByText(/are you sure you want to close/i)).toBeVisible({ timeout: 5_000 });
+      await page.getByRole("button", { name: /confirm/i }).click();
+    });
+  });
+});

--- a/apps/deploy-web/tests/ui/managed-wallet-deployment.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-deployment.spec.ts
@@ -1,3 +1,4 @@
+import { createManagedDeployment } from "./actions/deploy";
 import { expect, test } from "./fixture/authenticated-test";
 import { AuthPage } from "./pages/AuthPage";
 import { BillingPage } from "./pages/BillingPage";
@@ -22,49 +23,20 @@ test.describe("Managed wallet deployment", () => {
       await login();
     });
 
-    await test.step("select hello-world template", async () => {
-      await openHelloWorldTemplate();
-    });
-
     await test.step("create deployment", async () => {
-      let depositDialog = await deployPage.openDepositDialog();
-      let continueButton = depositDialog.getByRole("button", { name: /^continue$/i });
-
-      const needsTopUp = await expect(continueButton)
-        .toBeDisabled({ timeout: 10_000 })
-        .then(
-          () => true,
-          () => false
-        );
-
-      if (needsTopUp) {
-        await depositDialog.getByRole("button", { name: /buy credits/i }).click();
-        await billingPage.waitForPage();
-        await billingPage.submitPayment("20");
-        await expect(page.getByText("Payment Successful!")).toBeVisible({ timeout: 60_000 });
-        await expect(page.getByText("Payment Successful!")).toBeHidden({ timeout: 30_000 });
-
-        await openHelloWorldTemplate();
-        depositDialog = await deployPage.openDepositDialog();
-        continueButton = depositDialog.getByRole("button", { name: /^continue$/i });
-      }
-
-      await expect(continueButton).toBeEnabled({ timeout: 30_000 });
-      await continueButton.click();
-    });
-
-    async function openHelloWorldTemplate() {
-      await sidebar.openDeploy();
-      await deployPage.selectTemplate("Hello World");
-      await page.getByLabel("SDL editor").waitFor({ state: "visible", timeout: 15_000 });
-    }
-
-    await test.step("select provider and create lease", async () => {
-      await deployPage.createLease();
-    });
-
-    await test.step("verify lease is active", async () => {
-      await deployPage.validateLease();
+      await createManagedDeployment(
+        page,
+        { sidebar, deployPage, billingPage, templateName: "Hello World" },
+        {
+          onPaymentSuccess: async () => {
+            await expect(page.getByText("Payment Successful!")).toBeVisible({ timeout: 60_000 });
+            await expect(page.getByText("Payment Successful!")).toBeHidden({ timeout: 30_000 });
+          },
+          onDepositEnabled: async () => {
+            await expect(deployPage.page.getByRole("button", { name: /^continue$/i })).toBeEnabled({ timeout: 30_000 });
+          }
+        }
+      );
     });
 
     await test.step("verify auto-deposit is enabled", async () => {

--- a/apps/deploy-web/tests/ui/pages/AlertsPage.ts
+++ b/apps/deploy-web/tests/ui/pages/AlertsPage.ts
@@ -1,0 +1,21 @@
+import type { Locator, Page } from "@playwright/test";
+
+export class AlertsPage {
+  constructor(readonly page: Page) {}
+
+  async waitForPage() {
+    await this.page.waitForURL(/\/alerts/);
+  }
+
+  async openAlertsTab() {
+    await this.page.getByRole("tab", { name: /^alerts$/i }).click();
+  }
+
+  getAlertRow(index: number) {
+    return this.page.getByRole("row").nth(index + 1);
+  }
+
+  getAlertToggle(row: Locator) {
+    return row.getByRole("checkbox", { name: /toggle alert/i });
+  }
+}

--- a/apps/deploy-web/tests/ui/pages/DeployPage.tsx
+++ b/apps/deploy-web/tests/ui/pages/DeployPage.tsx
@@ -26,7 +26,7 @@ export class DeployPage {
   }
 
   async selectTemplate(name: string) {
-    await this.page.getByRole("button", { name }).or(this.page.getByRole("link", { name })).click();
+    await this.page.getByLabel(name).or(this.page.getByRole("link", { name })).first().click();
   }
 
   async fillImageName(name: string) {
@@ -95,7 +95,7 @@ export class DeployPage {
   }
 
   async openTab(name: string) {
-    await this.page.getByRole("tab", { name: new RegExp(name, "i") }).click();
+    await this.page.getByRole("tab", { name }).click();
   }
 
   async closeDeployment() {

--- a/apps/deploy-web/tests/ui/pages/DeployPage.tsx
+++ b/apps/deploy-web/tests/ui/pages/DeployPage.tsx
@@ -89,9 +89,13 @@ export class DeployPage {
 
   async validateLease() {
     await this.page.waitForURL(new RegExp(`${testEnvConfig.BASE_URL}/deployments/\\d+`));
-    await this.page.getByRole("tab", { name: /Leases/i }).click();
+    await this.openTab("Leases");
     await expect(this.page.getByLabel(/URIs/i).getByRole("link").first()).toBeVisible();
     await expect(this.page.getByLabel("Lease 0 state")).toHaveText("active");
+  }
+
+  async openTab(name: string) {
+    await this.page.getByRole("tab", { name: new RegExp(name, "i") }).click();
   }
 
   async closeDeployment() {

--- a/apps/deploy-web/tests/ui/pages/DeploymentAlertsForm.ts
+++ b/apps/deploy-web/tests/ui/pages/DeploymentAlertsForm.ts
@@ -1,0 +1,41 @@
+import type { Page } from "@playwright/test";
+
+export class DeploymentAlertsForm {
+  constructor(readonly page: Page) {}
+
+  private getSection(heading: string) {
+    return this.page.locator(".rounded-lg.border").filter({ hasText: heading });
+  }
+
+  getEscrowEnabledToggle() {
+    return this.getSection("Escrow Balance").getByRole("checkbox", { name: /enabled/i });
+  }
+
+  getEscrowThresholdInput() {
+    return this.getSection("Escrow Balance").getByRole("spinbutton");
+  }
+
+  getEscrowChannelSelect() {
+    return this.getSection("Escrow Balance").getByRole("combobox").first();
+  }
+
+  getCloseEnabledToggle() {
+    return this.getSection("Deployment Close").getByRole("checkbox", { name: /enabled/i });
+  }
+
+  getCloseChannelSelect() {
+    return this.getSection("Deployment Close").getByRole("combobox").first();
+  }
+
+  async saveChanges() {
+    await this.page.getByRole("button", { name: /save changes/i }).click();
+    await this.page.getByText("Alert configured!").waitFor({ state: "visible", timeout: 10_000 });
+    await this.page.getByText("Alert configured!").waitFor({ state: "hidden", timeout: 10_000 });
+  }
+
+  async setEscrowThreshold(value: string) {
+    const input = this.getEscrowThresholdInput();
+    await input.clear();
+    await input.fill(value);
+  }
+}

--- a/apps/deploy-web/tests/ui/pages/DeploymentAlertsForm.ts
+++ b/apps/deploy-web/tests/ui/pages/DeploymentAlertsForm.ts
@@ -3,8 +3,8 @@ import type { Page } from "@playwright/test";
 export class DeploymentAlertsForm {
   constructor(readonly page: Page) {}
 
-  private getSection(heading: string) {
-    return this.page.locator(".rounded-lg.border").filter({ hasText: heading });
+  private getSection(label: string) {
+    return this.page.getByLabel(label);
   }
 
   getEscrowEnabledToggle() {

--- a/apps/deploy-web/tests/ui/pages/Sidebar.ts
+++ b/apps/deploy-web/tests/ui/pages/Sidebar.ts
@@ -9,4 +9,8 @@ export class Sidebar {
       .first()
       .click();
   }
+
+  async openAlerts() {
+    await this.page.getByRole("link", { name: /^alerts$/i }).click();
+  }
 }

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -6,14 +6,12 @@ export const netConfigData = {
       "https://rpc.akt.dev/rest",
       "https://api.akashnet.net:443",
       "https://akash-api.polkachu.com:443",
-      "https://akash.c29r3.xyz:443/api",
       "https://rest-akash.ecostake.com",
       "https://rest.lavenderfive.com:443/akash",
-      "https://akash-mainnet-lcd.autostake.com:443",
+      "https://akash-api.polkachu.com",
+      "https://akash.c29r3.xyz:443/api",
       "https://akash-api.kleomedes.network",
-      "https://api-akash-01.stakeflow.io",
       "https://akash-mainnet-rest.cosmonautstakes.com:443",
-      "https://akash-api.w3coins.io",
       "https://akash-rest.publicnode.com",
       "https://akash-api.validatornode.com",
       "https://lcd.akash.bronbro.io:443"
@@ -21,17 +19,16 @@ export const netConfigData = {
     rpcUrls: [
       "https://rpc.akt.dev/rpc",
       "https://rpc.akashnet.net:443",
-      "https://rpc-akash.ecostake.com:443",
       "https://akash-rpc.polkachu.com:443",
       "https://akash.c29r3.xyz:443/rpc",
       "https://akash-rpc.europlots.com:443",
+      "https://rpc-akash.ecostake.com:443",
       "https://rpc.lavenderfive.com:443/akash",
+      "https://akash-rpc.polkachu.com",
       "https://akash.c29r3.xyz:80/rpc",
       "https://akash-rpc.kleomedes.network",
       "https://akash-mainnet-rpc.cosmonautstakes.com:443",
-      "https://akash-rpc.w3coins.io",
-      "https://akash-rpc.publicnode.com:443",
-      "https://rpc.akash.bronbro.io:443"
+      "https://akash-rpc.publicnode.com:443"
     ]
   },
   "sandbox-2": {


### PR DESCRIPTION
## Why

Part of CON-155

Deployment alerts configuration and the global alerts page had no E2E coverage. Additionally, the threshold display had a floating point rounding bug, and the unsaved changes detection had a race condition.

## What

**E2E test (`managed-wallet-alerts.spec.ts`):**
- Deploy hello-world → open Alerts tab → verify both escrow balance and deployment close alerts enabled by default
- Update escrow threshold → save → verify value persisted
- Toggle escrow alert off → save → re-enable → save
- Navigate to global alerts page → verify alerts listed → toggle from list
- Navigate back to deployment via DSEQ link → close deployment

**Page objects:**
- `AlertsPage` — global alerts list with tab navigation and alert toggle
- `DeploymentAlertsForm` — deployment detail alerts form (scoped via `aria-label` on Fieldset sections)
- `DeployPage.openTab(name)` — generic tab opener for deployment details
- `Sidebar.openAlerts()` — sidebar navigation

**Shared action:**
- `createManagedDeployment()` extracted to `actions/deploy.ts` — handles template selection, deposit dialog, top-up if needed, lease creation. Used by both deployment and alerts tests.

**App fixes:**
- `DeploymentAlertsContainer`: replace `ceilDecimal` with `roundDecimal(value * price, 6)` for threshold display — `ceilDecimal` added `Number.EPSILON` which caused `0.075` to display as `0.076`
- `DeploymentAlertsView`: reset `hasChanges` and notify parent after successful save to prevent stale navigation guard

**Accessibility:**
- `Fieldset` component: added `aria-label` prop passthrough
- `DeploymentBalanceAlert`: `aria-label="Escrow Balance alert"`
- `DeploymentCloseAlert`: `aria-label="Deployment Close alert"`

Depends on #3099

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment alert threshold now uses quantized rounding for more accurate balance display.

* **Accessibility**
  * Fieldset containers in deployment alert UIs accept and expose aria-labelledby references; specific alert titles wired for improved screen‑reader clarity.

* **Tests**
  * Added end-to-end coverage for managed‑wallet deployments and alerts.
  * Introduced reusable test helper flows and page‑object helpers (Alerts, DeploymentAlertsForm, Sidebar, DeployPage) to drive and validate alert workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->