### PR TITLE
feat(provider): discovery reconciler and multi-provider lifecycle

### DIFF
--- a/apps/provider-inventory/env/.env.functional.test
+++ b/apps/provider-inventory/env/.env.functional.test
@@ -1,0 +1,3 @@
+POSTGRES_BASE_URL=postgres://postgres:password@localhost:5432
+LOG_LEVEL=warn
+STD_OUT_LOG_FORMAT=pretty

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -18,6 +18,8 @@
     "prod": "node --permission --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --enable-source-maps --require ./dist/instrumentation.js ./dist/server.js",
     "start": "tsup --watch",
     "test": "vitest run --project unit --project functional",
+    "test:ci-setup": "dc up -d --wait --wait-timeout 60 db",
+    "test:ci-teardown": "dc down",
     "test:cov": "vitest run --project unit --project functional --coverage",
     "test:functional": "vitest run --project functional",
     "test:unit": "vitest run --project unit"
@@ -48,6 +50,8 @@
     "@types/node": "^24.0.0",
     "@typescript-eslint/eslint-plugin": "^7.12.0",
     "@vitest/coverage-v8": "^4.0.0",
+    "dotenv": "^16.5.0",
+    "dotenv-expand": "^12.0.2",
     "drizzle-kit": "^0.22.7",
     "eslint": "^8.57.0",
     "eslint-plugin-simple-import-sort": "^12.1.0",

--- a/apps/provider-inventory/src/index.ts
+++ b/apps/provider-inventory/src/index.ts
@@ -9,10 +9,10 @@ import { Hono } from "hono";
 import { container } from "tsyringe";
 
 import { APP_CONFIG } from "@src/providers/app-config.provider";
+import { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import { healthzRouter } from "@src/routes";
 import { DiscoverySchedulerService } from "@src/services/discovery-scheduler/discovery-scheduler.service";
 import { HonoErrorHandlerService } from "@src/services/hono-error-handler/hono-error-handler.service";
-import { ProviderInventoryWriterService } from "@src/services/provider-inventory-writer/provider-inventory-writer.service";
 import { startServer } from "@src/services/start-server/start-server";
 import { runStreamerBootstrap } from "@src/services/streamer-bootstrap/streamer-bootstrap";
 import type { AppEnv } from "@src/types/app-context";
@@ -32,6 +32,6 @@ export async function bootstrap(): Promise<void> {
 
   await startServer(app, createOtelLogger({ context: "APP" }), process, {
     port: container.resolve(APP_CONFIG).PORT,
-    beforeStart: () => runStreamerBootstrap(container.resolve(ProviderInventoryWriterService), container.resolve(DiscoverySchedulerService))
+    beforeStart: () => runStreamerBootstrap(container.resolve(ProviderInventoryRepository), container.resolve(DiscoverySchedulerService))
   });
 }

--- a/apps/provider-inventory/src/lib/discovery-reconciler/discovery-reconciler.spec.ts
+++ b/apps/provider-inventory/src/lib/discovery-reconciler/discovery-reconciler.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChainProvider } from "@src/types/chain-provider";
+import type { StreamHandle } from "./discovery-reconciler";
+import { reconcileDiscovery } from "./discovery-reconciler";
+
+describe(reconcileDiscovery.name, () => {
+  it("yields a start command for a brand-new provider not in the registry", () => {
+    const provider = createProvider({ owner: "a", hostUri: "https://a:8443" });
+
+    const commands = collect(reconcileDiscovery(new Map(), [provider]));
+
+    expect(commands).toEqual([{ kind: "start", provider }]);
+  });
+
+  it("yields a stop command for an owner present in the registry but absent from the latest poll", () => {
+    const registry = new Map<string, StreamHandle>([["gone", { hostUri: "https://gone:8443" }]]);
+
+    const commands = collect(reconcileDiscovery(registry, []));
+
+    expect(commands).toEqual([{ kind: "stop", owner: "gone" }]);
+  });
+
+  it("yields a restart command when the same owner now reports a different hostUri", () => {
+    const provider = createProvider({ owner: "a", hostUri: "https://new:8443" });
+    const registry = new Map<string, StreamHandle>([["a", { hostUri: "https://old:8443" }]]);
+
+    const commands = collect(reconcileDiscovery(registry, [provider]));
+
+    expect(commands).toEqual([{ kind: "restart", provider }]);
+  });
+
+  it("yields only refreshAttributes when an owner is unchanged", () => {
+    const provider = createProvider({ owner: "a", hostUri: "https://a:8443" });
+    const registry = new Map<string, StreamHandle>([["a", { hostUri: "https://a:8443" }]]);
+
+    const commands = collect(reconcileDiscovery(registry, [provider]));
+
+    expect(commands).toEqual([{ kind: "refreshAttributes", provider }]);
+  });
+
+  it("yields refreshAttributes only for unchanged providers and start for the rest", () => {
+    const a = createProvider({ owner: "a" });
+    const b = createProvider({ owner: "b" });
+    const registry = new Map<string, StreamHandle>([["a", { hostUri: a.hostUri }]]);
+
+    const commands = collect(reconcileDiscovery(registry, [a, b]));
+
+    expect(commands).toEqual([
+      { kind: "refreshAttributes", provider: a },
+      { kind: "start", provider: b }
+    ]);
+  });
+
+  it("does no hostUri tiebreaking — emits start commands for every owner sharing a hostUri", () => {
+    const a = createProvider({ owner: "a", hostUri: "https://shared:8443", createdHeight: 200n });
+    const b = createProvider({ owner: "b", hostUri: "https://shared:8443", createdHeight: 100n });
+
+    const commands = collect(reconcileDiscovery(new Map(), [a, b]));
+
+    const starts = commands.filter(c => c.kind === "start");
+    expect(starts.map(c => (c.kind === "start" ? c.provider.owner : null))).toEqual(["a", "b"]);
+  });
+
+  describe("ordering", () => {
+    it("yields all stops before any start/restart/refresh commands", () => {
+      const fresh = createProvider({ owner: "fresh", hostUri: "https://fresh:8443" });
+      const moved = createProvider({ owner: "moved", hostUri: "https://new:8443" });
+      const steady = createProvider({ owner: "steady", hostUri: "https://steady:8443" });
+      const registry = new Map<string, StreamHandle>([
+        ["moved", { hostUri: "https://old:8443" }],
+        ["steady", { hostUri: "https://steady:8443" }],
+        ["dead", { hostUri: "https://dead:8443" }]
+      ]);
+
+      const kinds = collect(reconcileDiscovery(registry, [fresh, moved, steady])).map(c => c.kind);
+
+      const lastStopIdx = kinds.lastIndexOf("stop");
+      const firstNonStopIdx = kinds.findIndex(k => k !== "stop");
+      expect(lastStopIdx).toBeLessThan(firstNonStopIdx);
+    });
+
+    it("emits start/restart/refresh commands in createdHeight DESC order so winners commit before losers", () => {
+      const high = createProvider({ owner: "high", hostUri: "https://h:8443", createdHeight: 300n });
+      const mid = createProvider({ owner: "mid", hostUri: "https://m:8443", createdHeight: 200n });
+      const low = createProvider({ owner: "low", hostUri: "https://l:8443", createdHeight: 100n });
+      const registry = new Map<string, StreamHandle>([
+        ["high", { hostUri: high.hostUri }],
+        ["mid", { hostUri: mid.hostUri }],
+        ["low", { hostUri: low.hostUri }]
+      ]);
+
+      const commands = collect(reconcileDiscovery(registry, [low, high, mid]));
+
+      const order = commands.map(c => (c.kind === "refreshAttributes" ? c.provider.owner : null));
+      expect(order).toEqual(["high", "mid", "low"]);
+    });
+  });
+});
+
+function collect<T>(iterable: Iterable<T>): T[] {
+  return [...iterable];
+}
+
+function createProvider(overrides?: Partial<ChainProvider>): ChainProvider {
+  return {
+    owner: "akash1owner",
+    hostUri: "https://p:8443",
+    createdHeight: 100n,
+    selfAttributes: [],
+    signedAttributes: [],
+    ...overrides
+  };
+}

