### PR TITLE
feat(provider): reconnect via Cockatiel + is_online gating + startup ritual

### DIFF
--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -29,6 +29,7 @@
     "@hono/node-server": "^1.19.0",
     "@hono/otel": "~0.4.0",
     "@hono/zod-openapi": "^0.18.4",
+    "cockatiel": "^3.2.1",
     "drizzle-orm": "^0.31.2",
     "hono": "4.6.12",
     "http-errors": "^2.0.0",

--- a/apps/provider-inventory/src/config/env.config.ts
+++ b/apps/provider-inventory/src/config/env.config.ts
@@ -6,7 +6,10 @@ export const envSchema = z.object({
   LOG_LEVEL: z.enum(["fatal", "error", "warn", "info", "debug", "trace"]).default("info"),
   STD_OUT_LOG_FORMAT: z.enum(["json", "pretty"]).default("json"),
   PORT: z.number({ coerce: true }).default(3092),
-  DISCOVERY_INTERVAL_MS: z.number({ coerce: true }).default(10 * 60 * 1000) // 10 minutes
+  DISCOVERY_INTERVAL_MS: z.number({ coerce: true }).default(10 * 60 * 1000), // 10 minutes
+  STREAM_RECONNECT_INITIAL_DELAY_MS: z.number({ coerce: true }).default(1_000),
+  STREAM_RECONNECT_MAX_DELAY_MS: z.number({ coerce: true }).default(5 * 60 * 1000), // 5 minutes
+  STREAM_FIRST_MESSAGE_TIMEOUT_MS: z.number({ coerce: true }).default(10_000)
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/apps/provider-inventory/src/index.ts
+++ b/apps/provider-inventory/src/index.ts
@@ -14,6 +14,7 @@ import { DiscoverySchedulerService } from "@src/services/discovery-scheduler/dis
 import { HonoErrorHandlerService } from "@src/services/hono-error-handler/hono-error-handler.service";
 import { ProviderInventoryWriterService } from "@src/services/provider-inventory-writer/provider-inventory-writer.service";
 import { startServer } from "@src/services/start-server/start-server";
+import { runStreamerBootstrap } from "@src/services/streamer-bootstrap/streamer-bootstrap";
 import type { AppEnv } from "@src/types/app-context";
 
 export function createApp(): Hono<AppEnv> {
@@ -31,9 +32,6 @@ export async function bootstrap(): Promise<void> {
 
   await startServer(app, createOtelLogger({ context: "APP" }), process, {
     port: container.resolve(APP_CONFIG).PORT,
-    beforeStart: async () => {
-      await container.resolve(ProviderInventoryWriterService).resetOnlineSince();
-      container.resolve(DiscoverySchedulerService).start();
-    }
+    beforeStart: () => runStreamerBootstrap(container.resolve(ProviderInventoryWriterService), container.resolve(DiscoverySchedulerService))
   });
 }

--- a/apps/provider-inventory/src/services/provider-inventory-writer/provider-inventory-writer.service.ts
+++ b/apps/provider-inventory/src/services/provider-inventory-writer/provider-inventory-writer.service.ts
@@ -1,5 +1,5 @@
 import type { LoggerService } from "@akashnetwork/logging";
-import { sql as rawSql } from "drizzle-orm";
+import { eq, sql as rawSql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { inject, singleton } from "tsyringe";
 
@@ -23,6 +23,14 @@ export class ProviderInventoryWriterService {
   async resetOnlineSince(): Promise<void> {
     await this.#db.update(providerInventory).set({ isOnlineSince: null });
     this.#logger.info({ event: "ONLINE_SINCE_RESET" });
+  }
+
+  async markOffline(owner: string): Promise<void> {
+    await this.#db
+      .update(providerInventory)
+      .set({ isOnline: false, isOnlineSince: null, updatedAt: rawSql`now()` })
+      .where(eq(providerInventory.owner, owner));
+    this.#logger.info({ event: "PROVIDER_MARKED_OFFLINE", owner });
   }
 
   async upsertInventory(provider: ChainProvider, row: ProjectedRow): Promise<void> {

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { mock } from "vitest-mock-extended";
+import type { LoggerService } from "@akashnetwork/logging";
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, expect, it, vi } from "vitest";
+import { mock, type MockProxy } from "vitest-mock-extended";
 
+import type { EnvConfig } from "@src/providers/app-config.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
 import type { ProviderStreamFactory } from "@src/providers/provider-stream.provider";
 import type { ProviderInventoryWriterService } from "@src/services/provider-inventory-writer/provider-inventory-writer.service";
@@ -11,31 +14,23 @@ import { StreamLifecycleManagerService } from "./stream-lifecycle-manager.servic
 describe(StreamLifecycleManagerService.name, () => {
   describe("reconcile", () => {
     it("opens a stream for a new provider", async () => {
-      const message = createMessage();
-      const { streamFactory } = setup({
-        streams: { "https://p1:8443": [message] }
-      });
+      const { streamFactory } = setup({ streams: { "https://p1:8443": "hang" } });
 
       expect(streamFactory.openStatusStream).toHaveBeenCalledWith("https://p1:8443", expect.any(AbortSignal));
     });
 
-    it("calls upsertInventory for each stream message", async () => {
+    it("calls upsertInventory for each unique stream message", async () => {
       const messages = [createMessage({ cpu: 1000 }), createMessage({ cpu: 2000 })];
-      const { writer, providers } = setup({
-        streams: { "https://p1:8443": messages }
-      });
+      const { writer, providers } = setup({ streams: { "https://p1:8443": msgsThenHang(messages) } });
 
-      await flush();
+      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(2));
 
-      expect(writer.upsertInventory).toHaveBeenCalledTimes(2);
       expect(writer.upsertInventory).toHaveBeenCalledWith(providers[0], expect.objectContaining({ totalAvailableCpu: 1000n }));
       expect(writer.upsertInventory).toHaveBeenCalledWith(providers[0], expect.objectContaining({ totalAvailableCpu: 2000n }));
     });
 
     it("skips providers that already have an active stream", async () => {
-      const { manager, streamFactory, providers } = setup({
-        streams: { "https://p1:8443": [createMessage()] }
-      });
+      const { manager, streamFactory, providers } = setup({ streams: { "https://p1:8443": "hang" } });
 
       manager.reconcile(providers);
 
@@ -43,30 +38,26 @@ describe(StreamLifecycleManagerService.name, () => {
     });
 
     it("stops streams for providers absent from the new list", async () => {
-      const signals: AbortSignal[] = [];
-      const { manager, streamFactory } = setup({
-        streams: { "https://p1:8443": "hang" }
-      });
-      signals.push(captureSignal(streamFactory));
+      const { manager, streamFactory } = setup({ streams: { "https://p1:8443": "hang" } });
+      const signal = captureSignal(streamFactory);
 
       manager.reconcile([]);
 
-      expect(signals[0].aborted).toBe(true);
+      expect(signal.aborted).toBe(true);
     });
 
     it("opens streams for new providers while stopping removed ones", async () => {
-      const signals: AbortSignal[] = [];
       const providerA = createProvider({ owner: "a", hostUri: "https://a:8443" });
       const providerB = createProvider({ owner: "b", hostUri: "https://b:8443" });
       const { manager, streamFactory } = setup({
         providers: [providerA],
-        streams: { "https://a:8443": "hang", "https://b:8443": [createMessage()] }
+        streams: { "https://a:8443": "hang", "https://b:8443": "hang" }
       });
-      signals.push(captureSignal(streamFactory));
+      const signal = captureSignal(streamFactory);
 
       manager.reconcile([providerB]);
 
-      expect(signals[0].aborted).toBe(true);
+      expect(signal.aborted).toBe(true);
       expect(streamFactory.openStatusStream).toHaveBeenCalledWith("https://b:8443", expect.any(AbortSignal));
     });
   });
@@ -74,23 +65,25 @@ describe(StreamLifecycleManagerService.name, () => {
   describe("diff cache", () => {
     it("performs a single write when two consecutive identical messages arrive", async () => {
       const message = createMessage({ cpu: 1000 });
-      const { writer } = setup({
-        streams: { "https://p1:8443": [message, structuredClone(message)] }
+      const { writer, logger } = setup({
+        streams: { "https://p1:8443": msgsThenHang([message, structuredClone(message)]) }
       });
 
-      await flush();
+      await vi.waitFor(() =>
+        expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_MESSAGE_SKIPPED_IDENTICAL" }))
+      );
 
       expect(writer.upsertInventory).toHaveBeenCalledTimes(1);
     });
 
     it("writes again when any meaningful field differs", async () => {
       const { writer } = setup({
-        streams: { "https://p1:8443": [createMessage({ cpu: 1000 }), createMessage({ cpu: 1001 })] }
+        streams: {
+          "https://p1:8443": msgsThenHang([createMessage({ cpu: 1000 }), createMessage({ cpu: 1001 })])
+        }
       });
 
-      await flush();
-
-      expect(writer.upsertInventory).toHaveBeenCalledTimes(2);
+      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(2));
     });
 
     it("considers messages with reordered nodes/gpus/storage equal", async () => {
@@ -136,11 +129,13 @@ describe(StreamLifecycleManagerService.name, () => {
         storage: [...first.storage].reverse()
       };
 
-      const { writer } = setup({
-        streams: { "https://p1:8443": [first, reordered] }
+      const { writer, logger } = setup({
+        streams: { "https://p1:8443": msgsThenHang([first, reordered]) }
       });
 
-      await flush();
+      await vi.waitFor(() =>
+        expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_MESSAGE_SKIPPED_IDENTICAL" }))
+      );
 
       expect(writer.upsertInventory).toHaveBeenCalledTimes(1);
     });
@@ -148,41 +143,20 @@ describe(StreamLifecycleManagerService.name, () => {
     it("writes the first message even when it would later be cacheable", async () => {
       const message = createMessage();
       const { writer } = setup({
-        streams: { "https://p1:8443": [message] }
+        streams: { "https://p1:8443": msgsThenHang([message]) }
       });
 
-      await flush();
-
-      expect(writer.upsertInventory).toHaveBeenCalledTimes(1);
+      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(1));
     });
 
     it("does not cache a row when the write fails — next identical message retries", async () => {
       const message = createMessage();
       const { writer } = setup({
-        streams: { "https://p1:8443": [message, structuredClone(message)] }
+        streams: { "https://p1:8443": msgsThenHang([message, structuredClone(message)]) }
       });
       writer.upsertInventory.mockRejectedValueOnce(new Error("DB down"));
 
-      await flush();
-
-      expect(writer.upsertInventory).toHaveBeenCalledTimes(2);
-    });
-
-    it("tracks skipped no-op messages via getStats", async () => {
-      const message = createMessage();
-      const { manager } = setup({
-        streams: { "https://p1:8443": [message, structuredClone(message), structuredClone(message)] }
-      });
-
-      await flush();
-
-      expect(manager.getStats().noopMessagesSkipped).toBe(2);
-    });
-
-    it("reports zero skipped messages when none have arrived", () => {
-      const { manager } = setup({ streams: { "https://p1:8443": "hang" } });
-
-      expect(manager.getStats().noopMessagesSkipped).toBe(0);
+      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(2));
     });
 
     it("isolates caches across providers", async () => {
@@ -190,15 +164,18 @@ describe(StreamLifecycleManagerService.name, () => {
       const providerB = createProvider({ owner: "b", hostUri: "https://b:8443" });
       const messageA = createMessage({ cpu: 1000 });
       const messageB = createMessage({ cpu: 1000 });
-      const { writer } = setup({
+      const { writer, logger } = setup({
         providers: [providerA, providerB],
         streams: {
-          "https://a:8443": [messageA, structuredClone(messageA)],
-          "https://b:8443": [messageB]
+          "https://a:8443": msgsThenHang([messageA, structuredClone(messageA)]),
+          "https://b:8443": msgsThenHang([messageB])
         }
       });
 
-      await flush();
+      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() =>
+        expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_MESSAGE_SKIPPED_IDENTICAL", owner: "a" }))
+      );
 
       expect(writer.upsertInventory).toHaveBeenCalledWith(providerA, expect.objectContaining({ totalAvailableCpu: 1000n }));
       expect(writer.upsertInventory).toHaveBeenCalledWith(providerB, expect.objectContaining({ totalAvailableCpu: 1000n }));
@@ -209,37 +186,27 @@ describe(StreamLifecycleManagerService.name, () => {
   describe("error handling", () => {
     it("logs and continues when upsertInventory throws", async () => {
       const messages = [createMessage({ cpu: 1000 }), createMessage({ cpu: 2000 })];
-      const { writer, logger } = setup({
-        streams: { "https://p1:8443": messages }
-      });
+      const { writer, logger } = setup({ streams: { "https://p1:8443": msgsThenHang(messages) } });
       writer.upsertInventory.mockRejectedValueOnce(new Error("DB down"));
 
-      await flush();
+      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(2));
 
       expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_PROVIDER_WRITE_ERROR", owner: "akash1owner" }));
-      expect(writer.upsertInventory).toHaveBeenCalledTimes(2);
     });
 
-    it("logs stream-level errors", async () => {
-      const { logger } = setup({
-        streams: { "https://p1:8443": new Error("connection lost") }
+    it("logs each failed attempt as STREAM_ATTEMPT_FAILED", async () => {
+      let attempt = 0;
+      const streamFactory = mock<ProviderStreamFactory>();
+      streamFactory.openStatusStream.mockImplementation(() => {
+        attempt++;
+        if (attempt === 1) return throwingStream(new Error("connection lost"));
+        return msgsThenHang([createMessage()]);
       });
+      const { logger } = setup({ streamFactory });
 
-      await flush();
-
-      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_ERROR", owner: "akash1owner" }));
-    });
-
-    it("does not log AbortError", async () => {
-      const abortError = new Error("aborted");
-      abortError.name = "AbortError";
-      const { logger } = setup({
-        streams: { "https://p1:8443": abortError }
-      });
-
-      await flush();
-
-      expect(logger.error).not.toHaveBeenCalled();
+      await vi.waitFor(() =>
+        expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_ATTEMPT_FAILED", owner: "akash1owner" }))
+      );
     });
   });
 
@@ -251,10 +218,6 @@ describe(StreamLifecycleManagerService.name, () => {
       });
       const provider = createProvider();
       const streamFactory = mock<ProviderStreamFactory>();
-      const writer = mock<ProviderInventoryWriterService>();
-      const logger = mock<ReturnType<LoggerFactory>>();
-      const loggerFactory: LoggerFactory = () => logger;
-
       let callCount = 0;
       streamFactory.openStatusStream.mockImplementation(() => {
         callCount++;
@@ -267,9 +230,7 @@ describe(StreamLifecycleManagerService.name, () => {
         }
         return hangingStream();
       });
-
-      const manager = new StreamLifecycleManagerService(streamFactory, writer, loggerFactory);
-      manager.reconcile([provider]);
+      const { manager } = setup({ streamFactory, providers: [provider] });
 
       manager.reconcile([]);
       manager.reconcile([provider]);
@@ -277,7 +238,7 @@ describe(StreamLifecycleManagerService.name, () => {
       expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(2);
 
       resolveOldStream();
-      await flush();
+      await delay(20);
 
       manager.reconcile([provider]);
       expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(2);
@@ -286,25 +247,23 @@ describe(StreamLifecycleManagerService.name, () => {
 
   describe("shutdown", () => {
     it("aborts all active streams", () => {
-      const signals: AbortSignal[] = [];
       const providerA = createProvider({ owner: "a", hostUri: "https://a:8443" });
       const providerB = createProvider({ owner: "b", hostUri: "https://b:8443" });
       const { manager, streamFactory } = setup({
         providers: [providerA, providerB],
         streams: { "https://a:8443": "hang", "https://b:8443": "hang" }
       });
-      signals.push(captureSignal(streamFactory, 0), captureSignal(streamFactory, 1));
+      const signalA = captureSignal(streamFactory, 0);
+      const signalB = captureSignal(streamFactory, 1);
 
       manager.shutdown();
 
-      expect(signals[0].aborted).toBe(true);
-      expect(signals[1].aborted).toBe(true);
+      expect(signalA.aborted).toBe(true);
+      expect(signalB.aborted).toBe(true);
     });
 
     it("allows new streams after shutdown and re-reconcile", async () => {
-      const { manager, streamFactory } = setup({
-        streams: { "https://p1:8443": "hang" }
-      });
+      const { manager, streamFactory } = setup({ streams: { "https://p1:8443": "hang" } });
 
       manager.shutdown();
       streamFactory.openStatusStream.mockReturnValue(hangingStream());
@@ -313,25 +272,48 @@ describe(StreamLifecycleManagerService.name, () => {
 
       expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(2);
     });
+
+    it("clears diff cache on shutdown", async () => {
+      const stable = createMessage({ cpu: 1000 });
+      const { manager, streamFactory, writer } = setup({ streams: { "https://p1:8443": msgsThenHang([stable]) } });
+
+      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(1));
+
+      manager.shutdown();
+      streamFactory.openStatusStream.mockReturnValue(msgsThenHang([stable]));
+      manager.reconcile([createProvider()]);
+
+      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(2));
+    });
   });
 
-  function setup(input?: { providers?: ChainProvider[]; streams?: Record<string, StreamStatusMessage[] | Error | "hang"> }) {
-    const streamFactory = mock<ProviderStreamFactory>();
+  function setup(input?: {
+    providers?: ChainProvider[];
+    streams?: Record<string, AsyncIterable<StreamStatusMessage> | "hang">;
+    streamFactory?: MockProxy<ProviderStreamFactory>;
+  }) {
+    const streamFactory = input?.streamFactory ?? mock<ProviderStreamFactory>();
     const writer = mock<ProviderInventoryWriterService>();
-    const logger = mock<ReturnType<LoggerFactory>>();
+    const logger = mock<LoggerService>();
     const loggerFactory: LoggerFactory = () => logger;
     const providers = input?.providers ?? [createProvider()];
-
-    const streams = input?.streams ?? {};
-    streamFactory.openStatusStream.mockImplementation((hostUri: string) => {
-      const value = streams[hostUri];
-      if (value === "hang") return hangingStream();
-      if (value instanceof Error) return throwingStream(value);
-      if (Array.isArray(value)) return arrayStream(value);
-      return arrayStream([]);
+    const config = mock<EnvConfig>({
+      STREAM_RECONNECT_INITIAL_DELAY_MS: 10,
+      STREAM_RECONNECT_MAX_DELAY_MS: 50,
+      STREAM_FIRST_MESSAGE_TIMEOUT_MS: 80
     });
 
-    const manager = new StreamLifecycleManagerService(streamFactory, writer, loggerFactory);
+    if (!input?.streamFactory) {
+      const streams = input?.streams ?? {};
+      streamFactory.openStatusStream.mockImplementation((hostUri: string, signal: AbortSignal) => {
+        const value = streams[hostUri];
+        if (value === "hang") return hangingStream(signal);
+        if (value) return value;
+        return hangingStream(signal);
+      });
+    }
+
+    const manager = new StreamLifecycleManagerService(streamFactory, writer, loggerFactory, config);
     manager.reconcile(providers);
 
     return { manager, streamFactory, writer, logger, providers };
@@ -365,21 +347,27 @@ function createMessage(overrides?: { cpu?: number }): StreamStatusMessage {
   };
 }
 
-async function* arrayStream(messages: StreamStatusMessage[]) {
-  for (const msg of messages) {
-    yield msg;
-  }
+async function* msgsThenHang(messages: StreamStatusMessage[]): AsyncGenerator<StreamStatusMessage> {
+  for (const msg of messages) yield msg;
+  await new Promise<never>(() => undefined);
 }
 
 async function* throwingStream(error: Error): AsyncGenerator<StreamStatusMessage> {
-  yield* []; // satisfy require-yield
+  yield* [];
   throw error;
 }
 
-function hangingStream(): AsyncIterable<StreamStatusMessage> {
+function hangingStream(signal?: AbortSignal): AsyncIterable<StreamStatusMessage> {
   return {
     [Symbol.asyncIterator]() {
-      return { next: () => new Promise<IteratorResult<StreamStatusMessage>>(() => {}) };
+      return {
+        next: () =>
+          new Promise<IteratorResult<StreamStatusMessage>>((_, reject) => {
+            if (!signal) return;
+            if (signal.aborted) reject(new DOMException("aborted", "AbortError"));
+            signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+          })
+      };
     }
   };
 }
@@ -387,9 +375,4 @@ function hangingStream(): AsyncIterable<StreamStatusMessage> {
 function captureSignal(streamFactory: { openStatusStream: { mock: { calls: Array<[string, AbortSignal]> } } }, callIndex?: number): AbortSignal {
   const idx = callIndex ?? streamFactory.openStatusStream.mock.calls.length - 1;
   return streamFactory.openStatusStream.mock.calls[idx][1];
-}
-
-async function flush() {
-  // setTimeout(0) fires after all pending microtasks (Promise callbacks, async generator yields) have drained
-  await new Promise(resolve => setTimeout(resolve, 0));
 }

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -1,8 +1,12 @@
 import type { LoggerService } from "@akashnetwork/logging";
+import type { RetryPolicy } from "cockatiel";
+import { ExponentialBackoff, handleAll, retry } from "cockatiel";
 import { inject, singleton } from "tsyringe";
 
 import { projectRow } from "@src/lib/project-row/project-row";
 import { projectedRowsEqual } from "@src/lib/projected-row-equals/projected-row-equals";
+import type { EnvConfig } from "@src/providers/app-config.provider";
+import { APP_CONFIG } from "@src/providers/app-config.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
 import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
 import type { ProviderStreamFactory } from "@src/providers/provider-stream.provider";
@@ -11,23 +15,36 @@ import { ProviderInventoryWriterService } from "@src/services/provider-inventory
 import type { ChainProvider } from "@src/types/chain-provider";
 import type { ProjectedRow } from "@src/types/inventory";
 
+const RETRY_EXPONENT = 2;
+
 @singleton()
 export class StreamLifecycleManagerService {
   readonly #logger: LoggerService;
   readonly #streamFactory: ProviderStreamFactory;
   readonly #writer: ProviderInventoryWriterService;
+  readonly #config: EnvConfig;
   readonly #activeStreams = new Map<string, AbortController>();
   readonly #lastInventoryPerProvider = new Map<string, ProjectedRow>();
-  #noopMessagesSkipped = 0;
+  readonly #retryStreamPolicy: RetryPolicy;
 
   constructor(
     @inject(PROVIDER_STREAM_FACTORY) streamFactory: ProviderStreamFactory,
     @inject(ProviderInventoryWriterService) writer: ProviderInventoryWriterService,
-    @inject(LOGGER_FACTORY) loggerFactory: LoggerFactory
+    @inject(LOGGER_FACTORY) loggerFactory: LoggerFactory,
+    @inject(APP_CONFIG) config: EnvConfig
   ) {
     this.#streamFactory = streamFactory;
     this.#writer = writer;
+    this.#config = config;
     this.#logger = loggerFactory({ context: "StreamLifecycleManager" });
+    this.#retryStreamPolicy = retry(handleAll, {
+      maxAttempts: Number.POSITIVE_INFINITY,
+      backoff: new ExponentialBackoff({
+        initialDelay: this.#config.STREAM_RECONNECT_INITIAL_DELAY_MS,
+        maxDelay: this.#config.STREAM_RECONNECT_MAX_DELAY_MS,
+        exponent: RETRY_EXPONENT
+      })
+    });
   }
 
   reconcile(providers: ChainProvider[]): void {
@@ -37,6 +54,8 @@ export class StreamLifecycleManagerService {
       if (!currentOwners.has(owner)) {
         controller.abort();
         this.#activeStreams.delete(owner);
+        this.#lastInventoryPerProvider.delete(owner);
+        void this.#tryMarkOffline(owner);
         this.#logger.info({ event: "STREAM_STOPPED_PROVIDER_GONE", owner });
       }
     }
@@ -55,36 +74,94 @@ export class StreamLifecycleManagerService {
 
   async #runStream(provider: ChainProvider, signal: AbortSignal): Promise<void> {
     try {
-      const stream = this.#streamFactory.openStatusStream(provider.hostUri, signal);
-
-      for await (const message of stream) {
-        if (signal.aborted) break;
-        const row = projectRow(message);
-        const cached = this.#lastInventoryPerProvider.get(provider.owner);
-        if (cached && projectedRowsEqual(row, cached)) {
-          this.#noopMessagesSkipped++;
-          continue;
+      await this.#retryStreamPolicy.execute((ctx) => {
+        if (ctx.attempt > 0) {
+          this.#logger.warn({
+            event: "STREAM_RECONNECTING",
+            owner: provider.owner,
+            attempt: ctx.attempt,
+          });
         }
-        try {
-          await this.#writer.upsertInventory(provider, row);
-          this.#lastInventoryPerProvider.set(provider.owner, row);
-        } catch (error) {
-          this.#logger.error({ event: "STREAM_PROVIDER_WRITE_ERROR", owner: provider.owner, error });
-        }
-      }
+        return this.#runAttempt(provider, signal);
+      }, signal);
     } catch (error) {
-      if (error instanceof Error && error.name !== "AbortError") {
-        this.#logger.error({ event: "STREAM_ERROR", owner: provider.owner, error });
+      if (!signal.aborted) {
+        this.#logger.error({ event: "STREAM_GAVE_UP", owner: provider.owner, error });
       }
     } finally {
+      this.#lastInventoryPerProvider.delete(provider.owner);
       if (this.#activeStreams.get(provider.owner)?.signal === signal) {
         this.#activeStreams.delete(provider.owner);
       }
     }
   }
 
-  getStats(): { noopMessagesSkipped: number } {
-    return { noopMessagesSkipped: this.#noopMessagesSkipped };
+  async #runAttempt(provider: ChainProvider, outerSignal: AbortSignal): Promise<void> {
+    if (outerSignal.aborted) return;
+
+    this.#lastInventoryPerProvider.delete(provider.owner);
+
+    const attemptController = new AbortController();
+    const composite = AbortSignal.any([outerSignal, attemptController.signal]);
+
+    let firstMessageReceived = false;
+    const firstMessageTimeoutId = setTimeout(() => {
+      attemptController.abort();
+    }, this.#config.STREAM_FIRST_MESSAGE_TIMEOUT_MS);
+
+    try {
+      const stream = this.#streamFactory.openStatusStream(provider.hostUri, composite);
+
+      for await (const message of stream) {
+        if (outerSignal.aborted) return;
+        if (!firstMessageReceived) {
+          firstMessageReceived = true;
+          clearTimeout(firstMessageTimeoutId);
+        }
+        await this.#applyMessage(provider, message);
+      }
+
+      if (outerSignal.aborted) return;
+
+      await this.#tryMarkOffline(provider.owner);
+
+      if (firstMessageReceived) {
+        throw new Error("stream ended after delivering messages")
+      }
+      throw new Error("first message not received within timeout");
+    } catch (error) {
+      if (outerSignal.aborted) return;
+      this.#logger.warn({ event: "STREAM_ATTEMPT_FAILED", owner: provider.owner, error });
+      await this.#tryMarkOffline(provider.owner);
+      throw error;
+    } finally {
+      clearTimeout(firstMessageTimeoutId);
+    }
+  }
+
+  async #applyMessage(provider: ChainProvider, message: Parameters<typeof projectRow>[0]): Promise<void> {
+    const row = projectRow(message);
+    const cached = this.#lastInventoryPerProvider.get(provider.owner);
+
+    if (cached && projectedRowsEqual(cached, row)) {
+      this.#logger.debug({ event: "STREAM_MESSAGE_SKIPPED_IDENTICAL", owner: provider.owner });
+      return;
+    }
+
+    try {
+      await this.#writer.upsertInventory(provider, row);
+      this.#lastInventoryPerProvider.set(provider.owner, row);
+    } catch (error) {
+      this.#logger.error({ event: "STREAM_PROVIDER_WRITE_ERROR", owner: provider.owner, error });
+    }
+  }
+
+  async #tryMarkOffline(owner: string): Promise<void> {
+    try {
+      await this.#writer.markOffline(owner);
+    } catch (error) {
+      this.#logger.error({ event: "MARK_OFFLINE_ERROR", owner, error });
+    }
   }
 
   shutdown(): void {
@@ -93,6 +170,7 @@ export class StreamLifecycleManagerService {
       this.#logger.info({ event: "STREAM_CLOSED", owner });
     }
     this.#activeStreams.clear();
+    this.#lastInventoryPerProvider.clear();
   }
 
   dispose(): void {

--- a/apps/provider-inventory/src/services/streamer-bootstrap/streamer-bootstrap.spec.ts
+++ b/apps/provider-inventory/src/services/streamer-bootstrap/streamer-bootstrap.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DiscoverySchedulerService } from "@src/services/discovery-scheduler/discovery-scheduler.service";
+import type { ProviderInventoryWriterService } from "@src/services/provider-inventory-writer/provider-inventory-writer.service";
+import { runStreamerBootstrap } from "./streamer-bootstrap";
+
+describe("runStreamerBootstrap", () => {
+  it("calls writer.resetOnlineSince before scheduler.start", async () => {
+    const { writer, scheduler } = setup();
+
+    await runStreamerBootstrap(writer, scheduler);
+
+    expect(writer.resetOnlineSince).toHaveBeenCalledTimes(1);
+    expect(scheduler.start).toHaveBeenCalledTimes(1);
+    expect(writer.resetOnlineSince.mock.invocationCallOrder[0]).toBeLessThan(scheduler.start.mock.invocationCallOrder[0]);
+  });
+
+  it("awaits resetOnlineSince before invoking scheduler.start", async () => {
+    let resetResolved = false;
+    const { writer, scheduler } = setup();
+    writer.resetOnlineSince.mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 5));
+      resetResolved = true;
+    });
+    scheduler.start.mockImplementation(() => {
+      expect(resetResolved).toBe(true);
+    });
+
+    await runStreamerBootstrap(writer, scheduler);
+
+    expect(scheduler.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates resetOnlineSince errors and skips scheduler.start", async () => {
+    const { writer, scheduler } = setup();
+    writer.resetOnlineSince.mockRejectedValueOnce(new Error("db down"));
+
+    await expect(runStreamerBootstrap(writer, scheduler)).rejects.toThrow("db down");
+    expect(scheduler.start).not.toHaveBeenCalled();
+  });
+
+  function setup() {
+    const writer = mock<ProviderInventoryWriterService>();
+    const scheduler = mock<DiscoverySchedulerService>();
+    writer.resetOnlineSince.mockResolvedValue(undefined);
+    return { writer, scheduler };
+  }
+});

--- a/apps/provider-inventory/src/services/streamer-bootstrap/streamer-bootstrap.ts
+++ b/apps/provider-inventory/src/services/streamer-bootstrap/streamer-bootstrap.ts
@@ -1,0 +1,7 @@
+import type { DiscoverySchedulerService } from "@src/services/discovery-scheduler/discovery-scheduler.service";
+import type { ProviderInventoryWriterService } from "@src/services/provider-inventory-writer/provider-inventory-writer.service";
+
+export async function runStreamerBootstrap(writer: ProviderInventoryWriterService, scheduler: DiscoverySchedulerService): Promise<void> {
+  await writer.resetOnlineSince();
+  scheduler.start();
+}

--- a/apps/provider-inventory/tsconfig.json
+++ b/apps/provider-inventory/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "exclude": ["node_modules", "dist", "test", "src/**/*.spec.ts"],
+  "exclude": ["node_modules", "dist"],
   "extends": "./tsconfig.build.json",
   "include": ["src/**/*"],
   "compilerOptions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4701,6 +4701,7 @@
         "@hono/node-server": "^1.19.0",
         "@hono/otel": "~0.4.0",
         "@hono/zod-openapi": "^0.18.4",
+        "cockatiel": "^3.2.1",
         "drizzle-orm": "^0.31.2",
         "hono": "4.6.12",
         "http-errors": "^2.0.0",


### PR DESCRIPTION
## Why

Ref CON-305

## What

Wraps each per-provider streamStatus subscribe in a Cockatiel retry policy (ExponentialBackoff: 1s initial, 2x, capped at 5min, jittered) that fires when the SDK surfaces a final error or fails to deliver a first message within 10s. Each fresh attempt clears the per-provider diff cache so the first message after reconnect always writes through. On any attempt failure we flip is_online=false / is_online_since=NULL before retrying, keeping the prefilter index from trusting stale state. The startup ritual (resetOnlineSince before any stream opens) is factored into a runStreamerBootstrap helper so the ordering invariant is unit-testable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable env vars for discovery/reconnect timing and first-message timeout.
  * Automatic stream reconnection with exponential backoff, first-message aborts, per-provider duplicate-message filtering, and explicit offline marking.
  * Improved startup flow to reset writer state before discovery and streamlined bootstrap sequencing.

* **Tests**
  * Expanded coverage for stream lifecycle, reconnection/retry behavior, timeouts, diff-cache, shutdown, and bootstrap.

* **Chores**
  * Adjusted TypeScript project exclusions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3163)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->