### PR TITLE
feat(log-collector): export image tag constant

### DIFF
--- a/apps/deploy-web/src/config/log-collector.config.ts
+++ b/apps/deploy-web/src/config/log-collector.config.ts
@@ -1,1 +1,2 @@
-export const LOG_COLLECTOR_IMAGE = "ghcr.io/akash-network/log-collector:2.25.0";
+export const LOG_COLLECTOR_IMAGE_TAG = "2.25.0";
+export const LOG_COLLECTOR_IMAGE = `ghcr.io/akash-network/log-collector:${LOG_COLLECTOR_IMAGE_TAG}`;


### PR DESCRIPTION
## Why

Trigger a deploy-web release so the previously merged log-collector image bump (#3115, committed as `chore` and therefore not released) actually ships.

## What

Extract `LOG_COLLECTOR_IMAGE_TAG` as a separate constant alongside the existing `LOG_COLLECTOR_IMAGE` in `apps/deploy-web/src/config/log-collector.config.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Configuration improvements to enhance code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->