### PR TITLE
fix(observability): tag chain-db pg connections with application_name

### DIFF
--- a/apps/api/src/chain/providers/sequelize.provider.ts
+++ b/apps/api/src/chain/providers/sequelize.provider.ts
@@ -33,6 +33,7 @@ container.register(CHAIN_DB, {
     const sequelize = new Sequelize(dbUri, {
       dialectModule: pg,
       dialectOptions: {
+        application_name: `console-api-${config.get("NETWORK")}`,
         connectionTimeoutMillis: config.get("SEQUELIZE_CONNECTION_TIMEOUT"),
         keepAlive: config.get("SEQUELIZE_KEEP_ALIVE")
       },

--- a/apps/indexer/src/db/dbConnection.ts
+++ b/apps/indexer/src/db/dbConnection.ts
@@ -12,6 +12,9 @@ if (!activeChain.connectionString) {
 
 export const sequelize = new Sequelize(activeChain.connectionString, {
   dialectModule: pg,
+  dialectOptions: {
+    application_name: `akash-indexer-${activeChain.code}`
+  },
   logging: false,
   transactionType: DbTransaction.TYPES.IMMEDIATE,
   define: {


### PR DESCRIPTION
## Why

We're seeing ~1.5K `SequelizeConnectionError: timeout expired` per hour against the chain DB on `console-api-mainnet`. Investigation via `pg_stat_activity` shows ~265 connections from a single Postgres user (`cloudmos-akash-syncer`), all with `client_addr = NULL` because the connection arrives through Cloud SQL Auth Proxy.

Both `apps/api` (chain-db Sequelize) and `apps/indexer` connect with that same user. Without `application_name`, `pg_stat_activity` cannot distinguish api-vs-indexer-vs-other, which makes it impossible to tell which service is saturating the connection pool.

This is a tiny instrumentation change to make the next pass of investigation actionable.

## What

- `apps/api/src/chain/providers/sequelize.provider.ts`: sets `application_name = console-api-${NETWORK}` in `dialectOptions`, matching the existing service naming used in Loki (`console-api-mainnet`, `console-api-sandbox`, ...).
- `apps/indexer/src/db/dbConnection.ts`: sets `application_name = akash-indexer-${activeChain.code}` so each chain's indexer process is labeled.

After the next deploy, this query gives a clean breakdown by service:

```sql
SELECT application_name, state, count(*)
FROM pg_stat_activity
WHERE datname = current_database()
GROUP BY 1, 2
ORDER BY count(*) DESC;
```

No behavior change beyond what Postgres reports about the connection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated database connection configuration for the API service to improve operational monitoring and make the service identifiable in database tooling.
  * Updated database connection configuration for the indexer service to improve operational monitoring and make the service identifiable in database tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->