### PR TITLE
feat(wallet): add self_custody feature flag plumbing

### DIFF
--- a/apps/deploy-web/src/hoc/guard/useIsSelfCustodyAccessible.spec.tsx
+++ b/apps/deploy-web/src/hoc/guard/useIsSelfCustodyAccessible.spec.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { useIsSelfCustodyAccessible } from "./useIsSelfCustodyAccessible";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useIsSelfCustodyAccessible.name, () => {
+  it("allows visit when self-custody is enabled", () => {
+    const { result } = setup({ enabled: true });
+
+    expect(result.current).toEqual({ canVisit: true, isLoading: false });
+  });
+
+  it("denies visit when self-custody is disabled", () => {
+    const { result } = setup({ enabled: false });
+
+    expect(result.current).toEqual({ canVisit: false, isLoading: false });
+  });
+
+  function setup(input: { enabled: boolean }) {
+    const useIsSelfCustodyEnabled = vi.fn(() => input.enabled);
+
+    return renderHook(() => useIsSelfCustodyAccessible({ useIsSelfCustodyEnabled }));
+  }
+});

--- a/apps/deploy-web/src/hoc/guard/useIsSelfCustodyAccessible.ts
+++ b/apps/deploy-web/src/hoc/guard/useIsSelfCustodyAccessible.ts
@@ -1,0 +1,12 @@
+import { useIsSelfCustodyEnabled } from "@src/hooks/useIsSelfCustodyEnabled";
+
+export const DEPENDENCIES = {
+  useIsSelfCustodyEnabled
+};
+
+export const useIsSelfCustodyAccessible = (dependencies: typeof DEPENDENCIES = DEPENDENCIES) => {
+  return {
+    canVisit: dependencies.useIsSelfCustodyEnabled(),
+    isLoading: false
+  };
+};

--- a/apps/deploy-web/src/hooks/useIsSelfCustodyEnabled.spec.tsx
+++ b/apps/deploy-web/src/hooks/useIsSelfCustodyEnabled.spec.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DEPENDENCIES } from "./useIsSelfCustodyEnabled";
+import { SELF_CUSTODY_FLAG, useIsSelfCustodyEnabled } from "./useIsSelfCustodyEnabled";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useIsSelfCustodyEnabled.name, () => {
+  it("returns true when the self_custody flag is enabled", () => {
+    const { result, useFlagSpy } = setup({ flagValue: true });
+
+    expect(result.current).toBe(true);
+    expect(useFlagSpy).toHaveBeenCalledWith(SELF_CUSTODY_FLAG);
+  });
+
+  it("returns false when the self_custody flag is disabled", () => {
+    const { result } = setup({ flagValue: false });
+
+    expect(result.current).toBe(false);
+  });
+
+  function setup(input: { flagValue: boolean }) {
+    const useFlagSpy = vi.fn<typeof DEPENDENCIES.useFlag>(() => input.flagValue);
+
+    const { result } = renderHook(() => useIsSelfCustodyEnabled({ useFlag: useFlagSpy }));
+
+    return { result, useFlagSpy };
+  }
+});

--- a/apps/deploy-web/src/hooks/useIsSelfCustodyEnabled.ts
+++ b/apps/deploy-web/src/hooks/useIsSelfCustodyEnabled.ts
@@ -1,0 +1,11 @@
+import { useFlag } from "@src/hooks/useFlag";
+
+export const SELF_CUSTODY_FLAG = "self_custody" as const;
+
+export const DEPENDENCIES = {
+  useFlag
+};
+
+export const useIsSelfCustodyEnabled = (dependencies: typeof DEPENDENCIES = DEPENDENCIES): boolean => {
+  return dependencies.useFlag(SELF_CUSTODY_FLAG);
+};