--- a/apps/provider-inventory/src/lib/discovery-reconciler/discovery-reconciler.ts
+++ b/apps/provider-inventory/src/lib/discovery-reconciler/discovery-reconciler.ts
@@ -1,0 +1,39 @@
+import type { ChainProvider } from "@src/types/chain-provider";
+
+export interface StreamHandle {
+  hostUri: string;
+}
+
+export type DiscoveryCommand =
+  | { kind: "stop"; owner: string }
+  | { kind: "refreshAttributes"; provider: ChainProvider }
+  | { kind: "start"; provider: ChainProvider }
+  | { kind: "restart"; provider: ChainProvider };
+
+export function* reconcileDiscovery(
+  currentRegistry: ReadonlyMap<string, StreamHandle>,
+  latestProviderState: readonly ChainProvider[]
+): Generator<DiscoveryCommand> {
+  const newProviders = new Set<string>(latestProviderState.map(p => p.owner));
+
+  for (const owner of currentRegistry.keys()) {
+    if (!newProviders.has(owner)) {
+      yield { kind: "stop", owner };
+    }
+  }
+
+  const orderedByHeightDesc = [...latestProviderState].sort((a, b) => {
+    if (a.createdHeight === b.createdHeight) return 0;
+    return a.createdHeight > b.createdHeight ? -1 : 1;
+  });
+  for (const provider of orderedByHeightDesc) {
+    const observedProvider = currentRegistry.get(provider.owner);
+    if (!observedProvider) {
+      yield { kind: "start", provider };
+    } else if (observedProvider.hostUri !== provider.hostUri) {
+      yield { kind: "restart", provider };
+    } else {
+      yield { kind: "refreshAttributes", provider };
+    }
+  }
+}

--- a/apps/provider-inventory/src/lib/generators/chunkify.ts
+++ b/apps/provider-inventory/src/lib/generators/chunkify.ts
@@ -1,0 +1,17 @@
+export function* chunkify<T>(iter: Iterable<T>, size: number): Generator<readonly T[]> {
+  const buf: T[] = new Array(size);
+  let i = 0;
+  for (const x of iter) {
+    buf[i++] = x;
+    if (i >= size) {
+      yield [...buf];
+      i = 0;
+    }
+  }
+
+  if (i !== 0) {
+    yield buf.slice(0, i);
+    i = 0;
+    buf.length = 0;
+  }
+}

