### PR TITLE
fix(observability): flush OTEL on clean process exit

### DIFF
--- a/packages/instrumentation/src/register.ts
+++ b/packages/instrumentation/src/register.ts
@@ -26,3 +26,4 @@ const shutdown = async () => {
 
 process.once("SIGINT", shutdown);
 process.once("SIGTERM", shutdown);
+process.once("beforeExit", shutdown);


### PR DESCRIPTION
## Summary

CLI commands (e.g. `top-up-deployments` run via Kubernetes CronJob) currently
lose all OTEL counters/histograms — they increment metrics during execution
but exit cleanly before `PeriodicExportingMetricReader`'s default 60s flush
interval. The existing `SIGINT`/`SIGTERM` shutdown handlers don't fire on
natural exit, so `sdk.shutdown()` never runs and the meter provider is
never flushed.

This adds a third listener on the same `shutdown` function for `beforeExit`,
which fires when Node's event loop drains naturally — the path every CLI
command takes.

## Why this matters

The Auto Top-Up dashboard panels (`auto_top_up_*`) have been empty despite
the CronJob running hourly (170 invocations / 7 days, confirmed via Loki
`COMMAND_START` logs). The job runs, increments counters, and exits
without ever exporting them. Long-running entrypoints (the API server,
JobQueue handlers) are unaffected because the periodic exporter keeps
firing while the process stays alive.

## Notes

- `sdk.shutdown()` is idempotent, so calling it twice (once on signal, once
  on `beforeExit`) is safe in practice. Wrapping `shutdown` in `lodash/once`
  would be a follow-up cleanup.
- Doesn't catch `process.exit()` or uncaught-exception paths, but neither
  would a per-CLI fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced shutdown behavior to ensure graceful resource cleanup during additional Node.js lifecycle events, improving application stability during exit scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->