### PR TITLE
fix: respond with proper status on blocked dns lookup

### DIFF
--- a/apps/provider-proxy/src/routes/proxyProviderRequest.ts
+++ b/apps/provider-proxy/src/routes/proxyProviderRequest.ts
@@ -134,6 +134,33 @@ export async function proxyProviderRequest(ctx: AppContext): Promise<Response | 
       );
     }
 
+    if ((Error as any).isError(proxyResult.error) && (proxyResult.error as NodeJS.ErrnoException).code === "EFORBIDDEN") {
+      ctx.get("container").appLogger?.warn({
+        event: "PROXY_REQUEST_ERROR",
+        code: (proxyResult.error as NodeJS.ErrnoException).code,
+        url,
+        method,
+        providerAddress,
+        error: proxyResult.error
+      });
+      return ctx.json(
+        {
+          error: {
+            code: "custom",
+            issues: [
+              {
+                path: ["url"],
+                params: {
+                  reason: "invalid"
+                }
+              }
+            ]
+          }
+        },
+        400
+      );
+    }
+
     return ctx.text(`Provider ${new URL(url).origin} is temporarily unavailable`, 503);
   }
 

--- a/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-http.spec.ts
@@ -805,5 +805,37 @@ describe("Provider HTTP proxy", () => {
         })
       );
     });
+
+    it("returns 400 when the hostname resolves to a private network address", async () => {
+      const providerAddress = generateBech32();
+      const validCertPair = await createX509CertPair({ commonName: providerAddress, validFrom: new Date(Date.now() - ONE_HOUR) });
+      const chainServer = await startChainApiServer([validCertPair.cert]);
+      const { providerUrl } = await startProviderServer({ certPair: validCertPair });
+      await startServer({ REST_API_NODE_URL: chainServer.url, ALLOW_PROXY_TO_LOCAL_NETWORK: "false" });
+
+      const response = await request("/", {
+        method: "POST",
+        body: JSON.stringify({
+          method: "GET",
+          url: `${providerUrl}/200.txt`,
+          providerAddress
+        })
+      });
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+      expect(body).toEqual(
+        expect.objectContaining({
+          error: expect.objectContaining({
+            issues: expect.arrayContaining([
+              expect.objectContaining({
+                path: ["url"],
+                params: { reason: "invalid" }
+              })
+            ])
+          })
+        })
+      );
+    });
   });
 });

--- a/apps/provider-proxy/test/setup/providerServer.ts
+++ b/apps/provider-proxy/test/setup/providerServer.ts
@@ -6,14 +6,12 @@ import WebSocket from "ws";
 
 import { shutdownServer } from "../../src/utils/shutdownServer";
 import type { CertPair } from "../seeders/createX509CertPair";
-import { createX509CertPair } from "../seeders/createX509CertPair";
-import { generateBech32 } from "./chainApiServer";
 
 let runningServer: https.Server | undefined;
 
 export function startProviderServer(options: ProviderServerOptions): Promise<ProviderServerResult> {
   return new Promise<ProviderServerResult>(resolve => {
-    const certPair = options.certPair || createX509CertPair({ commonName: generateBech32() });
+    const certPair = options.certPair;
     const httpServerOptions: ServerOptions = {
       key: certPair.key,
       cert: certPair.cert.toJSON()
@@ -77,7 +75,7 @@ export function stopProviderServer(): Promise<void> {
 type RequestHandlers = Record<string, (req: IncomingMessage, res: ServerResponse) => (() => void) | undefined | void>;
 export interface ProviderServerOptions {
   requireClientCertificate?: boolean;
-  certPair?: CertPair;
+  certPair: CertPair;
   handlers?: RequestHandlers;
   websocketServer?: {
     enable: boolean;


### PR DESCRIPTION
## Why

Ref CON-336

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Proxy now returns HTTP 400 with a validation issue (path: ["url"], reason: "invalid") for forbidden target URLs resolved to private network addresses.

* **Tests**
  * Added a functional test verifying rejection of requests to private network hostnames.
  * Test server setup tightened: test HTTPS server now requires an explicit certificate pair.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3179)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->