### PR TITLE
feat: adds API endpoint for bid-screening checks

### DIFF
--- a/apps/api/src/bid-screening/controllers/bid-screening/bid-screening.controller.spec.ts
+++ b/apps/api/src/bid-screening/controllers/bid-screening/bid-screening.controller.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import type { BidScreeningRequest } from "../../http-schemas/bid-screening.schema";
+import type { BidScreeningService } from "../../services/bid-screening/bid-screening.service";
+import { BidScreeningController } from "./bid-screening.controller";
+
+describe(BidScreeningController.name, () => {
+  describe("screenProviders", () => {
+    it("returns providers wrapped in response object", async () => {
+      const { controller, service } = setup();
+      service.findMatchingProviders.mockResolvedValue([
+        { owner: "akash1abc", hostUri: "https://provider.example.com:8443", region: "us-east", uptime7d: 0.998, isAudited: false }
+      ]);
+
+      const result = await controller.screenProviders(makeRequest());
+
+      expect(result).toEqual({
+        providers: [{ owner: "akash1abc", hostUri: "https://provider.example.com:8443", region: "us-east", uptime7d: 0.998, isAudited: false }]
+      });
+    });
+
+    it("returns empty providers array when no matches", async () => {
+      const { controller, service } = setup();
+      service.findMatchingProviders.mockResolvedValue([]);
+
+      const result = await controller.screenProviders(makeRequest());
+
+      expect(result).toEqual({ providers: [] });
+    });
+
+    it("passes request to service", async () => {
+      const { controller, service } = setup();
+      service.findMatchingProviders.mockResolvedValue([]);
+      const request = makeRequest();
+
+      await controller.screenProviders(request);
+
+      expect(service.findMatchingProviders).toHaveBeenCalledWith(request);
+    });
+  });
+
+  function setup() {
+    const service = mock<BidScreeningService>();
+    const featureFlagsService = mock<FeatureFlagsService>({
+      isEnabled: () => true
+    });
+    const controller = new BidScreeningController(service, featureFlagsService);
+    return { controller, service, featureFlagsService };
+  }
+});
+
+function makeRequest(): BidScreeningRequest {
+  return {
+    name: "westcoast",
+    requirements: { signedBy: { allOf: [], anyOf: [] }, attributes: [] },
+    resources: [
+      {
+        resource: {
+          id: 1,
+          cpu: { units: { val: "1000" }, attributes: [] },
+          memory: { quantity: { val: "1073741824" }, attributes: [] },
+          gpu: { units: { val: "0" }, attributes: [] },
+          storage: [{ name: "default", quantity: { val: "5368709120" }, attributes: [{ key: "persistent", value: "false" }] }],
+          endpoints: []
+        },
+        count: 1,
+        price: { denom: "uakt", amount: "1000" }
+      }
+    ]
+  };
+}

--- a/apps/api/src/bid-screening/controllers/bid-screening/bid-screening.controller.ts
+++ b/apps/api/src/bid-screening/controllers/bid-screening/bid-screening.controller.ts
@@ -1,0 +1,27 @@
+import { singleton } from "tsyringe";
+
+import type { GroupSpecJSON } from "@src/bid-screening/lib/groupspec-mapper/groupspec-mapper";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import type { BidScreeningRequest, BidScreeningResponse } from "../../http-schemas/bid-screening.schema";
+import { BidScreeningService } from "../../services/bid-screening/bid-screening.service";
+
+@singleton()
+export class BidScreeningController {
+  readonly #bidScreeningService: BidScreeningService;
+  readonly #featureFlagsService: FeatureFlagsService;
+
+  constructor(bidScreeningService: BidScreeningService, featureFlagsService: FeatureFlagsService) {
+    this.#bidScreeningService = bidScreeningService;
+    this.#featureFlagsService = featureFlagsService;
+  }
+
+  async screenProviders(request: BidScreeningRequest): Promise<BidScreeningResponse> {
+    if (!this.#featureFlagsService.isEnabled(FeatureFlags.BID_SCREENING)) {
+      return { providers: [] };
+    }
+
+    const results = await this.#bidScreeningService.findMatchingProviders(request as GroupSpecJSON);
+    return { providers: results };
+  }
+}

