### PR TITLE
feat: adds support for bigint in postgres JSONB

### DIFF
--- a/apps/provider-inventory/src/lib/jsonb-bigint/jsonb-bigint.spec.ts
+++ b/apps/provider-inventory/src/lib/jsonb-bigint/jsonb-bigint.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import { parseJsonb, serializeJsonb } from "./jsonb-bigint";
+
+describe("serializeJsonb", () => {
+  it("serializes bigint values as raw JSON numbers", () => {
+    const result = serializeJsonb({ cpu: 4000n, name: "node-1" });
+
+    expect(result).toBe('{"cpu":4000,"name":"node-1"}');
+  });
+
+  it("preserves precision for values exceeding Number.MAX_SAFE_INTEGER", () => {
+    const big = 9007199254740993n;
+    const result = serializeJsonb({ value: big });
+
+    expect(result).toBe('{"value":9007199254740993}');
+    expect(result).not.toContain('"9007199254740993"');
+  });
+
+  it("handles negative bigints", () => {
+    const result = serializeJsonb({ value: -42n });
+
+    expect(result).toBe('{"value":-42}');
+  });
+
+  it("handles nested objects with mixed types", () => {
+    const result = serializeJsonb({
+      nodes: [{ cpu: { available: 8000n }, name: "n1" }],
+      count: 1
+    });
+
+    expect(result).toBe('{"nodes":[{"cpu":{"available":8000},"name":"n1"}],"count":1}');
+  });
+});
+
+describe("parseJsonb", () => {
+  it("keeps safe integers as number", () => {
+    const result = parseJsonb('{"cpu": 4000, "name": "node-1"}') as { cpu: number; name: string };
+
+    expect(result.cpu).toBe(4000);
+    expect(typeof result.cpu).toBe("number");
+    expect(result.name).toBe("node-1");
+  });
+
+  it("promotes to bigint only when precision would be lost", () => {
+    const result = parseJsonb('{"value": 9007199254740993}') as { value: bigint };
+
+    expect(result.value).toBe(9007199254740993n);
+    expect(typeof result.value).toBe("bigint");
+  });
+
+  it("preserves floating-point numbers as number", () => {
+    const result = parseJsonb('{"rate": 3.14}') as { rate: number };
+
+    expect(result.rate).toBe(3.14);
+    expect(typeof result.rate).toBe("number");
+  });
+
+  it("handles nested structures", () => {
+    const result = parseJsonb('{"nodes": [{"cpu": {"available": 8000}}]}') as {
+      nodes: Array<{ cpu: { available: number } }>;
+    };
+
+    expect(result.nodes[0].cpu.available).toBe(8000);
+    expect(typeof result.nodes[0].cpu.available).toBe("number");
+  });
+});
+
+describe("round-trip", () => {
+  it("preserves unsafe bigint values through serialize then parse", () => {
+    const original = { memory: 9007199254740993n };
+
+    const parsed = parseJsonb(serializeJsonb(original)) as typeof original;
+
+    expect(parsed.memory).toBe(9007199254740993n);
+  });
+
+  it("keeps safe values as number through serialize then parse", () => {
+    const original = { cpu: 4000n, name: "node-1" };
+
+    const parsed = parseJsonb(serializeJsonb(original)) as { cpu: number; name: string };
+
+    expect(parsed.cpu).toBe(4000);
+    expect(typeof parsed.cpu).toBe("number");
+  });
+});

--- a/apps/provider-inventory/src/lib/jsonb-bigint/jsonb-bigint.ts
+++ b/apps/provider-inventory/src/lib/jsonb-bigint/jsonb-bigint.ts
@@ -1,0 +1,26 @@
+const BIGINT_SENTINEL = "__BIGINT__";
+const BIGINT_PATTERN = new RegExp(`"${BIGINT_SENTINEL}(-?\\d+)"`, "g");
+
+/**
+ * Preserves bigint values by serializing them as strings with a unique sentinel prefix
+ * and then replacing them with unquoted values in the final JSON string.
+ */
+export function serializeJsonb(value: unknown): string {
+  const json = JSON.stringify(value, (_key, val) => {
+    if (typeof val === "bigint") return `${BIGINT_SENTINEL}${val}`;
+    return val;
+  });
+  return json.replace(BIGINT_PATTERN, "$1");
+}
+
+type ReviverWithContext = (key: string, value: unknown, context: { source: string }) => unknown;
+
+const parseJSON = JSON.parse as (text: string, reviver?: ReviverWithContext) => unknown;
+export function parseJsonb(text: string): unknown {
+  return parseJSON(text, (_, value, context) => {
+    if (typeof value === "number" && context?.source !== undefined && /^-?\d+$/.test(context.source) && String(value) !== context.source) {
+      return BigInt(context.source);
+    }
+    return value;
+  });
+}

--- a/apps/provider-inventory/src/providers/postgres.provider.ts
+++ b/apps/provider-inventory/src/providers/postgres.provider.ts
@@ -3,6 +3,7 @@ import postgres from "postgres";
 import type { InjectionToken } from "tsyringe";
 import { container, instancePerContainerCachingFactory } from "tsyringe";
 
+import { parseJsonb, serializeJsonb } from "@src/lib/jsonb-bigint/jsonb-bigint";
 import { APP_CONFIG } from "@src/providers/app-config.provider";
 
 const logger = createOtelLogger({ context: "POSTGRES" });
@@ -14,7 +15,16 @@ container.register(APP_PG_CLIENT, {
     const config = c.resolve(APP_CONFIG);
     return postgres(config.PROVIDER_INVENTORY_POSTGRES_URL, {
       max: 10,
-      onnotice: logger.info.bind(logger)
+      onnotice: logger.info.bind(logger),
+      types: {
+        bigint: postgres.BigInt,
+        json: {
+          to: 114, // OID 114 = json
+          from: [114, 3802], // 114 = json, 3802 = jsonb
+          serialize: serializeJsonb,
+          parse: parseJsonb
+        }
+      }
     });
   })
 });


### PR DESCRIPTION
## Why

Because some values in provider inventory may be big ints. Ref CON-303

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database JSON fields now properly support large integer values that exceed JavaScript's safe integer limit, with guaranteed round-trip integrity.

* **Tests**
  * Added comprehensive test coverage for bigint serialization and parsing, validating edge cases and data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->