### PR TITLE
feat(notifications): start from latest block via env flag

### DIFF
--- a/apps/notifications/README.md
+++ b/apps/notifications/README.md
@@ -30,6 +30,12 @@ $ npm install
 ## Postgresql and Indexes 
 [More details here](./docs/sql.md)
 
+## Environment Variables
+
+| Name | Default | Description |
+|------|---------|-------------|
+| `START_FROM_LATEST_BLOCK` | `false` | When `true`, the block cursor is overwritten with the current chain height on startup, so the poller skips any backlog and begins from the latest block. Useful locally after the app has been off for a while, and occasionally in production when we need to skip blocks after failures or falling behind. |
+
 ## Compile and Run the Project
 
 ```bash

--- a/apps/notifications/src/modules/chain/config/env.config.ts
+++ b/apps/notifications/src/modules/chain/config/env.config.ts
@@ -3,7 +3,12 @@ import { z } from "zod";
 export const schema = z.object({
   BLOCK_TIME_SEC: z.number({ coerce: true }).optional().default(6),
   BLOCK_STALE_THRESHOLD_SEC: z.number({ coerce: true }).optional().default(300),
-  RPC_NODE_ENDPOINT: z.string()
+  RPC_NODE_ENDPOINT: z.string(),
+  START_FROM_LATEST_BLOCK: z
+    .enum(["true", "false"])
+    .optional()
+    .default("false")
+    .transform(value => value === "true")
 });
 
 export type ChainEventsEnvConfig = z.infer<typeof schema>;

--- a/apps/notifications/src/modules/chain/repositories/block-cursor/block-cursor.repository.spec.ts
+++ b/apps/notifications/src/modules/chain/repositories/block-cursor/block-cursor.repository.spec.ts
@@ -1,0 +1,71 @@
+import { faker } from "@faker-js/faker";
+import { ConfigModule } from "@nestjs/config";
+import type { TestingModule } from "@nestjs/testing";
+import { Test } from "@nestjs/testing";
+import { eq } from "drizzle-orm";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { DRIZZLE_PROVIDER_TOKEN } from "@src/infrastructure/db/config/db.config";
+import { register } from "@src/infrastructure/db/db.module";
+import * as schema from "@src/modules/chain/model-schemas";
+import { BlockCursorRepository } from "./block-cursor.repository";
+
+import { TestDatabaseService } from "@test/services/test-database.service";
+
+describe(BlockCursorRepository.name, () => {
+  const testDbService = new TestDatabaseService(expect.getState().testPath!);
+
+  beforeAll(async () => {
+    await testDbService.setup();
+  });
+
+  afterAll(async () => {
+    await testDbService.teardown();
+  });
+
+  describe("setBlockHeight", () => {
+    it("inserts the cursor row when none exists", async () => {
+      const { repository, db } = await setup();
+      const height = faker.number.int({ min: 1000, max: 9999999 });
+
+      await repository.setBlockHeight(height);
+
+      const rows = await db.select().from(schema.BlockCursor).where(eq(schema.BlockCursor.id, "latest"));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].lastProcessedBlock).toBe(height);
+    });
+
+    it("overwrites the existing cursor unconditionally", async () => {
+      const { repository, db } = await setup();
+      const initialHeight = faker.number.int({ min: 1000, max: 5000000 });
+      const newHeight = faker.number.int({ min: 5000001, max: 9999999 });
+
+      await repository.ensureInitialized(initialHeight);
+      await repository.setBlockHeight(newHeight);
+
+      const rows = await db.select().from(schema.BlockCursor).where(eq(schema.BlockCursor.id, "latest"));
+      expect(rows).toHaveLength(1);
+      expect(rows[0].lastProcessedBlock).toBe(newHeight);
+    });
+  });
+
+  let testModule: TestingModule | undefined;
+  afterEach(async () => {
+    await testModule?.get(DRIZZLE_PROVIDER_TOKEN).session.client.end();
+    await testModule?.close();
+  });
+
+  async function setup() {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule.forRoot({ isGlobal: true }), ...register(schema)],
+      providers: [BlockCursorRepository]
+    }).compile();
+    testModule = module;
+
+    const repository = module.get(BlockCursorRepository);
+    const db = module.get<NodePgDatabase<typeof schema>>(DRIZZLE_PROVIDER_TOKEN);
+
+    return { repository, db };
+  }
+});

--- a/apps/notifications/src/modules/chain/repositories/block-cursor/block-cursor.repository.ts
+++ b/apps/notifications/src/modules/chain/repositories/block-cursor/block-cursor.repository.ts
@@ -52,4 +52,14 @@ export class BlockCursorRepository {
   async ensureInitialized(height: number): Promise<void> {
     await this.db.insert(schema.BlockCursor).values({ id: this.id, lastProcessedBlock: height }).onConflictDoNothing();
   }
+
+  async setBlockHeight(height: number): Promise<void> {
+    await this.db
+      .insert(schema.BlockCursor)
+      .values({ id: this.id, lastProcessedBlock: height })
+      .onConflictDoUpdate({
+        target: schema.BlockCursor.id,
+        set: { lastProcessedBlock: height, updatedAt: new Date() }
+      });
+  }
 }

--- a/apps/notifications/src/modules/chain/services/block-cursor-initializer/block-cursor-initializer.service.spec.ts
+++ b/apps/notifications/src/modules/chain/services/block-cursor-initializer/block-cursor-initializer.service.spec.ts
@@ -1,9 +1,11 @@
 import type { StargateClient } from "@cosmjs/stargate";
 import { faker } from "@faker-js/faker";
+import type { ConfigService } from "@nestjs/config";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { LoggerService } from "@src/common/services/logger/logger.service";
+import type { ChainEventsConfig } from "@src/modules/chain/config";
 import type { BlockCursorRepository } from "@src/modules/chain/repositories/block-cursor/block-cursor.repository";
 import { BlockCursorInitializerService } from "./block-cursor-initializer.service";
 
@@ -16,6 +18,7 @@ describe(BlockCursorInitializerService.name, () => {
     await service.onModuleInit();
 
     expect(blockCursorRepository.ensureInitialized).toHaveBeenCalledWith(height);
+    expect(blockCursorRepository.setBlockHeight).not.toHaveBeenCalled();
   });
 
   it("retries getHeight on transient failure", async () => {
@@ -37,15 +40,33 @@ describe(BlockCursorInitializerService.name, () => {
     await expect(service.onModuleInit()).rejects.toThrow("ECONNREFUSED");
   }, 15_000);
 
-  function setup() {
+  it("resets cursor to current chain height when START_FROM_LATEST_BLOCK is true", async () => {
+    const { service, stargateClient, blockCursorRepository, loggerService, height } = setup({ startFromLatestBlock: true });
+
+    stargateClient.getHeight.mockResolvedValue(height);
+
+    await service.onModuleInit();
+
+    expect(blockCursorRepository.setBlockHeight).toHaveBeenCalledWith(height);
+    expect(blockCursorRepository.ensureInitialized).not.toHaveBeenCalled();
+    expect(loggerService.log).toHaveBeenCalledWith({ event: "BLOCK_CURSOR_RESET_TO_LATEST", height });
+  });
+
+  function setup(input?: { startFromLatestBlock?: boolean }) {
     const stargateClient = mock<StargateClient>();
     const blockCursorRepository = mock<BlockCursorRepository>();
     const loggerService = mock<LoggerService>();
+    const configService = mock<ConfigService<ChainEventsConfig>>();
+
+    configService.getOrThrow.mockImplementation((key: string) => {
+      if (key === "chain.START_FROM_LATEST_BLOCK") return input?.startFromLatestBlock ?? false;
+      throw new Error(`Unexpected config key: ${key}`);
+    });
 
     const height = faker.number.int({ min: 1000, max: 9999999 });
 
-    const service = new BlockCursorInitializerService(stargateClient, blockCursorRepository, loggerService);
+    const service = new BlockCursorInitializerService(stargateClient, blockCursorRepository, loggerService, configService);
 
-    return { service, stargateClient, blockCursorRepository, loggerService, height };
+    return { service, stargateClient, blockCursorRepository, loggerService, configService, height };
   }
 });

--- a/apps/notifications/src/modules/chain/services/block-cursor-initializer/block-cursor-initializer.service.ts
+++ b/apps/notifications/src/modules/chain/services/block-cursor-initializer/block-cursor-initializer.service.ts
@@ -1,8 +1,10 @@
 import { StargateClient } from "@cosmjs/stargate";
 import { Injectable, OnModuleInit } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import { ExponentialBackoff, handleAll, retry } from "cockatiel";
 
 import { LoggerService } from "@src/common/services/logger/logger.service";
+import type { ChainEventsConfig } from "@src/modules/chain/config";
 import { BlockCursorRepository } from "@src/modules/chain/repositories/block-cursor/block-cursor.repository";
 
 @Injectable()
@@ -15,13 +17,21 @@ export class BlockCursorInitializerService implements OnModuleInit {
   constructor(
     private readonly stargateClient: StargateClient,
     private readonly blockCursorRepository: BlockCursorRepository,
-    private readonly loggerService: LoggerService
+    private readonly loggerService: LoggerService,
+    private readonly configService: ConfigService<ChainEventsConfig>
   ) {
     this.loggerService.setContext(BlockCursorInitializerService.name);
   }
 
   async onModuleInit(): Promise<void> {
     const height = await this.retryExecutor.execute(() => this.stargateClient.getHeight());
+
+    if (this.configService.getOrThrow("chain.START_FROM_LATEST_BLOCK")) {
+      await this.blockCursorRepository.setBlockHeight(height);
+      this.loggerService.log({ event: "BLOCK_CURSOR_RESET_TO_LATEST", height });
+      return;
+    }
+
     await this.blockCursorRepository.ensureInitialized(height);
     this.loggerService.log({ event: "BLOCK_CURSOR_INITIALIZED", height });
   }


### PR DESCRIPTION
## Why

Allows the notifications service to skip catching up on missed blocks at startup and begin processing from the current chain tip. Useful locally after the app has been off for a while, and occasionally in prod when we need to skip blocks after failures or falling behind.

## What

- New optional env var `START_FROM_LATEST_BLOCK` (boolean, default `false`) on the `chain` config. When `true`, `BlockCursorInitializerService` overwrites the existing cursor with the current chain height on `OnModuleInit` instead of preserving it.
- Added `BlockCursorRepository.setBlockHeight(height)` (upsert via `onConflictDoUpdate`) — kept separate from `ensureInitialized` so the destructive path is named for what it actually does.
- New log event `BLOCK_CURSOR_RESET_TO_LATEST` so a forced reset is auditable in prod.
- Lifecycle order is safe: `OnModuleInit` (initializer) runs before `OnApplicationBootstrap` (poller), so the cursor is overwritten before polling begins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New START_FROM_LATEST_BLOCK environment option to start processing from the latest chain height, skipping historical backlog when enabled.

* **Behavior**
  * Initializer can now reset the block cursor to the current chain height on startup when configured.

* **Tests**
  * Added tests covering the new startup behavior and cursor reset.

* **Documentation**
  * README updated with the new environment option and its default/impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->