### PR TITLE
refactor(alert): remove AKT pricing from DeploymentAlertsContainer

### DIFF
--- a/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.spec.tsx
+++ b/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.spec.tsx
@@ -6,10 +6,9 @@ import type { RequestFn, RequestFnResponse } from "@openapi-qraft/react";
 import merge from "lodash/merge";
 import { describe, expect, it, vi } from "vitest";
 
-import type { ChildrenProps, ContainerInput, Props } from "@src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer";
+import type { ChildrenProps, ContainerInput } from "@src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer";
 import { DeploymentAlertsContainer } from "@src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer";
-import { UAKT_DENOM, USDC_IBC_DENOMS } from "@src/config/denom.config";
-import type { usePricing } from "@src/hooks/usePricing/usePricing";
+import { USDC_IBC_DENOMS } from "@src/config/denom.config";
 import { queryClient } from "@src/queries";
 import { deploymentToDto } from "@src/utils/deploymentDetailUtils";
 
@@ -20,38 +19,33 @@ import { createContainerTestingChildCapturer } from "@tests/unit/container-testi
 import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
 
 describe(DeploymentAlertsContainer.name, () => {
-  [
-    { denom: UAKT_DENOM, threshold: 2000000 },
-    { denom: USDC_IBC_DENOMS["mainnet"], threshold: 4000000 }
-  ].forEach(({ denom, threshold }) => {
-    it(`triggers ${denom} deployment alert request with the correct values`, async () => {
-      const { requestFn, input, child, dseq } = await setup({ denom });
+  it("triggers deployment alert request with the correct values", async () => {
+    const { requestFn, input, child, dseq } = await setup();
 
-      await act(() => child.upsert(input));
+    await act(() => child.upsert(input));
 
-      expect(requestFn).toHaveBeenCalledWith(
-        expect.objectContaining({
-          method: "post",
-          url: "/v1/deployment-alerts/{dseq}"
-        }),
-        expect.objectContaining({
-          parameters: {
-            path: { dseq }
-          },
-          body: {
-            data: merge({}, input, {
-              alerts: {
-                deploymentBalance: {
-                  threshold
-                }
+    expect(requestFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "post",
+        url: "/v1/deployment-alerts/{dseq}"
+      }),
+      expect.objectContaining({
+        parameters: {
+          path: { dseq }
+        },
+        body: {
+          data: merge({}, input, {
+            alerts: {
+              deploymentBalance: {
+                threshold: 4000000
               }
-            })
-          }
-        })
-      );
-      await vi.waitFor(() => {
-        expect(screen.getByTestId("alert-config-success-notification")).toBeInTheDocument();
-      });
+            }
+          })
+        }
+      })
+    );
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("alert-config-success-notification")).toBeInTheDocument();
     });
   });
 
@@ -192,8 +186,11 @@ describe(DeploymentAlertsContainer.name, () => {
     });
   });
 
