### PR TITLE
feat(wallet): support links and persistent dismiss in generic banner

### DIFF
--- a/apps/deploy-web/src/components/layout/TopBanner.tsx
+++ b/apps/deploy-web/src/components/layout/TopBanner.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import { useIntl } from "react-intl";
 import { Button } from "@akashnetwork/ui/components";
 import { Xmark } from "iconoir-react";
@@ -74,11 +74,21 @@ function MaintenanceBanner({ onClose }: { onClose: () => void }) {
 }
 
 function GenericBanner({ onClose }: { onClose: () => void }) {
-  const { message } = useGenericBannerDetails();
+  const { message, links } = useGenericBannerDetails();
 
   return (
-    <div className="fixed top-0 z-10 flex h-[40px] w-full items-center justify-center bg-primary px-3 py-2 text-primary-foreground md:space-x-4">
-      <span className="text-xs font-semibold md:text-sm">{message}</span>
+    <div className="fixed top-0 z-10 flex h-[40px] w-full items-center justify-center gap-2 bg-primary px-3 py-2 text-primary-foreground md:gap-4">
+      <span className="text-xs font-semibold md:text-sm">
+        {message}
+        {links?.map(link => (
+          <Fragment key={link.href}>
+            {" "}
+            <a href={link.href} target="_blank" rel="noopener noreferrer" className="underline hover:text-primary-foreground/80">
+              {link.label}
+            </a>
+          </Fragment>
+        ))}
+      </span>
       <Button variant="text" className="rounded-full hover:text-primary-foreground/80" size="icon" onClick={onClose}>
         <Xmark />
       </Button>

--- a/apps/deploy-web/src/components/layout/TopBanner.tsx
+++ b/apps/deploy-web/src/components/layout/TopBanner.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useIntl } from "react-intl";
 import { Button } from "@akashnetwork/ui/components";
 import { Xmark } from "iconoir-react";
@@ -81,12 +81,9 @@ function GenericBanner({ onClose }: { onClose: () => void }) {
       <span className="text-xs font-semibold md:text-sm">
         {message}
         {links?.map(link => (
-          <Fragment key={link.href}>
-            {" "}
-            <a href={link.href} target="_blank" rel="noopener noreferrer" className="underline hover:text-primary-foreground/80">
-              {link.label}
-            </a>
-          </Fragment>
+          <a key={link.href} href={link.href} target="_blank" rel="noopener noreferrer" className="ml-1 underline hover:text-primary-foreground/80">
+            {link.label}
+          </a>
         ))}
       </span>
       <Button variant="text" className="rounded-full hover:text-primary-foreground/80" size="icon" onClick={onClose}>

--- a/apps/deploy-web/src/hooks/useTopBanner.spec.tsx
+++ b/apps/deploy-web/src/hooks/useTopBanner.spec.tsx
@@ -1,0 +1,81 @@
+import { createStore, Provider as JotaiProvider } from "jotai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useGenericBannerVisibility } from "./useTopBanner";
+
+import { act, renderHook } from "@testing-library/react";
+
+const DISMISSED_KEY_PREFIX = "generic_banner_dismissed:";
+
+describe("useGenericBannerVisibility", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("opens the banner when the flag is enabled and not dismissed", async () => {
+    const { result } = await setup({ isFlagEnabled: true, dismissId: "console-air" });
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("does not open the banner when the flag is disabled", async () => {
+    const { result } = await setup({ isFlagEnabled: false, dismissId: "console-air" });
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("keeps the banner closed when the dismissId is already persisted", async () => {
+    window.localStorage.setItem(DISMISSED_KEY_PREFIX + "console-air", "true");
+    const { result } = await setup({ isFlagEnabled: true, dismissId: "console-air" });
+    expect(result.current[0]).toBe(false);
+  });
+
+  it("persists dismiss to localStorage when closed with a dismissId", async () => {
+    const { result } = await setup({ isFlagEnabled: true, dismissId: "console-air" });
+    expect(result.current[0]).toBe(true);
+
+    await act(async () => {
+      result.current[1](false);
+    });
+
+    expect(result.current[0]).toBe(false);
+    expect(window.localStorage.getItem(DISMISSED_KEY_PREFIX + "console-air")).toBe("true");
+  });
+
+  it("does not write to localStorage when dismissed without a dismissId", async () => {
+    const { result } = await setup({ isFlagEnabled: true, dismissId: undefined });
+
+    await act(async () => {
+      result.current[1](false);
+    });
+
+    expect(result.current[0]).toBe(false);
+    expect(window.localStorage.length).toBe(0);
+  });
+
+  it("re-opens the banner when the dismissId changes (new announcement)", async () => {
+    window.localStorage.setItem(DISMISSED_KEY_PREFIX + "old", "true");
+    const { result, rerender } = await setup({ isFlagEnabled: true, dismissId: "old" });
+    expect(result.current[0]).toBe(false);
+
+    await act(async () => {
+      rerender({ isFlagEnabled: true, dismissId: "new" });
+    });
+
+    expect(result.current[0]).toBe(true);
+  });
+
+  async function setup(initialProps: { isFlagEnabled: boolean; dismissId: string | undefined }) {
+    const store = createStore();
+    const wrapper = ({ children }: { children: React.ReactNode }) => <JotaiProvider store={store}>{children}</JotaiProvider>;
+
+    const result = renderHook((props: { isFlagEnabled: boolean; dismissId: string | undefined }) => useGenericBannerVisibility(props), {
+      wrapper,
+      initialProps
+    });
+    await act(async () => {});
+    return result;
+  }
+});

--- a/apps/deploy-web/src/hooks/useTopBanner.spec.tsx
+++ b/apps/deploy-web/src/hooks/useTopBanner.spec.tsx
@@ -1,7 +1,7 @@
 import { createStore, Provider as JotaiProvider } from "jotai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { useGenericBannerVisibility } from "./useTopBanner";
+import { isSafeLink, useGenericBannerVisibility } from "./useTopBanner";
 
 import { act, renderHook } from "@testing-library/react";
 
@@ -78,4 +78,26 @@ describe("useGenericBannerVisibility", () => {
     await act(async () => {});
     return result;
   }
+});
+
+describe(isSafeLink.name, () => {
+  it.each([
+    ["https://akash.network", true],
+    ["http://akash.network", true],
+    ["javascript:alert(1)", false],
+    ["data:text/html,<script>alert(1)</script>", false],
+    ["file:///etc/passwd", false],
+    ["not a url", false],
+    ["", false]
+  ])("returns %s for href %s", (href, expected) => {
+    expect(isSafeLink({ label: "Learn more", href })).toBe(expected);
+  });
+
+  it("rejects entries with non-string label or href", () => {
+    expect(isSafeLink({ label: 1, href: "https://akash.network" })).toBe(false);
+    expect(isSafeLink({ label: "Learn more", href: 1 })).toBe(false);
+    expect(isSafeLink(null)).toBe(false);
+    expect(isSafeLink(undefined)).toBe(false);
+    expect(isSafeLink("https://akash.network")).toBe(false);
+  });
 });

--- a/apps/deploy-web/src/hooks/useTopBanner.tsx
+++ b/apps/deploy-web/src/hooks/useTopBanner.tsx
@@ -37,9 +37,7 @@ export function useGenericBannerVisibility(input: { isFlagEnabled: boolean; dism
   const [isOpen, setIsOpenAtom] = useAtom(IS_GENERIC_BANNER_ATOM);
 
   useEffect(() => {
-    if (!isFlagEnabled) return;
-    if (isGenericBannerDismissed(dismissId)) return;
-    setIsOpenAtom(true);
+    setIsOpenAtom(isFlagEnabled && !isGenericBannerDismissed(dismissId));
   }, [isFlagEnabled, dismissId, setIsOpenAtom]);
 
   const setIsOpen = useCallback(
@@ -123,16 +121,20 @@ export type GenericBannerDetails = { message: string; links?: GenericBannerLink[
 export function useGenericBannerDetails(): GenericBannerDetails {
   const genericBannerFlag = useVariant("generic_banner");
   const { errorHandler } = useServices();
+  const enabled = genericBannerFlag?.enabled;
+  const payload = genericBannerFlag?.payload?.value;
 
-  try {
-    const details = genericBannerFlag?.enabled ? (JSON.parse(genericBannerFlag.payload?.value as string) as GenericBannerDetails) : { message: "" };
-    return details;
-  } catch (error) {
-    errorHandler.reportError({
-      error,
-      message: "Failed to parse generic banner details from feature flag",
-      tags: { category: "generic-banner" }
-    });
-    return { message: "" };
-  }
+  return useMemo(() => {
+    if (!enabled) return { message: "" };
+    try {
+      return JSON.parse(payload as string) as GenericBannerDetails;
+    } catch (error) {
+      errorHandler.reportError({
+        error,
+        message: "Failed to parse generic banner details from feature flag",
+        tags: { category: "generic-banner" }
+      });
+      return { message: "" };
+    }
+  }, [enabled, payload, errorHandler]);
 }

--- a/apps/deploy-web/src/hooks/useTopBanner.tsx
+++ b/apps/deploy-web/src/hooks/useTopBanner.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useVariant } from "@unleash/nextjs/client";
 import { atom, useAtom } from "jotai";
 
@@ -6,6 +6,18 @@ import { useServices } from "@src/context/ServicesProvider";
 import { useHasCreditCardBanner } from "@src/hooks/useHasCreditCardBanner";
 import { useWhen } from "@src/hooks/useWhen";
 import { useSettings } from "../context/SettingsProvider";
+
+const GENERIC_BANNER_DISMISSED_PREFIX = "generic_banner_dismissed:";
+
+const isGenericBannerDismissed = (dismissId: string | undefined) => {
+  if (!dismissId || typeof window === "undefined") return false;
+  return window.localStorage.getItem(GENERIC_BANNER_DISMISSED_PREFIX + dismissId) === "true";
+};
+
+const persistGenericBannerDismiss = (dismissId: string | undefined) => {
+  if (!dismissId || typeof window === "undefined") return;
+  window.localStorage.setItem(GENERIC_BANNER_DISMISSED_PREFIX + dismissId, "true");
+};
 
 interface ITopBannerContext {
   hasBanner: boolean;
@@ -20,16 +32,43 @@ interface ITopBannerContext {
 const IS_MAINTENANCE_ATOM = atom(false);
 const IS_GENERIC_BANNER_ATOM = atom(false);
 
+export function useGenericBannerVisibility(input: { isFlagEnabled: boolean; dismissId: string | undefined }) {
+  const { isFlagEnabled, dismissId } = input;
+  const [isOpen, setIsOpenAtom] = useAtom(IS_GENERIC_BANNER_ATOM);
+
+  useEffect(() => {
+    if (!isFlagEnabled) return;
+    if (isGenericBannerDismissed(dismissId)) return;
+    setIsOpenAtom(true);
+  }, [isFlagEnabled, dismissId, setIsOpenAtom]);
+
+  const setIsOpen = useCallback(
+    (open: boolean) => {
+      setIsOpenAtom(open);
+      if (!open) {
+        persistGenericBannerDismiss(dismissId);
+      }
+    },
+    [setIsOpenAtom, dismissId]
+  );
+
+  return [isOpen, setIsOpen] as const;
+}
+
 export function useTopBanner(): ITopBannerContext {
   const maintenanceBannerFlag = useVariant("maintenance_banner");
   const genericBannerFlag = useVariant("generic_banner");
   const { settings } = useSettings();
   const hasCreditCardBanner = useHasCreditCardBanner();
+  const { dismissId } = useGenericBannerDetails();
 
   const [isMaintenanceBannerOpen, setIsMaintenanceBannerOpen] = useAtom(IS_MAINTENANCE_ATOM);
-  const [isGenericBannerOpen, setIsGenericBannerOpen] = useAtom(IS_GENERIC_BANNER_ATOM);
   useWhen(maintenanceBannerFlag.enabled, () => setIsMaintenanceBannerOpen(true));
-  useWhen(genericBannerFlag.enabled, () => setIsGenericBannerOpen(true));
+
+  const [isGenericBannerOpen, setIsGenericBannerOpen] = useGenericBannerVisibility({
+    isFlagEnabled: !!genericBannerFlag.enabled,
+    dismissId
+  });
 
   const hasBanner = useMemo(
     () => isMaintenanceBannerOpen || isGenericBannerOpen || settings.isBlockchainDown || hasCreditCardBanner,
@@ -79,7 +118,8 @@ export function useChainMaintenanceDetails(): ChainMaintenanceDetails {
   }
 }
 
-export type GenericBannerDetails = { message: string };
+export type GenericBannerLink = { label: string; href: string };
+export type GenericBannerDetails = { message: string; links?: GenericBannerLink[]; dismissId?: string };
 export function useGenericBannerDetails(): GenericBannerDetails {
   const genericBannerFlag = useVariant("generic_banner");
   const { errorHandler } = useServices();

--- a/apps/deploy-web/src/hooks/useTopBanner.tsx
+++ b/apps/deploy-web/src/hooks/useTopBanner.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useVariant } from "@unleash/nextjs/client";
 import { atom, useAtom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useHasCreditCardBanner } from "@src/hooks/useHasCreditCardBanner";
@@ -8,16 +9,18 @@ import { useWhen } from "@src/hooks/useWhen";
 import { useSettings } from "../context/SettingsProvider";
 
 const GENERIC_BANNER_DISMISSED_PREFIX = "generic_banner_dismissed:";
+const SAFE_LINK_PROTOCOLS = new Set(["http:", "https:"]);
 
-const isGenericBannerDismissed = (dismissId: string | undefined) => {
-  if (!dismissId || typeof window === "undefined") return false;
-  return window.localStorage.getItem(GENERIC_BANNER_DISMISSED_PREFIX + dismissId) === "true";
+const dismissedAtomCache = new Map<string, ReturnType<typeof atomWithStorage<boolean>>>();
+const getGenericBannerDismissedAtom = (dismissId: string) => {
+  const cached = dismissedAtomCache.get(dismissId);
+  if (cached) return cached;
+  const dismissedAtom = atomWithStorage<boolean>(GENERIC_BANNER_DISMISSED_PREFIX + dismissId, false);
+  dismissedAtomCache.set(dismissId, dismissedAtom);
+  return dismissedAtom;
 };
 
-const persistGenericBannerDismiss = (dismissId: string | undefined) => {
-  if (!dismissId || typeof window === "undefined") return;
-  window.localStorage.setItem(GENERIC_BANNER_DISMISSED_PREFIX + dismissId, "true");
-};
+const SESSION_GENERIC_BANNER_DISMISSED_ATOM = atom(false);
 
 interface ITopBannerContext {
   hasBanner: boolean;
@@ -30,25 +33,14 @@ interface ITopBannerContext {
 }
 
 const IS_MAINTENANCE_ATOM = atom(false);
-const IS_GENERIC_BANNER_ATOM = atom(false);
 
 export function useGenericBannerVisibility(input: { isFlagEnabled: boolean; dismissId: string | undefined }) {
   const { isFlagEnabled, dismissId } = input;
-  const [isOpen, setIsOpenAtom] = useAtom(IS_GENERIC_BANNER_ATOM);
+  const dismissedAtom = useMemo(() => (dismissId ? getGenericBannerDismissedAtom(dismissId) : SESSION_GENERIC_BANNER_DISMISSED_ATOM), [dismissId]);
+  const [isDismissed, setIsDismissed] = useAtom(dismissedAtom);
 
-  useEffect(() => {
-    setIsOpenAtom(isFlagEnabled && !isGenericBannerDismissed(dismissId));
-  }, [isFlagEnabled, dismissId, setIsOpenAtom]);
-
-  const setIsOpen = useCallback(
-    (open: boolean) => {
-      setIsOpenAtom(open);
-      if (!open) {
-        persistGenericBannerDismiss(dismissId);
-      }
-    },
-    [setIsOpenAtom, dismissId]
-  );
+  const isOpen = isFlagEnabled && !isDismissed;
+  const setIsOpen = useCallback((open: boolean) => setIsDismissed(!open), [setIsDismissed]);
 
   return [isOpen, setIsOpen] as const;
 }
@@ -118,6 +110,18 @@ export function useChainMaintenanceDetails(): ChainMaintenanceDetails {
 
 export type GenericBannerLink = { label: string; href: string };
 export type GenericBannerDetails = { message: string; links?: GenericBannerLink[]; dismissId?: string };
+
+export function isSafeLink(link: unknown): link is GenericBannerLink {
+  if (!link || typeof link !== "object") return false;
+  const { label, href } = link as Partial<GenericBannerLink>;
+  if (typeof label !== "string" || typeof href !== "string") return false;
+  try {
+    return SAFE_LINK_PROTOCOLS.has(new URL(href).protocol);
+  } catch {
+    return false;
+  }
+}
+
 export function useGenericBannerDetails(): GenericBannerDetails {
   const genericBannerFlag = useVariant("generic_banner");
   const { errorHandler } = useServices();
@@ -127,7 +131,9 @@ export function useGenericBannerDetails(): GenericBannerDetails {
   return useMemo(() => {
     if (!enabled) return { message: "" };
     try {
-      return JSON.parse(payload as string) as GenericBannerDetails;
+      const parsed = JSON.parse(payload as string) as GenericBannerDetails;
+      const links = Array.isArray(parsed.links) ? parsed.links.filter(isSafeLink) : undefined;
+      return { ...parsed, links };
     } catch (error) {
       errorHandler.reportError({
         error,


### PR DESCRIPTION
## Why

Part of CON-266. Before pulling self-custody features out of Console, the team needs a way to surface an in-app announcement that:

- links out to the Console Air repo and the blog post
- stays dismissed across page reloads
- can be turned on/off and reworded by ops via Unleash

Rather than introduce a one-off banner component, this enhances the existing `generic_banner` flag so any future announcement can do the same.

## What

- Extends `GenericBannerDetails` payload with optional `links: { label, href }[]` and `dismissId: string`.
- `GenericBanner` renders payload links as `target="_blank" rel="noopener noreferrer"` anchors after the message.
- Extracts `useGenericBannerVisibility` from `useTopBanner`. When `dismissId` is set, dismiss is persisted in `localStorage` under `generic_banner_dismissed:<dismissId>`; if `dismissId` is omitted, the prior session-only dismiss behavior is preserved. Changing `dismissId` re-shows the banner (new announcement = fresh dismiss state).
- Adds `useTopBanner.spec.tsx` covering: flag on/off, prior dismiss, dismiss persistence, no-op without `dismissId`, reset on `dismissId` change.

### How ops will use it for Console Air (CON-266)

Configure the `generic_banner` Unleash flag with a payload like:

```json
{
  "message": "Self-custody is moving to Console Air.",
  "links": [
    { "label": "Read the announcement", "href": "https://akash.network/blog/introducing-console-air-self-host-self-custody" },
    { "label": "Open Console Air", "href": "https://github.com/akash-network/console-air" }
  ],
  "dismissId": "console-air-2026-05"
}
```

### Not in this PR

- The "self-custody only" audience gate from the CON-266 AC is not implemented — the banner shows to all users when the flag is on. Easiest follow-up if needed: add an `audience: "self-custody"` field to the payload and gate on `isCustodial`.
- The blog post itself is content work, tracked by CON-266.

## Test plan

- [ ] `npm run test:unit` passes in `apps/deploy-web` (6 new tests in `useTopBanner.spec.tsx`).
- [ ] `npx tsc --noEmit` is clean for changed files.
- [ ] `npm run lint -- --quiet` is clean for changed files.
- [ ] Manually verify in dev with the Unleash flag enabled:
  - [ ] Banner renders with the configured message and links.
  - [ ] Clicking a link opens it in a new tab.
  - [ ] Dismissing the banner hides it for the rest of the session.
  - [ ] Reloading the page keeps the banner dismissed (with `dismissId` set).
  - [ ] Without `dismissId`, dismiss is session-only (prior behavior).
  - [ ] Changing the `dismissId` payload value re-shows the banner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Top banners can include clickable external links that open in a new tab and are validated for safety.
  * Banner dismissal is now persisted per announcement so dismissed banners stay closed across sessions.
  * Banner layout spacing improved for clearer presentation.

* **Tests**
  * Added comprehensive tests covering banner visibility, dismissal persistence, and link safety validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->