### PR TITLE
docs(provider): relocate PRD, ADR 0001, and CONTEXT to apps/provider-inventory

### DIFF
--- a/apps/provider-inventory/CONTEXT.md
+++ b/apps/provider-inventory/CONTEXT.md
@@ -1,0 +1,135 @@
+# Bid Screening
+
+A read-side service that pre-filters Akash providers likely to satisfy a deployment's **GroupSpec**, before invoking the JS bin-packer. Optimised for low-latency reads of *current* provider state, not for storing on-chain history. Lives in **`apps/provider-inventory`** alongside the **streamer** that feeds it; `apps/api` retains the public route only as a thin **bid-screening proxy** to the new app.
+
+## Language
+
+### Providers and their state
+
+**provider**:
+An Akash entity that offers compute resources. Identified by **owner** address. Static-ish on-chain record (host URI, region, attributes).
+_Avoid_: node, host, vendor
+
+**provider inventory**:
+Live cluster state for a provider — nodes, GPUs, storage pools, and their allocation. Reflects "what could be leased right now". Stored as one row per provider in `provider_inventory`.
+_Avoid_: provider snapshot, current snapshot
+
+**provider snapshot**:
+The legacy append-only history written by the 15-min poll in `apps/indexer`. Powers daily uptime graphs, dashboards, and the GPU repo. **Not** read by bid screening.
+_Avoid_: provider inventory
+
+**node**:
+A physical or virtual machine within a provider's cluster, with its own CPU/memory/ephemeral-storage capacity, its own GPU set, and its own ephemeral storage capabilities (HDD/SSD/NVMe). The bin-packer places replicas on individual nodes; cluster-aggregate capacity is not enough on its own to host a replica.
+_Avoid_: machine, host, server
+
+**ephemeral storage**:
+Per-node scratch storage that disappears with the workload. Allocated against `nodeResources.ephemeralStorage`. Distinct from **persistent storage** which lives in cluster-wide pools.
+
+**persistent storage**:
+Cluster-wide storage pools identified by **storage class**. Each pool tracks `allocatable` and `allocated` independent of any node.
+
+**storage class**:
+A named pool of persistent storage on a provider (e.g. `beta1` for HDD, `beta2` for SSD, `beta3` for NVMe). `requirements.attributes.class` on a persistent volume must match a class the provider exposes.
+
+**RAM storage class**:
+A volume with `attributes.class = "ram"`. Allocated against node memory, not against ephemeral or persistent storage pools. **Persistent + RAM is invalid** and rejected by request validation.
+
+### Requests
+
+**GroupSpec**:
+The user-supplied deployment requirement, originating from SDL. Carries `resources` (CPU, memory, GPU, storage per replica × count) and `requirements` (attribute constraints + auditor signers).
+_Avoid_: deployment spec, manifest
+
+**replica**:
+A single instance of a service in a deployment. The **GroupSpec** lists resource units with `count` replicas each. The **bin-packer** must place every replica on some **node**.
+
+**resource unit** / **group**:
+One entry in **GroupSpec.resources**. A set of resources (CPU, memory, GPU, storage) requested for `count` replicas. All replicas in the same unit share the same resource shape; replicas in different units may have different shapes.
+
+**glob attribute**:
+A **GroupSpec.requirements.attributes** entry whose `key` contains `*` or `?`. Matched against provider attribute keys via PG regex (`~`). Works under SeqScan; not GIN-accelerated.
+
+### Attributes and auditing
+
+**self-attribute**:
+A `(key, value)` declared by the provider on chain in `MsgUpdateProvider`. Stored as one element of `self_attributes JSONB` on `provider_inventory`. The same key may appear with multiple values.
+
+**signed-attribute**:
+A `(key, value, auditor)` written on chain when an auditor signs an attribute about a provider. Stored as one element of `signed_attributes JSONB`. Multiple auditors may sign the same `(key, value)`; auditors may also sign values that disagree with the provider's self-declaration.
+
+**audited-by set**:
+Denormalised union of all auditor addresses that have signed any attribute on a provider. `audited_by TEXT[]` on `provider_inventory`. Used for the cheap "is this provider audited by AUDITOR" path that bypasses unpacking `signed_attributes`.
+
+**AUDITOR (constant)**:
+A specific auditor address used by the application to mark "audited" providers in bid-screening result responses. Distinct from the user-supplied `requirements.signedBy` filter, which can list arbitrary auditors.
+
+### Pipeline parts
+
+**streamer**:
+The component inside `apps/provider-inventory` that owns long-lived `streamStatus` gRPC connections to every active provider, diffs incoming messages against in-memory state, and writes changes to **provider inventory**. Runs in the same process as the **bid-screening API**; single replica, single writer to `provider_inventory`.
+_Avoid_: collector, indexer, sync worker
+
+**bid-screening proxy**:
+The handler in `apps/api` that owns the public `/v1/bid-screening` route after cutover. Validates auth, forwards request body and user context to `apps/provider-inventory`'s `/v1/bid-screening`, returns the response. Carries no bid-screening domain code itself.
+_Avoid_: bid-screening service (which lives in `apps/provider-inventory`), bid-screening client
+
+**discovery loop**:
+The streamer's polling loop that calls the akash chain SDK's `Provider/Providers` and `Audit/AllProvidersAttributes` queries to learn about new, removed, and renamed (hostUri-changed) providers and to refresh self- and signed-attributes. Runs immediately on service boot, then re-arms itself via recursive `setTimeout` every 10 min (self-pacing — never overlapping). Dedupes by `hostUri`, keeping the most recently created provider when two owners collide on the same hostUri. Independent of the legacy indexer's provider/attribute pipeline — does not read the legacy DB tables.
+
+**3-strike rule**:
+The streamer's reconnect policy — three exponential-backoff retries (~1 s, 2 s, 4 s, full jitter), then flip `is_online = false`. Reconnect attempts continue indefinitely afterward with a longer backoff (capped near 5 min).
+
+**diff cache**:
+Per-provider in-memory copy of the last successfully-applied state held by the streamer. Each incoming `streamStatus` message is compared against it; identical messages are silently dropped, divergent messages flow through **projectRow** to a single `UPDATE`. Reset to empty on every reconnect, so the first message after a reconnect always writes through.
+
+**projectRow**:
+Pure function `(streamMessage) → row`. Computes the rollup columns and denormalised `audited_by` from the streamed inventory, packs the bin-packer payload into `inventory` JSONB, and returns the full row to `UPDATE`. The single source of truth for how stream state maps to DB columns.
+
+**rollup columns**:
+Plain columns on `provider_inventory` (`total_available_*`, `max_node_free_*`, `gpu_models`, `storage_classes`) computed by the streamer from incoming inventory and written in the same `UPDATE` as the JSONB payload. They exist to keep the **prefilter** a single-table SeqScan.
+
+**is_online_since startup ritual**:
+The single `UPDATE provider_inventory SET is_online_since = NULL` the streamer issues before opening any streams on boot. Because the partial prefilter index is defined `WHERE is_online AND is_online_since IS NOT NULL`, this empties the index until each stream's first message reasserts liveness — preventing bid screening from trusting rows that may have gone stale during streamer downtime.
+
+**prefilter**:
+The SQL stage that narrows the provider set on cluster aggregates and per-node max-free dimensions. Intentionally lossy — false positives flow through to the **bin-packer**; false negatives are bugs. One round-trip, one row per candidate, JSONB carries the bin-packer payload.
+
+**bin-packer**:
+The JS algorithm in `cluster-inventory-matcher.service.ts` that places replicas onto nodes greedily and decides whether the cluster can host the **GroupSpec**. The strict check.
+_Avoid_: matcher, scheduler
+
+## Relationships
+
+- A **provider** has exactly one **provider inventory** row; the **streamer** is the only writer.
+- A **provider inventory** row carries the full **bin-packer** payload (`inventory` JSONB) and **rollup columns** for the **prefilter**.
+- A **provider inventory** row carries `self_attributes` and `signed_attributes` (denormalised from chain queries; see `discovery loop`) plus `audited_by`.
+- Two **providers** with the same `hostUri` collapse into one stream connection (latest by `createdHeight` wins).
+- The **prefilter** reads only `provider_inventory`; the legacy `provider*` tables are not joined.
+- `apps/api` calls the **bid-screening proxy** for every `/v1/bid-screening` request; the proxy makes a single internal HTTP call to `apps/provider-inventory` and returns the response unchanged.
+- The legacy **provider snapshot** tables coexist; readers other than bid screening still use them.
+
+## Example dialogue
+
+> **Engineer:** "If a provider goes offline mid-request, do we filter it out immediately?"
+>
+> **Domain expert:** "The **streamer** flips `is_online` to `false` after the **3-strike rule** completes (~7-10 s). The row stays. The **prefilter** filters by `is_online AND is_online_since IS NOT NULL`, so dead providers drop out without the row being deleted."
+>
+> **Engineer:** "And on streamer restart? The row's `is_online` may still claim true from before the crash."
+>
+> **Domain expert:** "That's what the **`is_online_since` startup ritual** handles. The streamer nulls `is_online_since` on every row before opening any streams. The prefilter index drops to zero rows. As streams reconnect, each first message resets `is_online_since = now()`. Healthy providers re-qualify within seconds; unreachable ones never do."
+>
+> **Engineer:** "So why don't we set `is_online = false` directly on startup instead of nulling a separate column?"
+>
+> **Domain expert:** "Because `is_online` is owned by the **3-strike rule** and represents a stream-local truth. The startup ritual is a *separate* invariant — 'this row was written by a *previous* streamer generation' — and a separate column keeps the two concerns from fighting each other."
+>
+> **Engineer:** "If the **GroupSpec** asks for region=us-west, do I match the **self-attribute** or the **signed-attribute**?"
+>
+> **Domain expert:** "`requirements.attributes` matches **self-attributes** only. `requirements.signedBy` is independent — it asserts the provider has *some* signature from those auditors, not that the matched attribute itself is signed. Different fields, different semantics, two columns."
+
+## Flagged ambiguities
+
+- **"snapshot"** was used for both the legacy historical row and the bid-screening current state. Resolved: legacy = **provider snapshot**, bid-screening = **provider inventory**.
+- **"online"** in `provider.isOnline` (legacy) means "passed the last 15-min HTTP probe". In `provider_inventory.is_online` it means "streamer has an open `streamStatus` channel and has received at least one message since reconnect". These will diverge intentionally.
+- **"attribute"** without qualifier is ambiguous. Always say **self-attribute** or **signed-attribute** — they are independent on-chain facts and the **prefilter** treats them differently.
+- **"available CPU"** vs **"max node free CPU"** — `total_available_cpu` is the cluster sum, used to filter on the GroupSpec total; `max_node_free_cpu` is the largest single-node free slice, used to filter on the largest replica. The first does not imply the second.
+- **"storage"** is overloaded. **Ephemeral storage** is per-node and disappears with the workload. **Persistent storage** is cluster-wide and survives. **RAM storage** is allocated against node memory. The three are tracked separately and flow through different rollup columns.

