### PR TITLE
feat(notifications): drop /v1/jobs/notification backward-compat route

### DIFF
--- a/apps/notifications/src/interfaces/rest/controllers/jobs/jobs.controller.spec.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/jobs/jobs.controller.spec.ts
@@ -8,7 +8,7 @@ import { BrokerService } from "@src/infrastructure/broker/services/broker/broker
 import { NotificationChannelRepository } from "@src/modules/notifications/repositories/notification-channel/notification-channel.repository";
 import { AuthService } from "../../services/auth/auth.service";
 import { notificationChannelOutputSchema } from "../notification-channel/notification-channel.controller";
-import { JobsBackwardCompatController, JobsController } from "./jobs.controller";
+import { JobsController } from "./jobs.controller";
 
 import { MockProvider } from "@test/mocks/provider.mock";
 
@@ -174,28 +174,4 @@ describe(JobsController.name, () => {
 
     return module;
   }
-});
-
-describe(JobsBackwardCompatController.name, () => {
-  it("delegates createNotification to the JobsController", async () => {
-    const module = await Test.createTestingModule({
-      controllers: [JobsBackwardCompatController],
-      providers: [
-        {
-          provide: JobsController,
-          useValue: { createNotification: vi.fn(async () => "delegated") }
-        }
-      ]
-    }).compile();
-
-    const job = {
-      notificationId: "notifyAboutStartTrial",
-      payload: { description: "test", summary: "test" }
-    };
-
-    const result = await module.get(JobsBackwardCompatController).createNotification(job);
-
-    expect(module.get(JobsController).createNotification).toHaveBeenCalledWith(job);
-    expect(result).toBe("delegated");
-  });
 });

--- a/apps/notifications/src/interfaces/rest/controllers/jobs/jobs.controller.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/jobs/jobs.controller.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Body, Controller, HttpCode, Post } from "@nestjs/common";
-import { ApiExcludeController, ApiNoContentResponse } from "@nestjs/swagger";
+import { ApiNoContentResponse } from "@nestjs/swagger";
 import { createZodDto } from "nestjs-zod";
 import { Err, Ok, Result } from "ts-results";
 import { z } from "zod";
@@ -64,25 +64,5 @@ export class JobsController {
       publishOptions
     );
     return Ok(undefined);
-  }
-}
-
-/**
- * Backward-compatibility shim for the legacy /v1/jobs/notification path,
- * which apps/api still calls until it picks up the /internal/v1/* migration.
- *
- * Revert this controller (and its registration in rest.module.ts) once
- * apps/api is deployed against the new path. Hidden from swagger.json with
- * @ApiExcludeController so the public spec stays clean.
- */
-@ApiExcludeController()
-@Controller({ path: "v1/jobs" })
-export class JobsBackwardCompatController {
-  constructor(private readonly jobsController: JobsController) {}
-
-  @Post("notification")
-  @HttpCode(204)
-  async createNotification(@Body() job: NotificationJobDto) {
-    return this.jobsController.createNotification(job);
   }
 }

--- a/apps/notifications/src/interfaces/rest/rest.module.ts
+++ b/apps/notifications/src/interfaces/rest/rest.module.ts
@@ -11,7 +11,7 @@ import { InternalAccountController } from "@src/interfaces/rest/controllers/inte
 import { AlertModule } from "@src/modules/alert/alert.module";
 import { NotificationsModule } from "@src/modules/notifications/notifications.module";
 import { AlertController } from "./controllers/alert/alert.controller";
-import { JobsBackwardCompatController, JobsController } from "./controllers/jobs/jobs.controller";
+import { JobsController } from "./controllers/jobs/jobs.controller";
 import { NotificationChannelController } from "./controllers/notification-channel/notification-channel.controller";
 import { AuthInterceptor } from "./interceptors/auth/auth.interceptor";
 import { LocalHttpLoggerMiddleware } from "./interceptors/http-logger/http-logger.middleware";
@@ -26,18 +26,9 @@ import { AuthService } from "./services/auth/auth.service";
     { provide: APP_INTERCEPTOR, useClass: HttpResultInterceptor },
     { provide: APP_INTERCEPTOR, useClass: AuthInterceptor },
     AccountPurgeService,
-    AuthService,
-    JobsController
+    AuthService
   ],
-  controllers: [
-    AlertController,
-    NotificationChannelController,
-    DeploymentAlertController,
-    HealthzController,
-    JobsController,
-    JobsBackwardCompatController,
-    InternalAccountController
-  ]
+  controllers: [AlertController, NotificationChannelController, DeploymentAlertController, HealthzController, JobsController, InternalAccountController]
 })
 export default class RestModule {
   configure(consumer: MiddlewareConsumer) {


### PR DESCRIPTION
## Why

Removes the deploy-window shim added in #3146. apps/api now calls
`/internal/v1/jobs/notification` through `@akashnetwork/openapi-sdk` +
`@akashnetwork/console-api-types/notifications/internal`, so the
`JobsBackwardCompatController` that re-exposed the legacy `/v1/jobs`
path can go.

> ⚠️ **Do not merge until apps/api has rolled out the new path.** The
> shim exists specifically to keep `/v1/jobs/notification` responding
> for in-flight apps/api instances during the deploy window for #3146;
> dropping it before apps/api ships would 404 those calls.

## Test plan

- [ ] Confirm apps/api is running against `/internal/v1/jobs/notification` in all environments
- [ ] `npm test -w apps/notifications` (5 JobsController tests, no delegation test now)
- [ ] Smoke a notification create end-to-end after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed deprecated backward-compatibility endpoint for notification job submissions. API users must migrate to the current internal endpoint.

* **Bug Fixes**
  * createNotification now properly returns a Bad Request when no notification channel is found and otherwise publishes the notification as expected.

* **Tests**
  * Server-side tests updated to validate the current controller behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->