### PR TITLE
fix(sdl): show ACT instead of AKT in placement pricing

### DIFF
--- a/apps/deploy-web/src/components/sdl/SimpleServiceFormControl.tsx
+++ b/apps/deploy-web/src/components/sdl/SimpleServiceFormControl.tsx
@@ -29,7 +29,7 @@ import { BinMinusIn, InfoCircle, NavArrowDown } from "iconoir-react";
 import Image from "next/legacy/image";
 
 import { SSHKeyFormControl } from "@src/components/sdl/SSHKeyFromControl";
-import { UAKT_DENOM } from "@src/config/denom.config";
+import { UACT_DENOM } from "@src/config/denom.config";
 import { useSdlBuilder } from "@src/context/SdlBuilderProvider/SdlBuilderProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useFlag } from "@src/hooks/useFlag";
@@ -477,11 +477,11 @@ export const SimpleServiceFormControl: React.FunctionComponent<Props> = ({
                         <div>
                           <strong>Pricing</strong>&nbsp;&nbsp;
                           <span className="inline-flex items-center text-muted-foreground">
-                            Max {udenomToDenom(currentService.placement.pricing.amount, 6)} AKT per block
+                            Max {udenomToDenom(currentService.placement.pricing.amount, 6)} ACT per block
                             <CustomTooltip
                               title={
                                 <>
-                                  The maximum amount of uAKT you're willing to pay per block (~6 seconds).
+                                  The maximum amount of uACT you're willing to pay per block (~6 seconds).
                                   <br />
                                   <br />
                                   Akash will only show providers costing <strong>less</strong> than this amount.
@@ -490,7 +490,7 @@ export const SimpleServiceFormControl: React.FunctionComponent<Props> = ({
                                   <div>
                                     <strong>
                                       ~
-                                      <PriceValue denom={UAKT_DENOM} value={udenomToDenom(getAvgCostPerMonth(currentService.placement.pricing.amount))} />
+                                      <PriceValue denom={UACT_DENOM} value={udenomToDenom(getAvgCostPerMonth(currentService.placement.pricing.amount))} />
                                     </strong>
                                     &nbsp; per month
                                   </div>


### PR DESCRIPTION
## Why

The SDL builder's Placement card was labelling pricing in **AKT / uAKT** even though placement amounts have been stored in **uACT** since the BME rollout. The per-month USD estimate compounded the bug by passing the value through the AKT/USD price feed (`PriceValue denom={UAKT_DENOM}`), so a 0.01 uACT/block placement was being multiplied by the AKT spot rate (~$0.63) and showing as ~$2,712/month instead of the correct ~$4,312/month (ACT is USD-pegged 1:1).

Closes CON-209

## What

In `apps/deploy-web/src/components/sdl/SimpleServiceFormControl.tsx`, the placement pricing block now uses `UACT_DENOM`:

- `Max … AKT per block` → `Max … ACT per block`
- Tooltip: `uAKT` → `uACT`
- `<PriceValue denom={UAKT_DENOM} …>` → `<PriceValue denom={UACT_DENOM} …>`

No logic added — purely swaps the hardcoded denom that was missed during BME, mirroring what `useSupportedDenoms` and the default `placement.pricing.denom` already declare. Verified locally that the per-month figure matches the expected ACT × $1.

| Before (prod) | After (local) |
| --- | --- |
| `Max 0.01 AKT per block` | `Max 0.01 ACT per block` |
| `~$2,712.58 per month` | `~$4,312.49 per month` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pricing display to use ACT/uACT denomination instead of AKT/uAKT in service pricing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->