--- a/apps/provider-inventory/docs/adr/0001-streamer-fed-provider-inventory.md
+++ b/apps/provider-inventory/docs/adr/0001-streamer-fed-provider-inventory.md
@@ -1,0 +1,153 @@
+# Streamer-fed denormalised provider inventory for bid screening
+
+Bid screening previously read the normalised legacy snapshot model (`provider`, `providerSnapshot`, `providerSnapshotNode*`, `providerSnapshotStorage`, `providerAttribute`, `providerAttributeSignature`) shared with stats / graphs / dashboards / GPU repo. The prefilter required a CTE with EXISTS subqueries plus a follow-up hydrate query plus a separate auditor-set query, all against tables sized for an append-only 15-minute history.
+
+We are introducing `provider_inventory` — one row per provider, JSONB payload sized for the JS bin-packer plus plain rollup columns (`total_available_*`, `max_node_free_*`, `gpu_models`, `storage_classes`), plus two JSONB attribute columns (`self_attributes`, `signed_attributes`) and a denormalised `audited_by TEXT[]`. A new app, **`apps/provider-inventory`**, owns the table end-to-end: it runs a long-lived **streamer** that holds `streamStatus` gRPC connections to every active provider, diffs each incoming message against in-memory state, and writes changes via a single `UPDATE`; **and** it exposes the bid-screening HTTP API as a reader. `apps/api` keeps the public `/v1/bid-screening` route as a thin proxy that forwards authenticated requests to the new app — no bid-screening domain code remains in `apps/api` after cutover. The new app runs as a single replica; bid-screening QPS fits comfortably alongside hundreds of streams in one event loop, and single-replica enforcement preserves the streamer's single-writer guarantee without leader election. The legacy snapshot tables remain untouched as the history store.
+
+## Schema
+
+```sql
+CREATE TABLE provider_inventory (
+  owner             TEXT PRIMARY KEY,
+  host_uri          TEXT NOT NULL,
+  ip_region         TEXT,
+  uptime_7d         DOUBLE PRECISION,
+  is_online         BOOLEAN NOT NULL DEFAULT false,
+  is_online_since   TIMESTAMPTZ,
+
+  inventory         JSONB NOT NULL DEFAULT '{}'::jsonb,
+                    -- shape: { nodes: [...], storage: [...] } — for the JS bin-packer
+
+  total_available_cpu        BIGINT NOT NULL DEFAULT 0,
+  total_available_memory     BIGINT NOT NULL DEFAULT 0,
+  total_available_gpu        BIGINT NOT NULL DEFAULT 0,
+  total_available_eph        BIGINT NOT NULL DEFAULT 0,
+  total_available_persistent BIGINT NOT NULL DEFAULT 0,
+  max_node_free_cpu          BIGINT NOT NULL DEFAULT 0,
+  max_node_free_memory       BIGINT NOT NULL DEFAULT 0,
+  max_node_free_gpu          BIGINT NOT NULL DEFAULT 0,
+  gpu_models                 TEXT[] NOT NULL DEFAULT '{}',
+  storage_classes            TEXT[] NOT NULL DEFAULT '{}',
+
+  self_attributes   JSONB  NOT NULL DEFAULT '[]'::jsonb,
+                    -- [{"key":"<k>","value":"<v>"}, ...]
+  signed_attributes JSONB  NOT NULL DEFAULT '[]'::jsonb,
+                    -- [{"key":"<k>","value":"<v>","auditor":"<a>"}, ...]
+  audited_by        TEXT[] NOT NULL DEFAULT '{}',
+
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+) WITH (FILLFACTOR = 70);
+
+CREATE INDEX idx_provider_inventory_online
+  ON provider_inventory (owner)
+  WHERE is_online AND is_online_since IS NOT NULL;
+```
+
+`FILLFACTOR = 70` reserves page-local space for HOT-update tuple versions. The single partial index is the only index because `is_online` flips rarely (3-strike rule), so high-frequency inventory updates touch no indexed column and qualify for HOT.
+
+## Read path
+
+The bid-screening prefilter collapses three legacy queries (`getCandidateOwners` + `getOnlineProvidersWithSnapshots` + `getAuditedProviderAddresses`) into one round-trip:
+
+```sql
+SELECT owner, host_uri, ip_region, uptime_7d, inventory,
+       audited_by @> ARRAY[$AUDITOR] AS is_audited
+FROM provider_inventory
+WHERE is_online
+  AND is_online_since IS NOT NULL
+  AND total_available_cpu       >= $totalCpu
+  AND total_available_memory    >= $totalMemory
+  AND total_available_eph       >= $totalEph
+  AND max_node_free_cpu         >= $maxPerReplicaCpu
+  AND max_node_free_memory      >= $maxPerReplicaMemory
+  -- conditional GPU / persistent / attribute / signedBy predicates
+;
+```
+
+JSON containment / array operators handle the rest:
+
+```sql
+-- self-declared K=V
+self_attributes @> '[{"key":"K","value":"V"}]'::jsonb
+
+-- (K=V) signed by auditor X
+signed_attributes @> '[{"key":"K","value":"V","auditor":"X"}]'::jsonb
+
+-- audited by anyOf [X,Y]    →   audited_by && ARRAY['X','Y']
+-- audited by allOf [X,Y]    →   audited_by @> ARRAY['X','Y']
+
+-- glob on self-declared key   (SeqScan, no index)
+EXISTS (
+  SELECT 1 FROM jsonb_array_elements(self_attributes) e
+  WHERE e->>'key' ~ '<regex>' AND e->>'value' = '<V>'
+)
+```
+
+The candidate rows return with their full `inventory` JSONB; the JS bin-packer reads it directly. No second hydrate query.
+
+## Write path
+
+Streamer flow per provider (single Node process, single event loop):
+
+1. Discovery loop polls the akash chain via the chain SDK's `Provider/Providers` query (provider list + self-declared attributes) and `Audit/AllProvidersAttributes` query (signed attributes). The loop is implemented with recursive `setTimeout` (not `setInterval`) so consecutive ticks never overlap under chain-RPC latency, and it runs **immediately on service boot** so the cold-start blackout window collapses to seconds rather than up to 10 min. Subsequent ticks re-arm 10 min after the previous tick completes. Dedupes by `hostUri`. The streamer never reads the legacy provider/attribute/signature tables.
+2. Open `streamStatus` gRPC stream for each owned provider.
+3. **First message after connect** triggers `projectRow(message)` → single `UPDATE` that sets `inventory`, all rollup columns, `is_online = true`, `is_online_since = now()`. The in-memory **diff cache** stores the projected row.
+4. **Subsequent messages**: structurally compare against the diff cache; identical messages are dropped silently; differing messages flow through `projectRow` and a single `UPDATE`.
+5. Stream errors trigger the **3-strike rule**. After three failed reconnects (~7-10 s), `UPDATE provider_inventory SET is_online = false, is_online_since = NULL WHERE owner = $1`. Backoff continues at slower cadence; on success, GOTO step 3.
+
+Attribute columns (`self_attributes`, `signed_attributes`, `audited_by`) are not part of the stream payload. They are refreshed by the discovery loop from the chain `Provider/Providers` and `Audit/AllProvidersAttributes` query results and written in an `UPDATE` that touches only the attribute and `audited_by` columns. Inventory and rollup columns are left alone, which avoids races between attribute and inventory writes.
+
+## Lifecycle scenarios
+
+- **Cold boot.** Streamer starts → `UPDATE provider_inventory SET is_online_since = NULL` (drops every row from the prefilter index) → **discovery loop fires immediately** (chain queries for providers + attributes) → streams open in parallel → first message per provider re-asserts `is_online_since = now()`. Healthy providers re-qualify within seconds. The next discovery tick is scheduled 10 min after the first one finishes, via recursive `setTimeout`.
+- **Stream disconnect.** Diff cache for that provider is cleared. Reconnect attempts: t=0, +1s, +2s, +4s (full jitter). After 3rd failure, `is_online = false, is_online_since = NULL`. Continued retries with cap ~5 min until success.
+- **Reconnect after disconnect.** First message is full state — written through unconditionally because the diff cache was cleared. `is_online`/`is_online_since` flip back.
+- **Provider hostUri changes** (`MsgUpdateProvider`). Discovery loop sees diff on next tick (≤10 min), closes old stream, opens new one against the new hostUri.
+- **Provider deleted on chain.** Discovery loop sees the provider absent from the next `Provider/Providers` result, closes stream, deletes row from `provider_inventory`.
+- **Two providers share hostUri.** Discovery loop dedupes by hostUri keeping the latest `createdHeight`. The "loser" has no row in `provider_inventory`; bid-screening cannot route to it.
+- **Worker crash.** Rows persist with `is_online = true, is_online_since = <pre-crash time>` until restart. Cold-boot ritual nulls `is_online_since`, prefilter rejects them, no stale data is served.
+
+## Migration plan
+
+1. Scaffold `apps/provider-inventory` with Hono + tsyringe + Drizzle, `/healthz`, single-replica deploy/compose stanza, env loading, logger.
+2. Land `provider_inventory` schema + Drizzle bindings + migrations in the new app.
+3. Build the streamer (chain poller, discovery scheduler, lifecycle manager, diff cache, projectRow, reduceAttributes, writer) inside `apps/provider-inventory`. Deploy alongside the legacy 15-min poll; the legacy poll keeps writing the legacy snapshot tables, the streamer writes only `provider_inventory`.
+4. Build the new bid-screening service + repository + HTTP route in `apps/provider-inventory` (libs and matcher copied/transplanted from `apps/api`). Integration test against real Postgres.
+5. Wait for the streamer's first sweep to populate `provider_inventory` for all online providers.
+6. Add a feature-flagged proxy handler in `apps/api` that forwards `/v1/bid-screening` to the new app. Default: legacy in-process path.
+7. Add metrics: prefilter result count, prefilter→bin-packer success rate, lease success rate per row-age bucket, proxy round-trip latency.
+8. Cutover: flip the feature flag in `apps/api` to use the proxy.
+9. After a stabilisation window, delete the bid-screening service / repository / libs / controllers / routes / tests from `apps/api`.
+
+## Considered options
+
+- **Optimise the existing tables in place.** Rejected: changes the write pattern of a table backing daily-history graph queries; couples bid-screening read latency to history append rate.
+- **Materialised view over existing tables.** Rejected: refresh latency is no better than the 15-min poll; doesn't address inventory staleness within a poll window.
+- **Reduce the legacy poll interval to seconds.** Rejected: hammers provider HTTP/gRPC endpoints without solving the "row reflects last poll, not last state change" lag.
+- **Replace the legacy snapshot tables.** Rejected: stats / graphs / dashboards / GPU repo all read them; would force a much wider change.
+- **Piscina worker pool for streams.** Rejected: persistent gRPC streams are I/O-bound, not CPU-bound. One Node event loop holds hundreds of streams cheaply; Piscina is designed for short-lived jobs and would force misuse of "task forever owns this state" patterns.
+- **Stage 1: populate `provider_inventory` from the existing 15-min poll, defer streaming.** Rejected: the long-term answer is streaming; an interim writer would be thrown away. Direct streaming from day one accepted on the team's conviction in `streamStatus` reliability.
+- **Relational child tables (`provider_inventory_node`, `_node_gpu`, `_storage`, `_attribute`).** Rejected: the bin-packer needs the full per-provider state anyway, so a single-row JSONB read collapses the legacy two-trip pattern to one round-trip without losing fidelity. Per-provider write becomes a single UPDATE rather than orchestrated multi-table UPSERT/DELETE.
+- **Generated columns projecting JSONB to typed rollup columns.** Rejected: the `derived` sub-blob inside JSONB existed only to feed the generated columns — circular. Plain columns set explicitly by `projectRow` give the same result with less PG-side machinery and easier schema migrations.
+- **GIN index on `attributes` JSONB.** Rejected for v1: at hundreds of rows, SeqScan with per-row containment is sub-10 ms. Add only if measured. Glob/regex on attribute keys is unindexable here; revisit at 10× scale.
+- **Per-key flat attribute structure** (`{ "<key>": { value, signed_by[] } }`). Rejected: assumes one value per `(provider, key)` and assumes auditors only sign the self-declared value, neither of which the legacy on-chain schema enforces.
+- **Multi-process sharding by `hash(owner) % N`.** Deferred. Single process is enough for current provider count; multi-process becomes the upgrade path if measured uptime is insufficient.
+- **Putting the bid-screening API in `apps/api` and the streamer in a separate app.** Rejected: the writer (streamer) and the reader (bid-screening repo) share the schema, the JSONB shapes, and the `ProviderWithSnapshot` hydration logic. Co-locating them in one process avoids cross-app type duplication, gives a single boundary for the eventual Go rewrite, and removes a network hop on the read path.
+- **Putting the streamer in `apps/api` with a single-replica gate.** Rejected: `apps/api` is multi-replica; gating the streamer behind an env var creates a "magic pod" that's not interchangeable with the others, and breaks rolling deploys.
+- **Putting the streamer in `apps/indexer`.** Considered: shares lifecycle pattern with the legacy 15-min provider poll. Rejected because the bid-screening reader (HTTP API) doesn't belong in `apps/indexer`, and splitting the new code across two apps duplicates types and adds a network hop.
+
+## Consequences
+
+- The streamer is the **single writer** to `provider_inventory`. Streamer death = up to ~10 s window of stale rows for active deployments. Mitigated by the **`is_online_since` startup ritual**: before opening any streams, the streamer runs `UPDATE provider_inventory SET is_online_since = NULL`, which empties the partial prefilter index until each stream's first message re-asserts liveness.
+- The prefilter is **intentionally lossy**. The JS bin-packer is the strict check. False positives are acceptable; false negatives are bugs.
+- **HOT updates are preserved.** The only index is partial on `WHERE is_online AND is_online_since IS NOT NULL`. `is_online` flips rarely (only on connect / 3-strike disconnect). High-frequency inventory updates touch no indexed column. `FILLFACTOR = 70` keeps page-local update space available.
+- **TOAST behaviour.** Large per-provider inventories (many nodes + GPUs) push `inventory` JSONB into TOAST. TOAST has its own MVCC and vacuum; updates rewrite the TOAST tuple but do not break HOT in the heap. Acceptable at current scale.
+- **JSONB `attributes` are not GIN-indexed.** At hundreds of providers, a SeqScan with per-row `@>` containment is sub-10 ms. Add GIN only if measured. Glob/regex on attribute keys falls back to SeqScan; revisit at 10× provider count.
+- **`is_online` semantics differ from legacy `provider.isOnline`** (see CONTEXT.md). Two systems, two truths, by design.
+- **One value per `(owner, key)` is _not_ assumed.** Both `self_attributes` and `signed_attributes` are arrays of facts, faithful to the legacy on-chain schema where multiple values per key and disagreeing auditors are permitted.
+- **Stream protocol risk.** Providers that don't implement `streamStatus` per the assumed contract (emit on state change, full state per message, send current state on connection) will be classified `is_online = false` after the 3-strike rule, identical to truly offline providers. Acceptable exposure.
+- **Discovery latency.** New providers and hostUri changes propagate at the discovery loop cadence (10 min). Acceptable because chain-level provider events are rare.
+- **Single point of failure.** No multi-process sharding for v1. HA via in-process retries only. Multi-process partitioning by `hash(owner) % N` is the upgrade path if measured uptime is insufficient.
+- **Audit/attribute write conflict.** The streamer is also the writer for attribute columns, refreshed during the discovery loop. The discovery-loop UPDATE must merge with the most recent inventory rather than overwriting it — implemented by reading the row first or by writing only the attribute / `audited_by` columns.
+- **`apps/api` becomes a thin proxy for bid screening.** The public route stays in `apps/api`; its handler validates auth, forwards user context as headers, makes an internal HTTP call to `apps/provider-inventory`, returns the response. After cutover, `apps/api` carries zero bid-screening domain code. Future Go rewrite replaces `apps/provider-inventory` wholesale; `apps/api`'s proxy handler is unchanged by the rewrite.
+- **Single replica, both writer and reader.** `apps/provider-inventory` is single-replica; bid-screening QPS (one per deployment creation) fits in one event loop alongside hundreds of streams. Horizontal scaling for the read path is deferred to the Go rewrite.

