### PR TITLE
feat(notifications): add internal account purge endpoint

### DIFF
--- a/apps/notifications/src/infrastructure/db/full-schema.ts
+++ b/apps/notifications/src/infrastructure/db/full-schema.ts
@@ -1,0 +1,9 @@
+import type * as alertSchema from "@src/modules/alert/model-schemas";
+import type * as notificationsSchema from "@src/modules/notifications/model-schemas";
+
+/**
+ * Type-only intersection of every module's Drizzle schema. Use as the generic
+ * for `NodePgDatabase<FullSchema>` when a service or controller needs to start
+ * a transaction that spans more than one module's repositories.
+ */
+export type FullSchema = typeof alertSchema & typeof notificationsSchema;

--- a/apps/notifications/src/infrastructure/db/services/db-healthz/db-healthz.service.ts
+++ b/apps/notifications/src/infrastructure/db/services/db-healthz/db-healthz.service.ts
@@ -8,6 +8,7 @@ import { NodePgDatabase } from "drizzle-orm/node-postgres";
 import { LoggerService } from "@src/common/services/logger/logger.service";
 import { HealthzService, ProbeResult } from "@src/common/types/healthz.type";
 import { DRIZZLE_PROVIDER_TOKEN } from "../../config/db.config";
+import type { FullSchema } from "../../full-schema";
 
 @Injectable()
 export class DbHealthzService implements HealthzService {
@@ -17,7 +18,7 @@ export class DbHealthzService implements HealthzService {
 
   constructor(
     @InjectDrizzle(DRIZZLE_PROVIDER_TOKEN)
-    private readonly db: NodePgDatabase<any>,
+    private readonly db: NodePgDatabase<FullSchema>,
     private readonly loggerService: LoggerService
   ) {
     loggerService.setContext(DbHealthzService.name);

--- a/apps/notifications/src/interfaces/rest/controllers/internal-account/internal-account.controller.spec.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/internal-account/internal-account.controller.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { LoggerService } from "@src/common/services/logger/logger.service";
+import type { AccountPurgeService } from "@src/interfaces/rest/services/account-purge/account-purge.service";
+import { InternalAccountController } from "./internal-account.controller";
+
+describe("InternalAccountController", () => {
+  it("logs ACCOUNT_PURGE_COMPLETED with the deletion counts on success", async () => {
+    const userId = "00000000-0000-0000-0000-000000000001";
+    const { controller, loggerService } = setup({ purgeReturns: { alertsDeleted: 3, channelsDeleted: 2 } });
+
+    await controller.purge(userId);
+
+    expect(loggerService.log).toHaveBeenCalledWith({
+      event: "ACCOUNT_PURGE_COMPLETED",
+      userId,
+      alertsDeleted: 3,
+      channelsDeleted: 2
+    });
+    expect(loggerService.error).not.toHaveBeenCalled();
+  });
+
+  it("logs ACCOUNT_PURGE_FAILED and rethrows when the service throws", async () => {
+    const userId = "00000000-0000-0000-0000-000000000002";
+    const error = new Error("db unavailable");
+    const { controller, loggerService } = setup({ purgeRejects: error });
+
+    await expect(controller.purge(userId)).rejects.toBe(error);
+
+    expect(loggerService.error).toHaveBeenCalledWith({
+      event: "ACCOUNT_PURGE_FAILED",
+      userId,
+      error
+    });
+    expect(loggerService.log).not.toHaveBeenCalled();
+  });
+
+  function setup(input: { purgeReturns?: { alertsDeleted: number; channelsDeleted: number }; purgeRejects?: unknown }) {
+    const accountPurgeService = mock<AccountPurgeService>({
+      purge: vi.fn(() =>
+        input.purgeRejects ? Promise.reject(input.purgeRejects) : Promise.resolve(input.purgeReturns ?? { alertsDeleted: 0, channelsDeleted: 0 })
+      )
+    });
+    const loggerService = mock<LoggerService>();
+    const controller = new InternalAccountController(accountPurgeService, loggerService);
+    return { controller, loggerService };
+  }
+});

--- a/apps/notifications/src/interfaces/rest/controllers/internal-account/internal-account.controller.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/internal-account/internal-account.controller.ts
@@ -1,0 +1,39 @@
+import { Controller, HttpCode, Param, ParseUUIDPipe, Post } from "@nestjs/common";
+import { ApiTags } from "@nestjs/swagger";
+
+import { LoggerService } from "@src/common/services/logger/logger.service";
+import { Unprotected } from "@src/interfaces/rest/interceptors/auth/auth.interceptor";
+import { AccountPurgeService } from "@src/interfaces/rest/services/account-purge/account-purge.service";
+
+@ApiTags("Internal/Account")
+@Controller({ path: "internal/users" })
+@Unprotected()
+export class InternalAccountController {
+  constructor(
+    private readonly accountPurgeService: AccountPurgeService,
+    private readonly loggerService: LoggerService
+  ) {
+    this.loggerService.setContext(InternalAccountController.name);
+  }
+
+  @Post(":userId/purge")
+  @HttpCode(204)
+  async purge(@Param("userId", new ParseUUIDPipe()) userId: string): Promise<void> {
+    try {
+      const { alertsDeleted, channelsDeleted } = await this.accountPurgeService.purge(userId);
+      this.loggerService.log({
+        event: "ACCOUNT_PURGE_COMPLETED",
+        userId,
+        alertsDeleted,
+        channelsDeleted
+      });
+    } catch (error) {
+      this.loggerService.error({
+        event: "ACCOUNT_PURGE_FAILED",
+        userId,
+        error
+      });
+      throw error;
+    }
+  }
+}

--- a/apps/notifications/src/interfaces/rest/rest.module.ts
+++ b/apps/notifications/src/interfaces/rest/rest.module.ts
@@ -7,6 +7,7 @@ import { CommonModule } from "@src/common/common.module";
 import { BrokerModule } from "@src/infrastructure/broker";
 import { DeploymentAlertController } from "@src/interfaces/rest/controllers/deployment-alert/deployment-alert.controller";
 import { HealthzController } from "@src/interfaces/rest/controllers/healthz/healthz.controller";
+import { InternalAccountController } from "@src/interfaces/rest/controllers/internal-account/internal-account.controller";
 import { AlertModule } from "@src/modules/alert/alert.module";
 import { NotificationsModule } from "@src/modules/notifications/notifications.module";
 import { AlertController } from "./controllers/alert/alert.controller";
@@ -15,6 +16,7 @@ import { NotificationChannelController } from "./controllers/notification-channe
 import { AuthInterceptor } from "./interceptors/auth/auth.interceptor";
 import { LocalHttpLoggerMiddleware } from "./interceptors/http-logger/http-logger.middleware";
 import { HttpResultInterceptor } from "./interceptors/http-result/http-result.interceptor";
+import { AccountPurgeService } from "./services/account-purge/account-purge.service";
 import { AuthService } from "./services/auth/auth.service";
 
 @Module({
@@ -23,9 +25,10 @@ import { AuthService } from "./services/auth/auth.service";
     { provide: APP_INTERCEPTOR, useClass: ZodSerializerInterceptor },
     { provide: APP_INTERCEPTOR, useClass: HttpResultInterceptor },
     { provide: APP_INTERCEPTOR, useClass: AuthInterceptor },
+    AccountPurgeService,
     AuthService
   ],
-  controllers: [AlertController, NotificationChannelController, DeploymentAlertController, HealthzController, JobsController]
+  controllers: [AlertController, NotificationChannelController, DeploymentAlertController, HealthzController, JobsController, InternalAccountController]
 })
 export default class RestModule {
   configure(consumer: MiddlewareConsumer) {

--- a/apps/notifications/src/interfaces/rest/services/account-purge/account-purge.service.ts
+++ b/apps/notifications/src/interfaces/rest/services/account-purge/account-purge.service.ts
@@ -1,0 +1,35 @@
+import { InjectDrizzle } from "@knaadh/nestjs-drizzle-pg";
+import { Injectable } from "@nestjs/common";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+
+import { DRIZZLE_PROVIDER_TOKEN } from "@src/infrastructure/db/config/db.config";
+import type { FullSchema } from "@src/infrastructure/db/full-schema";
+import { AlertRepository } from "@src/modules/alert/repositories/alert/alert.repository";
+import { NotificationChannelRepository } from "@src/modules/notifications/repositories/notification-channel/notification-channel.repository";
+
+export interface AccountPurgeResult {
+  alertsDeleted: number;
+  channelsDeleted: number;
+}
+
+@Injectable()
+export class AccountPurgeService {
+  constructor(
+    @InjectDrizzle(DRIZZLE_PROVIDER_TOKEN)
+    private readonly db: NodePgDatabase<FullSchema>,
+    private readonly alertRepository: AlertRepository,
+    private readonly notificationChannelRepository: NotificationChannelRepository
+  ) {}
+
+  /**
+   * Wraps both deletes in a single transaction so partial state is impossible.
+   * Alerts are deleted before channels — alerts FK channels with no cascade.
+   */
+  async purge(userId: string): Promise<AccountPurgeResult> {
+    return this.db.transaction(async tx => {
+      const alertsDeleted = await this.alertRepository.deleteAllByUserId(userId, tx);
+      const channelsDeleted = await this.notificationChannelRepository.deleteAllByUserId(userId, tx);
+      return { alertsDeleted, channelsDeleted };
+    });
+  }
+}

--- a/apps/notifications/src/lib/bootstrap/swagger-setup/swagger-scope-filter.spec.ts
+++ b/apps/notifications/src/lib/bootstrap/swagger-setup/swagger-scope-filter.spec.ts
@@ -1,0 +1,164 @@
+import type { OpenAPIObject } from "@nestjs/swagger";
+import { describe, expect, it } from "vitest";
+
+import { filterDocumentByScope } from "./swagger-scope-filter";
+
+describe("filterDocumentByScope", () => {
+  it("keeps only non-internal paths in the public scope", () => {
+    const document = setup({
+      paths: {
+        "/v1/things": pathItem(),
+        "/internal/users/{userId}/purge": pathItem()
+      }
+    });
+
+    const filtered = filterDocumentByScope(document, "public");
+
+    expect(Object.keys(filtered.paths)).toEqual(["/v1/things"]);
+  });
+
+  it("keeps only internal paths in the internal scope", () => {
+    const document = setup({
+      paths: {
+        "/v1/things": pathItem(),
+        "/internal/users/{userId}/purge": pathItem()
+      }
+    });
+
+    const filtered = filterDocumentByScope(document, "internal");
+
+    expect(Object.keys(filtered.paths)).toEqual(["/internal/users/{userId}/purge"]);
+  });
+
+  it("drops schemas not referenced by any kept path", () => {
+    const document = setup({
+      paths: {
+        "/v1/things": pathItem({ refs: ["Thing"] })
+      },
+      schemas: {
+        Thing: schemaObject(),
+        UnusedThing: schemaObject()
+      }
+    });
+
+    const filtered = filterDocumentByScope(document, "public");
+
+    expect(Object.keys(filtered.components?.schemas ?? {})).toEqual(["Thing"]);
+  });
+
+  it("follows transitive schema references", () => {
+    const document = setup({
+      paths: {
+        "/v1/things": pathItem({ refs: ["Outer"] })
+      },
+      schemas: {
+        Outer: schemaObject({ refs: ["Inner"] }),
+        Inner: schemaObject({ refs: ["Leaf"] }),
+        Leaf: schemaObject(),
+        Unrelated: schemaObject()
+      }
+    });
+
+    const filtered = filterDocumentByScope(document, "public");
+
+    expect(Object.keys(filtered.components?.schemas ?? {}).sort()).toEqual(["Inner", "Leaf", "Outer"]);
+  });
+
+  it("returns empty schemas when filtered paths reference nothing", () => {
+    const document = setup({
+      paths: {
+        "/internal/users/{userId}/purge": pathItem()
+      },
+      schemas: {
+        SomePublicSchema: schemaObject()
+      }
+    });
+
+    const filtered = filterDocumentByScope(document, "internal");
+
+    expect(filtered.components?.schemas).toEqual({});
+  });
+
+  it("does not bleed schemas from dropped paths into the kept scope", () => {
+    const document = setup({
+      paths: {
+        "/v1/public": pathItem({ refs: ["PublicOnly"] }),
+        "/internal/private": pathItem({ refs: ["InternalOnly"] })
+      },
+      schemas: {
+        PublicOnly: schemaObject(),
+        InternalOnly: schemaObject()
+      }
+    });
+
+    const publicDoc = filterDocumentByScope(document, "public");
+    const internalDoc = filterDocumentByScope(document, "internal");
+
+    expect(Object.keys(publicDoc.components?.schemas ?? {})).toEqual(["PublicOnly"]);
+    expect(Object.keys(internalDoc.components?.schemas ?? {})).toEqual(["InternalOnly"]);
+  });
+
+  it("treats an exact /internal path as internal (no trailing slash required)", () => {
+    const document = setup({
+      paths: {
+        "/internal": pathItem(),
+        "/internal/users/{userId}/purge": pathItem(),
+        "/internalfoo": pathItem()
+      }
+    });
+
+    const internalDoc = filterDocumentByScope(document, "internal");
+    const publicDoc = filterDocumentByScope(document, "public");
+
+    expect(Object.keys(internalDoc.paths).sort()).toEqual(["/internal", "/internal/users/{userId}/purge"]);
+    expect(Object.keys(publicDoc.paths)).toEqual(["/internalfoo"]);
+  });
+
+  it("preserves the rest of the document untouched", () => {
+    const document = setup({
+      paths: { "/v1/things": pathItem() },
+      info: { title: "Custom Title", version: "9.9.9" }
+    });
+
+    const filtered = filterDocumentByScope(document, "public");
+
+    expect(filtered.info).toEqual({ title: "Custom Title", version: "9.9.9" });
+    expect(filtered.openapi).toBe(document.openapi);
+  });
+
+  function setup(input: { paths: OpenAPIObject["paths"]; schemas?: Record<string, unknown>; info?: OpenAPIObject["info"] }): OpenAPIObject {
+    return {
+      openapi: "3.0.0",
+      info: input.info ?? { title: "Test", version: "1.0" },
+      paths: input.paths,
+      components: { schemas: (input.schemas as OpenAPIObject["components"] extends infer C ? (C extends { schemas?: infer S } ? S : never) : never) ?? {} }
+    };
+  }
+});
+
+function pathItem(input: { refs?: string[] } = {}): Record<string, unknown> {
+  return {
+    get: {
+      responses: {
+        "200": {
+          description: "ok",
+          content: {
+            "application/json": {
+              schema: input.refs?.length ? { $ref: `#/components/schemas/${input.refs[0]}` } : { type: "object" }
+            }
+          }
+        }
+      }
+    }
+  };
+}
+
+function schemaObject(input: { refs?: string[] } = {}): Record<string, unknown> {
+  if (!input.refs?.length) {
+    return { type: "object", properties: { id: { type: "string" } } };
+  }
+  return {
+    type: "object",
+    properties: Object.fromEntries(input.refs.map((name, idx) => [`field${idx}`, { $ref: `#/components/schemas/${name}` }]))
+  };
+}

--- a/apps/notifications/src/lib/bootstrap/swagger-setup/swagger-scope-filter.ts
+++ b/apps/notifications/src/lib/bootstrap/swagger-setup/swagger-scope-filter.ts
@@ -1,0 +1,60 @@
+import type { OpenAPIObject } from "@nestjs/swagger";
+
+export type SwaggerScope = "public" | "internal";
+
+const INTERNAL_PATH_RE = /^\/internal(?:\/|$)/;
+
+type Schemas = NonNullable<NonNullable<OpenAPIObject["components"]>["schemas"]>;
+
+export function filterDocumentByScope(document: OpenAPIObject, scope: SwaggerScope): OpenAPIObject {
+  const filteredPaths: OpenAPIObject["paths"] = {};
+  for (const [pathKey, pathValue] of Object.entries(document.paths)) {
+    const isInternal = INTERNAL_PATH_RE.test(pathKey);
+    const include = scope === "internal" ? isInternal : !isInternal;
+    if (include) {
+      filteredPaths[pathKey] = pathValue;
+    }
+  }
+
+  const allSchemas = document.components?.schemas ?? {};
+  const referenced = collectReferencedSchemas(filteredPaths, allSchemas);
+  const filteredSchemas: Schemas = {};
+  for (const [name, schema] of Object.entries(allSchemas)) {
+    if (referenced.has(name)) {
+      filteredSchemas[name] = schema;
+    }
+  }
+
+  return {
+    ...document,
+    paths: filteredPaths,
+    components: { ...document.components, schemas: filteredSchemas }
+  };
+}
+
+function collectReferencedSchemas(paths: OpenAPIObject["paths"], schemas: Schemas): Set<string> {
+  const referenced = new Set<string>();
+  const queue: string[] = [];
+
+  const enqueueRefsFrom = (value: unknown) => {
+    const json = JSON.stringify(value);
+    if (!json) return;
+    for (const match of json.matchAll(/"\$ref":\s*"#\/components\/schemas\/([^"]+)"/g)) {
+      const name = match[1];
+      if (!referenced.has(name)) {
+        referenced.add(name);
+        queue.push(name);
+      }
+    }
+  };
+
+  enqueueRefsFrom(paths);
+  while (queue.length > 0) {
+    const name = queue.shift() as string;
+    if (schemas[name]) {
+      enqueueRefsFrom(schemas[name]);
+    }
+  }
+
+  return referenced;
+}

--- a/apps/notifications/src/lib/bootstrap/swagger-setup/swagger-setup.spec.ts
+++ b/apps/notifications/src/lib/bootstrap/swagger-setup/swagger-setup.spec.ts
@@ -1,0 +1,131 @@
+import type { INestApplication } from "@nestjs/common";
+import type { OpenAPIObject } from "@nestjs/swagger";
+import type { DocumentBuilder } from "@nestjs/swagger";
+import type fs from "fs";
+import type { patchNestJsSwagger } from "nestjs-zod";
+import type path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { type SwaggerModuleAPI, SwaggerSetup } from "./swagger-setup";
+
+describe("SwaggerSetup", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  describe("serveSwagger", () => {
+    it("mounts a swagger UI for both the public and internal scopes", () => {
+      const { swaggerSetup, swaggerModule, app } = setup();
+
+      swaggerSetup.serveSwagger();
+
+      expect(swaggerModule.setup).toHaveBeenCalledTimes(2);
+      expect(swaggerModule.setup).toHaveBeenNthCalledWith(1, "api", app, expect.any(Function), expect.any(Object));
+      expect(swaggerModule.setup).toHaveBeenNthCalledWith(2, "api/internal", app, expect.any(Function), expect.any(Object));
+    });
+  });
+
+  describe("generateSwagger", () => {
+    it("creates the swagger directory if it does not exist", () => {
+      const { swaggerSetup, fsModule } = setup({ swaggerDirExists: false });
+
+      expect(() => swaggerSetup.generateSwagger()).toThrow("EXIT(0)");
+
+      expect(fsModule.mkdirSync).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not recreate the swagger directory when it already exists", () => {
+      const { swaggerSetup, fsModule } = setup({ swaggerDirExists: true });
+
+      expect(() => swaggerSetup.generateSwagger()).toThrow("EXIT(0)");
+
+      expect(fsModule.mkdirSync).not.toHaveBeenCalled();
+    });
+
+    it("writes one file per scope and exits with status 0", () => {
+      const { swaggerSetup, fsModule, exitSpy } = setup();
+
+      expect(() => swaggerSetup.generateSwagger()).toThrow("EXIT(0)");
+
+      const writtenFiles = (fsModule.writeFileSync as unknown as ReturnType<typeof vi.fn>).mock.calls.map(args => args[0]);
+      expect(writtenFiles).toHaveLength(2);
+      expect(writtenFiles[0]).toMatch(/swagger\.json$/);
+      expect(writtenFiles[1]).toMatch(/swagger\.internal\.json$/);
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe("createSwaggerDocument (via serveSwagger)", () => {
+    it("filters /internal/ paths out of the public document factory", () => {
+      const { swaggerSetup, swaggerModule } = setup({
+        documentPaths: { "/v1/things": pathItem(), "/internal/users/{userId}/purge": pathItem() }
+      });
+
+      swaggerSetup.serveSwagger();
+      const publicFactory = (swaggerModule.setup as unknown as ReturnType<typeof vi.fn>).mock.calls[0][2] as () => OpenAPIObject;
+      const internalFactory = (swaggerModule.setup as unknown as ReturnType<typeof vi.fn>).mock.calls[1][2] as () => OpenAPIObject;
+
+      const publicDoc = publicFactory();
+      const internalDoc = internalFactory();
+
+      expect(Object.keys(publicDoc.paths)).toEqual(["/v1/things"]);
+      expect(Object.keys(internalDoc.paths)).toEqual(["/internal/users/{userId}/purge"]);
+    });
+  });
+
+  function setup(
+    input: {
+      documentPaths?: OpenAPIObject["paths"];
+      swaggerDirExists?: boolean;
+    } = {}
+  ) {
+    const documentPaths = input.documentPaths ?? {};
+    const baseDocument: OpenAPIObject = {
+      openapi: "3.0.0",
+      info: { title: "Test", version: "1.0" },
+      paths: documentPaths,
+      components: { schemas: {} }
+    };
+
+    const app = mock<INestApplication>();
+    const patchSwagger = vi.fn() as unknown as typeof patchNestJsSwagger;
+    const documentBuilder = MockDocumentBuilder as unknown as typeof DocumentBuilder;
+    const swaggerModule = mock<SwaggerModuleAPI>({
+      setup: vi.fn(),
+      createDocument: vi.fn(() => baseDocument)
+    });
+    const fsModule = mock<typeof fs>({
+      existsSync: vi.fn().mockReturnValue(input.swaggerDirExists ?? true),
+      mkdirSync: vi.fn(),
+      writeFileSync: vi.fn()
+    });
+    const pathModule = mock<typeof path>({
+      resolve: vi.fn((...parts: string[]) => parts.join("/")),
+      join: vi.fn((...parts: string[]) => parts.join("/"))
+    });
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`EXIT(${code ?? 0})`);
+    }) as never);
+
+    const swaggerSetup = new SwaggerSetup(app, patchSwagger, documentBuilder, swaggerModule, fsModule, pathModule);
+
+    return { swaggerSetup, app, patchSwagger, documentBuilder, swaggerModule, fsModule, pathModule, exitSpy };
+  }
+});
+
+class MockDocumentBuilder {
+  setTitle = vi.fn().mockReturnThis();
+  setDescription = vi.fn().mockReturnThis();
+  setVersion = vi.fn().mockReturnThis();
+  addTag = vi.fn().mockReturnThis();
+  addApiKey = vi.fn().mockReturnThis();
+  addSecurityRequirements = vi.fn().mockReturnThis();
+  build = vi.fn(() => ({}));
+}
+
+function pathItem(): Record<string, unknown> {
+  return {
+    get: {
+      responses: { "200": { description: "ok" } }
+    }
+  };
+}

--- a/apps/notifications/src/lib/bootstrap/swagger-setup/swagger-setup.ts
+++ b/apps/notifications/src/lib/bootstrap/swagger-setup/swagger-setup.ts
@@ -8,6 +8,14 @@ import { patchNestJsSwagger } from "nestjs-zod";
 import path from "path";
 
 import { Logger } from "@src/common/providers/logger.provider";
+import { filterDocumentByScope, type SwaggerScope } from "./swagger-scope-filter";
+
+const SCOPES: { scope: SwaggerScope; mountPath: string; fileName: string }[] = [
+  { scope: "public", mountPath: "api", fileName: "swagger.json" },
+  { scope: "internal", mountPath: "api/internal", fileName: "swagger.internal.json" }
+];
+
+export type SwaggerModuleAPI = Pick<typeof SwaggerModule, "setup" | "createDocument">;
 
 export class SwaggerSetup {
   static serveSwagger(app: INestApplication): void {
@@ -22,70 +30,67 @@ export class SwaggerSetup {
     private readonly app: INestApplication,
     private readonly patchSwagger: typeof patchNestJsSwagger = patchNestJsSwagger,
     private readonly documentBuilder: typeof DocumentBuilder = DocumentBuilder,
-    private readonly swaggerModule: typeof SwaggerModule = SwaggerModule,
+    private readonly swaggerModule: SwaggerModuleAPI = SwaggerModule,
     private readonly fsModule: typeof fs = fs,
     private readonly pathModule: typeof path = path
   ) {}
 
   serveSwagger() {
-    const documentFactory = this.createSwaggerDocument();
+    const customSwaggerUiPath = this.pathModule.resolve(__dirname, "../dist/swagger-ui-dist");
 
-    this.swaggerModule.setup("api", this.app, documentFactory, {
-      customSwaggerUiPath: this.pathModule.resolve(__dirname, "../dist/swagger-ui-dist")
-    });
+    for (const { scope, mountPath } of SCOPES) {
+      const documentFactory = this.createSwaggerDocument(scope);
+      this.swaggerModule.setup(mountPath, this.app, documentFactory, { customSwaggerUiPath });
+    }
   }
 
   generateSwagger() {
     const logger = new Logger({ context: "SWAGGER" });
-
     const swaggerDir = this.pathModule.resolve(__dirname, "../swagger");
 
     if (!this.fsModule.existsSync(swaggerDir)) {
       this.fsModule.mkdirSync(swaggerDir);
     }
 
-    const file = this.pathModule.join(swaggerDir, "swagger.json");
-
-    const document = this.createSwaggerDocument()();
-    this.fsModule.writeFileSync(file, JSON.stringify(document, null, 2));
-
-    logger.info(`"${file}" created successfully. Exiting`);
+    for (const { scope, fileName } of SCOPES) {
+      const file = this.pathModule.join(swaggerDir, fileName);
+      const document = this.createSwaggerDocument(scope)();
+      this.fsModule.writeFileSync(file, JSON.stringify(document, null, 2));
+      logger.info(`"${file}" created successfully.`);
+    }
 
     process.exit(0);
   }
 
-  private createSwaggerDocument() {
+  private createSwaggerDocument(scope: SwaggerScope) {
     this.patchSwagger();
 
-    const config = new this.documentBuilder()
-      .setTitle("NotificationsAPI")
-      .setDescription("Notifications API")
-      .setVersion("1.0")
-      .addTag("NotificationChannel")
-      .addTag("Alert")
-      .addTag("DeploymentAlert")
-      .addApiKey(
-        {
-          type: "apiKey",
-          name: "x-user-id",
-          in: "header"
-        },
-        "x-user-id"
+    const builder = new this.documentBuilder()
+      .setTitle(scope === "public" ? "NotificationsAPI" : "NotificationsAPI (Internal)")
+      .setDescription(
+        scope === "public"
+          ? "Notifications API"
+          : "Internal-only endpoints for server-to-server use within the private network. Not exposed to the public internet."
       )
-      .addApiKey(
-        {
-          type: "apiKey",
-          name: "x-owner-address",
-          in: "header"
-        },
-        "x-owner-address"
-      )
-      .addSecurityRequirements({ "x-user-id": [], "x-owner-address": [] })
-      .build();
+      .setVersion("1.0");
 
-    return () =>
-      this.swaggerModule.createDocument(this.app, config, {
+    if (scope === "public") {
+      builder
+        .addTag("NotificationChannel")
+        .addTag("Alert")
+        .addTag("DeploymentAlert")
+        .addApiKey({ type: "apiKey", name: "x-user-id", in: "header" }, "x-user-id")
+        .addApiKey({ type: "apiKey", name: "x-owner-address", in: "header" }, "x-owner-address")
+        .addSecurityRequirements({ "x-user-id": [], "x-owner-address": [] });
+    }
+
+    const config = builder.build();
+
+    return () => {
+      const document = this.swaggerModule.createDocument(this.app, config, {
         operationIdFactory: (_, methodKey) => methodKey
       });
+      return filterDocumentByScope(document, scope);
+    };
   }
 }

--- a/apps/notifications/src/modules/alert/alert.module.ts
+++ b/apps/notifications/src/modules/alert/alert.module.ts
@@ -7,6 +7,7 @@ import type { Client } from "pg";
 import { CommonModule } from "@src/common/common.module";
 import { DRIZZLE_PROVIDER_TOKEN } from "@src/infrastructure/db/config/db.config";
 import { register } from "@src/infrastructure/db/db.module";
+import type { FullSchema } from "@src/infrastructure/db/full-schema";
 import { DbHealthzService } from "@src/infrastructure/db/services/db-healthz/db-healthz.service";
 import { AlertRepository } from "@src/modules/alert/repositories/alert/alert.repository";
 import { ChainAlertService } from "@src/modules/alert/services/chain-alert/chain-alert.service";
@@ -39,7 +40,7 @@ import * as schema from "./model-schemas";
   exports: [ChainAlertService, DeploymentBalanceAlertsService, WalletBalanceAlertsService, AlertRepository, DeploymentAlertService, DbHealthzService]
 })
 export class AlertModule implements OnApplicationShutdown {
-  constructor(@InjectDrizzle(DRIZZLE_PROVIDER_TOKEN) private readonly db: NodePgDatabase) {}
+  constructor(@InjectDrizzle(DRIZZLE_PROVIDER_TOKEN) private readonly db: NodePgDatabase<FullSchema>) {}
 
   async onApplicationShutdown(): Promise<void> {
     await (

--- a/apps/notifications/src/modules/alert/repositories/alert/alert.repository.ts
+++ b/apps/notifications/src/modules/alert/repositories/alert/alert.repository.ts
@@ -179,6 +179,12 @@ export class AlertRepository {
     });
   }
 
+  async deleteAllByUserId(userId: string, tx: NodePgDatabase<typeof schema> = this.db): Promise<number> {
+    const deleted = await tx.delete(schema.Alert).where(eq(schema.Alert.userId, userId)).returning({ id: schema.Alert.id });
+
+    return deleted.length;
+  }
+
   async countActiveByNotificationChannelId(notificationChannelId: string): Promise<number> {
     const result = await this.db
       .select({ count: count(schema.Alert.id) })

--- a/apps/notifications/src/modules/notifications/notifications.module.ts
+++ b/apps/notifications/src/modules/notifications/notifications.module.ts
@@ -7,6 +7,7 @@ import type { Client } from "pg";
 import { CommonModule } from "@src/common/common.module";
 import { DRIZZLE_PROVIDER_TOKEN } from "@src/infrastructure/db/config/db.config";
 import { register } from "@src/infrastructure/db/db.module";
+import type { FullSchema } from "@src/infrastructure/db/full-schema";
 import { DbHealthzService } from "@src/infrastructure/db/services/db-healthz/db-healthz.service";
 import moduleConfig from "@src/modules/notifications/config";
 import { AmplitudeProvider } from "./providers/amplitude.provider";
@@ -33,7 +34,7 @@ import * as schema from "./model-schemas";
   exports: [NotificationChannelRepository, NotificationRouterService, EmailSenderService, DbHealthzService]
 })
 export class NotificationsModule implements OnApplicationShutdown {
-  constructor(@InjectDrizzle(DRIZZLE_PROVIDER_TOKEN) private readonly db: NodePgDatabase) {}
+  constructor(@InjectDrizzle(DRIZZLE_PROVIDER_TOKEN) private readonly db: NodePgDatabase<FullSchema>) {}
 
   async onApplicationShutdown(): Promise<void> {
     await (

--- a/apps/notifications/src/modules/notifications/repositories/notification-channel/notification-channel.repository.ts
+++ b/apps/notifications/src/modules/notifications/repositories/notification-channel/notification-channel.repository.ts
@@ -175,6 +175,15 @@ export class NotificationChannelRepository {
     return notificationChannel && this.toOutput(notificationChannel);
   }
 
+  async deleteAllByUserId(userId: string, tx: NodePgDatabase<typeof schema> = this.db): Promise<number> {
+    const deleted = await tx
+      .delete(schema.NotificationChannel)
+      .where(eq(schema.NotificationChannel.userId, userId))
+      .returning({ id: schema.NotificationChannel.id });
+
+    return deleted.length;
+  }
+
   private toInput<T extends Partial<InternalNotificationChannelInput>>(alert: T): T {
     if (alert.config) {
       return {

--- a/apps/notifications/swagger/swagger.internal.json
+++ b/apps/notifications/swagger/swagger.internal.json
@@ -1,0 +1,39 @@
+{
+  "openapi": "3.0.0",
+  "paths": {
+    "/internal/users/{userId}/purge": {
+      "post": {
+        "operationId": "purge",
+        "parameters": [
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "Internal/Account"
+        ]
+      }
+    }
+  },
+  "info": {
+    "title": "NotificationsAPI (Internal)",
+    "description": "Internal-only endpoints for server-to-server use within the private network. Not exposed to the public internet.",
+    "version": "1.0",
+    "contact": {}
+  },
+  "tags": [],
+  "servers": [],
+  "components": {
+    "schemas": {}
+  }
+}

--- a/apps/notifications/test/functional/account-purge.spec.ts
+++ b/apps/notifications/test/functional/account-purge.spec.ts
@@ -1,0 +1,73 @@
+import { faker } from "@faker-js/faker";
+import { INestApplication, Module } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import type { NodePgDatabase } from "drizzle-orm/node-postgres";
+import request from "supertest";
+import { describe, expect, it, onTestFinished } from "vitest";
+
+import { LoggerService } from "@src/common/services/logger/logger.service";
+import { DRIZZLE_PROVIDER_TOKEN } from "@src/infrastructure/db/config/db.config";
+import { HttpExceptionFilter } from "@src/interfaces/rest/filters/http-exception/http-exception.filter";
+import RestModule from "@src/interfaces/rest/rest.module";
+import { Alert } from "@src/modules/alert/model-schemas";
+import * as alertSchema from "@src/modules/alert/model-schemas";
+import { NotificationChannel } from "@src/modules/notifications/model-schemas";
+
+import { generateGeneralAlert } from "@test/seeders/general-alert.seeder";
+import { generateNotificationChannel } from "@test/seeders/notification-channel.seeder";
+
+describe("Account Purge (internal)", () => {
+  it("removes the user's notification channels and alerts", async () => {
+    const { app, userId } = await setup({ withSeed: true });
+
+    const purgeRes = await request(app.getHttpServer()).post(`/internal/users/${userId}/purge`);
+    expect(purgeRes.status).toBe(204);
+
+    const channelsRes = await request(app.getHttpServer()).get("/v1/notification-channels").set("x-user-id", userId);
+    expect(channelsRes.status).toBe(200);
+    expect(channelsRes.body.data).toEqual([]);
+
+    const alertsRes = await request(app.getHttpServer()).get("/v1/alerts").set("x-user-id", userId);
+    expect(alertsRes.status).toBe(200);
+    expect(alertsRes.body.data).toEqual([]);
+  });
+
+  it("is idempotent — second call for the same user is a no-op", async () => {
+    const { app, userId } = await setup({ withSeed: false });
+
+    const first = await request(app.getHttpServer()).post(`/internal/users/${userId}/purge`);
+    const second = await request(app.getHttpServer()).post(`/internal/users/${userId}/purge`);
+
+    expect(first.status).toBe(204);
+    expect(second.status).toBe(204);
+  });
+
+  async function setup(input: { withSeed: boolean }): Promise<{ app: INestApplication; userId: string }> {
+    @Module({ imports: [RestModule] })
+    class TestModule {}
+
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [TestModule]
+    }).compile();
+
+    const app = module.createNestApplication();
+    app.enableVersioning();
+    app.useGlobalFilters(new HttpExceptionFilter(await app.resolve(LoggerService)));
+    await app.init();
+    onTestFinished(() => app.close());
+
+    const userId = faker.string.uuid();
+
+    if (input.withSeed) {
+      const schema = { ...alertSchema, NotificationChannel };
+      const db = module.get<NodePgDatabase<typeof schema>>(DRIZZLE_PROVIDER_TOKEN);
+      const [channel] = await db
+        .insert(NotificationChannel)
+        .values([generateNotificationChannel({ userId })])
+        .returning();
+      await db.insert(Alert).values([generateGeneralAlert({ userId, notificationChannelId: channel.id })]);
+    }
+
+    return { app, userId };
+  }
+});


### PR DESCRIPTION
## Why

Ref CON-281 (parent: CON-207 — Allow users to delete their account).

The account-deletion feature needs cross-service cleanup: when a user deletes their account on the API side, their notification channels and alerts (which live in this service's own DB) must be removed too. This PR ships the notifications-side endpoint that the API will call, sequenced first so the cleanup hook is in place before the user-facing deletion flow lands.

This PR ships dead code on its own — there is no caller yet. CON-282 wires the API to call this endpoint as part of its deletion transaction.

## What

- New endpoint `POST /internal/users/:userId/purge` — hard-deletes the user's notification channels and alerts. Idempotent. Returns 204.
- Two new repository methods: `NotificationChannelRepository.deleteAllByUserId` and `AlertRepository.deleteAllByUserId`. Alerts are deleted before channels because alerts FK channels with no cascade.
- **Trust model:** the endpoint is reachable only on the private network, so it has no application-layer auth. The route uses `@Unprotected()` to bypass the global `x-user-id` interceptor. If the service ever moves off the private network, an app-layer auth becomes a hard prerequisite.
- **Swagger split:** internal endpoints (paths starting with `/internal/`) now live under a dedicated swagger spec at `/api/internal` and `swagger.internal.json`, with unreferenced schemas tree-shaken away. The public `swagger.json` is byte-identical to before — no impact on the deploy-web SDK or downstream consumers.
- Functional test covers happy path (seeded channel + alert removed) and idempotency (repeated calls succeed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal account purge endpoint to remove a user's alerts and notification channels.

* **Documentation**
  * API docs now produced as separate public and internal OpenAPI outputs; internal OpenAPI JSON added and multi-scope Swagger generation introduced.

* **Tests**
  * Added functional tests for account purge (including idempotency) and unit tests for swagger scope filtering and multi-scope generation.

* **Chores**
  * Database typing tightened; repository bulk-delete support and a transactional account purge service added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->