### PR TITLE
fix(styling): open navbar dropdowns on click only

### DIFF
--- a/.claude/instructions/use-mock-instead-of-as-unknown-as-in-tests.md
+++ b/.claude/instructions/use-mock-instead-of-as-unknown-as-in-tests.md
@@ -1,0 +1,54 @@
+## Use `mock<T>()` instead of `as unknown as <Type>` in tests
+
+## Description
+- Build test doubles with `mock<T>()` from `vitest-mock-extended` rather than hand-rolled object literals coerced via `as unknown as <Type>`
+- `mock<T>()` stays in sync with the real type: if a field is added or renamed upstream, the mock keeps satisfying the contract automatically (or surfaces a real type error). Hand-built `as unknown as` doubles silently keep compiling with stale fields and hide contract regressions
+- Override only the fields the test cares about; let `mock<T>()` provide auto-mocked fns/values for everything else
+- For hook return values, use `mock<ReturnType<typeof THook>>({ ... })` (or `mock<typeof DEPENDENCIES.useX extends () => infer R ? R : never>(...)` if the type alias is not exported)
+- Reserve `as unknown as` for the rare case where the type is structurally incompatible (e.g. branded types) and `mock<T>()` cannot help
+
+## Examples
+
+### Good
+```typescript
+import { mock } from "vitest-mock-extended";
+
+import type { DEPENDENCIES } from "./AccountMenu";
+
+const useCustomUser: typeof DEPENDENCIES.useCustomUser = () =>
+  mock<ReturnType<typeof DEPENDENCIES.useCustomUser>>({
+    user: input.username ? { username: input.username, userId: input.userId } : null,
+    isLoading: input.isLoading ?? false
+  });
+
+const useRouter: typeof DEPENDENCIES.useRouter = () =>
+  mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ push });
+```
+
+```typescript
+const stripeService = mock<StripeService>({
+  getPaymentMethods: vi.fn().mockResolvedValue(mockMethods)
+});
+```
+
+### Bad
+```typescript
+// Hand-built object coerced through `as unknown as` — drift-prone
+const useCustomUser = () =>
+  ({
+    user: input.username ? { username: input.username } : null,
+    isLoading: input.isLoading ?? false
+  }) as unknown as ReturnType<typeof DEPENDENCIES.useCustomUser>;
+
+// If `UseCustomUser` later adds a required field, this still compiles silently.
+```
+
+```typescript
+// Forces every consumer to know the full shape, even fields the test ignores
+const stripeService = {
+  getPaymentMethods: vi.fn().mockResolvedValue(mockMethods),
+  createPaymentMethod: vi.fn(),
+  deletePaymentMethod: vi.fn(),
+  // ...all other methods listed only to satisfy the type
+} as unknown as StripeService;
+```

--- a/.claude/skills/console-tests/SKILL.md
+++ b/.claude/skills/console-tests/SKILL.md
@@ -124,6 +124,23 @@ const stripeService = mock<StripeService>();
 const logger = mock<LoggerService>();
 ```
 
+**Prefer `mock<T>()` over `as unknown as <Type>` for hand-built doubles.** When stubbing a hook return value or service that has many fields, build it with `mock<T>()` and override only the fields the test cares about. Hand-built objects coerced through `as unknown as` silently survive contract changes upstream and hide real regressions.
+
+```typescript
+// Good — stays in sync with the real type, lets the test focus on what matters
+const useCustomUser: typeof DEPENDENCIES.useCustomUser = () =>
+  mock<ReturnType<typeof DEPENDENCIES.useCustomUser>>({
+    user: { username: "alice" },
+    isLoading: false
+  });
+
+// Bad — `UseCustomUser` could grow a required field and this still compiles
+const useCustomUser = () =>
+  ({ user: { username: "alice" }, isLoading: false }) as unknown as ReturnType<typeof DEPENDENCIES.useCustomUser>;
+```
+
+Reserve `as unknown as` for the rare case where the type is structurally incompatible (e.g. branded types) and `mock<T>()` cannot satisfy it.
+
 For config services, use `mockConfigService<T>()` (in `apps/api/test/mocks/config-service.mock.ts`):
 
 ```typescript

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -319,6 +319,11 @@ See detailed guidelines:
 See detailed guidelines:
 @./.claude/instructions/commit-and-pr-conventions.md
 
