### PR TITLE
feat(template): mark Razer AIKit as recommended

### DIFF
--- a/apps/api/src/template/services/template-gallery/template-gallery.service.spec.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.spec.ts
@@ -216,6 +216,38 @@ describe(TemplateGalleryService.name, () => {
       expect(resultTemplates.find((t: Template) => t.id === "t3").tags).toBeUndefined();
     });
 
+    it("orders recommended templates by their position in recommendedIds", async () => {
+      const { service, templateFetcher, fsMock } = setup({
+        getTagsConfig: () => ({
+          recommendedIds: new Set(["t3", "t1", "t2"]),
+          popularIds: new Set(),
+          categoryPriority: { AI: 0 }
+        })
+      });
+      const template1 = { id: "t1", name: "Alpha" } as Template;
+      const template2 = { id: "t2", name: "Bravo" } as Template;
+      const template3 = { id: "t3", name: "Charlie" } as Template;
+      const templates = [createCategory({ title: "AI", templates: [template1, template2, template3] })];
+      const categoriesSchema = z.array(
+        z.object({
+          title: z.string(),
+          templates: z.array(z.object({ id: z.string(), name: z.string(), tags: z.array(z.string()).optional() }))
+        })
+      );
+
+      templateFetcher.fetchAwesomeAkashTemplates.mockResolvedValue(templates);
+      fsMock.mkdir.mockResolvedValue(undefined);
+      fsMock.writeFile.mockResolvedValue(undefined);
+
+      await service.buildTemplateGalleryCache(categoriesSchema);
+
+      const summaryCall = fsMock.writeFile.mock.calls.find(call => String(call[0]).includes("templates-list.json"));
+      const summaryData = JSON.parse(String(summaryCall![1]));
+      const resultTemplates = summaryData.data[0].templates;
+
+      expect(resultTemplates.map((t: Template) => t.id)).toEqual(["t3", "t1", "t2"]);
+    });
+
     it("writes individual template files", async () => {
       const { service, templateFetcher, fsMock } = setup();
       const template1 = { id: "t1", name: "Template 1" } as Template;

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.ts
@@ -14,11 +14,11 @@ import { REPOSITORIES, TemplateFetcherService } from "../template-fetcher/templa
 import { TemplateProcessorService } from "../template-processor/template-processor.service.ts";
 
 const DEFAULT_RECOMMENDED_TEMPLATE_IDS = new Set([
+  "akash-network-awesome-akash-Razer-AIKit",
   "akash-network-awesome-akash-openclaw",
   "akash-network-awesome-akash-comfyui",
   "akash-network-awesome-akash-DeepSeek-V3.1",
-  "akash-network-awesome-akash-DeepSeek-R1",
-  "akash-network-awesome-akash-Razer-AIKit"
+  "akash-network-awesome-akash-DeepSeek-R1"
 ]);
 
 const DEFAULT_MOST_POPULAR_TEMPLATE_IDS = new Set([
@@ -145,11 +145,24 @@ export class TemplateGalleryService {
       return a.title.localeCompare(b.title);
     });
 
+    const recommendedOrder = new Map<string, number>();
+    let recommendedIndex = 0;
+    for (const id of config.recommendedIds) {
+      recommendedOrder.set(id, recommendedIndex++);
+    }
+
     for (const category of gallery) {
       category.templates.sort((a, b) => {
-        const aTagged = config.recommendedIds.has(a.id) || config.popularIds.has(a.id);
-        const bTagged = config.recommendedIds.has(b.id) || config.popularIds.has(b.id);
+        const aRecommendedRank = recommendedOrder.get(a.id);
+        const bRecommendedRank = recommendedOrder.get(b.id);
+        const aTagged = aRecommendedRank !== undefined || config.popularIds.has(a.id);
+        const bTagged = bRecommendedRank !== undefined || config.popularIds.has(b.id);
         if (aTagged !== bTagged) return aTagged ? -1 : 1;
+        if (aRecommendedRank !== undefined && bRecommendedRank !== undefined) {
+          return aRecommendedRank - bRecommendedRank;
+        }
+        if (aRecommendedRank !== undefined) return -1;
+        if (bRecommendedRank !== undefined) return 1;
         return (a.name || "").localeCompare(b.name || "");
       });
     }

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.ts
@@ -17,7 +17,8 @@ const DEFAULT_RECOMMENDED_TEMPLATE_IDS = new Set([
   "akash-network-awesome-akash-openclaw",
   "akash-network-awesome-akash-comfyui",
   "akash-network-awesome-akash-DeepSeek-V3.1",
-  "akash-network-awesome-akash-DeepSeek-R1"
+  "akash-network-awesome-akash-DeepSeek-R1",
+  "akash-network-awesome-akash-Razer-AIKit"
 ]);
 
 const DEFAULT_MOST_POPULAR_TEMPLATE_IDS = new Set([


### PR DESCRIPTION
## Why

Promote the [Razer AIKit template](https://console.akash.network/templates/akash-network-awesome-akash-Razer-AIKit) in the gallery so it surfaces first with the `recommended` tag and gets sort priority alongside our other featured AI templates.

## What

- Adds `akash-network-awesome-akash-Razer-AIKit` as the **first** entry of `DEFAULT_RECOMMENDED_TEMPLATE_IDS` in `apps/api/src/template/services/template-gallery/template-gallery.service.ts`.
- Updates the per-category template sort to honor the configured position in `recommendedIds` — recommended templates now appear in the order they are listed (instead of falling back to alphabetical for ties), so the first ID in the set displays first.
- Adds a unit test covering the new ordering behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the template gallery default recommended templates and made recommended templates order deterministic relative to others.
* **Tests**
  * Added a unit test to verify deterministic ordering of recommended templates in the gallery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->