### PR TITLE
fix(auth): catch refresh-token failures in defineApiHandler

### DIFF
--- a/apps/deploy-web/src/lib/auth0/clearSessionCookies/clearSessionCookies.spec.ts
+++ b/apps/deploy-web/src/lib/auth0/clearSessionCookies/clearSessionCookies.spec.ts
@@ -1,0 +1,48 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { clearSessionCookies } from "./clearSessionCookies";
+
+describe("clearSessionCookies", () => {
+  it("sets Set-Cookie headers that expire every appSession* cookie", () => {
+    const { req, res } = setup({
+      cookies: {
+        appSession: "abc",
+        "appSession.0": "def",
+        "appSession.1": "ghi",
+        unrelated: "xyz"
+      }
+    });
+
+    clearSessionCookies(req, res);
+
+    expect(res.setHeader).toHaveBeenCalledWith("Set-Cookie", [
+      "appSession=; Path=/; HttpOnly; SameSite=Lax; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+      "appSession.0=; Path=/; HttpOnly; SameSite=Lax; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
+      "appSession.1=; Path=/; HttpOnly; SameSite=Lax; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    ]);
+  });
+
+  it("does not set any header when no appSession cookies are present", () => {
+    const { req, res } = setup({ cookies: { other: "value" } });
+
+    clearSessionCookies(req, res);
+
+    expect(res.setHeader).not.toHaveBeenCalled();
+  });
+
+  it("does not set any header when there are no cookies at all", () => {
+    const { req, res } = setup({ cookies: {} });
+
+    clearSessionCookies(req, res);
+
+    expect(res.setHeader).not.toHaveBeenCalled();
+  });
+
+  function setup(input: { cookies: Record<string, string> }) {
+    const req = mock<NextApiRequest>({ cookies: input.cookies });
+    const res = mock<NextApiResponse>();
+    return { req, res };
+  }
+});

--- a/apps/deploy-web/src/lib/auth0/clearSessionCookies/clearSessionCookies.spec.ts
+++ b/apps/deploy-web/src/lib/auth0/clearSessionCookies/clearSessionCookies.spec.ts
@@ -40,9 +40,39 @@ describe("clearSessionCookies", () => {
     expect(res.setHeader).not.toHaveBeenCalled();
   });
 
-  function setup(input: { cookies: Record<string, string> }) {
+  it("preserves existing Set-Cookie headers when clearing session cookies", () => {
+    const existing = ["other=value; Path=/"];
+    const { req, res } = setup({
+      cookies: { appSession: "abc" },
+      existingSetCookie: existing
+    });
+
+    clearSessionCookies(req, res);
+
+    expect(res.setHeader).toHaveBeenCalledWith("Set-Cookie", [
+      "other=value; Path=/",
+      "appSession=; Path=/; HttpOnly; SameSite=Lax; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    ]);
+  });
+
+  it("preserves an existing Set-Cookie header set as a single string", () => {
+    const { req, res } = setup({
+      cookies: { appSession: "abc" },
+      existingSetCookie: "other=value; Path=/"
+    });
+
+    clearSessionCookies(req, res);
+
+    expect(res.setHeader).toHaveBeenCalledWith("Set-Cookie", [
+      "other=value; Path=/",
+      "appSession=; Path=/; HttpOnly; SameSite=Lax; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
+    ]);
+  });
+
+  function setup(input: { cookies: Record<string, string>; existingSetCookie?: string | string[] }) {
     const req = mock<NextApiRequest>({ cookies: input.cookies });
     const res = mock<NextApiResponse>();
+    res.getHeader.mockReturnValue(input.existingSetCookie);
     return { req, res };
   }
 });

--- a/apps/deploy-web/src/lib/auth0/clearSessionCookies/clearSessionCookies.ts
+++ b/apps/deploy-web/src/lib/auth0/clearSessionCookies/clearSessionCookies.ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+
+const SESSION_COOKIE_PREFIX = "appSession";
+const EXPIRED_COOKIE_OPTIONS = "Path=/; HttpOnly; SameSite=Lax; Expires=Thu, 01 Jan 1970 00:00:00 GMT";
+
+export function clearSessionCookies(req: NextApiRequest, res: NextApiResponse): void {
+  const cookies = req.cookies;
+  const expiredCookies = Object.keys(cookies)
+    .filter(key => key.startsWith(SESSION_COOKIE_PREFIX))
+    .map(key => `${key}=; ${EXPIRED_COOKIE_OPTIONS}`);
+
+  if (expiredCookies.length > 0) {
+    res.setHeader("Set-Cookie", expiredCookies);
+  }
+}

--- a/apps/deploy-web/src/lib/auth0/clearSessionCookies/clearSessionCookies.ts
+++ b/apps/deploy-web/src/lib/auth0/clearSessionCookies/clearSessionCookies.ts
@@ -10,6 +10,8 @@ export function clearSessionCookies(req: NextApiRequest, res: NextApiResponse): 
     .map(key => `${key}=; ${EXPIRED_COOKIE_OPTIONS}`);
 
   if (expiredCookies.length > 0) {
-    res.setHeader("Set-Cookie", expiredCookies);
+    const existing = res.getHeader("Set-Cookie");
+    const existingCookies = Array.isArray(existing) ? existing.map(String) : existing ? [String(existing)] : [];
+    res.setHeader("Set-Cookie", [...existingCookies, ...expiredCookies]);
   }
 }

--- a/apps/deploy-web/src/lib/auth0/isInvalidSessionError/isInvalidSessionError.spec.ts
+++ b/apps/deploy-web/src/lib/auth0/isInvalidSessionError/isInvalidSessionError.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { AccessTokenError, AccessTokenErrorCode } from "@src/lib/auth0";
+import { isInvalidSessionError } from "./isInvalidSessionError";
+
+describe("isInvalidSessionError", () => {
+  it("returns true for AccessTokenError with EXPIRED_ACCESS_TOKEN", () => {
+    const error = new AccessTokenError(AccessTokenErrorCode.EXPIRED_ACCESS_TOKEN, "expired");
+    expect(isInvalidSessionError(error)).toBe(true);
+  });
+
+  it("returns true for AccessTokenError with FAILED_REFRESH_GRANT", () => {
+    const error = new AccessTokenError(AccessTokenErrorCode.FAILED_REFRESH_GRANT, "refresh failed");
+    expect(isInvalidSessionError(error)).toBe(true);
+  });
+
+  it("returns false for AccessTokenError with other codes", () => {
+    const error = new AccessTokenError(AccessTokenErrorCode.MISSING_SESSION, "no session");
+    expect(isInvalidSessionError(error)).toBe(false);
+  });
+
+  it("returns false for non-AccessTokenError instances", () => {
+    expect(isInvalidSessionError(new Error("boom"))).toBe(false);
+  });
+
+  it("returns false for null/undefined", () => {
+    expect(isInvalidSessionError(null)).toBe(false);
+    expect(isInvalidSessionError(undefined)).toBe(false);
+  });
+});

--- a/apps/deploy-web/src/lib/auth0/isInvalidSessionError/isInvalidSessionError.ts
+++ b/apps/deploy-web/src/lib/auth0/isInvalidSessionError/isInvalidSessionError.ts
@@ -1,11 +1,11 @@
 import { AccessTokenError, AccessTokenErrorCode } from "@src/lib/auth0";
 
-const INVALID_SESSION_CODES: string[] = [AccessTokenErrorCode.EXPIRED_ACCESS_TOKEN, AccessTokenErrorCode.FAILED_REFRESH_GRANT];
+const INVALID_SESSION_CODES = [AccessTokenErrorCode.EXPIRED_ACCESS_TOKEN, AccessTokenErrorCode.FAILED_REFRESH_GRANT];
 
 export function isInvalidSessionError(error: unknown): boolean {
   if (!(error instanceof AccessTokenError)) {
     return false;
   }
 
-  return INVALID_SESSION_CODES.includes(error.code);
+  return INVALID_SESSION_CODES.some(code => code === error.code);
 }

--- a/apps/deploy-web/src/lib/auth0/isInvalidSessionError/isInvalidSessionError.ts
+++ b/apps/deploy-web/src/lib/auth0/isInvalidSessionError/isInvalidSessionError.ts
@@ -1,0 +1,11 @@
+import { AccessTokenError, AccessTokenErrorCode } from "@src/lib/auth0";
+
+const INVALID_SESSION_CODES: string[] = [AccessTokenErrorCode.EXPIRED_ACCESS_TOKEN, AccessTokenErrorCode.FAILED_REFRESH_GRANT];
+
+export function isInvalidSessionError(error: unknown): boolean {
+  if (!(error instanceof AccessTokenError)) {
+    return false;
+  }
+
+  return INVALID_SESSION_CODES.includes(error.code);
+}

--- a/apps/deploy-web/src/lib/nextjs/defineApiHandler/defineApiHandler.spec.ts
+++ b/apps/deploy-web/src/lib/nextjs/defineApiHandler/defineApiHandler.spec.ts
@@ -5,7 +5,9 @@ import { mock } from "vitest-mock-extended";
 import { z } from "zod";
 
 import type { Session } from "@src/lib/auth0";
+import { AccessTokenError, AccessTokenErrorCode } from "@src/lib/auth0";
 import { services } from "@src/services/app-di-container/server-di-container.service";
+import type { ErrorHandlerService } from "@src/services/error-handler/error-handler.service";
 import type { NextApiRequestWithServices } from "./defineApiHandler";
 import { defineApiHandler, REQ_SERVICES_KEY } from "./defineApiHandler";
 
@@ -107,6 +109,95 @@ describe("defineApiHandler", () => {
         body: { name: "test", age: 10 }
       })
     );
+  });
+
+  it("clears appSession cookies and passes session=null to handler when getSession throws an invalid session error", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const logger = mock<LoggerService>();
+    const req = createRequest({
+      url: "/api/proxy/v1/tx",
+      cookies: { appSession: "stale", "appSession.0": "stale-0", other: "keep" }
+    });
+    const res = mock<NextApiResponse>();
+
+    await setup({
+      handler,
+      context: {
+        req,
+        res,
+        services: {
+          logger,
+          getSession: vi.fn(async () => {
+            throw new AccessTokenError(AccessTokenErrorCode.FAILED_REFRESH_GRANT, "refresh failed");
+          })
+        }
+      }
+    });
+
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "Set-Cookie",
+      expect.arrayContaining([
+        expect.stringMatching(/^appSession=;.*Expires=Thu, 01 Jan 1970/),
+        expect.stringMatching(/^appSession\.0=;.*Expires=Thu, 01 Jan 1970/)
+      ])
+    );
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "API_SESSION_INVALID" }));
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ session: null }));
+  });
+
+  it("clears appSession cookies when access token is expired", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const req = createRequest({
+      url: "/api/proxy/v1/tx",
+      cookies: { appSession: "stale" }
+    });
+    const res = mock<NextApiResponse>();
+
+    await setup({
+      handler,
+      context: {
+        req,
+        res,
+        services: {
+          logger: mock<LoggerService>(),
+          getSession: vi.fn(async () => {
+            throw new AccessTokenError(AccessTokenErrorCode.EXPIRED_ACCESS_TOKEN, "expired");
+          })
+        }
+      }
+    });
+
+    expect(res.setHeader).toHaveBeenCalledWith("Set-Cookie", expect.arrayContaining([expect.stringMatching(/^appSession=;/)]));
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ session: null }));
+  });
+
+  it("reports unexpected getSession errors and passes session=null to handler", async () => {
+    const handler = vi.fn().mockResolvedValue(undefined);
+    const errorHandler = mock<ErrorHandlerService>();
+    const error = new Error("decryption boom");
+    const req = createRequest({ cookies: {} });
+    const res = mock<NextApiResponse>();
+
+    await setup({
+      handler,
+      context: {
+        req,
+        res,
+        services: {
+          errorHandler,
+          getSession: vi.fn(async () => {
+            throw error;
+          })
+        }
+      }
+    });
+
+    expect(errorHandler.reportError).toHaveBeenCalledWith({
+      error,
+      tags: { category: "auth0", event: "API_GET_SESSION_ERROR" }
+    });
+    expect(res.setHeader).not.toHaveBeenCalledWith("Set-Cookie", expect.anything());
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ session: null }));
   });
 
   it("returns 400 error and logs warning when schema validation fails", async () => {

--- a/apps/deploy-web/src/lib/nextjs/defineApiHandler/defineApiHandler.ts
+++ b/apps/deploy-web/src/lib/nextjs/defineApiHandler/defineApiHandler.ts
@@ -22,9 +22,9 @@ export function defineApiHandler<TResponse, TSchema extends z.ZodSchema<any> | u
       }
 
       const requestServices = (req as NextApiRequestWithServices)[REQ_SERVICES_KEY] || services;
-      let session: Session | null | undefined = null;
+      let session: Session | null = null;
       try {
-        session = await requestServices.getSession(req, res);
+        session = (await requestServices.getSession(req, res)) ?? null;
       } catch (error) {
         if (isInvalidSessionError(error)) {
           requestServices.logger.warn({ event: "API_SESSION_INVALID", url: req.url, error });

--- a/apps/deploy-web/src/lib/nextjs/defineApiHandler/defineApiHandler.ts
+++ b/apps/deploy-web/src/lib/nextjs/defineApiHandler/defineApiHandler.ts
@@ -3,6 +3,8 @@ import type { NextApiHandler, NextApiRequest, NextApiResponse } from "next";
 import type { z } from "zod";
 
 import type { Session } from "@src/lib/auth0";
+import { clearSessionCookies } from "@src/lib/auth0/clearSessionCookies/clearSessionCookies";
+import { isInvalidSessionError } from "@src/lib/auth0/isInvalidSessionError/isInvalidSessionError";
 import { services } from "@src/services/app-di-container/server-di-container.service";
 import { createRequestExecutionContext, requestExecutionContext } from "../requestExecutionContext";
 
@@ -20,7 +22,17 @@ export function defineApiHandler<TResponse, TSchema extends z.ZodSchema<any> | u
       }
 
       const requestServices = (req as NextApiRequestWithServices)[REQ_SERVICES_KEY] || services;
-      const session = await requestServices.getSession(req, res);
+      let session: Session | null | undefined = null;
+      try {
+        session = await requestServices.getSession(req, res);
+      } catch (error) {
+        if (isInvalidSessionError(error)) {
+          requestServices.logger.warn({ event: "API_SESSION_INVALID", url: req.url, error });
+          clearSessionCookies(req, res);
+        } else {
+          requestServices.errorHandler.reportError({ error, tags: { category: "auth0", event: "API_GET_SESSION_ERROR" } });
+        }
+      }
 
       requestServices.userTracker.track(session?.user);
       const context: ApiHandlerContext<TResponse, TSchema> = {

--- a/apps/deploy-web/src/pages/api/auth/[...auth0].ts
+++ b/apps/deploy-web/src/pages/api/auth/[...auth0].ts
@@ -5,8 +5,10 @@ import { once } from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import type { Session } from "@src/lib/auth0";
-import { AccessTokenError, AccessTokenErrorCode, CallbackHandlerError, IdentityProviderError, MissingStateCookieError } from "@src/lib/auth0";
+import { CallbackHandlerError, IdentityProviderError, MissingStateCookieError } from "@src/lib/auth0";
 import { handleAuth, handleCallback, handleLogin, handleLogout } from "@src/lib/auth0";
+import { clearSessionCookies } from "@src/lib/auth0/clearSessionCookies/clearSessionCookies";
+import { isInvalidSessionError } from "@src/lib/auth0/isInvalidSessionError/isInvalidSessionError";
 import { defineApiHandler } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
 import type { AppServices } from "@src/services/app-di-container/server-di-container.service";
 import { rewriteLocalRedirect } from "@src/services/auth/auth/rewrite-local-redirect";
@@ -70,14 +72,8 @@ const authHandler = once((services: AppServices) =>
     },
     logout: services.privateConfig.AUTH0_LOCAL_ENABLED
       ? async function (req: NextApiRequest, res: NextApiResponse) {
-          const cookies = req.cookies;
-          const expiredCookies = Object.keys(cookies)
-            .filter(key => key.startsWith("appSession"))
-            .map(key => `${key}=; Path=/; HttpOnly; SameSite=Lax; Expires=Thu, 01 Jan 1970 00:00:00 GMT`);
-
-          res.setHeader("Set-Cookie", expiredCookies);
+          clearSessionCookies(req, res);
           res.writeHead(302, { Location: "/" });
-
           res.end();
         }
       : handleLogout,
@@ -123,16 +119,6 @@ const authHandler = once((services: AppServices) =>
   })
 );
 
-function isInvalidSessionError(error: unknown): boolean {
-  if (!(error instanceof AccessTokenError)) {
-    return false;
-  }
-
-  const invalidSessionCodes: string[] = [AccessTokenErrorCode.EXPIRED_ACCESS_TOKEN, AccessTokenErrorCode.FAILED_REFRESH_GRANT];
-
-  return invalidSessionCodes.includes(error.code);
-}
-
 function isGeneralAxiosError(error: unknown): error is AxiosError {
   return isAxiosError(error) && !!error?.status && error.status >= 400 && error.status < 500;
 }
@@ -146,15 +132,7 @@ function isAccessDeniedError(error: unknown): boolean {
 }
 
 function clearSessionAndRedirectToLogin(req: NextApiRequest, res: NextApiResponse): void {
-  // Clear invalid session cookies before redirecting
-  const cookies = req.cookies;
-  const expiredCookies = Object.keys(cookies)
-    .filter(key => key.startsWith("appSession"))
-    .map(key => `${key}=; Path=/; HttpOnly; SameSite=Lax; Expires=Thu, 01 Jan 1970 00:00:00 GMT`);
-
-  if (expiredCookies.length > 0) {
-    res.setHeader("Set-Cookie", expiredCookies);
-  }
+  clearSessionCookies(req, res);
 
   const returnTo = encodeURIComponent(req.url || "/");
   const loginUrl = `/api/auth/login?returnTo=${returnTo}`;

--- a/apps/deploy-web/src/pages/api/proxy/[...path].spec.ts
+++ b/apps/deploy-web/src/pages/api/proxy/[...path].spec.ts
@@ -1,0 +1,78 @@
+import type { LoggerService } from "@akashnetwork/logging";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { Session } from "@src/lib/auth0";
+import type { NextApiRequestWithServices } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
+import { REQ_SERVICES_KEY } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
+import type { ApiUrlService } from "@src/services/api-url/api-url.service";
+import { services } from "@src/services/app-di-container/server-di-container.service";
+import handler from "./[...path]";
+
+describe("proxy [...path] handler", () => {
+  it("forwards Bearer token when session has accessToken", async () => {
+    const { proxyRequest } = await invokeHandler({
+      session: { accessToken: "valid-token", user: { id: "u1" } } as Session
+    });
+
+    const headers = proxyRequest.mock.calls[0]![2].headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer valid-token");
+  });
+
+  it("does not forward Authorization header when session has no accessToken", async () => {
+    const { proxyRequest } = await invokeHandler({
+      session: { user: { id: "u1" } } as Session
+    });
+
+    const headers = proxyRequest.mock.calls[0]![2].headers as Record<string, string>;
+    expect(headers.authorization).toBeUndefined();
+  });
+
+  it("does not forward Authorization header when there is no session at all", async () => {
+    const { proxyRequest } = await invokeHandler({ session: null });
+
+    const headers = proxyRequest.mock.calls[0]![2].headers as Record<string, string>;
+    expect(headers.authorization).toBeUndefined();
+  });
+
+  it("forwards cf-connecting-ip and request-id headers", async () => {
+    const { proxyRequest } = await invokeHandler({ session: null });
+
+    const headers = proxyRequest.mock.calls[0]![2].headers as Record<string, string>;
+    expect(headers["cf-connecting-ip"]).toBe("127.0.0.1");
+  });
+
+  async function invokeHandler(input: { session: Session | null }) {
+    const proxyRequest = vi.fn().mockResolvedValue(undefined);
+    const getSession = vi.fn().mockResolvedValue(input.session);
+    const logger = mock<LoggerService>();
+
+    const apiUrlService = mock<ApiUrlService>({
+      getBaseApiUrlFor: vi.fn().mockReturnValue("http://api.test")
+    });
+
+    const req = {
+      url: "/api/proxy/v1/tx",
+      method: "POST",
+      headers: {} as Record<string, string | string[] | undefined>,
+      cookies: {},
+      socket: { remoteAddress: "127.0.0.1" }
+    } as unknown as NextApiRequest;
+    const res = mock<NextApiResponse>();
+
+    (req as NextApiRequestWithServices)[REQ_SERVICES_KEY] = {
+      ...services,
+      getSession,
+      proxyRequest,
+      logger,
+      apiUrlService,
+      privateConfig: { NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID: "mainnet" } as typeof services.privateConfig,
+      userTracker: mock<typeof services.userTracker>()
+    };
+
+    await handler(req, res);
+
+    return { proxyRequest, getSession, logger, req, res };
+  }
+});

--- a/apps/deploy-web/src/pages/api/proxy/[...path].spec.ts
+++ b/apps/deploy-web/src/pages/api/proxy/[...path].spec.ts
@@ -1,5 +1,7 @@
 import type { LoggerService } from "@akashnetwork/logging";
 import type { NextApiRequest, NextApiResponse } from "next";
+import type { Socket } from "node:net";
+import type { Mock } from "vitest";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -12,38 +14,38 @@ import handler from "./[...path]";
 
 describe("proxy [...path] handler", () => {
   it("forwards Bearer token when session has accessToken", async () => {
-    const { proxyRequest } = await invokeHandler({
+    const { proxyRequest } = await setup({
       session: { accessToken: "valid-token", user: { id: "u1" } } as Session
     });
 
-    const headers = proxyRequest.mock.calls[0]![2].headers as Record<string, string>;
-    expect(headers.authorization).toBe("Bearer valid-token");
+    expect(getForwardedHeaders(proxyRequest).authorization).toBe("Bearer valid-token");
   });
 
   it("does not forward Authorization header when session has no accessToken", async () => {
-    const { proxyRequest } = await invokeHandler({
+    const { proxyRequest } = await setup({
       session: { user: { id: "u1" } } as Session
     });
 
-    const headers = proxyRequest.mock.calls[0]![2].headers as Record<string, string>;
-    expect(headers.authorization).toBeUndefined();
+    expect(getForwardedHeaders(proxyRequest).authorization).toBeUndefined();
   });
 
   it("does not forward Authorization header when there is no session at all", async () => {
-    const { proxyRequest } = await invokeHandler({ session: null });
+    const { proxyRequest } = await setup({ session: null });
 
-    const headers = proxyRequest.mock.calls[0]![2].headers as Record<string, string>;
-    expect(headers.authorization).toBeUndefined();
+    expect(getForwardedHeaders(proxyRequest).authorization).toBeUndefined();
   });
 
   it("forwards cf-connecting-ip and request-id headers", async () => {
-    const { proxyRequest } = await invokeHandler({ session: null });
+    const { proxyRequest } = await setup({ session: null });
 
-    const headers = proxyRequest.mock.calls[0]![2].headers as Record<string, string>;
-    expect(headers["cf-connecting-ip"]).toBe("127.0.0.1");
+    expect(getForwardedHeaders(proxyRequest)["cf-connecting-ip"]).toBe("127.0.0.1");
   });
 
-  async function invokeHandler(input: { session: Session | null }) {
+  function getForwardedHeaders(proxyRequest: Mock): Record<string, string> {
+    return proxyRequest.mock.calls[0]![2].headers as Record<string, string>;
+  }
+
+  async function setup(input: { session: Session | null }) {
     const proxyRequest = vi.fn().mockResolvedValue(undefined);
     const getSession = vi.fn().mockResolvedValue(input.session);
     const logger = mock<LoggerService>();
@@ -55,9 +57,9 @@ describe("proxy [...path] handler", () => {
     const req = {
       url: "/api/proxy/v1/tx",
       method: "POST",
-      headers: {} as Record<string, string | string[] | undefined>,
+      headers: {} as NextApiRequest["headers"],
       cookies: {},
-      socket: { remoteAddress: "127.0.0.1" }
+      socket: { remoteAddress: "127.0.0.1" } as Socket
     } as unknown as NextApiRequest;
     const res = mock<NextApiResponse>();
 

--- a/apps/deploy-web/src/pages/api/proxy/[...path].spec.ts
+++ b/apps/deploy-web/src/pages/api/proxy/[...path].spec.ts
@@ -35,7 +35,7 @@ describe("proxy [...path] handler", () => {
     expect(getForwardedHeaders(proxyRequest).authorization).toBeUndefined();
   });
 
-  it("forwards cf-connecting-ip and request-id headers", async () => {
+  it("forwards cf-connecting-ip header", async () => {
     const { proxyRequest } = await setup({ session: null });
 
     expect(getForwardedHeaders(proxyRequest)["cf-connecting-ip"]).toBe("127.0.0.1");

--- a/apps/deploy-web/src/pages/api/proxy/[...path].spec.ts
+++ b/apps/deploy-web/src/pages/api/proxy/[...path].spec.ts
@@ -1,5 +1,5 @@
 import type { LoggerService } from "@akashnetwork/logging";
-import type { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiResponse } from "next";
 import type { Socket } from "node:net";
 import type { Mock } from "vitest";
 import { describe, expect, it, vi } from "vitest";
@@ -54,16 +54,17 @@ describe("proxy [...path] handler", () => {
       getBaseApiUrlFor: vi.fn().mockReturnValue("http://api.test")
     });
 
-    const req = {
+    const req = mock<NextApiRequestWithServices>({
       url: "/api/proxy/v1/tx",
       method: "POST",
-      headers: {} as NextApiRequest["headers"],
       cookies: {},
-      socket: { remoteAddress: "127.0.0.1" } as Socket
-    } as unknown as NextApiRequest;
+      socket: mock<Socket>({ remoteAddress: "127.0.0.1" })
+    });
+    // assigned post-construction so unknown header lookups return undefined; vitest-mock-extended deep-mocks override values
+    req.headers = {};
     const res = mock<NextApiResponse>();
 
-    (req as NextApiRequestWithServices)[REQ_SERVICES_KEY] = {
+    req[REQ_SERVICES_KEY] = {
       ...services,
       getSession,
       proxyRequest,

--- a/apps/deploy-web/src/pages/api/proxy/[...path].ts
+++ b/apps/deploy-web/src/pages/api/proxy/[...path].ts
@@ -1,10 +1,9 @@
 import { defineApiHandler } from "@src/lib/nextjs/defineApiHandler/defineApiHandler";
-import { proxyRequest } from "@src/lib/nextjs/proxyRequest/proxyRequest";
 import { sentryTraceToW3C } from "@src/services/error-handler/error-handler.service";
 
 export default defineApiHandler({
   route: "/api/proxy/[...path]",
-  async handler({ req, res, services }) {
+  async handler({ req, res, services, session }) {
     services.logger.info({ event: "PROXY_API_REQUEST", url: req.url });
     const url = req.url?.replace(/^\/api\/proxy\//, "/") || "";
 
@@ -22,8 +21,6 @@ export default defineApiHandler({
       headers["baggage"] = req.headers["baggage"] as string;
     }
 
-    const session = await services.getSession(req, res);
-
     // Extract and forward cf_clearance and unleash-session-id cookies
     const cookiesToForward = req.headers.cookie
       ?.split(";")
@@ -38,7 +35,7 @@ export default defineApiHandler({
       headers.authorization = `Bearer ${session.accessToken}`;
     }
 
-    await proxyRequest(req, res, {
+    await services.proxyRequest(req, res, {
       target: services.apiUrlService.getBaseApiUrlFor(services.privateConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID) + url,
       headers,
       onError: error => {

--- a/apps/deploy-web/src/pages/api/proxy/[...path].ts
+++ b/apps/deploy-web/src/pages/api/proxy/[...path].ts
@@ -21,7 +21,6 @@ export default defineApiHandler({
       headers["baggage"] = req.headers["baggage"] as string;
     }
 
-    // Extract and forward cf_clearance and unleash-session-id cookies
     const cookiesToForward = req.headers.cookie
       ?.split(";")
       .map(c => c.trim())

--- a/apps/deploy-web/src/services/app-di-container/server-di-container.service.ts
+++ b/apps/deploy-web/src/services/app-di-container/server-di-container.service.ts
@@ -4,6 +4,7 @@ import * as unleashModule from "@unleash/nextjs";
 
 import { serverEnvConfig } from "@src/config/server-env.config";
 import { getSession } from "@src/lib/auth0";
+import { proxyRequest } from "@src/lib/nextjs/proxyRequest/proxyRequest";
 import { ApiUrlService } from "../api-url/api-url.service";
 import { clientIpForwardingInterceptor } from "../client-ip-forwarding/client-ip-forwarding.interceptor";
 import { createChildContainer } from "../container/createContainer";
@@ -23,6 +24,7 @@ const rootContainer = createAppRootContainer({
 
 export const services = createChildContainer(rootContainer, {
   getSession: () => getSession,
+  proxyRequest: () => proxyRequest,
   featureFlagService: () => new FeatureFlagService(unleashModule, serverEnvConfig),
   notificationsApi: () =>
     createAPIClient({

--- a/apps/deploy-web/vitest.config.ts
+++ b/apps/deploy-web/vitest.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
           environment: "jsdom",
           isolate: false,
           include: ["src/**/*.spec.{tsx,ts}"],
-          exclude: ["**/node_modules/**", "src/lib/nextjs/**", "src/lib/auth0/**"],
+          exclude: ["**/node_modules/**", "src/lib/nextjs/**", "src/lib/auth0/**", "src/pages/api/**"],
           setupFiles: ["tests/unit/setup.ts"]
         },
         resolve: {
@@ -50,7 +50,7 @@ export default defineConfig({
         test: {
           name: "unit-node",
           environment: "node",
-          include: ["src/lib/{nextjs,auth0}/**/*.spec.{tsx,ts}"],
+          include: ["src/lib/{nextjs,auth0}/**/*.spec.{tsx,ts}", "src/pages/api/**/*.spec.{tsx,ts}"],
           setupFiles: ["src/lib/nextjs/setup-node-tests.ts"]
         },
         resolve: {


### PR DESCRIPTION
## Why

When Auth0's `getSession` throws (e.g. `ERR_FAILED_REFRESH_GRANT`, `ERR_EXPIRED_ACCESS_TOKEN`, corrupt session cookie), the `defineApiHandler` chain crashes before any route runs. The `/api/proxy/[...path]` route is wrapped by `defineApiHandler` and its own `proxyRequest` catch path converts thrown errors into `502`s — so users whose refresh token expired (or whose session cookie is invalid) see `502` when they try to create a deployment instead of the clean `401` they need to be redirected to login.

Refs #2465 — and is the same family of failures originally seen in #2148 (`ProfileHandlerError ... refresh token is not available`).

## What

- `defineApiHandler` now wraps `getSession` in `try/catch`:
  - On `AccessTokenError` with code `EXPIRED_ACCESS_TOKEN` or `FAILED_REFRESH_GRANT`: log `API_SESSION_INVALID`, clear `appSession*` cookies, pass `session = null` to the route handler.
  - On any other unexpected error: report via `errorHandler` with `event: API_GET_SESSION_ERROR`, pass `session = null`.
- Routes (proxy, profile, etc.) get a usable context. The proxy now reads `session` from context (was redundantly calling `getSession` again) and forwards the request without the `Authorization` header when the session is gone — the upstream API returns a clean `401` which the proxy faithfully proxies. `502` is reserved for genuine upstream failure, as the existing `proxyRequest.spec.ts` contract intends.
- Extract `clearSessionCookies` and `isInvalidSessionError` into shared utils (`src/lib/auth0/...`), replacing the inline duplicates in `[...auth0].ts`. The local-Auth0 logout path also uses the shared helper now.
- `proxyRequest` is registered on the server DI container so `[...path]` can be unit-tested via the existing `REQ_SERVICES_KEY` injection pattern.
- `vitest.config.ts`: route `src/pages/api/**/*.spec.ts` to the `unit-node` project so the new `[...path].spec.ts` runs in the right environment.

## Test plan
- [x] `npx vitest run src/lib/auth0/clearSessionCookies/...` — 3 new tests
- [x] `npx vitest run src/lib/auth0/isInvalidSessionError/...` — 5 new tests
- [x] `npx vitest run src/lib/nextjs/defineApiHandler/...` — 3 new tests cover `EXPIRED_ACCESS_TOKEN`, `FAILED_REFRESH_GRANT`, and unexpected errors
- [x] `npx vitest run "src/pages/api/proxy/[...path].spec.ts"` — 4 new tests cover Bearer forwarding behavior
- [x] `npm run test:unit` — only pre-existing failures remain (unrelated `TrendIndicator` test, fails on `main` too)
- [x] `npx tsc --noEmit` — no new TS errors in touched files
- [x] `npx eslint --quiet` on touched files — clean
- [ ] Manual smoke: corrupt the `appSession` cookie in DevTools → reload → trigger a deployment action → confirm browser receives **401** (not 502), the bad cookie is cleared via `Set-Cookie`, and the app routes to login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added utilities to detect invalid sessions and to clear stale session cookies; proxy handler now accepts session info and DI container exposes proxy functionality.

* **Bug Fixes**
  * Improved handling of expired/invalid authentication sessions with automatic cookie cleanup, warning logs for invalid sessions, and safer session retrieval with error reporting.

* **Tests**
  * Added unit tests covering session invalidation, cookie clearing, API proxy behavior, header forwarding, and edge cases.

* **Chores**
  * Updated test configuration to include API tests and adjust coverage exclusions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->