--- a/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
+++ b/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
@@ -1,0 +1,80 @@
+import { z } from "@hono/zod-openapi";
+
+const ResourceValueSchema = z.object({
+  val: z.string().openapi({ description: "String-encoded integer value", example: "1000" })
+});
+
+const AttributeSchema = z.object({
+  key: z.string().openapi({ description: "Attribute key", example: "persistent" }),
+  value: z.string().openapi({ description: "Attribute value", example: "false" })
+});
+
+const StorageResourceSchema = z.object({
+  name: z.string().openapi({ description: "Storage volume name", example: "default" }),
+  quantity: ResourceValueSchema,
+  attributes: z.array(AttributeSchema)
+});
+
+const ResourceSchema = z.object({
+  id: z.number().int().openapi({ description: "Resource unit ID", example: 1 }),
+  cpu: z.object({
+    units: ResourceValueSchema,
+    attributes: z.array(AttributeSchema)
+  }),
+  memory: z.object({
+    quantity: ResourceValueSchema,
+    attributes: z.array(AttributeSchema)
+  }),
+  gpu: z.object({
+    units: ResourceValueSchema,
+    attributes: z.array(AttributeSchema)
+  }),
+  storage: z.array(StorageResourceSchema),
+  endpoints: z.array(z.unknown()).optional()
+});
+
+const PriceSchema = z.object({
+  denom: z.string(),
+  amount: z.string()
+});
+
+const ResourceUnitSchema = z.object({
+  resource: ResourceSchema,
+  count: z.number().int().min(1).openapi({ description: "Replica count", example: 1 }),
+  price: PriceSchema
+});
+
+const SignedBySchema = z.object({
+  allOf: z.array(z.string()).default([]),
+  anyOf: z.array(z.string()).default([])
+});
+
+const RequirementsSchema = z.object({
+  signedBy: SignedBySchema.default({}),
+  attributes: z.array(AttributeSchema).default([])
+});
+
+export const BidScreeningRequestSchema = z.object({
+  name: z.string().openapi({ description: "Group name", example: "westcoast" }),
+  requirements: RequirementsSchema.default({}),
+  resources: z.array(ResourceUnitSchema).min(1).openapi({ description: "Resource units with replica counts" })
+});
+export type BidScreeningRequest = z.infer<typeof BidScreeningRequestSchema>;
+
+const ProviderResultSchema = z.object({
+  owner: z.string().openapi({ description: "Provider address", example: "akash1q7spv2cw06yszgfp4f9ed59lkka6ytn8g4tkjf" }),
+  hostUri: z.string().openapi({ description: "Provider HTTPS endpoint", example: "https://provider.europlots.com:8443" }),
+  region: z.string().nullable().openapi({ description: "Geo-resolved region from IP" }),
+  uptime7d: z.number().nullable().openapi({ description: "7-day uptime as decimal (0.0-1.0)", example: 0.998 }),
+  isAudited: z.boolean().openapi({ description: "True if signed by a known auditor" })
+});
+
+export const BidScreeningResponseSchema = z.object({
+  providers: z.array(ProviderResultSchema)
+});
+export type BidScreeningResponse = z.infer<typeof BidScreeningResponseSchema>;
+
+export const BidScreeningErrorSchema = z.object({
+  error: z.string(),
+  message: z.string()
+});

--- a/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
+++ b/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
@@ -1,7 +1,9 @@
 import { z } from "@hono/zod-openapi";
 
