### PR TITLE
fix: Markdown image regex and horizontal badge styling

### DIFF
--- a/apps/api/src/template/services/template-processor/template-processor.service.spec.ts
+++ b/apps/api/src/template/services/template-processor/template-processor.service.spec.ts
@@ -78,13 +78,26 @@ describe(TemplateProcessorService.name, () => {
       expect(result).toBeNull();
     });
 
-    it("removes images from markdown", () => {
+    it("removes standalone images from markdown", () => {
       const { service } = setup();
       const readme = "![Alt text](image.png)\nThis is the content.";
 
       const result = service.getTemplateSummary(readme);
 
       expect(result).toBe("This is the content.");
+    });
+
+    it("removes linked images (badge pattern) without leaving stray [ characters", () => {
+      const { service } = setup();
+      const readme =
+        "[![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)\n" +
+        "[![Build](https://img.shields.io/github/actions/workflow/status/foo/bar/ci.yml)](https://github.com/foo/bar)\n" +
+        "[![Stars](https://img.shields.io/github/stars/foo/bar.svg)](https://github.com/foo/bar/stargazers)\n\n" +
+        "An open-source AI development toolkit.";
+
+      const result = service.getTemplateSummary(readme);
+
+      expect(result).toBe("An open-source AI development toolkit.");
     });
 
     it("removes first header from markdown", () => {

--- a/apps/api/src/template/services/template-processor/template-processor.service.ts
+++ b/apps/api/src/template/services/template-processor/template-processor.service.ts
@@ -28,7 +28,8 @@ export class TemplateProcessorService {
     if (!readme) return null;
 
     const markdown = readme
-      .replace(/!\[.*\]\(.+\)\n*/g, "") // Remove images
+      .replace(/\[!\[.*?\]\(.*?\)\]\(.*?\)\n*/g, "") // Remove linked images (badge pattern [![alt](img)](link))
+      .replace(/!\[.*?\]\(.*?\)\n*/g, "") // Remove standalone images (![alt](img))
       .replace(/^#+ .*\n+/g, ""); // Remove first header
 
     const readmeTxt = markdownToTxt(markdown).trim();

--- a/apps/deploy-web/src/components/shared/Markdown.tsx
+++ b/apps/deploy-web/src/components/shared/Markdown.tsx
@@ -26,7 +26,7 @@ const Markdown: React.FunctionComponent<MarkdownProps> = ({ children, hasHtml })
   return (
     <ReactMarkdown
       className={cn(
-        "markdownContainerRoot prose max-w-full dark:prose-invert prose-code:before:hidden prose-code:after:hidden",
+        "markdownContainerRoot prose max-w-full dark:prose-invert prose-code:before:hidden prose-code:after:hidden prose-img:inline",
         resolvedTheme === "dark" ? "markdownContainer-dark" : "markdownContainer"
       )}
       linkTarget="_blank"


### PR DESCRIPTION
## Why

Shield badge images in template READMEs use the `[![alt](img)](link)` pattern. The image-stripping regex in getTemplateSummary matched starting from the ! inside `[![, removing ![alt](img)](link)` but leaving the outer [ behind, one per badge, producing [[[An open-source... in template preview cards.                        
Separately, Tailwind's preflight CSS globally sets img { display: block }, which caused badge images in the full README view to stack vertically instead of flowing inline as they do on GitHub.                       

## What

  - Fixed the regex in getTemplateSummary (apps/api) to strip the full linked image pattern `[![alt](img)](link)` before falling back to standalone image removing stray [ characters in template summaries                             
  - Added prose-img:inline to the Markdown component className (apps/deploy-web) to override Tailwind's preflight display: block on images, restoring horizontal badge flow in the README viewer
  - Added regression tests covering the buggy badge pattern 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown cleanup in template summaries to properly remove linked badge-style images and standalone images, ensuring cleaner summary text.
  * Updated markdown rendering so images display inline, improving layout and flow.

* **Tests**
  * Enhanced test coverage for image-removal patterns in template summary generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->