### PR TITLE
chore(repo): add akash-bid-matcher skill

### DIFF
--- a/.claude/skills/akash-bid-matcher/SKILL.md
+++ b/.claude/skills/akash-bid-matcher/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: akash-bid-matcher
+description: Diagnose why an Akash SDL isn't getting bids (or predict if it will) by matching its compute requirements against the live provider set from console-api.akash.network. Use whenever the user asks "why am I not getting bids", "will this SDL get bids", "which providers can run this", "adapt my SDL to get bids", "check provider availability for my deployment", or pastes an SDL and wants a feasibility check. Also trigger when a bid/auction is failing or stuck, when a user complains about empty bid lists on the Console, or when planning a GPU/large deployment and wants to verify provider capacity beforehand. Filters to isOnline + isAudited providers, matches CPU/memory/storage/GPU/IP capabilities, and produces a funnel showing which single constraint is filtering the pool. Companion to the `akash` skill (which handles SDL syntax/validation) — this one answers the live-market feasibility question the akash skill can't.
+---
+
+# Akash Bid Matcher
+
+## What this skill does
+
+Given an SDL, it answers: **"Can this deployment actually get bids right now, and if not, what's blocking it?"**
+
+It does this by:
+
+1. Fetching live providers from `https://console-api.akash.network/v1/providers`.
+2. Keeping only providers where `isOnline === true` AND `isAudited === true`. Both filters matter — offline providers won't bid at all, and audited providers are what Console surfaces by default.
+3. Extracting compute requirements from every profile in the SDL (CPU millis, memory, ephemeral + persistent storage, storage class, GPU count + vendor + model, IP endpoint need, denom).
+4. Checking each provider's `stats.*.available` and capability flags against those requirements.
+5. Producing a funnel that shows which single constraint collapses the provider pool. This is almost always more useful than knowing the final count, because the *biggest filter* tells the user what to relax.
+
+## When to use
+
+- User asks "why am I not getting bids" on an Akash deployment
+- User pastes an SDL and wants a feasibility check before deploying
+- User is planning a GPU deployment (where provider scarcity is the usual blocker)
+- Bid lists on Console are empty or too small
+- User asks to "adapt" or "optimize" an SDL for better bid coverage
+
+Pair this with the `akash` skill. The `akash` skill validates SDL syntax; this skill validates SDL against live supply.
+
+## How to run
+
+The skill ships with `scripts/match_providers.py`. Given an SDL file path, it fetches live providers and prints a JSON report.
+
+```bash
+python3 scripts/match_providers.py /path/to/deploy.yaml
+```
+
+Optional flags:
+- `--top N` — include top N matching providers per profile (default 5)
+- `--api URL` — override the providers endpoint
+- `--json` — emit only JSON (default behavior anyway)
+
+If the user pasted an SDL inline, save it to a temp file first:
+
+```bash
+TMP=$(mktemp --suffix=.yaml)
+cat > "$TMP" <<'EOF'
+<paste SDL here>
+EOF
+python3 scripts/match_providers.py "$TMP"
+```
+
+Requires `pyyaml`. If missing: `pip3 install --user pyyaml` (or use a venv).
+
+## Interpreting the report
+
+The script returns a JSON document with this shape:
+
+```json
+{
+  "total_providers": 60,
+  "online_providers": 34,
+  "online_audited_providers": 22,
+  "profiles": [
+    {
+      "profile": "sglang",
+      "services": ["sglang"],
+      "count": 1,
+      "requirements": { ... },
+      "funnel": [
+        {"stage": "total_providers", "count": 60},
+        {"stage": "online", "count": 34},
+        {"stage": "online_audited", "count": 22},
+        {"stage": "passes_cpu", "count": 8, "applicable": true},
+        {"stage": "passes_memory", "count": 6, "applicable": true},
+        {"stage": "passes_gpu_model", "count": 0, "applicable": true},
+        ...
+      ],
+      "biggest_filter": "passes_gpu_model",
+      "match_count": 0,
+      "top_matches": [],
+      "feasible": false,
+      "denom_note": "denom 'uact' is not uakt/ibc — ..."
+    }
+  ]
+}
+```
+
+**The most important field is `biggest_filter`.** It names the single constraint that the fewest providers pass. That's the lever the user should pull first to widen the pool.
+
+Each `passes_<check>` stage has an `applicable` flag — checks that don't apply to this profile (e.g., `passes_gpu_model` when the profile has no GPU) should be ignored.
+
+## How to present results
+
+Every response must include both the diagnosis **and** a complete adapted SDL — even if the verdict is "feasible" (in which case the adapted SDL is identical to the input, noted as such). The user wants to copy/paste a ready-to-deploy file, not hand-merge snippets.
+
+Structure:
+
+1. **One-line feasibility verdict** — "X of Y online+audited providers can satisfy profile `<name>`." If zero, say so plainly.
+2. **Funnel** — show the dropoff stage by stage. A compact table works well. Highlight the biggest filter.
+3. **Requirement summary** — what the profile asks for (human-readable: "96 cores, 512 GiB RAM, 8× nvidia/h200, 800 GiB persistent beta3").
+4. **Top matching providers** (if any) — name, region, GPUs. Don't dump all fields.
+5. **Changes made** — a tight bullet list naming every field you're about to modify and why, ordered by impact. One line per change.
+6. **Full adapted SDL** — a single fenced ```yaml``` block containing the entire adapted document, not a diff or partial snippet. Preserve the user's original keys, comments, ordering, and structure except where you're deliberately changing things.
+7. **Caveats** — anything the report can't verify (denom acceptance, per-model GPU availability, provider price floors). See "Known limitations" below.
+
+The full SDL is required on every invocation; never skip it with "here are the changes, apply them to your file." If the SDL already matches ≥5 providers and no change is warranted, output the original SDL verbatim under step 6 and say "no changes needed" in step 5.
+
+When picking changes:
+
+- Work from the biggest filter outward — don't relax things that aren't filtering.
+- Never silently change semantics (e.g., don't drop a persistent volume the app needs, don't remove an IP endpoint the service depends on). If a relaxation would break the app, say so in step 5 and skip it rather than applying it.
+- If the user's app intent is ambiguous (e.g., can the workload fit on fewer GPUs?), make the conservative choice (keep the count) and mention the alternative in step 5 for them to opt into.
+- Preserve the input's version, image tags, env vars, command/args, and anything else untouched by your changes. Do not reformat YAML or restyle it.
+
+## Adapting the SDL — what to change, what to leave alone
+
+**Never modify `pricing.<profile>.amount` or `pricing.<profile>.denom`.** The Akash chain enforces a max bid price; raising the amount can trip a "Unit price exceeds the maximum allowed by the network" error and reject the deployment outright. The denom is a deployer choice, not a bid-matching lever (the providers endpoint doesn't expose denom acceptance anyway). The skill's job is to match the SDL's compute requirements to provider supply — pricing is out of scope.
+
+Changes the skill *does* make, in order — try each tier before reaching for the next:
+
+1. **Reduce GPU count, keep the requested model.** This is the safest first move because the model the user picked is presumably the one their workload actually runs on; smaller count keeps GPU architecture, memory-per-card, and bandwidth identical, so behavior at startup is predictable. If the workload (TP/DP config, model memory footprint) genuinely needs N GPUs, this lever is unavailable — but always try it first. Example: 8× H200 → 4× H200 before considering H100.
+2. **Add fallback GPU models *of similar or larger memory*.** Only after step 1. Order from closest match downward (H200 → H100 → A100). For each model added, sanity-check the workload's memory budget — adding a smaller-memory GPU just trades "no bids" for "bids that OOM at startup," which costs the user real money on the lease before they can close it. **Never add a model the workload cannot fit.** When unsure of fit, say so and let the user confirm.
+3. **Drop the model constraint entirely** (`nvidia:` with no model list). Last resort; only if step 2 still yields nothing and the user has explicitly accepted the OOM/quality risk.
+4. **Storage class** — `beta3` is supported by fewer providers than `beta2`. RAM-class volumes require opt-in. Class support is read from `attributes[]` keys `capabilities/storage/<N>/class` (paired with `.../persistent`).
+5. **Persistent storage** — if the workload can tolerate ephemeral, skip persistent entirely. Verify provider has `featPersistentStorage=true` (or attribute `feat-persistent-storage=true`) before assuming a persistent volume will land.
+6. **IP endpoints** — `featEndpointIp` is relatively rare; avoid if not essential.
+7. **CPU/memory size** — very large single-node asks (>64 CPU, >256 GiB) narrow the pool. Sizing should follow real workload need; oversized asks filter providers without buying anything.
+
+When changes are exhausted (e.g., 1–2 capability matches and the workload can't be relaxed further), say so directly. Don't keep mutating the SDL — recommend out-of-band actions instead (direct provider contact, smaller-model functional test, pre-arranged capacity).
+
+## What can the providers endpoint tell us about feature support?
+
+Use these fields/attributes when deciding whether a provider can satisfy a feature:
+
+| Feature | Where to look |
+|---|---|
+| Persistent storage at all | top-level `featPersistentStorage` boolean, OR attribute `feat-persistent-storage=true` |
+| Specific persistent class (`beta2`/`beta3`) | attributes `capabilities/storage/<N>/class=<cls>` paired with `capabilities/storage/<N>/persistent=true`; fallback `feat-persistent-storage-type=<cls>` |
+| RAM-class volumes | attribute `capabilities/storage/<N>/class=ram` |
+| IP endpoints | top-level `featEndpointIp` boolean |
+| Custom domains | top-level `featEndpointCustomDomain` boolean |
+| CPU architecture | top-level `hardwareCpuArch` (`x86-64`, `arm64`) or attribute `capabilities/cpu/arch` |
+| GPU vendor/model | `gpuModels[]` with `{vendor, model, ram, interface}` |
+| GPU free count (any model) | `stats.gpu.available` |
+| Region / location | `locationRegion`, `country`, `ipCountry`, attributes `region`, `location-region` |
+
+**Note `stats.gpu.available` is not broken down by model** — a provider with mixed GPU models reports a single total. Treat the match as best-effort and surface the caveat.
+
+The providers endpoint does **not** expose: accepted denoms, bid-engine price floors, deployment ACLs, or per-model GPU availability. When a deployment capability-matches but gets no bids, those invisible factors are usually the gate; the skill should say so rather than keep tweaking the SDL.
+
+## Known limitations
+
+- **Denom support is not in the providers endpoint.** The script notes this when denom is neither `uakt` nor `ibc/…`, but can't verify custom denoms (e.g., `uact`) directly.
+- **Per-GPU-model availability is not exposed.** The endpoint reports total GPU count via `stats.gpu.available` and a list of models via `gpuModels[]`, but not a per-model available count. The skill treats "provider has this model in `gpuModels` AND total GPUs available ≥ requested" as a match — it can overcount if one provider has mixed models.
+- **Provider-side bid config (floor prices, deployment filters) is not exposed.** A provider can technically satisfy the SDL but refuse the bid based on its own pricing rules. The report predicts *capability*, not *intent*.
+- **Stats are snapshots.** Available capacity changes minute-to-minute as leases come and go.
+
+Surface these caveats when they matter — especially when the verdict is "feasible" but the user is still not getting bids.
+
+## References
+
+- `references/matching-rules.md` — details on how SDL fields map to provider capability fields, unit conversions, and edge cases.

--- a/.claude/skills/akash-bid-matcher/references/matching-rules.md
+++ b/.claude/skills/akash-bid-matcher/references/matching-rules.md
@@ -1,0 +1,104 @@
+# SDL ↔ Provider Field Mapping
+
+Reference for how the matcher maps SDL compute requirements to provider capability fields returned by `https://console-api.akash.network/v1/providers`.
+
+## Filter: which providers to consider
+
+| Provider field | Required value | Why |
+|----------------|----------------|-----|
+| `isOnline` | `true` | Offline providers don't respond to bid requests at all. |
+| `isAudited` | `true` | Console and most tooling surfaces audited providers by default; unaudited providers exist but are not the pool most deployments land on. |
+
+Both filters are applied up front before any capability checks. The funnel reports the dropoff at each stage.
+
+## CPU
+
+- **SDL:** `resources.cpu.units` — accepts `0.5`, `2`, or `"500m"` (millicores)
+- **Provider:** `stats.cpu.available` — reported in millicores
+- **Match:** `stats.cpu.available >= requested_millis * deployment.count`
+
+The script multiplies per-service requirements by `deployment[svc][placement].count` because a single provider typically has to fit all replicas.
+
+## Memory
+
+- **SDL:** `resources.memory.size` — accepts `Ki`/`Mi`/`Gi`/`Ti` (binary) and `k`/`M`/`G`/`T` (decimal)
+- **Provider:** `stats.memory.available` — bytes
+- **Match:** `stats.memory.available >= requested_bytes * count`
+
+## Storage
+
+SDL storage can be a single object (`size: 5Gi`) or an array of named volumes with attributes.
+
+### Ephemeral
+
+- **SDL:** storage entries without `attributes.persistent: true`
+- **Provider:** `stats.storage.ephemeral.available`
+- **Match:** sum of ephemeral requests ≤ available
+
+### Persistent
+
+- **SDL:** storage entries with `attributes.persistent: true` and a `class` (e.g., `beta2`, `beta3`)
+- **Provider capacity:** `stats.storage.persistent.available` (bytes)
+- **Provider class support:** derived from the `attributes[]` array, which declares pairs of:
+  - `capabilities/storage/<N>/class = <beta1|beta2|beta3|ram|...>`
+  - `capabilities/storage/<N>/persistent = true|false`
+
+  A class counts as persistent-capable when the matching slot's `persistent` is `true`. The older `feat-persistent-storage-type=<class>` attribute is also honored as a fallback.
+- **Match:** capacity sufficient AND the requested class is in the provider's set of persistent-capable classes.
+
+Do **not** use `featPersistentStorageType` to match SDL classes — that field uses hardware taxonomy (`hdd`, `ssd`, `nvme`), not Akash's SDL class taxonomy (`beta1`, `beta2`, `beta3`). They are unrelated.
+
+The providers endpoint does not break down persistent capacity by class, so total persistent availability is the only capacity check available — class support is verified via the attribute pairs above.
+
+### RAM-class volumes
+
+RAM-class storage (`class: ram`) is ephemeral by definition. The current matcher treats it as ephemeral capacity. Not all providers expose RAM-class volumes, but this endpoint doesn't explicitly report that — be aware the match can be optimistic for RAM volumes.
+
+## GPU
+
+- **SDL:** `resources.gpu.units` + `resources.gpu.attributes.vendor.<vendor>[{ model, ram, interface }]`
+- **Provider:** `stats.gpu.available` (count), `gpuModels[]` (array of `{ vendor, model, ram, interface }`)
+- **Match:**
+  - `stats.gpu.available >= units * count`, AND
+  - if a specific model is requested, the provider's `gpuModels` contains at least one entry matching the vendor and model (case-insensitive)
+
+### GPU matching caveats
+
+- `stats.gpu.available` is not broken down by model. A provider with 4× A100 and 4× H100 reports `available: 8` even if only A100s are free. The match can overcount.
+- Rare models (H200, B200, MI300X) appear in very few providers' `gpuModels`. The biggest-filter analysis surfaces this automatically.
+- For multi-model fallback, the user can declare multiple entries under `vendor.nvidia:` — the matcher considers any match a pass.
+
+## IP endpoints
+
+- **SDL v2.1 trigger:** a service's `expose[*].to[*]` contains `{ ip: <name> }`, or the top-level `endpoints:` block declares one
+- **Provider:** `featEndpointIp === true`
+- **Match:** required iff the SDL uses an IP endpoint
+
+## Pricing / denom
+
+After the BME rollout, **`uact` (ACT) is the primary denom** on Akash; `uakt` still works as a fallback, and USDC is supported via its IBC denom. The providers endpoint does **not** expose which denominations a provider accepts, so denom support can't be verified from this data.
+
+The matcher treats `uakt`, `uact`, and any `ibc/[A-F0-9]{64}` denom as recognized (no warning). Anything else gets a note that it's unrecognized. Do **not** advise switching denoms to "fix bids" — in practice the bottleneck is almost always GPU model/count/storage class, not denom.
+
+## Unit conversion quick reference
+
+| Input | Parsed as |
+|-------|-----------|
+| `0.5` (cpu.units) | 500 millicores |
+| `2` (cpu.units) | 2000 millicores |
+| `"500m"` | 500 millicores |
+| `512Mi` | 536,870,912 bytes |
+| `2Gi` | 2,147,483,648 bytes |
+| `100M` | 100,000,000 bytes |
+
+## Edge cases
+
+- **Missing `count`** — defaults to 1 per placement.
+- **Multiple placements for one service** — the matcher uses the pricing/placement pair from each deployment entry; each profile is checked against the union of its usages.
+- **Storage name without `class`** — treated as ephemeral with no class constraint.
+- **GPU with `units: 0` and attributes** — invalid per SDL rules, ignored by the matcher (no GPU check applied).
+- **`gpuModels` empty but `stats.gpu.available > 0`** — provider has GPUs but model is unknown; the model check fails for any model-constrained request.
+
+## Keep in mind
+
+This matcher predicts **capability**, not **intent**. A provider can satisfy the SDL on paper and still decline to bid because of its own price floor, regional policy, or deployment filter. Treat a positive match as "the bid can land here if the provider's price engine agrees," not as a guarantee.

--- a/.claude/skills/akash-bid-matcher/scripts/match_providers.py
+++ b/.claude/skills/akash-bid-matcher/scripts/match_providers.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""
+Match an Akash SDL against the live provider set.
+
+Fetches providers from https://console-api.akash.network/v1/providers,
+filters for online + audited, then checks how many can satisfy each profile
+in the SDL. Outputs a JSON report with a filter funnel, matching providers,
+and the single biggest constraint.
+
+Usage:
+    python match_providers.py <sdl.yaml> [--json] [--top N] [--api URL]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+from dataclasses import dataclass, field
+from typing import Any
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("Missing dependency: PyYAML. Install with: pip install pyyaml\n")
+    sys.exit(2)
+
+
+DEFAULT_API = "https://console-api.akash.network/v1/providers"
+IBC_DENOM_RE = re.compile(r"^ibc/[A-F0-9]{64}$", re.IGNORECASE)
+
+
+# ---------- Unit parsing ----------
+
+_CPU_SUFFIX = {"m": 1}  # millicores
+_MEM_SUFFIX_BIN = {"Ki": 1024, "Mi": 1024**2, "Gi": 1024**3, "Ti": 1024**4, "Pi": 1024**5}
+_MEM_SUFFIX_DEC = {"k": 1000, "M": 1000**2, "G": 1000**3, "T": 1000**4, "P": 1000**5}
+
+
+def parse_cpu_millis(v: Any) -> int:
+    """SDL cpu.units accepts 0.5, 2, '500m'. Returns millicores."""
+    if v is None:
+        return 0
+    if isinstance(v, (int, float)):
+        return int(round(float(v) * 1000))
+    s = str(v).strip()
+    if s.endswith("m"):
+        return int(s[:-1])
+    return int(round(float(s) * 1000))
+
+
+def parse_bytes(v: Any) -> int:
+    """Parse memory/storage size like '512Mi', '2Gi', '100M', or a raw integer of bytes."""
+    if v is None:
+        return 0
+    if isinstance(v, (int, float)):
+        return int(v)
+    s = str(v).strip()
+    for suf, mult in {**_MEM_SUFFIX_BIN, **_MEM_SUFFIX_DEC}.items():
+        if s.endswith(suf):
+            return int(float(s[: -len(suf)]) * mult)
+    return int(float(s))
+
+
+def fmt_bytes(n: int) -> str:
+    if n <= 0:
+        return "0"
+    for suf, mult in [("Ti", 1024**4), ("Gi", 1024**3), ("Mi", 1024**2), ("Ki", 1024)]:
+        if n >= mult:
+            return f"{n / mult:.1f}{suf}"
+    return f"{n}B"
+
+
+# ---------- SDL extraction ----------
+
+@dataclass
+class ProfileRequirement:
+    profile: str
+    services: list[str]
+    count: int
+    cpu_millis: int
+    memory_bytes: int
+    storage_ephemeral_bytes: int
+    storage_persistent_bytes: int
+    storage_classes: list[str]
+    gpu_units: int
+    gpu_vendor: str | None
+    gpu_models: list[str]
+    needs_ip_endpoint: bool
+    denom: str | None
+    price_amount: int | None
+
+
+def extract_requirements(sdl: dict) -> list[ProfileRequirement]:
+    compute = (sdl.get("profiles") or {}).get("compute") or {}
+    placement = (sdl.get("profiles") or {}).get("placement") or {}
+    deployment = sdl.get("deployment") or {}
+    services = sdl.get("services") or {}
+    endpoints = sdl.get("endpoints") or {}
+
+    # services that use an IP endpoint (v2.1)
+    services_using_ip: set[str] = set()
+    for svc_name, svc in services.items():
+        for exp in svc.get("expose", []) or []:
+            for to in exp.get("to", []) or []:
+                if "ip" in to:
+                    services_using_ip.add(svc_name)
+    ip_endpoint_declared = bool(endpoints)
+
+    # profile -> services using it; deployment maps service -> placement -> {profile, count}
+    profile_to_services: dict[str, list[tuple[str, int]]] = {}
+    denom_by_profile: dict[str, tuple[str | None, int | None]] = {}
+
+    for svc_name, placements in deployment.items():
+        for place_name, spec in (placements or {}).items():
+            prof = spec.get("profile")
+            count = int(spec.get("count", 1))
+            if not prof:
+                continue
+            profile_to_services.setdefault(prof, []).append((svc_name, count))
+            price = ((placement.get(place_name) or {}).get("pricing") or {}).get(prof)
+            if price:
+                denom_by_profile[prof] = (price.get("denom"), price.get("amount"))
+
+    reqs: list[ProfileRequirement] = []
+    for prof_name, prof in compute.items():
+        resources = prof.get("resources") or {}
+        cpu_millis = parse_cpu_millis((resources.get("cpu") or {}).get("units"))
+        memory_bytes = parse_bytes((resources.get("memory") or {}).get("size"))
+
+        storage_raw = resources.get("storage")
+        ephemeral = 0
+        persistent = 0
+        classes: list[str] = []
+        if isinstance(storage_raw, dict):
+            ephemeral = parse_bytes(storage_raw.get("size"))
+        elif isinstance(storage_raw, list):
+            for entry in storage_raw:
+                size = parse_bytes(entry.get("size"))
+                attrs = entry.get("attributes") or {}
+                cls = attrs.get("class")
+                is_persistent = bool(attrs.get("persistent"))
+                if is_persistent:
+                    persistent += size
+                else:
+                    ephemeral += size
+                if cls and cls != "ram" and is_persistent:
+                    classes.append(cls)
+
+        gpu_raw = resources.get("gpu") or {}
+        gpu_units = int(gpu_raw.get("units", 0) or 0)
+        gpu_vendor = None
+        gpu_models: list[str] = []
+        if gpu_units > 0:
+            vendor_attr = (gpu_raw.get("attributes") or {}).get("vendor") or {}
+            for v, models in vendor_attr.items():
+                gpu_vendor = v
+                for m in models or []:
+                    if isinstance(m, dict) and m.get("model"):
+                        gpu_models.append(str(m["model"]).lower())
+
+        svc_list = profile_to_services.get(prof_name, [])
+        total_count = sum(c for _, c in svc_list) or 1
+        needs_ip = any(s in services_using_ip for s, _ in svc_list) or ip_endpoint_declared
+        denom, amount = denom_by_profile.get(prof_name, (None, None))
+
+        reqs.append(
+            ProfileRequirement(
+                profile=prof_name,
+                services=[s for s, _ in svc_list],
+                count=total_count,
+                cpu_millis=cpu_millis * total_count,
+                memory_bytes=memory_bytes * total_count,
+                storage_ephemeral_bytes=ephemeral * total_count,
+                storage_persistent_bytes=persistent * total_count,
+                storage_classes=sorted(set(classes)),
+                gpu_units=gpu_units * total_count,
+                gpu_vendor=gpu_vendor,
+                gpu_models=sorted(set(gpu_models)),
+                needs_ip_endpoint=needs_ip,
+                denom=denom,
+                price_amount=amount,
+            )
+        )
+    return reqs
+
+
+# ---------- Provider matching ----------
+
+_STORAGE_CLASS_ATTR_RE = re.compile(r"^capabilities/storage/(\d+)/class$")
+_STORAGE_PERSIST_ATTR_RE = re.compile(r"^capabilities/storage/(\d+)/persistent$")
+
+
+def provider_persistent_classes(provider: dict) -> set[str]:
+    """Return the set of persistent storage classes a provider supports, based on its attributes.
+
+    Providers declare class support via attribute pairs:
+      capabilities/storage/<N>/class       = beta2 | beta3 | ram | ...
+      capabilities/storage/<N>/persistent  = true | false
+
+    A class counts as persistent-capable only when the matching slot's persistent=true.
+    Also honors the alternate `feat-persistent-storage-type=<class>` attribute form.
+    """
+    by_slot_class: dict[str, str] = {}
+    by_slot_persist: dict[str, bool] = {}
+    extra_persistent: set[str] = set()
+    for attr in provider.get("attributes") or []:
+        key = (attr.get("key") or "").strip()
+        val = str(attr.get("value") or "").strip().lower()
+        m = _STORAGE_CLASS_ATTR_RE.match(key)
+        if m:
+            by_slot_class[m.group(1)] = val
+            continue
+        m = _STORAGE_PERSIST_ATTR_RE.match(key)
+        if m:
+            by_slot_persist[m.group(1)] = val == "true"
+            continue
+        if key == "feat-persistent-storage-type" and val:
+            extra_persistent.add(val)
+    out: set[str] = set(extra_persistent)
+    for slot, cls in by_slot_class.items():
+        if by_slot_persist.get(slot) and cls not in ("ram",):
+            out.add(cls)
+    return out
+
+
+def provider_supports_storage_class(provider: dict, cls: str) -> bool:
+    return cls.lower() in provider_persistent_classes(provider)
+
+
+def provider_gpu_models(provider: dict, vendor: str | None) -> set[str]:
+    out: set[str] = set()
+    for g in provider.get("gpuModels") or []:
+        if vendor and (g.get("vendor") or "").lower() != vendor.lower():
+            continue
+        model = (g.get("model") or "").lower()
+        if model:
+            out.add(model)
+    return out
+
+
+def check_provider(provider: dict, req: ProfileRequirement) -> dict[str, bool]:
+    stats = provider.get("stats") or {}
+    cpu_avail = int((stats.get("cpu") or {}).get("available", 0) or 0)
+    mem_avail = int((stats.get("memory") or {}).get("available", 0) or 0)
+    storage = stats.get("storage") or {}
+    eph_avail = int((storage.get("ephemeral") or {}).get("available", 0) or 0)
+    pers_avail = int((storage.get("persistent") or {}).get("available", 0) or 0)
+    gpu_avail = int((stats.get("gpu") or {}).get("available", 0) or 0)
+
+    checks = {
+        "cpu": cpu_avail >= req.cpu_millis,
+        "memory": mem_avail >= req.memory_bytes,
+        "storage_ephemeral": eph_avail >= req.storage_ephemeral_bytes,
+        "storage_persistent": (
+            pers_avail >= req.storage_persistent_bytes if req.storage_persistent_bytes > 0 else True
+        ),
+        "storage_classes": (
+            all(provider_supports_storage_class(provider, c) for c in req.storage_classes)
+            if req.storage_classes
+            else True
+        ),
+        "gpu_count": gpu_avail >= req.gpu_units if req.gpu_units > 0 else True,
+        "gpu_model": (
+            (not req.gpu_models)
+            or bool(provider_gpu_models(provider, req.gpu_vendor) & set(req.gpu_models))
+            if req.gpu_units > 0
+            else True
+        ),
+        "ip_endpoint": bool(provider.get("featEndpointIp")) if req.needs_ip_endpoint else True,
+    }
+    return checks
+
+
+# ---------- Reporting ----------
+
+def fetch_providers(api_url: str) -> list[dict]:
+    req = urllib.request.Request(
+        api_url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "akash-bid-matcher/0.1 (+https://github.com/akash-network/console)",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        data = json.loads(resp.read())
+    if isinstance(data, dict) and "providers" in data:
+        data = data["providers"]
+    return data
+
+
+def summarize(providers: list[dict], reqs: list[ProfileRequirement], top_n: int = 5) -> dict:
+    online = [p for p in providers if p.get("isOnline")]
+    online_audited = [p for p in online if p.get("isAudited")]
+
+    per_profile = []
+    for req in reqs:
+        funnel_stages: list[tuple[str, int]] = [
+            ("total_providers", len(providers)),
+            ("online", len(online)),
+            ("online_audited", len(online_audited)),
+        ]
+
+        check_names = [
+            "cpu",
+            "memory",
+            "storage_ephemeral",
+            "storage_persistent",
+            "storage_classes",
+            "gpu_count",
+            "gpu_model",
+            "ip_endpoint",
+        ]
+
+        matches: list[dict] = []
+        per_check_pass = {name: 0 for name in check_names}
+        pool = online_audited
+
+        for p in pool:
+            checks = check_provider(p, req)
+            for k, v in checks.items():
+                if v:
+                    per_check_pass[k] += 1
+            if all(checks.values()):
+                matches.append(
+                    {
+                        "owner": p.get("owner"),
+                        "organization": p.get("organization") or p.get("host"),
+                        "hostUri": p.get("hostUri"),
+                        "region": p.get("locationRegion"),
+                        "country": p.get("country"),
+                        "tier": p.get("tier"),
+                        "gpuModels": [
+                            f"{g.get('vendor')}/{g.get('model')}" for g in p.get("gpuModels") or []
+                        ],
+                    }
+                )
+
+        # Biggest filter = applicable check with lowest pass count (among checks that matter)
+        applicable = [n for n in check_names if _check_applies(n, req)]
+        biggest_filter = None
+        if applicable:
+            biggest_filter = min(applicable, key=lambda n: per_check_pass[n])
+
+        per_profile.append(
+            {
+                "profile": req.profile,
+                "services": req.services,
+                "count": req.count,
+                "requirements": {
+                    "cpu_millis": req.cpu_millis,
+                    "memory": fmt_bytes(req.memory_bytes),
+                    "storage_ephemeral": fmt_bytes(req.storage_ephemeral_bytes),
+                    "storage_persistent": fmt_bytes(req.storage_persistent_bytes),
+                    "storage_classes": req.storage_classes,
+                    "gpu_units": req.gpu_units,
+                    "gpu_vendor": req.gpu_vendor,
+                    "gpu_models": req.gpu_models,
+                    "needs_ip_endpoint": req.needs_ip_endpoint,
+                    "denom": req.denom,
+                    "price_amount": req.price_amount,
+                },
+                "funnel": [{"stage": s, "count": c} for s, c in funnel_stages]
+                + [
+                    {"stage": f"passes_{n}", "count": per_check_pass[n], "applicable": _check_applies(n, req)}
+                    for n in check_names
+                ],
+                "biggest_filter": biggest_filter,
+                "match_count": len(matches),
+                "top_matches": matches[:top_n],
+                "feasible": len(matches) > 0,
+                "denom_note": _denom_note(req.denom),
+            }
+        )
+
+    return {
+        "api": "console-api.akash.network/v1/providers",
+        "total_providers": len(providers),
+        "online_providers": len(online),
+        "online_audited_providers": len(online_audited),
+        "profiles": per_profile,
+    }
+
+
+def _check_applies(name: str, req: ProfileRequirement) -> bool:
+    if name == "storage_persistent":
+        return req.storage_persistent_bytes > 0
+    if name == "storage_classes":
+        return bool(req.storage_classes)
+    if name in ("gpu_count", "gpu_model"):
+        return req.gpu_units > 0
+    if name == "ip_endpoint":
+        return req.needs_ip_endpoint
+    return True
+
+
+KNOWN_DENOMS = {"uakt", "uact"}
+
+
+def _denom_note(denom: str | None) -> str | None:
+    if denom is None:
+        return None
+    if denom in KNOWN_DENOMS:
+        return None
+    if IBC_DENOM_RE.match(denom):
+        return None
+    return (
+        f"denom '{denom}' is not a recognized Akash denom (uakt, uact) or ibc/… — "
+        "providers endpoint does not expose accepted denoms; verify support separately."
+    )
+
+
+# ---------- CLI ----------
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Match an SDL against live Akash providers.")
+    parser.add_argument("sdl", help="Path to SDL YAML file")
+    parser.add_argument("--api", default=DEFAULT_API, help="Providers API URL")
+    parser.add_argument("--top", type=int, default=5, help="Top matching providers to include")
+    parser.add_argument("--json", action="store_true", help="Emit JSON only (no pretty header)")
+    args = parser.parse_args(argv)
+
+    with open(args.sdl, "r") as f:
+        sdl = yaml.safe_load(f)
+
+    reqs = extract_requirements(sdl)
+    providers = fetch_providers(args.api)
+    report = summarize(providers, reqs, top_n=args.top)
+
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

Adds a Claude Code skill that diagnoses why an Akash SDL isn't getting bids by matching its compute requirements against the live audited + online provider set. Born out of a debugging session on a GPU-heavy SDL where the bid pool collapsed to 0–2 providers; codifies the lessons so the next person doesn't iterate blind.

## What

New skill at [.claude/skills/akash-bid-matcher/](.claude/skills/akash-bid-matcher/), co-located with the existing `branch-namer` / `console-tests` / `linear-issue` skills.

- [SKILL.md](.claude/skills/akash-bid-matcher/SKILL.md) — trigger description, presentation rules, adaptation ordering. Always returns a complete adapted SDL alongside the diagnosis.
- [scripts/match_providers.py](.claude/skills/akash-bid-matcher/scripts/match_providers.py) — fetches `console-api.akash.network/v1/providers`, filters to `isOnline && isAudited`, parses the SDL, runs per-profile capability checks (CPU / memory / storage / GPU / IP endpoint), outputs a JSON funnel that names the single biggest filter.
- [references/matching-rules.md](.claude/skills/akash-bid-matcher/references/matching-rules.md) — SDL-field ↔ provider-field mapping, including the attribute-based mechanism for SDL storage classes (`capabilities/storage/<N>/class` paired with `.../persistent`).

Notable rules baked in:

- **Reduce GPU count before relaxing the GPU model.** Keeps the workload's GPU architecture and memory-per-card constant; avoids the "bids land then the lease OOMs at startup" failure mode.
- **Never propose a GPU model the workload can't fit.** Skill must do the memory math and surface uncertainty rather than maximize bidder count.
- **Pricing and denom are out of scope.** The chain enforces a max bid price, so raising the amount can trip "Unit price exceeds the maximum allowed by the network" and reject the deployment outright. The providers endpoint also does not expose accepted denoms, so denom changes are guesswork. ACT (`uact`) is the post-BME default.
- **Online + Audited filter** is applied up front; the funnel makes the dropoff visible at each stage.

Requires Python 3 + `pyyaml` to run the matcher. Stdlib otherwise (urllib).

## Test plan

- [ ] Invoke the skill on a small SDL (e.g., a basic nginx) and verify the funnel reports a healthy match count.
- [ ] Invoke on a GPU-heavy SDL and verify the funnel correctly identifies the biggest filter (GPU model, count, or storage class) and proposes a workload-preserving adaptation.
- [ ] Confirm the skill never modifies `pricing.<profile>.amount` or `pricing.<profile>.denom` in its proposed SDL.
- [ ] Confirm reducing GPU count is proposed before adding fallback GPU models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Akash bid matcher skill for diagnosing SDL feasibility against live providers
  * Provides diagnostic reports identifying resource constraint bottlenecks
  * Outputs JSON reports with top matching providers and adaptation recommendations
  * Includes command-line utility for querying and matching provider capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->