### PR TITLE
fix(notifications): retry on RPC failure instead of crash-looping

### DIFF
--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -59,6 +59,7 @@
     "@opentelemetry/auto-instrumentations-node": "^0.57.1",
     "@ucast/core": "^1.10.2",
     "@ucast/js": "^3.0.4",
+    "cockatiel": "^3.2.1",
     "date-fns": "^4.1.0",
     "drizzle-kit": "^0.30.5",
     "drizzle-orm": "^0.41.0",

--- a/apps/notifications/src/modules/chain/chain.module.ts
+++ b/apps/notifications/src/modules/chain/chain.module.ts
@@ -10,6 +10,7 @@ import { TxEventsService } from "@src/modules/chain/services/tx-events-service/t
 import { RegistryProvider } from "./providers/registry.provider";
 import { StargateClientProvider } from "./providers/stargate-client/stargate-client.provider";
 import { BlockCursorRepository } from "./repositories/block-cursor/block-cursor.repository";
+import { BlockCursorInitializerService } from "./services/block-cursor-initializer/block-cursor-initializer.service";
 import { BlockMessageService } from "./services/block-message/block-message.service";
 import { BlockMessageParserService } from "./services/block-message-parser/block-message-parser.service";
 import { BlockchainClientService } from "./services/blockchain-client/blockchain-client.service";
