### PR TITLE
fix(stats): format negative values in net burn graph

### DIFF
--- a/apps/stats-web/src/lib/mathHelpers.spec.ts
+++ b/apps/stats-web/src/lib/mathHelpers.spec.ts
@@ -1,6 +1,28 @@
 import { describe, expect, it } from "vitest";
 
-import { percIncrease } from "./mathHelpers";
+import { nFormatter, percIncrease } from "./mathHelpers";
+
+describe(nFormatter.name, () => {
+  it("formats positive values below 1k without a suffix", () => {
+    expect(nFormatter(0, 2)).toBe("0");
+    expect(nFormatter(42, 2)).toBe("42");
+  });
+
+  it("formats positive values with the matching suffix", () => {
+    expect(nFormatter(1500, 2)).toBe("1.5k");
+    expect(nFormatter(2_500_000, 2)).toBe("2.5M");
+  });
+
+  it("formats negative values with the matching suffix", () => {
+    expect(nFormatter(-1500, 2)).toBe("-1.5k");
+    expect(nFormatter(-2_500_000, 2)).toBe("-2.5M");
+    expect(nFormatter(-200_000, 2)).toBe("-200k");
+  });
+
+  it("formats small negative values without a suffix", () => {
+    expect(nFormatter(-42, 2)).toBe("-42");
+  });
+});
 
 describe(percIncrease.name, () => {
   it("returns standard percentage change for non-zero values", () => {

--- a/apps/stats-web/src/lib/mathHelpers.ts
+++ b/apps/stats-web/src/lib/mathHelpers.ts
@@ -11,11 +11,12 @@ export function nFormatter(num: number, digits: number) {
     { value: 1e18, symbol: "E" }
   ];
   const rx = /\.0+$|(\.[0-9]*[1-9])0+$/;
+  const absNum = Math.abs(num);
   const item = lookup
     .slice()
     .reverse()
     .find(function (item) {
-      return num >= item.value;
+      return absNum >= item.value;
     });
   return item ? (num / item.value).toFixed(digits).replace(rx, "$1") + item.symbol : "0";
 }


### PR DESCRIPTION
## Why

After a large ACT burn pushed Daily Net AKT Burned below zero, the stats graph rendered the negative spike and every negative y-axis tick as `0`, hiding the actual burn magnitude.

## What

`nFormatter` compared the raw number against the suffix thresholds (`1`, `1e3`, ...) to pick a unit. Negative numbers never matched (since `-200000 < 1`), so the fallback `"0"` was returned for every negative input. Switched the comparison to `Math.abs(num)` while still dividing the original signed number, so the sign is preserved in the output (e.g. `-200000` → `"-200k"`).

Added `nFormatter` unit tests covering positive, negative, and small-value cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved number formatting to correctly handle negative values, ensuring proper magnitude display with appropriate suffixes (k, M, etc.).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->