### PR TITLE
Revert "chore: moves more jobs to be executed on self-hosted runner (#3128)"

### DIFF
--- a/.github/workflows/all-ci-unsafe.yml
+++ b/.github/workflows/all-ci-unsafe.yml
@@ -91,7 +91,7 @@ jobs:
   setup-static-analyses:
     needs: [create-check-run]
     if: ${{ needs.create-check-run.outputs.run_scan == 'true' }}
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.value }}
       should_run: ${{ !contains(fromJSON(steps.associated_pr.outputs.labels), 'ignore-static-analyses') }}
@@ -154,7 +154,7 @@ jobs:
   apps-deps-scan:
     needs: [create-check-run]
     if: needs.create-check-run.outputs.run_scan == 'true'
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -197,7 +197,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     permissions:
       # required for all workflows
       security-events: write
@@ -247,7 +247,7 @@ jobs:
           max_retries: 10
 
   finalize:
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     needs: [create-check-run, static-analyses, codeql-scan, apps-deps-scan]
     if: ${{ always() && needs.create-check-run.result == 'success' }}
     steps:

--- a/.github/workflows/all-ci.yml
+++ b/.github/workflows/all-ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   setup:
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.matrix.outputs.value }}
     steps:

--- a/.github/workflows/all-release.yml
+++ b/.github/workflows/all-release.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   setup:
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     outputs:
       backends: ${{ steps.matrix.outputs.backends }}
       nextjs: ${{ steps.matrix.outputs.nextjs }}

--- a/.github/workflows/auto-approval.yml
+++ b/.github/workflows/auto-approval.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/console-web-release.yml
+++ b/.github/workflows/console-web-release.yml
@@ -47,7 +47,7 @@ jobs:
       environment: staging
 
   test-beta:
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     needs:
       - setup
       - deploy-beta
@@ -71,7 +71,7 @@ jobs:
 
   auto-approve-decision:
     needs: [setup, test-beta]
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/notifications-release.yml
+++ b/.github/workflows/notifications-release.yml
@@ -48,7 +48,7 @@ jobs:
 
   auto-approve-decision:
     needs: [setup, deploy-beta]
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/provider-proxy-release.yml
+++ b/.github/workflows/provider-proxy-release.yml
@@ -71,7 +71,7 @@ jobs:
       - setup
       - deploy-beta-sandbox
     name: Test beta sandbox
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-e2e-tests
@@ -95,7 +95,7 @@ jobs:
       - setup
       - deploy-beta-mainnet
     name: Test beta mainnet
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-e2e-tests
@@ -153,7 +153,7 @@ jobs:
       - setup
       - deploy-prod-sandbox
     name: Test prod sandbox
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-e2e-tests

--- a/.github/workflows/reusable-create-github-release.yml
+++ b/.github/workflows/reusable-create-github-release.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   release:
     name: Create GitHub Release
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
 
     outputs:
       git_tag: ${{ steps.bumps.outputs.git_tag }}

--- a/.github/workflows/reusable-deploy-k8s.yml
+++ b/.github/workflows/reusable-deploy-k8s.yml
@@ -98,7 +98,7 @@ concurrency:
 
 jobs:
   deployment-prerequisites:
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     outputs:
       environment: ${{ steps.determine-environment.outputs.environment }}
       require_approval: ${{ steps.approval-status.outputs.require_approval }}
@@ -151,7 +151,7 @@ jobs:
     permissions:
       contents: read
       deployments: write
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     needs: deployment-prerequisites
     if: >-
       needs.deployment-prerequisites.outputs.require_approval != 'true' || inputs.approve == 'true' || inputs.approve == true

--- a/.github/workflows/reusable-deploy-setup.yml
+++ b/.github/workflows/reusable-deploy-setup.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   setup:
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     outputs:
       image_tag: ${{ steps.extract.outputs.image_tag }}
       skip: ${{ steps.stale-guard.outputs.skip }}

--- a/.github/workflows/reusable-release-app.yml
+++ b/.github/workflows/reusable-release-app.yml
@@ -52,7 +52,7 @@ jobs:
   deploy:
     needs: [release, build]
     if: needs.release.outputs.git_tag != '' && inputs.deploy_workflow != ''
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     permissions:
       actions: write
     steps:

--- a/.github/workflows/reusable-release-nextjs-app.yml
+++ b/.github/workflows/reusable-release-nextjs-app.yml
@@ -69,7 +69,7 @@ jobs:
   deploy:
     needs: [release, build-beta, build-prod]
     if: needs.release.outputs.git_tag != '' && inputs.deploy_workflow != ''
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     permissions:
       actions: write
     steps:

--- a/.github/workflows/reusable-should-validate.yml
+++ b/.github/workflows/reusable-should-validate.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
   should-validate:
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     outputs:
       enabled: ${{ github.event_name == 'push' || steps.has_changes.outputs.value == 'true' }}
       has_changes: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || github.event_name == 'merge_group') && steps.has_changes.outputs.value }}

--- a/.github/workflows/reusable-validate-app.yml
+++ b/.github/workflows/reusable-validate-app.yml
@@ -122,7 +122,7 @@ jobs:
           npm run -w apps/${{ inputs.app }} build:container
 
   result:
-    runs-on: [self-hosted, akash]
+    runs-on: ubuntu-latest
     needs: [should-validate, validate, test-build]
     if: always()
     permissions:


### PR DESCRIPTION
## Why

This reverts commit 9922adf5a042b199e3219e15690f19fbfcb32517. self-hosted runner is very slow on picking up new jobs,  this adds additional random delay from 2-5mins on every CI job

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow infrastructure to use standard hosted runners across continuous integration, release, and deployment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->