@@ -22,6 +23,7 @@ import * as schema from "./model-schemas";
 @Module({
   imports: [CommonModule, ConfigModule.forFeature(moduleConfig), ...register(schema), BrokerModule],
   providers: [
+    BlockCursorInitializerService,
     ChainEventsPollerService,
     BlockMessageService,
     BlockMessageParserService,

--- a/apps/notifications/src/modules/chain/config/env.config.ts
+++ b/apps/notifications/src/modules/chain/config/env.config.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const schema = z.object({
   BLOCK_TIME_SEC: z.number({ coerce: true }).optional().default(6),
+  BLOCK_STALE_THRESHOLD_SEC: z.number({ coerce: true }).optional().default(300),
   RPC_NODE_ENDPOINT: z.string()
 });
 

--- a/apps/notifications/src/modules/chain/config/index.ts
+++ b/apps/notifications/src/modules/chain/config/index.ts
@@ -1,16 +1,16 @@
 import { registerAs } from "@nestjs/config";
-import type { BackoffOptions } from "exponential-backoff";
 
 import type { Namespaced } from "@src/lib/types/namespaced-config.type";
 import type { ChainEventsEnvConfig } from "./env.config";
 import { schema } from "./env.config";
+import type { PollingConfig } from "./polling.config";
 import { pollingConfig } from "./polling.config";
 
 export const NAMESPACE = "chain" as const;
 export type ChainEventsConfig = Namespaced<
   typeof NAMESPACE,
   ChainEventsEnvConfig & {
-    pollingConfig: BackoffOptions;
+    pollingConfig: PollingConfig;
   }
 >;
 export default registerAs(NAMESPACE, () => ({

--- a/apps/notifications/src/modules/chain/config/polling.config.ts
+++ b/apps/notifications/src/modules/chain/config/polling.config.ts
@@ -1,9 +1,13 @@
-import type { BackoffOptions } from "exponential-backoff";
+export interface PollingConfig {
+  maxDelay: number;
+  startingDelay: number;
+  timeMultiple: number;
+  numOfAttempts: number;
+}
 
-export const pollingConfig: BackoffOptions = {
+export const pollingConfig: PollingConfig = {
   maxDelay: 5_000,
   startingDelay: 500,
   timeMultiple: 2,
-  numOfAttempts: 5,
-  jitter: "none"
+  numOfAttempts: 5
 };

--- a/apps/notifications/src/modules/chain/providers/comet-client/comet-client.provider.spec.ts
+++ b/apps/notifications/src/modules/chain/providers/comet-client/comet-client.provider.spec.ts
@@ -1,39 +1,39 @@
-import type { StargateClient } from "@cosmjs/stargate";
+import type { Comet38Client } from "@cosmjs/tendermint-rpc";
 import { faker } from "@faker-js/faker";
 import type { ConfigService } from "@nestjs/config";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import { createStargateClientFactory } from "./stargate-client.provider";
+import { createCometClientFactory } from "./comet-client.provider";
 
-describe("createStargateClient", () => {
+describe("createCometClient", () => {
   it("should connect to the Akash network", async () => {
     const config = mock<ConfigService>();
-    const mockClient = mock<StargateClient>();
-    const MockStargateClient = {
+    const mockClient = mock<Comet38Client>();
+    const MockCometClient = {
       connect: vi.fn().mockResolvedValue(mockClient)
     };
     const rpcNodeEndpoint = faker.internet.url();
     config.getOrThrow.mockReturnValue(rpcNodeEndpoint);
 
-    const client = await createStargateClientFactory(MockStargateClient as unknown as typeof StargateClient)(config);
+    const client = await createCometClientFactory(MockCometClient as unknown as typeof Comet38Client)(config);
 
-    expect(MockStargateClient.connect).toHaveBeenCalledWith(rpcNodeEndpoint);
+    expect(MockCometClient.connect).toHaveBeenCalledWith(rpcNodeEndpoint);
     expect(client).toBe(mockClient);
   });
 
   it("should retry connecting when RPC is temporarily unavailable", async () => {
     const config = mock<ConfigService>();
-    const mockClient = mock<StargateClient>();
-    const MockStargateClient = {
+    const mockClient = mock<Comet38Client>();
+    const MockCometClient = {
       connect: vi.fn().mockRejectedValueOnce(new Error("ECONNREFUSED")).mockRejectedValueOnce(new Error("ECONNREFUSED")).mockResolvedValue(mockClient)
     };
     const rpcNodeEndpoint = faker.internet.url();
     config.getOrThrow.mockReturnValue(rpcNodeEndpoint);
 
-    const client = await createStargateClientFactory(MockStargateClient as unknown as typeof StargateClient)(config);
+    const client = await createCometClientFactory(MockCometClient as unknown as typeof Comet38Client)(config);
 
-    expect(MockStargateClient.connect).toHaveBeenCalledTimes(3);
+    expect(MockCometClient.connect).toHaveBeenCalledTimes(3);
     expect(client).toBe(mockClient);
   });
 });

--- a/apps/notifications/src/modules/chain/providers/comet-client/comet-client.provider.ts
+++ b/apps/notifications/src/modules/chain/providers/comet-client/comet-client.provider.ts
@@ -1,13 +1,26 @@
 import { Comet38Client } from "@cosmjs/tendermint-rpc";
 import type { Provider } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import { backOff } from "exponential-backoff";
 
+import { Logger } from "@src/common/providers/logger.provider";
 import type { ChainEventsConfig } from "@src/modules/chain/config";
 
 export const createCometClientFactory =
   (Client: typeof Comet38Client) =>
   async (config: ConfigService<ChainEventsConfig>): Promise<Comet38Client> => {
-    return await Client.connect(config.getOrThrow("chain.RPC_NODE_ENDPOINT"));
+    const logger = new Logger({ context: "CometClientProvider" });
+    return await backOff(() => Client.connect(config.getOrThrow("chain.RPC_NODE_ENDPOINT")), {
+      numOfAttempts: 15,
+      maxDelay: 30_000,
+      startingDelay: 500,
+      timeMultiple: 2,
+      jitter: "none",
+      retry: (error, attempt) => {
+        logger.debug({ event: "RPC_CONNECT_RETRY", attempt, error });
+        return true;
+      }
+    });
   };
 
 export const CometClientProvider: Provider<Comet38Client> = {

--- a/apps/notifications/src/modules/chain/providers/stargate-client/stargate-client.provider.ts
+++ b/apps/notifications/src/modules/chain/providers/stargate-client/stargate-client.provider.ts
@@ -1,13 +1,26 @@
 import { StargateClient } from "@cosmjs/stargate";
 import type { Provider } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import { backOff } from "exponential-backoff";
 
+import { Logger } from "@src/common/providers/logger.provider";
 import type { ChainEventsConfig } from "@src/modules/chain/config";
 
 export const createStargateClientFactory =
   (Client: typeof StargateClient) =>
   async (config: ConfigService<ChainEventsConfig>): Promise<StargateClient> => {
-    return await Client.connect(config.getOrThrow("chain.RPC_NODE_ENDPOINT"));
+    const logger = new Logger({ context: "StargateClientProvider" });
+    return await backOff(() => Client.connect(config.getOrThrow("chain.RPC_NODE_ENDPOINT")), {
+      numOfAttempts: 15,
+      maxDelay: 30_000,
+      startingDelay: 500,
+      timeMultiple: 2,
+      jitter: "none",
+      retry: (error, attempt) => {
+        logger.debug({ event: "RPC_CONNECT_RETRY", attempt, error });
+        return true;
+      }
+    });
   };
 
 export const StargateClientProvider: Provider<StargateClient> = {

--- a/apps/notifications/src/modules/chain/services/block-cursor-initializer/block-cursor-initializer.service.spec.ts
+++ b/apps/notifications/src/modules/chain/services/block-cursor-initializer/block-cursor-initializer.service.spec.ts
@@ -1,0 +1,51 @@
+import type { StargateClient } from "@cosmjs/stargate";
+import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { LoggerService } from "@src/common/services/logger/logger.service";
+import type { BlockCursorRepository } from "@src/modules/chain/repositories/block-cursor/block-cursor.repository";
+import { BlockCursorInitializerService } from "./block-cursor-initializer.service";
+
+describe(BlockCursorInitializerService.name, () => {
+  it("initializes block cursor with current chain height", async () => {
+    const { service, stargateClient, blockCursorRepository, height } = setup();
+
+    stargateClient.getHeight.mockResolvedValue(height);
+
+    await service.onModuleInit();
+
+    expect(blockCursorRepository.ensureInitialized).toHaveBeenCalledWith(height);
+  });
+
+  it("retries getHeight on transient failure", async () => {
+    const { service, stargateClient, blockCursorRepository, height } = setup();
+
+    stargateClient.getHeight.mockRejectedValueOnce(new Error("ECONNREFUSED")).mockRejectedValueOnce(new Error("ECONNREFUSED")).mockResolvedValue(height);
+
+    await service.onModuleInit();
+
+    expect(stargateClient.getHeight).toHaveBeenCalledTimes(3);
+    expect(blockCursorRepository.ensureInitialized).toHaveBeenCalledWith(height);
+  });
+
+  it("throws when retries are exhausted", async () => {
+    const { service, stargateClient } = setup();
+
+    stargateClient.getHeight.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    await expect(service.onModuleInit()).rejects.toThrow("ECONNREFUSED");
+  }, 15_000);
+
+  function setup() {
+    const stargateClient = mock<StargateClient>();
+    const blockCursorRepository = mock<BlockCursorRepository>();
+    const loggerService = mock<LoggerService>();
+
+    const height = faker.number.int({ min: 1000, max: 9999999 });
+
+    const service = new BlockCursorInitializerService(stargateClient, blockCursorRepository, loggerService);
+
+    return { service, stargateClient, blockCursorRepository, loggerService, height };
+  }
+});

--- a/apps/notifications/src/modules/chain/services/block-cursor-initializer/block-cursor-initializer.service.ts
+++ b/apps/notifications/src/modules/chain/services/block-cursor-initializer/block-cursor-initializer.service.ts
@@ -1,0 +1,28 @@
+import { StargateClient } from "@cosmjs/stargate";
+import { Injectable, OnModuleInit } from "@nestjs/common";
+import { ExponentialBackoff, handleAll, retry } from "cockatiel";
+
+import { LoggerService } from "@src/common/services/logger/logger.service";
+import { BlockCursorRepository } from "@src/modules/chain/repositories/block-cursor/block-cursor.repository";
+
+@Injectable()
+export class BlockCursorInitializerService implements OnModuleInit {
+  private readonly retryExecutor = retry(handleAll, {
+    maxAttempts: 5,
+    backoff: new ExponentialBackoff({ initialDelay: 500, maxDelay: 5_000, exponent: 2 })
+  });
+
+  constructor(
+    private readonly stargateClient: StargateClient,
+    private readonly blockCursorRepository: BlockCursorRepository,
+    private readonly loggerService: LoggerService
+  ) {
+    this.loggerService.setContext(BlockCursorInitializerService.name);
+  }
+
+  async onModuleInit(): Promise<void> {
+    const height = await this.retryExecutor.execute(() => this.stargateClient.getHeight());
+    await this.blockCursorRepository.ensureInitialized(height);
+    this.loggerService.log({ event: "BLOCK_CURSOR_INITIALIZED", height });
+  }
+}

--- a/apps/notifications/src/modules/chain/services/block-message/block-message.service.spec.ts
+++ b/apps/notifications/src/modules/chain/services/block-message/block-message.service.spec.ts
@@ -35,7 +35,7 @@ describe(BlockMessageService.name, () => {
 
       const result = await service.getMessages(height);
 
-      expect(blockchainClientService.getBlock).toHaveBeenCalledWith(height);
+      expect(blockchainClientService.getBlock).toHaveBeenCalledWith(height, undefined);
       expect(blockMessageParserService.parseBlockMessages).toHaveBeenCalledWith(mockBlock, undefined);
       expect(result).toEqual(mockBlockData);
     });
@@ -52,7 +52,7 @@ describe(BlockMessageService.name, () => {
 
       const result = await service.getMessages("latest");
 
-      expect(blockchainClientService.getBlock).toHaveBeenCalledWith("latest");
+      expect(blockchainClientService.getBlock).toHaveBeenCalledWith("latest", undefined);
       expect(blockMessageParserService.parseBlockMessages).toHaveBeenCalledWith(mockBlock, undefined);
       expect(result).toEqual(mockBlockData);
     });
@@ -75,7 +75,7 @@ describe(BlockMessageService.name, () => {
 
       const result = await service.getMessages(height, messageTypes);
 
-      expect(blockchainClientService.getBlock).toHaveBeenCalledWith(height);
+      expect(blockchainClientService.getBlock).toHaveBeenCalledWith(height, undefined);
       expect(blockMessageParserService.parseBlockMessages).toHaveBeenCalledWith(mockBlock, messageTypes);
       expect(result).toEqual(mockBlockData);
     });

--- a/apps/notifications/src/modules/chain/services/block-message/block-message.service.ts
+++ b/apps/notifications/src/modules/chain/services/block-message/block-message.service.ts
@@ -16,8 +16,8 @@ export class BlockMessageService {
    * @param messageTypes Optional array of message types to filter for
    * @returns The block data with messages
    */
-  async getMessages(height: number | "latest", messageTypes?: MessageTypeFilter[]): Promise<BlockData> {
-    const block = await this.blockchainClient.getBlock(height);
+  async getMessages(height: number | "latest", messageTypes?: MessageTypeFilter[], signal?: AbortSignal): Promise<BlockData> {
+    const block = await this.blockchainClient.getBlock(height, signal);
     return this.blockMessageParser.parseBlockMessages(block, messageTypes);
   }
 }

--- a/apps/notifications/src/modules/chain/services/blockchain-client/blockchain-client.service.ts
+++ b/apps/notifications/src/modules/chain/services/blockchain-client/blockchain-client.service.ts
@@ -1,6 +1,6 @@
 import { Block, StargateClient } from "@cosmjs/stargate";
 import { Injectable } from "@nestjs/common";
-import { backOff } from "exponential-backoff";
+import { ExponentialBackoff, handleAll, retry } from "cockatiel";
 
 import { LoggerService } from "@src/common/services/logger/logger.service";
 
@@ -18,10 +18,10 @@ export class BlockchainClientService {
    * @param height The block height to fetch or 'latest' for the latest block
    * @returns The block data
    */
-  async getBlock(height: number | "latest"): Promise<Block> {
+  async getBlock(height: number | "latest", signal?: AbortSignal): Promise<Block> {
     const blockHeight = await this.toBlockHeight(height);
     this.loggerService.debug(`Fetching block at height: ${blockHeight}`);
-    return await this.getBlockAwaited(blockHeight);
+    return await this.getBlockAwaited(blockHeight, signal);
   }
 
   /**
@@ -33,13 +33,19 @@ export class BlockchainClientService {
     return height === "latest" ? this.stargateClient.getHeight() : height;
   }
 
-  private async getBlockAwaited(height: number): Promise<Block> {
-    return await backOff(() => this.stargateClient.getBlock(height), {
+  private readonly retryExecutor = retry(handleAll, {
+    maxAttempts: 5,
+    backoff: new ExponentialBackoff({
+      initialDelay: 500,
       maxDelay: 5_000,
-      startingDelay: 500,
-      timeMultiple: 2,
-      numOfAttempts: 5,
-      jitter: "none"
-    });
+      exponent: 2
+    })
+  });
+
+  private async getBlockAwaited(height: number, signal?: AbortSignal): Promise<Block> {
+    return await this.retryExecutor.execute(async ({ signal: retrySignal }) => {
+      retrySignal.throwIfAborted();
+      return await this.stargateClient.getBlock(height);
+    }, signal);
   }
 }

--- a/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.spec.ts
+++ b/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.spec.ts
@@ -1,15 +1,13 @@
 import { MsgCloseDeployment, MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
-import { StargateClient } from "@cosmjs/stargate";
 import { ConfigModule, registerAs } from "@nestjs/config";
 import type { TestingModule } from "@nestjs/testing";
 import { Test } from "@nestjs/testing";
 import { setTimeout as delay } from "timers/promises";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";
 
 import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import { LoggerService } from "@src/common/services/logger/logger.service";
-import { ShutdownService } from "@src/common/services/shutdown/shutdown.service";
 import { BrokerService } from "@src/infrastructure/broker";
 import { NAMESPACE } from "@src/modules/chain/config";
 import { BlockCursorRepository } from "@src/modules/chain/repositories/block-cursor/block-cursor.repository";
@@ -24,7 +22,7 @@ import { generateMsgCloseDeployment, generateMsgCreateDeployment } from "@test/s
 
 describe(ChainEventsPollerService.name, () => {
   it("initializes poller, processes a new block and publishes related events", async () => {
-    const { service, blockCursorRepository, blockMessageService, module, CURRENT_HEIGHT } = await setup();
+    const { service, blockMessageService, module, CURRENT_HEIGHT } = await setup();
 
     const createDeploymentMessage = generateMsgCreateDeployment();
     const closeDeploymentMessage = generateMsgCloseDeployment();
@@ -36,13 +34,15 @@ describe(ChainEventsPollerService.name, () => {
 
     blockMessageService.getMessages.mockResolvedValueOnce(mockBlock);
 
-    service.onModuleInit();
+    service.onApplicationBootstrap();
     await delay(500);
     service.onModuleDestroy();
 
-    expect(blockCursorRepository.ensureInitialized).toHaveBeenCalledWith(CURRENT_HEIGHT);
-
-    expect(blockMessageService.getMessages).toHaveBeenCalledWith(CURRENT_HEIGHT + 1, [MsgCloseDeployment["$type"], MsgCreateDeployment["$type"]]);
+    expect(blockMessageService.getMessages).toHaveBeenCalledWith(
+      CURRENT_HEIGHT + 1,
+      [MsgCloseDeployment["$type"], MsgCreateDeployment["$type"]],
+      expect.any(AbortSignal)
+    );
 
     expect(module.get(BrokerService).publishAll).toHaveBeenCalledWith([
       {
@@ -70,23 +70,80 @@ describe(ChainEventsPollerService.name, () => {
     ]);
   });
 
-  it("shuts down application when block processing consistently fails", async () => {
-    const { service, module, blockCursorRepository, blockMessageService, CURRENT_HEIGHT } = await setup();
+  it("retries instead of shutting down when block processing consistently fails", async () => {
+    const { service, blockCursorRepository, blockMessageService, CURRENT_HEIGHT } = await setup();
 
-    blockCursorRepository.getNextBlockForProcessing.mockImplementation(async () => {
-      throw new Error("Block Cursor lookup failed");
-    });
+    const successBlock = generateMockBlockData({ height: CURRENT_HEIGHT + 1, time: new Date().toISOString() });
 
-    const mockBlock: BlockData = generateMockBlockData({
-      height: CURRENT_HEIGHT + 1
-    });
+    blockCursorRepository.getNextBlockForProcessing
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockImplementationOnce(async cb => await cb(CURRENT_HEIGHT + 1));
 
-    blockMessageService.getMessages.mockResolvedValueOnce(mockBlock);
+    blockMessageService.getMessages.mockResolvedValueOnce(successBlock);
 
-    service.onModuleInit();
-    await delay(500);
+    service.onApplicationBootstrap();
+    await delay(1000);
+    await service.onModuleDestroy();
 
-    expect(module.get(ShutdownService).shutdown).toHaveBeenCalled();
+    expect(blockMessageService.getMessages).toHaveBeenCalled();
+  });
+
+  it("logs CHAIN_POLLER_STALE when blocks fall behind threshold", async () => {
+    const { service, blockCursorRepository, blockMessageService, loggerService, CURRENT_HEIGHT } = await setup();
+
+    const staleTime = new Date(Date.now() - 2000).toISOString();
+    const staleBlock = generateMockBlockData({ height: CURRENT_HEIGHT + 1, time: staleTime });
+
+    blockMessageService.getMessages.mockResolvedValueOnce(staleBlock);
+
+    blockCursorRepository.getNextBlockForProcessing
+      .mockImplementationOnce(async cb => await cb(CURRENT_HEIGHT + 1))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"));
+
+    service.onApplicationBootstrap();
+    await delay(1000);
+    await service.onModuleDestroy();
+
+    expect(loggerService.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "CHAIN_POLLER_STALE",
+        lastBlockTime: staleTime
+      })
+    );
+  });
+
+  it("logs CHAIN_POLLER_RECOVERED when catching up after being stale", async () => {
+    const { service, blockCursorRepository, blockMessageService, loggerService, CURRENT_HEIGHT } = await setup();
+
+    const staleTime = new Date(Date.now() - 2000).toISOString();
+    const staleBlock = generateMockBlockData({ height: CURRENT_HEIGHT + 1, time: staleTime });
+    const freshBlock = generateMockBlockData({ height: CURRENT_HEIGHT + 2, time: new Date().toISOString() });
+
+    blockMessageService.getMessages.mockResolvedValueOnce(staleBlock).mockResolvedValueOnce(freshBlock);
+
+    blockCursorRepository.getNextBlockForProcessing
+      .mockImplementationOnce(async cb => await cb(CURRENT_HEIGHT + 1))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockImplementationOnce(async cb => await cb(CURRENT_HEIGHT + 2));
+
+    service.onApplicationBootstrap();
+    await delay(1500);
+    await service.onModuleDestroy();
+
+    expect(loggerService.error).toHaveBeenCalledWith(expect.objectContaining({ event: "CHAIN_POLLER_STALE" }));
+    expect(loggerService.log).toHaveBeenCalledWith(expect.objectContaining({ event: "CHAIN_POLLER_RECOVERED" }));
   });
 
   describe("getReadinessStatus", () => {
@@ -102,7 +159,7 @@ describe(ChainEventsPollerService.name, () => {
       const { service, blockMessageService } = await setup();
       blockMessageService.getMessages.mockResolvedValue(generateMockBlockData({ time: new Date().toISOString() }));
 
-      await service.onModuleInit();
+      await service.onApplicationBootstrap();
       await delay(50);
 
       const result = await service.getReadinessStatus();
@@ -112,16 +169,18 @@ describe(ChainEventsPollerService.name, () => {
       await service.onModuleDestroy();
     });
 
-    it("returns error after poller crashes", async () => {
+    it("returns ok while poller retries after errors", async () => {
       const { service, blockCursorRepository } = await setup();
       blockCursorRepository.getNextBlockForProcessing.mockRejectedValue(new Error("fail"));
 
-      service.onModuleInit();
+      service.onApplicationBootstrap();
       await delay(500);
 
       const result = await service.getReadinessStatus();
 
-      expect(result).toEqual({ status: "error", data: { poller: false } });
+      expect(result).toEqual({ status: "ok", data: { poller: true } });
+
+      await service.onModuleDestroy();
     });
   });
 
@@ -136,24 +195,13 @@ describe(ChainEventsPollerService.name, () => {
     });
   });
 
-  it("completes currently processed block before shutdown is finalized", async () => {
+  it("shuts down cleanly when poller is running", async () => {
     const { service, blockMessageService } = await setup();
-    const controller = Promise.withResolvers<ReturnType<typeof generateMockBlockData>>();
+    blockMessageService.getMessages.mockResolvedValue(generateMockBlockData({ time: new Date().toISOString() }));
 
-    blockMessageService.getMessages.mockImplementation(() => controller.promise);
-
-    await service.onModuleInit();
-    await delay(10);
-    const finalizeDestroy = vi.fn();
-    service.onModuleDestroy().finally(finalizeDestroy);
-    await delay(100);
-
-    expect(blockMessageService.getMessages).toHaveBeenCalledTimes(1);
-    expect(finalizeDestroy).not.toHaveBeenCalled();
-
-    controller.resolve(generateMockBlockData({ time: new Date().toISOString() }));
-    await delay(100);
-    expect(finalizeDestroy).toHaveBeenCalled();
+    await service.onApplicationBootstrap();
+    await delay(50);
+    await service.onModuleDestroy();
   });
 
   async function setup(): Promise<{
@@ -170,6 +218,7 @@ describe(ChainEventsPollerService.name, () => {
         ConfigModule.forFeature(
           registerAs(NAMESPACE, () => ({
             BLOCK_TIME_SEC: 0.1,
+            BLOCK_STALE_THRESHOLD_SEC: 0.3,
             pollingConfig: {
               maxDelay: 30,
               startingDelay: 3,
@@ -185,17 +234,12 @@ describe(ChainEventsPollerService.name, () => {
         MockProvider(BrokerService),
         MockProvider(BlockMessageService),
         MockProvider(BlockCursorRepository),
-        MockProvider(StargateClient as any),
-        MockProvider(ShutdownService),
         MockProvider(LoggerService),
         MockProvider(TxEventsService)
       ]
     }).compile();
 
     const CURRENT_HEIGHT = 100;
-
-    const stargateClient = module.get<MockProxy<StargateClient>>(StargateClient);
-    stargateClient.getHeight.mockResolvedValue(CURRENT_HEIGHT);
 
     const blockCursorRepository = module.get<MockProxy<BlockCursorRepository>>(BlockCursorRepository);
     blockCursorRepository.getNextBlockForProcessing.mockImplementation(async cb => {

--- a/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.ts
+++ b/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.ts
@@ -1,14 +1,12 @@
 import { MsgCloseDeployment, MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
-import { StargateClient } from "@cosmjs/stargate";
-import { Injectable, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
+import { Injectable, OnApplicationBootstrap, OnModuleDestroy } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import { ExponentialBackoff, handleAll, retry, TaskCancelledError } from "cockatiel";
 import { once } from "events";
-import { backOff } from "exponential-backoff";
 import { setTimeout as delay } from "timers/promises";
 
 import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import { LoggerService } from "@src/common/services/logger/logger.service";
-import { ShutdownService } from "@src/common/services/shutdown/shutdown.service";
 import type { HealthzService, ProbeResult } from "@src/common/types/healthz.type";
 import { BrokerService } from "@src/infrastructure/broker";
 import type { ChainEventsConfig } from "@src/modules/chain/config";
@@ -18,10 +16,33 @@ import { TxEventsService } from "@src/modules/chain/services/tx-events-service/t
 import { BlockMessageService } from "../block-message/block-message.service";
 
 @Injectable()
-export class ChainEventsPollerService implements OnModuleInit, OnModuleDestroy, HealthzService {
+export class ChainEventsPollerService implements OnApplicationBootstrap, OnModuleDestroy, HealthzService {
   readonly name = "chain-events-poller";
 
-  private abortController?: AbortController;
+  private readonly abortController = new AbortController();
+
+  private lastProcessedBlockTime?: Date;
+
+  private isStale = false;
+
+  private staleStartedAt?: Date;
+
+  private get signal() {
+    return this.abortController.signal;
+  }
+
+  private get pollingConfig() {
+    return this.configService.getOrThrow("chain.pollingConfig");
+  }
+
+  private readonly blockRetryExecutor = retry(handleAll, {
+    maxAttempts: this.pollingConfig.numOfAttempts,
+    backoff: new ExponentialBackoff({
+      initialDelay: this.pollingConfig.startingDelay,
+      maxDelay: this.pollingConfig.maxDelay,
+      exponent: this.pollingConfig.timeMultiple
+    })
+  });
 
   constructor(
     private readonly brokerService: BrokerService,
@@ -29,56 +50,90 @@ export class ChainEventsPollerService implements OnModuleInit, OnModuleDestroy, 
     private readonly txEventsService: TxEventsService,
     private readonly loggerService: LoggerService,
     private readonly blockCursorRepository: BlockCursorRepository,
-    private readonly stargateClient: StargateClient,
-    private readonly shutdownService: ShutdownService,
     private readonly configService: ConfigService<ChainEventsConfig>
   ) {
     this.loggerService.setContext(ChainEventsPollerService.name);
+    this.blockRetryExecutor.onRetry(event => {
+      this.logProcessingError("error" in event ? event.error : undefined, event.attempt);
+      this.trackBlockStaleness();
+    });
   }
 
-  async onModuleInit(): Promise<void> {
-    const blockHeight = await this.ensureInitialized();
-    this.subscribeToChainEvents(blockHeight);
+  async onApplicationBootstrap(): Promise<void> {
+    this.subscribeToChainEvents();
   }
 
-  private async ensureInitialized(): Promise<number> {
-    const height = await this.stargateClient.getHeight();
-    await this.blockCursorRepository.ensureInitialized(height);
-
-    return height;
-  }
-
-  private subscribeToChainEvents(blockHeight: number) {
-    this.abortController = new AbortController();
-    this.loggerService.log({ event: "START_CHAIN_POLLER", blockHeight });
+  private subscribeToChainEvents() {
+    this.loggerService.log({ event: "START_CHAIN_POLLER" });
     this.processBlocksLooping().catch(error => {
-      this.abortController?.abort();
-      this.loggerService.error({
-        event: "CHAIN_POLLER_FAILURE",
-        error
-      });
-      this.loggerService.fatal({ event: "APPLICATION_STOP" });
-      this.shutdownService.shutdown();
+      if (!this.abortController.signal.aborted) {
+        this.loggerService.error({ event: "UNEXPECTED_POLLER_FAILURE", error });
+      }
     });
   }
 
   private async processBlocksLooping() {
-    const signal = this.abortController?.signal;
-    while (signal && !signal.aborted) {
-      const processedBlock = await this.processNextBlockWithRetries();
-      await this.delayAfterBlock(processedBlock, signal);
+    try {
+      while (!this.signal.aborted) {
+        try {
+          const processedBlock = await this.processNextBlockWithRetries();
+          this.trackBlockProgress(processedBlock);
+          await this.delayAfterBlock(processedBlock);
+        } catch (error) {
+          if (this.signal.aborted || error instanceof TaskCancelledError) break;
+          this.loggerService.debug({ event: "CHAIN_POLLER_RETRY", error });
+          this.trackBlockStaleness();
+          await delay(this.configService.getOrThrow("chain.pollingConfig").maxDelay, null, { signal: this.signal }).catch(e =>
+            e?.name === "AbortError" ? undefined : Promise.reject(e)
+          );
+        }
+      }
+    } catch (error) {
+      if (!this.signal.aborted && !(error instanceof TaskCancelledError)) throw error;
+    } finally {
+      this.signal.dispatchEvent(new Event("complete"));
     }
-    signal?.dispatchEvent(new Event("complete"));
+  }
+
+  private trackBlockProgress(block: BlockData) {
+    this.lastProcessedBlockTime = new Date(block.time);
+
+    if (this.isStale) {
+      const staleDurationSeconds = Math.round((Date.now() - (this.staleStartedAt?.getTime() ?? Date.now())) / 1000);
+      this.loggerService.log({
+        event: "CHAIN_POLLER_RECOVERED",
+        blockHeight: block.height,
+        staleDurationSeconds
+      });
+      this.isStale = false;
+      this.staleStartedAt = undefined;
+    }
+  }
+
+  private trackBlockStaleness() {
+    if (!this.lastProcessedBlockTime) {
+      return;
+    }
+
+    const gapSeconds = Math.round((Date.now() - this.lastProcessedBlockTime.getTime()) / 1000);
+    const thresholdSeconds = this.configService.getOrThrow("chain.BLOCK_STALE_THRESHOLD_SEC");
+
+    if (gapSeconds > thresholdSeconds && !this.isStale) {
+      this.isStale = true;
+      this.staleStartedAt = new Date();
+      this.loggerService.error({
+        event: "CHAIN_POLLER_STALE",
+        lastBlockTime: this.lastProcessedBlockTime.toISOString(),
+        gapSeconds
+      });
+    }
   }
 
   private async processNextBlockWithRetries(): Promise<BlockData> {
-    return await backOff(async () => await this.processNextBlock(), {
-      ...this.configService.getOrThrow("chain.pollingConfig"),
-      retry: (error, attempt) => {
-        this.logProcessingError(error, attempt);
-        return true;
-      }
-    });
+    return await this.blockRetryExecutor.execute(async ({ signal: retrySignal }) => {
+      retrySignal.throwIfAborted();
+      return await this.processNextBlock();
+    }, this.signal);
   }
 
   private async processNextBlock(): Promise<BlockData> {
@@ -88,14 +143,18 @@ export class ChainEventsPollerService implements OnModuleInit, OnModuleDestroy, 
         blockHeight: nextBlockHeight
       });
 
-      const block = await this.blockMessageService.getMessages(nextBlockHeight, [MsgCloseDeployment["$type"], MsgCreateDeployment["$type"]]);
+      const block = await this.blockMessageService.getMessages(nextBlockHeight, [MsgCloseDeployment["$type"], MsgCreateDeployment["$type"]], this.signal);
 
-      const txEvents = await this.txEventsService.getBlockEvents(nextBlockHeight, {
-        module: "deployment",
-        version: "v1",
-        source: "akash",
-        action: ["deployment-closed"]
-      });
+      const txEvents = await this.txEventsService.getBlockEvents(
+        nextBlockHeight,
+        {
+          module: "deployment",
+          version: "v1",
+          source: "akash",
+          action: ["deployment-closed"]
+        },
+        this.signal
+      );
 
       await this.brokerService.publishAll([
         {
@@ -126,19 +185,19 @@ export class ChainEventsPollerService implements OnModuleInit, OnModuleDestroy, 
     });
   }
 
-  private async delayAfterBlock(block: BlockData, signal: AbortSignal) {
+  private async delayAfterBlock(block: BlockData) {
     const blockTimeMs = this.configService.getOrThrow("chain.BLOCK_TIME_SEC") * 1000;
     const date = new Date(block.time);
     const nextBlockDate = new Date(date.getTime() + blockTimeMs);
     const nextRunDelay = nextBlockDate.getTime() - Date.now();
 
     if (nextRunDelay > 0) {
-      await delay(nextRunDelay, null, { signal }).catch(error => (error?.name === "AbortError" ? undefined : Promise.reject(error)));
+      await delay(nextRunDelay, null, { signal: this.signal }).catch(error => (error?.name === "AbortError" ? undefined : Promise.reject(error)));
     }
   }
 
   async getReadinessStatus(): Promise<ProbeResult> {
-    const isLive = !this.abortController?.signal?.aborted;
+    const isLive = !this.abortController.signal.aborted;
     return {
       status: isLive ? "ok" : "error",
       data: { poller: isLive }
@@ -154,11 +213,10 @@ export class ChainEventsPollerService implements OnModuleInit, OnModuleDestroy, 
   }
 
   private async finishPolling() {
-    if (this.abortController && !this.abortController.signal.aborted) {
+    if (!this.abortController.signal.aborted) {
       const completePolling = once(this.abortController.signal, "complete");
       this.abortController.abort();
       await completePolling;
-      this.abortController = undefined;
     }
   }
 }

--- a/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.ts
+++ b/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.ts
@@ -1,7 +1,7 @@
 import { Comet38Client } from "@cosmjs/tendermint-rpc";
 import { BlockResultsResponse, Event } from "@cosmjs/tendermint-rpc/build/comet38";
 import { Injectable } from "@nestjs/common";
-import { backOff } from "exponential-backoff";
+import { ExponentialBackoff, handleAll, retry } from "cockatiel";
 
 import { LoggerService } from "@src/common/services/logger/logger.service";
 
@@ -35,7 +35,7 @@ interface EventFilter {
  * Handles event filtering, parsing, and transformation to a standardized format.
  *
  * Features:
- * - Fetches block results using Comet38Client with exponential backoff retry
+ * - Fetches block results using Comet38Client with exponential backoff retry (cockatiel)
  * - Filters events by source, module, version, and action
  * - Transforms raw blockchain events to standardized v1 format
  * - Handles both new Comet38 event format and legacy format
@@ -66,9 +66,9 @@ export class TxEventsService {
    * @param filter - Optional filter to apply to events
    * @returns Array of processed events matching the filter criteria
    */
-  async getBlockEvents(blockHeight: number, filter?: EventFilter): Promise<ProcessedEvent[]> {
+  async getBlockEvents(blockHeight: number, filter?: EventFilter, signal?: AbortSignal): Promise<ProcessedEvent[]> {
     try {
-      const blockResults = await this.fetchBlockResultsWithRetry(blockHeight);
+      const blockResults = await this.fetchBlockResultsWithRetry(blockHeight, signal);
 
       this.loggerService.debug({
         event: "BLOCK_RESULTS_FETCHED",
@@ -87,19 +87,25 @@ export class TxEventsService {
     }
   }
 
+  private readonly retryExecutor = retry(handleAll, {
+    maxAttempts: 5,
+    backoff: new ExponentialBackoff({
+      initialDelay: 500,
+      maxDelay: 7_000,
+      exponent: 2
+    })
+  });
+
   /**
    * Fetches block results from Tendermint with exponential backoff retry logic
    * @param blockHeight - The height of the block to fetch
    * @returns Block results response from Tendermint
    */
-  private async fetchBlockResultsWithRetry(blockHeight: number): Promise<BlockResultsResponse> {
-    return await backOff(() => this.comet38Client.blockResults(blockHeight), {
-      maxDelay: 7_000,
-      startingDelay: 500,
-      timeMultiple: 2,
-      numOfAttempts: 5,
-      jitter: "none"
-    });
+  private async fetchBlockResultsWithRetry(blockHeight: number, signal?: AbortSignal): Promise<BlockResultsResponse> {
+    return await this.retryExecutor.execute(async ({ signal: retrySignal }) => {
+      retrySignal.throwIfAborted();
+      return await this.comet38Client.blockResults(blockHeight);
+    }, signal);
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -4118,6 +4118,7 @@
         "@opentelemetry/auto-instrumentations-node": "^0.57.1",
         "@ucast/core": "^1.10.2",
         "@ucast/js": "^3.0.4",
+        "cockatiel": "^3.2.1",
         "date-fns": "^4.1.0",
         "drizzle-kit": "^0.30.5",
         "drizzle-orm": "^0.41.0",


### PR DESCRIPTION
## Why

Fixes CON-248

When the Akash RPC endpoint is temporarily unhealthy, `notifications-chain-events` enters a crash loop instead of tolerating the disruption. A transient upstream blip becomes a pod outage, amplifying what should be a recoverable glitch and waking on-call unnecessarily.

## What

- Add exponential backoff retry (~5 min) to stargate/comet provider factories so startup tolerates brief RPC outages
- Replace the polling loop's shutdown-on-failure with retry-forever — the service never crashes on transient errors
- Add block staleness detection: `CHAIN_POLLER_STALE` (error) when latest processed block is >5 min behind wall clock, `CHAIN_POLLER_RECOVERED` (info) when it catches up — for Loki/Grafana alerting
- Switch inner services (`BlockchainClientService`, `TxEventsService`, `BlockMessageService`) from `exponential-backoff` to `cockatiel` for abort-signal-aware retry, enabling graceful shutdown
- Extract `BlockCursorInitializerService` for idempotent cursor setup on startup (runs via `OnModuleInit` before the poller's `OnApplicationBootstrap`)
- Add `BLOCK_STALE_THRESHOLD_SEC` config (default 300s)
- Replace `BackoffOptions` type dependency on `exponential-backoff` with own `PollingConfig` interface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection of stale blockchain data with logging when the chain falls behind a configured threshold and recovers.
  * Improved request cancellation support across RPC operations.

* **Chores**
  * Added `cockatiel` library dependency for enhanced retry logic.
  * Migrated retry mechanisms to use the new library with improved logging for connection attempts and chain synchronization events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->