### PR TITLE
fix: uses RegExp.escape to escape USDC denoms

### DIFF
--- a/apps/api/src/billing/services/chain-error/chain-error.service.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.ts
@@ -141,10 +141,10 @@ export class ChainErrorService {
     denom: string;
   } | null {
     const usdcDenoms = Object.values(this.billingConfigService.get("USDC_IBC_DENOMS"))
-      .map(denom => denom.replace(/\//g, "\\/"))
+      .map(denom => RegExp.escape(denom))
       .join("|");
 
-    const pattern = new RegExp(`(\\d+)(uakt|${usdcDenoms}) is smaller than (\\d+)\\2`);
+    const pattern = new RegExp(`(\\d+)(uakt|uact|${usdcDenoms}) is smaller than (\\d+)\\2`);
 
     const match = message.match(pattern);
 

--- a/apps/api/src/types/global.d.ts
+++ b/apps/api/src/types/global.d.ts
@@ -1,0 +1,3 @@
+interface RegExpConstructor {
+  escape(str: string): string;
+}


### PR DESCRIPTION
## Why

Sanitizing untrusted input is a common technique for preventing injection attacks such as SQL injection or cross-site scripting. Usually, this is done by escaping meta-characters such as quotes in a domain-specific way so that they are treated as normal characters.

However, directly using the string replace method to perform escaping is notoriously error-prone. Common mistakes include only replacing the first occurrence of a meta-character, or backslash-escaping various meta-characters but not the backslash itself.

In the former case, later meta-characters are left undisturbed and can be used to subvert the sanitization. In the latter case, preceding a meta-character with a backslash leads to the backslash being escaped, but the meta-character appearing un-escaped, which again makes the sanitization ineffective.

Even if the escaped string is not used in a security-critical context, incomplete escaping may still have undesirable effects, such as badly rendered or confusing output.

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of insufficient-funds error messages so denomination values (including an additional denom) are reliably extracted and shown.
  * Made regex escaping type-safe to ensure denomination matching is robust and avoids mis-parsing.
  * Enhanced extraction of available and required amounts from error text for clearer user-facing messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->