### PR TITLE
fix(billing): handle invalid unit price chain error as 400

### DIFF
--- a/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
@@ -141,6 +141,29 @@ describe(ChainErrorService.name, () => {
       expect(appErr.message).toBe("Failed to create deployment: Invalid deployment hash");
     });
 
+    it("returns 400 for invalid unit price error", async () => {
+      const { service } = setup();
+      const err = new Error(
+        "Query failed with (6): rpc error: code = Unknown desc = group dcloud: error: invalid unit price (10000000 > 12000000.000000000000000000uact fails) with gas used: '1150': unknown request"
+      );
+
+      const appErr = await service.toAppError(err, encodeMessages);
+      expect(appErr).toBeInstanceOf(BadRequest);
+      expect(appErr.message).toBe("Unit price exceeds the maximum allowed by the network");
+    });
+
+    it("returns 400 for invalid unit price error with message prefix", async () => {
+      const { service } = setup();
+      const err = new Error(
+        "Query failed with (6): rpc error: code = Unknown desc = group dcloud: error: invalid unit price (10000000 > 12000000.000000000000000000uact fails) message index: 0"
+      );
+      const messages: EncodeObject[] = [{ typeUrl: "/akash.deployment.v1beta4.MsgCreateDeployment", value: {} }];
+
+      const appErr = await service.toAppError(err, messages);
+      expect(appErr).toBeInstanceOf(BadRequest);
+      expect(appErr.message).toBe("Failed to create deployment: Unit price exceeds the maximum allowed by the network");
+    });
+
     it("returns 402 for insufficient balance error", async () => {
       const { service } = setup();
       const err = new Error(

--- a/apps/api/src/billing/services/chain-error/chain-error.service.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.ts
@@ -58,6 +58,10 @@ export class ChainErrorService {
       code: 400,
       message: "Cannot create lease: The associated order has already been matched or closed. Re-create the deployment to generate a new order and try again."
     },
+    "invalid unit price": {
+      code: 400,
+      message: "Unit price exceeds the maximum allowed by the network"
+    },
     "insufficient balance": {
       code: 402,
       message: "Insufficient balance"


### PR DESCRIPTION
## Why

When a user submits a deployment with a per-resource price exceeding the network's maximum (10,000,000), the chain rejects it with a cryptic `invalid unit price` error. The API was not mapping this to a proper 400 response, so the user got an unhelpful error message.

## What

Added `invalid unit price` to the API's `ChainErrorService` error map so it returns a clear 400 response: "Unit price exceeds the maximum allowed by the network".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for invalid unit price errors during deployment creation with improved contextual error messages to better assist users when pricing validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->