### PR TITLE
feat: collects tendermint error like cause during logging

### DIFF
--- a/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.spec.ts
+++ b/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.spec.ts
@@ -128,4 +128,15 @@ describe(collectFullErrorStack.name, () => {
     const result = collectFullErrorStack("Log: \rl�dqz\u0015M�J�\t���\\�ͺ� does not allow");
     expect(result).toBe("Log: \\rl\\uFFFD+dqz\\u0015M\\uFFFD+J\\uFFFD+\\t\\uFFFD+\\\\uFFFD+ͺ\\uFFFD+ does not allow");
   });
+
+  it("collects data from error like cause", () => {
+    const errorLike = { message: "inner cause", body: "error body", status: 500 };
+    const causeError = new Error("cause error", { cause: errorLike });
+    const result = collectFullErrorStack(causeError);
+
+    expect(result).toContain("cause error");
+    expect(result).toContain("inner cause");
+    expect(result).toContain("Status: 500");
+    expect(result).toContain("Body: error body");
+  });
 });

--- a/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.ts
+++ b/packages/logging/src/utils/collect-full-error-stack/collect-full-error-stack.ts
@@ -1,4 +1,7 @@
-export function collectFullErrorStack(error: string | Error | AggregateError | ErrorWithResponse | ErrorWithData | undefined | null, indent = 0): string {
+export function collectFullErrorStack(
+  error: string | Error | AggregateError | ErrorWithResponse | ErrorWithData | ErrorLike | undefined | null,
+  indent = 0
+): string {
   if (!error) return "";
   if (typeof error === "string") return sanitizeString(error);
 
@@ -31,6 +34,20 @@ export function collectFullErrorStack(error: string | Error | AggregateError | E
       `\nStatus: ${currentError.response.status}`,
       `\nError: ${sanitizeString(currentError.response.data?.message) || "Not specified"} (code: ${currentError.response.data?.code || "Not specified"})`,
       `\nBody: ${body.length > 200 ? `${body.slice(0, 200)}...` : body}`
+    );
+  }
+
+  if (isErrorLike(currentError)) {
+    let body = typeof currentError.body === "string" ? sanitizeString(currentError.body) : "No body";
+    if (typeof currentError.body === "object") {
+      body = JSON.stringify(currentError.body);
+      if (body.length > 200) body = `${body.slice(0, 200)}...`;
+    }
+    stack.push(
+      "\nResponse:" +
+        `\nStatus: ${currentError.status ?? "Not specified"}` +
+        (currentError.message ? `\nError: ${sanitizeString(currentError.message)}` : "") +
+        `\nBody: ${body}`
     );
   }
 
@@ -78,4 +95,18 @@ function scrubControls(str: string): string {
       // eslint-disable-next-line no-control-regex
       .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, ch => `\\u${ch.charCodeAt(0).toString(16).padStart(4, "0")}`)
   );
+}
+
+/**
+ * Can be found in Error.cause of @cosmjs/tendermint-rpc's HttpClient errors, but also in other places, so we check for it generically.
+ */
+type ErrorLike = {
+  message?: string;
+  stack?: string;
+  body?: unknown;
+  status?: number;
+  cause?: unknown;
+};
+function isErrorLike(obj: unknown): obj is ErrorLike {
+  return typeof obj === "object" && obj !== null && !(obj instanceof Error) && ("status" in obj || "body" in obj);
 }


### PR DESCRIPTION
## Why

We have a bunch of errors like:
```
Error: Bad status on response: 500
    at filterBadStatus (/app/apps/tx-signer/node_modules/@cosmjs/tendermint-rpc/src/rpcclients/http.ts:4:11)
```

and their `Caused by` in logs is empty

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error collection to support a broader range of error types in logging.

* **Tests**
  * Added test coverage for error collection with cause-like error data from non-standard error objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->