### PR TITLE
fix(billing): widen master-wallet mint slippage buffer to 5%

### DIFF
--- a/apps/api/src/billing/services/master-wallet-mint/master-wallet-mint.service.spec.ts
+++ b/apps/api/src/billing/services/master-wallet-mint/master-wallet-mint.service.spec.ts
@@ -42,22 +42,22 @@ describe(MasterWalletMintService.name, () => {
       expect(txManagerService.signAndBroadcastWithFundingWallet).not.toHaveBeenCalled();
     });
 
-    it("should mint with 2% price slippage margin on AKT to burn", async () => {
+    it("should mint with 5% price slippage margin on AKT to burn", async () => {
       const { service, masterAddress, chainSdk, rpcMessageService } = setup({
         targetActBalance: 10_000_000_000,
         balances: { uact: 5_000_000_000, uakt: 99_999_999_999 },
         aktPrice: 0.5
       });
-      mockBalancesOnce(chainSdk, { uact: 10_100_000_000, uakt: 89_799_999_999 });
+      mockBalancesOnce(chainSdk, { uact: 10_100_000_000, uakt: 89_499_999_999 });
 
       const result = await service.mintIfNeeded();
 
       expect(result).toEqual(Ok.EMPTY);
       // deficit = 10_000_000_000 - 5_000_000_000 = 5_000_000_000 uact
-      // aktToBurn = ceil(5_000_000_000 / 0.5 * 1.02) = 10_200_000_000
+      // aktToBurn = ceil(5_000_000_000 / 0.5 * 1.05) = 10_500_000_000
       expect(rpcMessageService.getMintACTMsg).toHaveBeenCalledWith({
         owner: masterAddress,
-        amount: 10_200_000_000
+        amount: 10_500_000_000
       });
     });
 
@@ -168,9 +168,9 @@ describe(MasterWalletMintService.name, () => {
       const result = await service.mintIfNeeded();
 
       expect(result).toEqual(Ok.EMPTY);
-      // available = 5_200_000_000 - 100_000_000 reserve = 5_100_000_000 (< 10_200_000_000 requested)
-      // expected ACT = floor(5_100_000_000 * 0.5 / 1.02) = 2_500_000_000
-      // expectedActBalance = 5_000_000_000 + 2_500_000_000 = 7_500_000_000
+      // available = 5_200_000_000 - 100_000_000 reserve = 5_100_000_000 (< 10_500_000_000 requested)
+      // expected ACT = floor(5_100_000_000 * 0.5 / 1.05) = 2_428_571_428
+      // expectedActBalance = 5_000_000_000 + 2_428_571_428 = 7_428_571_428
       expect(rpcMessageService.getMintACTMsg).toHaveBeenCalledWith({
         owner: masterAddress,
         amount: 5_100_000_000
@@ -189,10 +189,10 @@ describe(MasterWalletMintService.name, () => {
 
       expect(result).toEqual(Ok.EMPTY);
       // deficit = 1_000_000 uact, BME minMintUact = 10_000_000
-      // aktToBurn = ceil(10_000_000 / 0.5 * 1.02) = 20_400_000
+      // aktToBurn = ceil(10_000_000 / 0.5 * 1.05) = 21_000_000
       expect(rpcMessageService.getMintACTMsg).toHaveBeenCalledWith({
         owner: masterAddress,
-        amount: 20_400_000
+        amount: 21_000_000
       });
     });
 
@@ -208,10 +208,10 @@ describe(MasterWalletMintService.name, () => {
       const result = await service.mintIfNeeded();
 
       expect(result).toEqual(Ok.EMPTY);
-      // fallback minMintUact = 10_000_000; aktToBurn = ceil(10_000_000 / 0.5 * 1.02) = 20_400_000
+      // fallback minMintUact = 10_000_000; aktToBurn = ceil(10_000_000 / 0.5 * 1.05) = 21_000_000
       expect(rpcMessageService.getMintACTMsg).toHaveBeenCalledWith({
         owner: masterAddress,
-        amount: 20_400_000
+        amount: 21_000_000
       });
     });
 

--- a/apps/api/src/billing/services/master-wallet-mint/master-wallet-mint.service.ts
+++ b/apps/api/src/billing/services/master-wallet-mint/master-wallet-mint.service.ts
@@ -17,7 +17,7 @@ type Balances = Awaited<ReturnType<ChainSDK["cosmos"]["bank"]["v1beta1"]["getAll
 @singleton()
 export class MasterWalletMintService {
   private readonly logger = createOtelLogger({ context: MasterWalletMintService.name });
-  private readonly PRICE_SLIPPAGE_MULTIPLIER = 1.02;
+  private readonly PRICE_SLIPPAGE_MULTIPLIER = 1.05;
   private readonly POLL_INTERVAL_MS = 5_000;
   private readonly MAX_POLL_ATTEMPTS = 24;
   private readonly BALANCE_CHECK_INTERVAL_MS = 10_000;


### PR DESCRIPTION
## Why

The `mint-act` cron job in `apps/api` intermittently fails post-mint balance verification with `MASTER_WALLET_MINT_FAILED: ACT balance still below expected after mint`. Investigation of a recent failure on `console-api-mainnet-mint-act-29625480-cj59q` (2026-04-30 06:00–06:04 UTC) showed the on-chain BME mint price diverged from the AKT/USD oracle price by ~4%, fully consuming the 2% `PRICE_SLIPPAGE_MULTIPLIER` buffer used in `MasterWalletMintService.calculateAktToBurn`. The transaction succeeded on-chain but the realized ACT balance came in 201M uact below the expected target, so `verifyMintedBalance` exhausted its 18 × 10s polls and returned an error. The next cron run picked up the residual deficit and recovered, but the false-failure alert is noisy.

## What

- `PRICE_SLIPPAGE_MULTIPLIER`: `1.02` → `1.05` in `master-wallet-mint.service.ts`
- Updated `master-wallet-mint.service.spec.ts` test cases that hardcoded the previous multiplier (test name, expected `aktToBurn` values, arithmetic comments)

Wider buffer covers the observed ~4% oracle/BME divergence with cushion. Any overshoot is absorbed by the next cron tick burning proportionally less AKT, so funds are not wasted — the wallet just sits slightly above target between runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the price slippage margin used in ACT token minting calculations from 2% to 5%. This adjustment impacts the AKT burn amount calculated during the minting process across all scenarios, including full mints, partial coverage adjustments, and minimum balance bumping. All corresponding test cases have been updated to verify the new slippage calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->