### PR TITLE
fix(wallet): make generic banner links visible on primary background

### DIFF
--- a/apps/deploy-web/src/components/layout/TopBanner.spec.tsx
+++ b/apps/deploy-web/src/components/layout/TopBanner.spec.tsx
@@ -6,7 +6,7 @@ import { type DEPENDENCIES, GenericBanner } from "./TopBanner";
 import { render, screen } from "@testing-library/react";
 
 describe(GenericBanner.name, () => {
-  it("renders the message and links with the foreground color so they are visible on bg-primary", () => {
+  it("renders the message and each provided link with safe external attributes", () => {
     setup({
       message: "Self-custody is moving to Console Air.",
       links: [
@@ -21,11 +21,8 @@ describe(GenericBanner.name, () => {
     expect(announcementLink).toHaveAttribute("href", "https://akash.network/announcement");
     expect(announcementLink).toHaveAttribute("target", "_blank");
     expect(announcementLink).toHaveAttribute("rel", "noopener noreferrer");
-    expect(announcementLink.className).toContain("text-primary-foreground");
-    expect(announcementLink.className).toContain("underline");
 
-    const consoleAirLink = screen.getByRole("link", { name: "Open Console Air" });
-    expect(consoleAirLink.className).toContain("text-primary-foreground");
+    expect(screen.getByRole("link", { name: "Open Console Air" })).toHaveAttribute("href", "https://console.air");
   });
 
   it("renders nothing for links when none are provided", () => {

--- a/apps/deploy-web/src/components/layout/TopBanner.spec.tsx
+++ b/apps/deploy-web/src/components/layout/TopBanner.spec.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { type DEPENDENCIES, GenericBanner } from "./TopBanner";
+
+import { render, screen } from "@testing-library/react";
+
+describe(GenericBanner.name, () => {
+  it("renders the message and links with the foreground color so they are visible on bg-primary", () => {
+    setup({
+      message: "Self-custody is moving to Console Air.",
+      links: [
+        { label: "Read the announcement", href: "https://akash.network/announcement" },
+        { label: "Open Console Air", href: "https://console.air" }
+      ]
+    });
+
+    expect(screen.getByText("Self-custody is moving to Console Air.")).toBeInTheDocument();
+
+    const announcementLink = screen.getByRole("link", { name: "Read the announcement" });
+    expect(announcementLink).toHaveAttribute("href", "https://akash.network/announcement");
+    expect(announcementLink).toHaveAttribute("target", "_blank");
+    expect(announcementLink).toHaveAttribute("rel", "noopener noreferrer");
+    expect(announcementLink.className).toContain("text-primary-foreground");
+    expect(announcementLink.className).toContain("underline");
+
+    const consoleAirLink = screen.getByRole("link", { name: "Open Console Air" });
+    expect(consoleAirLink.className).toContain("text-primary-foreground");
+  });
+
+  it("renders nothing for links when none are provided", () => {
+    setup({ message: "Heads up!" });
+
+    expect(screen.getByText("Heads up!")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("invokes onClose when the close button is clicked", () => {
+    const { onClose } = setup({ message: "anything" });
+
+    screen.getByRole("button").click();
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  function setup(input: { message: string; links?: { label: string; href: string }[] }) {
+    const onClose = vi.fn();
+    const useGenericBannerDetails: typeof DEPENDENCIES.useGenericBannerDetails = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useGenericBannerDetails>>({
+        message: input.message,
+        links: input.links
+      });
+
+    render(<GenericBanner onClose={onClose} dependencies={{ useGenericBannerDetails }} />);
+    return { onClose };
+  }
+});

--- a/apps/deploy-web/src/components/layout/TopBanner.tsx
+++ b/apps/deploy-web/src/components/layout/TopBanner.tsx
@@ -81,7 +81,13 @@ function GenericBanner({ onClose }: { onClose: () => void }) {
       <span className="text-xs font-semibold md:text-sm">
         {message}
         {links?.map(link => (
-          <a key={link.href} href={link.href} target="_blank" rel="noopener noreferrer" className="ml-1 underline hover:text-primary-foreground/80">
+          <a
+            key={link.href}
+            href={link.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ml-1 text-primary-foreground underline hover:text-primary-foreground/80"
+          >
             {link.label}
           </a>
         ))}

--- a/apps/deploy-web/src/components/layout/TopBanner.tsx
+++ b/apps/deploy-web/src/components/layout/TopBanner.tsx
@@ -86,7 +86,7 @@ function GenericBanner({ onClose }: { onClose: () => void }) {
             href={link.href}
             target="_blank"
             rel="noopener noreferrer"
-            className="ml-1 text-primary-foreground underline hover:text-primary-foreground/80"
+            className="ml-3 text-primary-foreground underline hover:text-primary-foreground/80"
           >
             {link.label}
           </a>

--- a/apps/deploy-web/src/components/layout/TopBanner.tsx
+++ b/apps/deploy-web/src/components/layout/TopBanner.tsx
@@ -73,8 +73,10 @@ function MaintenanceBanner({ onClose }: { onClose: () => void }) {
   );
 }
 
-function GenericBanner({ onClose }: { onClose: () => void }) {
-  const { message, links } = useGenericBannerDetails();
+export const DEPENDENCIES = { useGenericBannerDetails };
+
+export function GenericBanner({ onClose, dependencies = DEPENDENCIES }: { onClose: () => void; dependencies?: typeof DEPENDENCIES }) {
+  const { message, links } = dependencies.useGenericBannerDetails();
 
   return (
     <div className="fixed top-0 z-10 flex h-[40px] w-full items-center justify-center gap-2 bg-primary px-3 py-2 text-primary-foreground md:gap-4">


### PR DESCRIPTION
## Why

The generic top banner uses `bg-primary`, but the global stylesheet sets `a { color: hsl(var(--primary)) }`. As a result, the links added in #3131 rendered in the same color as the banner background and were effectively invisible.

## What

Set `text-primary-foreground` on the anchor so links inherit the banner's foreground color and remain visible on the primary background. Hover state was already correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Top banner updated to support configurable data sources (no visible behavior change).
* **Style**
  * Increased spacing in top-banner link items for improved visual alignment.
* **Tests**
  * Added test coverage for banner rendering, link attributes/behavior, absence of links when none configured, and close-button interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->