--- a/apps/provider-inventory/docs/prd-streamer-fed-provider-inventory.md
+++ b/apps/provider-inventory/docs/prd-streamer-fed-provider-inventory.md
@@ -1,0 +1,194 @@
+# PRD — Streamer-fed provider inventory for bid screening
+
+> Companion documents:
+> - [CONTEXT.md](../CONTEXT.md) — domain language and relationships
+> - [ADR 0001](./adr/0001-streamer-fed-provider-inventory.md) — design decision and trade-offs
+
+## Problem Statement
+
+When a deployment owner submits a **GroupSpec** through the Console, bid screening must surface only the providers that have a realistic chance of fulfilling it. Today the prefilter runs against the legacy `providerSnapshot` family of tables, which are append-only history tables refreshed by a 15-minute HTTP poll across every provider. Three problems flow from that:
+
+- **Stale inventory.** A provider may have accepted multiple leases minutes ago and have no real capacity left, yet still appear as a candidate for up to 15 minutes. The user submits a deployment, the provider doesn't bid back, and the user has no signal that they wasted their time.
+- **Slow read path.** The legacy prefilter is a CTE with EXISTS subqueries against per-node history rows, plus a follow-up hydrate query that joins five tables, plus a third query for the auditor set. Three round-trips per request, all against tables sized for history rather than live state.
+- **Coupling.** The same tables back daily uptime graphs, dashboards, and the GPU repository. Any optimisation aimed at bid screening risks regressing the others.
+
+## Solution
+
+Bid screening becomes the consumer of a new `provider_inventory` read model that always reflects each provider's *current* cluster state, sourced from a long-lived gRPC `streamStatus` connection per provider. The legacy snapshot tables remain untouched as the history store for graphs and dashboards.
+
+The new model is owned end-to-end by a new app, **`apps/provider-inventory`**, which contains both the writer (streamer + chain discovery loop) and the reader (bid-screening HTTP API). `apps/api` keeps its public `/v1/bid-screening` route as a thin proxy that forwards authenticated requests to the new app — no bid-screening domain logic remains in `apps/api` after cutover. The new app exposes `/healthz` for k8s probes and runs as a single replica because it owns the streamer's single-writer guarantee.
+
+From the user's point of view: when they submit a GroupSpec, the candidate list reflects whatever the provider's cluster looked like seconds ago — not minutes. Providers that just got fully booked drop out. Providers that just freed up capacity reappear. The list itself returns faster because there's only one round-trip and one row per candidate, with the bin-packer payload already carried in JSONB.
+
+## User Stories
+
+1. As an Akash deployment owner, I want the list of bidding providers to reflect each provider's real available capacity, so that I do not waste time deploying to providers that just got fully booked.
+2. As an Akash deployment owner, I want bid-screening responses to be fast, so that the deployment flow does not stall.
+3. As an Akash deployment owner, I want providers that match my GPU vendor and model requirement to be surfaced, so that my workload runs on suitable hardware.
+4. As an Akash deployment owner, I want providers that match my persistent storage class requirement to be surfaced, so that my data stays on the storage tier I asked for.
+5. As an Akash deployment owner, I want providers signed by my listed auditors to be surfaced, so that I can trust attestations about the provider's identity and capabilities.
+6. As an Akash deployment owner, I want providers with self-declared attributes that match my requirements (region, tier, etc.) to be surfaced, so that placement reflects my preferences.
+7. As an Akash deployment owner, I want offline providers to be excluded from candidates, so that I do not deploy to a host that cannot accept the lease.
+8. As an Akash deployment owner, I want providers that recently went offline to drop out within seconds, so that I am not shown a stale candidate.
+9. As an Akash deployment owner, I want providers that recently came back online to be included as candidates promptly, so that available capacity is not under-reported.
+10. As an Akash deployment owner, I want bid screening to clearly mark providers audited by the platform's known auditor, so that I can identify trusted candidates at a glance.
+11. As an Akash deployment owner submitting a multi-replica GroupSpec, I want the prefilter to reject providers that obviously lack capacity for any single replica, so that infeasible candidates are filtered before I review them.
+12. As an Akash deployment owner submitting a deployment with mixed resource units (different replica shapes), I want the prefilter to consider all units rather than just one, so that I am not shown providers that cannot host every unit.
+13. As an Akash deployment owner, I want glob attribute matchers (e.g. `gpu/vendor/*`) to work, so that broad attribute requirements still find candidates.
+14. As a Console developer, I want `provider_inventory` to be the only table the bid-screening repository reads, so that bid-screening latency is not coupled to history-table layout or cross-team write patterns.
+15. As a Console developer, I want the bid-screening read path to be a single SQL round-trip, so that response latency is predictable and easy to reason about.
+16. As a Console developer, I want the bin-packer's input shape to be the same as today, so that the matcher service does not change.
+17. As a Console developer, I want clear separation between the legacy snapshot pipeline and the new streamer pipeline, so that one's failures do not affect the other.
+18. As a Console developer, I want the streamer's diff cache to suppress no-op writes, so that DB write rate tracks real change rate, not message rate.
+19. As a Console developer, I want the streamer to write only via a single `projectRow` mapping function, so that there is one obvious place to evolve the row contract.
+20. As a Console developer, I want HOT updates to be preserved on the high-churn parent row, so that table bloat stays bounded without aggressive autovacuum tuning.
+21. As a Console developer, I want the pre-existing legacy snapshot tables and their consumers to keep working unchanged, so that history graphs, dashboards, and the GPU repository are not regressed.
+22. As an operator running the streamer, I want a single Node process to hold all provider streams, so that the runtime footprint is small and operationally simple.
+23. As an operator running the streamer, I want stream disconnects to be handled with bounded exponential-backoff retries, so that transient network issues do not flap providers offline and back.
+24. As an operator running the streamer, I want providers that fail three reconnect attempts to be marked offline immediately, so that bid screening stops returning them as candidates.
+25. As an operator running the streamer, I want the streamer to keep retrying disconnected providers indefinitely with a longer cap, so that providers that come back online are picked up automatically.
+26. As an operator running the streamer, I want a startup ritual that prevents stale rows from being trusted after a streamer crash, so that bid-screening responses are not built on pre-crash data.
+27. As an operator running the streamer, I want logs and metrics on stream lifecycle events (connect, disconnect, retry, give-up), so that I can debug provider-side issues.
+28. As an operator running the streamer, I want metrics on diff-cache hit rate, so that I can verify the no-op suppression is effective.
+29. As an operator running the streamer, I want metrics on row update rate per provider, so that I can spot pathological providers that emit excessive traffic.
+30. As an operator running the streamer, I want graceful shutdown that closes streams cleanly, so that providers do not see abrupt disconnects on deploys.
+31. As an operator running the streamer, I want a failed discovery-loop chain poll to be retried on the next tick without crashing the streamer, so that a temporary chain RPC outage does not interrupt the live `streamStatus` connections that are still healthy.
+32. As an operator running the streamer, I want the discovery loop to dedupe providers that share a hostUri, so that we do not open redundant streams to the same physical endpoint.
+33. As an Akash provider operator, I want the streamer's reconnection cadence to be reasonable, so that my gRPC endpoint is not hammered by retries during transient downtime.
+34. As an auditor, I want my signatures to surface in `audited_by` within one discovery-loop cycle (≤10 min), so that providers I have signed are reflected in deployment owners' filters with bounded lag.
+35. As a Console developer reviewing a bid-screening PR, I want the prefilter SQL to be obvious and indexable, so that performance regressions are easy to spot.
+36. As a Console developer adding a new resource dimension in the future (say "FPGA"), I want the rollup-column pattern to be the obvious extension point, so that I know where to add it.
+37. As a Console developer, I want `provider_inventory` to live in the shared database package alongside the legacy schemas, so that schema migrations follow the existing flow.
+38. As a Console developer, I want the bid-screening integration test to exercise the new prefilter against a real Postgres, so that JSONB-containment and array-operator behaviour is validated end-to-end.
+39. As an Akash deployment owner whose GroupSpec mixes ephemeral and persistent storage, I want both classes to be considered correctly in the prefilter, so that valid providers are not excluded.
+40. As an Akash deployment owner whose GroupSpec uses RAM-backed storage, I want it to consume the provider's memory budget rather than ephemeral or persistent pools, so that the prefilter is dimensionally correct.
+41. As an Akash deployment owner, I want providers with disagreeing self-declared and signed attribute values to be filtered faithfully (signed-only filters consult signed attributes, self-only filters consult self-declared), so that the prefilter respects the on-chain truth even in edge cases.
+42. As a Console developer, I want the streamer (writer) and the bid-screening API (reader) to live in the same process, so that they share types and the read-path code is colocated with the data it depends on.
+43. As a Console developer, I want `apps/api` to keep zero bid-screening domain code after cutover, so that `apps/api` stays focused on its public-API gateway role and the bid-screening service has a clean boundary for the eventual Go rewrite.
+44. As an operator, I want the new app to expose a `/healthz` endpoint, so that k8s liveness and readiness probes can detect failures.
+45. As an operator, I want `apps/api` to surface a clear error when the bid-screening backend is unreachable, so that bid-screening outages are not silently masked or replaced with empty candidate lists.
+46. As an operator, I want the new app to run as a single replica enforced at the deployment topology level, so that the streamer's single-writer guarantee holds without leader-election machinery.
+47. As an operator, I want the bid-screening proxy in `apps/api` to be feature-flagged at cutover, so that we can revert to the legacy in-process bid-screening path quickly if a regression appears.
+
+## Implementation Decisions
+
+### Architecture
+
+- A new app, **`apps/provider-inventory`**, owns the entire bid-screening domain end-to-end: the streamer (writer to `provider_inventory`), the chain discovery loop, the bid-screening HTTP API (reader), and a `/healthz` probe endpoint.
+- The new app runs as a **single Node process, single replica**. Single replica is enforced by the k8s/compose deployment topology, not by code, so the streamer's single-writer guarantee holds without leader election. Bid-screening QPS (one request per deployment creation) fits comfortably alongside hundreds of streams in one event loop.
+- The **streamer** owns one `streamStatus` gRPC connection per active provider. No worker threads. HA via in-process retries; multi-process sharding is deferred.
+- The streamer is the **only writer** to `provider_inventory`.
+- The streamer ingests provider/attribute/signature state by **polling the chain** via the akash chain SDK's `akash.provider.v1beta4.Query/Providers` (provider list + self-declared attributes) and `akash.audit.v1.Query/AllProvidersAttributes` (signed attributes). The discovery loop runs **immediately on service boot** (not after a wait), then re-arms itself with recursive `setTimeout` 10 min after each tick completes — never `setInterval`, so consecutive ticks cannot overlap under chain-RPC latency. The streamer does **not** read the legacy `provider`, `providerAttribute`, or `providerAttributeSignature` tables.
+- **`apps/api` becomes a thin proxy** for bid-screening. The public `/v1/bid-screening` route stays in `apps/api`; its handler validates auth, forwards the request body to the new app over an internal HTTP call, and returns the response. After cutover, `apps/api` carries zero bid-screening domain code (no service, no repository, no libs, no schemas, no tests).
+- The legacy 15-min poll in `apps/indexer` is unchanged. The legacy snapshot tables coexist and continue to serve graphs / dashboards / GPU repo.
+- Same framework stack as `apps/api`: Hono + `@hono/zod-openapi`, tsyringe, Drizzle, Pino-based `LoggerService`, Zod, Vitest, env-loader. Reuses `OpenApiHonoHandler`, `createRoute`, and the project's testing patterns from CLAUDE.md.
+
+### Data model
+
+- `provider_inventory` is a single-row-per-provider table.
+- The full bin-packer payload (nodes + per-node CPU/GPU/memory/ephemeral allocation, storage pools) is stored as a JSONB `inventory` column.
+- Plain rollup columns (`total_available_*`, `max_node_free_*`, `gpu_models TEXT[]`, `storage_classes TEXT[]`) are written by the streamer in the same `UPDATE` as `inventory`. They feed the SQL prefilter.
+- Self-declared and signed attributes are stored as **two separate JSONB array columns**: `self_attributes` (`[{key, value}]`) and `signed_attributes` (`[{key, value, auditor}]`). The legacy schema permits multiple values per `(owner, key)` and disagreeing auditors; the array shape preserves that fidelity.
+- A denormalised `audited_by TEXT[]` carries the union of all auditors that have signed any attribute on a provider, for the cheap "audited by AUDITOR" path.
+- `is_online BOOLEAN` is owned by the streamer's stream lifecycle (connect / 3-strike / disconnect).
+- `is_online_since TIMESTAMPTZ` is set to `now()` on stream-becomes-live and cleared on disconnect. Its purpose is to gate the prefilter index against rows written by a previous streamer generation.
+- The single index is partial, on `(owner) WHERE is_online AND is_online_since IS NOT NULL`. No GIN. Default `FILLFACTOR = 70`.
+- The schema lives in `packages/database` alongside legacy schemas. Drizzle bindings. Migrations are run by `apps/provider-inventory`'s `migration:exec` script.
+
+### Modules in `apps/provider-inventory`
+
+| Module | Responsibility | Deep? |
+|---|---|---|
+| `ChainProviderPoller` | Polls the akash chain via the chain SDK's `Provider/Providers` and `Audit/AllProvidersAttributes` queries. Returns a normalised snapshot of `(owner, hostUri, createdHeight, selfAttributes, signedAttributes)` records. Stateless — diffing happens downstream. Caller is responsible for the loop cadence; the poller itself is a single-call function. | Yes |
+| Discovery scheduler | Wires `ChainProviderPoller` → `DiscoveryReconciler` → `StreamLifecycleManager`. Runs the first tick immediately on boot, schedules subsequent ticks via recursive `setTimeout` 10 min after each tick completes. Catches and logs poll failures without breaking the schedule. | Shallow |
+| `DiscoveryReconciler` | Pure function `(currentRegistry, latestProviderState) → { toStart, toStop, toRestart, toUpdateAttributes }`. Dedupes providers sharing a hostUri (latest `createdHeight` wins). | Yes |
+| `StreamLifecycleManager` | Owns `Map<owner, StreamHandle>`. State machine: connecting → live → disconnected → retrying → offline. Implements the 3-strike rule (~7-10s) and the indefinite slow-retry tail. Holds the in-memory diff cache per stream. | Yes |
+| `projectRow` | Pure function: `(streamMessage) → { inventory JSONB, total_available_*, max_node_free_*, gpu_models, storage_classes }`. | Yes |
+| `computeRollups` | Pure function: `(inventory) → rollups`. Sub-component of projectRow, isolatable for testing. | Yes |
+| `reduceAttributes` | Pure function: `(selfFacts, signedFacts) → { self_attributes, signed_attributes, audited_by }`. | Yes |
+| `ProviderInventoryWriter` | Thin wrapper around the single `UPDATE` statement; also performs the startup `is_online_since = NULL` ritual. | Shallow |
+| `BidScreeningRepository` | New implementation reading `provider_inventory` exclusively (no legacy joins). Single round-trip query, hydrates JSONB into the existing `ProviderWithSnapshot`-shaped object for the bin-packer. | Yes |
+| `BidScreeningService` | Orchestrates request validation → repository read → matcher. Moved from `apps/api`. | Shallow |
+| `ClusterInventoryMatcherService` and the matcher libs (`groupspec-mapper`, `resource-aggregator`, `gpu-attribute-parser`, `storage-attribute-parser`, `inventory-mapper`, `resource-pair`) | Moved unchanged from `apps/api`. | Yes (already pure) |
+| `POST /v1/bid-screening` route | Hono + `@hono/zod-openapi`. Same request/response contract as the existing route in `apps/api`. Trusts user-context headers set by the proxy in `apps/api`. | Shallow |
+| `GET /healthz` | k8s liveness/readiness probe. Returns OK if process is alive and DB ping succeeds. | Shallow |
+| Bootstrap orchestrator | Wires the modules together; runs the startup ritual, schedules the discovery loop, starts the lifecycle manager, starts the HTTP server. | Shallow |
+
+### Modules in `apps/api`
+
+| Module | Responsibility |
+|---|---|
+| Bid-screening proxy handler | Replaces the existing in-process bid-screening service. Validates auth, forwards user context as headers, makes an internal HTTP call to `apps/provider-inventory`'s `/v1/bid-screening`, returns the response. Behind a feature flag at first; legacy in-process path remains until cutover. |
+| Bid-screening domain code | **Removed** after cutover (services, repositories, libs, schemas, controllers, tests). |
+
+### Stream lifecycle (locked-in semantics)
+
+- **First message after connect** triggers an `UPDATE` setting the full row plus `is_online = true, is_online_since = now()`. Stream-handshake-without-message does **not** flip `is_online`. If no message arrives within ~10s of handshake, treat as connect failure.
+- **Subsequent messages** are diffed against the in-memory cache; identical messages are dropped silently.
+- **Disconnect** clears the in-memory diff cache for that provider. After 3 reconnect failures (1s, 2s, 4s with full jitter), set `is_online = false, is_online_since = NULL`. Continue retrying with a longer cap (~5 min).
+- **HostUri change.** When a discovery-loop tick reports a different `hostUri` for the same `owner`, the old stream is closed and a new one is opened against the new endpoint.
+- **Provider deletion.** When a discovery-loop tick no longer returns a previously known `owner`, the streamer closes the stream and removes the row from `provider_inventory`.
+
+### Read path (locked-in)
+
+- Bid screening reads `provider_inventory` only — never legacy tables.
+- One SQL round-trip filters on `is_online AND is_online_since IS NOT NULL` plus the prefilter predicates and returns each candidate's `inventory` JSONB plus `is_audited` (precomputed via `audited_by @> ARRAY[$AUDITOR]`).
+- The bin-packer continues to consume the same `ProviderWithSnapshot`-shaped object; the repository hydrates it from the JSONB.
+
+### Attribute write path (locked-in)
+
+- Each discovery-loop tick passes the chain query results through `reduceAttributes` and issues a per-provider UPDATE that touches **only** `self_attributes`, `signed_attributes`, `audited_by`, and `updated_at` — leaving `inventory` and rollup columns alone. This avoids attribute-update vs inventory-update races.
+
+### What stays unchanged
+
+- `ClusterInventoryMatcherService` and its data-shape contract.
+- Legacy `apps/indexer` and the `providerSnapshot*` tables.
+- Any non-bid-screening reader of legacy provider data.
+
+## Testing Decisions
+
+### What makes a good test here
+
+- Tests should describe **observable behaviour**, not implementation steps. A test for `projectRow` should describe input → expected row, not "calls computeRollups internally".
+- Use the project's `setup()` convention rather than `beforeEach` — see CLAUDE.md and the prior-art tests.
+- For modules that depend on gRPC or chain SDK, prefer `mock<T>()` over hand-rolled `as unknown as` casts (per project convention).
+
+### Modules with unit tests
+
+- **`projectRow`** — table-driven cases over the full stream-message → row mapping. Cover: empty cluster, single-node cluster, multi-node, mixed GPU vendors, ephemeral-only and persistent-only and mixed storage, RAM storage class, providers with no GPUs, providers with no nodes.
+- **`computeRollups`** — boundary cases: max-node-free vs total-available, GPU models deduplication, storage class set, all-zero capacity, overcommit handling (negative free clamped to zero).
+- **`reduceAttributes`** — multi-auditor signing the same attribute, auditors signing values that disagree with self-declared, missing self-declared but present signature, missing signature but present self-declared, audited_by union correctness.
+- **`StreamLifecycleManager`** — state-machine transitions exercised against a fake gRPC client. Cover: first-message-becomes-live, identical-message-skipped, divergent-message-writes, three-strike-flips-offline, reconnect-resets-diff-cache, hostUri-change-restart, graceful-shutdown.
+- **`DiscoveryReconciler`** — diff outputs for: brand-new provider, deleted provider, hostUri-changed provider, two providers sharing hostUri (latest wins), no-op tick.
+
+### Modules with integration tests
+
+- **`BidScreeningRepository`** — full prefilter behaviour against a real Postgres. Cover: aggregate filters (CPU/memory/GPU/ephemeral/persistent), per-node max-free filters, GPU vendor/model match, persistent storage class match, self-attribute exact match, self-attribute glob match, signedBy anyOf, signedBy allOf, audited-by precompute, offline filter, `is_online_since` filter, multi-resource-unit GroupSpec aggregation. Models and extends the prior art at the existing `bid-screening.repository.integration.ts`.
+
+### Skipped on purpose
+
+- `ProviderInventoryWriter` (single-statement wrapper) and the bootstrap orchestrator are pass-through code; their behaviour is exercised through the integration test and the lifecycle-manager unit tests.
+- `ChainProviderPoller` is heavily I/O-bound on a third-party SDK; covered by manual smoke tests and runtime metrics rather than unit tests.
+- The bid-screening proxy handler in `apps/api` is a thin HTTP forwarder; covered by an end-to-end test that hits `apps/api`'s public route and asserts the response from `apps/provider-inventory` is returned faithfully.
+
+## Out of Scope
+
+- Replacing or removing the legacy `providerSnapshot` family of tables.
+- Changing daily-history graphs, dashboards, or the GPU repository to read from `provider_inventory`.
+- Multi-process sharding of the streamer for HA. Single process, in-process retries only. The upgrade path (`hash(owner) % N` partitioning, lease coordination) is acknowledged but not built.
+- GIN indexing of `self_attributes` / `signed_attributes`. Defer until measured.
+- Materialised view alternatives.
+- A worker pool (Piscina or otherwise). Single event loop is adequate.
+- Generated columns projecting JSONB to typed rollups. Plain columns written by the writer.
+- A "warm" migration that backfills `provider_inventory` from the legacy poll. The streamer's first sweep populates the table.
+- Removing the legacy bid-screening repository code. Switch consumers first; clean up later.
+
+## Further Notes
+
+- The migration plan: scaffold `apps/provider-inventory` with `/healthz` → land schema → build streamer → build new bid-screening service + HTTP route in the new app → add proxy in `apps/api` behind feature flag → wait for streamer's first sweep to populate `provider_inventory` → flip the feature flag → remove legacy bid-screening code from `apps/api`.
+- Suggested metrics to add at cutover: prefilter result count, prefilter→bin-packer success rate, lease success rate per row-age bucket, streamer connect/disconnect/strike counts per provider, diff-cache hit rate, bid-screening request latency from `apps/api`'s perspective (proxy round-trip).
+- Risk: providers that don't implement `streamStatus` per the assumed contract (emit on state change, full state per message, send current state on connection) will remain `is_online = false` after the 3-strike rule, identical to truly offline providers. We accept this exposure.
+- Risk: duplicate chain ingest. The legacy indexer also reads provider/attribute state from chain. The streamer's poll is independent (separate RPC client, separate cadence) and will not interact with the legacy indexer's flow. The minor extra load on the chain RPC node is acceptable.
+- Risk: `apps/provider-inventory` becomes a single point of failure for bid screening. Mitigated by `apps/api`'s proxy handler returning a clear error (not silent empty list) when the backend is unreachable, and by k8s health probes restarting the process on failure. Multi-process HA is deferred.
+- Forward-compat: when the Go rewrite happens, it replaces `apps/provider-inventory` wholesale. The schema, JSONB shapes, `/v1/bid-screening` request/response contract, and `streamStatus` assumptions are the durable interfaces; the Go service inherits them. `apps/api`'s proxy handler is unchanged by the rewrite.
+- Bid-screening domain language and decisions are documented in [CONTEXT.md](../CONTEXT.md) and [ADR 0001](./adr/0001-streamer-fed-provider-inventory.md). Use the same vocabulary in PR descriptions and follow-up tickets.


### PR DESCRIPTION
## Why

Ref CON-302

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for provider inventory architecture, establishing domain terminology, system invariants, and core concepts.
  * Introduced architecture design record specifying the new provider inventory table model, streaming architecture, and read/write operation paths.
  * Published product requirements document detailing streamer-fed provider inventory design, lifecycle semantics, component relationships, and migration strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->