--- a/apps/provider-inventory/src/providers/postgres.provider.ts
+++ b/apps/provider-inventory/src/providers/postgres.provider.ts
@@ -14,7 +14,7 @@ container.register(APP_PG_CLIENT, {
   useFactory: instancePerContainerCachingFactory(c => {
     const config = c.resolve(APP_CONFIG);
     return postgres(config.PROVIDER_INVENTORY_POSTGRES_URL, {
-      max: 10,
+      max: 50,
       onnotice: logger.info.bind(logger),
       types: {
         bigint: postgres.BigInt,

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.spec.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.spec.ts
@@ -1,0 +1,113 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { LoggerFactory } from "@src/providers/logger-factory.provider";
+import type { ChainProvider } from "@src/types/chain-provider";
+import type { ProjectedRow } from "@src/types/inventory";
+import { ProviderInventoryRepository } from "./provider-inventory.repository";
+
+describe(ProviderInventoryRepository.name, () => {
+  describe("deleteByOwner", () => {
+    it("deletes the row for the given owner", async () => {
+      const { writer, db } = setup();
+
+      await writer.deleteByOwner("akash1gone");
+
+      expect(db.delete).toHaveBeenCalledTimes(1);
+      expect(db._deleteWhere).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("upsertAttributes", () => {
+    it("upserts the row with the provider's attributes", async () => {
+      const { writer, db } = setup();
+
+      await writer.upsertAttributes(createProvider({ owner: "a", hostUri: "https://h:8443", createdHeight: 100n }));
+
+      expect(db.insert).toHaveBeenCalledTimes(1);
+      expect(db._insertValues).toHaveBeenCalledWith(expect.objectContaining({ owner: "a", hostUri: "https://h:8443", createdHeight: 100n }));
+    });
+
+    it("computes auditedBy as a sorted, deduped list of auditors", async () => {
+      const provider = createProvider({
+        owner: "a",
+        signedAttributes: [
+          { key: "k1", value: "v1", auditor: "auditor-z" },
+          { key: "k2", value: "v2", auditor: "auditor-a" },
+          { key: "k3", value: "v3", auditor: "auditor-a" }
+        ]
+      });
+      const { writer, db } = setup();
+
+      await writer.upsertAttributes(provider);
+
+      expect(db._insertValues).toHaveBeenCalledWith(expect.objectContaining({ auditedBy: ["auditor-a", "auditor-z"] }));
+    });
+  });
+
+  describe("updateInventory", () => {
+    it("only UPDATEs the existing row — a loser without an attributes row never gets one written", async () => {
+      const { writer, db } = setup();
+      const row: ProjectedRow = createProjectedRow({ cpu: 1000n });
+
+      await writer.updateInventory(createProvider({ owner: "a", hostUri: "https://h:8443" }), row);
+
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(db.update).toHaveBeenCalledTimes(1);
+      expect(db._updateSet).toHaveBeenCalledWith(expect.objectContaining({ totalAvailableCpu: 1000n, isOnline: true }));
+    });
+  });
+
+  function setup() {
+    const deleteWhere = vi.fn().mockResolvedValue(undefined);
+    const insertOnConflict = vi.fn().mockResolvedValue(undefined);
+    const insertValues = vi.fn().mockReturnValue({ onConflictDoUpdate: insertOnConflict });
+    const updateWhere = vi.fn().mockResolvedValue(undefined);
+    const updateSet = vi.fn().mockReturnValue({ where: updateWhere });
+
+    const db = {
+      delete: vi.fn().mockReturnValue({ where: deleteWhere }),
+      insert: vi.fn().mockReturnValue({ values: insertValues }),
+      update: vi.fn().mockReturnValue({ set: updateSet }),
+      _deleteWhere: deleteWhere,
+      _insertValues: insertValues,
+      _onConflictDoUpdate: insertOnConflict,
+      _updateSet: updateSet,
+      _updateWhere: updateWhere
+    };
+
+    const logger = mock<ReturnType<LoggerFactory>>();
+    const loggerFactory: LoggerFactory = () => logger;
+
+    const writer = new ProviderInventoryRepository(db as unknown as PostgresJsDatabase, loggerFactory);
+    return { writer, db, logger };
+  }
+});
+
+function createProvider(overrides?: Partial<ChainProvider>): ChainProvider {
+  return {
+    owner: "akash1owner",
+    hostUri: "https://p:8443",
+    createdHeight: 100n,
+    selfAttributes: [],
+    signedAttributes: [],
+    ...overrides
+  };
+}
+
+function createProjectedRow(overrides?: { cpu?: bigint }): ProjectedRow {
+  return {
+    inventory: { nodes: [], storage: [] },
+    totalAvailableCpu: overrides?.cpu ?? 0n,
+    totalAvailableMemory: 0n,
+    totalAvailableGpu: 0n,
+    totalAvailableEph: 0n,
+    totalAvailablePersistent: 0n,
+    maxNodeFreeCpu: 0n,
+    maxNodeFreeMemory: 0n,
+    maxNodeFreeGpu: 0n,
+    gpuModels: [],
+    storageClasses: []
+  };
+}

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
@@ -11,18 +11,23 @@ import type { ChainProvider } from "@src/types/chain-provider";
 import type { ProjectedRow } from "@src/types/inventory";
 
 @singleton()
-export class ProviderInventoryWriterService {
+export class ProviderInventoryRepository {
   readonly #logger: LoggerService;
   readonly #db: PostgresJsDatabase;
 
   constructor(@inject(DRIZZLE_DB) db: PostgresJsDatabase, @inject(LOGGER_FACTORY) loggerFactory: LoggerFactory) {
     this.#db = db;
-    this.#logger = loggerFactory({ context: "ProviderInventoryWriter" });
+    this.#logger = loggerFactory({ context: "ProviderInventoryRepository" });
   }
 
   async resetOnlineSince(): Promise<void> {
     await this.#db.update(providerInventory).set({ isOnlineSince: null });
     this.#logger.info({ event: "ONLINE_SINCE_RESET" });
+  }
+
+  async deleteByOwner(owner: string): Promise<void> {
+    await this.#db.delete(providerInventory).where(eq(providerInventory.owner, owner));
+    this.#logger.info({ event: "PROVIDER_INVENTORY_DELETED", owner });
   }
 
   async markOffline(owner: string): Promise<void> {
@@ -33,37 +38,32 @@ export class ProviderInventoryWriterService {
     this.#logger.info({ event: "PROVIDER_MARKED_OFFLINE", owner });
   }
 
-  async upsertInventory(provider: ChainProvider, row: ProjectedRow): Promise<void> {
-    const set = {
-      hostUri: provider.hostUri,
-      createdHeight: provider.createdHeight,
-      inventory: row.inventory,
-      totalAvailableCpu: row.totalAvailableCpu,
-      totalAvailableMemory: row.totalAvailableMemory,
-      totalAvailableGpu: row.totalAvailableGpu,
-      totalAvailableEph: row.totalAvailableEph,
-      totalAvailablePersistent: row.totalAvailablePersistent,
-      maxNodeFreeCpu: row.maxNodeFreeCpu,
-      maxNodeFreeMemory: row.maxNodeFreeMemory,
-      maxNodeFreeGpu: row.maxNodeFreeGpu,
-      gpuModels: row.gpuModels,
-      storageClasses: row.storageClasses,
-      isOnline: true as const,
-      isOnlineSince: rawSql`coalesce(${providerInventory.isOnlineSince}, now())`,
-      updatedAt: rawSql`now()`
-    };
-
+  async updateInventory(provider: ChainProvider, row: ProjectedRow): Promise<void> {
     await this.#db
-      .insert(providerInventory)
-      .values({ owner: provider.owner, ...set })
-      .onConflictDoUpdate({ target: providerInventory.owner, set });
+      .update(providerInventory)
+      .set({
+        inventory: row.inventory,
+        totalAvailableCpu: row.totalAvailableCpu,
+        totalAvailableMemory: row.totalAvailableMemory,
+        totalAvailableGpu: row.totalAvailableGpu,
+        totalAvailableEph: row.totalAvailableEph,
+        totalAvailablePersistent: row.totalAvailablePersistent,
+        maxNodeFreeCpu: row.maxNodeFreeCpu,
+        maxNodeFreeMemory: row.maxNodeFreeMemory,
+        maxNodeFreeGpu: row.maxNodeFreeGpu,
+        gpuModels: row.gpuModels,
+        storageClasses: row.storageClasses,
+        isOnline: true,
+        isOnlineSince: rawSql`coalesce(${providerInventory.isOnlineSince}, now())`,
+        updatedAt: rawSql`now()`
+      })
+      .where(eq(providerInventory.owner, provider.owner));
 
-    this.#logger.debug({ event: "PROVIDER_INVENTORY_UPSERTED", owner: provider.owner });
+    this.#logger.debug({ event: "PROVIDER_INVENTORY_UPDATED", owner: provider.owner });
   }
 
   async upsertAttributes(provider: ChainProvider): Promise<void> {
     const auditedBy = [...new Set(provider.signedAttributes.map(a => a.auditor))].sort();
-
     const set = {
       hostUri: provider.hostUri,
       createdHeight: provider.createdHeight,

--- a/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.spec.ts
+++ b/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.spec.ts
@@ -3,9 +3,10 @@ import { mock } from "vitest-mock-extended";
 
 import type { EnvConfig } from "@src/providers/app-config.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
+import type { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import type { ChainProviderPollerService } from "@src/services/chain-provider-poller/chain-provider-poller.service";
-import type { ProviderInventoryWriterService } from "@src/services/provider-inventory-writer/provider-inventory-writer.service";
 import type { StreamLifecycleManagerService } from "@src/services/stream-lifecycle-manager/stream-lifecycle-manager.service";
+import type { ChainProvider } from "@src/types/chain-provider";
 import { DiscoverySchedulerService } from "./discovery-scheduler.service";
 
 describe(DiscoverySchedulerService.name, () => {
@@ -50,44 +51,64 @@ describe(DiscoverySchedulerService.name, () => {
 
   it("does not overlap ticks when a tick is slow", async () => {
     const pollDuration = 1_200_000;
-    const { poller, config } = setup({
-      pollDelay: () => pollDuration
-    });
+    const { poller, config } = setup({ pollDelay: () => pollDuration });
 
     await vi.advanceTimersByTimeAsync(0);
     expect(poller.poll).toHaveBeenCalledTimes(1);
 
-    // Mid-poll: no second tick despite interval elapsed
     await vi.advanceTimersByTimeAsync(config.DISCOVERY_INTERVAL_MS);
     expect(poller.poll).toHaveBeenCalledTimes(1);
 
-    // Poll completes at pollDuration; next tick is scheduled DISCOVERY_INTERVAL_MS later
     await vi.advanceTimersByTimeAsync(pollDuration - config.DISCOVERY_INTERVAL_MS);
     expect(poller.poll).toHaveBeenCalledTimes(1);
 
-    // Advance past the scheduled interval after tick completion
     await vi.advanceTimersByTimeAsync(config.DISCOVERY_INTERVAL_MS);
     expect(poller.poll).toHaveBeenCalledTimes(2);
   });
 
-  it("writes attributes and reconciles streams on each tick", async () => {
-    const fakeProviders = [{ owner: "akash1abc", hostUri: "https://provider.example.com:8443", createdHeight: 100n, selfAttributes: [], signedAttributes: [] }];
-    const { writer, lifecycle } = setup({ providers: fakeProviders });
+  it("dispatches each reconciler command to the right handler", async () => {
+    const fresh = createProvider({ owner: "fresh", hostUri: "https://fresh:8443" });
+    const { writer, lifecycle } = setup({ providers: [fresh] });
 
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(writer.upsertAttributes).toHaveBeenCalledWith(fakeProviders[0]);
-    expect(lifecycle.reconcile).toHaveBeenCalledWith(fakeProviders);
+    expect(lifecycle.getRegistry).toHaveBeenCalled();
+    expect(writer.upsertAttributes).toHaveBeenCalledWith(fresh);
+    expect(lifecycle.start).toHaveBeenCalledWith(fresh);
   });
 
-  it("continues scheduling after a poll error", async () => {
-    const { poller, config } = setup({ pollError: new Error("chain RPC unavailable") });
+  it("dispatches refreshAttributes in createdHeight DESC order so winners commit before losers", async () => {
+    const a = createProvider({ owner: "a", createdHeight: 100n });
+    const b = createProvider({ owner: "b", createdHeight: 200n });
+    const c = createProvider({ owner: "c", createdHeight: 50n });
+    const { writer } = setup({ providers: [a, b, c] });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    const orderedOwners = writer.upsertAttributes.mock.calls.map(([p]) => p.owner);
+    expect(orderedOwners).toEqual(["b", "a", "c"]);
+  });
+
+  it("continues after a poll error and re-arms the next tick", async () => {
+    const { poller, config, logger } = setup({ pollError: new Error("chain RPC unavailable") });
 
     await vi.advanceTimersByTimeAsync(0);
     expect(poller.poll).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "DISCOVERY_TICK_ERROR" }));
 
     await vi.advanceTimersByTimeAsync(config.DISCOVERY_INTERVAL_MS);
     expect(poller.poll).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs and continues when upsertAttributes throws", async () => {
+    const provider = createProvider();
+    const { writer, lifecycle, logger } = setup({ providers: [provider] });
+    writer.upsertAttributes.mockRejectedValueOnce(new Error("DB down"));
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "REFRESH_ATTRIBUTES_ERROR", owner: provider.owner }));
+    expect(lifecycle.start).toHaveBeenCalled();
   });
 
   it("stops scheduling after stop is called", async () => {
@@ -112,21 +133,21 @@ describe(DiscoverySchedulerService.name, () => {
     expect(poller.poll).toHaveBeenCalledTimes(1);
   });
 
-  function setup(input?: {
-    providers?: Array<{ owner: string; hostUri: string; createdHeight: bigint; selfAttributes: never[]; signedAttributes: never[] }>;
-    pollError?: Error;
-    pollDelay?: (config: EnvConfig) => number;
-  }) {
+  function setup(input?: { providers?: ChainProvider[]; pollError?: Error; pollDelay?: (config: EnvConfig) => number }) {
     const poller = mock<ChainProviderPollerService>();
-    const writer = mock<ProviderInventoryWriterService>();
+    const writer = mock<ProviderInventoryRepository>();
     const lifecycle = mock<StreamLifecycleManagerService>();
-    const loggerFactory: LoggerFactory = () => mock<ReturnType<LoggerFactory>>();
+    lifecycle.getRegistry.mockReturnValue(new Map());
+    lifecycle.stopAndDelete.mockResolvedValue();
+    writer.upsertAttributes.mockResolvedValue();
+
+    const logger = mock<ReturnType<LoggerFactory>>();
+    const loggerFactory: LoggerFactory = () => logger;
     const config: EnvConfig = {
       PROVIDER_INVENTORY_POSTGRES_URL: "postgres://localhost/test",
       DRIZZLE_MIGRATIONS_FOLDER: "./drizzle",
       LOG_LEVEL: "info",
       STD_OUT_LOG_FORMAT: "json",
-      NODE_ENV: "test",
       PORT: 3092,
       DISCOVERY_INTERVAL_MS: 600_000
     };
@@ -148,6 +169,17 @@ describe(DiscoverySchedulerService.name, () => {
     const scheduler = new DiscoverySchedulerService(poller, writer, lifecycle, config, loggerFactory);
     scheduler.start();
 
-    return { scheduler, poller, writer, lifecycle, config };
+    return { scheduler, poller, writer, lifecycle, config, logger };
   }
 });
+
+function createProvider(overrides?: Partial<ChainProvider>): ChainProvider {
+  return {
+    owner: "akash1abc",
+    hostUri: "https://provider.example.com:8443",
+    createdHeight: 100n,
+    selfAttributes: [],
+    signedAttributes: [],
+    ...overrides
+  };
+}

--- a/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
+++ b/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
@@ -1,19 +1,23 @@
 import type { LoggerService } from "@akashnetwork/logging";
 import { inject, singleton } from "tsyringe";
 
+import type { DiscoveryCommand } from "@src/lib/discovery-reconciler/discovery-reconciler";
+import { reconcileDiscovery } from "@src/lib/discovery-reconciler/discovery-reconciler";
+import { chunkify } from "@src/lib/generators/chunkify";
 import type { EnvConfig } from "@src/providers/app-config.provider";
 import { APP_CONFIG } from "@src/providers/app-config.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
 import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
+import { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import { ChainProviderPollerService } from "@src/services/chain-provider-poller/chain-provider-poller.service";
-import { ProviderInventoryWriterService } from "@src/services/provider-inventory-writer/provider-inventory-writer.service";
 import { StreamLifecycleManagerService } from "@src/services/stream-lifecycle-manager/stream-lifecycle-manager.service";
+import type { ChainProvider } from "@src/types/chain-provider";
 
 @singleton()
 export class DiscoverySchedulerService {
   readonly #logger: LoggerService;
   readonly #poller: ChainProviderPollerService;
-  readonly #writer: ProviderInventoryWriterService;
+  readonly #writer: ProviderInventoryRepository;
   readonly #lifecycle: StreamLifecycleManagerService;
   readonly #config: EnvConfig;
   #timer: ReturnType<typeof setTimeout> | null = null;
@@ -21,7 +25,7 @@ export class DiscoverySchedulerService {
 
   constructor(
     @inject(ChainProviderPollerService) poller: ChainProviderPollerService,
-    @inject(ProviderInventoryWriterService) writer: ProviderInventoryWriterService,
+    @inject(ProviderInventoryRepository) writer: ProviderInventoryRepository,
     @inject(StreamLifecycleManagerService) lifecycle: StreamLifecycleManagerService,
     @inject(APP_CONFIG) config: EnvConfig,
     @inject(LOGGER_FACTORY) loggerFactory: LoggerFactory
@@ -51,21 +55,54 @@ export class DiscoverySchedulerService {
     this.stop();
   }
 
-  async #tick(): Promise<void> {
-    if (!this.#running) return;
-
+  async discoverProviders(): Promise<void> {
     try {
       this.#logger.info({ event: "DISCOVERY_TICK_START" });
       const providers = await this.#poller.poll();
-      await Promise.all(providers.map(p => this.#writer.upsertAttributes(p)));
-      this.#lifecycle.reconcile(providers);
+
+      const chunkedCommands = chunkify(reconcileDiscovery(this.#lifecycle.getRegistry(), providers), 50);
+      for (const commands of chunkedCommands) {
+        await Promise.allSettled(commands.map(c => this.#dispatch(c)));
+      }
+
       this.#logger.info({ event: "DISCOVERY_TICK_COMPLETE", providerCount: providers.length });
     } catch (error) {
       this.#logger.error({ event: "DISCOVERY_TICK_ERROR", error });
     }
+  }
 
+  async #tick(): Promise<void> {
+    if (!this.#running) return;
+    await this.discoverProviders();
     if (this.#running) {
       this.#timer = setTimeout(() => void this.#tick(), this.#config.DISCOVERY_INTERVAL_MS);
+    }
+  }
+
+  async #dispatch(command: DiscoveryCommand): Promise<void> {
+    switch (command.kind) {
+      case "stop":
+        await this.#lifecycle.stopAndDelete(command.owner);
+        return;
+      case "refreshAttributes":
+        await this.#refreshAttributes(command.provider);
+        return;
+      case "start":
+        await this.#refreshAttributes(command.provider);
+        this.#lifecycle.start(command.provider);
+        return;
+      case "restart":
+        await this.#refreshAttributes(command.provider);
+        this.#lifecycle.restart(command.provider);
+        return;
+    }
+  }
+
+  async #refreshAttributes(provider: ChainProvider): Promise<void> {
+    try {
+      await this.#writer.upsertAttributes(provider);
+    } catch (error) {
+      this.#logger.error({ event: "REFRESH_ATTRIBUTES_ERROR", owner: provider.owner, error });
     }
   }
 }

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
@@ -6,84 +6,113 @@ import { mock, type MockProxy } from "vitest-mock-extended";
 import type { EnvConfig } from "@src/providers/app-config.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
 import type { ProviderStreamFactory } from "@src/providers/provider-stream.provider";
-import type { ProviderInventoryWriterService } from "@src/services/provider-inventory-writer/provider-inventory-writer.service";
+import type { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import type { ChainProvider } from "@src/types/chain-provider";
 import type { StreamStatusMessage } from "@src/types/stream-status";
 import { StreamLifecycleManagerService } from "./stream-lifecycle-manager.service";
 
 describe(StreamLifecycleManagerService.name, () => {
-  describe("reconcile", () => {
-    it("opens a stream for a new provider", async () => {
-      const { streamFactory } = setup({ streams: { "https://p1:8443": "hang" } });
-
-      expect(streamFactory.openStatusStream).toHaveBeenCalledWith("https://p1:8443", expect.any(AbortSignal));
-    });
-
-    it("calls upsertInventory for each unique stream message", async () => {
-      const messages = [createMessage({ cpu: 1000 }), createMessage({ cpu: 2000 })];
-      const { writer, providers } = setup({ streams: { "https://p1:8443": msgsThenHang(messages) } });
-
-      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(2));
-
-      expect(writer.upsertInventory).toHaveBeenCalledWith(providers[0], expect.objectContaining({ totalAvailableCpu: 1000n }));
-      expect(writer.upsertInventory).toHaveBeenCalledWith(providers[0], expect.objectContaining({ totalAvailableCpu: 2000n }));
-    });
-
-    it("skips providers that already have an active stream", async () => {
-      const { manager, streamFactory, providers } = setup({ streams: { "https://p1:8443": "hang" } });
-
-      manager.reconcile(providers);
-
-      expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(1);
-    });
-
-    it("stops streams for providers absent from the new list", async () => {
+  describe("start", () => {
+    it("opens a stream for the provider", () => {
+      const provider = createProvider();
       const { manager, streamFactory } = setup({ streams: { "https://p1:8443": "hang" } });
-      const signal = captureSignal(streamFactory);
 
-      manager.reconcile([]);
+      manager.start(provider);
 
-      expect(signal.aborted).toBe(true);
+      expect(streamFactory.openStatusStream).toHaveBeenCalledWith(provider.hostUri, expect.any(AbortSignal));
     });
 
-    it("opens streams for new providers while stopping removed ones", async () => {
-      const providerA = createProvider({ owner: "a", hostUri: "https://a:8443" });
-      const providerB = createProvider({ owner: "b", hostUri: "https://b:8443" });
-      const { manager, streamFactory } = setup({
-        providers: [providerA],
-        streams: { "https://a:8443": "hang", "https://b:8443": "hang" }
-      });
+    it("calls updateInventory for each unique stream message", async () => {
+      const provider = createProvider();
+      const messages = [createMessage({ cpu: 1000 }), createMessage({ cpu: 2000 })];
+      const { manager, writer } = setup({ streams: { "https://p1:8443": msgsThenHang(messages) } });
+
+      manager.start(provider);
+
+      await vi.waitFor(() => expect(writer.updateInventory).toHaveBeenCalledTimes(2));
+      expect(writer.updateInventory).toHaveBeenCalledWith(provider, expect.objectContaining({ totalAvailableCpu: 1000n }));
+      expect(writer.updateInventory).toHaveBeenCalledWith(provider, expect.objectContaining({ totalAvailableCpu: 2000n }));
+    });
+  });
+
+  describe("stopAndDelete", () => {
+    it("aborts the stream and deletes the row for a vanished provider", async () => {
+      const provider = createProvider();
+      const { manager, streamFactory, writer } = setup({ streams: { "https://p1:8443": "hang" } });
+      manager.start(provider);
       const signal = captureSignal(streamFactory);
 
-      manager.reconcile([providerB]);
+      await manager.stopAndDelete(provider.owner);
 
       expect(signal.aborted).toBe(true);
-      expect(streamFactory.openStatusStream).toHaveBeenCalledWith("https://b:8443", expect.any(AbortSignal));
+      expect(writer.deleteByOwner).toHaveBeenCalledWith(provider.owner);
+    });
+
+    it("still deletes the row even when no stream is active for that owner", async () => {
+      const { manager, writer } = setup();
+
+      await manager.stopAndDelete("ghost");
+
+      expect(writer.deleteByOwner).toHaveBeenCalledWith("ghost");
+    });
+  });
+
+  describe("restart", () => {
+    it("aborts the existing stream and opens a new one on the new hostUri", () => {
+      const old = createProvider({ owner: "a", hostUri: "https://old:8443" });
+      const updated = createProvider({ owner: "a", hostUri: "https://new:8443" });
+      const { manager, streamFactory, writer } = setup({
+        streams: { "https://old:8443": "hang", "https://new:8443": "hang" }
+      });
+      manager.start(old);
+      const oldSignal = captureSignal(streamFactory, 0);
+
+      manager.restart(updated);
+
+      expect(oldSignal.aborted).toBe(true);
+      expect(streamFactory.openStatusStream).toHaveBeenLastCalledWith("https://new:8443", expect.any(AbortSignal));
+      expect(writer.deleteByOwner).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getRegistry", () => {
+    it("exposes a snapshot of active streams keyed by owner with hostUri", () => {
+      const a = createProvider({ owner: "a", hostUri: "https://a:8443" });
+      const b = createProvider({ owner: "b", hostUri: "https://b:8443" });
+      const { manager } = setup({ streams: { "https://a:8443": "hang", "https://b:8443": "hang" } });
+
+      manager.start(a);
+      manager.start(b);
+
+      const registry = manager.getRegistry();
+      expect(registry.size).toBe(2);
+      expect(registry.get("a")).toEqual({ hostUri: "https://a:8443" });
+      expect(registry.get("b")).toEqual({ hostUri: "https://b:8443" });
     });
   });
 
   describe("diff cache", () => {
     it("performs a single write when two consecutive identical messages arrive", async () => {
       const message = createMessage({ cpu: 1000 });
-      const { writer, logger } = setup({
+      const { manager, writer, logger } = setup({
         streams: { "https://p1:8443": msgsThenHang([message, structuredClone(message)]) }
       });
+      manager.start(createProvider());
 
-      await vi.waitFor(() =>
-        expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_MESSAGE_SKIPPED_IDENTICAL" }))
-      );
+      await vi.waitFor(() => expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_MESSAGE_SKIPPED_IDENTICAL" })));
 
-      expect(writer.upsertInventory).toHaveBeenCalledTimes(1);
+      expect(writer.updateInventory).toHaveBeenCalledTimes(1);
     });
 
     it("writes again when any meaningful field differs", async () => {
-      const { writer } = setup({
+      const { manager, writer } = setup({
         streams: {
           "https://p1:8443": msgsThenHang([createMessage({ cpu: 1000 }), createMessage({ cpu: 1001 })])
         }
       });
+      manager.start(createProvider());
 
-      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(writer.updateInventory).toHaveBeenCalledTimes(2));
     });
 
     it("considers messages with reordered nodes/gpus/storage equal", async () => {
@@ -129,34 +158,35 @@ describe(StreamLifecycleManagerService.name, () => {
         storage: [...first.storage].reverse()
       };
 
-      const { writer, logger } = setup({
+      const { manager, writer, logger } = setup({
         streams: { "https://p1:8443": msgsThenHang([first, reordered]) }
       });
+      manager.start(createProvider());
 
-      await vi.waitFor(() =>
-        expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_MESSAGE_SKIPPED_IDENTICAL" }))
-      );
+      await vi.waitFor(() => expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_MESSAGE_SKIPPED_IDENTICAL" })));
 
-      expect(writer.upsertInventory).toHaveBeenCalledTimes(1);
+      expect(writer.updateInventory).toHaveBeenCalledTimes(1);
     });
 
     it("writes the first message even when it would later be cacheable", async () => {
       const message = createMessage();
-      const { writer } = setup({
+      const { manager, writer } = setup({
         streams: { "https://p1:8443": msgsThenHang([message]) }
       });
+      manager.start(createProvider());
 
-      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(writer.updateInventory).toHaveBeenCalledTimes(1));
     });
 
     it("does not cache a row when the write fails — next identical message retries", async () => {
       const message = createMessage();
-      const { writer } = setup({
+      const { manager, writer } = setup({
         streams: { "https://p1:8443": msgsThenHang([message, structuredClone(message)]) }
       });
-      writer.upsertInventory.mockRejectedValueOnce(new Error("DB down"));
+      writer.updateInventory.mockRejectedValueOnce(new Error("DB down"));
+      manager.start(createProvider());
 
-      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(writer.updateInventory).toHaveBeenCalledTimes(2));
     });
 
     it("isolates caches across providers", async () => {
@@ -164,32 +194,32 @@ describe(StreamLifecycleManagerService.name, () => {
       const providerB = createProvider({ owner: "b", hostUri: "https://b:8443" });
       const messageA = createMessage({ cpu: 1000 });
       const messageB = createMessage({ cpu: 1000 });
-      const { writer, logger } = setup({
-        providers: [providerA, providerB],
+      const { manager, writer, logger } = setup({
         streams: {
           "https://a:8443": msgsThenHang([messageA, structuredClone(messageA)]),
           "https://b:8443": msgsThenHang([messageB])
         }
       });
+      manager.start(providerA);
+      manager.start(providerB);
 
-      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(2));
-      await vi.waitFor(() =>
-        expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_MESSAGE_SKIPPED_IDENTICAL", owner: "a" }))
-      );
+      await vi.waitFor(() => expect(writer.updateInventory).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_MESSAGE_SKIPPED_IDENTICAL", owner: "a" })));
 
-      expect(writer.upsertInventory).toHaveBeenCalledWith(providerA, expect.objectContaining({ totalAvailableCpu: 1000n }));
-      expect(writer.upsertInventory).toHaveBeenCalledWith(providerB, expect.objectContaining({ totalAvailableCpu: 1000n }));
-      expect(writer.upsertInventory).toHaveBeenCalledTimes(2);
+      expect(writer.updateInventory).toHaveBeenCalledWith(providerA, expect.objectContaining({ totalAvailableCpu: 1000n }));
+      expect(writer.updateInventory).toHaveBeenCalledWith(providerB, expect.objectContaining({ totalAvailableCpu: 1000n }));
+      expect(writer.updateInventory).toHaveBeenCalledTimes(2);
     });
   });
 
   describe("error handling", () => {
-    it("logs and continues when upsertInventory throws", async () => {
+    it("logs and continues when updateInventory throws", async () => {
       const messages = [createMessage({ cpu: 1000 }), createMessage({ cpu: 2000 })];
-      const { writer, logger } = setup({ streams: { "https://p1:8443": msgsThenHang(messages) } });
-      writer.upsertInventory.mockRejectedValueOnce(new Error("DB down"));
+      const { manager, writer, logger } = setup({ streams: { "https://p1:8443": msgsThenHang(messages) } });
+      writer.updateInventory.mockRejectedValueOnce(new Error("DB down"));
+      manager.start(createProvider());
 
-      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(writer.updateInventory).toHaveBeenCalledTimes(2));
 
       expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_PROVIDER_WRITE_ERROR", owner: "akash1owner" }));
     });
@@ -202,16 +232,15 @@ describe(StreamLifecycleManagerService.name, () => {
         if (attempt === 1) return throwingStream(new Error("connection lost"));
         return msgsThenHang([createMessage()]);
       });
-      const { logger } = setup({ streamFactory });
+      const { manager, logger } = setup({ streamFactory });
+      manager.start(createProvider());
 
-      await vi.waitFor(() =>
-        expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_ATTEMPT_FAILED", owner: "akash1owner" }))
-      );
+      await vi.waitFor(() => expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_ATTEMPT_FAILED", owner: "akash1owner" })));
     });
   });
 
   describe("stale finalizer", () => {
-    it("does not remove a replacement stream when the old one finishes", async () => {
+    it("does not evict a replacement stream's registry entry when the old stream finishes", async () => {
       let resolveOldStream!: () => void;
       const oldStreamPromise = new Promise<IteratorResult<StreamStatusMessage>>(r => {
         resolveOldStream = () => r({ done: true, value: undefined });
@@ -230,18 +259,19 @@ describe(StreamLifecycleManagerService.name, () => {
         }
         return hangingStream();
       });
-      const { manager } = setup({ streamFactory, providers: [provider] });
+      const { manager } = setup({ streamFactory });
 
-      manager.reconcile([]);
-      manager.reconcile([provider]);
+      manager.start(provider);
+      await manager.stopAndDelete(provider.owner);
+      manager.start(provider);
 
       expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(2);
+      expect(manager.getRegistry().get(provider.owner)).toEqual({ hostUri: provider.hostUri });
 
       resolveOldStream();
       await delay(20);
 
-      manager.reconcile([provider]);
-      expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(2);
+      expect(manager.getRegistry().get(provider.owner)).toEqual({ hostUri: provider.hostUri });
     });
   });
 
@@ -249,10 +279,9 @@ describe(StreamLifecycleManagerService.name, () => {
     it("aborts all active streams", () => {
       const providerA = createProvider({ owner: "a", hostUri: "https://a:8443" });
       const providerB = createProvider({ owner: "b", hostUri: "https://b:8443" });
-      const { manager, streamFactory } = setup({
-        providers: [providerA, providerB],
-        streams: { "https://a:8443": "hang", "https://b:8443": "hang" }
-      });
+      const { manager, streamFactory } = setup({ streams: { "https://a:8443": "hang", "https://b:8443": "hang" } });
+      manager.start(providerA);
+      manager.start(providerB);
       const signalA = captureSignal(streamFactory, 0);
       const signalB = captureSignal(streamFactory, 1);
 
@@ -262,41 +291,38 @@ describe(StreamLifecycleManagerService.name, () => {
       expect(signalB.aborted).toBe(true);
     });
 
-    it("allows new streams after shutdown and re-reconcile", async () => {
-      const { manager, streamFactory } = setup({ streams: { "https://p1:8443": "hang" } });
+    it("clears the registry on shutdown", () => {
+      const { manager } = setup({ streams: { "https://p1:8443": "hang" } });
+      manager.start(createProvider());
 
       manager.shutdown();
-      streamFactory.openStatusStream.mockReturnValue(hangingStream());
 
-      manager.reconcile([createProvider()]);
-
-      expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(2);
+      expect(manager.getRegistry().size).toBe(0);
     });
 
     it("clears diff cache on shutdown", async () => {
       const stable = createMessage({ cpu: 1000 });
       const { manager, streamFactory, writer } = setup({ streams: { "https://p1:8443": msgsThenHang([stable]) } });
+      manager.start(createProvider());
 
-      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(1));
+      await vi.waitFor(() => expect(writer.updateInventory).toHaveBeenCalledTimes(1));
 
       manager.shutdown();
       streamFactory.openStatusStream.mockReturnValue(msgsThenHang([stable]));
-      manager.reconcile([createProvider()]);
+      manager.start(createProvider());
 
-      await vi.waitFor(() => expect(writer.upsertInventory).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => expect(writer.updateInventory).toHaveBeenCalledTimes(2));
     });
   });
 
-  function setup(input?: {
-    providers?: ChainProvider[];
-    streams?: Record<string, AsyncIterable<StreamStatusMessage> | "hang">;
-    streamFactory?: MockProxy<ProviderStreamFactory>;
-  }) {
+  function setup(input?: { streams?: Record<string, AsyncIterable<StreamStatusMessage> | "hang">; streamFactory?: MockProxy<ProviderStreamFactory> }) {
     const streamFactory = input?.streamFactory ?? mock<ProviderStreamFactory>();
-    const writer = mock<ProviderInventoryWriterService>();
+    const writer = mock<ProviderInventoryRepository>();
+    writer.deleteByOwner.mockResolvedValue();
+    writer.markOffline.mockResolvedValue();
+    writer.updateInventory.mockResolvedValue();
     const logger = mock<LoggerService>();
     const loggerFactory: LoggerFactory = () => logger;
-    const providers = input?.providers ?? [createProvider()];
     const config = mock<EnvConfig>({
       STREAM_RECONNECT_INITIAL_DELAY_MS: 10,
       STREAM_RECONNECT_MAX_DELAY_MS: 50,
@@ -314,9 +340,8 @@ describe(StreamLifecycleManagerService.name, () => {
     }
 
     const manager = new StreamLifecycleManagerService(streamFactory, writer, loggerFactory, config);
-    manager.reconcile(providers);
 
-    return { manager, streamFactory, writer, logger, providers };
+    return { manager, streamFactory, writer, logger };
   }
 });
 

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -3,6 +3,7 @@ import type { RetryPolicy } from "cockatiel";
 import { ExponentialBackoff, handleAll, retry } from "cockatiel";
 import { inject, singleton } from "tsyringe";
 
+import type { StreamHandle } from "@src/lib/discovery-reconciler/discovery-reconciler";
 import { projectRow } from "@src/lib/project-row/project-row";
 import { projectedRowsEqual } from "@src/lib/projected-row-equals/projected-row-equals";
 import type { EnvConfig } from "@src/providers/app-config.provider";
@@ -11,25 +12,29 @@ import type { LoggerFactory } from "@src/providers/logger-factory.provider";
 import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
 import type { ProviderStreamFactory } from "@src/providers/provider-stream.provider";
 import { PROVIDER_STREAM_FACTORY } from "@src/providers/provider-stream.provider";
-import { ProviderInventoryWriterService } from "@src/services/provider-inventory-writer/provider-inventory-writer.service";
+import { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import type { ChainProvider } from "@src/types/chain-provider";
 import type { ProjectedRow } from "@src/types/inventory";
-
-const RETRY_EXPONENT = 2;
 
 @singleton()
 export class StreamLifecycleManagerService {
   readonly #logger: LoggerService;
   readonly #streamFactory: ProviderStreamFactory;
-  readonly #writer: ProviderInventoryWriterService;
+  readonly #writer: ProviderInventoryRepository;
   readonly #config: EnvConfig;
-  readonly #activeStreams = new Map<string, AbortController>();
+  readonly #activeStreams = new Map<
+    string,
+    {
+      controller: AbortController;
+      hostUri: string;
+    }
+  >();
   readonly #lastInventoryPerProvider = new Map<string, ProjectedRow>();
   readonly #retryStreamPolicy: RetryPolicy;
 
   constructor(
     @inject(PROVIDER_STREAM_FACTORY) streamFactory: ProviderStreamFactory,
-    @inject(ProviderInventoryWriterService) writer: ProviderInventoryWriterService,
+    @inject(ProviderInventoryRepository) writer: ProviderInventoryRepository,
     @inject(LOGGER_FACTORY) loggerFactory: LoggerFactory,
     @inject(APP_CONFIG) config: EnvConfig
   ) {
@@ -41,45 +46,55 @@ export class StreamLifecycleManagerService {
       maxAttempts: Number.POSITIVE_INFINITY,
       backoff: new ExponentialBackoff({
         initialDelay: this.#config.STREAM_RECONNECT_INITIAL_DELAY_MS,
-        maxDelay: this.#config.STREAM_RECONNECT_MAX_DELAY_MS,
-        exponent: RETRY_EXPONENT
+        maxDelay: this.#config.STREAM_RECONNECT_MAX_DELAY_MS
       })
     });
   }
 
-  reconcile(providers: ChainProvider[]): void {
-    const currentOwners = new Set(providers.map(p => p.owner));
-
-    for (const [owner, controller] of this.#activeStreams) {
-      if (!currentOwners.has(owner)) {
-        controller.abort();
-        this.#activeStreams.delete(owner);
-        this.#lastInventoryPerProvider.delete(owner);
-        void this.#tryMarkOffline(owner);
-        this.#logger.info({ event: "STREAM_STOPPED_PROVIDER_GONE", owner });
-      }
+  getRegistry(): ReadonlyMap<string, StreamHandle> {
+    const view = new Map<string, StreamHandle>();
+    for (const [owner, stream] of this.#activeStreams) {
+      view.set(owner, { hostUri: stream.hostUri });
     }
+    return view;
+  }
 
-    for (const provider of providers) {
-      if (this.#activeStreams.has(provider.owner)) continue;
-      this.#startStream(provider);
+  start(provider: ChainProvider): void {
+    const controller = new AbortController();
+    this.#activeStreams.set(provider.owner, { controller, hostUri: provider.hostUri });
+    void this.#runStream(provider, controller.signal);
+  }
+
+  restart(provider: ChainProvider): void {
+    this.#abortIfActive(provider.owner, "STREAM_STOPPED_HOSTURI_CHANGE");
+    this.start(provider);
+  }
+
+  async stopAndDelete(owner: string): Promise<void> {
+    this.#abortIfActive(owner, "STREAM_STOPPED_PROVIDER_GONE");
+    try {
+      await this.#writer.deleteByOwner(owner);
+    } catch (error) {
+      this.#logger.error({ event: "STREAM_PROVIDER_DELETE_ERROR", owner, error });
     }
   }
 
-  #startStream(provider: ChainProvider): void {
-    const controller = new AbortController();
-    this.#activeStreams.set(provider.owner, controller);
-    void this.#runStream(provider, controller.signal);
+  #abortIfActive(owner: string, event: string): void {
+    const existing = this.#activeStreams.get(owner);
+    if (!existing) return;
+    existing.controller.abort();
+    this.#activeStreams.delete(owner);
+    this.#logger.info({ event, owner });
   }
 
   async #runStream(provider: ChainProvider, signal: AbortSignal): Promise<void> {
     try {
-      await this.#retryStreamPolicy.execute((ctx) => {
+      await this.#retryStreamPolicy.execute(ctx => {
         if (ctx.attempt > 0) {
           this.#logger.warn({
             event: "STREAM_RECONNECTING",
             owner: provider.owner,
-            attempt: ctx.attempt,
+            attempt: ctx.attempt
           });
         }
         return this.#runAttempt(provider, signal);
@@ -90,7 +105,7 @@ export class StreamLifecycleManagerService {
       }
     } finally {
       this.#lastInventoryPerProvider.delete(provider.owner);
-      if (this.#activeStreams.get(provider.owner)?.signal === signal) {
+      if (this.#activeStreams.get(provider.owner)?.controller.signal === signal) {
         this.#activeStreams.delete(provider.owner);
       }
     }
@@ -126,7 +141,7 @@ export class StreamLifecycleManagerService {
       await this.#tryMarkOffline(provider.owner);
 
       if (firstMessageReceived) {
-        throw new Error("stream ended after delivering messages")
+        throw new Error("stream ended after delivering messages");
       }
       throw new Error("first message not received within timeout");
     } catch (error) {
@@ -149,7 +164,7 @@ export class StreamLifecycleManagerService {
     }
 
     try {
-      await this.#writer.upsertInventory(provider, row);
+      await this.#writer.updateInventory(provider, row);
       this.#lastInventoryPerProvider.set(provider.owner, row);
     } catch (error) {
       this.#logger.error({ event: "STREAM_PROVIDER_WRITE_ERROR", owner: provider.owner, error });
@@ -165,8 +180,8 @@ export class StreamLifecycleManagerService {
   }
 
   shutdown(): void {
-    for (const [owner, controller] of this.#activeStreams) {
-      controller.abort();
+    for (const [owner, stream] of this.#activeStreams) {
+      stream.controller.abort();
       this.#logger.info({ event: "STREAM_CLOSED", owner });
     }
     this.#activeStreams.clear();

--- a/apps/provider-inventory/src/services/streamer-bootstrap/streamer-bootstrap.spec.ts
+++ b/apps/provider-inventory/src/services/streamer-bootstrap/streamer-bootstrap.spec.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import type { DiscoverySchedulerService } from "@src/services/discovery-scheduler/discovery-scheduler.service";
-import type { ProviderInventoryWriterService } from "@src/services/provider-inventory-writer/provider-inventory-writer.service";
 import { runStreamerBootstrap } from "./streamer-bootstrap";
 
-describe("runStreamerBootstrap", () => {
+describe(runStreamerBootstrap.name, () => {
   it("calls writer.resetOnlineSince before scheduler.start", async () => {
     const { writer, scheduler } = setup();
 
@@ -41,7 +41,7 @@ describe("runStreamerBootstrap", () => {
   });
 
   function setup() {
-    const writer = mock<ProviderInventoryWriterService>();
+    const writer = mock<ProviderInventoryRepository>();
     const scheduler = mock<DiscoverySchedulerService>();
     writer.resetOnlineSince.mockResolvedValue(undefined);
     return { writer, scheduler };

--- a/apps/provider-inventory/src/services/streamer-bootstrap/streamer-bootstrap.ts
+++ b/apps/provider-inventory/src/services/streamer-bootstrap/streamer-bootstrap.ts
@@ -1,7 +1,7 @@
+import type { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import type { DiscoverySchedulerService } from "@src/services/discovery-scheduler/discovery-scheduler.service";
-import type { ProviderInventoryWriterService } from "@src/services/provider-inventory-writer/provider-inventory-writer.service";
 
-export async function runStreamerBootstrap(writer: ProviderInventoryWriterService, scheduler: DiscoverySchedulerService): Promise<void> {
+export async function runStreamerBootstrap(writer: ProviderInventoryRepository, scheduler: DiscoverySchedulerService): Promise<void> {
   await writer.resetOnlineSince();
   scheduler.start();
 }

--- a/apps/provider-inventory/test/functional/discovery-pipeline.spec.ts
+++ b/apps/provider-inventory/test/functional/discovery-pipeline.spec.ts
@@ -1,0 +1,198 @@
+import { container, Lifecycle } from "tsyringe";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ChainQueryClient } from "@src/providers/chain-query.provider";
+import { CHAIN_QUERY_CLIENT } from "@src/providers/chain-query.provider";
+import { PG_CLIENT } from "@src/providers/postgres.provider";
+import type { ProviderStreamFactory } from "@src/providers/provider-stream.provider";
+import { PROVIDER_STREAM_FACTORY } from "@src/providers/provider-stream.provider";
+import { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
+import { ChainProviderPollerService } from "@src/services/chain-provider-poller/chain-provider-poller.service";
+import { DiscoverySchedulerService } from "@src/services/discovery-scheduler/discovery-scheduler.service";
+import { StreamLifecycleManagerService } from "@src/services/stream-lifecycle-manager/stream-lifecycle-manager.service";
+import type { ChainProvider } from "@src/types/chain-provider";
+import type { StreamStatusMessage } from "@src/types/stream-status";
+import { testDb } from "../setup-functional-tests";
+
+describe("DiscoveryScheduler pipeline (functional)", () => {
+  beforeEach(async () => {
+    await testDb.truncate();
+  });
+
+  it("writes a row and opens a stream when a brand-new provider appears", async () => {
+    const provider = createProvider({ owner: "a", hostUri: "https://a:8443" });
+    const { runTick, openedHosts, readRow } = setup({ providers: [provider] });
+
+    await runTick();
+
+    const row = await readRow("a");
+    expect(row).toMatchObject({ owner: "a", host_uri: "https://a:8443", created_height: 100n });
+    expect(openedHosts).toContain("https://a:8443");
+  });
+
+  it("closes the old stream and opens a new one when the provider's hostUri changes", async () => {
+    const before = createProvider({ owner: "a", hostUri: "https://old:8443" });
+    const after = createProvider({ owner: "a", hostUri: "https://new:8443" });
+    const { runTick, abortedHosts, openedHosts, lifecycle, setProviders } = setup({ providers: [before] });
+
+    await runTick();
+    setProviders([after]);
+    await runTick();
+    lifecycle.shutdown();
+
+    expect(abortedHosts).toContain("https://old:8443");
+    expect(openedHosts).toEqual(["https://old:8443", "https://new:8443"]);
+  });
+
+  it("deletes the row and aborts the stream when the provider is removed from chain", async () => {
+    const provider = createProvider({ owner: "a", hostUri: "https://a:8443" });
+    const { runTick, readRow, abortedHosts, lifecycle, setProviders } = setup({ providers: [provider] });
+
+    await runTick();
+    expect(await readRow("a")).toBeDefined();
+
+    setProviders([]);
+    await runTick();
+    lifecycle.shutdown();
+
+    expect(await readRow("a")).toBeUndefined();
+    expect(abortedHosts).toContain("https://a:8443");
+  });
+
+  it("propagates inventory writes from stream messages into the database", async () => {
+    const provider = createProvider({ owner: "a", hostUri: "https://a:8443" });
+    const { runTick, readRow, queueStreamMessages, lifecycle } = setup({ providers: [provider] });
+    queueStreamMessages("https://a:8443", [
+      {
+        nodes: [
+          {
+            name: "n1",
+            cpuAvailable: 4000,
+            memoryAvailable: 8_000_000_000,
+            gpus: [],
+            ephStorageAvailable: 100_000_000_000,
+            persistentStorage: []
+          }
+        ],
+        storage: []
+      }
+    ]);
+
+    await runTick();
+    await vi.waitFor(async () => {
+      const current = await readRow("a");
+      expect(current).toMatchObject({ is_online: true, total_available_cpu: 4000n });
+    });
+    lifecycle.shutdown();
+  });
+
+  it("swallows poller errors and leaves prior state intact", async () => {
+    const provider = createProvider({ owner: "a", hostUri: "https://a:8443" });
+    const { runTick, readRow, setPollError, lifecycle } = setup({ providers: [provider] });
+
+    await runTick();
+    expect(await readRow("a")).toBeDefined();
+
+    setPollError(new Error("chain RPC unavailable"));
+    await runTick();
+    lifecycle.shutdown();
+
+    expect(await readRow("a")).toBeDefined();
+  });
+
+  function setup(input: { providers?: ChainProvider[] }) {
+    const testContainer = container.createChildContainer();
+
+    const openedHosts: string[] = [];
+    const abortedHosts: string[] = [];
+    const queuedMessages = new Map<string, StreamStatusMessage[]>();
+    let pollError: Error | null = null;
+    let providers: ChainProvider[] = input.providers ?? [];
+
+    const chainClient = mock<ChainQueryClient>();
+    chainClient.getProviders.mockImplementation(() => {
+      if (pollError) return Promise.reject(pollError);
+      return Promise.resolve(
+        providers.map(p => ({
+          owner: p.owner,
+          hostUri: p.hostUri,
+          createdHeight: p.createdHeight,
+          attributes: p.selfAttributes
+        }))
+      );
+    });
+    chainClient.getAllProvidersAttributes.mockImplementation(() => Promise.resolve(providers.map(p => ({ owner: p.owner, attributes: p.signedAttributes }))));
+
+    const streamFactory = mock<ProviderStreamFactory>();
+    streamFactory.openStatusStream.mockImplementation((hostUri: string, signal: AbortSignal) => {
+      openedHosts.push(hostUri);
+      signal.addEventListener("abort", () => abortedHosts.push(hostUri), { once: true });
+      const messages = queuedMessages.get(hostUri) ?? [];
+      queuedMessages.delete(hostUri);
+      return makeStream(messages, signal);
+    });
+
+    testContainer.register(CHAIN_QUERY_CLIENT, { useValue: chainClient });
+    testContainer.register(PROVIDER_STREAM_FACTORY, { useValue: streamFactory });
+    testContainer.register(ProviderInventoryRepository, { useClass: ProviderInventoryRepository }, { lifecycle: Lifecycle.ContainerScoped });
+    testContainer.register(ChainProviderPollerService, { useClass: ChainProviderPollerService }, { lifecycle: Lifecycle.ContainerScoped });
+    testContainer.register(StreamLifecycleManagerService, { useClass: StreamLifecycleManagerService }, { lifecycle: Lifecycle.ContainerScoped });
+    testContainer.register(DiscoverySchedulerService, { useClass: DiscoverySchedulerService }, { lifecycle: Lifecycle.ContainerScoped });
+
+    const scheduler = testContainer.resolve(DiscoverySchedulerService);
+    const lifecycle = testContainer.resolve(StreamLifecycleManagerService);
+    const pg = testContainer.resolve(PG_CLIENT);
+
+    return {
+      lifecycle,
+      openedHosts,
+      abortedHosts,
+      async runTick(): Promise<void> {
+        await scheduler.discoverProviders();
+      },
+      async readRow(owner: string): Promise<Record<string, unknown> | undefined> {
+        const [row] = await pg`SELECT * FROM provider_inventory WHERE owner = ${owner}`;
+        return row;
+      },
+      queueStreamMessages(hostUri: string, messages: StreamStatusMessage[]) {
+        queuedMessages.set(hostUri, messages);
+      },
+      setPollError(error: Error | null) {
+        pollError = error;
+      },
+      setProviders(next: ChainProvider[]) {
+        providers = next;
+      }
+    };
+  }
+});
+
+function createProvider(overrides: Partial<ChainProvider> & Pick<ChainProvider, "owner" | "hostUri">): ChainProvider {
+  return {
+    createdHeight: 100n,
+    selfAttributes: [],
+    signedAttributes: [],
+    ...overrides
+  };
+}
+
+function makeStream(messages: StreamStatusMessage[], signal: AbortSignal): AsyncIterable<StreamStatusMessage> {
+  return {
+    [Symbol.asyncIterator]() {
+      let index = 0;
+      return {
+        async next(): Promise<IteratorResult<StreamStatusMessage>> {
+          if (signal.aborted) return { done: true, value: undefined };
+          if (index < messages.length) {
+            return { done: false, value: messages[index++] };
+          }
+          return new Promise<IteratorResult<StreamStatusMessage>>(resolve => {
+            const onAbort = () => resolve({ done: true, value: undefined });
+            signal.addEventListener("abort", onAbort, { once: true });
+          });
+        }
+      };
+    }
+  };
+}

--- a/apps/provider-inventory/test/services/test-database.service.ts
+++ b/apps/provider-inventory/test/services/test-database.service.ts
@@ -1,0 +1,70 @@
+import { drizzle } from "drizzle-orm/postgres-js";
+import { migrate } from "drizzle-orm/postgres-js/migrator";
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import postgres from "postgres";
+
+export class TestDatabaseService {
+  readonly #postgresUri: string;
+  readonly #dbName: string;
+
+  constructor(testPath: string) {
+    if (!process.env.POSTGRES_BASE_URL) {
+      throw new Error("POSTGRES_BASE_URL is not set");
+    }
+    const fileName = path.basename(testPath, ".spec.ts");
+    const prefix = randomUUID().replace(/-/g, "");
+    this.#postgresUri = process.env.POSTGRES_BASE_URL;
+    this.#dbName = `pi_test_${prefix}_${fileName}`.replace(/\W+/g, "_");
+    process.env.PROVIDER_INVENTORY_POSTGRES_URL = `${this.#postgresUri}/${this.#dbName}`;
+  }
+
+  async setup(): Promise<void> {
+    await this.#createDatabase();
+    await this.#runMigrations();
+  }
+
+  async teardown(): Promise<void> {
+    const sql = postgres(this.#postgresUri, { max: 1 });
+    try {
+      await sql`
+        SELECT pg_terminate_backend(pid)
+        FROM pg_stat_activity
+        WHERE datname = ${this.#dbName} AND pid <> pg_backend_pid()
+      `;
+      await sql`DROP DATABASE IF EXISTS ${sql(this.#dbName)}`;
+    } finally {
+      await sql.end();
+    }
+  }
+
+  async truncate(): Promise<void> {
+    const sql = postgres(`${this.#postgresUri}/${this.#dbName}`, { max: 1 });
+    try {
+      await sql`TRUNCATE TABLE provider_inventory RESTART IDENTITY CASCADE`;
+    } finally {
+      await sql.end();
+    }
+  }
+
+  async #createDatabase(): Promise<void> {
+    const sql = postgres(this.#postgresUri, { max: 1 });
+    try {
+      const [exists] = await sql`SELECT 1 FROM pg_database WHERE datname = ${this.#dbName}`;
+      if (!exists) {
+        await sql`CREATE DATABASE ${sql(this.#dbName)}`;
+      }
+    } finally {
+      await sql.end();
+    }
+  }
+
+  async #runMigrations(): Promise<void> {
+    const migrationClient = postgres(`${this.#postgresUri}/${this.#dbName}`, { max: 1 });
+    try {
+      await migrate(drizzle(migrationClient), { migrationsFolder: path.resolve(process.cwd(), "drizzle") });
+    } finally {
+      await migrationClient.end();
+    }
+  }
+}

--- a/apps/provider-inventory/test/setup-functional-env.ts
+++ b/apps/provider-inventory/test/setup-functional-env.ts
@@ -1,0 +1,6 @@
+import "reflect-metadata";
+
+import dotenv from "dotenv";
+import dotenvExpand from "dotenv-expand";
+
+dotenvExpand.expand(dotenv.config({ path: "env/.env.functional.test" }));

--- a/apps/provider-inventory/test/setup-functional-tests.ts
+++ b/apps/provider-inventory/test/setup-functional-tests.ts
@@ -1,0 +1,26 @@
+import "reflect-metadata";
+
+import { container } from "tsyringe";
+import { afterAll, beforeAll, expect } from "vitest";
+
+import { TestDatabaseService } from "./services/test-database.service";
+
+const testPath = expect.getState().testPath;
+if (!testPath) {
+  throw new Error("Unable to detect test path for functional setup");
+}
+
+export const testDb = new TestDatabaseService(testPath);
+
+beforeAll(async () => {
+  await testDb.setup();
+}, 30_000);
+
+afterAll(async () => {
+  try {
+    await container.dispose();
+  } catch {
+    // container may already be disposed
+  }
+  await testDb.teardown();
+}, 30_000);

--- a/apps/provider-inventory/vitest.config.ts
+++ b/apps/provider-inventory/vitest.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
         test: {
           name: "functional",
           include: ["test/functional/**/*.spec.ts"],
+          setupFiles: ["./test/setup-functional-env.ts", "./test/setup-functional-tests.ts"],
           testTimeout: 60_000,
           hookTimeout: 30_000
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4720,6 +4720,8 @@
         "@types/node": "^24.0.0",
         "@typescript-eslint/eslint-plugin": "^7.12.0",
         "@vitest/coverage-v8": "^4.0.0",
+        "dotenv": "^16.5.0",
+        "dotenv-expand": "^12.0.2",
         "drizzle-kit": "^0.22.7",
         "eslint": "^8.57.0",
         "eslint-plugin-simple-import-sort": "^12.1.0",
@@ -4750,6 +4752,35 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "apps/provider-inventory/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "apps/provider-inventory/node_modules/dotenv-expand": {
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-12.0.3.tgz",
+      "integrity": "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "apps/provider-inventory/node_modules/undici-types": {


### PR DESCRIPTION
## Why

ref CON-306

## What

Replace the inline reconcile loop with a pure generator that yields tagged commands in execution order: stops first, then refresh-attribute writes sorted by createdHeight DESC, then starts/restarts. The scheduler becomes a thin dispatcher; the lifecycle manager owns only stream state.

HostUri dedup moves into the writer. upsertAttributes deletes lower-createdHeight rivals on win and drops the own row on loss; upsertInventory switches to UPDATE-only so a loser's stream messages silently no-op against a missing row, and the same stream resumes persisting once the loser is later promoted to winner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discovery now emits ordered lifecycle commands (stop → start/restart/refresh) with deterministic ordering and attribute-refresh prioritized by provider creation time.

* **Refactor**
  * Stream lifecycle moved to explicit start/restart/stop APIs with safer shutdown and clearer registry semantics.
  * Scheduler dispatches batched commands with targeted handling and improved error logging/recovery.

* **Tests**
  * Expanded unit and functional suites covering discovery, scheduling, lifecycle, repository, and end-to-end behavior.

* **Chores**
  * Functional test environment and DB setup utilities added; DB pool increased.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3164)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->