### PR TITLE
chore(ci): auto-approve prod deploys during author working hours

### DIFF
--- a/.github/actions/working-hours-check/action.yml
+++ b/.github/actions/working-hours-check/action.yml
@@ -1,0 +1,75 @@
+name: Working Hours Check
+description: >-
+  Resolves whether the given GitHub actor is currently within their configured
+  working hours. Used to decide whether to auto-approve a prod deploy or fall
+  back to manual approval. Config is a JSON map, e.g.
+  {"ygrishajev":{"tz":"Europe/Berlin","start":9,"end":18}}. Window is Mon-Fri,
+  [start, end) in the actor's local hour. Unknown actors and unparseable
+  config resolve to in-window=false.
+
+inputs:
+  actor:
+    description: GitHub login to evaluate
+    required: true
+  working-hours-config:
+    description: JSON map of actor -> { tz, start, end }
+    required: false
+    default: "{}"
+
+outputs:
+  in-window:
+    description: "'true' if the actor is currently within their working hours window, otherwise 'false'"
+    value: ${{ steps.check.outputs.in-window }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      id: check
+      env:
+        ACTOR: ${{ inputs.actor }}
+        CONFIG: ${{ inputs.working-hours-config }}
+      with:
+        script: | # js
+          const actor = process.env.ACTOR || "";
+          let config;
+          try {
+            config = JSON.parse(process.env.CONFIG || "{}");
+          } catch (err) {
+            core.warning(`Could not parse working-hours-config: ${err.message}`);
+            core.setOutput("in-window", "false");
+            return;
+          }
+
+          const cfg = config && typeof config === "object" ? config[actor] : null;
+          if (!cfg) {
+            core.info(`No working-hours config for actor "${actor}" — requiring manual approval`);
+            core.setOutput("in-window", "false");
+            return;
+          }
+
+          let day, hour;
+          try {
+            const fmt = new Intl.DateTimeFormat("en-US", {
+              timeZone: cfg.tz,
+              hour: "2-digit",
+              hour12: false,
+              weekday: "short",
+            });
+            const parts = Object.fromEntries(fmt.formatToParts(new Date()).map(p => [p.type, p.value]));
+            day = parts.weekday;
+            hour = parseInt(parts.hour, 10);
+          } catch (err) {
+            core.warning(`Invalid working-hours config for actor "${actor}": ${err.message}`);
+            core.setOutput("in-window", "false");
+            return;
+          }
+
+          const isWeekday = !["Sat", "Sun"].includes(day);
+          const inWindow = isWeekday && hour >= cfg.start && hour < cfg.end;
+
+          core.info(
+            `actor=${actor} day=${day} hour=${hour} tz=${cfg.tz} ` +
+            `window=${cfg.start}:00-${cfg.end}:00 in_window=${inWindow}`
+          );
+          core.setOutput("in-window", String(inWindow));

--- a/.github/workflows/console-web-release.yml
+++ b/.github/workflows/console-web-release.yml
@@ -69,12 +69,35 @@ jobs:
           test-user-email: ${{ secrets.CONSOLE_WEB_E2E_TEST_USER_EMAIL }}
           test-user-password: ${{ secrets.CONSOLE_WEB_E2E_TEST_USER_PASSWORD }}
 
+  auto-approve-decision:
+    needs: [setup, test-beta]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      approve: ${{ steps.check.outputs.in-window }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions
+      - uses: ./.github/actions/associated-pr
+        id: pr
+        continue-on-error: true
+        with:
+          ref: console-web/v${{ needs.setup.outputs.image_tag }}
+      - uses: ./.github/actions/working-hours-check
+        id: check
+        with:
+          actor: ${{ steps.pr.outputs.author }}
+          working-hours-config: ${{ vars.WORKING_HOURS_BY_ACTOR }}
+
   deploy-prod:
     permissions:
       contents: read
       pull-requests: read
       deployments: write
-    needs: [setup, test-beta]
+    needs: [setup, test-beta, auto-approve-decision]
     name: Deploy to prod
     uses: ./.github/workflows/reusable-deploy-k8s.yml
     secrets: inherit
@@ -82,3 +105,4 @@ jobs:
       app: console-web
       appVersion: ${{ needs.setup.outputs.image_tag }}
       environment: prod
+      approve: ${{ needs.auto-approve-decision.outputs.approve == 'true' }}

--- a/.github/workflows/notifications-release.yml
+++ b/.github/workflows/notifications-release.yml
@@ -46,12 +46,35 @@ jobs:
       appVersion: ${{ needs.setup.outputs.image_tag }}
       environment: staging
 
+  auto-approve-decision:
+    needs: [setup, deploy-beta]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      approve: ${{ steps.check.outputs.in-window }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions
+      - uses: ./.github/actions/associated-pr
+        id: pr
+        continue-on-error: true
+        with:
+          ref: notifications/v${{ needs.setup.outputs.image_tag }}
+      - uses: ./.github/actions/working-hours-check
+        id: check
+        with:
+          actor: ${{ steps.pr.outputs.author }}
+          working-hours-config: ${{ vars.WORKING_HOURS_BY_ACTOR }}
+
   deploy-prod:
     permissions:
       contents: read
       pull-requests: read
       deployments: write
-    needs: [setup, deploy-beta]
+    needs: [setup, deploy-beta, auto-approve-decision]
     name: Deploy to prod
     uses: ./.github/workflows/reusable-deploy-k8s.yml
     secrets: inherit
@@ -59,3 +82,4 @@ jobs:
       app: notifications
       appVersion: ${{ needs.setup.outputs.image_tag }}
       environment: prod
+      approve: ${{ needs.auto-approve-decision.outputs.approve == 'true' }}


### PR DESCRIPTION
## Why

Follow-up on the original idea of removing the manual prod-deploy approval for `console-web` and `notifications`. Unconditional auto-approve was too coarse — if a release is triggered outside the author's working hours, no one is around to react if the deploy misbehaves. This PR keeps the approval gate by default and only auto-approves when the original PR author is currently within their configured working hours.

For other apps (`tx-signer`, `indexer`, `console-api`, etc.) nothing changes — they still require manual approval as before.

## What

- New composite action `.github/actions/working-hours-check` — pure-logic action (no GitHub API calls), takes an `actor` and a JSON config, outputs `in-window: 'true'|'false'`. Mon-Fri only, `[start, end)` in the actor's local hour. Defensive on input: malformed JSON, `null`/non-object config, unknown actors, and invalid timezones all resolve to `false`.
- `console-web-release.yml` and `notifications-release.yml` each gain an `auto-approve-decision` job that:
  1. Resolves the original PR author from the version tag via the existing `associated-pr` action (so it works correctly for CI-chain dispatches where `github.actor` would otherwise be `github-actions[bot]`).
  2. Runs `working-hours-check` against `vars.WORKING_HOURS_BY_ACTOR`.
  3. Threads the boolean output into the existing `approve` input of `reusable-deploy-k8s.yml`.

Falls back to manual approval (existing behavior) whenever the boolean is `false`.

## How to enable

Set the repo variable `WORKING_HOURS_BY_ACTOR` (Settings → Secrets and variables → Actions → Variables):

```json
{
  "ygrishajev": { "tz": "Europe/Madrid", "start": 10, "end": 17 }
}
```

Anyone not listed gets the manual-approval flow.

## Local testing

Validated locally with [`act`](https://github.com/nektos/act) against an ad-hoc test workflow (not committed — `.github/workflows/test*.yml` is gitignored). The workflow exercises every branch of the action and an `if:` consumer of the output.

<details>
<summary>Test workflow (drop into <code>.github/workflows/test-working-hours-check.yml</code> and run <code>act workflow_dispatch -W .github/workflows/test-working-hours-check.yml</code>)</summary>

```yaml
name: Test Working Hours Check

on:
  workflow_dispatch:

permissions:
  contents: read

jobs:
  test:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

      - name: Case 1 — actor in map, 24h window (expected true on weekdays)
        id: case1
        uses: ./.github/actions/working-hours-check
        with:
          actor: test-user
          working-hours-config: '{"test-user":{"tz":"UTC","start":0,"end":24}}'

      - name: Case 2 — actor in map, empty window (expected false)
        id: case2
        uses: ./.github/actions/working-hours-check
        with:
          actor: test-user
          working-hours-config: '{"test-user":{"tz":"UTC","start":0,"end":0}}'

      - name: Case 3 — actor not in map (expected false)
        id: case3
        uses: ./.github/actions/working-hours-check
        with:
          actor: unknown-user
          working-hours-config: '{"test-user":{"tz":"UTC","start":0,"end":24}}'

      - name: Case 4 — empty config (expected false)
        id: case4
        uses: ./.github/actions/working-hours-check
        with:
          actor: test-user
          working-hours-config: ""

      - name: Case 5 — malformed config (expected false)
        id: case5
        uses: ./.github/actions/working-hours-check
        with:
          actor: test-user
          working-hours-config: "{not-json"

      - name: Case 6 — null JSON config (expected false)
        id: case6
        uses: ./.github/actions/working-hours-check
        with:
          actor: test-user
          working-hours-config: "null"

      - name: Case 7 — invalid timezone (expected false)
        id: case7
        uses: ./.github/actions/working-hours-check
        with:
          actor: test-user
          working-hours-config: '{"test-user":{"tz":"Foo/Bar","start":9,"end":17}}'

      - name: Assert results
        env:
          C1: ${{ steps.case1.outputs.in-window }}
          C2: ${{ steps.case2.outputs.in-window }}
          C3: ${{ steps.case3.outputs.in-window }}
          C4: ${{ steps.case4.outputs.in-window }}
          C5: ${{ steps.case5.outputs.in-window }}
          C6: ${{ steps.case6.outputs.in-window }}
          C7: ${{ steps.case7.outputs.in-window }}
        run: |
          fail=0
          check() {
            local name=$1 actual=$2 expected=$3
            if [ "$actual" = "$expected" ]; then
              echo "PASS  $name = $actual"
            else
              echo "FAIL  $name  expected=$expected actual=$actual"
              fail=1
            fi
          }
          dow=$(date -u +%u)
          if [ "$dow" -lt 6 ]; then
            check "case1 (24h window, weekday)" "$C1" "true"
          else
            check "case1 (24h window, weekend)" "$C1" "false"
          fi
          check "case2 (empty window)"       "$C2" "false"
          check "case3 (unknown actor)"      "$C3" "false"
          check "case4 (empty config)"       "$C4" "false"
          check "case5 (malformed config)"   "$C5" "false"
          check "case6 (null config)"        "$C6" "false"
          check "case7 (invalid timezone)"   "$C7" "false"
          exit $fail

      - name: Demo gated step — only runs when case1 is in window
        if: steps.case1.outputs.in-window == 'true'
        run: echo "Gated step ran because case1 evaluated to in-window"
```

</details>

### Test report

Run on Tuesday 2026-04-28, ~12:00 UTC, via `act 0.2.87`.

```
| actor=test-user day=Tue hour=12 tz=UTC window=0:00-24:00 in_window=true
| actor=test-user day=Tue hour=12 tz=UTC window=0:00-0:00  in_window=false
| No working-hours config for actor "unknown-user" — requiring manual approval
| No working-hours config for actor "test-user"   — requiring manual approval
| ::warning::Could not parse working-hours-config: Expected property name or '}' in JSON at position 1 (line 1 column 2)
| No working-hours config for actor "test-user"   — requiring manual approval        # case 6 (null)
| ::warning::Invalid working-hours config for actor "test-user": Invalid time zone specified: Foo/Bar

| PASS  case1 (24h window, weekday) = true
| PASS  case2 (empty window)        = false
| PASS  case3 (unknown actor)       = false
| PASS  case4 (empty config)        = false
| PASS  case5 (malformed config)    = false
| PASS  case6 (null config)         = false
| PASS  case7 (invalid timezone)    = false

| Gated step ran because case1 evaluated to in-window
```

The final demo step is gated by `if: steps.case1.outputs.in-window == 'true'` — the same shape used to thread the boolean into the reusable workflow's `approve` input. It executed only for case 1, confirming end-to-end wiring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated working-hours checks that evaluate team-member local timezones to determine deployment approval windows.

* **Chores**
  * Production deploy workflows now incorporate the working-hours decision to gate or allow automated approvals across release pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->