### PR TITLE
fix(deployment): prefer bash with sh fallback in lease shell

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
@@ -2,8 +2,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Alert, AlertDescription, AlertTitle, Button, Spinner } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
-import { OpenInWindow, WarningCircle } from "iconoir-react";
-import Link from "next/link";
+import { WarningCircle } from "iconoir-react";
 
 import { ViewPanel } from "@src/components/shared/ViewPanel";
 import { useServices } from "@src/context/ServicesProvider";
@@ -16,7 +15,6 @@ import type { ReceivedShellMessage } from "@src/services/provider-proxy/provider
 import type { LeaseDto } from "@src/types/deployment";
 import { LeaseShellCode } from "@src/types/shell";
 import { forEachGeneratedItem } from "@src/utils/array";
-import { UrlService } from "@src/utils/urlUtils";
 import { CreateCredentialsButton } from "./CreateCredentialsButton/CreateCredentialsButton";
 import { LeaseSelect } from "./LeaseSelect";
 import { ServiceSelect } from "./ServiceSelect";
@@ -38,7 +36,6 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
   const [selectedLease, setSelectedLease] = useState<LeaseDto | null>(null);
   const [isShowingDownloadModal, setIsShowingDownloadModal] = useState(false);
   const [isChangingSocket, setIsChangingSocket] = useState(false);
-  const [showArrowAndTabWarning, setShowArrowAndTabWarning] = useState(false);
   const { data: providers } = useProviderList();
   const providerCredentials = useProviderCredentials();
   const providerInfo = providers?.find(p => p.owner === selectedLease?.provider);
