### PR TITLE
fix(dx): use in-memory storage for Unleash client

### DIFF
--- a/apps/api/src/core/services/feature-flags/feature-flags.service.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.service.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import { Disposable, inject, registry, singleton } from "tsyringe";
-import { Unleash, UnleashConfig } from "unleash-client";
+import { InMemStorageProvider, Unleash, UnleashConfig } from "unleash-client";
 
 import { APP_INITIALIZER, AppInitializer, ON_APP_START } from "@src/core/providers/app-initializer";
 import type { AppContext } from "@src/core/types/app-context";
@@ -72,7 +72,8 @@ export class FeatureFlagsService implements Disposable, AppInitializer {
     const client = this.createClient({
       url,
       appName: this.configService.get("UNLEASH_APP_NAME"),
-      customHeaders: { Authorization: token }
+      customHeaders: { Authorization: token },
+      storageProvider: new InMemStorageProvider()
     });
 
     await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Why

The default Unleash `FileStorageProvider` writes a backup of feature-flag state to disk on every poll. In sandboxed Node.js runtimes (`--permission` / `--allow-fs-write`) this fails with `ERR_ACCESS_DENIED` and crashes startup:

```
Error: Unleash Repository error: Access to this API has been restricted. Use --allow-fs-write to manage permissions. (code: ERR_ACCESS_DENIED)
    at FileStorageProvider.set (/app/node_modules/unleash-client/src/repository/storage-provider-file.ts:23:12)
```

In k8s the backup file is also wiped on every pod restart / reschedule, so it provides no real cold-start resilience. Initialization already blocks on the `synchronized` event before the app serves traffic, so the on-disk backup is dead weight either way.

## What

- Pass `storageProvider: new InMemStorageProvider()` to the Unleash client config in `apps/api`.
- No behavioral change at runtime — toggles are still cached in memory and refreshed on the normal poll interval. Only the disk write is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal infrastructure improvements to feature flags initialization and storage handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->