### PR TITLE
fix(auth): pin Turnstile size to unblock login after CF api.js update

### DIFF
--- a/apps/deploy-web/src/components/turnstile/Turnstile.tsx
+++ b/apps/deploy-web/src/components/turnstile/Turnstile.tsx
@@ -118,7 +118,7 @@ export const Turnstile = forwardRef<TurnstileRef, TurnstileProps>(function Turns
               className="flex-1"
               ref={turnstileRef}
               siteKey={injectedConfig?.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? siteKey}
-              options={{ execution: "execute" }}
+              options={{ execution: "execute", size: "normal" }}
               onError={error => {
                 setStatus("error");
                 eventBus.current.dispatchEvent(new CustomEvent("error", { detail: { error, reason: "error" } }));


### PR DESCRIPTION
## Why

Login is broken on prod (`console.akash.network`) and beta after Cloudflare deployed a new Turnstile `api.js` bundle on **2026-04-23 23:09 UTC** that tightened the param-equality check inside `execute()`. With `size` unset, `@marsidev/react-turnstile` passes `size: undefined` while Cloudflare stored `widget.params.size = "normal"` from `render()`, so the new check throws:

```
TurnstileError ... is/are not allowed be changed between the calls of render() and execute() of a widget. (code: 3618)
Consider rendering a new widget if you want to change the following parameters size.
```

The widget never resolves, the `signInOrSignUp` mutation rejects with a non-`HttpError`, and the user sees the generic _"An unexpected error occurred…"_ from `RemoteApiError`. Manifests in Sentry as `TurnstileError` events on `/login` (release `3.63.0`).

Evidence:
- Public archive of CF's `api.js` shows the bundle bump `0b8fb825cb67` → `a80f1640690f` at 2026-04-23 23:09 UTC: https://github.com/Le0Developer/captcha-mining/tree/main/turnstile
- Library issue with the `api.js` diff: https://github.com/marsidev/react-turnstile/issues/129
- Cloudflare Status logged a Turnstile incident on 2026-04-27 06:15–07:09 UTC.

Local dev was unaffected because it uses a Cloudflare test/dummy site key (e.g. `1x00000000000000000000AA`), which is exempt from this strictness.

## What

Pin `size: "normal"` explicitly in the `<ReactTurnstile>` `options` prop so it matches Cloudflare's stored default and the equality check passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Turnstile widget sizing configuration for optimal display consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->