### PR TITLE
feat(dx): expose deploy flow in typed console API SDK

### DIFF
--- a/apps/api/src/bid/routes/bids/bids.router.ts
+++ b/apps/api/src/bid/routes/bids/bids.router.ts
@@ -12,6 +12,7 @@ const listRoute = createRoute({
   method: "get",
   path: "/v1/bids",
   summary: "List bids",
+  operationId: "listBids",
   tags: ["Bids"],
   security: SECURITY_BEARER_OR_API_KEY,
   request: {

--- a/apps/api/src/deployment/routes/deployments/deployments.router.ts
+++ b/apps/api/src/deployment/routes/deployments/deployments.router.ts
@@ -38,6 +38,7 @@ const getRoute = createRoute({
   method: "get",
   path: "/v1/deployments/{dseq}",
   summary: "Get a deployment",
+  operationId: "getDeployment",
   tags: ["Deployments"],
   security: SECURITY_BEARER_OR_API_KEY,
   request: {
@@ -64,6 +65,7 @@ const postRoute = createRoute({
   method: "post",
   path: "/v1/deployments",
   summary: "Create new deployment",
+  operationId: "createDeployment",
   tags: ["Deployments"],
   security: SECURITY_BEARER_OR_API_KEY,
   request: {
@@ -96,6 +98,7 @@ const deleteRoute = createRoute({
   method: "delete",
   path: "/v1/deployments/{dseq}",
   summary: "Close a deployment",
+  operationId: "closeDeployment",
   tags: ["Deployments"],
   security: SECURITY_BEARER_OR_API_KEY,
   request: {
@@ -122,6 +125,7 @@ const depositRoute = createRoute({
   method: "post",
   path: "/v1/deposit-deployment",
   summary: "Deposit into a deployment",
+  operationId: "depositDeployment",
   tags: ["Deployments"],
   security: SECURITY_BEARER_OR_API_KEY,
   request: {
@@ -154,6 +158,7 @@ const updateRoute = createRoute({
   method: "put",
   path: "/v1/deployments/{dseq}",
   summary: "Update a deployment",
+  operationId: "updateDeployment",
   tags: ["Deployments"],
   security: SECURITY_BEARER_OR_API_KEY,
   request: {
@@ -188,6 +193,7 @@ const listRoute = createRoute({
   method: "get",
   path: "/v1/deployments",
   summary: "List deployments with pagination and filtering",
+  operationId: "listDeployments",
   tags: ["Deployments"],
   security: SECURITY_BEARER_OR_API_KEY,
   request: {

--- a/apps/api/src/deployment/routes/leases/leases.router.ts
+++ b/apps/api/src/deployment/routes/leases/leases.router.ts
@@ -14,6 +14,7 @@ const createLeaseRoute = createRoute({
   method: "post",
   path: "/v1/leases",
   summary: "Create leases and send manifest",
+  operationId: "createLease",
   tags: ["Leases"],
   security: SECURITY_BEARER_OR_API_KEY,
   request: {

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -1947,7 +1947,7 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "default": "2026-05-12",
+              "default": "2026-05-14",
               "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
               "example": "2024-01-31"
             },
@@ -2073,7 +2073,7 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "default": "2026-05-12",
+              "default": "2026-05-14",
               "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
               "example": "2024-01-31"
             },
@@ -3791,6 +3791,7 @@
     "/v1/deployments/{dseq}": {
       "get": {
         "summary": "Get a deployment",
+        "operationId": "getDeployment",
         "tags": [
           "Deployments"
         ],
@@ -4192,6 +4193,7 @@
       },
       "delete": {
         "summary": "Close a deployment",
+        "operationId": "closeDeployment",
         "tags": [
           "Deployments"
         ],
@@ -4247,6 +4249,7 @@
       },
       "put": {
         "summary": "Update a deployment",
+        "operationId": "updateDeployment",
         "tags": [
           "Deployments"
         ],
@@ -4675,6 +4678,7 @@
     "/v1/deployments": {
       "post": {
         "summary": "Create new deployment",
+        "operationId": "createDeployment",
         "tags": [
           "Deployments"
         ],
@@ -4772,6 +4776,7 @@
       },
       "get": {
         "summary": "List deployments with pagination and filtering",
+        "operationId": "listDeployments",
         "tags": [
           "Deployments"
         ],
@@ -5102,6 +5107,7 @@
     "/v1/deposit-deployment": {
       "post": {
         "summary": "Deposit into a deployment",
+        "operationId": "depositDeployment",
         "tags": [
           "Deployments"
         ],
@@ -7605,6 +7611,7 @@
     "/v1/leases": {
       "post": {
         "summary": "Create leases and send manifest",
+        "operationId": "createLease",
         "tags": [
           "Leases"
         ],
@@ -8837,6 +8844,7 @@
     "/v1/bids": {
       "get": {
         "summary": "List bids",
+        "operationId": "listBids",
         "tags": [
           "Bids"
         ],

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -3126,6 +3126,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
     },
     "/v1/bids": {
       "get": {
+        "operationId": "listBids",
         "parameters": [
           {
             "in": "query",
@@ -6163,6 +6164,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
     },
     "/v1/deployments": {
       "get": {
+        "operationId": "listDeployments",
         "parameters": [
           {
             "in": "query",
@@ -6491,6 +6493,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
       "post": {
+        "operationId": "createDeployment",
         "requestBody": {
           "content": {
             "application/json": {
@@ -6590,6 +6593,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
     },
     "/v1/deployments/{dseq}": {
       "delete": {
+        "operationId": "closeDeployment",
         "parameters": [
           {
             "description": "Deployment sequence number",
@@ -6645,6 +6649,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
       "get": {
+        "operationId": "getDeployment",
         "parameters": [
           {
             "description": "Deployment sequence number",
@@ -7046,6 +7051,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
       "put": {
+        "operationId": "updateDeployment",
         "parameters": [
           {
             "description": "Deployment sequence number",
@@ -7474,6 +7480,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
     },
     "/v1/deposit-deployment": {
       "post": {
+        "operationId": "depositDeployment",
         "requestBody": {
           "content": {
             "application/json": {
@@ -8388,6 +8395,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
     },
     "/v1/leases": {
       "post": {
+        "operationId": "createLease",
         "requestBody": {
           "content": {
             "application/json": {

--- a/packages/console-api-types/src/operations.gen.ts
+++ b/packages/console-api-types/src/operations.gen.ts
@@ -3,7 +3,22 @@
 
 export const operations = {
   v1: {
+    getDeployment: { path: "/v1/deployments/{dseq}", method: "get", operationId: "getDeployment", pathParams: ["dseq"], queryParams: [], hasBody: false },
+    closeDeployment: {
+      path: "/v1/deployments/{dseq}",
+      method: "delete",
+      operationId: "closeDeployment",
+      pathParams: ["dseq"],
+      queryParams: [],
+      hasBody: false
+    },
+    updateDeployment: { path: "/v1/deployments/{dseq}", method: "put", operationId: "updateDeployment", pathParams: ["dseq"], queryParams: [], hasBody: true },
+    createDeployment: { path: "/v1/deployments", method: "post", operationId: "createDeployment", pathParams: [], queryParams: [], hasBody: true },
+    listDeployments: { path: "/v1/deployments", method: "get", operationId: "listDeployments", pathParams: [], queryParams: ["skip", "limit"], hasBody: false },
+    depositDeployment: { path: "/v1/deposit-deployment", method: "post", operationId: "depositDeployment", pathParams: [], queryParams: [], hasBody: true },
+    createLease: { path: "/v1/leases", method: "post", operationId: "createLease", pathParams: [], queryParams: [], hasBody: true },
     listApiKeys: { path: "/v1/api-keys", method: "get", operationId: "listApiKeys", pathParams: [], queryParams: [], hasBody: false },
+    listBids: { path: "/v1/bids", method: "get", operationId: "listBids", pathParams: [], queryParams: ["dseq"], hasBody: false },
     listGpuPrices: { path: "/v1/gpu-prices", method: "get", operationId: "listGpuPrices", pathParams: [], queryParams: [], hasBody: false },
     createAlert: { path: "/v1/alerts", method: "post", operationId: "createAlert", pathParams: [], queryParams: [], hasBody: true },
     listAlerts: {

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -2585,268 +2585,12 @@ export interface paths {
       cookie?: never;
     };
     /** Get a deployment */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description Deployment sequence number */
-          dseq: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Returns deployment info */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                deployment: {
-                  id: {
-                    owner: string;
-                    dseq: string;
-                  };
-                  state: string;
-                  hash: string;
-                  created_at: string;
-                };
-                leases: {
-                  id: {
-                    owner: string;
-                    dseq: string;
-                    gseq: number;
-                    oseq: number;
-                    provider: string;
-                    bseq: number;
-                  };
-                  state: string;
-                  price: {
-                    denom: string;
-                    amount: string;
-                  };
-                  created_at: string;
-                  closed_on: string;
-                  reason?: string;
-                  status: {
-                    forwarded_ports: {
-                      [key: string]: {
-                        port: number;
-                        externalPort: number;
-                        host?: string;
-                        available?: number;
-                      }[];
-                    };
-                    ips: {
-                      [key: string]: {
-                        IP: string;
-                        Port: number;
-                        ExternalPort: number;
-                        Protocol: string;
-                      }[];
-                    };
-                    services: {
-                      [key: string]: {
-                        name: string;
-                        available: number;
-                        total: number;
-                        uris: string[];
-                        observed_generation: number;
-                        replicas: number;
-                        updated_replicas: number;
-                        ready_replicas: number;
-                        available_replicas: number;
-                      };
-                    };
-                  } | null;
-                }[];
-                escrow_account: {
-                  id: {
-                    scope: string;
-                    xid: string;
-                  };
-                  state: {
-                    owner: string;
-                    state: string;
-                    transferred: {
-                      denom: string;
-                      amount: string;
-                    }[];
-                    settled_at: string;
-                    funds: {
-                      denom: string;
-                      amount: string;
-                    }[];
-                    deposits: {
-                      owner: string;
-                      height: string;
-                      source: string;
-                      balance: {
-                        denom: string;
-                        amount: string;
-                      };
-                    }[];
-                  };
-                };
-              };
-            };
-          };
-        };
-      };
-    };
+    get: operations["getDeployment"];
     /** Update a deployment */
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description Deployment sequence number */
-          dseq: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": {
-            data: {
-              sdl: string;
-            };
-          };
-        };
-      };
-      responses: {
-        /** @description Deployment updated successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                deployment: {
-                  id: {
-                    owner: string;
-                    dseq: string;
-                  };
-                  state: string;
-                  hash: string;
-                  created_at: string;
-                };
-                leases: {
-                  id: {
-                    owner: string;
-                    dseq: string;
-                    gseq: number;
-                    oseq: number;
-                    provider: string;
-                    bseq: number;
-                  };
-                  state: string;
-                  price: {
-                    denom: string;
-                    amount: string;
-                  };
-                  created_at: string;
-                  closed_on: string;
-                  reason?: string;
-                  status: {
-                    forwarded_ports: {
-                      [key: string]: {
-                        port: number;
-                        externalPort: number;
-                        host?: string;
-                        available?: number;
-                      }[];
-                    };
-                    ips: {
-                      [key: string]: {
-                        IP: string;
-                        Port: number;
-                        ExternalPort: number;
-                        Protocol: string;
-                      }[];
-                    };
-                    services: {
-                      [key: string]: {
-                        name: string;
-                        available: number;
-                        total: number;
-                        uris: string[];
-                        observed_generation: number;
-                        replicas: number;
-                        updated_replicas: number;
-                        ready_replicas: number;
-                        available_replicas: number;
-                      };
-                    };
-                  } | null;
-                }[];
-                escrow_account: {
-                  id: {
-                    scope: string;
-                    xid: string;
-                  };
-                  state: {
-                    owner: string;
-                    state: string;
-                    transferred: {
-                      denom: string;
-                      amount: string;
-                    }[];
-                    settled_at: string;
-                    funds: {
-                      denom: string;
-                      amount: string;
-                    }[];
-                    deposits: {
-                      owner: string;
-                      height: string;
-                      source: string;
-                      balance: {
-                        denom: string;
-                        amount: string;
-                      };
-                    }[];
-                  };
-                };
-              };
-            };
-          };
-        };
-      };
-    };
+    put: operations["updateDeployment"];
     post?: never;
     /** Close a deployment */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          /** @description Deployment sequence number */
-          dseq: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Deployment closed successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                success: boolean;
-              };
-            };
-          };
-        };
-      };
-    };
+    delete: operations["closeDeployment"];
     options?: never;
     head?: never;
     patch?: never;
@@ -2860,137 +2604,10 @@ export interface paths {
       cookie?: never;
     };
     /** List deployments with pagination and filtering */
-    get: {
-      parameters: {
-        query?: {
-          skip?: number | null;
-          limit?: number;
-        };
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Returns paginated list of deployments */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                deployments: {
-                  deployment: {
-                    id: {
-                      owner: string;
-                      dseq: string;
-                    };
-                    state: string;
-                    hash: string;
-                    created_at: string;
-                  };
-                  leases: {
-                    id: {
-                      owner: string;
-                      dseq: string;
-                      gseq: number;
-                      oseq: number;
-                      provider: string;
-                      bseq: number;
-                    };
-                    state: string;
-                    price: {
-                      denom: string;
-                      amount: string;
-                    };
-                    created_at: string;
-                    closed_on: string;
-                    reason?: string;
-                  }[];
-                  escrow_account: {
-                    id: {
-                      scope: string;
-                      xid: string;
-                    };
-                    state: {
-                      owner: string;
-                      state: string;
-                      transferred: {
-                        denom: string;
-                        amount: string;
-                      }[];
-                      settled_at: string;
-                      funds: {
-                        denom: string;
-                        amount: string;
-                      }[];
-                      deposits: {
-                        owner: string;
-                        height: string;
-                        source: string;
-                        balance: {
-                          denom: string;
-                          amount: string;
-                        };
-                      }[];
-                    };
-                  };
-                }[];
-                pagination: {
-                  total: number;
-                  skip: number;
-                  limit: number;
-                  hasMore: boolean;
-                };
-              };
-            };
-          };
-        };
-      };
-    };
+    get: operations["listDeployments"];
     put?: never;
     /** Create new deployment */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": {
-            data: {
-              sdl: string;
-              /** @description Amount to deposit in dollars (e.g. 5.5) */
-              deposit: number;
-            };
-          };
-        };
-      };
-      responses: {
-        /** @description Create deployment successfully */
-        201: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                dseq: string;
-                manifest: string;
-                signTx: {
-                  code: number;
-                  transactionHash: string;
-                  rawLog: string;
-                };
-              };
-            };
-          };
-        };
-      };
-    };
+    post: operations["createDeployment"];
     delete?: never;
     options?: never;
     head?: never;
@@ -3007,126 +2624,7 @@ export interface paths {
     get?: never;
     put?: never;
     /** Deposit into a deployment */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": {
-            data: {
-              /** @description Deployment sequence number */
-              dseq: string;
-              /** @description Amount to deposit in dollars (e.g. 5.5) */
-              deposit: number;
-            };
-          };
-        };
-      };
-      responses: {
-        /** @description Deposit successful */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                deployment: {
-                  id: {
-                    owner: string;
-                    dseq: string;
-                  };
-                  state: string;
-                  hash: string;
-                  created_at: string;
-                };
-                leases: {
-                  id: {
-                    owner: string;
-                    dseq: string;
-                    gseq: number;
-                    oseq: number;
-                    provider: string;
-                    bseq: number;
-                  };
-                  state: string;
-                  price: {
-                    denom: string;
-                    amount: string;
-                  };
-                  created_at: string;
-                  closed_on: string;
-                  reason?: string;
-                  status: {
-                    forwarded_ports: {
-                      [key: string]: {
-                        port: number;
-                        externalPort: number;
-                        host?: string;
-                        available?: number;
-                      }[];
-                    };
-                    ips: {
-                      [key: string]: {
-                        IP: string;
-                        Port: number;
-                        ExternalPort: number;
-                        Protocol: string;
-                      }[];
-                    };
-                    services: {
-                      [key: string]: {
-                        name: string;
-                        available: number;
-                        total: number;
-                        uris: string[];
-                        observed_generation: number;
-                        replicas: number;
-                        updated_replicas: number;
-                        ready_replicas: number;
-                        available_replicas: number;
-                      };
-                    };
-                  } | null;
-                }[];
-                escrow_account: {
-                  id: {
-                    scope: string;
-                    xid: string;
-                  };
-                  state: {
-                    owner: string;
-                    state: string;
-                    transferred: {
-                      denom: string;
-                      amount: string;
-                    }[];
-                    settled_at: string;
-                    funds: {
-                      denom: string;
-                      amount: string;
-                    }[];
-                    deposits: {
-                      owner: string;
-                      height: string;
-                      source: string;
-                      balance: {
-                        denom: string;
-                        amount: string;
-                      };
-                    }[];
-                  };
-                };
-              };
-            };
-          };
-        };
-      };
-    };
+    post: operations["depositDeployment"];
     delete?: never;
     options?: never;
     head?: never;
@@ -3782,127 +3280,7 @@ export interface paths {
     get?: never;
     put?: never;
     /** Create leases and send manifest */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": {
-            manifest: string;
-            leases: {
-              dseq: string;
-              gseq: number;
-              oseq: number;
-              provider: string;
-            }[];
-          };
-        };
-      };
-      responses: {
-        /** @description Leases created and manifest sent */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                deployment: {
-                  id: {
-                    owner: string;
-                    dseq: string;
-                  };
-                  state: string;
-                  hash: string;
-                  created_at: string;
-                };
-                leases: {
-                  id: {
-                    owner: string;
-                    dseq: string;
-                    gseq: number;
-                    oseq: number;
-                    provider: string;
-                    bseq: number;
-                  };
-                  state: string;
-                  price: {
-                    denom: string;
-                    amount: string;
-                  };
-                  created_at: string;
-                  closed_on: string;
-                  reason?: string;
-                  status: {
-                    forwarded_ports: {
-                      [key: string]: {
-                        port: number;
-                        externalPort: number;
-                        host?: string;
-                        available?: number;
-                      }[];
-                    };
-                    ips: {
-                      [key: string]: {
-                        IP: string;
-                        Port: number;
-                        ExternalPort: number;
-                        Protocol: string;
-                      }[];
-                    };
-                    services: {
-                      [key: string]: {
-                        name: string;
-                        available: number;
-                        total: number;
-                        uris: string[];
-                        observed_generation: number;
-                        replicas: number;
-                        updated_replicas: number;
-                        ready_replicas: number;
-                        available_replicas: number;
-                      };
-                    };
-                  } | null;
-                }[];
-                escrow_account: {
-                  id: {
-                    scope: string;
-                    xid: string;
-                  };
-                  state: {
-                    owner: string;
-                    state: string;
-                    transferred: {
-                      denom: string;
-                      amount: string;
-                    }[];
-                    settled_at: string;
-                    funds: {
-                      denom: string;
-                      amount: string;
-                    }[];
-                    deposits: {
-                      owner: string;
-                      height: string;
-                      source: string;
-                      balance: {
-                        denom: string;
-                        amount: string;
-                      };
-                    }[];
-                  };
-                };
-              };
-            };
-          };
-        };
-      };
-    };
+    post: operations["createLease"];
     delete?: never;
     options?: never;
     head?: never;
@@ -4233,121 +3611,7 @@ export interface paths {
       cookie?: never;
     };
     /** List bids */
-    get: {
-      parameters: {
-        query: {
-          dseq: string;
-        };
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description List of bids */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                bid: {
-                  id: {
-                    owner: string;
-                    dseq: string;
-                    gseq: number;
-                    oseq: number;
-                    provider: string;
-                    bseq: number;
-                  };
-                  state: string;
-                  price: {
-                    denom: string;
-                    amount: string;
-                  };
-                  created_at: string;
-                  resources_offer: {
-                    resources: {
-                      cpu: {
-                        units: {
-                          val: string;
-                        };
-                        attributes: {
-                          key: string;
-                          value: string;
-                        }[];
-                      };
-                      gpu: {
-                        units: {
-                          val: string;
-                        };
-                        attributes: {
-                          key: string;
-                          value: string;
-                        }[];
-                      };
-                      memory: {
-                        quantity: {
-                          val: string;
-                        };
-                        attributes: {
-                          key: string;
-                          value: string;
-                        }[];
-                      };
-                      storage: {
-                        name: string;
-                        quantity: {
-                          val: string;
-                        };
-                        attributes: {
-                          key: string;
-                          value: string;
-                        }[];
-                      }[];
-                      endpoints: {
-                        kind: string;
-                        sequence_number: number;
-                      }[];
-                    };
-                    count: number;
-                  }[];
-                };
-                escrow_account: {
-                  id: {
-                    scope: string;
-                    xid: string;
-                  };
-                  state: {
-                    owner: string;
-                    state: string;
-                    transferred: {
-                      denom: string;
-                      amount: string;
-                    }[];
-                    settled_at: string;
-                    funds: {
-                      denom: string;
-                      amount: string;
-                    }[];
-                    deposits: {
-                      owner: string;
-                      height: string;
-                      source: string;
-                      balance: {
-                        denom: string;
-                        amount: string;
-                      };
-                    }[];
-                  };
-                };
-              }[];
-            };
-          };
-        };
-      };
-    };
+    get: operations["listBids"];
     put?: never;
     post?: never;
     delete?: never;
@@ -8612,6 +7876,635 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  getDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Deployment sequence number */
+        dseq: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Returns deployment info */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              deployment: {
+                id: {
+                  owner: string;
+                  dseq: string;
+                };
+                state: string;
+                hash: string;
+                created_at: string;
+              };
+              leases: {
+                id: {
+                  owner: string;
+                  dseq: string;
+                  gseq: number;
+                  oseq: number;
+                  provider: string;
+                  bseq: number;
+                };
+                state: string;
+                price: {
+                  denom: string;
+                  amount: string;
+                };
+                created_at: string;
+                closed_on: string;
+                reason?: string;
+                status: {
+                  forwarded_ports: {
+                    [key: string]: {
+                      port: number;
+                      externalPort: number;
+                      host?: string;
+                      available?: number;
+                    }[];
+                  };
+                  ips: {
+                    [key: string]: {
+                      IP: string;
+                      Port: number;
+                      ExternalPort: number;
+                      Protocol: string;
+                    }[];
+                  };
+                  services: {
+                    [key: string]: {
+                      name: string;
+                      available: number;
+                      total: number;
+                      uris: string[];
+                      observed_generation: number;
+                      replicas: number;
+                      updated_replicas: number;
+                      ready_replicas: number;
+                      available_replicas: number;
+                    };
+                  };
+                } | null;
+              }[];
+              escrow_account: {
+                id: {
+                  scope: string;
+                  xid: string;
+                };
+                state: {
+                  owner: string;
+                  state: string;
+                  transferred: {
+                    denom: string;
+                    amount: string;
+                  }[];
+                  settled_at: string;
+                  funds: {
+                    denom: string;
+                    amount: string;
+                  }[];
+                  deposits: {
+                    owner: string;
+                    height: string;
+                    source: string;
+                    balance: {
+                      denom: string;
+                      amount: string;
+                    };
+                  }[];
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+  updateDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Deployment sequence number */
+        dseq: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          data: {
+            sdl: string;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Deployment updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              deployment: {
+                id: {
+                  owner: string;
+                  dseq: string;
+                };
+                state: string;
+                hash: string;
+                created_at: string;
+              };
+              leases: {
+                id: {
+                  owner: string;
+                  dseq: string;
+                  gseq: number;
+                  oseq: number;
+                  provider: string;
+                  bseq: number;
+                };
+                state: string;
+                price: {
+                  denom: string;
+                  amount: string;
+                };
+                created_at: string;
+                closed_on: string;
+                reason?: string;
+                status: {
+                  forwarded_ports: {
+                    [key: string]: {
+                      port: number;
+                      externalPort: number;
+                      host?: string;
+                      available?: number;
+                    }[];
+                  };
+                  ips: {
+                    [key: string]: {
+                      IP: string;
+                      Port: number;
+                      ExternalPort: number;
+                      Protocol: string;
+                    }[];
+                  };
+                  services: {
+                    [key: string]: {
+                      name: string;
+                      available: number;
+                      total: number;
+                      uris: string[];
+                      observed_generation: number;
+                      replicas: number;
+                      updated_replicas: number;
+                      ready_replicas: number;
+                      available_replicas: number;
+                    };
+                  };
+                } | null;
+              }[];
+              escrow_account: {
+                id: {
+                  scope: string;
+                  xid: string;
+                };
+                state: {
+                  owner: string;
+                  state: string;
+                  transferred: {
+                    denom: string;
+                    amount: string;
+                  }[];
+                  settled_at: string;
+                  funds: {
+                    denom: string;
+                    amount: string;
+                  }[];
+                  deposits: {
+                    owner: string;
+                    height: string;
+                    source: string;
+                    balance: {
+                      denom: string;
+                      amount: string;
+                    };
+                  }[];
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+  closeDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Deployment sequence number */
+        dseq: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Deployment closed successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              success: boolean;
+            };
+          };
+        };
+      };
+    };
+  };
+  listDeployments: {
+    parameters: {
+      query?: {
+        skip?: number | null;
+        limit?: number;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Returns paginated list of deployments */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              deployments: {
+                deployment: {
+                  id: {
+                    owner: string;
+                    dseq: string;
+                  };
+                  state: string;
+                  hash: string;
+                  created_at: string;
+                };
+                leases: {
+                  id: {
+                    owner: string;
+                    dseq: string;
+                    gseq: number;
+                    oseq: number;
+                    provider: string;
+                    bseq: number;
+                  };
+                  state: string;
+                  price: {
+                    denom: string;
+                    amount: string;
+                  };
+                  created_at: string;
+                  closed_on: string;
+                  reason?: string;
+                }[];
+                escrow_account: {
+                  id: {
+                    scope: string;
+                    xid: string;
+                  };
+                  state: {
+                    owner: string;
+                    state: string;
+                    transferred: {
+                      denom: string;
+                      amount: string;
+                    }[];
+                    settled_at: string;
+                    funds: {
+                      denom: string;
+                      amount: string;
+                    }[];
+                    deposits: {
+                      owner: string;
+                      height: string;
+                      source: string;
+                      balance: {
+                        denom: string;
+                        amount: string;
+                      };
+                    }[];
+                  };
+                };
+              }[];
+              pagination: {
+                total: number;
+                skip: number;
+                limit: number;
+                hasMore: boolean;
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+  createDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          data: {
+            sdl: string;
+            /** @description Amount to deposit in dollars (e.g. 5.5) */
+            deposit: number;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Create deployment successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              dseq: string;
+              manifest: string;
+              signTx: {
+                code: number;
+                transactionHash: string;
+                rawLog: string;
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+  depositDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          data: {
+            /** @description Deployment sequence number */
+            dseq: string;
+            /** @description Amount to deposit in dollars (e.g. 5.5) */
+            deposit: number;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Deposit successful */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              deployment: {
+                id: {
+                  owner: string;
+                  dseq: string;
+                };
+                state: string;
+                hash: string;
+                created_at: string;
+              };
+              leases: {
+                id: {
+                  owner: string;
+                  dseq: string;
+                  gseq: number;
+                  oseq: number;
+                  provider: string;
+                  bseq: number;
+                };
+                state: string;
+                price: {
+                  denom: string;
+                  amount: string;
+                };
+                created_at: string;
+                closed_on: string;
+                reason?: string;
+                status: {
+                  forwarded_ports: {
+                    [key: string]: {
+                      port: number;
+                      externalPort: number;
+                      host?: string;
+                      available?: number;
+                    }[];
+                  };
+                  ips: {
+                    [key: string]: {
+                      IP: string;
+                      Port: number;
+                      ExternalPort: number;
+                      Protocol: string;
+                    }[];
+                  };
+                  services: {
+                    [key: string]: {
+                      name: string;
+                      available: number;
+                      total: number;
+                      uris: string[];
+                      observed_generation: number;
+                      replicas: number;
+                      updated_replicas: number;
+                      ready_replicas: number;
+                      available_replicas: number;
+                    };
+                  };
+                } | null;
+              }[];
+              escrow_account: {
+                id: {
+                  scope: string;
+                  xid: string;
+                };
+                state: {
+                  owner: string;
+                  state: string;
+                  transferred: {
+                    denom: string;
+                    amount: string;
+                  }[];
+                  settled_at: string;
+                  funds: {
+                    denom: string;
+                    amount: string;
+                  }[];
+                  deposits: {
+                    owner: string;
+                    height: string;
+                    source: string;
+                    balance: {
+                      denom: string;
+                      amount: string;
+                    };
+                  }[];
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+  createLease: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          manifest: string;
+          leases: {
+            dseq: string;
+            gseq: number;
+            oseq: number;
+            provider: string;
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description Leases created and manifest sent */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              deployment: {
+                id: {
+                  owner: string;
+                  dseq: string;
+                };
+                state: string;
+                hash: string;
+                created_at: string;
+              };
+              leases: {
+                id: {
+                  owner: string;
+                  dseq: string;
+                  gseq: number;
+                  oseq: number;
+                  provider: string;
+                  bseq: number;
+                };
+                state: string;
+                price: {
+                  denom: string;
+                  amount: string;
+                };
+                created_at: string;
+                closed_on: string;
+                reason?: string;
+                status: {
+                  forwarded_ports: {
+                    [key: string]: {
+                      port: number;
+                      externalPort: number;
+                      host?: string;
+                      available?: number;
+                    }[];
+                  };
+                  ips: {
+                    [key: string]: {
+                      IP: string;
+                      Port: number;
+                      ExternalPort: number;
+                      Protocol: string;
+                    }[];
+                  };
+                  services: {
+                    [key: string]: {
+                      name: string;
+                      available: number;
+                      total: number;
+                      uris: string[];
+                      observed_generation: number;
+                      replicas: number;
+                      updated_replicas: number;
+                      ready_replicas: number;
+                      available_replicas: number;
+                    };
+                  };
+                } | null;
+              }[];
+              escrow_account: {
+                id: {
+                  scope: string;
+                  xid: string;
+                };
+                state: {
+                  owner: string;
+                  state: string;
+                  transferred: {
+                    denom: string;
+                    amount: string;
+                  }[];
+                  settled_at: string;
+                  funds: {
+                    denom: string;
+                    amount: string;
+                  }[];
+                  deposits: {
+                    owner: string;
+                    height: string;
+                    source: string;
+                    balance: {
+                      denom: string;
+                      amount: string;
+                    };
+                  }[];
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
   listApiKeys: {
     parameters: {
       query?: never;
@@ -8641,6 +8534,121 @@ export interface operations {
               /** Format: date-time */
               lastUsedAt: string | null;
               keyFormat: string;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  listBids: {
+    parameters: {
+      query: {
+        dseq: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of bids */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              bid: {
+                id: {
+                  owner: string;
+                  dseq: string;
+                  gseq: number;
+                  oseq: number;
+                  provider: string;
+                  bseq: number;
+                };
+                state: string;
+                price: {
+                  denom: string;
+                  amount: string;
+                };
+                created_at: string;
+                resources_offer: {
+                  resources: {
+                    cpu: {
+                      units: {
+                        val: string;
+                      };
+                      attributes: {
+                        key: string;
+                        value: string;
+                      }[];
+                    };
+                    gpu: {
+                      units: {
+                        val: string;
+                      };
+                      attributes: {
+                        key: string;
+                        value: string;
+                      }[];
+                    };
+                    memory: {
+                      quantity: {
+                        val: string;
+                      };
+                      attributes: {
+                        key: string;
+                        value: string;
+                      }[];
+                    };
+                    storage: {
+                      name: string;
+                      quantity: {
+                        val: string;
+                      };
+                      attributes: {
+                        key: string;
+                        value: string;
+                      }[];
+                    }[];
+                    endpoints: {
+                      kind: string;
+                      sequence_number: number;
+                    }[];
+                  };
+                  count: number;
+                }[];
+              };
+              escrow_account: {
+                id: {
+                  scope: string;
+                  xid: string;
+                };
+                state: {
+                  owner: string;
+                  state: string;
+                  transferred: {
+                    denom: string;
+                    amount: string;
+                  }[];
+                  settled_at: string;
+                  funds: {
+                    denom: string;
+                    amount: string;
+                  }[];
+                  deposits: {
+                    owner: string;
+                    height: string;
+                    source: string;
+                    balance: {
+                      denom: string;
+                      amount: string;
+                    };
+                  }[];
+                };
+              };
             }[];
           };
         };

--- a/packages/dev-config/.eslintrc.base.js
+++ b/packages/dev-config/.eslintrc.base.js
@@ -35,7 +35,15 @@ module.exports = {
     "import-x/no-self-import": ["error"],
     "import-x/no-useless-path-segments": ["error"],
     "akash/no-mnemonic": ["error"],
-    "akash/operation-id-format": ["error"]
+    "akash/operation-id-format": [
+      "error",
+      {
+        additionalVerbs: {
+          post: { collection: ["deposit"] },
+          delete: { single: ["close"] }
+        }
+      }
+    ]
   },
   overrides: [
     {

--- a/packages/dev-config/eslint-plugin-akash/rules/operation-id-format.js
+++ b/packages/dev-config/eslint-plugin-akash/rules/operation-id-format.js
@@ -1,5 +1,15 @@
 const CAMEL_CASE_IDENTIFIER = /^[a-z][a-zA-Z]*$/;
-const DISABLE_HINT = "For action-style endpoints, add // eslint-disable-next-line akash/operation-id-format above the operationId line.";
+const DISABLE_HINT =
+  "Extend additionalVerbs in the rule config (packages/dev-config/.eslintrc.base.js) when you need a new domain verb, or add // eslint-disable-next-line akash/operation-id-format for a one-off.";
+
+const methodVerbsSchema = {
+  type: "object",
+  properties: {
+    collection: { type: "array", items: { type: "string" } },
+    single: { type: "array", items: { type: "string" } }
+  },
+  additionalProperties: false
+};
 
 module.exports = {
   meta: {
@@ -8,9 +18,28 @@ module.exports = {
       description:
         "Enforce createRoute operationId follows <verb><Resource> convention and matches the route's HTTP method and path (collection vs single-resource)."
     },
-    schema: []
+    schema: [
+      {
+        type: "object",
+        properties: {
+          additionalVerbs: {
+            type: "object",
+            properties: {
+              get: methodVerbsSchema,
+              post: methodVerbsSchema,
+              put: methodVerbsSchema,
+              patch: methodVerbsSchema,
+              delete: methodVerbsSchema
+            },
+            additionalProperties: false
+          }
+        },
+        additionalProperties: false
+      }
+    ]
   },
   create(context) {
+    const additionalVerbs = context.options[0]?.additionalVerbs ?? {};
     return {
       CallExpression(node) {
         if (!isCreateRouteCall(node)) return;
@@ -39,7 +68,7 @@ module.exports = {
         if (!method || !path) return;
 
         const isSingleResource = isSingleResourcePath(path);
-        const expectedVerbs = getExpectedVerbs(method, isSingleResource);
+        const expectedVerbs = getExpectedVerbs(method, isSingleResource, additionalVerbs);
         if (!expectedVerbs) return;
 
         const actualVerb = extractLeadingVerb(operationId);
@@ -113,16 +142,20 @@ const EXPECTED_VERBS_BY_METHOD = {
 
 /**
  * Returns the verbs allowed to start an operationId for a given HTTP method
- * and route shape. Returns null for unknown methods, signalling the rule to
+ * and route shape, merging built-in CRUD verbs with `additionalVerbs` from the
+ * rule's options. Returns null for unknown methods, signalling the rule to
  * skip semantic validation for that call.
  * @param {string} method - Lowercase HTTP method (e.g. "get", "post").
  * @param {boolean} isSingleResource - True if the route path ends with "{id}".
+ * @param {Record<string, { collection?: string[], single?: string[] }>} additionalVerbs
  * @returns {string[] | null}
  */
-function getExpectedVerbs(method, isSingleResource) {
+function getExpectedVerbs(method, isSingleResource, additionalVerbs) {
   const expectations = EXPECTED_VERBS_BY_METHOD[method];
   if (!expectations) return null;
-  return isSingleResource ? expectations.single : expectations.collection;
+  const shape = isSingleResource ? "single" : "collection";
+  const extra = additionalVerbs[method]?.[shape] ?? [];
+  return [...expectations[shape], ...extra];
 }
 
 const LEADING_LOWERCASE_WORD = /^[a-z]+/;


### PR DESCRIPTION
## Why

Currently the deploy lifecycle (`POST /v1/deployments`, `GET /v1/bids`, `POST /v1/leases`, `POST /v1/deposit-deployment`, `GET|PUT|DELETE /v1/deployments/{dseq}`) is reachable over HTTP but absent from `@akashnetwork/console-api-types` — the typed client at `api.v1.*` only surfaces routes that declare an `operationId`. Public docs ([Getting started](https://akash.network/docs/api-documentation/console-api/getting-started/)) advertise this flow, so it should be the first-class typed surface.

> Note: the public quickstart's request/response shapes (e.g. `{ sdl }`, `{ dseq, bidId }`, `{ amount: "10.00" }`) are out of date — the runtime contract is what's encoded in the Zod schemas in this repo and shown in the examples below. The docs need a separate update.

Also extends the `akash/operation-id-format` lint rule so command-style verbs (`close`, `deposit`, …) don't each need a per-route disable comment.

## What

- Add `operationId` to the 9 deploy-flow routes:
  - `createDeployment`, `listDeployments`, `getDeployment`, `updateDeployment`, `closeDeployment`, `depositDeployment`
  - `listBids`
  - `createLease`
- Extend `akash/operation-id-format` with a configurable `additionalVerbs` option and seed `.eslintrc.base.js` with `post.collection: ["deposit"]` and `delete.single: ["close"]`. New domain verbs go in one place instead of scattered eslint-disable comments.
- Regenerate `apps/api/swagger/openapi.json` and `packages/console-api-types/src/{schema.d.ts,operations.gen.ts}` via `npm run sdk:gen`.
- Refresh `apps/api/test/functional/__snapshots__/docs.spec.ts.snap` for the new operationIds.

## Usage

### In a Node script / non-React caller

```ts
import { createApi } from "@akashnetwork/openapi-sdk";
import { operations, type paths } from "@akashnetwork/console-api-types";

const api = createApi<paths, typeof operations>(operations, {
  baseUrl: "https://console-api.akash.network",
  defaultHeaders: { "x-api-key": process.env.AKASH_API_KEY! }
});

// 1. Create a deployment
const { data: created } = await api.v1.createDeployment({
  data: { sdl, deposit: 5 }
});
const { dseq, manifest } = created;

// 2. Poll for bids
let bids: Awaited<ReturnType<typeof api.v1.listBids>>["data"] = [];
for (let i = 0; i < 20 && !bids.length; i++) {
  ({ data: bids } = await api.v1.listBids({ dseq }));
  if (!bids.length) await new Promise(r => setTimeout(r, 3000));
}
const winner = bids[0];

// 3. Create the lease + send the manifest
await api.v1.createLease({
  manifest,
  leases: [{ dseq, gseq: winner.gseq, oseq: winner.oseq, provider: winner.provider }]
});

// 4. Top up later, inspect, close
await api.v1.depositDeployment({ data: { dseq, deposit: 2.5 } });
const { data: deployment } = await api.v1.getDeployment({ dseq });
await api.v1.closeDeployment({ dseq });
```

### In `apps/deploy-web` (already wired)

`useServices().api` is the `createApiSdk` proxy (`apps/deploy-web/src/services/api-sdk/createApiSdk.ts`) wrapped with `createProxy` from `@akashnetwork/react-query-proxy`, which adds `.useQuery`, `.useMutation`, and `.getKey` to every operation. The new operations are immediately available — no extra wiring.

Reactive style: mutations are fired with `.mutate(...)` and state transitions are driven by query gating + `useWhen`. The mutation's own `data` is the source of truth for `dseq`/`manifest` and `createLease.isIdle` is the natural "we haven't leased yet" gate — no parallel `useState`:

```ts
import { useServices } from "@src/context/ServicesProvider";
import { useWhen } from "@src/hooks/useWhen";

export function useDeployFlow(sdl: string) {
  const { api } = useServices();
  const createDeployment = api.v1.createDeployment.useMutation();
  const createLease = api.v1.createLease.useMutation();
  const deposit = api.v1.depositDeployment.useMutation();
  const closeDeployment = api.v1.closeDeployment.useMutation();

  // The mutation already owns dseq + manifest — derive, don't duplicate.
  const created = createDeployment.data?.data;

  // Poll bids while we have a dseq and haven't kicked off the lease yet.
  const bids = api.v1.listBids.useQuery(
    { dseq: created?.dseq ?? "" },
    {
      enabled: !!created && createLease.isIdle,
      refetchInterval: q => (q.state.data?.data.length ? false : 3000)
    }
  );

  // Auto-accept the first bid that appears.
  useWhen(!!created && !!bids.data?.data.length && createLease.isIdle, () => {
    const winner = bids.data!.data[0];
    createLease.mutate({
      manifest: created!.manifest,
      leases: [{ dseq: created!.dseq, gseq: winner.gseq, oseq: winner.oseq, provider: winner.provider }]
    });
  });

  // Live deployment view; force a refresh as soon as the lease lands.
  const status = api.v1.getDeployment.useQuery(
    { dseq: created?.dseq ?? "" },
    { enabled: !!created, refetchInterval: 5000 }
  );
  useWhen(createLease.isSuccess, () => status.refetch());

  return {
    start: () => createDeployment.mutate({ data: { sdl, deposit: 5 } }),
    topUp: (amount: number) => created && deposit.mutate({ data: { dseq: created.dseq, deposit: amount } }),
    close: () => created && closeDeployment.mutate({ dseq: created.dseq }),
    dseq: created?.dseq,
    deployment: status.data?.data
  };
}
```

Server-side usage works the same — `context.services.api.v1.getDeployment({ dseq })` etc. (see `apps/deploy-web/src/pages/alerts/notification-channels/[id]/index.tsx` for the existing pattern).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added explicit operation identifiers to API endpoint definitions for improved OpenAPI documentation clarity.
  * Updated API schema date defaults.
  * Enhanced ESLint configuration to support additional operation ID verb patterns for API routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3176)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->