### PR TITLE
fix(template): promote Razer AIKit on deploy-web frontend

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
+++ b/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
@@ -22,6 +22,7 @@ import { TemplateBox } from "../templates/TemplateBox";
 import { DeployOptionBox } from "./DeployOptionBox";
 
 const previewTemplateIds = [
+  "akash-network-awesome-akash-Razer-AIKit",
   "akash-network-awesome-akash-openclaw",
   "akash-network-awesome-akash-DeepSeek-R1-Distill-Llama-70B",
   "akash-network-awesome-akash-Llama-3.1-8B",

--- a/apps/deploy-web/src/components/templates/TemplateGallery.spec.tsx
+++ b/apps/deploy-web/src/components/templates/TemplateGallery.spec.tsx
@@ -13,7 +13,7 @@ describe(TemplateGallery.name, () => {
       templates: [
         makeTemplate({ id: "plain-id", name: "Plain Template" }),
         makeTemplate({ id: "other-id", name: "Recommended Template", tags: ["recommended"] }),
-        makeTemplate({ id: "akash-network-awesome-akash-openclaw", name: "Featured Template" })
+        makeTemplate({ id: "akash-network-awesome-akash-Razer-AIKit", name: "Featured Template" })
       ]
     });
 

--- a/apps/deploy-web/src/components/templates/TemplateGallery.tsx
+++ b/apps/deploy-web/src/components/templates/TemplateGallery.tsx
@@ -23,7 +23,7 @@ let timeoutId: NodeJS.Timeout | null = null;
 const isRecommended = (t: TemplateOutputSummaryWithCategory) => t.tags?.includes("recommended") ?? false;
 const isPopular = (t: TemplateOutputSummaryWithCategory) => t.tags?.includes("popular") ?? false;
 
-const FEATURED_TEMPLATE_IDS = ["akash-network-awesome-akash-openclaw"];
+const FEATURED_TEMPLATE_IDS = ["akash-network-awesome-akash-Razer-AIKit"];
 
 export const DEPENDENCIES = {
   useRouter,


### PR DESCRIPTION
## Why

Follow-up to #3116. The API change made Razer AIKit the first recommended template, but the deploy-web frontend was still surfacing OpenClaw first in the gallery and not showing Razer at all in the deployment creation flow's "Explore Templates" section.

## What

- Replace OpenClaw with Razer AIKit in `FEATURED_TEMPLATE_IDS` (the gallery's pinned-first slot, which overrides the API's recommended ordering).
- Add `akash-network-awesome-akash-Razer-AIKit` as the first entry of `previewTemplateIds` in the deployment creation flow so Razer shows up in the "Explore Templates" preview row.
- Update the corresponding gallery spec to assert featured-pinning against the new ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new template to the deployment preview template gallery.

* **Updates**
  * Updated the featured template selection to highlight a different template option in the template gallery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->