@@ -118,12 +115,6 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
 
     if (message?.data) {
       const parsedData = textDecoder.decode(Uint8Array.from(message.data.slice(1)));
-
-      // Check if parsedData is either ^[[A, ^[[B, ^[[C or ^[[D
-      const arrowKeyPattern = /\^\[\[[A-D]/;
-      if (arrowKeyPattern.test(parsedData)) {
-        setShowArrowAndTabWarning(true);
-      }
 
       let exitCode;
       try {
@@ -245,40 +236,29 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
           {selectedLease && (
             <>
               {!isConnectionClosed && (
-                <>
-                  <div className="flex h-[56px] items-center space-x-4 p-2">
-                    <div className="flex items-center">
-                      {(leases?.length || 0) > 1 && <LeaseSelect leases={leases || []} defaultValue={selectedLease.id} onSelectedChange={handleLeaseChange} />}
+                <div className="flex h-[56px] items-center space-x-4 p-2">
+                  <div className="flex items-center">
+                    {(leases?.length || 0) > 1 && <LeaseSelect leases={leases || []} defaultValue={selectedLease.id} onSelectedChange={handleLeaseChange} />}
 
-                      {services?.length > 0 && selectedService && (
-                        <div className={cn({ ["ml-2"]: (leases?.length || 0) > 1 })}>
-                          <ServiceSelect services={services} defaultValue={selectedService} onSelectedChange={onSelectedServiceChange} />
-                        </div>
-                      )}
-                    </div>
-
-                    <div className="flex items-center">
-                      <Button onClick={onDownloadFileClick} variant="default" size="sm" disabled={!isConnectionEstablished}>
-                        Download file
-                      </Button>
-                    </div>
-
-                    {(isLoadingStatus || isLoadingData) && (
-                      <div>
-                        <Spinner size="small" />
+                    {services?.length > 0 && selectedService && (
+                      <div className={cn({ ["ml-2"]: (leases?.length || 0) > 1 })}>
+                        <ServiceSelect services={services} defaultValue={selectedService} onSelectedChange={onSelectedServiceChange} />
                       </div>
                     )}
                   </div>
 
-                  {showArrowAndTabWarning && (
-                    <Alert variant="warning" className="mb-1 rounded-none">
-                      <Link href={UrlService.faq("shell-arrows-and-completion")} target="_blank" className="inline-flex items-center space-x-2">
-                        <span>Why is my UP arrow and TAB autocompletion not working?</span>
-                        <OpenInWindow className="text-xs" />
-                      </Link>
-                    </Alert>
+                  <div className="flex items-center">
+                    <Button onClick={onDownloadFileClick} variant="default" size="sm" disabled={!isConnectionEstablished}>
+                      Download file
+                    </Button>
+                  </div>
+
+                  {(isLoadingStatus || isLoadingData) && (
+                    <div>
+                      <Spinner size="small" />
+                    </div>
                   )}
-                </>
+                </div>
               )}
 
               <ViewPanel stickToBottom className="overflow-hidden">

--- a/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
@@ -236,29 +236,31 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
           {selectedLease && (
             <>
               {!isConnectionClosed && (
-                <div className="flex h-[56px] items-center space-x-4 p-2">
-                  <div className="flex items-center">
-                    {(leases?.length || 0) > 1 && <LeaseSelect leases={leases || []} defaultValue={selectedLease.id} onSelectedChange={handleLeaseChange} />}
+                <>
+                  <div className="flex h-[56px] items-center space-x-4 p-2">
+                    <div className="flex items-center">
+                      {(leases?.length || 0) > 1 && <LeaseSelect leases={leases || []} defaultValue={selectedLease.id} onSelectedChange={handleLeaseChange} />}
 
-                    {services?.length > 0 && selectedService && (
-                      <div className={cn({ ["ml-2"]: (leases?.length || 0) > 1 })}>
-                        <ServiceSelect services={services} defaultValue={selectedService} onSelectedChange={onSelectedServiceChange} />
+                      {services?.length > 0 && selectedService && (
+                        <div className={cn({ ["ml-2"]: (leases?.length || 0) > 1 })}>
+                          <ServiceSelect services={services} defaultValue={selectedService} onSelectedChange={onSelectedServiceChange} />
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="flex items-center">
+                      <Button onClick={onDownloadFileClick} variant="default" size="sm" disabled={!isConnectionEstablished}>
+                        Download file
+                      </Button>
+                    </div>
+
+                    {(isLoadingStatus || isLoadingData) && (
+                      <div>
+                        <Spinner size="small" />
                       </div>
                     )}
                   </div>
-
-                  <div className="flex items-center">
-                    <Button onClick={onDownloadFileClick} variant="default" size="sm" disabled={!isConnectionEstablished}>
-                      Download file
-                    </Button>
-                  </div>
-
-                  {(isLoadingStatus || isLoadingData) && (
-                    <div>
-                      <Spinner size="small" />
-                    </div>
-                  )}
-                </div>
+                </>
               )}
 
               <ViewPanel stickToBottom className="overflow-hidden">

--- a/apps/deploy-web/src/pages/faq/index.tsx
+++ b/apps/deploy-web/src/pages/faq/index.tsx
@@ -63,16 +63,6 @@ const FaqEntries = [
     )
   },
   {
-    anchor: "shell-arrows-and-completion",
-    title: "Shell: UP arrow and TAB autocompletion does not work",
-    content: (
-      <p>
-        Some docker images use "sh" as the default shell. This shell does not support up arrow and TAB autocompletion. You may try sending the "bash" command to
-        switch to a bash shell which support those feature.
-      </p>
-    )
-  },
-  {
     anchor: "send-manifest-resources-mismatch",
     title: `Error while sending manifest to provider. Error: manifest cross-validation error: group "X": service "X": CPU/Memory resources mismatch for ID 1`,
     content: (

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
@@ -773,7 +773,7 @@ describe(ProviderProxyService.name, () => {
 
       const sentMessage = JSON.parse((websocket.send as Mock).mock.calls[0][0]);
       expect(sentMessage.url).toBe(
-        "https://provider.example.com/lease/100/2/3/shell?stdin=0&tty=0&podIndex=0&&cmd0=sh&cmd1=-c&cmd2=command%20-v%20bash%20%3E%2Fdev%2Fnull%202%3E%261%20%26%26%20exec%20bash%20%7C%7C%20exec%20sh&service=web-service"
+        "https://provider.example.com/lease/100/2/3/shell?stdin=0&tty=0&podIndex=0&cmd0=sh&cmd1=-c&cmd2=command%20-v%20bash%20%3E%2Fdev%2Fnull%202%3E%261%20%26%26%20exec%20bash%20%7C%7C%20exec%20sh&service=web-service"
       );
     });
 

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
@@ -755,7 +755,7 @@ describe(ProviderProxyService.name, () => {
   });
 
   describe("connectToShell", () => {
-    it("constructs correct URL with default command", async () => {
+    it("constructs correct URL with default command (bash with sh fallback)", async () => {
       const { service, websocket } = setup();
       const input = {
         providerBaseUrl: "https://provider.example.com",
@@ -772,7 +772,9 @@ describe(ProviderProxyService.name, () => {
       await dispatchWsEvent(websocket, new Event("open"));
 
       const sentMessage = JSON.parse((websocket.send as Mock).mock.calls[0][0]);
-      expect(sentMessage.url).toBe("https://provider.example.com/lease/100/2/3/shell?stdin=0&tty=0&podIndex=0&&cmd0=%2Fbin%2Fsh&service=web-service");
+      expect(sentMessage.url).toBe(
+        "https://provider.example.com/lease/100/2/3/shell?stdin=0&tty=0&podIndex=0&&cmd0=sh&cmd1=-c&cmd2=command%20-v%20bash%20%3E%2Fdev%2Fnull%202%3E%261%20%26%26%20exec%20bash%20%7C%7C%20exec%20sh&service=web-service"
+      );
     });
 
     it("constructs correct URL with custom command", async () => {
@@ -785,7 +787,7 @@ describe(ProviderProxyService.name, () => {
         gseq: 1,
         oseq: 1,
         service: "api",
-        command: "cat /app/config.json"
+        command: ["cat", "/app/config.json"]
       };
 
       const session = service.connectToShell(input);
@@ -830,7 +832,7 @@ describe(ProviderProxyService.name, () => {
         gseq: 1,
         oseq: 1,
         service: "web",
-        command: "ls -la /app"
+        command: ["ls", "-la", "/app"]
       };
 
       const session = service.connectToShell(input);

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
@@ -148,7 +148,7 @@ export class ProviderProxyService {
     filePath: string;
   }): Promise<DownloadMessagesResult> {
     const printCommand = "cat"; // print command on Windows is "type"
-    const session = this.connectToShell({ ...input, command: `${printCommand} ${input.filePath}` });
+    const session = this.connectToShell({ ...input, command: [printCommand, input.filePath] });
 
     session.send(new Uint8Array());
 
@@ -270,13 +270,11 @@ export class ProviderProxyService {
     service: string;
     useStdIn?: boolean;
     useTTY?: boolean;
-    command?: string;
+    command?: string[];
     signal?: AbortSignal;
   }): WebsocketSession<Uint8Array, ReceivedShellMessage> {
-    const command = (input.command || "/bin/sh")
-      .split(" ")
-      .map((c, i) => `&cmd${i}=${encodeURIComponent(c.replace(" ", "+"))}`)
-      .join("");
+    const argv = input.command ?? ["sh", "-c", "command -v bash >/dev/null 2>&1 && exec bash || exec sh"];
+    const command = argv.map((c, i) => `&cmd${i}=${encodeURIComponent(c)}`).join("");
     const url = `${providerLeaseUrl({ ...input, type: "shell" })}?stdin=${input.useStdIn ? "1" : "0"}&tty=${input.useTTY ? "1" : "0"}&podIndex=0&${command}&service=${encodeURIComponent(input.service)}`;
 
     return new WebsocketSession<Uint8Array, ReceivedShellMessage>({

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
@@ -274,7 +274,7 @@ export class ProviderProxyService {
     signal?: AbortSignal;
   }): WebsocketSession<Uint8Array, ReceivedShellMessage> {
     const argv = input.command ?? ["sh", "-c", "command -v bash >/dev/null 2>&1 && exec bash || exec sh"];
-    const command = argv.map((c, i) => `&cmd${i}=${encodeURIComponent(c)}`).join("");
+    const command = argv.map((c, i) => `cmd${i}=${encodeURIComponent(c)}`).join("&");
     const url = `${providerLeaseUrl({ ...input, type: "shell" })}?stdin=${input.useStdIn ? "1" : "0"}&tty=${input.useTTY ? "1" : "0"}&podIndex=0&${command}&service=${encodeURIComponent(input.service)}`;
 
     return new WebsocketSession<Uint8Array, ReceivedShellMessage>({


### PR DESCRIPTION
## Why

The in-browser deployment shell defaulted to `/bin/sh`, which has no readline support — pressing **Tab** inserts a literal tab character instead of triggering autocomplete, and **Up arrow** does not recall history. The existing FAQ entry and in-app warning acknowledged this as a workaround ("type `bash` to switch") rather than fixing it.

This PR makes the shell prefer `bash` when the container has it, falling back to `sh` transparently — so users get autocomplete + history out of the box without manual intervention, and alpine/busybox/distroless images keep working as before.

## What

- `connectToShell` now defaults to `sh -c 'command -v bash >/dev/null 2>&1 && exec bash || exec sh'` instead of `/bin/sh`. Tested locally against a deployment that has bash (autocomplete works) and the array path itself was confirmed by intermediate iterations.
- Refactored `connectToShell`'s `command` parameter from `string` (space-split) to `string[]`. The old encoding couldn't represent argv elements containing spaces — so it dropped the buggy `c.replace(" ", "+")` workaround. As a side effect, this closes a latent shell-injection footgun in `downloadFileFromShell` where a `filePath` containing spaces would split into multiple `kubectl exec` args.
- Removed the now-misleading "UP arrow and TAB autocompletion" warning and its arrow-key sniffing from `DeploymentLeaseShell`, plus the dead `Link` / `UrlService` / `OpenInWindow` imports.
- Removed the corresponding FAQ entry (`shell-arrows-and-completion`).
- Updated `provider-proxy.service.spec.ts` to reflect the new default URL shape and the array-form `command` input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the UP-arrow/TAB autocompletion warning from the deployment shell interface.

* **Documentation**
  * Removed the related FAQ entry about shell autocompletion issues.

* **Improvements**
  * Improved remote shell command handling and file download reliability, resulting in more robust and predictable remote command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->