--- a/apps/deploy-web/src/lib/nextjs/pageGuards/selfCustody.spec.ts
+++ b/apps/deploy-web/src/lib/nextjs/pageGuards/selfCustody.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { SELF_CUSTODY_FLAG } from "@src/hooks/useIsSelfCustodyEnabled";
+import type { FeatureFlagService } from "@src/services/feature-flag/feature-flag.service";
+import type { AppTypedContext } from "../defineServerSideProps/defineServerSideProps";
+import { isSelfCustodyEnabled } from "./selfCustody";
+
+describe(isSelfCustodyEnabled.name, () => {
+  it("returns true when the self_custody flag is enabled in context", async () => {
+    const context = setup({ enabled: true });
+
+    expect(await isSelfCustodyEnabled(context)).toBe(true);
+    expect(context.services.featureFlagService.isEnabledForCtx).toHaveBeenCalledWith(SELF_CUSTODY_FLAG, context, expect.anything());
+  });
+
+  it("returns false when the self_custody flag is disabled in context", async () => {
+    const context = setup({ enabled: false });
+
+    expect(await isSelfCustodyEnabled(context)).toBe(false);
+  });
+
+  function setup(input: { enabled: boolean }) {
+    return mock<AppTypedContext>({
+      getCurrentSession: vi.fn().mockResolvedValue(null),
+      services: {
+        featureFlagService: mock<FeatureFlagService>({
+          isEnabledForCtx: vi.fn().mockResolvedValue(input.enabled)
+        })
+      }
+    });
+  }
+});

--- a/apps/deploy-web/src/lib/nextjs/pageGuards/selfCustody.ts
+++ b/apps/deploy-web/src/lib/nextjs/pageGuards/selfCustody.ts
@@ -1,0 +1,7 @@
+import { SELF_CUSTODY_FLAG } from "@src/hooks/useIsSelfCustodyEnabled";
+import type { AppTypedContext } from "../defineServerSideProps/defineServerSideProps";
+import { isFeatureEnabled } from "./pageGuards";
+
+export function isSelfCustodyEnabled(context: AppTypedContext): Promise<boolean> {
+  return isFeatureEnabled(SELF_CUSTODY_FLAG, context);
+}

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -7,4 +7,5 @@ export type FeatureFlag =
   | "ui_sdl_log_collector_enabled"
   | "maintenance_banner"
   | "auto_credit_reload"
-  | "console_embedded_login";
+  | "console_embedded_login"
+  | "self_custody";


### PR DESCRIPTION
## Why

Adds the dormant plumbing for a single `self_custody` feature flag that gates every self-custody crypto surface in deploy-web (Keplr/Leap connection, mint/burn, custodial wallet popup, get-started/wallet, certificates, liquidity modal, etc.).

This is the first of two PRs splitting CON-293. Landing it dormant lets the follow-up "wire consumers" PR be a single mechanical pass that imports an already-typed flag from one well-known place. On cutover day the flag is flipped off in Unleash and the entire self-custody surface disappears for users; afterwards we begin removing the gated code.

Closes CON-294
Part of CON-293

## What

- Adds `self_custody` to the `FeatureFlag` union ([feature-flags.ts](apps/deploy-web/src/types/feature-flags.ts)).
- New client hook `useIsSelfCustodyEnabled()` ([useIsSelfCustodyEnabled.ts](apps/deploy-web/src/hooks/useIsSelfCustodyEnabled.ts)) — thin wrapper over the existing `useFlag()` so `NEXT_PUBLIC_UNLEASH_ENABLE_ALL` keeps working in dev. Exports `SELF_CUSTODY_FLAG` so client and server code share a single source-of-truth constant.
- New server-side helper `isSelfCustodyEnabled(ctx)` ([selfCustody.ts](apps/deploy-web/src/lib/nextjs/pageGuards/selfCustody.ts)) — composes into `defineServerSideProps({ if: ... })` exactly like the existing `isFeatureEnabled("billing_usage", ctx)` pattern in [pages/billing/index.tsx](apps/deploy-web/src/pages/billing/index.tsx).
- New `Guard`-compatible adapter `useIsSelfCustodyAccessible` ([useIsSelfCustodyAccessible.ts](apps/deploy-web/src/hoc/guard/useIsSelfCustodyAccessible.ts)) so the flag composes with `composeGuards`.
- Unit tests for all three modules following the team `setup()` pattern with `vitest-mock-extended` and DEPENDENCIES injection (no `vi.mock`).

PR is **dormant**: no production file outside the new modules imports the new symbols. No user-visible behavior change. The follow-up PR will wire consumers and add a custom 404 page (linking to the Console Air repo) for stale custodial users hitting gated routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added self-custody feature flag support with access control and validation mechanisms.
  * Introduced feature flag checks to enable or disable self-custody functionality.

* **Tests**
  * Added comprehensive test coverage for self-custody feature flag and access guard functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->