-  async function setup({ denom }: { denom?: "uakt" | (typeof USDC_IBC_DENOMS)["mainnet"] | (typeof USDC_IBC_DENOMS)["sandbox"] } = {}) {
-    const rpcDeployment = buildRpcDeployment({ denom });
+  async function setup() {
+    const rpcDeployment = buildRpcDeployment({
+      denom: USDC_IBC_DENOMS["mainnet"],
+      escrow_account: { state: { funds: [{ denom: USDC_IBC_DENOMS["mainnet"], amount: "5000000.000000000000000000" }] } }
+    });
     const deployment = deploymentToDto(rpcDeployment);
     const dseq = deployment.dseq;
     const input: ContainerInput = {
@@ -230,30 +227,12 @@ describe(DeploymentAlertsContainer.name, () => {
         })
     };
 
-    const AKT_PRICE = 2;
-    const mockPricing = {
-      usdToAkt: vi.fn((amount: number) => amount / AKT_PRICE),
-      getPriceForDenom: vi.fn((denom: string) => {
-        if (denom === "uakt") {
-          return AKT_PRICE;
-        } else {
-          return 1;
-        }
-      })
-    } as unknown as ReturnType<typeof usePricing>;
-
-    const dependencies: NonNullable<Props["dependencies"]> = {
-      usePricing: () => mockPricing
-    };
-
     const childCapturer = createContainerTestingChildCapturer<ChildrenProps>();
 
     render(
       <CustomSnackbarProvider>
         <TestContainerProvider services={services}>
-          <DeploymentAlertsContainer deployment={deployment} dependencies={dependencies}>
-            {childCapturer.renderChild}
-          </DeploymentAlertsContainer>
+          <DeploymentAlertsContainer deployment={deployment}>{childCapturer.renderChild}</DeploymentAlertsContainer>
         </TestContainerProvider>
       </CustomSnackbarProvider>
     );

--- a/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.tsx
@@ -1,18 +1,16 @@
 "use client";
 
 import type { FC, ReactNode } from "react";
-import { useMemo } from "react";
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import type { components } from "@akashnetwork/react-query-sdk/notifications";
 import { useQueryClient } from "@tanstack/react-query";
 import { merge } from "lodash";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useNotificator } from "@src/hooks/useNotificator";
-import { usePricing } from "@src/hooks/usePricing/usePricing";
 import { useWhen } from "@src/hooks/useWhen";
 import type { DeploymentDto } from "@src/types/deployment";
-import { ceilDecimal, denomToUdenom, roundDecimal, udenomToDenom } from "@src/utils/mathHelpers";
+import { denomToUdenom, udenomToDenom } from "@src/utils/mathHelpers";
 
 type DeploymentAlertsInput = components["schemas"]["DeploymentAlertCreateInput"]["data"];
 export type DeploymentAlertsOutput = components["schemas"]["DeploymentAlertsResponse"]["data"];
@@ -42,21 +40,15 @@ export type ChildrenProps = {
   maxBalanceThreshold: number;
 };
 
-const DEPENDENCIES = {
-  usePricing
-};
-
 export type Props = {
-  deployment: Pick<DeploymentDto, "dseq" | "denom" | "escrowBalance">;
+  deployment: Pick<DeploymentDto, "dseq" | "escrowBalance">;
   children: (props: ChildrenProps) => ReactNode;
-  dependencies?: typeof DEPENDENCIES;
 };
 
-export const DeploymentAlertsContainer: FC<Props> = ({ children, deployment, dependencies: d = DEPENDENCIES }) => {
+export const DeploymentAlertsContainer: FC<Props> = ({ children, deployment }) => {
   const { notificationsApi } = useServices();
   const queryClient = useQueryClient();
   const notificator = useNotificator();
-  const { usdToAkt, getPriceForDenom } = d.usePricing();
 
   const { data, isLoading, isFetched, isError } = notificationsApi.v1.getDeploymentAlerts.useQuery({
     path: {
@@ -66,65 +58,34 @@ export const DeploymentAlertsContainer: FC<Props> = ({ children, deployment, dep
 
   const mutation = notificationsApi.v1.upsertDeploymentAlert.useMutation();
 
-  const convert = useCallback(
-    (value: number) => {
-      if (deployment.denom !== "uakt") {
-        return denomToUdenom(value);
-      }
-      const akt = usdToAkt(value);
-
-      if (akt === null) {
-        throw new Error("Could not convert balance to AKT");
-      }
-
-      const converted = denomToUdenom(akt);
-
-      if (converted === null) {
-        throw new Error("Could not convert balance to AKT");
-      }
-
-      return converted;
-    },
-    [deployment.denom, usdToAkt]
-  );
-
-  const prepareInput = useCallback(
-    (input: ContainerInput) => {
-      if ("deploymentBalance" in input.alerts && input.alerts.deploymentBalance.threshold) {
-        return merge({}, input, {
-          alerts: {
-            deploymentBalance: {
-              threshold: convert(input.alerts.deploymentBalance.threshold)
-            }
+  const prepareInput = useCallback((input: ContainerInput) => {
+    if ("deploymentBalance" in input.alerts && input.alerts.deploymentBalance.threshold) {
+      return merge({}, input, {
+        alerts: {
+          deploymentBalance: {
+            threshold: denomToUdenom(input.alerts.deploymentBalance.threshold)
           }
-        });
-      }
+        }
+      });
+    }
 
-      return input;
-    },
-    [convert]
-  );
+    return input;
+  }, []);
 
-  const toOutput = useCallback(
-    (data?: components["schemas"]["DeploymentAlertsResponse"]) => {
-      const deploymentBalance = data?.data?.alerts?.deploymentBalance;
-      if (deploymentBalance?.threshold) {
-        const value = udenomToDenom(deploymentBalance.threshold);
-        const price = getPriceForDenom(deployment.denom);
-
-        return merge({}, data?.data, {
-          alerts: {
-            deploymentBalance: {
-              threshold: roundDecimal(value * price, 6)
-            }
+  const toOutput = useCallback((data?: components["schemas"]["DeploymentAlertsResponse"]) => {
+    const deploymentBalance = data?.data?.alerts?.deploymentBalance;
+    if (deploymentBalance?.threshold) {
+      return merge({}, data?.data, {
+        alerts: {
+          deploymentBalance: {
+            threshold: udenomToDenom(deploymentBalance.threshold)
           }
-        });
-      }
+        }
+      });
+    }
 
-      return data?.data;
-    },
-    [deployment.denom, getPriceForDenom]
-  );
+    return data?.data;
+  }, []);
 
   const output = useMemo(() => toOutput(data), [data, toOutput]);
 
@@ -164,14 +125,8 @@ export const DeploymentAlertsContainer: FC<Props> = ({ children, deployment, dep
   );
 
   const maxBalanceThreshold = useMemo(() => {
-    const denom = udenomToDenom(deployment.escrowBalance);
-    if (deployment.denom !== "uakt") {
-      return denom;
-    }
-    const price = getPriceForDenom(deployment.denom);
-
-    return ceilDecimal(denom * price);
-  }, [deployment.denom, deployment.escrowBalance, getPriceForDenom]);
+    return udenomToDenom(deployment.escrowBalance);
+  }, [deployment.escrowBalance]);
 
   return (
     <>


### PR DESCRIPTION
## Why

AKT is no longer a supported deployment denom, so the USD↔AKT conversion paths and the `usePricing` dependency in `DeploymentAlertsContainer` are dead weight.

## What

- Drop `usePricing` (and the `dependencies` test-injection wrapper) from `DeploymentAlertsContainer`.
- Remove the `uakt` branches in `convert`, `toOutput`, and `maxBalanceThreshold`; threshold values now flow through `denomToUdenom`/`udenomToDenom` directly.
- Drop the now-unused `denom` field from the `Pick<DeploymentDto, …>` on the container's `Props`.
- Update the spec: remove the AKT param case + pricing mock, and seed a realistic USDC escrow so `maxBalanceThreshold > 0` without relying on the `ceilDecimal(0) = 0.001` EPSILON quirk that was masking a zero result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified deployment balance threshold calculations by removing pricing-based conversions and using direct denomination conversions.
  * Streamlined component configuration by removing optional pricing dependencies.

* **Tests**
  * Updated test suite with cleaner setup and more focused test cases for deployment alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->