### PR TITLE
fix(onboarding): replace history when redirecting to deployment

### DIFF
--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
@@ -7,6 +7,7 @@ import { mock } from "vitest-mock-extended";
 import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import type { AuthService } from "@src/services/auth/auth/auth.service";
 import type { ErrorHandlerService } from "@src/services/error-handler/error-handler.service";
+import { RouteStep } from "@src/types/route-steps.type";
 import type { TransactionMessageData } from "@src/utils/TransactionMessageData";
 import { UrlService } from "@src/utils/urlUtils";
 import { OnboardingContainer, OnboardingStepIndex } from "./OnboardingContainer";
@@ -101,14 +102,18 @@ describe("OnboardingContainer", () => {
   });
 
   it("should redirect to deployment and connect managed wallet when onboarding is completed", async () => {
-    const { child, mockRouter, mockConnectManagedWallet } = setup();
+    const { child, mockRouter, mockUrlService, mockConnectManagedWallet } = setup();
 
     const { onComplete } = child.mock.calls[0][0];
     await act(async () => {
       await onComplete("hello-akash");
     });
 
-    expect(mockRouter.replace).toHaveBeenCalled();
+    expect(mockUrlService.newDeployment).toHaveBeenCalledWith({
+      step: RouteStep.createLeases,
+      dseq: "123"
+    });
+    expect(mockRouter.replace).toHaveBeenCalledWith("/deployments/new");
     expect(mockConnectManagedWallet).toHaveBeenCalled();
   });
 

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
@@ -108,7 +108,7 @@ describe("OnboardingContainer", () => {
       await onComplete("hello-akash");
     });
 
-    expect(mockRouter.push).toHaveBeenCalled();
+    expect(mockRouter.replace).toHaveBeenCalled();
     expect(mockConnectManagedWallet).toHaveBeenCalled();
   });
 

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
@@ -315,7 +315,7 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
 
           d.localStorage?.removeItem(ONBOARDING_STEP_KEY);
           wallet.connectManagedWallet();
-          router.push(urlService.newDeployment({ step: RouteStep.createLeases, dseq: dd.deploymentId.dseq }));
+          router.replace(urlService.newDeployment({ step: RouteStep.createLeases, dseq: dd.deploymentId.dseq }));
         }
       } catch (error) {
         notificator.error("Failed to deploy template. Please try again.");


### PR DESCRIPTION
## Why

A user reported that on the onboarding flow, after deploying a trial template, pressing back on the deployment detail page sends them back to the signup/onboarding wizard. Onboarding is a one-way completion flow — users shouldn't be able to navigate back into it once they've completed it.

Tracing the navigation:

1. User on `/signup` (onboarding) selects a template — `OnboardingContainer.complete()` calls `router.push('/new-deployment?step=createLeases&dseq=X')`. History: `[..., /signup, /new-deployment?…]`.
2. The lease-creation step in `CreateLease.tsx` finishes and calls `router.replace('/deployments/X')`, which removes the `/new-deployment` entry. History: `[..., /signup, /deployments/X]`.
3. Pressing back on the deployment detail page triggers `router.back()` and lands the user on `/signup` — the onboarding wizard.

## What

- Switch the onboarding → new-deployment hop to `router.replace` so the onboarding wizard is removed from history. Back from the deployment detail page now lands on whatever the user came from before signup, mirroring the pattern already used by the downstream `CreateLease` redirect and `OnboardingRedirect` component.
- Updated the matching unit test assertion in `OnboardingContainer.spec.tsx` from `mockRouter.push` to `mockRouter.replace`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding completion navigation to replace the current browser history entry when moving to the next deployment step, preventing users from returning to the finished onboarding via the back button.

* **Tests**
  * Tightened onboarding test to assert the specific redirect and route-replacement behavior to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->