### PR TITLE
fix(deployment): refresh SDL builder when re-selecting a template

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
@@ -14,6 +14,7 @@ import type { TemplateCreation } from "@src/types";
 import { RouteStep } from "@src/types/route-steps.type";
 import { hardcodedTemplates } from "@src/utils/templates";
 import { UrlService } from "@src/utils/urlUtils";
+import type { Props as ManifestEditProps } from "../ManifestEdit/ManifestEdit";
 import { DEPENDENCIES, NewDeploymentContainer } from "./NewDeploymentContainer";
 
 import { render, screen } from "@testing-library/react";
@@ -309,7 +310,7 @@ describe(NewDeploymentContainer.name, () => {
     });
   });
 
-  it("does not reload editedManifest when re-rendered with the same templateId", async () => {
+  it("preserves user-edited manifest when re-rendered with the same templateId", async () => {
     const templateA = makeTemplate({ id: "template-A", deploy: "version: 2.0\n# template A content" });
 
     const { ManifestEdit, rerender } = setup({
@@ -323,8 +324,7 @@ describe(NewDeploymentContainer.name, () => {
     });
 
     const userEditedManifest = "version: 2.0\n# user-edited content";
-    const calls = ManifestEdit.mock.calls as unknown as Array<[{ setEditedManifest: (next: string) => void }]>;
-    const lastProps = calls.at(-1)?.[0];
+    const lastProps = ManifestEdit.mock.calls.at(-1)?.[0];
     expect(lastProps).toBeDefined();
     lastProps!.setEditedManifest(userEditedManifest);
 
@@ -340,21 +340,6 @@ describe(NewDeploymentContainer.name, () => {
     });
     expect(ManifestEdit).toHaveBeenLastCalledWith(expect.objectContaining({ editedManifest: userEditedManifest }), {});
   });
-
-  function makeTemplate(overrides: Partial<TemplateOutput> & { id: string; deploy: string }): TemplateOutput {
-    return {
-      name: `Template ${overrides.id}`,
-      config: { ssh: false },
-      summary: "",
-      logoUrl: "",
-      readme: "",
-      path: "",
-      guide: "",
-      githubUrl: "",
-      persistentStorageEnabled: false,
-      ...overrides
-    };
-  }
 
   function setup(
     input: {
@@ -398,7 +383,7 @@ describe(NewDeploymentContainer.name, () => {
 
     const Layout = vi.fn(({ children }: { children: React.ReactNode }) => <div data-testid="layout">{children}</div>);
     const TemplateList = vi.fn(() => <div data-testid="template-list">TemplateList</div>);
-    const ManifestEdit = vi.fn(() => <div data-testid="manifest-edit">ManifestEdit</div>);
+    const ManifestEdit = vi.fn<(props: ManifestEditProps) => React.ReactElement>(() => <div data-testid="manifest-edit">ManifestEdit</div>);
     const CreateLease = vi.fn(() => <div data-testid="create-lease">CreateLease</div>);
     const CustomizedSteppers = vi.fn(() => <div data-testid="stepper">Stepper</div>);
 
@@ -437,7 +422,7 @@ describe(NewDeploymentContainer.name, () => {
       store.set(sdlStore.deploySdl, input.deploySdl);
     }
 
-    const view = render(
+    const renderTree = () => (
       <TestContainerProvider
         services={{
           sdlAnalyzer: () => sdlAnalyzer
@@ -449,22 +434,14 @@ describe(NewDeploymentContainer.name, () => {
       </TestContainerProvider>
     );
 
+    const view = render(renderTree());
+
     const rerender = (next: Partial<typeof input>) => {
       const merged = { ...input, ...next };
       mockSearchParams = buildSearchParams(merged);
-      currentRequestedTemplate = "requestedTemplate" in next ? next.requestedTemplate : currentRequestedTemplate;
-      currentTemplateId = "templateId" in next ? next.templateId : currentTemplateId;
-      view.rerender(
-        <TestContainerProvider
-          services={{
-            sdlAnalyzer: () => sdlAnalyzer
-          }}
-        >
-          <JotaiStoreProvider store={store}>
-            <NewDeploymentContainer template={currentRequestedTemplate} templateId={currentTemplateId} dependencies={dependencies} />
-          </JotaiStoreProvider>
-        </TestContainerProvider>
-      );
+      currentRequestedTemplate = merged.requestedTemplate;
+      currentTemplateId = merged.templateId;
+      view.rerender(renderTree());
     };
 
     return {
@@ -476,6 +453,21 @@ describe(NewDeploymentContainer.name, () => {
       ManifestEdit,
       TemplateList,
       rerender
+    };
+  }
+
+  function makeTemplate(overrides: Partial<TemplateOutput> & { id: string; deploy: string }): TemplateOutput {
+    return {
+      name: `Template ${overrides.id}`,
+      config: { ssh: false },
+      summary: "",
+      logoUrl: "",
+      readme: "",
+      path: "",
+      guide: "",
+      githubUrl: "",
+      persistentStorageEnabled: false,
+      ...overrides
     };
   }
 });

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.spec.tsx
@@ -287,6 +287,75 @@ describe(NewDeploymentContainer.name, () => {
     expect(screen.queryByTestId("stepper")).not.toBeInTheDocument();
   });
 
+  it("loads new template content when user re-selects a different template", async () => {
+    const templateA = makeTemplate({ id: "template-A", deploy: "version: 2.0\n# template A content" });
+    const templateB = makeTemplate({ id: "template-B", deploy: "version: 2.0\n# template B content" });
+
+    const { ManifestEdit, rerender } = setup({
+      step: RouteStep.editDeployment,
+      templateId: templateA.id,
+      requestedTemplate: templateA
+    });
+
+    await vi.waitFor(() => {
+      expect(ManifestEdit).toHaveBeenCalledWith(expect.objectContaining({ editedManifest: templateA.deploy }), {});
+    });
+
+    ManifestEdit.mockClear();
+    rerender({ templateId: templateB.id, requestedTemplate: templateB });
+
+    await vi.waitFor(() => {
+      expect(ManifestEdit).toHaveBeenCalledWith(expect.objectContaining({ editedManifest: templateB.deploy }), {});
+    });
+  });
+
+  it("does not reload editedManifest when re-rendered with the same templateId", async () => {
+    const templateA = makeTemplate({ id: "template-A", deploy: "version: 2.0\n# template A content" });
+
+    const { ManifestEdit, rerender } = setup({
+      step: RouteStep.editDeployment,
+      templateId: templateA.id,
+      requestedTemplate: templateA
+    });
+
+    await vi.waitFor(() => {
+      expect(ManifestEdit).toHaveBeenCalledWith(expect.objectContaining({ editedManifest: templateA.deploy }), {});
+    });
+
+    const userEditedManifest = "version: 2.0\n# user-edited content";
+    const calls = ManifestEdit.mock.calls as unknown as Array<[{ setEditedManifest: (next: string) => void }]>;
+    const lastProps = calls.at(-1)?.[0];
+    expect(lastProps).toBeDefined();
+    lastProps!.setEditedManifest(userEditedManifest);
+
+    await vi.waitFor(() => {
+      expect(ManifestEdit).toHaveBeenLastCalledWith(expect.objectContaining({ editedManifest: userEditedManifest }), {});
+    });
+
+    ManifestEdit.mockClear();
+    rerender({ templateId: templateA.id, requestedTemplate: templateA });
+
+    await vi.waitFor(() => {
+      expect(ManifestEdit).toHaveBeenCalled();
+    });
+    expect(ManifestEdit).toHaveBeenLastCalledWith(expect.objectContaining({ editedManifest: userEditedManifest }), {});
+  });
+
+  function makeTemplate(overrides: Partial<TemplateOutput> & { id: string; deploy: string }): TemplateOutput {
+    return {
+      name: `Template ${overrides.id}`,
+      config: { ssh: false },
+      summary: "",
+      logoUrl: "",
+      readme: "",
+      path: "",
+      guide: "",
+      githubUrl: "",
+      persistentStorageEnabled: false,
+      ...overrides
+    };
+  }
+
   function setup(
     input: {
       step?: RouteStep;
@@ -303,19 +372,24 @@ describe(NewDeploymentContainer.name, () => {
       hasCiCdImageInSDL?: boolean;
     } = {}
   ) {
-    const searchParams = new Map<string, string>();
-    if (input.step) searchParams.set("step", input.step);
-    if (input.dseq) searchParams.set("dseq", input.dseq);
-    if (input.templateId) searchParams.set("templateId", input.templateId);
-    if (input.gitProvider) searchParams.set("gitProvider", input.gitProvider);
-    if (input.code) searchParams.set("code", input.code);
-    if (input.state) searchParams.set("state", input.state);
-    if (input.redeploy) searchParams.set("redeploy", input.redeploy);
+    const buildSearchParams = (next: typeof input) => {
+      const params = new Map<string, string>();
+      if (next.step) params.set("step", next.step);
+      if (next.dseq) params.set("dseq", next.dseq);
+      if (next.templateId) params.set("templateId", next.templateId);
+      if (next.gitProvider) params.set("gitProvider", next.gitProvider);
+      if (next.code) params.set("code", next.code);
+      if (next.state) params.set("state", next.state);
+      if (next.redeploy) params.set("redeploy", next.redeploy);
+      return {
+        get: (key: string) => params.get(key) ?? null,
+        entries: () => params.entries()
+      } as unknown as ReadonlyURLSearchParams;
+    };
 
-    const mockSearchParams = {
-      get: (key: string) => searchParams.get(key) ?? null,
-      entries: () => searchParams.entries()
-    } as unknown as ReadonlyURLSearchParams;
+    let mockSearchParams = buildSearchParams(input);
+    let currentRequestedTemplate = input.requestedTemplate;
+    let currentTemplateId = input.templateId;
 
     const mockRouter = {
       replace: vi.fn(),
@@ -363,17 +437,35 @@ describe(NewDeploymentContainer.name, () => {
       store.set(sdlStore.deploySdl, input.deploySdl);
     }
 
-    render(
+    const view = render(
       <TestContainerProvider
         services={{
           sdlAnalyzer: () => sdlAnalyzer
         }}
       >
         <JotaiStoreProvider store={store}>
-          <NewDeploymentContainer template={input.requestedTemplate} templateId={input.templateId} dependencies={dependencies} />
+          <NewDeploymentContainer template={currentRequestedTemplate} templateId={currentTemplateId} dependencies={dependencies} />
         </JotaiStoreProvider>
       </TestContainerProvider>
     );
+
+    const rerender = (next: Partial<typeof input>) => {
+      const merged = { ...input, ...next };
+      mockSearchParams = buildSearchParams(merged);
+      currentRequestedTemplate = "requestedTemplate" in next ? next.requestedTemplate : currentRequestedTemplate;
+      currentTemplateId = "templateId" in next ? next.templateId : currentTemplateId;
+      view.rerender(
+        <TestContainerProvider
+          services={{
+            sdlAnalyzer: () => sdlAnalyzer
+          }}
+        >
+          <JotaiStoreProvider store={store}>
+            <NewDeploymentContainer template={currentRequestedTemplate} templateId={currentTemplateId} dependencies={dependencies} />
+          </JotaiStoreProvider>
+        </TestContainerProvider>
+      );
+    };
 
     return {
       mockRouter,
@@ -382,7 +474,8 @@ describe(NewDeploymentContainer.name, () => {
       Layout,
       CreateLease,
       ManifestEdit,
-      TemplateList
+      TemplateList,
+      rerender
     };
   }
 });

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
@@ -91,7 +91,8 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
     const templateId = searchParams?.get("templateId");
     const isCreating = !!activeStep && activeStep > getStepIndexByParam(RouteStep.chooseTemplate);
 
-    if (!templates || (isCreating && !!editedManifest && !!templateId && loadedTemplateIdRef.current === templateId)) return;
+    const isSameTemplateAlreadyLoaded = !!templateId && loadedTemplateIdRef.current === templateId;
+    if (!templates || (isCreating && !!editedManifest && isSameTemplateAlreadyLoaded)) return;
 
     const template = getRedeployTemplate() || getGalleryTemplate() || deploySdl;
     const isUserTemplate = template?.code === USER_TEMPLATE_CODE;
@@ -100,7 +101,7 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
 
     setSelectedTemplate(template as TemplateCreation);
     setEditedManifest(template.content as string);
-    loadedTemplateIdRef.current = templateId ?? "";
+    loadedTemplateIdRef.current = templateId ?? null;
 
     if ("config" in template && (template.config?.ssh || (!template.config?.ssh && hasComponent("ssh")))) {
       toggleCmp("ssh");

--- a/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
+++ b/apps/deploy-web/src/components/new-deployment/NewDeploymentContainer/NewDeploymentContainer.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type { FC } from "react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { TemplateOutput } from "@akashnetwork/http-sdk";
 import { useAtomValue } from "jotai";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -52,6 +52,7 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
   const [isGitProviderTemplate, setIsGitProviderTemplate] = useState<boolean>(false);
   const [selectedTemplate, setSelectedTemplate] = useState<TemplateCreation | null>(null);
   const [editedManifest, setEditedManifest] = useState("");
+  const loadedTemplateIdRef = useRef<string | null>(null);
   const deploySdl = useAtomValue(sdlStore.deploySdl);
   const { getDeploymentData } = d.useLocalNotes();
   const router = d.useRouter();
@@ -90,7 +91,7 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
     const templateId = searchParams?.get("templateId");
     const isCreating = !!activeStep && activeStep > getStepIndexByParam(RouteStep.chooseTemplate);
 
-    if (!templates || (isCreating && !!editedManifest && !!templateId)) return;
+    if (!templates || (isCreating && !!editedManifest && !!templateId && loadedTemplateIdRef.current === templateId)) return;
 
     const template = getRedeployTemplate() || getGalleryTemplate() || deploySdl;
     const isUserTemplate = template?.code === USER_TEMPLATE_CODE;
@@ -99,6 +100,7 @@ export const NewDeploymentContainer: FC<NewDeploymentContainerProps> = ({ templa
 
     setSelectedTemplate(template as TemplateCreation);
     setEditedManifest(template.content as string);
+    loadedTemplateIdRef.current = templateId ?? "";
 
     if ("config" in template && (template.config?.ssh || (!template.config?.ssh && hasComponent("ssh")))) {
       toggleCmp("ssh");

--- a/apps/deploy-web/src/components/new-deployment/SdlBuilder.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/SdlBuilder.spec.tsx
@@ -1,0 +1,149 @@
+import type { ComponentProps } from "react";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ServiceType } from "@src/types";
+import { type DEPENDENCIES, SdlBuilder } from "./SdlBuilder";
+
+import { act, render } from "@testing-library/react";
+
+type SimpleServiceFormControlProps = ComponentProps<typeof DEPENDENCIES.SimpleServiceFormControl>;
+
+const buildSdl = (image: string) =>
+  [
+    "version: '2.0'",
+    "services:",
+    "  web:",
+    `    image: ${image}`,
+    "    expose:",
+    "      - port: 80",
+    "        as: 80",
+    "        to:",
+    "          - global: true",
+    "profiles:",
+    "  compute:",
+    "    web:",
+    "      resources:",
+    "        cpu:",
+    "          units: 0.5",
+    "        memory:",
+    "          size: 512Mi",
+    "        storage:",
+    "          - size: 512Mi",
+    "  placement:",
+    "    dcloud:",
+    "      pricing:",
+    "        web:",
+    "          denom: uact",
+    "          amount: 1000",
+    "deployment:",
+    "  web:",
+    "    dcloud:",
+    "      profile: web",
+    "      count: 1"
+  ].join("\n");
+
+describe("SdlBuilder", () => {
+  it("imports services from sdlString on mount", async () => {
+    const { SimpleServiceFormControl } = setup({ sdlString: buildSdl("nginx:1.0") });
+
+    await vi.waitFor(() => {
+      expect(getLastServices(SimpleServiceFormControl)?.[0]?.image).toBe("nginx:1.0");
+    });
+  });
+
+  it("re-imports services when sdlString changes externally", async () => {
+    const { SimpleServiceFormControl, rerender } = setup({ sdlString: buildSdl("nginx:1.0") });
+
+    await vi.waitFor(() => {
+      expect(getLastServices(SimpleServiceFormControl)?.[0]?.image).toBe("nginx:1.0");
+    });
+
+    rerender({ sdlString: buildSdl("redis:7.0") });
+
+    await vi.waitFor(() => {
+      expect(getLastServices(SimpleServiceFormControl)?.[0]?.image).toBe("redis:7.0");
+    });
+  });
+
+  it("preserves user form edits when sdlString does not change externally", async () => {
+    const initialSdl = buildSdl("nginx:1.0");
+    const { SimpleServiceFormControl, setEditedManifest, rerender } = setup({ sdlString: initialSdl });
+
+    await vi.waitFor(() => {
+      expect(getLastServices(SimpleServiceFormControl)?.[0]?.image).toBe("nginx:1.0");
+    });
+
+    const lastSetValue = SimpleServiceFormControl.mock.calls.at(-1)?.[0].setValue;
+    expect(lastSetValue).toBeDefined();
+
+    act(() => {
+      (lastSetValue as (path: string, value: string) => void)("services.0.image", "user-edited-image");
+    });
+
+    await vi.waitFor(() => {
+      expect(getLastServices(SimpleServiceFormControl)?.[0]?.image).toBe("user-edited-image");
+    });
+
+    const lastEditedManifest = setEditedManifest.mock.calls.at(-1)?.[0] as string | undefined;
+    expect(lastEditedManifest).toBeDefined();
+    rerender({ sdlString: lastEditedManifest! });
+
+    await Promise.resolve();
+    expect(getLastServices(SimpleServiceFormControl)?.[0]?.image).toBe("user-edited-image");
+  });
+
+  function getLastServices(SimpleServiceFormControl: ReturnType<typeof createSimpleServiceFormControl>): ServiceType[] | undefined {
+    return SimpleServiceFormControl.mock.calls.at(-1)?.[0]._services;
+  }
+
+  function createSimpleServiceFormControl() {
+    return vi.fn<(props: SimpleServiceFormControlProps) => null>(() => null);
+  }
+
+  function setup(input: { sdlString: string | null }) {
+    const setEditedManifest = vi.fn();
+    const SimpleServiceFormControl = createSimpleServiceFormControl();
+    const RemoteRepositoryDeployManager = vi.fn(() => null);
+
+    const dependencies: typeof DEPENDENCIES = {
+      SimpleServiceFormControl: SimpleServiceFormControl as unknown as typeof DEPENDENCIES.SimpleServiceFormControl,
+      RemoteRepositoryDeployManager: RemoteRepositoryDeployManager as unknown as typeof DEPENDENCIES.RemoteRepositoryDeployManager,
+      useSdlBuilder: () =>
+        mock<ReturnType<typeof DEPENDENCIES.useSdlBuilder>>({
+          hasComponent: () => false,
+          toggleCmp: vi.fn(),
+          imageList: undefined
+        }),
+      useWallet: () =>
+        mock<ReturnType<typeof DEPENDENCIES.useWallet>>({
+          isManaged: false
+        }),
+      useSdlServiceManager: () =>
+        mock<ReturnType<typeof DEPENDENCIES.useSdlServiceManager>>({
+          add: vi.fn(),
+          remove: vi.fn()
+        }),
+      useGpuModels: () => mock<ReturnType<typeof DEPENDENCIES.useGpuModels>>({ data: undefined })
+    };
+
+    const view = render(
+      <SdlBuilder sdlString={input.sdlString} setEditedManifest={setEditedManifest} setDeploymentName={vi.fn()} deploymentName="" dependencies={dependencies} />
+    );
+
+    const rerender = (next: { sdlString: string | null }) => {
+      view.rerender(
+        <SdlBuilder
+          sdlString={next.sdlString}
+          setEditedManifest={setEditedManifest}
+          setDeploymentName={vi.fn()}
+          deploymentName=""
+          dependencies={dependencies}
+        />
+      );
+    };
+
+    return { SimpleServiceFormControl, RemoteRepositoryDeployManager, setEditedManifest, rerender };
+  }
+});

--- a/apps/deploy-web/src/components/new-deployment/SdlBuilder.tsx
+++ b/apps/deploy-web/src/components/new-deployment/SdlBuilder.tsx
@@ -18,7 +18,16 @@ import { transformCustomSdlFields, TransformError } from "@src/utils/sdl/transfo
 import RemoteRepositoryDeployManager from "../remote-deploy/RemoteRepositoryDeployManager";
 import { SimpleServiceFormControl } from "../sdl/SimpleServiceFormControl";
 
-interface Props {
+export const DEPENDENCIES = {
+  SimpleServiceFormControl,
+  RemoteRepositoryDeployManager,
+  useSdlBuilder,
+  useWallet,
+  useSdlServiceManager,
+  useGpuModels
+};
+
+export interface Props {
   sdlString: string | null;
   setEditedManifest: Dispatch<string>;
   isGitProviderTemplate?: boolean;
@@ -26,6 +35,7 @@ interface Props {
   deploymentName: string;
   setIsRepoInputValid?: Dispatch<boolean>;
   onValidate?: (event: { isValid: boolean }) => void;
+  dependencies?: typeof DEPENDENCIES;
 }
 
 export type SdlBuilderRefType = {
@@ -34,11 +44,14 @@ export type SdlBuilderRefType = {
 };
 
 export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
-  ({ sdlString, setEditedManifest, isGitProviderTemplate, setDeploymentName, deploymentName, setIsRepoInputValid, onValidate }, ref) => {
+  (
+    { sdlString, setEditedManifest, isGitProviderTemplate, setDeploymentName, deploymentName, setIsRepoInputValid, onValidate, dependencies: d = DEPENDENCIES },
+    ref
+  ) => {
     const [error, setError] = useState<string | null>(null);
     const formRef = useRef<HTMLFormElement>(null);
     const [isInit, setIsInit] = useState(false);
-    const { hasComponent, imageList } = useSdlBuilder();
+    const { hasComponent, imageList } = d.useSdlBuilder();
     const form = useForm<SdlBuilderFormValuesType>({
       defaultValues: {
         services: [getDefaultService({ supportsSSH: hasComponent("ssh") })],
@@ -48,13 +61,13 @@ export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
       resolver: zodResolver(SdlBuilderFormValuesSchema)
     });
     const { control, trigger, watch, setValue, formState } = form;
-    const serviceManager = useSdlServiceManager({ control });
+    const serviceManager = d.useSdlServiceManager({ control });
 
     const { services: formServices = [] } = watch();
-    const { data: gpuModels } = useGpuModels();
+    const { data: gpuModels } = d.useGpuModels();
     const [serviceCollapsed, setServiceCollapsed] = useState(isGitProviderTemplate ? [0] : []);
 
-    const wallet = useWallet();
+    const wallet = d.useWallet();
 
     useEffect(() => {
       if (wallet.isManaged) {
@@ -75,27 +88,33 @@ export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
       }
     }));
 
+    const lastSyncedSdlRef = useRef<string | null>(null);
+
     useEffect(() => {
       const { unsubscribe } = watch(data => {
         const sdl = generateSdl(data.services as ServiceType[]);
+        lastSyncedSdlRef.current = sdl;
         setEditedManifest(sdl);
       });
-
-      try {
-        if (sdlString) {
-          const services = createAndValidateSdl(sdlString);
-          setValue("services", services as ServiceType[]);
-        }
-      } catch (error) {
-        setError("Error importing SDL");
-      }
-
-      setIsInit(true);
-
       return () => {
         unsubscribe();
       };
-    }, [watch]);
+    }, [watch, setEditedManifest]);
+
+    useEffect(() => {
+      if (sdlString && sdlString !== lastSyncedSdlRef.current) {
+        try {
+          const services = createAndValidateSdl(sdlString);
+          if (services) {
+            lastSyncedSdlRef.current = sdlString;
+            setValue("services", services as ServiceType[]);
+          }
+        } catch (error) {
+          setError("Error importing SDL");
+        }
+      }
+      setIsInit(true);
+    }, [sdlString, setValue]);
 
     useEffect(() => {
       onValidate?.({ isValid: formState.isValid });
@@ -140,7 +159,7 @@ export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
         ) : (
           <>
             {isGitProviderTemplate && (
-              <RemoteRepositoryDeployManager
+              <d.RemoteRepositoryDeployManager
                 setValue={setValue}
                 services={formServices as ServiceType[]}
                 control={control}
@@ -153,7 +172,7 @@ export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
               <form ref={formRef} autoComplete="off">
                 {formServices &&
                   formServices.map((service, serviceIndex) => (
-                    <SimpleServiceFormControl
+                    <d.SimpleServiceFormControl
                       key={service.id}
                       serviceIndex={serviceIndex}
                       gpuModels={gpuModels}


### PR DESCRIPTION
## Why

Closes CON-280.

When a user starts a deployment from a template, navigates back, and picks a different template, the SDL builder kept showing the previous template's data — the image input often appeared empty and template-specific defaults were missing.

Root cause: `NewDeploymentContainer`'s template-loading effect short-circuited whenever `editedManifest` was non-empty, so a fresh `templateId` in the URL never triggered a reload. The guard was meant to preserve in-progress edits to the same template, not to ignore template switches.

## What

- Track the currently loaded `templateId` via a `useRef` and only short-circuit the loader when the URL `templateId` matches it. New `templateId` → manifest is replaced; same `templateId` re-render → user edits are preserved.
- Two new unit tests covering both cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests validating template re-selection behavior and that manual edits to a manifest persist across re-renders.

* **Bug Fixes**
  * Preserve user-edited manifests across re-renders when the selected template hasn’t changed; ensure re-import occurs when a new template is selected.
  * Ensure SDL-derived services are re-imported when external SDL changes, without overwriting user edits.

* **Performance**
  * Skip redundant template loading when the same template is already active.

* **Refactor**
  * Internal restructuring to improve SDL sync and dependency handling for greater stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->