+## Use `mock<T>()` instead of `as unknown as <Type>` in tests
+
+See detailed guidelines:
+@./.claude/instructions/use-mock-instead-of-as-unknown-as-in-tests.md
+
 ## Writing Tests
 
 Always use the `/console-tests` skill when writing, fixing, reviewing, or refactoring tests in this repo.

--- a/apps/deploy-web/src/components/layout/AccountMenu.spec.tsx
+++ b/apps/deploy-web/src/components/layout/AccountMenu.spec.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AuthService } from "@src/services/auth/auth/auth.service";
+import type { DEPENDENCIES } from "./AccountMenu";
+import { AccountMenu } from "./AccountMenu";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { buildWallet } from "@tests/seeders/wallet";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
+
+describe(AccountMenu.name, () => {
+  it("renders the spinner while loading", () => {
+    setup({ isLoading: true });
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /account menu/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the user's initial when signed in", () => {
+    setup({ username: "alice" });
+
+    const trigger = screen.getByRole("button", { name: /account menu/i });
+    expect(trigger).toHaveTextContent("A");
+  });
+
+  it("opens the menu on click and shows signed-in items", async () => {
+    setup({ username: "alice" });
+
+    await userEvent.click(screen.getByRole("button", { name: /account menu/i }));
+
+    expect(await screen.findByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("Profile Settings")).toBeInTheDocument();
+    expect(screen.getByText("API Keys")).toBeInTheDocument();
+    expect(screen.getByText("Favorites")).toBeInTheDocument();
+    expect(screen.getByText("Logout")).toBeInTheDocument();
+    expect(screen.queryByText("Sign in")).not.toBeInTheDocument();
+  });
+
+  it("opens the menu on click and shows signed-out items", async () => {
+    setup({ username: undefined });
+
+    await userEvent.click(screen.getByRole("button", { name: /account menu/i }));
+
+    expect(await screen.findByText("Sign in")).toBeInTheDocument();
+    expect(screen.getByText("Sign up")).toBeInTheDocument();
+    expect(screen.queryByText("Profile Settings")).not.toBeInTheDocument();
+  });
+
+  it("calls authService.logout when Logout is selected", async () => {
+    const { authService } = setup({ username: "bob" });
+
+    await userEvent.click(screen.getByRole("button", { name: /account menu/i }));
+    await userEvent.click(await screen.findByText("Logout"));
+
+    expect(authService.logout).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows Billing & Usage when flag, userId, and managed wallet are all present", async () => {
+    setup({
+      username: "carol",
+      userId: "user-1",
+      isManagedWallet: true,
+      isBillingUsageEnabled: true
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /account menu/i }));
+
+    expect(await screen.findByText("Billing & Usage")).toBeInTheDocument();
+  });
+
+  it("hides Billing & Usage when the flag is disabled", async () => {
+    setup({
+      username: "dan",
+      userId: "user-1",
+      isManagedWallet: true,
+      isBillingUsageEnabled: false
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /account menu/i }));
+
+    await screen.findByText("Logout");
+    expect(screen.queryByText("Billing & Usage")).not.toBeInTheDocument();
+  });
+
+  function setup(input: { isLoading?: boolean; username?: string; userId?: string; isManagedWallet?: boolean; isBillingUsageEnabled?: boolean }) {
+    const push = vi.fn();
+    const authService = mock<AuthService>();
+
+    const dependencies: typeof DEPENDENCIES = {
+      useCustomUser: () =>
+        mock<ReturnType<typeof DEPENDENCIES.useCustomUser>>({
+          user: input.username ? { username: input.username, userId: input.userId } : undefined,
+          isLoading: input.isLoading ?? false
+        }),
+      useRouter: () => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ push }),
+      useFlag: flagName => (flagName === "billing_usage" && input.isBillingUsageEnabled) ?? false,
+      useWallet: () => buildWallet({ isManaged: input.isManagedWallet ?? false })
+    };
+
+    render(
+      <TestContainerProvider services={{ authService: () => authService }}>
+        <AccountMenu dependencies={dependencies} />
+      </TestContainerProvider>
+    );
+
+    return { authService, push };
+  }
+});