+const UIntStringSchema = z.string().regex(/^\d+$/, "Must be an unsigned integer string");
+
 const ResourceValueSchema = z.object({
-  val: z.string().openapi({ description: "String-encoded integer value", example: "1000" })
+  val: UIntStringSchema.openapi({ description: "String-encoded integer value", example: "1000" })
 });
 
 const AttributeSchema = z.object({
@@ -35,7 +37,7 @@ const ResourceSchema = z.object({
 
 const PriceSchema = z.object({
   denom: z.string(),
-  amount: z.string()
+  amount: UIntStringSchema
 });
 
 const ResourceUnitSchema = z.object({

--- a/apps/api/src/bid-screening/index.ts
+++ b/apps/api/src/bid-screening/index.ts
@@ -1,0 +1,1 @@
+export { bidScreeningRouter } from "./routes/bid-screening.router";

--- a/apps/api/src/bid-screening/repositories/bid-screening/bid-screening.repository.integration.ts
+++ b/apps/api/src/bid-screening/repositories/bid-screening/bid-screening.repository.integration.ts
@@ -46,10 +46,11 @@ describe(BidScreeningRepository.name, () => {
       await ProviderSnapshotStorage.create({ snapshotId: provider.snapshotId, class: "beta3", allocatable: 100000000000, allocated: 0 });
 
       const results = await repository.getOnlineProvidersWithSnapshots();
+      const matchedProvider = results.find(p => p.owner === provider.owner);
 
-      expect(results[0].lastSuccessfulSnapshot.nodes).toHaveLength(1);
-      expect(results[0].lastSuccessfulSnapshot.storage).toHaveLength(1);
-      expect(results[0].lastSuccessfulSnapshot.storage[0].class).toBe("beta3");
+      expect(matchedProvider?.lastSuccessfulSnapshot.nodes).toHaveLength(1);
+      expect(matchedProvider?.lastSuccessfulSnapshot.storage).toHaveLength(1);
+      expect(matchedProvider?.lastSuccessfulSnapshot.storage[0].class).toBe("beta3");
     });
 
     it("returns empty array when owner list is empty", async () => {

--- a/apps/api/src/bid-screening/repositories/bid-screening/bid-screening.repository.integration.ts
+++ b/apps/api/src/bid-screening/repositories/bid-screening/bid-screening.repository.integration.ts
@@ -1,0 +1,185 @@
+import { Provider, ProviderAttributeSignature, ProviderSnapshot, ProviderSnapshotStorage } from "@akashnetwork/database/dbSchemas/akash";
+import { Op } from "sequelize";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CHAIN_DB } from "@src/chain";
+import { BidScreeningRepository } from "./bid-screening.repository";
+
+import { createAkashAddress, createProviderSeed, createProviderSnapshot, createProviderSnapshotNode } from "@test/seeders";
+
+describe(BidScreeningRepository.name, () => {
+  const providerOwners = new Set<string>();
+  const snapshotIds = new Set<string>();
+
+  afterEach(async () => {
+    if (providerOwners.size > 0) {
+      await Provider.update({ lastSuccessfulSnapshotId: null, lastSnapshotId: null }, { where: { owner: { [Op.in]: Array.from(providerOwners) } } });
+      await Provider.destroy({ where: { owner: { [Op.in]: Array.from(providerOwners) } }, cascade: true });
+      providerOwners.clear();
+    }
+    if (snapshotIds.size > 0) {
+      await ProviderSnapshot.destroy({ where: { id: { [Op.in]: Array.from(snapshotIds) } }, cascade: true });
+      snapshotIds.clear();
+    }
+  });
+
+  describe("getOnlineProvidersWithSnapshots", () => {
+    it("returns full provider and snapshot data", async () => {
+      const { repository } = setup();
+      const provider = await createTestProvider({ availableCPU: 4000, availableMemory: 4294967296, availableEphemeralStorage: 10737418240 });
+      const other = await createTestProvider({ availableCPU: 4000, availableMemory: 4294967296, availableEphemeralStorage: 10737418240 });
+
+      const results = await repository.getOnlineProvidersWithSnapshots();
+
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ owner: other.owner, lastSuccessfulSnapshot: expect.any(Object) }),
+          expect.objectContaining({ owner: provider.owner, lastSuccessfulSnapshot: expect.any(Object) })
+        ])
+      );
+    });
+
+    it("includes nodes and storage in the snapshot", async () => {
+      const { repository } = setup();
+      const provider = await createTestProvider({ availableCPU: 4000, availableMemory: 4294967296, availableEphemeralStorage: 10737418240 });
+      await ProviderSnapshotStorage.create({ snapshotId: provider.snapshotId, class: "beta3", allocatable: 100000000000, allocated: 0 });
+
+      const results = await repository.getOnlineProvidersWithSnapshots();
+
+      expect(results[0].lastSuccessfulSnapshot.nodes).toHaveLength(1);
+      expect(results[0].lastSuccessfulSnapshot.storage).toHaveLength(1);
+      expect(results[0].lastSuccessfulSnapshot.storage[0].class).toBe("beta3");
+    });
+
+    it("returns empty array when owner list is empty", async () => {
+      const { repository } = setup();
+
+      const results = await repository.getOnlineProvidersWithSnapshots();
+
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe("getAuditedProviderAddresses", () => {
+    it("returns provider addresses signed by any of the given auditors", async () => {
+      const { repository } = setup();
+      const auditor = createAkashAddress();
+
+      const audited = await createTestProviderWithoutSnapshot();
+      await ProviderAttributeSignature.create({ provider: audited.owner, auditor, key: "region", value: "us-east" });
+
+      const notAudited = await createTestProviderWithoutSnapshot();
+
+      const result = await repository.getAuditedProviderAddresses([auditor]);
+
+      expect(result).toBeInstanceOf(Set);
+      expect(result.has(audited.owner)).toBe(true);
+      expect(result.has(notAudited.owner)).toBe(false);
+    });
+
+    it("returns addresses audited by any of multiple auditors", async () => {
+      const { repository } = setup();
+      const [auditor1, auditor2] = [createAkashAddress(), createAkashAddress()];
+
+      const byFirst = await createTestProviderWithoutSnapshot();
+      await ProviderAttributeSignature.create({ provider: byFirst.owner, auditor: auditor1, key: "region", value: "us-east" });
+
+      const bySecond = await createTestProviderWithoutSnapshot();
+      await ProviderAttributeSignature.create({ provider: bySecond.owner, auditor: auditor2, key: "region", value: "us-east" });
+
+      const result = await repository.getAuditedProviderAddresses([auditor1, auditor2]);
+
+      expect(result.has(byFirst.owner)).toBe(true);
+      expect(result.has(bySecond.owner)).toBe(true);
+    });
+
+    it("returns empty set when no providers are audited", async () => {
+      const { repository } = setup();
+      const auditor = createAkashAddress();
+
+      const result = await repository.getAuditedProviderAddresses([auditor]);
+
+      expect(result.size).toBe(0);
+    });
+  });
+
+  function setup() {
+    return { repository: new BidScreeningRepository() };
+  }
+
+  let providerIndex = 0;
+
+  async function createTestProvider(
+    snapshotOverrides: {
+      availableCPU?: number;
+      availableMemory?: number;
+      availableEphemeralStorage?: number;
+      availableGPU?: number;
+      availablePersistentStorage?: number;
+      isOnline?: boolean;
+      deletedHeight?: number;
+      skipDefaultNode?: boolean;
+    } = {}
+  ): Promise<{ owner: string; hostUri: string; snapshotId: string }> {
+    const { isOnline = true, deletedHeight, skipDefaultNode = false, ...snapshotFields } = snapshotOverrides;
+    const height = await container.resolve(CHAIN_DB).models.block.max("height");
+
+    const owner = createAkashAddress();
+    const hostUri = `https://test-provider-${++providerIndex}-${Date.now()}.akash.network:8443`;
+    const provider = await Provider.create({
+      ...createProviderSeed({ owner, hostUri, isOnline, lastSnapshotId: null, createdHeight: height, updatedHeight: height }),
+      deletedHeight: deletedHeight ?? null,
+      lastSuccessfulSnapshotId: null
+    });
+    providerOwners.add(provider.owner);
+
+    const nodeCpu = snapshotFields.availableCPU ?? 8000;
+    const nodeMemory = snapshotFields.availableMemory ?? 17179869184;
+    const nodeEphemeral = snapshotFields.availableEphemeralStorage ?? 107374182400;
+    const nodeGpu = snapshotFields.availableGPU ?? 0;
+
+    const snapshot = await createProviderSnapshot({
+      owner: provider.owner,
+      availableCPU: nodeCpu,
+      availableMemory: nodeMemory,
+      availableEphemeralStorage: nodeEphemeral,
+      availableGPU: nodeGpu,
+      availablePersistentStorage: snapshotFields.availablePersistentStorage ?? 0
+    });
+    snapshotIds.add(snapshot.id);
+
+    if (!skipDefaultNode) {
+      await createProviderSnapshotNode({
+        snapshotId: snapshot.id,
+        cpuAllocatable: nodeCpu,
+        cpuAllocated: 0,
+        memoryAllocatable: nodeMemory,
+        memoryAllocated: 0,
+        ephemeralStorageAllocatable: nodeEphemeral,
+        ephemeralStorageAllocated: 0,
+        gpuAllocatable: nodeGpu,
+        gpuAllocated: 0,
+        capabilitiesStorageSSD: false,
+        capabilitiesStorageHDD: false,
+        capabilitiesStorageNVME: false
+      });
+    }
+
+    await provider.update({ lastSuccessfulSnapshotId: snapshot.id });
+
+    return { owner: provider.owner, hostUri: provider.hostUri, snapshotId: snapshot.id };
+  }
+
+  async function createTestProviderWithoutSnapshot(): Promise<{ owner: string }> {
+    const height = await container.resolve(CHAIN_DB).models.block.max("height");
+    const owner = createAkashAddress();
+    const hostUri = `https://test-provider-${++providerIndex}-${Date.now()}.akash.network:8443`;
+    await Provider.create({
+      ...createProviderSeed({ owner, hostUri, isOnline: true, lastSnapshotId: null, createdHeight: height, updatedHeight: height }),
+      lastSuccessfulSnapshotId: null
+    });
+    providerOwners.add(owner);
+    return { owner };
+  }
+});

--- a/apps/api/src/bid-screening/repositories/bid-screening/bid-screening.repository.ts
+++ b/apps/api/src/bid-screening/repositories/bid-screening/bid-screening.repository.ts
@@ -45,7 +45,7 @@ export class BidScreeningRepository {
       ]
     });
 
-    return providers as unknown as ProviderWithSnapshot[];
+    return providers;
   }
 
   async getAuditedProviderAddresses(auditorAddresses: string[]): Promise<Set<string>> {

--- a/apps/api/src/bid-screening/repositories/bid-screening/bid-screening.repository.ts
+++ b/apps/api/src/bid-screening/repositories/bid-screening/bid-screening.repository.ts
@@ -1,0 +1,62 @@
+import {
+  Provider,
+  ProviderAttributeSignature,
+  ProviderSnapshot,
+  ProviderSnapshotNode,
+  ProviderSnapshotNodeCPU,
+  ProviderSnapshotNodeGPU,
+  ProviderSnapshotStorage
+} from "@akashnetwork/database/dbSchemas/akash";
+import { Op } from "sequelize";
+import { singleton } from "tsyringe";
+
+import { ProviderWithSnapshot } from "@src/bid-screening/types/provider";
+
+@singleton()
+export class BidScreeningRepository {
+  async getOnlineProvidersWithSnapshots(): Promise<ProviderWithSnapshot[]> {
+    const providers = await Provider.findAll({
+      attributes: ["owner", "hostUri", "ipRegion", "uptime7d"],
+      where: {
+        isOnline: true,
+        deletedHeight: null,
+        lastSuccessfulSnapshotId: { [Op.ne]: null }
+      },
+      include: [
+        {
+          model: ProviderSnapshot,
+          as: "lastSuccessfulSnapshot",
+          required: true,
+          include: [
+            {
+              model: ProviderSnapshotNode,
+              required: false,
+              include: [
+                { model: ProviderSnapshotNodeGPU, required: false },
+                { model: ProviderSnapshotNodeCPU, required: false }
+              ]
+            },
+            {
+              model: ProviderSnapshotStorage,
+              required: false
+            }
+          ]
+        }
+      ]
+    });
+
+    return providers as unknown as ProviderWithSnapshot[];
+  }
+
+  async getAuditedProviderAddresses(auditorAddresses: string[]): Promise<Set<string>> {
+    const signatures = await ProviderAttributeSignature.findAll({
+      attributes: ["provider"],
+      where: {
+        auditor: { [Op.in]: auditorAddresses }
+      },
+      raw: true
+    });
+
+    return new Set(signatures.map(s => s.provider));
+  }
+}

--- a/apps/api/src/bid-screening/routes/bid-screening.router.ts
+++ b/apps/api/src/bid-screening/routes/bid-screening.router.ts
@@ -1,0 +1,46 @@
+import { container } from "tsyringe";
+
+import { createRoute } from "@src/core/lib/create-route/create-route";
+import { OpenApiHonoHandler } from "@src/core/services/open-api-hono-handler/open-api-hono-handler";
+import { SECURITY_NONE } from "@src/core/services/openapi-docs/openapi-security";
+import { BidScreeningController } from "../controllers/bid-screening/bid-screening.controller";
+import { BidScreeningRequestSchema, BidScreeningResponseSchema } from "../http-schemas/bid-screening.schema";
+
+export const bidScreeningRouter = new OpenApiHonoHandler();
+
+const postBidScreeningRoute = createRoute({
+  method: "post",
+  path: "/v1/bid-screening",
+  summary: "Screen providers by deployment resource requirements",
+  tags: ["Bid Screening"],
+  security: SECURITY_NONE,
+  bodyLimit: { maxSize: 64 * 1024 },
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: BidScreeningRequestSchema
+        }
+      }
+    }
+  },
+  responses: {
+    200: {
+      description: "Returns matching providers",
+      content: {
+        "application/json": {
+          schema: BidScreeningResponseSchema
+        }
+      }
+    },
+    400: {
+      description: "Invalid request body"
+    }
+  }
+});
+
+bidScreeningRouter.openapi(postBidScreeningRoute, async function routePostBidScreening(c) {
+  const request = c.req.valid("json");
+  const response = await container.resolve(BidScreeningController).screenProviders(request);
+  return c.json(response, 200);
+});

