### PR TITLE
feat(wallet): wire self_custody flag consumers and 404 link

### DIFF
--- a/apps/deploy-web/src/components/liquidity-modal/index.tsx
+++ b/apps/deploy-web/src/components/liquidity-modal/index.tsx
@@ -9,9 +9,14 @@ import { Modal } from "@mui/material";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
+import { useIsSelfCustodyEnabled } from "@src/hooks/useIsSelfCustodyEnabled";
 import { useSelectedChain } from "@src/hooks/useSelectedChain/useSelectedChain";
 
 export type NonUndefined<T> = T extends undefined ? never : T;
+
+export const DEPENDENCIES = {
+  useIsSelfCustodyEnabled
+};
 
 const ToggleLiquidityModalButton: React.FC<{ onClick: () => void }> = ({ onClick }) => {
   const { analyticsService } = useServices();
@@ -106,9 +111,10 @@ const getTabsConfig = (txnLifecycleHooks: any) => {
   // } satisfies Elements.TabsConfig;
 };
 
-type Props = { address: string; aktBalance: number; refreshBalances: () => void };
+type Props = { address: string; aktBalance: number; refreshBalances: () => void; dependencies?: typeof DEPENDENCIES };
 
-const LiquidityModal: React.FC<Props> = ({ refreshBalances }) => {
+const LiquidityModal: React.FC<Props> = ({ refreshBalances, dependencies: d = DEPENDENCIES }) => {
+  const isSelfCustodyEnabled = d.useIsSelfCustodyEnabled();
   const { analyticsService } = useServices();
   const [isOpen, setIsOpen] = useState(false);
   const [isElementsReady, setIsElementsReady] = useState(false);
@@ -196,6 +202,8 @@ const LiquidityModal: React.FC<Props> = ({ refreshBalances }) => {
       window.removeEventListener("@leapwallet/elements:load", cb);
     };
   }, []);
+
+  if (!isSelfCustodyEnabled) return null;
 
   return (
     <>

--- a/apps/deploy-web/src/components/wallet/CustodialWalletPopup/CustodialWalletPopup.spec.tsx
+++ b/apps/deploy-web/src/components/wallet/CustodialWalletPopup/CustodialWalletPopup.spec.tsx
@@ -71,7 +71,20 @@ describe(CustodialWalletPopup.name, () => {
     expect(screen.getByTestId("connect-managed-wallet")).toBeInTheDocument();
   });
 
-  function setup(input?: { address?: string; walletBalance?: WalletBalance | null; isSignedInWithTrial?: boolean; user?: Record<string, unknown> | null }) {
+  it("renders nothing when self_custody flag is disabled", () => {
+    setup({ address: "akash1abc123", isSelfCustodyEnabled: false });
+
+    expect(screen.queryByLabelText("wallet address")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("connect-managed-wallet")).not.toBeInTheDocument();
+  });
+
+  function setup(input?: {
+    address?: string;
+    walletBalance?: WalletBalance | null;
+    isSignedInWithTrial?: boolean;
+    user?: Record<string, unknown> | null;
+    isSelfCustodyEnabled?: boolean;
+  }) {
     const logout = vi.fn();
     const push = vi.fn();
     const store = createStore();
@@ -83,6 +96,7 @@ describe(CustodialWalletPopup.name, () => {
       useWallet: () => ({ address: input?.address ?? "akash1default", logout }),
       useRouter: () => ({ push }),
       useCustomUser: () => ({ user: input?.user !== undefined ? input.user : { id: "user-1" } }),
+      useIsSelfCustodyEnabled: () => input?.isSelfCustodyEnabled ?? true,
       Address: (props: React.HTMLAttributes<HTMLSpanElement> & { address: string }) => <span aria-label={props["aria-label"]}>{props.address}</span>,
       FormattedNumber: ({ value }: { value: number }) => <span>{value}</span>,
       Link: ({ href, children, className }: { href: string; children: React.ReactNode; className?: string }) =>

--- a/apps/deploy-web/src/components/wallet/CustodialWalletPopup/CustodialWalletPopup.tsx
+++ b/apps/deploy-web/src/components/wallet/CustodialWalletPopup/CustodialWalletPopup.tsx
@@ -10,6 +10,7 @@ import { useRouter } from "next/router";
 import { UAKT_DENOM } from "@src/config/denom.config";
 import { useWallet } from "@src/context/WalletProvider";
 import { useCustomUser } from "@src/hooks/useCustomUser";
+import { useIsSelfCustodyEnabled } from "@src/hooks/useIsSelfCustodyEnabled";
 import type { WalletBalance } from "@src/hooks/useWalletBalance";
 import walletStore from "@src/store/walletStore";
 import { udenomToDenom } from "@src/utils/mathHelpers";
@@ -36,14 +37,18 @@ export const DEPENDENCIES = {
   PriceValue,
   useWallet,
   useRouter,
-  useCustomUser
+  useCustomUser,
+  useIsSelfCustodyEnabled
 };
 
 export const CustodialWalletPopup: React.FC<CustodialWalletPopupProps> = ({ walletBalance, dependencies: d = DEPENDENCIES }) => {
+  const isSelfCustodyEnabled = d.useIsSelfCustodyEnabled();
   const { address, logout } = d.useWallet();
   const router = d.useRouter();
   const [isSignedInWithTrial] = useAtom(walletStore.isSignedInWithTrial);
   const { user } = d.useCustomUser();
+
+  if (!isSelfCustodyEnabled) return null;
 
   return (
     <div className="w-[300px] p-2">

--- a/apps/deploy-web/src/components/wallet/ManagedWalletPopup/ManagedWalletPopup.spec.tsx
+++ b/apps/deploy-web/src/components/wallet/ManagedWalletPopup/ManagedWalletPopup.spec.tsx
@@ -73,7 +73,25 @@ describe(ManagedWalletPopup.name, () => {
     expect(switchWalletType).toHaveBeenCalledTimes(1);
   });
 
-  function setup(input?: { walletBalance?: WalletBalance | null; isManaged?: boolean; isTrialing?: boolean; isWalletConnected?: boolean }) {
+  it("hides Switch to Wallet Payments button when self_custody flag is OFF", () => {
+    setup({ isSelfCustodyEnabled: false });
+
+    expect(screen.queryByRole("button", { name: /Switch to Wallet Payments/ })).not.toBeInTheDocument();
+  });
+
+  it("renders Switch to Wallet Payments button when self_custody flag is ON", () => {
+    setup({ isSelfCustodyEnabled: true });
+
+    expect(screen.getByRole("button", { name: /Switch to Wallet Payments/ })).toBeInTheDocument();
+  });
+
+  function setup(input?: {
+    walletBalance?: WalletBalance | null;
+    isManaged?: boolean;
+    isTrialing?: boolean;
+    isWalletConnected?: boolean;
+    isSelfCustodyEnabled?: boolean;
+  }) {
     const switchWalletType = vi.fn();
     const showManagedEscrowFaqModal = vi.fn();
 
@@ -90,6 +108,7 @@ describe(ManagedWalletPopup.name, () => {
           billing: ({ openPayment }: { openPayment?: boolean } = {}) => (openPayment ? "/billing?openPayment=true" : "/billing")
         }
       }),
+      useIsSelfCustodyEnabled: () => input?.isSelfCustodyEnabled ?? true,
       FormattedNumber: ({ value }: { value: number }) => <span>{value}</span>,
       LinkTo: ({ children, className, onClick }: { children: React.ReactNode; className?: string; onClick?: () => void }) => (
         <a className={className} onClick={onClick}>

--- a/apps/deploy-web/src/components/wallet/ManagedWalletPopup/ManagedWalletPopup.tsx
+++ b/apps/deploy-web/src/components/wallet/ManagedWalletPopup/ManagedWalletPopup.tsx
@@ -6,6 +6,7 @@ import { CoinsSwap, HandCard } from "iconoir-react";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
+import { useIsSelfCustodyEnabled } from "@src/hooks/useIsSelfCustodyEnabled";
 import { useManagedEscrowFaqModal } from "@src/hooks/useManagedEscrowFaqModal";
 import type { WalletBalance } from "@src/hooks/useWalletBalance";
 import { LinkTo } from "../../shared/LinkTo";
@@ -28,13 +29,15 @@ export const DEPENDENCIES = {
   FormattedNumber,
   useWallet,
   useManagedEscrowFaqModal,
-  useServices
+  useServices,
+  useIsSelfCustodyEnabled
 };
 
 export const ManagedWalletPopup: React.FC<ManagedWalletPopupProps> = ({ walletBalance, dependencies: d = DEPENDENCIES }) => {
   const { isManaged, isTrialing, switchWalletType } = d.useWallet();
   const { showManagedEscrowFaqModal } = d.useManagedEscrowFaqModal();
   const { urlService } = d.useServices();
+  const isSelfCustodyEnabled = d.useIsSelfCustodyEnabled();
 
   return (
     <div className="w-[300px] p-2">
@@ -97,11 +100,15 @@ export const ManagedWalletPopup: React.FC<ManagedWalletPopupProps> = ({ walletBa
           <HandCard className="text-xs" />
           <span className="whitespace-nowrap">Add Funds</span>
         </d.AddFundsLink>
-        <d.Separator className="my-2 bg-secondary/90 dark:bg-white/10" />
-        <d.Button onClick={switchWalletType} variant="outline" className="w-full space-x-2">
-          <d.CoinsSwap />
-          <span>Switch to Wallet Payments</span>
-        </d.Button>
+        {isSelfCustodyEnabled && (
+          <>
+            <d.Separator className="my-2 bg-secondary/90 dark:bg-white/10" />
+            <d.Button onClick={switchWalletType} variant="outline" className="w-full space-x-2">
+              <d.CoinsSwap />
+              <span>Switch to Wallet Payments</span>
+            </d.Button>
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/deploy-web/src/components/wallet/WalletConnectionButtons.spec.tsx
+++ b/apps/deploy-web/src/components/wallet/WalletConnectionButtons.spec.tsx
@@ -1,0 +1,66 @@
+import { createStore, Provider } from "jotai";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import walletStore from "@src/store/walletStore";
+import type { DEPENDENCIES } from "./WalletConnectionButtons";
+import { WalletConnectionButtons } from "./WalletConnectionButtons";
+
+import { render, screen } from "@testing-library/react";
+import { ComponentMock } from "@tests/unit/mocks";
+
+describe(WalletConnectionButtons.name, () => {
+  it("renders the Keplr/Leap connect button when self_custody is enabled", () => {
+    const ConnectWalletButton = vi.fn(ComponentMock);
+    setup({ isSelfCustodyEnabled: true, dependencies: { ConnectWalletButton } });
+
+    expect(ConnectWalletButton).toHaveBeenCalled();
+  });
+
+  it("hides the Keplr/Leap connect button when self_custody is disabled", () => {
+    const ConnectWalletButton = vi.fn(ComponentMock);
+    setup({ isSelfCustodyEnabled: false, dependencies: { ConnectWalletButton } });
+
+    expect(ConnectWalletButton).not.toHaveBeenCalled();
+  });
+
+  it("always renders the managed-wallet connect button", () => {
+    const ConnectManagedWalletButton = vi.fn(ComponentMock);
+    setup({ isSelfCustodyEnabled: false, dependencies: { ConnectManagedWalletButton } });
+
+    expect(ConnectManagedWalletButton).toHaveBeenCalled();
+  });
+
+  it("shows the Sign in link when signed in with trial and no user, regardless of flag", () => {
+    setup({ isSelfCustodyEnabled: false, isSignedInWithTrial: true, user: null });
+
+    expect(screen.getByRole("link", { name: /Sign in/ })).toBeInTheDocument();
+  });
+
+  function setup(input: {
+    isSelfCustodyEnabled?: boolean;
+    isSignedInWithTrial?: boolean;
+    user?: Record<string, unknown> | null;
+    dependencies?: Partial<typeof DEPENDENCIES>;
+  }) {
+    const store = createStore();
+    store.set(walletStore.isSignedInWithTrial, input.isSignedInWithTrial ?? false);
+
+    const dependencies: typeof DEPENDENCIES = {
+      useIsSelfCustodyEnabled: () => input.isSelfCustodyEnabled ?? true,
+      useCustomUser: () =>
+        mock<ReturnType<typeof DEPENDENCIES.useCustomUser>>({
+          user: ("user" in input ? input.user : { id: "user-1" }) as ReturnType<typeof DEPENDENCIES.useCustomUser>["user"]
+        }),
+      ConnectManagedWalletButton: vi.fn(ComponentMock) as unknown as typeof DEPENDENCIES.ConnectManagedWalletButton,
+      ConnectWalletButton: vi.fn(ComponentMock) as unknown as typeof DEPENDENCIES.ConnectWalletButton,
+      ...input.dependencies
+    };
+
+    return render(
+      <Provider store={store}>
+        <WalletConnectionButtons dependencies={dependencies} />
+      </Provider>
+    );
+  }
+});

--- a/apps/deploy-web/src/components/wallet/WalletConnectionButtons.tsx
+++ b/apps/deploy-web/src/components/wallet/WalletConnectionButtons.tsx
@@ -7,6 +7,7 @@ import { useAtom } from "jotai";
 import Link from "next/link";
 
 import { useCustomUser } from "@src/hooks/useCustomUser";
+import { useIsSelfCustodyEnabled } from "@src/hooks/useIsSelfCustodyEnabled";
 import walletStore from "@src/store/walletStore";
 import { UrlService } from "@src/utils/urlUtils";
 import { ConnectManagedWalletButton } from "./ConnectManagedWalletButton";
@@ -16,26 +17,36 @@ interface WalletConnectionButtonsProps {
   className?: string;
   connectManagedWalletButtonClassName?: string;
   connectWalletButtonClassName?: string;
+  dependencies?: typeof DEPENDENCIES;
 }
+
+export const DEPENDENCIES = {
+  useIsSelfCustodyEnabled,
+  useCustomUser,
+  ConnectManagedWalletButton,
+  ConnectWalletButton
+};
 
 export const WalletConnectionButtons: React.FC<WalletConnectionButtonsProps> = ({
   className,
   connectManagedWalletButtonClassName,
-  connectWalletButtonClassName
+  connectWalletButtonClassName,
+  dependencies: d = DEPENDENCIES
 }) => {
   const [isSignedInWithTrial] = useAtom(walletStore.isSignedInWithTrial);
-  const { user } = useCustomUser();
+  const { user } = d.useCustomUser();
+  const isSelfCustodyEnabled = d.useIsSelfCustodyEnabled();
 
   return (
     <div className={cn("flex items-center gap-4", className)}>
-      {!isSignedInWithTrial && <ConnectManagedWalletButton className={connectManagedWalletButtonClassName} />}
+      {!isSignedInWithTrial && <d.ConnectManagedWalletButton className={connectManagedWalletButtonClassName} />}
       {isSignedInWithTrial && !user && (
         <Link className={cn(buttonVariants({ variant: "outline" }), "flex items-center gap-2")} href={UrlService.newLogin()} passHref prefetch={false}>
           <LogIn className="text-xs" />
           Sign in
         </Link>
       )}
-      <ConnectWalletButton className={connectWalletButtonClassName} />
+      {isSelfCustodyEnabled && <d.ConnectWalletButton className={connectWalletButtonClassName} />}
     </div>
   );
 };

--- a/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
@@ -17,7 +17,7 @@ import { useManagedWallet } from "@src/hooks/useManagedWallet";
 import { useSelectedChain } from "@src/hooks/useSelectedChain/useSelectedChain";
 import { useUser } from "@src/hooks/useUser";
 import { useWhen } from "@src/hooks/useWhen";
-import { useManager } from "@src/lib/cosmos-kit-jotai";
+import { CURRENT_WALLET_KEY, useManager } from "@src/lib/cosmos-kit-jotai";
 import { useBalances } from "@src/queries/useBalancesQuery";
 import networkStore from "@src/store/networkStore";
 import walletStore from "@src/store/walletStore";
@@ -27,6 +27,7 @@ import { useServices } from "../ServicesProvider";
 import { useSettings } from "../SettingsProvider";
 import { settingsIdAtom } from "../SettingsProvider/settingsStore";
 import { deriveWalletIsLoading } from "./deriveWalletIsLoading";
+import { useEnforceSelfCustodyFlag } from "./useEnforceSelfCustodyFlag";
 
 const CONSOLE_MEMO = "akash console";
 
@@ -123,6 +124,13 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     isCustodialConnecting: userWallet.isWalletConnecting
   });
 
+  useEnforceSelfCustodyFlag({
+    isWalletConnected: userWallet.isWalletConnected,
+    selectedWalletType,
+    setSelectedWalletType,
+    disconnect: userWallet.disconnect
+  });
+
   useWhen(walletAddress, loadWallet);
 
   useWhen(isWalletConnected && selectedWalletType, () => {
@@ -169,6 +177,10 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
       userWallet.disconnect();
     }
 
+    if (selectedWalletType === "custodial" && typeof window !== "undefined") {
+      window.localStorage.removeItem(CURRENT_WALLET_KEY);
+    }
+
     if (selectedWalletType === "managed" && !userWallet.isWalletConnected) {
       userWallet.connect();
     }
@@ -192,6 +204,10 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
 
   function logout() {
     userWallet.disconnect();
+
+    if (typeof window !== "undefined") {
+      window.localStorage.removeItem(CURRENT_WALLET_KEY);
+    }
 
     analyticsService.track("disconnect_wallet", {
       category: "wallet",

--- a/apps/deploy-web/src/context/WalletProvider/useEnforceSelfCustodyFlag.spec.ts
+++ b/apps/deploy-web/src/context/WalletProvider/useEnforceSelfCustodyFlag.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
 
 import { CURRENT_WALLET_KEY } from "@src/lib/cosmos-kit-jotai";
 import type { SelectedWalletType } from "@src/store/walletStore";
@@ -8,61 +9,60 @@ import { renderHook } from "@testing-library/react";
 
 describe(useEnforceSelfCustodyFlag.name, () => {
   it("disconnects, clears CURRENT_WALLET_KEY, and switches to managed when flag is OFF and a custodial wallet is connected", () => {
-    window.localStorage.setItem(CURRENT_WALLET_KEY, "keplr-extension");
-    const { disconnect, setSelectedWalletType } = setup({
+    const { disconnect, setSelectedWalletType, localStorage } = setup({
       isSelfCustodyEnabled: false,
       isWalletConnected: true,
       selectedWalletType: "custodial"
     });
 
     expect(disconnect).toHaveBeenCalledOnce();
-    expect(window.localStorage.getItem(CURRENT_WALLET_KEY)).toBeNull();
+    expect(localStorage.removeItem).toHaveBeenCalledWith(CURRENT_WALLET_KEY);
     expect(setSelectedWalletType).toHaveBeenCalledWith("managed");
   });
 
   it("clears stored wallet name and switches type when flag is OFF and selectedWalletType is still custodial without an active connection", () => {
-    window.localStorage.setItem(CURRENT_WALLET_KEY, "leap-extension");
-    const { disconnect, setSelectedWalletType } = setup({
+    const { disconnect, setSelectedWalletType, localStorage } = setup({
       isSelfCustodyEnabled: false,
       isWalletConnected: false,
       selectedWalletType: "custodial"
     });
 
     expect(disconnect).not.toHaveBeenCalled();
-    expect(window.localStorage.getItem(CURRENT_WALLET_KEY)).toBeNull();
+    expect(localStorage.removeItem).toHaveBeenCalledWith(CURRENT_WALLET_KEY);
     expect(setSelectedWalletType).toHaveBeenCalledWith("managed");
   });
 
   it("does nothing when flag is OFF and the user is already on managed without a custodial connection", () => {
-    window.localStorage.removeItem(CURRENT_WALLET_KEY);
-    const { disconnect, setSelectedWalletType } = setup({
+    const { disconnect, setSelectedWalletType, localStorage } = setup({
       isSelfCustodyEnabled: false,
       isWalletConnected: false,
       selectedWalletType: "managed"
     });
 
     expect(disconnect).not.toHaveBeenCalled();
+    expect(localStorage.removeItem).not.toHaveBeenCalled();
     expect(setSelectedWalletType).not.toHaveBeenCalled();
   });
 
   it("does nothing when flag is ON regardless of wallet state", () => {
-    window.localStorage.setItem(CURRENT_WALLET_KEY, "keplr-extension");
-    const { disconnect, setSelectedWalletType } = setup({
+    const { disconnect, setSelectedWalletType, localStorage } = setup({
       isSelfCustodyEnabled: true,
       isWalletConnected: true,
       selectedWalletType: "custodial"
     });
 
     expect(disconnect).not.toHaveBeenCalled();
-    expect(window.localStorage.getItem(CURRENT_WALLET_KEY)).toBe("keplr-extension");
+    expect(localStorage.removeItem).not.toHaveBeenCalled();
     expect(setSelectedWalletType).not.toHaveBeenCalled();
   });
 
   function setup(input: { isSelfCustodyEnabled: boolean; isWalletConnected: boolean; selectedWalletType: SelectedWalletType }) {
     const disconnect = vi.fn();
     const setSelectedWalletType = vi.fn();
+    const localStorage = mock<Storage>();
     const dependencies: typeof DEPENDENCIES = {
-      useIsSelfCustodyEnabled: () => input.isSelfCustodyEnabled
+      useIsSelfCustodyEnabled: () => input.isSelfCustodyEnabled,
+      localStorage
     };
 
     const hookInput: UseEnforceSelfCustodyFlagInput = {
@@ -74,6 +74,6 @@ describe(useEnforceSelfCustodyFlag.name, () => {
 
     renderHook(() => useEnforceSelfCustodyFlag(hookInput, dependencies));
 
-    return { disconnect, setSelectedWalletType };
+    return { disconnect, setSelectedWalletType, localStorage };
   }
 });

--- a/apps/deploy-web/src/context/WalletProvider/useEnforceSelfCustodyFlag.spec.ts
+++ b/apps/deploy-web/src/context/WalletProvider/useEnforceSelfCustodyFlag.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CURRENT_WALLET_KEY } from "@src/lib/cosmos-kit-jotai";
+import type { SelectedWalletType } from "@src/store/walletStore";
+import { type DEPENDENCIES, useEnforceSelfCustodyFlag, type UseEnforceSelfCustodyFlagInput } from "./useEnforceSelfCustodyFlag";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useEnforceSelfCustodyFlag.name, () => {
+  it("disconnects, clears CURRENT_WALLET_KEY, and switches to managed when flag is OFF and a custodial wallet is connected", () => {
+    window.localStorage.setItem(CURRENT_WALLET_KEY, "keplr-extension");
+    const { disconnect, setSelectedWalletType } = setup({
+      isSelfCustodyEnabled: false,
+      isWalletConnected: true,
+      selectedWalletType: "custodial"
+    });
+
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(window.localStorage.getItem(CURRENT_WALLET_KEY)).toBeNull();
+    expect(setSelectedWalletType).toHaveBeenCalledWith("managed");
+  });
+
+  it("clears stored wallet name and switches type when flag is OFF and selectedWalletType is still custodial without an active connection", () => {
+    window.localStorage.setItem(CURRENT_WALLET_KEY, "leap-extension");
+    const { disconnect, setSelectedWalletType } = setup({
+      isSelfCustodyEnabled: false,
+      isWalletConnected: false,
+      selectedWalletType: "custodial"
+    });
+
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(CURRENT_WALLET_KEY)).toBeNull();
+    expect(setSelectedWalletType).toHaveBeenCalledWith("managed");
+  });
+
+  it("does nothing when flag is OFF and the user is already on managed without a custodial connection", () => {
+    window.localStorage.removeItem(CURRENT_WALLET_KEY);
+    const { disconnect, setSelectedWalletType } = setup({
+      isSelfCustodyEnabled: false,
+      isWalletConnected: false,
+      selectedWalletType: "managed"
+    });
+
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(setSelectedWalletType).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when flag is ON regardless of wallet state", () => {
+    window.localStorage.setItem(CURRENT_WALLET_KEY, "keplr-extension");
+    const { disconnect, setSelectedWalletType } = setup({
+      isSelfCustodyEnabled: true,
+      isWalletConnected: true,
+      selectedWalletType: "custodial"
+    });
+
+    expect(disconnect).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(CURRENT_WALLET_KEY)).toBe("keplr-extension");
+    expect(setSelectedWalletType).not.toHaveBeenCalled();
+  });
+
+  function setup(input: { isSelfCustodyEnabled: boolean; isWalletConnected: boolean; selectedWalletType: SelectedWalletType }) {
+    const disconnect = vi.fn();
+    const setSelectedWalletType = vi.fn();
+    const dependencies: typeof DEPENDENCIES = {
+      useIsSelfCustodyEnabled: () => input.isSelfCustodyEnabled
+    };
+
+    const hookInput: UseEnforceSelfCustodyFlagInput = {
+      isWalletConnected: input.isWalletConnected,
+      selectedWalletType: input.selectedWalletType,
+      setSelectedWalletType,
+      disconnect
+    };
+
+    renderHook(() => useEnforceSelfCustodyFlag(hookInput, dependencies));
+
+    return { disconnect, setSelectedWalletType };
+  }
+});

--- a/apps/deploy-web/src/context/WalletProvider/useEnforceSelfCustodyFlag.ts
+++ b/apps/deploy-web/src/context/WalletProvider/useEnforceSelfCustodyFlag.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+
+import { useIsSelfCustodyEnabled } from "@src/hooks/useIsSelfCustodyEnabled";
+import { CURRENT_WALLET_KEY } from "@src/lib/cosmos-kit-jotai";
+import type { SelectedWalletType } from "@src/store/walletStore";
+
+export const DEPENDENCIES = {
+  useIsSelfCustodyEnabled
+};
+
+export type UseEnforceSelfCustodyFlagInput = {
+  isWalletConnected: boolean;
+  selectedWalletType: SelectedWalletType;
+  setSelectedWalletType: (type: SelectedWalletType) => void;
+  disconnect: () => void;
+};
+
+export function useEnforceSelfCustodyFlag(input: UseEnforceSelfCustodyFlagInput, dependencies: typeof DEPENDENCIES = DEPENDENCIES): void {
+  const isSelfCustodyEnabled = dependencies.useIsSelfCustodyEnabled();
+  const { isWalletConnected, selectedWalletType, setSelectedWalletType, disconnect } = input;
+
+  useEffect(() => {
+    if (isSelfCustodyEnabled) return;
+    if (selectedWalletType !== "custodial" && !isWalletConnected) return;
+
+    if (isWalletConnected) {
+      disconnect();
+    }
+
+    if (typeof window !== "undefined") {
+      window.localStorage.removeItem(CURRENT_WALLET_KEY);
+    }
+
+    if (selectedWalletType !== "managed") {
+      setSelectedWalletType("managed");
+    }
+  }, [isSelfCustodyEnabled, isWalletConnected, selectedWalletType, disconnect, setSelectedWalletType]);
+}

--- a/apps/deploy-web/src/context/WalletProvider/useEnforceSelfCustodyFlag.ts
+++ b/apps/deploy-web/src/context/WalletProvider/useEnforceSelfCustodyFlag.ts
@@ -5,7 +5,8 @@ import { CURRENT_WALLET_KEY } from "@src/lib/cosmos-kit-jotai";
 import type { SelectedWalletType } from "@src/store/walletStore";
 
 export const DEPENDENCIES = {
-  useIsSelfCustodyEnabled
+  useIsSelfCustodyEnabled,
+  localStorage: typeof window !== "undefined" ? window.localStorage : null
 };
 
 export type UseEnforceSelfCustodyFlagInput = {
@@ -17,6 +18,7 @@ export type UseEnforceSelfCustodyFlagInput = {
 
 export function useEnforceSelfCustodyFlag(input: UseEnforceSelfCustodyFlagInput, dependencies: typeof DEPENDENCIES = DEPENDENCIES): void {
   const isSelfCustodyEnabled = dependencies.useIsSelfCustodyEnabled();
+  const { localStorage } = dependencies;
   const { isWalletConnected, selectedWalletType, setSelectedWalletType, disconnect } = input;
 
   useEffect(() => {
@@ -27,12 +29,10 @@ export function useEnforceSelfCustodyFlag(input: UseEnforceSelfCustodyFlagInput,
       disconnect();
     }
 
-    if (typeof window !== "undefined") {
-      window.localStorage.removeItem(CURRENT_WALLET_KEY);
-    }
+    localStorage?.removeItem(CURRENT_WALLET_KEY);
 
     if (selectedWalletType !== "managed") {
       setSelectedWalletType("managed");
     }
-  }, [isSelfCustodyEnabled, isWalletConnected, selectedWalletType, disconnect, setSelectedWalletType]);
+  }, [isSelfCustodyEnabled, isWalletConnected, selectedWalletType, disconnect, setSelectedWalletType, localStorage]);
 }

--- a/apps/deploy-web/src/context/WalletProvider/useEnforceSelfCustodyFlag.ts
+++ b/apps/deploy-web/src/context/WalletProvider/useEnforceSelfCustodyFlag.ts
@@ -6,7 +6,9 @@ import type { SelectedWalletType } from "@src/store/walletStore";
 
 export const DEPENDENCIES = {
   useIsSelfCustodyEnabled,
-  localStorage: typeof window !== "undefined" ? window.localStorage : null
+  get localStorage(): Storage | null {
+    return typeof window !== "undefined" ? window.localStorage : null;
+  }
 };
 
 export type UseEnforceSelfCustodyFlagInput = {

--- a/apps/deploy-web/src/lib/cosmos-kit-jotai/components/ChainStoreInitializer/ChainStoreInitializer.spec.tsx
+++ b/apps/deploy-web/src/lib/cosmos-kit-jotai/components/ChainStoreInitializer/ChainStoreInitializer.spec.tsx
@@ -1,0 +1,64 @@
+import { SnackbarProvider } from "notistack";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ChainStore } from "../../store/ChainStore";
+import { CURRENT_WALLET_KEY } from "../../store/constants";
+import type { DEPENDENCIES } from "./ChainStoreInitializer";
+import { ChainStoreInitializer } from "./ChainStoreInitializer";
+
+import { render } from "@testing-library/react";
+
+describe(ChainStoreInitializer.name, () => {
+  it("clears CURRENT_WALLET_KEY before initialize when self_custody flag is OFF", () => {
+    window.localStorage.setItem(CURRENT_WALLET_KEY, "keplr-extension");
+
+    const { chainStore } = setup({ isSelfCustodyEnabled: false });
+
+    expect(window.localStorage.getItem(CURRENT_WALLET_KEY)).toBeNull();
+    expect(chainStore.initialize).toHaveBeenCalledOnce();
+  });
+
+  it("leaves CURRENT_WALLET_KEY untouched when self_custody flag is ON", () => {
+    window.localStorage.setItem(CURRENT_WALLET_KEY, "keplr-extension");
+
+    const { chainStore } = setup({ isSelfCustodyEnabled: true });
+
+    expect(window.localStorage.getItem(CURRENT_WALLET_KEY)).toBe("keplr-extension");
+    expect(chainStore.initialize).toHaveBeenCalledOnce();
+  });
+
+  it("is a no-op on the localStorage key when no wallet was previously stored", () => {
+    window.localStorage.removeItem(CURRENT_WALLET_KEY);
+
+    const { chainStore } = setup({ isSelfCustodyEnabled: false });
+
+    expect(window.localStorage.getItem(CURRENT_WALLET_KEY)).toBeNull();
+    expect(chainStore.initialize).toHaveBeenCalledOnce();
+  });
+
+  it("calls chainStore.cleanup on unmount", () => {
+    const { chainStore, unmount } = setup({ isSelfCustodyEnabled: true });
+
+    unmount();
+
+    expect(chainStore.cleanup).toHaveBeenCalledOnce();
+  });
+
+  function setup(input: { isSelfCustodyEnabled: boolean }) {
+    const chainStore = mock<ChainStore>();
+    const dependencies: typeof DEPENDENCIES = {
+      useIsSelfCustodyEnabled: () => input.isSelfCustodyEnabled,
+      useChain: vi.fn(() => mock<ReturnType<typeof DEPENDENCIES.useChain>>({ message: undefined, isWalletError: false })),
+      useChainStore: () => chainStore
+    };
+
+    const { unmount } = render(
+      <SnackbarProvider>
+        <ChainStoreInitializer chainName="akashnet-2" dependencies={dependencies} />
+      </SnackbarProvider>
+    );
+
+    return { chainStore, unmount };
+  }
+});

--- a/apps/deploy-web/src/lib/cosmos-kit-jotai/components/ChainStoreInitializer/ChainStoreInitializer.spec.tsx
+++ b/apps/deploy-web/src/lib/cosmos-kit-jotai/components/ChainStoreInitializer/ChainStoreInitializer.spec.tsx
@@ -3,52 +3,29 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { ChainStore } from "../../store/ChainStore";
-import { CURRENT_WALLET_KEY } from "../../store/constants";
 import type { DEPENDENCIES } from "./ChainStoreInitializer";
 import { ChainStoreInitializer } from "./ChainStoreInitializer";
 
 import { render } from "@testing-library/react";
 
 describe(ChainStoreInitializer.name, () => {
-  it("clears CURRENT_WALLET_KEY before initialize when self_custody flag is OFF", () => {
-    window.localStorage.setItem(CURRENT_WALLET_KEY, "keplr-extension");
+  it("calls chainStore.initialize on mount", () => {
+    const { chainStore } = setup();
 
-    const { chainStore } = setup({ isSelfCustodyEnabled: false });
-
-    expect(window.localStorage.getItem(CURRENT_WALLET_KEY)).toBeNull();
-    expect(chainStore.initialize).toHaveBeenCalledOnce();
-  });
-
-  it("leaves CURRENT_WALLET_KEY untouched when self_custody flag is ON", () => {
-    window.localStorage.setItem(CURRENT_WALLET_KEY, "keplr-extension");
-
-    const { chainStore } = setup({ isSelfCustodyEnabled: true });
-
-    expect(window.localStorage.getItem(CURRENT_WALLET_KEY)).toBe("keplr-extension");
-    expect(chainStore.initialize).toHaveBeenCalledOnce();
-  });
-
-  it("is a no-op on the localStorage key when no wallet was previously stored", () => {
-    window.localStorage.removeItem(CURRENT_WALLET_KEY);
-
-    const { chainStore } = setup({ isSelfCustodyEnabled: false });
-
-    expect(window.localStorage.getItem(CURRENT_WALLET_KEY)).toBeNull();
     expect(chainStore.initialize).toHaveBeenCalledOnce();
   });
 
   it("calls chainStore.cleanup on unmount", () => {
-    const { chainStore, unmount } = setup({ isSelfCustodyEnabled: true });
+    const { chainStore, unmount } = setup();
 
     unmount();
 
     expect(chainStore.cleanup).toHaveBeenCalledOnce();
   });
 
-  function setup(input: { isSelfCustodyEnabled: boolean }) {
+  function setup() {
     const chainStore = mock<ChainStore>();
     const dependencies: typeof DEPENDENCIES = {
-      useIsSelfCustodyEnabled: () => input.isSelfCustodyEnabled,
       useChain: vi.fn(() => mock<ReturnType<typeof DEPENDENCIES.useChain>>({ message: undefined, isWalletError: false })),
       useChainStore: () => chainStore
     };

--- a/apps/deploy-web/src/lib/cosmos-kit-jotai/components/ChainStoreInitializer/ChainStoreInitializer.tsx
+++ b/apps/deploy-web/src/lib/cosmos-kit-jotai/components/ChainStoreInitializer/ChainStoreInitializer.tsx
@@ -7,20 +7,33 @@ import { useEffect, useRef } from "react";
 import { Snackbar } from "@akashnetwork/ui/components";
 import { useSnackbar } from "notistack";
 
+import { useIsSelfCustodyEnabled } from "@src/hooks/useIsSelfCustodyEnabled";
 import { useChainStore } from "../../context/ChainStoreProvider";
 import { useChain } from "../../hooks/useChain/useChain";
+import { CURRENT_WALLET_KEY } from "../../store/constants";
 
 type Props = {
   chainName: string;
+  dependencies?: typeof DEPENDENCIES;
 };
 
-export function ChainStoreInitializer({ chainName }: Props) {
+export const DEPENDENCIES = {
+  useIsSelfCustodyEnabled,
+  useChain,
+  useChainStore
+};
+
+export function ChainStoreInitializer({ chainName, dependencies = DEPENDENCIES }: Props) {
   const { enqueueSnackbar } = useSnackbar();
-  const { message, isWalletError } = useChain(chainName);
-  const chainStore = useChainStore();
+  const { message, isWalletError } = dependencies.useChain(chainName);
+  const chainStore = dependencies.useChainStore();
+  const isSelfCustodyEnabled = dependencies.useIsSelfCustodyEnabled();
   const lastShownErrorRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
+    if (!isSelfCustodyEnabled && typeof window !== "undefined") {
+      window.localStorage.removeItem(CURRENT_WALLET_KEY);
+    }
     chainStore.initialize();
     return () => {
       chainStore.cleanup();

--- a/apps/deploy-web/src/lib/cosmos-kit-jotai/components/ChainStoreInitializer/ChainStoreInitializer.tsx
+++ b/apps/deploy-web/src/lib/cosmos-kit-jotai/components/ChainStoreInitializer/ChainStoreInitializer.tsx
@@ -7,10 +7,8 @@ import { useEffect, useRef } from "react";
 import { Snackbar } from "@akashnetwork/ui/components";
 import { useSnackbar } from "notistack";
 
-import { useIsSelfCustodyEnabled } from "@src/hooks/useIsSelfCustodyEnabled";
 import { useChainStore } from "../../context/ChainStoreProvider";
 import { useChain } from "../../hooks/useChain/useChain";
-import { CURRENT_WALLET_KEY } from "../../store/constants";
 
 type Props = {
   chainName: string;
@@ -18,7 +16,6 @@ type Props = {
 };
 
 export const DEPENDENCIES = {
-  useIsSelfCustodyEnabled,
   useChain,
   useChainStore
 };
@@ -27,13 +24,9 @@ export function ChainStoreInitializer({ chainName, dependencies = DEPENDENCIES }
   const { enqueueSnackbar } = useSnackbar();
   const { message, isWalletError } = dependencies.useChain(chainName);
   const chainStore = dependencies.useChainStore();
-  const isSelfCustodyEnabled = dependencies.useIsSelfCustodyEnabled();
   const lastShownErrorRef = useRef<string | undefined>(undefined);
 
   useEffect(() => {
-    if (!isSelfCustodyEnabled && typeof window !== "undefined") {
-      window.localStorage.removeItem(CURRENT_WALLET_KEY);
-    }
     chainStore.initialize();
     return () => {
       chainStore.cleanup();

--- a/apps/deploy-web/src/lib/nextjs/pageGuards/selfCustody.spec.ts
+++ b/apps/deploy-web/src/lib/nextjs/pageGuards/selfCustody.spec.ts
@@ -4,7 +4,7 @@ import { mock } from "vitest-mock-extended";
 import { SELF_CUSTODY_FLAG } from "@src/hooks/useIsSelfCustodyEnabled";
 import type { FeatureFlagService } from "@src/services/feature-flag/feature-flag.service";
 import type { AppTypedContext } from "../defineServerSideProps/defineServerSideProps";
-import { isSelfCustodyEnabled } from "./selfCustody";
+import { isSelfCustodyEnabled, isSelfCustodyRoute, SELF_CUSTODY_ROUTES } from "./selfCustody";
 
 describe(isSelfCustodyEnabled.name, () => {
   it("returns true when the self_custody flag is enabled in context", async () => {
@@ -30,4 +30,22 @@ describe(isSelfCustodyEnabled.name, () => {
       }
     });
   }
+});
+
+describe(isSelfCustodyRoute.name, () => {
+  it.each(SELF_CUSTODY_ROUTES)("returns true for self-custody route %s", route => {
+    expect(isSelfCustodyRoute(route)).toBe(true);
+  });
+
+  it("ignores trailing slashes, query strings, and hash fragments", () => {
+    expect(isSelfCustodyRoute("/settings/")).toBe(true);
+    expect(isSelfCustodyRoute("/mint-burn?ref=foo")).toBe(true);
+    expect(isSelfCustodyRoute("/get-started/wallet#section")).toBe(true);
+  });
+
+  it("returns false for routes that are not gated by the self-custody flag", () => {
+    expect(isSelfCustodyRoute("/")).toBe(false);
+    expect(isSelfCustodyRoute("/deployments")).toBe(false);
+    expect(isSelfCustodyRoute("/settings/billing")).toBe(false);
+  });
 });

--- a/apps/deploy-web/src/lib/nextjs/pageGuards/selfCustody.ts
+++ b/apps/deploy-web/src/lib/nextjs/pageGuards/selfCustody.ts
@@ -2,6 +2,13 @@ import { SELF_CUSTODY_FLAG } from "@src/hooks/useIsSelfCustodyEnabled";
 import type { AppTypedContext } from "../defineServerSideProps/defineServerSideProps";
 import { isFeatureEnabled } from "./pageGuards";
 
+export const SELF_CUSTODY_ROUTES = ["/get-started/wallet", "/mint-burn", "/settings", "/settings/authorizations"];
+
 export function isSelfCustodyEnabled(context: AppTypedContext): Promise<boolean> {
   return isFeatureEnabled(SELF_CUSTODY_FLAG, context);
+}
+
+export function isSelfCustodyRoute(path: string): boolean {
+  const normalized = path.split("?")[0].split("#")[0].replace(/\/+$/, "") || "/";
+  return SELF_CUSTODY_ROUTES.includes(normalized);
 }

--- a/apps/deploy-web/src/pages/404.tsx
+++ b/apps/deploy-web/src/pages/404.tsx
@@ -3,15 +3,20 @@ import { buttonVariants, Card, CardContent } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import { ArrowLeft, OpenInWindow } from "iconoir-react";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
 
 import { Title } from "@src/components/shared/Title";
+import { isSelfCustodyRoute } from "@src/lib/nextjs/pageGuards/selfCustody";
 import { UrlService } from "@src/utils/urlUtils";
 import Layout from "../components/layout/Layout";
 
 export const CONSOLE_AIR_REPO_URL = "https://github.com/akash-network/console-air";
 
 const FourOhFour: React.FunctionComponent = () => {
+  const router = useRouter();
+  const showSelfCustodyHint = isSelfCustodyRoute(router.asPath);
+
   return (
     <Layout>
       <NextSeo title="Page not found" />
@@ -27,23 +32,25 @@ const FourOhFour: React.FunctionComponent = () => {
           </Link>
         </div>
 
-        <Card className="mx-auto mt-10 max-w-xl text-left">
-          <CardContent className="space-y-2 p-6">
-            <p className="text-sm font-bold text-secondary-foreground">Looking for self-custody crypto features?</p>
-            <p className="text-sm text-muted-foreground">
-              Self-custody (Keplr/Leap connection, mint/burn, certificates, on-chain authorizations, and the liquidity modal) has moved to Console Air.
-            </p>
-            <Link
-              href={CONSOLE_AIR_REPO_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={cn(buttonVariants({ variant: "outline" }), "inline-flex items-center")}
-            >
-              <OpenInWindow className="mr-2" />
-              Open the Console Air repo
-            </Link>
-          </CardContent>
-        </Card>
+        {showSelfCustodyHint && (
+          <Card className="mx-auto mt-10 max-w-xl text-left">
+            <CardContent className="space-y-2 p-6">
+              <p className="text-sm font-bold text-secondary-foreground">Looking for self-custody crypto features?</p>
+              <p className="text-sm text-muted-foreground">
+                Self-custody (Keplr/Leap connection, mint/burn, certificates, on-chain authorizations, and the liquidity modal) has moved to Console Air.
+              </p>
+              <Link
+                href={CONSOLE_AIR_REPO_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={cn(buttonVariants({ variant: "outline" }), "inline-flex items-center")}
+              >
+                <OpenInWindow className="mr-2" />
+                Open the Console Air repo
+              </Link>
+            </CardContent>
+          </Card>
+        )}
       </div>
     </Layout>
   );

--- a/apps/deploy-web/src/pages/404.tsx
+++ b/apps/deploy-web/src/pages/404.tsx
@@ -1,13 +1,15 @@
 import React from "react";
-import { buttonVariants } from "@akashnetwork/ui/components";
+import { buttonVariants, Card, CardContent } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
-import { ArrowLeft } from "iconoir-react";
+import { ArrowLeft, OpenInWindow } from "iconoir-react";
 import Link from "next/link";
 import { NextSeo } from "next-seo";
 
 import { Title } from "@src/components/shared/Title";
 import { UrlService } from "@src/utils/urlUtils";
 import Layout from "../components/layout/Layout";
+
+export const CONSOLE_AIR_REPO_URL = "https://github.com/akash-network/console-air";
 
 const FourOhFour: React.FunctionComponent = () => {
   return (
@@ -24,6 +26,24 @@ const FourOhFour: React.FunctionComponent = () => {
             Go to homepage
           </Link>
         </div>
+
+        <Card className="mx-auto mt-10 max-w-xl text-left">
+          <CardContent className="space-y-2 p-6">
+            <p className="text-sm font-bold text-secondary-foreground">Looking for self-custody crypto features?</p>
+            <p className="text-sm text-muted-foreground">
+              Self-custody (Keplr/Leap connection, mint/burn, certificates, on-chain authorizations, and the liquidity modal) has moved to Console Air.
+            </p>
+            <Link
+              href={CONSOLE_AIR_REPO_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn(buttonVariants({ variant: "outline" }), "inline-flex items-center")}
+            >
+              <OpenInWindow className="mr-2" />
+              Open the Console Air repo
+            </Link>
+          </CardContent>
+        </Card>
       </div>
     </Layout>
   );

--- a/apps/deploy-web/src/pages/get-started/wallet.tsx
+++ b/apps/deploy-web/src/pages/get-started/wallet.tsx
@@ -19,6 +19,10 @@ import { NoWalletSection } from "@src/components/get-started/NoWalletSection";
 import { WithKeplrSection } from "@src/components/get-started/WithKeplrSection";
 import Layout from "@src/components/layout/Layout";
 import { CustomNextSeo } from "@src/components/shared/CustomNextSeo";
+import { Guard } from "@src/hoc/guard/guard.hoc";
+import { useIsSelfCustodyAccessible } from "@src/hoc/guard/useIsSelfCustodyAccessible";
+import { defineServerSideProps } from "@src/lib/nextjs/defineServerSideProps/defineServerSideProps";
+import { isSelfCustodyEnabled } from "@src/lib/nextjs/pageGuards/selfCustody";
 import { domainName, UrlService } from "@src/utils/urlUtils";
 
 enum GetWalletSection {
@@ -93,4 +97,9 @@ const GetStartedWallet: React.FunctionComponent = () => {
   );
 };
 
-export default GetStartedWallet;
+export default Guard(GetStartedWallet, useIsSelfCustodyAccessible);
+
+export const getServerSideProps = defineServerSideProps({
+  route: "/get-started/wallet",
+  if: ctx => isSelfCustodyEnabled(ctx)
+});

--- a/apps/deploy-web/src/pages/mint-burn/index.tsx
+++ b/apps/deploy-web/src/pages/mint-burn/index.tsx
@@ -1,3 +1,12 @@
 import { MintBurnPage } from "@src/components/MintBurnPage/MintBurnPage";
+import { Guard } from "@src/hoc/guard/guard.hoc";
+import { useIsSelfCustodyAccessible } from "@src/hoc/guard/useIsSelfCustodyAccessible";
+import { defineServerSideProps } from "@src/lib/nextjs/defineServerSideProps/defineServerSideProps";
+import { isSelfCustodyEnabled } from "@src/lib/nextjs/pageGuards/selfCustody";
 
-export default MintBurnPage;
+export default Guard(MintBurnPage, useIsSelfCustodyAccessible);
+
+export const getServerSideProps = defineServerSideProps({
+  route: "/mint-burn",
+  if: ctx => isSelfCustodyEnabled(ctx)
+});

--- a/apps/deploy-web/src/pages/settings/authorizations/index.tsx
+++ b/apps/deploy-web/src/pages/settings/authorizations/index.tsx
@@ -1,7 +1,16 @@
 import { Authorizations } from "@src/components/authorizations/Authorizations";
+import { Guard } from "@src/hoc/guard/guard.hoc";
+import { useIsSelfCustodyAccessible } from "@src/hoc/guard/useIsSelfCustodyAccessible";
+import { defineServerSideProps } from "@src/lib/nextjs/defineServerSideProps/defineServerSideProps";
+import { isSelfCustodyEnabled } from "@src/lib/nextjs/pageGuards/selfCustody";
 
 const AuthorizationsPage: React.FunctionComponent = () => {
   return <Authorizations />;
 };
 
-export default AuthorizationsPage;
+export default Guard(AuthorizationsPage, useIsSelfCustodyAccessible);
+
+export const getServerSideProps = defineServerSideProps({
+  route: "/settings/authorizations",
+  if: ctx => isSelfCustodyEnabled(ctx)
+});

--- a/apps/deploy-web/src/pages/settings/index.tsx
+++ b/apps/deploy-web/src/pages/settings/index.tsx
@@ -1,7 +1,12 @@
 import { SettingsContainer } from "@src/components/settings/SettingsContainer";
+import { Guard } from "@src/hoc/guard/guard.hoc";
+import { useIsSelfCustodyAccessible } from "@src/hoc/guard/useIsSelfCustodyAccessible";
+import { defineServerSideProps } from "@src/lib/nextjs/defineServerSideProps/defineServerSideProps";
+import { isSelfCustodyEnabled } from "@src/lib/nextjs/pageGuards/selfCustody";
 
-const SettingsPage: React.FunctionComponent = () => {
-  return <SettingsContainer />;
-};
+export default Guard(SettingsContainer, useIsSelfCustodyAccessible);
 
-export default SettingsPage;
+export const getServerSideProps = defineServerSideProps({
+  route: "/settings",
+  if: ctx => isSelfCustodyEnabled(ctx)
+});


### PR DESCRIPTION
## Why

Second of two PRs splitting CON-293. PR #3147 (CON-294) landed the **dormant** plumbing — a typed `self_custody` flag entry, a client hook (`useIsSelfCustodyEnabled`), a server helper (`isSelfCustodyEnabled(ctx)`), and a `Guard`-compatible adapter. This PR is the **mechanical wiring pass**: every surface the parent PR's description called out (Keplr/Leap connection, mint/burn, custodial wallet popup, get-started/wallet, certificates, liquidity modal) now imports the already-typed flag from one well-known place. When the flag is flipped off in Unleash, those surfaces disappear; when it's on, behavior is unchanged from today.

The 404 page now also links to https://github.com/akash-network/console-air so stale custodial users hitting a now-gated route land on the new home for self-custody features.

Part of CON-293

## What

### Page-level gates (request-time)
Each of these pages now uses `defineServerSideProps({ if: isSelfCustodyEnabled })` and `Guard(..., useIsSelfCustodyAccessible)` — flag off → `notFound: true` server-side; client-side fallback is the customized 404. Mirrors the existing `billing_usage` precedent in `apps/deploy-web/src/pages/billing/index.tsx`.

- `/mint-burn`
- `/get-started/wallet`
- `/settings` (the whole page is already self-custody-only at runtime — `useWhen` redirects managed users — so gating it at the route is consistent)
- `/settings/authorizations`

Gating `/settings` and `/get-started/wallet` transitively covers the certificate management section, the auto top-up section, the get-started Keplr/swap/wallet-creation steps, and the on-chain authorization/grant flows — they're all rendered inside those gated pages.

### Component-level gates (render-time)
- `CustodialWalletPopup` returns `null` — defense in depth for users with a previously-connected Keplr wallet still in cookie state when the flag flips off.
- `LiquidityModal` (Leap Elements: swap/bridge, fiat on-ramp, IBC transfer) returns `null`.
- Inside `WalletConnectionButtons`, the Keplr/Leap **Connect Wallet** button is hidden; the **managed wallet** connect button and the **Sign in** link are unaffected.

### Custom 404
Added a Console Air banner card under the existing "Page not found" content with a link to https://github.com/akash-network/console-air. The original "Go to homepage" CTA is preserved so the page still serves as a generic 404.

### Tests
- New: `WalletConnectionButtons.spec.tsx` (4 tests) — covers Keplr button visibility under flag on/off and verifies the managed-wallet button and Sign-in link are flag-independent.
- Updated: `CustodialWalletPopup.spec.tsx` — added a `setup({ isSelfCustodyEnabled: false })` case asserting the popup renders nothing.
- All new dependencies follow the team `DEPENDENCIES` injection + `setup()` pattern (no `vi.mock`).
- `LiquidityModal` did not get a dedicated spec — the component would need broader DI rework (`useWallet`, `useSelectedChain`, `useServices` are direct imports) and the flag wiring is one line. The hook itself is covered in `useIsSelfCustodyEnabled.spec.tsx`.

### Verified before push
- `npx tsc --noEmit` — no new errors in any modified file (the pre-existing errors on main are unchanged from PR #3147's baseline).
- `npx eslint --quiet` on changed files — clean (caught one rules-of-hooks issue mid-implementation, fixed).
- `npx vitest run` — 1499/1500 pass; the one failure is `TrendIndicator.spec.tsx`, the same date-sensitive flake the parent PR also flagged, unrelated to this branch.

### Deliberately out of scope
- `DeploymentDepositModal` ACT/AKT denom selector and `useMintACT` path — not on the parent PR's enumerated list, and the modal is shared with managed-wallet add-funds. The Mint-ACT button now leads to a 404 (with the Console Air link), so the route is unreachable, but the entry-point UI text would still render in the modal. Worth a focused follow-up if QA wants those entry points hidden too rather than 404-trapped.
- Cosmetic changes to the 404 page beyond adding the Console Air card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Self-custody features are now conditionally available across the app and routes based on the self-custody flag.
  * Several wallet flows (connection, switching, sign-in) and relevant pages are gated and now enforce access rules; switching/logging out clears stored wallet selection.
  * 404 page includes a contextual hint linking to the Console Air repo when relevant.

* **Tests**
  * Added extensive tests covering self-custody gating and related wallet/page behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->