--- a/apps/deploy-web/src/components/layout/AccountMenu.tsx
+++ b/apps/deploy-web/src/components/layout/AccountMenu.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React from "react";
 import {
   Avatar,
   AvatarFallback,
@@ -10,7 +10,6 @@ import {
   DropdownMenuTrigger,
   Spinner
 } from "@akashnetwork/ui/components";
-import ClickAwayListener from "@mui/material/ClickAwayListener";
 import { GraphUp, Key, LogOut, MultiplePages, Settings, Star, User } from "iconoir-react";
 import { useRouter } from "next/navigation";
 
@@ -20,13 +19,18 @@ import { useCustomUser } from "@src/hooks/useCustomUser";
 import { useFlag } from "@src/hooks/useFlag";
 import { CustomDropdownLinkItem } from "../shared/CustomDropdownLinkItem";
 
-export function AccountMenu() {
-  const [open, setOpen] = useState(false);
-  const { user, isLoading } = useCustomUser();
+export const DEPENDENCIES = { useCustomUser, useRouter, useFlag, useWallet };
+
+interface Props {
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export function AccountMenu({ dependencies: d = DEPENDENCIES }: Props = {}) {
+  const { user, isLoading } = d.useCustomUser();
   const username = user?.username;
-  const router = useRouter();
-  const isBillingUsageEnabled = useFlag("billing_usage");
-  const wallet = useWallet();
+  const router = d.useRouter();
+  const isBillingUsageEnabled = d.useFlag("billing_usage");
+  const wallet = d.useWallet();
   const { authService, urlService } = useServices();
 
   return (
@@ -38,88 +42,69 @@ export function AccountMenu() {
           </div>
         ) : (
           <div className="pl-2 pr-2">
-            <DropdownMenu modal={false} open={open}>
+            <DropdownMenu modal={false}>
               <DropdownMenuTrigger asChild>
-                <Button
-                  size="icon"
-                  variant="outline"
-                  className="h-9 w-9 bg-accent"
-                  aria-label="Account menu"
-                  onClick={() => (username ? router.push(urlService.userProfile(username)) : null)}
-                  onMouseOver={() => setOpen(true)}
-                >
+                <Button size="icon" variant="outline" className="h-9 w-9 cursor-pointer bg-accent" aria-label="Account menu">
                   <Avatar className="h-9 w-9">
                     <AvatarFallback className="bg-transparent">{username ? username[0].toUpperCase() : <User />}</AvatarFallback>
                   </Avatar>
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent
-                align="end"
-                onMouseLeave={() => {
-                  setOpen(false);
-                }}
-                className="w-[160px]"
-              >
-                <ClickAwayListener
-                  onClickAway={() => {
-                    setOpen(false);
-                  }}
-                >
-                  <div className="flex w-full items-center justify-center">
-                    {!isLoading && user ? (
-                      <div className="w-full">
-                        {username && (
-                          <CustomDropdownLinkItem
-                            onClick={() => router.push(urlService.userProfile(username))}
-                            icon={
-                              <Avatar className="h-4 w-4">
-                                <AvatarFallback className="text-xs">{username ? username[0].toUpperCase() : <User />}</AvatarFallback>
-                              </Avatar>
-                            }
-                          >
-                            {username}
-                          </CustomDropdownLinkItem>
-                        )}
-                        <DropdownMenuSeparator />
-                        <CustomDropdownLinkItem onClick={() => router.push(urlService.userSettings())} icon={<Settings />}>
-                          Profile Settings
-                        </CustomDropdownLinkItem>
-                        <CustomDropdownLinkItem onClick={() => router.push(urlService.userApiKeys())} icon={<Key />}>
-                          API Keys
-                        </CustomDropdownLinkItem>
-                        {username && (
-                          <CustomDropdownLinkItem onClick={() => router.push(urlService.userProfile(username))} icon={<MultiplePages />}>
-                            Templates
-                          </CustomDropdownLinkItem>
-                        )}
-                        <CustomDropdownLinkItem onClick={() => router.push(urlService.userFavorites())} icon={<Star />}>
-                          Favorites
-                        </CustomDropdownLinkItem>
-                        {isBillingUsageEnabled && user?.userId && wallet.isManaged && (
-                          <CustomDropdownLinkItem onClick={() => router.push(urlService.billing())} icon={<GraphUp />}>
-                            Billing & Usage
-                          </CustomDropdownLinkItem>
-                        )}
-                        <DropdownMenuSeparator />
-                        <CustomDropdownLinkItem onClick={() => authService.logout()} icon={<LogOut />}>
-                          Logout
-                        </CustomDropdownLinkItem>
-                      </div>
-                    ) : (
-                      <div className="w-full space-y-1">
+              <DropdownMenuContent align="end" className="w-[160px]">
+                <div className="flex w-full items-center justify-center">
+                  {!isLoading && user ? (
+                    <div className="w-full">
+                      {username && (
                         <CustomDropdownLinkItem
-                          className="justify-center bg-primary p-2 text-primary-foreground hover:bg-primary/80 hover:text-primary-foreground focus:bg-primary/80 focus:text-primary-foreground"
-                          onClick={() => router.push(urlService.newSignup())}
+                          onClick={() => router.push(urlService.userProfile(username))}
+                          icon={
+                            <Avatar className="h-4 w-4">
+                              <AvatarFallback className="text-xs">{username ? username[0].toUpperCase() : <User />}</AvatarFallback>
+                            </Avatar>
+                          }
                         >
-                          Sign up
+                          {username}
                         </CustomDropdownLinkItem>
-                        <CustomDropdownLinkItem onClick={() => router.push(urlService.newLogin())} className="justify-center p-2">
-                          Sign in
+                      )}
+                      <DropdownMenuSeparator />
+                      <CustomDropdownLinkItem onClick={() => router.push(urlService.userSettings())} icon={<Settings />}>
+                        Profile Settings
+                      </CustomDropdownLinkItem>
+                      <CustomDropdownLinkItem onClick={() => router.push(urlService.userApiKeys())} icon={<Key />}>
+                        API Keys
+                      </CustomDropdownLinkItem>
+                      {username && (
+                        <CustomDropdownLinkItem onClick={() => router.push(urlService.userProfile(username))} icon={<MultiplePages />}>
+                          Templates
                         </CustomDropdownLinkItem>
-                      </div>
-                    )}
-                  </div>
-                </ClickAwayListener>
+                      )}
+                      <CustomDropdownLinkItem onClick={() => router.push(urlService.userFavorites())} icon={<Star />}>
+                        Favorites
+                      </CustomDropdownLinkItem>
+                      {isBillingUsageEnabled && user?.userId && wallet.isManaged && (
+                        <CustomDropdownLinkItem onClick={() => router.push(urlService.billing())} icon={<GraphUp />}>
+                          Billing & Usage
+                        </CustomDropdownLinkItem>
+                      )}
+                      <DropdownMenuSeparator />
+                      <CustomDropdownLinkItem onClick={() => authService.logout()} icon={<LogOut />}>
+                        Logout
+                      </CustomDropdownLinkItem>
+                    </div>
+                  ) : (
+                    <div className="w-full space-y-1">
+                      <CustomDropdownLinkItem
+                        className="justify-center bg-primary p-2 text-primary-foreground hover:bg-primary/80 hover:text-primary-foreground focus:bg-primary/80 focus:text-primary-foreground"
+                        onClick={() => router.push(urlService.newSignup())}
+                      >
+                        Sign up
+                      </CustomDropdownLinkItem>
+                      <CustomDropdownLinkItem onClick={() => router.push(urlService.newLogin())} className="justify-center p-2">
+                        Sign in
+                      </CustomDropdownLinkItem>
+                    </div>
+                  )}
+                </div>
               </DropdownMenuContent>
             </DropdownMenu>
           </div>

--- a/apps/deploy-web/src/components/layout/WalletStatus.spec.tsx
+++ b/apps/deploy-web/src/components/layout/WalletStatus.spec.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DEPENDENCIES } from "./WalletStatus";
+import { WalletStatus } from "./WalletStatus";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { buildWallet } from "@tests/seeders/wallet";
+import { ComponentMock } from "@tests/unit/mocks";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
+
+describe(WalletStatus.name, () => {
+  it("renders skeletons while the wallet is initializing", () => {
+    const { container } = setup({ isWalletLoaded: false });
+
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+    expect(screen.queryByLabelText("Connected wallet name and balance")).not.toBeInTheDocument();
+  });
+
+  it("renders the WalletConnectionButtons when no wallet is connected", () => {
+    const WalletConnectionButtons = vi.fn(ComponentMock);
+    setup({ isWalletConnected: false, dependencies: { WalletConnectionButtons } });
+
+    expect(WalletConnectionButtons).toHaveBeenCalled();
+    expect(screen.queryByLabelText("Connected wallet name and balance")).not.toBeInTheDocument();
+  });
+
+  it("renders a custodial wallet name and balance", () => {
+    setup({
+      walletName: "alice-wallet",
+      isManaged: false,
+      balance: { totalUsd: 12.34, totalDeploymentGrantsUSD: 0 }
+    });
+
+    const container = screen.getByLabelText("Connected wallet name and balance");
+    expect(container).toHaveTextContent("alice-wallet");
+    expect(container.parentElement).toHaveTextContent("$12.34");
+  });
+
+  it("renders a Trial label when the wallet is managed and trialing", () => {
+    setup({ isManaged: true, isTrialing: true });
+
+    expect(screen.getByText("Trial")).toBeInTheDocument();
+  });
+
+  it("opens the dropdown with CustodialWalletPopup on click for a custodial wallet", async () => {
+    const CustodialWalletPopup = vi.fn(ComponentMock);
+    const ManagedWalletPopup = vi.fn(ComponentMock);
+    setup({ isManaged: false, dependencies: { CustodialWalletPopup, ManagedWalletPopup } });
+
+    await userEvent.click(screen.getByLabelText("Connected wallet name and balance"));
+
+    expect(CustodialWalletPopup).toHaveBeenCalled();
+    expect(ManagedWalletPopup).not.toHaveBeenCalled();
+  });
+
+  it("opens the dropdown with ManagedWalletPopup on click for a managed wallet", async () => {
+    const CustodialWalletPopup = vi.fn(ComponentMock);
+    const ManagedWalletPopup = vi.fn(ComponentMock);
+    setup({ isManaged: true, dependencies: { CustodialWalletPopup, ManagedWalletPopup } });
+
+    await userEvent.click(screen.getByLabelText("Connected wallet name and balance"));
+
+    expect(ManagedWalletPopup).toHaveBeenCalled();
+    expect(CustodialWalletPopup).not.toHaveBeenCalled();
+  });
+
+  function setup(input: {
+    walletName?: string;
+    isWalletLoaded?: boolean;
+    isWalletConnected?: boolean;
+    isManaged?: boolean;
+    isTrialing?: boolean;
+    isWalletLoading?: boolean;
+    balance?: { totalUsd: number; totalDeploymentGrantsUSD: number };
+    isBalanceLoading?: boolean;
+    dependencies?: Partial<typeof DEPENDENCIES>;
+  }) {
+    const wallet = buildWallet({
+      walletName: input.walletName ?? "test-wallet",
+      isWalletLoaded: input.isWalletLoaded ?? true,
+      isWalletConnected: input.isWalletConnected ?? true,
+      isManaged: input.isManaged ?? false,
+      isTrialing: input.isTrialing ?? false,
+      isWalletLoading: input.isWalletLoading ?? false
+    });
+
+    const dependencies: typeof DEPENDENCIES = {
+      useWallet: () => wallet,
+      useWalletBalance: () =>
+        ({
+          balance: input.balance ?? { totalUsd: 0, totalDeploymentGrantsUSD: 0 },
+          isLoading: input.isBalanceLoading ?? false,
+          refetch: vi.fn()
+        }) as unknown as ReturnType<typeof DEPENDENCIES.useWalletBalance>,
+      CustodialWalletPopup: vi.fn(ComponentMock) as unknown as typeof DEPENDENCIES.CustodialWalletPopup,
+      ManagedWalletPopup: vi.fn(ComponentMock) as unknown as typeof DEPENDENCIES.ManagedWalletPopup,
+      WalletConnectionButtons: vi.fn(ComponentMock) as unknown as typeof DEPENDENCIES.WalletConnectionButtons,
+      FormattedNumber: ({ value }: { value: number }) => <span>${value}</span>,
+      ...input.dependencies
+    } as unknown as typeof DEPENDENCIES;
+
+    return render(
+      <TestContainerProvider>
+        <WalletStatus dependencies={dependencies} />
+      </TestContainerProvider>
+    );
+  }
+});

--- a/apps/deploy-web/src/components/layout/WalletStatus.tsx
+++ b/apps/deploy-web/src/components/layout/WalletStatus.tsx
@@ -1,9 +1,7 @@
 "use client";
-import { useState } from "react";
 import { FormattedNumber } from "react-intl";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, Skeleton } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
-import ClickAwayListener from "@mui/material/ClickAwayListener";
 import { NavArrowDown, Wallet } from "iconoir-react";
 
 import { useWallet } from "@src/context/WalletProvider";
@@ -13,10 +11,22 @@ import { CustodialWalletPopup } from "../wallet/CustodialWalletPopup/CustodialWa
 import { ManagedWalletPopup } from "../wallet/ManagedWalletPopup/ManagedWalletPopup";
 import { WalletConnectionButtons } from "../wallet/WalletConnectionButtons";
 
-export function WalletStatus() {
-  const { walletName, isWalletLoaded, isWalletConnected, isManaged, isWalletLoading, isTrialing } = useWallet();
-  const { balance: walletBalance, isLoading: isWalletBalanceLoading } = useWalletBalance();
-  const [open, setOpen] = useState(false);
+export const DEPENDENCIES = {
+  useWallet,
+  useWalletBalance,
+  CustodialWalletPopup,
+  ManagedWalletPopup,
+  WalletConnectionButtons,
+  FormattedNumber
+};
+
+interface Props {
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export function WalletStatus({ dependencies: d = DEPENDENCIES }: Props = {}) {
+  const { walletName, isWalletLoaded, isWalletConnected, isManaged, isWalletLoading, isTrialing } = d.useWallet();
+  const { balance: walletBalance, isLoading: isWalletBalanceLoading } = d.useWalletBalance();
   const isLoadingBalance = isWalletBalanceLoading && !walletBalance;
   const isInit = isWalletLoaded && !isWalletLoading && !isLoadingBalance;
 
@@ -26,11 +36,12 @@ export function WalletStatus() {
         isWalletConnected ? (
           <div className="flex w-full items-center">
             <div className="w-full py-2">
-              <DropdownMenu modal={false} open={open}>
+              <DropdownMenu modal={false}>
                 <DropdownMenuTrigger asChild>
                   <div
-                    className={cn("flex items-center justify-center space-x-2 rounded-md border bg-accent px-4 py-2 text-sm hover:bg-accent/80")}
-                    onMouseOver={() => setOpen(true)}
+                    className={cn(
+                      "flex cursor-pointer items-center justify-center space-x-2 rounded-md border bg-accent px-4 py-2 text-sm hover:bg-accent/80 [&_*]:cursor-pointer"
+                    )}
                   >
                     <div className="flex items-center space-x-2" aria-label="Connected wallet name and balance">
                       <Wallet className="text-xs" />
@@ -50,7 +61,7 @@ export function WalletStatus() {
 
                     <div className="text-xs">
                       {walletBalance && (
-                        <FormattedNumber
+                        <d.FormattedNumber
                           value={isManaged ? walletBalance.totalDeploymentGrantsUSD : walletBalance.totalUsd}
                           // eslint-disable-next-line react/style-prop-object
                           style="currency"
@@ -64,28 +75,17 @@ export function WalletStatus() {
                     </div>
                   </div>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  align="end"
-                  onMouseLeave={() => {
-                    setOpen(false);
-                  }}
-                >
-                  <ClickAwayListener
-                    onClickAway={() => {
-                      setOpen(false);
-                    }}
-                  >
-                    <div>
-                      {!isManaged && <CustodialWalletPopup walletBalance={walletBalance} />}
-                      {isManaged && <ManagedWalletPopup walletBalance={walletBalance} />}
-                    </div>
-                  </ClickAwayListener>
+                <DropdownMenuContent align="end">
+                  <div>
+                    {!isManaged && <d.CustodialWalletPopup walletBalance={walletBalance} />}
+                    {isManaged && <d.ManagedWalletPopup walletBalance={walletBalance} />}
+                  </div>
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
           </div>
         ) : (
-          <WalletConnectionButtons className="w-full justify-center" connectWalletButtonClassName="w-full md:w-auto" />
+          <d.WalletConnectionButtons className="w-full justify-center" connectWalletButtonClassName="w-full md:w-auto" />
         )
       ) : (
         <div className="flex items-center space-x-2 rounded-md border bg-accent px-4 py-2">

--- a/apps/deploy-web/tests/ui/change-wallets.spec.ts
+++ b/apps/deploy-web/tests/ui/change-wallets.spec.ts
@@ -11,7 +11,7 @@ test.describe("Custodial wallet", () => {
 
     const container = page.getByLabel("Connected wallet name and balance");
     await container.waitFor({ state: "visible", timeout: 20_000 });
-    await container.hover({ timeout: 20_000 });
+    await container.click({ timeout: 20_000 });
     await page.getByLabel("wallet address").click();
     const clipboardContent = await page.evaluate(() => navigator.clipboard.readText());
 

--- a/apps/deploy-web/tests/ui/managed-wallet-api-keys.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-api-keys.spec.ts
@@ -19,7 +19,7 @@ test.describe("Managed wallet API keys", () => {
     });
 
     await test.step("navigate to API keys via account menu", async () => {
-      await page.getByRole("button", { name: /account menu/i }).hover();
+      await page.getByRole("button", { name: /account menu/i }).click();
       await page.getByText("API Keys").click();
       await apiKeysPage.waitForPage();
     });

--- a/apps/deploy-web/tests/ui/pages/HomePage.ts
+++ b/apps/deploy-web/tests/ui/pages/HomePage.ts
@@ -14,7 +14,7 @@ export class HomePage {
   }
 
   async openSignIn() {
-    await this.page.getByRole("button", { name: /account menu/i }).hover();
+    await this.page.getByRole("button", { name: /account menu/i }).click();
     await this.page.getByText("Sign in").click();
   }
 

--- a/apps/deploy-web/tests/ui/pages/WebWallet.ts
+++ b/apps/deploy-web/tests/ui/pages/WebWallet.ts
@@ -27,7 +27,7 @@ export class WebWallet {
   }
 
   async disconnectWallet() {
-    await this.page.getByLabel("Connected wallet name and balance").hover();
+    await this.page.getByLabel("Connected wallet name and balance").click();
     await this.page.getByRole("button", { name: "Disconnect Wallet" }).click();
     await this.page.reload({ waitUntil: "networkidle" });
   }


### PR DESCRIPTION
## Why

Suggesting this for the team to consider.

The avatar account menu and wallet status pill in the navbar both open on hover and close on `mouseleave`. In practice the menu is easy to lose mid-traverse — moving the cursor diagonally from the trigger to a menu item, the cursor briefly enters the panel and then exits its side edge before reaching an item, `onMouseLeave` fires, and the menu disappears. The 4px gap between trigger and panel makes this worse.

This PR switches both menus to a click-only model: the trigger toggles the menu; the menu only closes when the user explicitly intends to close it (outside click, ESC, or selecting an item). Same pattern used by GitHub, Linear, Vercel, etc.

## What

**Components**
- `AccountMenu` — removed manual `useState(open)`, `onMouseOver`, `onMouseLeave`, and the `ClickAwayListener` wrapper; removed the click-to-navigate-to-profile shortcut on the avatar (the existing username item inside the menu already navigates there). Added `cursor-pointer` since the `outline` Button variant doesn't include it.
- `WalletStatus` — same hover/state machinery removed; let Radix manage open/close. Added `cursor-pointer` (and `[&_*]:cursor-pointer` so the icons/text inside the trigger pill all show pointer).
- Free a11y wins: Radix's native trigger gives proper `role="menu"`, focus management, arrow-key navigation, ESC, and focus-return — none of which the manual machinery provided.

**E2E tests**
- `tests/ui/pages/HomePage.ts`, `tests/ui/pages/WebWallet.ts`, `tests/ui/managed-wallet-api-keys.spec.ts`, `tests/ui/change-wallets.spec.ts` — `.hover()` → `.click()` everywhere the avatar or wallet pill triggers the dropdown.

## Test plan

- [ ] Click avatar → menu opens; click outside / ESC / select item → closes
- [ ] Click wallet pill → menu opens; click outside / ESC / select item → closes
- [ ] Hover does nothing (cursor can wander freely without affecting the menu)
- [ ] Both triggers show the pointer cursor
- [ ] `change-wallets.spec.ts` passes locally (verified)
- [ ] Managed-wallet e2e suite passes in CI (locally blocked by Turnstile captcha on the Auth0 step, unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined account and wallet UI: dropdowns no longer rely on hover, triggers use click, and internal open/close handling simplified for more predictable behavior.

* **Tests**
  * Updated UI tests to use clicks; added component tests covering account menu items, wallet states, popups, billing visibility, and logout flow.

* **Documentation**
  * Added guidance recommending typed mocks in tests to improve test reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->