--- a/apps/api/src/bid-screening/services/bid-screening/bid-screening.service.spec.ts
+++ b/apps/api/src/bid-screening/services/bid-screening/bid-screening.service.spec.ts
@@ -1,0 +1,159 @@
+import type { LoggerService } from "@akashnetwork/logging";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { GroupSpecJSON } from "@src/bid-screening/lib/groupspec-mapper/groupspec-mapper";
+import type { BidScreeningRepository } from "../../repositories/bid-screening/bid-screening.repository";
+import type { ProviderWithSnapshot } from "../../types/provider";
+import type { ClusterInventoryMatcherService } from "../cluster-inventory-matcher/cluster-inventory-matcher.service";
+import { BidScreeningService } from "./bid-screening.service";
+
+describe(BidScreeningService.name, () => {
+  describe("findMatchingProviders", () => {
+    it("returns passing providers with metadata", async () => {
+      const { service, repository, matcher } = setup();
+      repository.getOnlineProvidersWithSnapshots.mockResolvedValue([makeProvider("akash1abc")]);
+      repository.getAuditedProviderAddresses.mockResolvedValue(new Set());
+      matcher.match.mockReturnValue({ matched: true });
+
+      const results = await service.findMatchingProviders(makeRequest());
+
+      expect(results).toEqual([
+        {
+          owner: "akash1abc",
+          hostUri: "https://provider.example.com:8443",
+          region: "us-east",
+          uptime7d: 0.998,
+          isAudited: false
+        }
+      ]);
+    });
+
+    it("filters out providers that fail matching", async () => {
+      const { service, repository, matcher } = setup();
+      repository.getOnlineProvidersWithSnapshots.mockResolvedValue([makeProvider("akash1abc"), makeProvider("akash1def")]);
+      repository.getAuditedProviderAddresses.mockResolvedValue(new Set());
+      matcher.match.mockReturnValueOnce({ matched: true }).mockReturnValueOnce({ matched: false, error: "INSUFFICIENT_CAPACITY" });
+
+      const results = await service.findMatchingProviders(makeRequest());
+
+      expect(results).toHaveLength(1);
+      expect(results[0].owner).toBe("akash1abc");
+    });
+
+    it("returns empty array when no providers are online", async () => {
+      const { service, repository } = setup();
+      repository.getOnlineProvidersWithSnapshots.mockResolvedValue([]);
+      repository.getAuditedProviderAddresses.mockResolvedValue(new Set());
+
+      const results = await service.findMatchingProviders(makeRequest());
+
+      expect(results).toEqual([]);
+    });
+
+    it("returns empty array when all providers fail matching", async () => {
+      const { service, repository, matcher } = setup();
+      repository.getOnlineProvidersWithSnapshots.mockResolvedValue([makeProvider("akash1abc")]);
+      repository.getAuditedProviderAddresses.mockResolvedValue(new Set());
+      matcher.match.mockReturnValue({ matched: false, error: "INSUFFICIENT_CAPACITY" });
+
+      const results = await service.findMatchingProviders(makeRequest());
+
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe("filtering", () => {
+    it("loads providers and audited owners in parallel after pre-filter", async () => {
+      const { service, repository, matcher } = setup();
+      repository.getOnlineProvidersWithSnapshots.mockResolvedValue([makeProvider("akash1abc")]);
+      repository.getAuditedProviderAddresses.mockResolvedValue(new Set());
+      matcher.match.mockReturnValue({ matched: true });
+
+      await service.findMatchingProviders(makeRequest());
+
+      expect(repository.getOnlineProvidersWithSnapshots).toHaveBeenCalledTimes(1);
+      expect(repository.getAuditedProviderAddresses).toHaveBeenCalledTimes(1);
+    });
+
+    it("enriches isAudited=true for providers with matching auditor signatures", async () => {
+      const { service, repository, matcher } = setup();
+      repository.getOnlineProvidersWithSnapshots.mockResolvedValue([makeProvider("akash1abc"), makeProvider("akash1def")]);
+      repository.getAuditedProviderAddresses.mockResolvedValue(new Set(["akash1abc"]));
+      matcher.match.mockReturnValue({ matched: true });
+
+      const results = await service.findMatchingProviders(makeRequest());
+
+      expect(results).toHaveLength(2);
+      expect(results.find(r => r.owner === "akash1abc")?.isAudited).toBe(true);
+      expect(results.find(r => r.owner === "akash1def")?.isAudited).toBe(false);
+    });
+  });
+
+  function setup() {
+    const repository = mock<BidScreeningRepository>();
+    const matcher = mock<ClusterInventoryMatcherService>();
+    const logger = mock<LoggerService>();
+    const service = new BidScreeningService(repository, matcher, logger);
+    return { service, repository, matcher, logger };
+  }
+});
+
+function makeProvider(owner: string, hostUri = "https://provider.example.com:8443"): ProviderWithSnapshot {
+  return {
+    owner,
+    hostUri,
+    ipRegion: "us-east",
+    uptime7d: 0.998,
+    lastSuccessfulSnapshot: {
+      nodes: [
+        {
+          name: "node1",
+          cpuAllocatable: 8000,
+          cpuAllocated: 0,
+          memoryAllocatable: 17179869184,
+          memoryAllocated: 0,
+          ephemeralStorageAllocatable: 107374182400,
+          ephemeralStorageAllocated: 0,
+          gpuAllocatable: 0,
+          gpuAllocated: 0,
+          capabilitiesStorageHDD: false,
+          capabilitiesStorageSSD: true,
+          capabilitiesStorageNVME: false,
+          gpus: [],
+          cpus: []
+        }
+      ],
+      storage: []
+    }
+  };
+}
+
+function makeRequest(
+  overrides?: Partial<{
+    attributes: { key: string; value: string }[];
+    signedBy: { allOf: string[]; anyOf: string[] };
+  }>
+): GroupSpecJSON {
+  return {
+    name: "westcoast",
+    requirements: {
+      signedBy: overrides?.signedBy ?? { allOf: [], anyOf: [] },
+      attributes: overrides?.attributes ?? []
+    },
+    resources: [
+      {
+        resource: {
+          id: 1,
+          cpu: { units: { val: "1000" }, attributes: [] },
+          memory: { quantity: { val: "1073741824" }, attributes: [] },
+          gpu: { units: { val: "0" }, attributes: [] },
+          storage: [{ name: "default", quantity: { val: "5368709120" }, attributes: [{ key: "persistent", value: "false" }] }],
+          endpoints: []
+        },
+        count: 1,
+        price: { denom: "uakt", amount: "1000" }
+      }
+    ]
+  };
+}

--- a/apps/api/src/bid-screening/services/bid-screening/bid-screening.service.ts
+++ b/apps/api/src/bid-screening/services/bid-screening/bid-screening.service.ts
@@ -1,0 +1,103 @@
+import { BadRequest } from "http-errors";
+import { singleton } from "tsyringe";
+
+import { LoggerService } from "@src/core/providers/logging.provider";
+import { AUDITOR } from "@src/deployment/config/provider.config";
+import { GroupSpecJSON, mapGroupSpecToResourceUnits } from "../../lib/groupspec-mapper/groupspec-mapper";
+import { BidScreeningRepository } from "../../repositories/bid-screening/bid-screening.repository";
+import type { BidScreeningResult } from "../../types/inventory.types";
+import type { ProviderWithSnapshot } from "../../types/provider";
+import { ClusterInventoryMatcherService } from "../cluster-inventory-matcher/cluster-inventory-matcher.service";
+
+@singleton()
+export class BidScreeningService {
+  readonly #repository: BidScreeningRepository;
+  readonly #matcher: ClusterInventoryMatcherService;
+  readonly #logger: LoggerService;
+
+  constructor(repository: BidScreeningRepository, matcher: ClusterInventoryMatcherService, logger: LoggerService) {
+    this.#repository = repository;
+    this.#matcher = matcher;
+    this.#logger = logger;
+  }
+
+  async findMatchingProviders(request: GroupSpecJSON): Promise<BidScreeningResult[]> {
+    const startTime = Date.now();
+
+    this.#validateRequest(request);
+
+    const resourceUnits = mapGroupSpecToResourceUnits(request);
+
+    this.#logger.info({ event: "BID_SCREENING_START", resourceGroupCount: resourceUnits.length });
+
+    const [providers, auditedOwners] = await Promise.all([
+      this.#repository.getOnlineProvidersWithSnapshots(),
+      this.#repository.getAuditedProviderAddresses([AUDITOR])
+    ]);
+
+    const results: BidScreeningResult[] = [];
+
+    for (const provider of providers) {
+      const matchResult = this.#matcher.match(provider, resourceUnits);
+
+      if (matchResult.matched) {
+        results.push(this.#toResult(provider, auditedOwners.has(provider.owner)));
+      }
+    }
+
+    this.#logger.info({
+      event: "BID_SCREENING_COMPLETE",
+      providerCount: providers.length,
+      matchedCount: results.length,
+      durationMs: Date.now() - startTime
+    });
+
+    return results;
+  }
+
+  #validateRequest(request: GroupSpecJSON): void {
+    if (request.resources.length === 0) {
+      throw new BadRequest("GroupSpec must contain at least one resource unit");
+    }
+
+    for (let i = 0; i < request.resources.length; i++) {
+      const resource = request.resources[i].resource;
+
+      for (let j = 0; j < resource.storage.length; j++) {
+        const vol = resource.storage[j];
+        const isPersistent = vol.attributes.some(a => a.key === "persistent" && a.value === "true");
+        const storageClass = vol.attributes.find(a => a.key === "class")?.value;
+        const isRam = storageClass === "ram";
+
+        if (isPersistent && (!storageClass || storageClass === "ram")) {
+          throw new BadRequest(`Persistent storage volume "${vol.name}" must specify a valid storage class (not "${storageClass || "empty"}")`);
+        }
+
+        if (isPersistent && isRam) {
+          throw new BadRequest(`Persistent storage volume "${vol.name}" cannot use RAM storage class`);
+        }
+      }
+
+      if (resource.gpu.units.val !== "0") {
+        const gpuAttrs = resource.gpu.attributes.filter(a => a.value === "true");
+        for (const attr of gpuAttrs) {
+          const parts = attr.key.split("/");
+          const hasVendor = parts.includes("vendor") && parts.indexOf("vendor") + 1 < parts.length;
+          if (!hasVendor) {
+            throw new BadRequest(`GPU attribute "${attr.key}" must include a vendor (e.g., vendor/nvidia/model/a100)`);
+          }
+        }
+      }
+    }
+  }
+
+  #toResult(provider: ProviderWithSnapshot, isAudited: boolean): BidScreeningResult {
+    return {
+      owner: provider.owner,
+      hostUri: provider.hostUri,
+      region: provider.ipRegion ?? null,
+      uptime7d: provider.uptime7d ?? null,
+      isAudited
+    };
+  }
+}

--- a/apps/api/src/bid-screening/services/bid-screening/bid-screening.service.ts
+++ b/apps/api/src/bid-screening/services/bid-screening/bid-screening.service.ts
@@ -69,23 +69,8 @@ export class BidScreeningService {
         const storageClass = vol.attributes.find(a => a.key === "class")?.value;
         const isRam = storageClass === "ram";
 
-        if (isPersistent && (!storageClass || storageClass === "ram")) {
+        if (isPersistent && (!storageClass || isRam)) {
           throw new BadRequest(`Persistent storage volume "${vol.name}" must specify a valid storage class (not "${storageClass || "empty"}")`);
-        }
-
-        if (isPersistent && isRam) {
-          throw new BadRequest(`Persistent storage volume "${vol.name}" cannot use RAM storage class`);
-        }
-      }
-
-      if (resource.gpu.units.val !== "0") {
-        const gpuAttrs = resource.gpu.attributes.filter(a => a.value === "true");
-        for (const attr of gpuAttrs) {
-          const parts = attr.key.split("/");
-          const hasVendor = parts.includes("vendor") && parts.indexOf("vendor") + 1 < parts.length;
-          if (!hasVendor) {
-            throw new BadRequest(`GPU attribute "${attr.key}" must include a vendor (e.g., vendor/nvidia/model/a100)`);
-          }
         }
       }
     }

--- a/apps/api/src/bid-screening/types/provider.ts
+++ b/apps/api/src/bid-screening/types/provider.ts
@@ -1,8 +1,8 @@
 export interface ProviderWithSnapshot {
   owner: string;
   hostUri: string;
-  ipRegion: string | null;
-  uptime7d: number | null;
+  ipRegion?: string | null;
+  uptime7d?: number | null;
   lastSuccessfulSnapshot: {
     nodes: {
       name: string;

--- a/apps/api/src/core/services/feature-flags/feature-flags.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.ts
@@ -2,7 +2,8 @@ export const FeatureFlags = {
   NOTIFICATIONS_ALERT_CREATE: "notifications_general_alerts_create",
   NOTIFICATIONS_ALERT_UPDATE: "notifications_general_alerts_update",
   AUTO_CREDIT_RELOAD: "auto_credit_reload",
-  TRIAL_FINGERPRINT_CHECK: "trial_fingerprint_check"
+  TRIAL_FINGERPRINT_CHECK: "trial_fingerprint_check",
+  BID_SCREENING: "bid_screening"
 } as const;
 
 export type FeatureFlagValue = (typeof FeatureFlags)[keyof typeof FeatureFlags];

--- a/apps/api/src/rest-app.ts
+++ b/apps/api/src/rest-app.ts
@@ -33,6 +33,7 @@ import { web3IndexRouter } from "./routers/web3indexRouter";
 import { bytesToHumanReadableSize } from "./utils/files";
 import { addressRouter } from "./address";
 import { apiKeysRouter, sendVerificationCodeRouter, sendVerificationEmailRouter, signupRouter, verifyEmailCodeRouter } from "./auth";
+import { bidScreeningRouter } from "./bid-screening";
 import {
   getBalancesRouter,
   getWalletListRouter,
@@ -160,7 +161,8 @@ const openApiHonoHandlers: OpenApiHonoHandler[] = [
   templatesRouter,
   leasesDurationRouter,
   addressRouter,
-  blockchainStatusRouter
+  blockchainStatusRouter,
+  bidScreeningRouter
 ];
 for (const handler of openApiHonoHandlers) {
   appHono.route("/", handler);

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -2810,6 +2810,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "price": {
                           "properties": {
                             "amount": {
+                              "pattern": "^\\d+$",
                               "type": "string",
                             },
                             "denom": {
@@ -2853,6 +2854,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "val": {
                                       "description": "String-encoded integer value",
                                       "example": "1000",
+                                      "pattern": "^\\d+$",
                                       "type": "string",
                                     },
                                   },
@@ -2903,6 +2905,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "val": {
                                       "description": "String-encoded integer value",
                                       "example": "1000",
+                                      "pattern": "^\\d+$",
                                       "type": "string",
                                     },
                                   },
@@ -2952,6 +2955,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                     "val": {
                                       "description": "String-encoded integer value",
                                       "example": "1000",
+                                      "pattern": "^\\d+$",
                                       "type": "string",
                                     },
                                   },
@@ -3002,6 +3006,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                       "val": {
                                         "description": "String-encoded integer value",
                                         "example": "1000",
+                                        "pattern": "^\\d+$",
                                         "type": "string",
                                       },
                                     },

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -2736,6 +2736,388 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
     },
+    "/v1/bid-screening": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "name": {
+                    "description": "Group name",
+                    "example": "westcoast",
+                    "type": "string",
+                  },
+                  "requirements": {
+                    "default": {},
+                    "properties": {
+                      "attributes": {
+                        "default": [],
+                        "items": {
+                          "properties": {
+                            "key": {
+                              "description": "Attribute key",
+                              "example": "persistent",
+                              "type": "string",
+                            },
+                            "value": {
+                              "description": "Attribute value",
+                              "example": "false",
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "key",
+                            "value",
+                          ],
+                          "type": "object",
+                        },
+                        "type": "array",
+                      },
+                      "signedBy": {
+                        "default": {},
+                        "properties": {
+                          "allOf": {
+                            "default": [],
+                            "items": {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                          "anyOf": {
+                            "default": [],
+                            "items": {
+                              "type": "string",
+                            },
+                            "type": "array",
+                          },
+                        },
+                        "type": "object",
+                      },
+                    },
+                    "type": "object",
+                  },
+                  "resources": {
+                    "description": "Resource units with replica counts",
+                    "items": {
+                      "properties": {
+                        "count": {
+                          "description": "Replica count",
+                          "example": 1,
+                          "minimum": 1,
+                          "type": "integer",
+                        },
+                        "price": {
+                          "properties": {
+                            "amount": {
+                              "type": "string",
+                            },
+                            "denom": {
+                              "type": "string",
+                            },
+                          },
+                          "required": [
+                            "denom",
+                            "amount",
+                          ],
+                          "type": "object",
+                        },
+                        "resource": {
+                          "properties": {
+                            "cpu": {
+                              "properties": {
+                                "attributes": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "description": "Attribute key",
+                                        "example": "persistent",
+                                        "type": "string",
+                                      },
+                                      "value": {
+                                        "description": "Attribute value",
+                                        "example": "false",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "key",
+                                      "value",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "type": "array",
+                                },
+                                "units": {
+                                  "properties": {
+                                    "val": {
+                                      "description": "String-encoded integer value",
+                                      "example": "1000",
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "val",
+                                  ],
+                                  "type": "object",
+                                },
+                              },
+                              "required": [
+                                "units",
+                                "attributes",
+                              ],
+                              "type": "object",
+                            },
+                            "endpoints": {
+                              "items": {
+                                "nullable": true,
+                              },
+                              "type": "array",
+                            },
+                            "gpu": {
+                              "properties": {
+                                "attributes": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "description": "Attribute key",
+                                        "example": "persistent",
+                                        "type": "string",
+                                      },
+                                      "value": {
+                                        "description": "Attribute value",
+                                        "example": "false",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "key",
+                                      "value",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "type": "array",
+                                },
+                                "units": {
+                                  "properties": {
+                                    "val": {
+                                      "description": "String-encoded integer value",
+                                      "example": "1000",
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "val",
+                                  ],
+                                  "type": "object",
+                                },
+                              },
+                              "required": [
+                                "units",
+                                "attributes",
+                              ],
+                              "type": "object",
+                            },
+                            "id": {
+                              "description": "Resource unit ID",
+                              "example": 1,
+                              "type": "integer",
+                            },
+                            "memory": {
+                              "properties": {
+                                "attributes": {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "description": "Attribute key",
+                                        "example": "persistent",
+                                        "type": "string",
+                                      },
+                                      "value": {
+                                        "description": "Attribute value",
+                                        "example": "false",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "key",
+                                      "value",
+                                    ],
+                                    "type": "object",
+                                  },
+                                  "type": "array",
+                                },
+                                "quantity": {
+                                  "properties": {
+                                    "val": {
+                                      "description": "String-encoded integer value",
+                                      "example": "1000",
+                                      "type": "string",
+                                    },
+                                  },
+                                  "required": [
+                                    "val",
+                                  ],
+                                  "type": "object",
+                                },
+                              },
+                              "required": [
+                                "quantity",
+                                "attributes",
+                              ],
+                              "type": "object",
+                            },
+                            "storage": {
+                              "items": {
+                                "properties": {
+                                  "attributes": {
+                                    "items": {
+                                      "properties": {
+                                        "key": {
+                                          "description": "Attribute key",
+                                          "example": "persistent",
+                                          "type": "string",
+                                        },
+                                        "value": {
+                                          "description": "Attribute value",
+                                          "example": "false",
+                                          "type": "string",
+                                        },
+                                      },
+                                      "required": [
+                                        "key",
+                                        "value",
+                                      ],
+                                      "type": "object",
+                                    },
+                                    "type": "array",
+                                  },
+                                  "name": {
+                                    "description": "Storage volume name",
+                                    "example": "default",
+                                    "type": "string",
+                                  },
+                                  "quantity": {
+                                    "properties": {
+                                      "val": {
+                                        "description": "String-encoded integer value",
+                                        "example": "1000",
+                                        "type": "string",
+                                      },
+                                    },
+                                    "required": [
+                                      "val",
+                                    ],
+                                    "type": "object",
+                                  },
+                                },
+                                "required": [
+                                  "name",
+                                  "quantity",
+                                  "attributes",
+                                ],
+                                "type": "object",
+                              },
+                              "type": "array",
+                            },
+                          },
+                          "required": [
+                            "id",
+                            "cpu",
+                            "memory",
+                            "gpu",
+                            "storage",
+                          ],
+                          "type": "object",
+                        },
+                      },
+                      "required": [
+                        "resource",
+                        "count",
+                        "price",
+                      ],
+                      "type": "object",
+                    },
+                    "minItems": 1,
+                    "type": "array",
+                  },
+                },
+                "required": [
+                  "name",
+                  "resources",
+                ],
+                "type": "object",
+              },
+            },
+          },
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "providers": {
+                      "items": {
+                        "properties": {
+                          "hostUri": {
+                            "description": "Provider HTTPS endpoint",
+                            "example": "https://provider.europlots.com:8443",
+                            "type": "string",
+                          },
+                          "isAudited": {
+                            "description": "True if signed by a known auditor",
+                            "type": "boolean",
+                          },
+                          "owner": {
+                            "description": "Provider address",
+                            "example": "akash1q7spv2cw06yszgfp4f9ed59lkka6ytn8g4tkjf",
+                            "type": "string",
+                          },
+                          "region": {
+                            "description": "Geo-resolved region from IP",
+                            "nullable": true,
+                            "type": "string",
+                          },
+                          "uptime7d": {
+                            "description": "7-day uptime as decimal (0.0-1.0)",
+                            "example": 0.998,
+                            "nullable": true,
+                            "type": "number",
+                          },
+                        },
+                        "required": [
+                          "owner",
+                          "hostUri",
+                          "region",
+                          "uptime7d",
+                          "isAudited",
+                        ],
+                        "type": "object",
+                      },
+                      "type": "array",
+                    },
+                  },
+                  "required": [
+                    "providers",
+                  ],
+                  "type": "object",
+                },
+              },
+            },
+            "description": "Returns matching providers",
+          },
+          "400": {
+            "description": "Invalid request body",
+          },
+        },
+        "security": [],
+        "summary": "Screen providers by deployment resource requirements",
+        "tags": [
+          "Bid Screening",
+        ],
+      },
+    },
     "/v1/bids": {
       "get": {
         "parameters": [


### PR DESCRIPTION
## Why

Ref CON-285

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bid-screening API endpoint (POST /v1/bid-screening) with JSON validation, 64KB body limit, and OpenAPI docs.
  * Added a feature flag to enable/disable bid screening.
  * Request/response schemas and client-facing types for bid screening introduced; provider results may include region and uptime.

* **Tests**
  * Added unit tests for the bid-screening controller and service.
  * Added integration tests covering provider snapshot retrieval and audited provider matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->