### PR TITLE
chore(repo): extend CLAUDE.md with workflow, UI, and validation conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,12 @@ npm run lint -- --fix
 
 The project uses **semantic release** with **conventional commits** for automated versioning and changelog generation. All commit messages **must comply with the rules defined in `commitlintrc.json`**.
 
+## Git & PR Workflow
+
+- Never push directly to master/main; always create a feature branch and open a PR
+- Use conventional commit types that trigger releases (feat:, fix:, refactor:) — avoid hidden types like test:, chore:, docs: when a release tag is needed
+- After addressing PR review comments, always run lint + typecheck + tests before pushing
+
 ## Dependency Injection
 
 Most backend apps use **tsyringe** for DI. The exception is `apps/notifications` (NestJS built-in DI) and `apps/indexer` (no DI — direct imports).
@@ -297,6 +303,13 @@ All backend apps use these TypeScript path aliases (defined in `tsconfig.build.j
 - `@src/*` → `./src/*`
 - `@test/*` → `./test/*`
 
+## UI Styling Conventions
+
+- Always use design system tokens (not hardcoded hex colors) when styling components
+- Match existing page patterns (e.g., providers page table styling) before introducing new visual treatments
+- For Input components, use `inputClassName` for the inner input element and `className` only for the wrapper
+- When asked to make something 'smaller', ask whether the user means horizontally, vertically, or both before changing CSS
+
 ## Test File Conventions
 
 - **Naming**: `*.spec.ts` (not `*.test.ts`)
@@ -322,3 +335,9 @@ See detailed guidelines:
 ## Writing Tests
 
 Always use the `/console-tests` skill when writing, fixing, reviewing, or refactoring tests in this repo.
+
+## Validation Before Commit
+
+- Always run lint, typecheck, and relevant tests before committing
+- After a fix, verify the dist/build is fresh — stale builds have masked working fixes
+- For DB migrations, prefer DROP + CREATE over `CREATE IF NOT EXISTS` when changing index uniqueness, since the IF NOT EXISTS path silently no-ops on name collision


### PR DESCRIPTION
## Why

Captures conventions surfaced during recent sessions so future contributors (and AI assistants) can pick them up without rediscovering the rules.

## What

Adds three new top-level sections to `CLAUDE.md`:

- **Git & PR Workflow** — never push direct to main, choose release-triggering commit types intentionally, re-run lint/typecheck/tests after addressing review.
- **UI Styling Conventions** — design tokens over hex, match existing page patterns, `inputClassName` vs `className` for `Input`, clarify axis when asked to make something "smaller".
- **Validation Before Commit** — run lint + typecheck + tests, verify dist is fresh, prefer DROP+CREATE over `CREATE IF NOT EXISTS` when changing index uniqueness.

Docs-only change — no code or build behavior is affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with formalized repository workflow and branching rules
  * Added required validation sequence and commit-preflight checklist for code quality assurance
  * Documented UI styling standards and design-system token usage requirements
  * Added migration guidance for index behavior changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->