### PR TITLE
refactor(api): standardize operationId naming and enforce via lint

### DIFF
--- a/apps/api/src/auth/routes/api-keys/api-keys.router.ts
+++ b/apps/api/src/auth/routes/api-keys/api-keys.router.ts
@@ -20,7 +20,7 @@ const listRoute = createRoute({
   method: "get",
   path: "/v1/api-keys",
   summary: "List all API keys",
-  operationId: "getApiKeys",
+  operationId: "listApiKeys",
   tags: ["API Keys"],
   security: SECURITY_BEARER_OR_API_KEY,
   responses: {

--- a/apps/api/src/core/services/openapi-docs/openapi-docs.service.spec.ts
+++ b/apps/api/src/core/services/openapi-docs/openapi-docs.service.spec.ts
@@ -18,7 +18,7 @@ describe("OpenApiDocsService", () => {
       paths: {
         "/v1/alerts": {
           get: {
-            operationId: "getAlerts",
+            operationId: "listAlerts",
             tags: ["v1"],
             responses: { "200": { description: "ok" } }
           }

--- a/apps/api/src/notifications/services/notification/notification.service.spec.ts
+++ b/apps/api/src/notifications/services/notification/notification.service.spec.ts
@@ -17,11 +17,11 @@ describe(NotificationService.name, () => {
       const { service, api } = setup();
 
       const user = { id: "user-1", email: "user@example.com" };
-      api.v1.createDefaultChannel.mockResolvedValue({} as never);
+      api.v1.createDefaultNotificationChannel.mockResolvedValue({} as never);
 
       await Promise.all([service.createDefaultChannel(user), jest.runAllTimersAsync()]);
 
-      expect(api.v1.createDefaultChannel).toHaveBeenCalledWith(
+      expect(api.v1.createDefaultNotificationChannel).toHaveBeenCalledWith(
         {
           data: {
             name: "Default",
@@ -40,12 +40,12 @@ describe(NotificationService.name, () => {
       const { service, api } = setup();
 
       const user = { id: "user-1", email: "user@example.com" };
-      api.v1.createDefaultChannel.mockRejectedValueOnce(new ApiError(500, { message: "boom" }, "POST /v1/notification-channels/default → 500"));
-      api.v1.createDefaultChannel.mockResolvedValueOnce({} as never);
+      api.v1.createDefaultNotificationChannel.mockRejectedValueOnce(new ApiError(500, { message: "boom" }, "POST /v1/notification-channels/default → 500"));
+      api.v1.createDefaultNotificationChannel.mockResolvedValueOnce({} as never);
 
       await Promise.all([service.createDefaultChannel(user), jest.runAllTimersAsync()]);
 
-      expect(api.v1.createDefaultChannel).toHaveBeenCalledTimes(2);
+      expect(api.v1.createDefaultNotificationChannel).toHaveBeenCalledTimes(2);
     });
   });
 
@@ -86,14 +86,14 @@ describe(NotificationService.name, () => {
 
       const channelMissing = new ApiError(400, { code: "NOTIFICATION_CHANNEL_NOT_FOUND" }, "POST /internal/v1/jobs/notification → 400");
       apiInternal.v1.createNotification.mockRejectedValueOnce(channelMissing).mockResolvedValueOnce(undefined as never);
-      api.v1.createDefaultChannel.mockResolvedValueOnce({} as never);
+      api.v1.createDefaultNotificationChannel.mockResolvedValueOnce({} as never);
 
       await Promise.all([service.createNotification(input), jest.runAllTimersAsync()]);
 
-      expect(api.v1.createDefaultChannel).toHaveBeenCalledTimes(1);
+      expect(api.v1.createDefaultNotificationChannel).toHaveBeenCalledTimes(1);
       expect(apiInternal.v1.createNotification).toHaveBeenCalledTimes(2);
 
-      expect(api.v1.createDefaultChannel).toHaveBeenCalledWith(
+      expect(api.v1.createDefaultNotificationChannel).toHaveBeenCalledWith(
         expect.objectContaining({ data: expect.objectContaining({ config: { addresses: [input.user.email!] } }) }),
         { headers: { "x-user-id": input.user.id } }
       );
@@ -111,13 +111,13 @@ describe(NotificationService.name, () => {
 
       const channelMissing = new ApiError(400, { code: "NOTIFICATION_CHANNEL_NOT_FOUND" }, "POST /internal/v1/jobs/notification → 400");
       apiInternal.v1.createNotification.mockRejectedValue(channelMissing);
-      api.v1.createDefaultChannel.mockResolvedValue({} as never);
+      api.v1.createDefaultNotificationChannel.mockResolvedValue({} as never);
 
       const [result] = await Promise.allSettled([service.createNotification(input), jest.runAllTimersAsync()]);
 
       expect(result.status).toBe("rejected");
       expect(apiInternal.v1.createNotification).toHaveBeenCalledTimes(5);
-      expect(api.v1.createDefaultChannel).toHaveBeenCalledTimes(1);
+      expect(api.v1.createDefaultNotificationChannel).toHaveBeenCalledTimes(1);
     });
 
     it("does not create default channel when user has no email and rejects after exhausting retries", async () => {
@@ -137,7 +137,7 @@ describe(NotificationService.name, () => {
 
       expect(result.status).toBe("rejected");
       expect((result as PromiseRejectedResult).reason.cause).toBe(channelMissing);
-      expect(api.v1.createDefaultChannel).not.toHaveBeenCalled();
+      expect(api.v1.createDefaultNotificationChannel).not.toHaveBeenCalled();
       expect(apiInternal.v1.createNotification).toHaveBeenCalledTimes(5);
     });
 
@@ -167,14 +167,14 @@ describe(NotificationService.name, () => {
       const { service, api, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue({ id: "user-1", email: "user@example.com" } as UserOutput);
-      api.v1.getNotificationChannels.mockResolvedValueOnce({ data: [] } as never).mockResolvedValueOnce({ data: [{ id: "channel-1" }] } as never);
-      api.v1.createDefaultChannel.mockResolvedValue({} as never);
+      api.v1.listNotificationChannels.mockResolvedValueOnce({ data: [] } as never).mockResolvedValueOnce({ data: [{ id: "channel-1" }] } as never);
+      api.v1.createDefaultNotificationChannel.mockResolvedValue({} as never);
       api.v1.upsertDeploymentAlert.mockResolvedValue({} as never);
 
       await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: 1000000 });
 
-      expect(api.v1.getNotificationChannels).toHaveBeenCalledTimes(2);
-      expect(api.v1.createDefaultChannel).toHaveBeenCalled();
+      expect(api.v1.listNotificationChannels).toHaveBeenCalledTimes(2);
+      expect(api.v1.createDefaultNotificationChannel).toHaveBeenCalled();
       expect(api.v1.upsertDeploymentAlert).toHaveBeenCalledWith(
         {
           dseq: "123",
@@ -194,8 +194,8 @@ describe(NotificationService.name, () => {
       const { service, api, userRepository, logger } = setup();
 
       userRepository.findById.mockResolvedValue({ id: "user-1", email: "user@example.com" } as UserOutput);
-      api.v1.getNotificationChannels.mockResolvedValueOnce({ data: [] } as never).mockResolvedValueOnce({ data: [{ id: "channel-x" }] } as never);
-      api.v1.createDefaultChannel.mockRejectedValue(new ApiError(409, { code: "ALREADY_EXISTS" }, "POST /v1/notification-channels/default → 409"));
+      api.v1.listNotificationChannels.mockResolvedValueOnce({ data: [] } as never).mockResolvedValueOnce({ data: [{ id: "channel-x" }] } as never);
+      api.v1.createDefaultNotificationChannel.mockRejectedValue(new ApiError(409, { code: "ALREADY_EXISTS" }, "POST /v1/notification-channels/default → 409"));
       api.v1.upsertDeploymentAlert.mockResolvedValue({} as never);
 
       await Promise.all([
@@ -203,7 +203,7 @@ describe(NotificationService.name, () => {
         jest.runAllTimersAsync()
       ]);
 
-      expect(api.v1.getNotificationChannels).toHaveBeenCalledTimes(2);
+      expect(api.v1.listNotificationChannels).toHaveBeenCalledTimes(2);
       expect(api.v1.upsertDeploymentAlert).toHaveBeenCalled();
       expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "AUTO_ENABLE_ALERT_CHANNEL_CREATE_FAILED" }));
       jest.useRealTimers();
@@ -213,13 +213,13 @@ describe(NotificationService.name, () => {
       const { service, api, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue({ id: "user-1", email: "user@example.com" } as UserOutput);
-      api.v1.getNotificationChannels.mockResolvedValue({ data: [{ id: "channel-1" }] } as never);
+      api.v1.listNotificationChannels.mockResolvedValue({ data: [{ id: "channel-1" }] } as never);
       api.v1.upsertDeploymentAlert.mockResolvedValue({} as never);
 
       await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: 1000000 });
 
-      expect(api.v1.getNotificationChannels).toHaveBeenCalledTimes(1);
-      expect(api.v1.createDefaultChannel).not.toHaveBeenCalled();
+      expect(api.v1.listNotificationChannels).toHaveBeenCalledTimes(1);
+      expect(api.v1.createDefaultNotificationChannel).not.toHaveBeenCalled();
       expect(api.v1.upsertDeploymentAlert).toHaveBeenCalled();
     });
 
@@ -230,8 +230,8 @@ describe(NotificationService.name, () => {
 
       await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: 1000000 });
 
-      expect(api.v1.getNotificationChannels).not.toHaveBeenCalled();
-      expect(api.v1.createDefaultChannel).not.toHaveBeenCalled();
+      expect(api.v1.listNotificationChannels).not.toHaveBeenCalled();
+      expect(api.v1.createDefaultNotificationChannel).not.toHaveBeenCalled();
       expect(api.v1.upsertDeploymentAlert).not.toHaveBeenCalled();
     });
 
@@ -242,8 +242,8 @@ describe(NotificationService.name, () => {
 
       await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: 1000000 });
 
-      expect(api.v1.getNotificationChannels).not.toHaveBeenCalled();
-      expect(api.v1.createDefaultChannel).not.toHaveBeenCalled();
+      expect(api.v1.listNotificationChannels).not.toHaveBeenCalled();
+      expect(api.v1.createDefaultNotificationChannel).not.toHaveBeenCalled();
       expect(api.v1.upsertDeploymentAlert).not.toHaveBeenCalled();
     });
 
@@ -251,12 +251,12 @@ describe(NotificationService.name, () => {
       const { service, api, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue({ id: "user-1", email: "user@example.com" } as UserOutput);
-      api.v1.getNotificationChannels.mockResolvedValue({ data: [] } as never);
-      api.v1.createDefaultChannel.mockResolvedValue({} as never);
+      api.v1.listNotificationChannels.mockResolvedValue({ data: [] } as never);
+      api.v1.createDefaultNotificationChannel.mockResolvedValue({} as never);
 
       await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: 1000000 });
 
-      expect(api.v1.createDefaultChannel).toHaveBeenCalled();
+      expect(api.v1.createDefaultNotificationChannel).toHaveBeenCalled();
       expect(api.v1.upsertDeploymentAlert).not.toHaveBeenCalled();
     });
 
@@ -264,11 +264,11 @@ describe(NotificationService.name, () => {
       const { service, api, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue({ id: "user-1", email: "user@example.com" } as UserOutput);
-      api.v1.getNotificationChannels.mockResolvedValue({ data: [{ id: "channel-1" }] } as never);
+      api.v1.listNotificationChannels.mockResolvedValue({ data: [{ id: "channel-1" }] } as never);
 
       await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: 0 });
 
-      expect(api.v1.createDefaultChannel).not.toHaveBeenCalled();
+      expect(api.v1.createDefaultNotificationChannel).not.toHaveBeenCalled();
       expect(api.v1.upsertDeploymentAlert).not.toHaveBeenCalled();
     });
 
@@ -276,7 +276,7 @@ describe(NotificationService.name, () => {
       const { service, api, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue({ id: "user-1", email: "user@example.com" } as UserOutput);
-      api.v1.getNotificationChannels.mockResolvedValue({ data: [{ id: "channel-1" }] } as never);
+      api.v1.listNotificationChannels.mockResolvedValue({ data: [{ id: "channel-1" }] } as never);
 
       await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: NaN });
 

--- a/apps/api/src/notifications/services/notification/notification.service.ts
+++ b/apps/api/src/notifications/services/notification/notification.service.ts
@@ -44,7 +44,7 @@ export class NotificationService {
   async createDefaultChannel(user: UserInput): Promise<void> {
     await backOff(async () => {
       try {
-        await this.notificationsApi.v1.createDefaultChannel(
+        await this.notificationsApi.v1.createDefaultNotificationChannel(
           { data: { name: "Default", type: "email", config: { addresses: [user.email!] } } },
           { headers: { "x-user-id": user.id } }
         );
@@ -97,7 +97,7 @@ export class NotificationService {
 
   private async getNotificationChannels(userId: string) {
     return backOff(
-      () => this.notificationsApi.v1.getNotificationChannels({ page: 1, limit: 1 }, { headers: { "x-user-id": userId } }),
+      () => this.notificationsApi.v1.listNotificationChannels({ page: 1, limit: 1 }, { headers: { "x-user-id": userId } }),
       DEFAULT_BACKOFF_OPTIONS
     );
   }

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -1947,7 +1947,6 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "default": "2026-05-06",
               "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
               "example": "2024-01-31"
             },
@@ -2073,7 +2072,6 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "default": "2026-05-06",
               "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
               "example": "2024-01-31"
             },
@@ -8376,7 +8374,7 @@
     "/v1/api-keys": {
       "get": {
         "summary": "List all API keys",
-        "operationId": "getApiKeys",
+        "operationId": "listApiKeys",
         "tags": [
           "API Keys"
         ],
@@ -16876,7 +16874,7 @@
         ]
       },
       "get": {
-        "operationId": "getAlerts",
+        "operationId": "listAlerts",
         "parameters": [
           {
             "name": "limit",
@@ -17058,7 +17056,7 @@
         ]
       },
       "patch": {
-        "operationId": "patchAlert",
+        "operationId": "updateAlert",
         "parameters": [
           {
             "name": "id",
@@ -17300,7 +17298,7 @@
         ]
       },
       "get": {
-        "operationId": "getNotificationChannels",
+        "operationId": "listNotificationChannels",
         "parameters": [
           {
             "name": "limit",
@@ -17388,7 +17386,7 @@
     },
     "/v1/notification-channels/default": {
       "post": {
-        "operationId": "createDefaultChannel",
+        "operationId": "createDefaultNotificationChannel",
         "parameters": [],
         "requestBody": {
           "required": true,
@@ -17498,7 +17496,7 @@
         ]
       },
       "patch": {
-        "operationId": "patchNotificationChannel",
+        "operationId": "updateNotificationChannel",
         "parameters": [
           {
             "name": "id",
@@ -17777,7 +17775,7 @@
         ]
       },
       "get": {
-        "operationId": "getDeploymentAlerts",
+        "operationId": "listDeploymentAlerts",
         "parameters": [
           {
             "name": "dseq",

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -2139,7 +2139,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
     },
     "/v1/api-keys": {
       "get": {
-        "operationId": "getApiKeys",
+        "operationId": "listApiKeys",
         "responses": {
           "200": {
             "content": {

--- a/apps/deploy-web/src/components/alerts/AlertsListContainer/AlertsListContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/AlertsListContainer/AlertsListContainer.tsx
@@ -38,11 +38,11 @@ export const AlertsListContainer: FC<AlertsListContainerProps> = ({ children }) 
   const [loadingIds, setLoadingIds] = useState<Set<string>>(new Set());
   const { api } = useServices();
   const queryClient = useQueryClient();
-  const { data, isError, isLoading, refetch } = api.v1.getAlerts.useQuery({ page, limit });
+  const { data, isError, isLoading, refetch } = api.v1.listAlerts.useQuery({ page, limit });
   const { getDeploymentName } = useLocalNotes();
   const notificator = useNotificator();
   const deleteMutation = api.v1.deleteAlert.useMutation();
-  const patchMutation = api.v1.patchAlert.useMutation();
+  const patchMutation = api.v1.updateAlert.useMutation();
   const { address } = useWallet();
 
   const remove = useCallback(

--- a/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/DeploymentAlertsContainer/DeploymentAlertsContainer.tsx
@@ -50,7 +50,7 @@ export const DeploymentAlertsContainer: FC<Props> = ({ children, deployment }) =
   const queryClient = useQueryClient();
   const notificator = useNotificator();
 
-  const { data, isLoading, isFetched, isError } = api.v1.getDeploymentAlerts.useQuery({ dseq: deployment.dseq });
+  const { data, isLoading, isFetched, isError } = api.v1.listDeploymentAlerts.useQuery({ dseq: deployment.dseq });
 
   const mutation = api.v1.upsertDeploymentAlert.useMutation();
 
@@ -106,7 +106,7 @@ export const DeploymentAlertsContainer: FC<Props> = ({ children, deployment }) =
     async () => {
       notificator.success("Alert configured!", { dataTestId: "alert-config-success-notification" });
       await queryClient.invalidateQueries({
-        queryKey: api.v1.getDeploymentAlerts.getKey({ dseq: deployment.dseq })
+        queryKey: api.v1.listDeploymentAlerts.getKey({ dseq: deployment.dseq })
       });
     },
     [deployment.dseq]

--- a/apps/deploy-web/src/components/alerts/NotificationChannelCreateContainer/NotificationChannelCreateContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/NotificationChannelCreateContainer/NotificationChannelCreateContainer.tsx
@@ -43,7 +43,7 @@ export const NotificationChannelCreateContainer: FC<{ children: (props: Children
 
   useWhen(mutation.isSuccess, async () => {
     notificator.success("Notification channel created!", { dataTestId: "notification-channel-create-success-notification" });
-    await queryClient.invalidateQueries({ queryKey: api.v1.getNotificationChannels.getKey() });
+    await queryClient.invalidateQueries({ queryKey: api.v1.listNotificationChannels.getKey() });
     onCreate?.();
   });
 

--- a/apps/deploy-web/src/components/alerts/NotificationChannelEditContainer/NotificationChannelEditContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/NotificationChannelEditContainer/NotificationChannelEditContainer.tsx
@@ -28,7 +28,7 @@ type NotificationChannelEditContainerProps = {
 
 export const NotificationChannelEditContainer: FC<NotificationChannelEditContainerProps> = ({ id, children, onEditSuccess }) => {
   const { api } = useServices();
-  const mutation = api.v1.patchNotificationChannel.useMutation();
+  const mutation = api.v1.updateNotificationChannel.useMutation();
   const notificator = useNotificator();
 
   const edit: ChildrenProps["onEdit"] = useCallback(

--- a/apps/deploy-web/src/components/alerts/NotificationChannelsListContainer/NotificationChannelsListContainer.tsx
+++ b/apps/deploy-web/src/components/alerts/NotificationChannelsListContainer/NotificationChannelsListContainer.tsx
@@ -40,7 +40,7 @@ export const NotificationChannelsListContainer: FC<NotificationChannelsListConta
   const [limit, setLimit] = useState(10);
   const [removingIds, setRemovingIds] = React.useState<Set<NotificationChannel["id"]>>(new Set());
   const { api } = useServices();
-  const { data, isError, isLoading, isFetched, refetch } = api.v1.getNotificationChannels.useQuery({ page, limit });
+  const { data, isError, isLoading, isFetched, refetch } = api.v1.listNotificationChannels.useQuery({ page, limit });
   const mutation = api.v1.deleteNotificationChannel.useMutation();
   const notificator = useNotificator();
 

--- a/apps/notifications/src/interfaces/rest/controllers/alert/alert.controller.spec.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/alert/alert.controller.spec.ts
@@ -35,7 +35,7 @@ describe(AlertController.name, () => {
     });
   });
 
-  describe("patchAlert", () => {
+  describe("updateAlert", () => {
     it("should call alertRepository.updateById() and return the updated alert", async () => {
       const { controller, alertRepository } = await setup();
 
@@ -45,7 +45,7 @@ describe(AlertController.name, () => {
 
       alertRepository.updateById.mockResolvedValue(output);
 
-      const result = await controller.patchAlert(id, { data: input });
+      const result = await controller.updateAlert(id, { data: input });
 
       expect(alertRepository.updateById).toHaveBeenCalledWith(id, input);
       expect(result).toEqual(Ok({ data: output }));
@@ -59,7 +59,7 @@ describe(AlertController.name, () => {
 
       alertRepository.updateById.mockResolvedValue(undefined);
 
-      await expect(controller.patchAlert(id, { data: input })).resolves.toMatchObject({
+      await expect(controller.updateAlert(id, { data: input })).resolves.toMatchObject({
         err: true,
         val: expect.objectContaining({ message: "Alert not found" })
       });

--- a/apps/notifications/src/interfaces/rest/controllers/alert/alert.controller.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/alert/alert.controller.ts
@@ -77,7 +77,7 @@ export class AlertController {
     type: Number,
     description: "Number of items per page"
   })
-  async getAlerts(@Query() { page, limit, ...query }: AlertListQuery): Promise<Result<AlertListOutputResponse, NotFoundException>> {
+  async listAlerts(@Query() { page, limit, ...query }: AlertListQuery): Promise<Result<AlertListOutputResponse, NotFoundException>> {
     return Ok(await this.alertRepository.accessibleBy(this.authService.ability, "read").paginate({ page, limit, query }));
   }
 
@@ -85,7 +85,7 @@ export class AlertController {
   @ValidateHttp({
     200: { schema: AlertOutputResponse, description: "Returns the updated alert" }
   })
-  async patchAlert(@Param("id") id: string, @Body() { data }: AlertPatchInput): Promise<Result<AlertOutputResponse, NotFoundException | BadRequestException>> {
+  async updateAlert(@Param("id") id: string, @Body() { data }: AlertPatchInput): Promise<Result<AlertOutputResponse, NotFoundException | BadRequestException>> {
     const alert = await this.alertRepository.accessibleBy(this.authService.ability, "update").updateById(id, data);
     return this.toResponse(alert);
   }

--- a/apps/notifications/src/interfaces/rest/controllers/deployment-alert/deployment-alert.controller.spec.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/deployment-alert/deployment-alert.controller.spec.ts
@@ -33,7 +33,7 @@ describe(DeploymentAlertController.name, () => {
 
     service.get.mockResolvedValue(output.data);
 
-    const result = await controller.getDeploymentAlerts(dseq);
+    const result = await controller.listDeploymentAlerts(dseq);
 
     expect(service.get).toHaveBeenCalledWith(dseq, authService.ability);
     expect(result).toEqual(Ok(output));

--- a/apps/notifications/src/interfaces/rest/controllers/deployment-alert/deployment-alert.controller.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/deployment-alert/deployment-alert.controller.ts
@@ -98,7 +98,7 @@ export class DeploymentAlertController {
   @ValidateHttp({
     200: { schema: DeploymentAlertsResponse, description: "Returns alerts for the specified deployment" }
   })
-  async getDeploymentAlerts(@Param("dseq") dseq: string): Promise<Result<DeploymentAlertsResponse, unknown>> {
+  async listDeploymentAlerts(@Param("dseq") dseq: string): Promise<Result<DeploymentAlertsResponse, unknown>> {
     return Ok({
       data: await this.deploymentAlertService.get(dseq, this.authService.ability)
     });

--- a/apps/notifications/src/interfaces/rest/controllers/notification-channel/notification-channel.controller.spec.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/notification-channel/notification-channel.controller.spec.ts
@@ -38,7 +38,7 @@ describe(NotificationChannelController.name, () => {
     });
   });
 
-  describe("patchNotificationChannel", () => {
+  describe("updateNotificationChannel", () => {
     it("should call notificationChannelRepository.updateById() and return the updated notification channel", async () => {
       const { controller, notificationChannelRepository } = await setup();
       const id = faker.string.uuid();
@@ -47,7 +47,7 @@ describe(NotificationChannelController.name, () => {
 
       notificationChannelRepository.updateById.mockResolvedValue(output);
 
-      const result = await controller.patchNotificationChannel(id, { data: input });
+      const result = await controller.updateNotificationChannel(id, { data: input });
 
       expect(notificationChannelRepository.updateById).toHaveBeenCalledWith(id, input);
       expect(result).toEqual(Ok({ data: output }));
@@ -60,7 +60,7 @@ describe(NotificationChannelController.name, () => {
 
       notificationChannelRepository.updateById.mockResolvedValue(undefined);
 
-      await expect(controller.patchNotificationChannel(id, { data: input })).resolves.toMatchObject({
+      await expect(controller.updateNotificationChannel(id, { data: input })).resolves.toMatchObject({
         err: true,
         val: expect.objectContaining({
           message: "Notification channel not found"
@@ -146,12 +146,12 @@ describe(NotificationChannelController.name, () => {
     });
   });
 
-  describe("createDefaultChannel", () => {
+  describe("createDefaultNotificationChannel", () => {
     it("should call notificationChannelRepository.createDefaultChannel()", async () => {
       const { controller, notificationChannelRepository, userId } = await setup();
       const input = generateMock(notificationChannelCreateInputSchema);
 
-      await controller.createDefaultChannel({ data: input });
+      await controller.createDefaultNotificationChannel({ data: input });
 
       expect(notificationChannelRepository.createDefaultChannel).toHaveBeenCalledWith({
         ...input,

--- a/apps/notifications/src/interfaces/rest/controllers/notification-channel/notification-channel.controller.ts
+++ b/apps/notifications/src/interfaces/rest/controllers/notification-channel/notification-channel.controller.ts
@@ -80,7 +80,7 @@ export class NotificationChannelController {
   @Post("default")
   @HttpCode(204)
   @ApiNoContentResponse({ description: "Creates the default notification channel only if it doesn't exist." })
-  async createDefaultChannel(@Body() { data }: NotificationChannelCreateDefaultInput): Promise<Result<void, unknown>> {
+  async createDefaultNotificationChannel(@Body() { data }: NotificationChannelCreateDefaultInput): Promise<Result<void, unknown>> {
     await this.notificationChannelRepository.accessibleBy(this.authService.ability, "create").createDefaultChannel({
       ...data,
       userId: this.authService.userId
@@ -126,7 +126,7 @@ export class NotificationChannelController {
     type: Number,
     description: "Number of items per page"
   })
-  async getNotificationChannels(@Query() query: NotificationChannelListQuery): Promise<Result<NotificationChannelListOutput, unknown>> {
+  async listNotificationChannels(@Query() query: NotificationChannelListQuery): Promise<Result<NotificationChannelListOutput, unknown>> {
     return Ok(await this.notificationChannelRepository.accessibleBy(this.authService.ability, "read").paginate(query));
   }
 
@@ -135,7 +135,7 @@ export class NotificationChannelController {
     200: { schema: NotificationChannelOutput, description: "Returns the updated notification channel" },
     404: { schema: NotFoundErrorResponse, description: "Returns 404 if the notification channel is not found" }
   })
-  async patchNotificationChannel(
+  async updateNotificationChannel(
     @Param("id") id: string,
     @Body() { data }: NotificationChannelPatchInput
   ): Promise<Result<NotificationChannelOutputResponse, NotFoundException>> {

--- a/apps/notifications/swagger/swagger.json
+++ b/apps/notifications/swagger/swagger.json
@@ -81,7 +81,7 @@
         ]
       },
       "get": {
-        "operationId": "getAlerts",
+        "operationId": "listAlerts",
         "parameters": [
           {
             "name": "limit",
@@ -263,7 +263,7 @@
         ]
       },
       "patch": {
-        "operationId": "patchAlert",
+        "operationId": "updateAlert",
         "parameters": [
           {
             "name": "id",
@@ -505,7 +505,7 @@
         ]
       },
       "get": {
-        "operationId": "getNotificationChannels",
+        "operationId": "listNotificationChannels",
         "parameters": [
           {
             "name": "limit",
@@ -593,7 +593,7 @@
     },
     "/v1/notification-channels/default": {
       "post": {
-        "operationId": "createDefaultChannel",
+        "operationId": "createDefaultNotificationChannel",
         "parameters": [],
         "requestBody": {
           "required": true,
@@ -703,7 +703,7 @@
         ]
       },
       "patch": {
-        "operationId": "patchNotificationChannel",
+        "operationId": "updateNotificationChannel",
         "parameters": [
           {
             "name": "id",
@@ -982,7 +982,7 @@
         ]
       },
       "get": {
-        "operationId": "getDeploymentAlerts",
+        "operationId": "listDeploymentAlerts",
         "parameters": [
           {
             "name": "dseq",

--- a/package-lock.json
+++ b/package-lock.json
@@ -43951,7 +43951,7 @@
     },
     "packages/console-api-types": {
       "name": "@akashnetwork/console-api-types",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@akashnetwork/dev-config": "*",
@@ -44920,7 +44920,7 @@
     },
     "packages/openapi-sdk": {
       "name": "@akashnetwork/openapi-sdk",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@akashnetwork/dev-config": "*",

--- a/packages/console-api-types/package.json
+++ b/packages/console-api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashnetwork/console-api-types",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Generated types and operations table for the akash console API.",
   "license": "Apache-2.0",
   "author": "Akash Network",

--- a/packages/console-api-types/src/notifications/operations.gen.ts
+++ b/packages/console-api-types/src/notifications/operations.gen.ts
@@ -4,9 +4,16 @@
 export const operations = {
   v1: {
     createAlert: { path: "/v1/alerts", method: "post", operationId: "createAlert", pathParams: [], queryParams: [], hasBody: true },
-    getAlerts: { path: "/v1/alerts", method: "get", operationId: "getAlerts", pathParams: [], queryParams: ["limit", "page", "type", "dseq"], hasBody: false },
+    listAlerts: {
+      path: "/v1/alerts",
+      method: "get",
+      operationId: "listAlerts",
+      pathParams: [],
+      queryParams: ["limit", "page", "type", "dseq"],
+      hasBody: false
+    },
     getAlert: { path: "/v1/alerts/{id}", method: "get", operationId: "getAlert", pathParams: ["id"], queryParams: [], hasBody: false },
-    patchAlert: { path: "/v1/alerts/{id}", method: "patch", operationId: "patchAlert", pathParams: ["id"], queryParams: [], hasBody: true },
+    updateAlert: { path: "/v1/alerts/{id}", method: "patch", operationId: "updateAlert", pathParams: ["id"], queryParams: [], hasBody: true },
     deleteAlert: { path: "/v1/alerts/{id}", method: "delete", operationId: "deleteAlert", pathParams: ["id"], queryParams: [], hasBody: false },
     createNotificationChannel: {
       path: "/v1/notification-channels",
@@ -16,18 +23,18 @@ export const operations = {
       queryParams: [],
       hasBody: true
     },
-    getNotificationChannels: {
+    listNotificationChannels: {
       path: "/v1/notification-channels",
       method: "get",
-      operationId: "getNotificationChannels",
+      operationId: "listNotificationChannels",
       pathParams: [],
       queryParams: ["limit", "page"],
       hasBody: false
     },
-    createDefaultChannel: {
+    createDefaultNotificationChannel: {
       path: "/v1/notification-channels/default",
       method: "post",
-      operationId: "createDefaultChannel",
+      operationId: "createDefaultNotificationChannel",
       pathParams: [],
       queryParams: [],
       hasBody: true
@@ -40,10 +47,10 @@ export const operations = {
       queryParams: [],
       hasBody: false
     },
-    patchNotificationChannel: {
+    updateNotificationChannel: {
       path: "/v1/notification-channels/{id}",
       method: "patch",
-      operationId: "patchNotificationChannel",
+      operationId: "updateNotificationChannel",
       pathParams: ["id"],
       queryParams: [],
       hasBody: true
@@ -64,10 +71,10 @@ export const operations = {
       queryParams: [],
       hasBody: true
     },
-    getDeploymentAlerts: {
+    listDeploymentAlerts: {
       path: "/v1/deployment-alerts/{dseq}",
       method: "get",
-      operationId: "getDeploymentAlerts",
+      operationId: "listDeploymentAlerts",
       pathParams: ["dseq"],
       queryParams: [],
       hasBody: false

--- a/packages/console-api-types/src/notifications/schema.d.ts
+++ b/packages/console-api-types/src/notifications/schema.d.ts
@@ -11,7 +11,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get: operations["getAlerts"];
+    get: operations["listAlerts"];
     put?: never;
     post: operations["createAlert"];
     delete?: never;
@@ -33,7 +33,7 @@ export interface paths {
     delete: operations["deleteAlert"];
     options?: never;
     head?: never;
-    patch: operations["patchAlert"];
+    patch: operations["updateAlert"];
     trace?: never;
   };
   "/v1/notification-channels": {
@@ -43,7 +43,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get: operations["getNotificationChannels"];
+    get: operations["listNotificationChannels"];
     put?: never;
     post: operations["createNotificationChannel"];
     delete?: never;
@@ -61,7 +61,7 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    post: operations["createDefaultChannel"];
+    post: operations["createDefaultNotificationChannel"];
     delete?: never;
     options?: never;
     head?: never;
@@ -81,7 +81,7 @@ export interface paths {
     delete: operations["deleteNotificationChannel"];
     options?: never;
     head?: never;
-    patch: operations["patchNotificationChannel"];
+    patch: operations["updateNotificationChannel"];
     trace?: never;
   };
   "/v1/deployment-alerts/{dseq}": {
@@ -91,7 +91,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get: operations["getDeploymentAlerts"];
+    get: operations["listDeploymentAlerts"];
     put?: never;
     post: operations["upsertDeploymentAlert"];
     delete?: never;
@@ -894,7 +894,7 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  getAlerts: {
+  listAlerts: {
     parameters: {
       query?: {
         /** @description Number of items per page */
@@ -1143,7 +1143,7 @@ export interface operations {
       };
     };
   };
-  patchAlert: {
+  updateAlert: {
     parameters: {
       query?: never;
       header?: {
@@ -1207,7 +1207,7 @@ export interface operations {
       };
     };
   };
-  getNotificationChannels: {
+  listNotificationChannels: {
     parameters: {
       query?: {
         /** @description Number of items per page */
@@ -1332,7 +1332,7 @@ export interface operations {
       };
     };
   };
-  createDefaultChannel: {
+  createDefaultNotificationChannel: {
     parameters: {
       query?: never;
       header?: never;
@@ -1492,7 +1492,7 @@ export interface operations {
       };
     };
   };
-  patchNotificationChannel: {
+  updateNotificationChannel: {
     parameters: {
       query?: never;
       header?: {
@@ -1565,7 +1565,7 @@ export interface operations {
       };
     };
   };
-  getDeploymentAlerts: {
+  listDeploymentAlerts: {
     parameters: {
       query?: never;
       header?: {

--- a/packages/console-api-types/src/operations.gen.ts
+++ b/packages/console-api-types/src/operations.gen.ts
@@ -3,11 +3,18 @@
 
 export const operations = {
   v1: {
-    getApiKeys: { path: "/v1/api-keys", method: "get", operationId: "getApiKeys", pathParams: [], queryParams: [], hasBody: false },
+    listApiKeys: { path: "/v1/api-keys", method: "get", operationId: "listApiKeys", pathParams: [], queryParams: [], hasBody: false },
     createAlert: { path: "/v1/alerts", method: "post", operationId: "createAlert", pathParams: [], queryParams: [], hasBody: true },
-    getAlerts: { path: "/v1/alerts", method: "get", operationId: "getAlerts", pathParams: [], queryParams: ["limit", "page", "type", "dseq"], hasBody: false },
+    listAlerts: {
+      path: "/v1/alerts",
+      method: "get",
+      operationId: "listAlerts",
+      pathParams: [],
+      queryParams: ["limit", "page", "type", "dseq"],
+      hasBody: false
+    },
     getAlert: { path: "/v1/alerts/{id}", method: "get", operationId: "getAlert", pathParams: ["id"], queryParams: [], hasBody: false },
-    patchAlert: { path: "/v1/alerts/{id}", method: "patch", operationId: "patchAlert", pathParams: ["id"], queryParams: [], hasBody: true },
+    updateAlert: { path: "/v1/alerts/{id}", method: "patch", operationId: "updateAlert", pathParams: ["id"], queryParams: [], hasBody: true },
     deleteAlert: { path: "/v1/alerts/{id}", method: "delete", operationId: "deleteAlert", pathParams: ["id"], queryParams: [], hasBody: false },
     createNotificationChannel: {
       path: "/v1/notification-channels",
@@ -17,18 +24,18 @@ export const operations = {
       queryParams: [],
       hasBody: true
     },
-    getNotificationChannels: {
+    listNotificationChannels: {
       path: "/v1/notification-channels",
       method: "get",
-      operationId: "getNotificationChannels",
+      operationId: "listNotificationChannels",
       pathParams: [],
       queryParams: ["limit", "page"],
       hasBody: false
     },
-    createDefaultChannel: {
+    createDefaultNotificationChannel: {
       path: "/v1/notification-channels/default",
       method: "post",
-      operationId: "createDefaultChannel",
+      operationId: "createDefaultNotificationChannel",
       pathParams: [],
       queryParams: [],
       hasBody: true
@@ -41,10 +48,10 @@ export const operations = {
       queryParams: [],
       hasBody: false
     },
-    patchNotificationChannel: {
+    updateNotificationChannel: {
       path: "/v1/notification-channels/{id}",
       method: "patch",
-      operationId: "patchNotificationChannel",
+      operationId: "updateNotificationChannel",
       pathParams: ["id"],
       queryParams: [],
       hasBody: true
@@ -65,10 +72,10 @@ export const operations = {
       queryParams: [],
       hasBody: true
     },
-    getDeploymentAlerts: {
+    listDeploymentAlerts: {
       path: "/v1/deployment-alerts/{dseq}",
       method: "get",
-      operationId: "getDeploymentAlerts",
+      operationId: "listDeploymentAlerts",
       pathParams: ["dseq"],
       queryParams: [],
       hasBody: false

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -4019,7 +4019,7 @@ export interface paths {
       cookie?: never;
     };
     /** List all API keys */
-    get: operations["getApiKeys"];
+    get: operations["listApiKeys"];
     put?: never;
     /** Create new API key */
     post: {
@@ -7776,7 +7776,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get: operations["getAlerts"];
+    get: operations["listAlerts"];
     put?: never;
     post: operations["createAlert"];
     delete?: never;
@@ -7798,7 +7798,7 @@ export interface paths {
     delete: operations["deleteAlert"];
     options?: never;
     head?: never;
-    patch: operations["patchAlert"];
+    patch: operations["updateAlert"];
     trace?: never;
   };
   "/v1/notification-channels": {
@@ -7808,7 +7808,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get: operations["getNotificationChannels"];
+    get: operations["listNotificationChannels"];
     put?: never;
     post: operations["createNotificationChannel"];
     delete?: never;
@@ -7826,7 +7826,7 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    post: operations["createDefaultChannel"];
+    post: operations["createDefaultNotificationChannel"];
     delete?: never;
     options?: never;
     head?: never;
@@ -7846,7 +7846,7 @@ export interface paths {
     delete: operations["deleteNotificationChannel"];
     options?: never;
     head?: never;
-    patch: operations["patchNotificationChannel"];
+    patch: operations["updateNotificationChannel"];
     trace?: never;
   };
   "/v1/deployment-alerts/{dseq}": {
@@ -7856,7 +7856,7 @@ export interface paths {
       path?: never;
       cookie?: never;
     };
-    get: operations["getDeploymentAlerts"];
+    get: operations["listDeploymentAlerts"];
     put?: never;
     post: operations["upsertDeploymentAlert"];
     delete?: never;
@@ -8659,7 +8659,7 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  getApiKeys: {
+  listApiKeys: {
     parameters: {
       query?: never;
       header?: never;
@@ -8694,7 +8694,7 @@ export interface operations {
       };
     };
   };
-  getAlerts: {
+  listAlerts: {
     parameters: {
       query?: {
         /** @description Number of items per page */
@@ -8943,7 +8943,7 @@ export interface operations {
       };
     };
   };
-  patchAlert: {
+  updateAlert: {
     parameters: {
       query?: never;
       header?: {
@@ -9007,7 +9007,7 @@ export interface operations {
       };
     };
   };
-  getNotificationChannels: {
+  listNotificationChannels: {
     parameters: {
       query?: {
         /** @description Number of items per page */
@@ -9132,7 +9132,7 @@ export interface operations {
       };
     };
   };
-  createDefaultChannel: {
+  createDefaultNotificationChannel: {
     parameters: {
       query?: never;
       header?: never;
@@ -9292,7 +9292,7 @@ export interface operations {
       };
     };
   };
-  patchNotificationChannel: {
+  updateNotificationChannel: {
     parameters: {
       query?: never;
       header?: {
@@ -9365,7 +9365,7 @@ export interface operations {
       };
     };
   };
-  getDeploymentAlerts: {
+  listDeploymentAlerts: {
     parameters: {
       query?: never;
       header?: {

--- a/packages/dev-config/.eslintrc.base.js
+++ b/packages/dev-config/.eslintrc.base.js
@@ -34,7 +34,8 @@ module.exports = {
     "import-x/no-cycle": ["error", { ignoreExternal: true }],
     "import-x/no-self-import": ["error"],
     "import-x/no-useless-path-segments": ["error"],
-    "akash/no-mnemonic": ["error"]
+    "akash/no-mnemonic": ["error"],
+    "akash/operation-id-format": ["error"]
   },
   overrides: [
     {

--- a/packages/dev-config/eslint-plugin-akash/index.js
+++ b/packages/dev-config/eslint-plugin-akash/index.js
@@ -1,7 +1,9 @@
 const noMnemonic = require("./rules/no-mnemonic");
+const operationIdFormat = require("./rules/operation-id-format");
 
 module.exports = {
   rules: {
-    "no-mnemonic": noMnemonic
+    "no-mnemonic": noMnemonic,
+    "operation-id-format": operationIdFormat
   }
 };

--- a/packages/dev-config/eslint-plugin-akash/rules/operation-id-format.js
+++ b/packages/dev-config/eslint-plugin-akash/rules/operation-id-format.js
@@ -1,0 +1,159 @@
+const CAMEL_CASE_IDENTIFIER = /^[a-z][a-zA-Z]*$/;
+const DISABLE_HINT = "For action-style endpoints, add // eslint-disable-next-line akash/operation-id-format above the operationId line.";
+
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Enforce createRoute operationId follows <verb><Resource> convention and matches the route's HTTP method and path (collection vs single-resource)."
+    },
+    schema: []
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!isCreateRouteCall(node)) return;
+        const routeConfig = node.arguments[0];
+
+        const operationIdProperty = findObjectProperty(routeConfig, "operationId");
+        if (!operationIdProperty) return;
+
+        if (operationIdProperty.value.type !== "Literal" || typeof operationIdProperty.value.value !== "string") {
+          context.report({ node: operationIdProperty.value, message: "operationId must be a string literal." });
+          return;
+        }
+
+        const operationId = operationIdProperty.value.value;
+
+        if (!CAMEL_CASE_IDENTIFIER.test(operationId)) {
+          context.report({
+            node: operationIdProperty.value,
+            message: `operationId "${operationId}" must be camelCase (start with a lowercase letter, alphanumeric only).`
+          });
+          return;
+        }
+
+        const method = getStringLiteralValue(findObjectProperty(routeConfig, "method"))?.toLowerCase();
+        const path = getStringLiteralValue(findObjectProperty(routeConfig, "path"));
+        if (!method || !path) return;
+
+        const isSingleResource = isSingleResourcePath(path);
+        const expectedVerbs = getExpectedVerbs(method, isSingleResource);
+        if (!expectedVerbs) return;
+
+        const actualVerb = extractLeadingVerb(operationId);
+        if (expectedVerbs.includes(actualVerb)) return;
+
+        context.report({
+          node: operationIdProperty.value,
+          message: `${method.toUpperCase()} ${path}: operationId "${operationId}" starts with "${actualVerb}", but ${method.toUpperCase()} on a ${describeRouteShape(isSingleResource)} expects ${formatVerbList(expectedVerbs)}. ${DISABLE_HINT}`
+        });
+      }
+    };
+  }
+};
+
+/**
+ * Tests whether an AST CallExpression node is a `createRoute({...})` invocation
+ * with an object literal as its first argument.
+ * @param {object} node - ESTree CallExpression node.
+ * @returns {boolean}
+ */
+function isCreateRouteCall(node) {
+  return node.callee.type === "Identifier" && node.callee.name === "createRoute" && node.arguments[0]?.type === "ObjectExpression";
+}
+
+/**
+ * Looks up a property on an object literal AST node by name. Matches both
+ * identifier keys (`name: ...`) and string-literal keys (`"name": ...`).
+ * Computed and spread keys are ignored.
+ * @param {object} objectExpression - ESTree ObjectExpression node.
+ * @param {string} name
+ * @returns {object | undefined} The matching ESTree Property, or undefined.
+ */
+function findObjectProperty(objectExpression, name) {
+  return objectExpression.properties.find(
+    p => p.type === "Property" && !p.computed && ((p.key.type === "Identifier" && p.key.name === name) || (p.key.type === "Literal" && p.key.value === name))
+  );
+}
+
+/**
+ * Returns the string value of a property whose value is a string literal.
+ * Returns null for missing properties, non-literals, or non-string literals —
+ * the caller decides whether the absence is an error.
+ * @param {object | undefined} property - ESTree Property node, or undefined.
+ * @returns {string | null}
+ */
+function getStringLiteralValue(property) {
+  if (!property || property.value.type !== "Literal" || typeof property.value.value !== "string") {
+    return null;
+  }
+  return property.value.value;
+}
+
+/**
+ * Returns true when an OpenAPI path targets a single resource — i.e. it ends
+ * with a path parameter like "/foo/{id}". A trailing slash after the parameter
+ * is tolerated.
+ * @param {string} path
+ * @returns {boolean}
+ */
+function isSingleResourcePath(path) {
+  return path.endsWith("}") || path.endsWith("}/");
+}
+
+const EXPECTED_VERBS_BY_METHOD = {
+  get: { collection: ["list"], single: ["get"] },
+  post: { collection: ["create"], single: ["create", "upsert"] },
+  put: { collection: ["update"], single: ["update"] },
+  patch: { collection: ["update"], single: ["update"] },
+  delete: { collection: ["delete"], single: ["delete"] }
+};
+
+/**
+ * Returns the verbs allowed to start an operationId for a given HTTP method
+ * and route shape. Returns null for unknown methods, signalling the rule to
+ * skip semantic validation for that call.
+ * @param {string} method - Lowercase HTTP method (e.g. "get", "post").
+ * @param {boolean} isSingleResource - True if the route path ends with "{id}".
+ * @returns {string[] | null}
+ */
+function getExpectedVerbs(method, isSingleResource) {
+  const expectations = EXPECTED_VERBS_BY_METHOD[method];
+  if (!expectations) return null;
+  return isSingleResource ? expectations.single : expectations.collection;
+}
+
+const LEADING_LOWERCASE_WORD = /^[a-z]+/;
+
+/**
+ * Extracts the leading lowercase verb segment from a camelCase operationId,
+ * e.g. "listApiKeys" → "list", "upsertDeploymentAlert" → "upsert".
+ * Assumes the input has already been validated as a camelCase identifier.
+ * @param {string} operationId
+ * @returns {string}
+ */
+function extractLeadingVerb(operationId) {
+  return operationId.match(LEADING_LOWERCASE_WORD)[0];
+}
+
+/**
+ * Returns a human-readable description of the route's shape, used in error
+ * messages to explain why a verb is expected.
+ * @param {boolean} isSingleResource
+ * @returns {string}
+ */
+function describeRouteShape(isSingleResource) {
+  return isSingleResource ? "single resource (path ends with {id})" : "collection (no trailing {id})";
+}
+
+/**
+ * Formats a list of expected verbs for an error message, e.g.
+ * ["create", "upsert"] → '"create" or "upsert"'.
+ * @param {string[]} verbs
+ * @returns {string}
+ */
+function formatVerbList(verbs) {
+  return verbs.map(v => `"${v}"`).join(" or ");
+}

--- a/packages/openapi-sdk/package.json
+++ b/packages/openapi-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashnetwork/openapi-sdk",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Typed OpenAPI client runtime (Proxy-based createApi).",
   "license": "Apache-2.0",
   "author": "Akash Network",


### PR DESCRIPTION
## Why

Sets up the operationId surface for `@akashnetwork/console-api-types` so follow-up PRs can migrate `apps/deploy-web` from hand-written `@akashnetwork/http-sdk` axios services to the typed `@akashnetwork/openapi-sdk` + `@akashnetwork/react-query-proxy` hooks. This is Phase 0 of a multi-PR rollout — it renames the existing operationIds to a uniform convention and adds a lint rule to keep new operationIds consistent.

## What

**Renames seven existing operationIds** so the typed-client surface is uniform:

| Old | New |
|---|---|
| `getApiKeys` | `listApiKeys` |
| `getAlerts` | `listAlerts` |
| `patchAlert` | `updateAlert` |
| `getNotificationChannels` | `listNotificationChannels` |
| `patchNotificationChannel` | `updateNotificationChannel` |
| `createDefaultChannel` | `createDefaultNotificationChannel` |
| `getDeploymentAlerts` | `listDeploymentAlerts` |

Renames apply at both producer (Hono `operationId` in `apps/api`, NestJS controller method names in `apps/notifications`) and consumer (in-tree calls in `apps/deploy-web/src/components/alerts/**` and `apps/api/src/notifications/services/notification/notification.service.{ts,spec.ts}`). Regenerates `apps/api/swagger/openapi.json`, `apps/notifications/swagger/swagger.json`, and all `packages/console-api-types/src/**/operations.gen.ts` + `schema.d.ts`.

**Adds the `akash/operation-id-format` ESLint rule** (`packages/dev-config/eslint-plugin-akash/rules/operation-id-format.js`). Validates that any operationId set on a `createRoute({...})` call:

1. Is a string literal in camelCase.
2. Starts with a verb appropriate for the route's HTTP method and path shape:
   - `GET` on a collection → `list`
   - `GET` on `/{id}` → `get`
   - `POST` on a collection → `create`
   - `POST` on `/{id}` → `create` or `upsert`
   - `PUT`/`PATCH` → `update`
   - `DELETE` → `delete`

The rule does NOT yet enforce *presence* (a missing `operationId` on `createRoute` doesn't error) — that check lands in a follow-up PR alongside the `internal: true` flag, once every route has either an operationId or is opted out.

**Bumps `@akashnetwork/console-api-types` and `@akashnetwork/openapi-sdk` to 1.1.0.**

HTTP paths and behavior are unchanged. The renames are TypeScript-level only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized API operation names across the platform (get*/patch* → list*/update*), updating API surfaces and client bindings for consistent list/update endpoints.
  * Bumped API type packages and OpenAPI SDK versions (1.0.0 → 1.1.0).

* **New Features**
  * Added an ESLint rule to enforce operationId naming and format conventions for API routes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3167)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->