### PR TITLE
feat(notification-channel): add managed wallet E2E and fix label a11y

### DIFF
--- a/apps/deploy-web/src/components/alerts/NotificationChannelsListView/NotificationChannelsListView.tsx
+++ b/apps/deploy-web/src/components/alerts/NotificationChannelsListView/NotificationChannelsListView.tsx
@@ -81,6 +81,7 @@ export const NotificationChannelsListView: FC<NotificationChannelsListViewProps>
                 type="button"
                 className={cn(buttonVariants({ variant: "ghost", size: "icon" }), "text-gray-500 hover:text-gray-700", isRemoving && "pointer-events-none")}
                 aria-disabled={isRemoving}
+                aria-label="Edit notification channel"
                 data-testid="edit-notification-channel-button"
               >
                 <Edit className="text-xs" />
@@ -91,6 +92,7 @@ export const NotificationChannelsListView: FC<NotificationChannelsListViewProps>
                 variant="ghost"
                 size="icon"
                 disabled={isRemoving}
+                aria-label="Remove notification channel"
                 onClick={async () => {
                   const isConfirmed = await confirm({
                     title: "Are you sure you want to remove this notification channel?",

--- a/apps/deploy-web/tests/ui/managed-wallet-notification-channels.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-notification-channels.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "./fixture/authenticated-test";
+import { AlertsPage } from "./pages/AlertsPage";
+import { AuthPage } from "./pages/AuthPage";
+import { HomePage } from "./pages/HomePage";
+import { NotificationChannelsPage } from "./pages/NotificationChannelsPage";
+import { Sidebar } from "./pages/Sidebar";
+
+test.describe("Managed wallet notification channels", () => {
+  const channelName = `e2e-channel-${Date.now()}`;
+  const channelEmail = `e2e-channel-${Date.now()}@test.example.com`;
+
+  test("creates and deletes a notification channel", async ({ page, login }) => {
+    const homePage = new HomePage(page);
+    const authPage = new AuthPage(page);
+    const sidebar = new Sidebar(page);
+    const alertsPage = new AlertsPage(page);
+    const notificationChannelsPage = new NotificationChannelsPage(page);
+
+    await test.step("login", async () => {
+      await homePage.goto();
+      await homePage.openSignIn();
+      await authPage.waitForPage();
+      await login();
+    });
+
+    await test.step("navigate to notification channels tab", async () => {
+      await sidebar.openAlerts();
+      await alertsPage.waitForPage();
+      await alertsPage.openNotificationChannelsTab();
+      await page.waitForURL(/\/alerts\/notification-channels$/);
+    });
+
+    await test.step("create notification channel", async () => {
+      await notificationChannelsPage.openCreate();
+      await notificationChannelsPage.fillForm({ name: channelName, emails: channelEmail });
+      await notificationChannelsPage.submitForm();
+      await page.waitForURL(/\/alerts\/notification-channels$/, { timeout: 10_000 });
+    });
+
+    await test.step("verify channel appears in list", async () => {
+      const row = notificationChannelsPage.getChannelRow(channelName);
+      await expect(row).toBeVisible({ timeout: 10_000 });
+      await expect(row).toContainText("email");
+      await expect(row).toContainText(channelEmail);
+    });
+
+    await test.step("delete notification channel", async () => {
+      await notificationChannelsPage.deleteChannel(channelName);
+      await expect(page.getByText("Notification channel removed")).toBeVisible({ timeout: 10_000 });
+    });
+
+    await test.step("verify channel is removed", async () => {
+      await expect(notificationChannelsPage.getChannelRow(channelName)).toBeHidden({ timeout: 10_000 });
+    });
+  });
+});

--- a/apps/deploy-web/tests/ui/pages/AlertsPage.ts
+++ b/apps/deploy-web/tests/ui/pages/AlertsPage.ts
@@ -11,6 +11,10 @@ export class AlertsPage {
     await this.page.getByRole("tab", { name: /^alerts$/i }).click();
   }
 
+  async openNotificationChannelsTab() {
+    await this.page.getByRole("tab", { name: /notification channels/i }).click();
+  }
+
   getAlertRow(index: number) {
     return this.page.getByRole("row").nth(index + 1);
   }

--- a/apps/deploy-web/tests/ui/pages/NotificationChannelsPage.ts
+++ b/apps/deploy-web/tests/ui/pages/NotificationChannelsPage.ts
@@ -1,0 +1,30 @@
+import type { Page } from "@playwright/test";
+
+export class NotificationChannelsPage {
+  constructor(readonly page: Page) {}
+
+  async openCreate() {
+    await this.page.getByRole("link", { name: /create/i }).click();
+    await this.page.waitForURL(/\/alerts\/notification-channels\/new/);
+  }
+
+  async fillForm(input: { name: string; emails: string }) {
+    await this.page.getByLabel("Name", { exact: true }).fill(input.name);
+    await this.page.getByLabel("Emails", { exact: true }).fill(input.emails);
+  }
+
+  async submitForm() {
+    await this.page.getByRole("button", { name: /^save$/i }).click();
+  }
+
+  getChannelRow(name: string) {
+    return this.page.getByRole("row").filter({ hasText: name });
+  }
+
+  async deleteChannel(name: string) {
+    await this.getChannelRow(name)
+      .getByRole("button", { name: /remove notification channel/i })
+      .click();
+    await this.page.getByRole("button", { name: /^confirm$/i }).click();
+  }
+}

--- a/packages/ui/components/input.tsx
+++ b/packages/ui/components/input.tsx
@@ -96,9 +96,10 @@ export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextArea
   label?: string | React.ReactNode;
 }
 
-const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, onChange, inputClassName, label, ...props }, ref) => {
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, onChange, inputClassName, label, id: textareaId, ...props }, ref) => {
   const id = React.useId();
   const formField = useFormField();
+  const finalId = textareaId ?? formField.id ?? id;
 
   const [value, setValue] = useState("");
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
@@ -117,9 +118,9 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ classNa
 
   return (
     <div className={cn("space-y-1", className)}>
-      {label && (formField.id ? <FormLabel>{label}</FormLabel> : <Label htmlFor={`${id}-input`}>{label}</Label>)}
+      {label && (formField.id ? <FormLabel htmlFor={`${finalId}-input`}>{label}</FormLabel> : <Label htmlFor={`${finalId}-input`}>{label}</Label>)}
       <textarea
-        id={`${formField.id ? formField.id : id}-input`}
+        id={`${finalId}-input`}
         className={cn(
           "border-input bg-popover ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full resize-y rounded-md border px-3 py-2 text-sm file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           inputClassName


### PR DESCRIPTION
## Why

Closes CON-155

The remaining acceptance criteria for CON-155 — notification channel create, list, and delete — were not covered by #3102. This PR adds dedicated E2E coverage and fixes two related a11y issues surfaced by the work.

## What

- Add `tests/ui/managed-wallet-notification-channels.spec.ts` covering: open the Notification Channels tab → create a channel → assert it appears in the list → delete it → assert it's removed.
- Add `NotificationChannelsPage` page object and `openNotificationChannelsTab()` on `AlertsPage`.
- `NotificationChannelsListView`: add `aria-label` to the icon-only Edit/Remove buttons (previously had no accessible name).
- `Textarea` (`packages/ui/components/input.tsx`): accept `id` from props and use it for both the label `htmlFor` and the textarea `id` — mirrors what `Input` already does. Fixes a label-association mismatch when `Textarea` is used inside `FormField`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Accessibility**
  * Added descriptive labels to notification channel action buttons for improved screen reader support.
  * Improved form input label associations for better assistive technology compatibility.

* **Tests**
  * Added comprehensive test coverage for notification channels creation, management, and deletion workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->