### PR TITLE
chore(log-collector): bump image to 2.25.0

### DIFF
--- a/apps/deploy-web/src/config/log-collector.config.ts
+++ b/apps/deploy-web/src/config/log-collector.config.ts
@@ -1,1 +1,1 @@
-export const LOG_COLLECTOR_IMAGE = "ghcr.io/akash-network/log-collector:2.20.1";
+export const LOG_COLLECTOR_IMAGE = "ghcr.io/akash-network/log-collector:2.25.0";


### PR DESCRIPTION
## Why

Bump the log-collector image used by deploy-web from 2.20.1 to 2.25.0 to pick up the latest log-collector release.

## What

- Update `LOG_COLLECTOR_IMAGE` in `apps/deploy-web/src/config/log-collector.config.ts` to `ghcr.io/akash-network/log-collector:2.25.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated log collector service to use container image version 2.25.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->