### PR TITLE
fix(notifications): don't auto-enable deployment balance alert

### DIFF
--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.spec.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.spec.ts
@@ -1,4 +1,3 @@
-import type { DeploymentHttpService, DeploymentInfo, RestAkashDeploymentInfoResponse } from "@akashnetwork/http-sdk";
 import { mock } from "vitest-mock-extended";
 
 import type { EnableDeploymentAlertCommand } from "@src/billing/commands/enable-deployment-alert.command";
@@ -8,16 +7,8 @@ import type { NotificationService } from "@src/notifications/services/notificati
 import { EnableDeploymentAlertHandler } from "./enable-deployment-alert.handler";
 
 describe(EnableDeploymentAlertHandler.name, () => {
-  it("fetches deployment and calls autoEnableDeploymentAlert with escrow balance", async () => {
-    const { handler, notificationService, deploymentHttpService } = setup();
-
-    deploymentHttpService.findByOwnerAndDseq.mockResolvedValue({
-      escrow_account: {
-        state: {
-          funds: [{ denom: "uakt", amount: "1000000" }]
-        }
-      }
-    } as DeploymentInfo);
+  it("calls autoEnableDeploymentAlert with the payload identifiers", async () => {
+    const { handler, notificationService } = setup();
 
     const payload: JobPayload<EnableDeploymentAlertCommand> = {
       userId: "user-1",
@@ -28,50 +19,24 @@ describe(EnableDeploymentAlertHandler.name, () => {
 
     await handler.handle(payload);
 
-    expect(deploymentHttpService.findByOwnerAndDseq).toHaveBeenCalledWith("akash1abc", "123");
     expect(notificationService.autoEnableDeploymentAlert).toHaveBeenCalledWith({
       userId: "user-1",
       walletAddress: "akash1abc",
-      dseq: "123",
-      escrowBalance: 1000000
+      dseq: "123"
     });
   });
 
-  it("skips when deployment is not found", async () => {
-    const { handler, notificationService, deploymentHttpService } = setup();
-
-    deploymentHttpService.findByOwnerAndDseq.mockResolvedValue({ code: 5, message: "not found", details: [] } satisfies RestAkashDeploymentInfoResponse);
-
-    const payload: JobPayload<EnableDeploymentAlertCommand> = {
-      userId: "user-1",
-      walletAddress: "akash1abc",
-      dseq: "123",
-      version: 1
-    };
-
-    await handler.handle(payload);
-
-    expect(notificationService.autoEnableDeploymentAlert).not.toHaveBeenCalled();
-  });
-
-  function setup(params?: {
-    notificationService?: Partial<NotificationService>;
-    deploymentHttpService?: Partial<DeploymentHttpService>;
-    logger?: Partial<LoggerService>;
-  }) {
+  function setup(params?: { notificationService?: Partial<NotificationService>; logger?: Partial<LoggerService> }) {
     const notificationService = mock<NotificationService>({
       autoEnableDeploymentAlert: jest.fn().mockResolvedValue(undefined),
       ...params?.notificationService
-    });
-    const deploymentHttpService = mock<DeploymentHttpService>({
-      ...params?.deploymentHttpService
     });
     const logger = mock<LoggerService>({
       ...params?.logger
     });
 
-    const handler = new EnableDeploymentAlertHandler(notificationService, deploymentHttpService, logger);
+    const handler = new EnableDeploymentAlertHandler(notificationService, logger);
 
-    return { handler, notificationService, deploymentHttpService, logger };
+    return { handler, notificationService, logger };
   }
 });

--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.ts
@@ -1,5 +1,3 @@
-import { DeploymentHttpService } from "@akashnetwork/http-sdk";
-import { backOff } from "exponential-backoff";
 import { singleton } from "tsyringe";
 
 import { EnableDeploymentAlertCommand } from "@src/billing/commands/enable-deployment-alert.command";
@@ -15,37 +13,16 @@ export class EnableDeploymentAlertHandler implements JobHandler<EnableDeployment
 
   constructor(
     private readonly notificationService: NotificationService,
-    private readonly deploymentHttpService: DeploymentHttpService,
     private readonly logger: LoggerService
   ) {}
 
   async handle(payload: JobPayload<EnableDeploymentAlertCommand>): Promise<void> {
     this.logger.debug({ event: "ENABLE_DEPLOYMENT_ALERT", userId: payload.userId, dseq: payload.dseq });
 
-    const escrowBalance = await this.getDeploymentEscrowBalance(payload.walletAddress, payload.dseq);
-    if (escrowBalance === undefined) return;
-
     await this.notificationService.autoEnableDeploymentAlert({
       userId: payload.userId,
       walletAddress: payload.walletAddress,
-      dseq: payload.dseq,
-      escrowBalance
+      dseq: payload.dseq
     });
-  }
-
-  private async getDeploymentEscrowBalance(walletAddress: string, dseq: string): Promise<number | undefined> {
-    const deployment = await backOff(() => this.deploymentHttpService.findByOwnerAndDseq(walletAddress, dseq), {
-      maxDelay: 5_000,
-      startingDelay: 500,
-      timeMultiple: 2,
-      numOfAttempts: 5
-    });
-
-    if ("code" in deployment) {
-      this.logger.warn({ event: "SKIP_AUTO_ENABLE_ALERT", reason: "Deployment not found", dseq });
-      return undefined;
-    }
-
-    return parseFloat(deployment.escrow_account.state.funds.reduce((sum, { amount }) => sum + parseFloat(amount), 0).toFixed(18));
   }
 }

--- a/apps/api/src/notifications/services/notification/notification.service.spec.ts
+++ b/apps/api/src/notifications/services/notification/notification.service.spec.ts
@@ -163,7 +163,7 @@ describe(NotificationService.name, () => {
   });
 
   describe("autoEnableDeploymentAlert", () => {
-    it("creates default channel when no channels exist, then upserts alert", async () => {
+    it("creates default channel when no channels exist, then upserts only the deployment-closed alert", async () => {
       const { service, api, userRepository } = setup();
 
       userRepository.findById.mockResolvedValue({ id: "user-1", email: "user@example.com" } as UserOutput);
@@ -171,7 +171,7 @@ describe(NotificationService.name, () => {
       api.v1.createDefaultNotificationChannel.mockResolvedValue({} as never);
       api.v1.upsertDeploymentAlert.mockResolvedValue({} as never);
 
-      await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: 1000000 });
+      await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123" });
 
       expect(api.v1.listNotificationChannels).toHaveBeenCalledTimes(2);
       expect(api.v1.createDefaultNotificationChannel).toHaveBeenCalled();
@@ -180,7 +180,6 @@ describe(NotificationService.name, () => {
           dseq: "123",
           data: {
             alerts: {
-              deploymentBalance: { notificationChannelId: "channel-1", enabled: true, threshold: 300000 },
               deploymentClosed: { notificationChannelId: "channel-1", enabled: true }
             }
           }
@@ -198,10 +197,7 @@ describe(NotificationService.name, () => {
       api.v1.createDefaultNotificationChannel.mockRejectedValue(new ApiError(409, { code: "ALREADY_EXISTS" }, "POST /v1/notification-channels/default → 409"));
       api.v1.upsertDeploymentAlert.mockResolvedValue({} as never);
 
-      await Promise.all([
-        service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: 1000000 }),
-        jest.runAllTimersAsync()
-      ]);
+      await Promise.all([service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123" }), jest.runAllTimersAsync()]);
 
       expect(api.v1.listNotificationChannels).toHaveBeenCalledTimes(2);
       expect(api.v1.upsertDeploymentAlert).toHaveBeenCalled();
@@ -216,7 +212,7 @@ describe(NotificationService.name, () => {
       api.v1.listNotificationChannels.mockResolvedValue({ data: [{ id: "channel-1" }] } as never);
       api.v1.upsertDeploymentAlert.mockResolvedValue({} as never);
 
-      await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: 1000000 });
+      await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123" });
 
       expect(api.v1.listNotificationChannels).toHaveBeenCalledTimes(1);
       expect(api.v1.createDefaultNotificationChannel).not.toHaveBeenCalled();
@@ -228,7 +224,7 @@ describe(NotificationService.name, () => {
 
       userRepository.findById.mockResolvedValue({ id: "user-1", email: null } as UserOutput);
 
-      await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: 1000000 });
+      await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123" });
 
       expect(api.v1.listNotificationChannels).not.toHaveBeenCalled();
       expect(api.v1.createDefaultNotificationChannel).not.toHaveBeenCalled();
@@ -240,7 +236,7 @@ describe(NotificationService.name, () => {
 
       userRepository.findById.mockResolvedValue(undefined);
 
-      await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: 1000000 });
+      await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123" });
 
       expect(api.v1.listNotificationChannels).not.toHaveBeenCalled();
       expect(api.v1.createDefaultNotificationChannel).not.toHaveBeenCalled();
@@ -254,32 +250,9 @@ describe(NotificationService.name, () => {
       api.v1.listNotificationChannels.mockResolvedValue({ data: [] } as never);
       api.v1.createDefaultNotificationChannel.mockResolvedValue({} as never);
 
-      await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: 1000000 });
+      await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123" });
 
       expect(api.v1.createDefaultNotificationChannel).toHaveBeenCalled();
-      expect(api.v1.upsertDeploymentAlert).not.toHaveBeenCalled();
-    });
-
-    it("skips when threshold would be 0", async () => {
-      const { service, api, userRepository } = setup();
-
-      userRepository.findById.mockResolvedValue({ id: "user-1", email: "user@example.com" } as UserOutput);
-      api.v1.listNotificationChannels.mockResolvedValue({ data: [{ id: "channel-1" }] } as never);
-
-      await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: 0 });
-
-      expect(api.v1.createDefaultNotificationChannel).not.toHaveBeenCalled();
-      expect(api.v1.upsertDeploymentAlert).not.toHaveBeenCalled();
-    });
-
-    it("skips when escrow balance is NaN", async () => {
-      const { service, api, userRepository } = setup();
-
-      userRepository.findById.mockResolvedValue({ id: "user-1", email: "user@example.com" } as UserOutput);
-      api.v1.listNotificationChannels.mockResolvedValue({ data: [{ id: "channel-1" }] } as never);
-
-      await service.autoEnableDeploymentAlert({ userId: "user-1", walletAddress: "akash1abc", dseq: "123", escrowBalance: NaN });
-
       expect(api.v1.upsertDeploymentAlert).not.toHaveBeenCalled();
     });
   });

--- a/apps/api/src/notifications/services/notification/notification.service.ts
+++ b/apps/api/src/notifications/services/notification/notification.service.ts
@@ -7,8 +7,6 @@ import { UserRepository } from "@src/user/repositories";
 import type { NotificationsApiClient, NotificationsInternalApiClient, NotificationsInternalOperationDefs } from "../../providers/notifications-api.provider";
 import { NOTIFICATIONS_API_CLIENT, NOTIFICATIONS_INTERNAL_API_CLIENT } from "../../providers/notifications-api.provider";
 
-const DEPLOYMENT_BALANCE_ALERT_THRESHOLD_RATIO = 0.3;
-
 const DEFAULT_BACKOFF_OPTIONS: BackoffOptions = {
   maxDelay: 5_000,
   startingDelay: 500,
@@ -67,15 +65,11 @@ export class NotificationService {
       return;
     }
 
-    const threshold = this.calculateAlertThreshold(input.escrowBalance);
-    if (!threshold) return;
-
-    await this.upsertDeploymentBalanceAlert({
+    await this.upsertDeploymentClosedAlert({
       userId: input.userId,
       walletAddress: input.walletAddress,
       dseq: input.dseq,
-      channelId,
-      threshold
+      channelId
     });
   }
 
@@ -102,14 +96,7 @@ export class NotificationService {
     );
   }
 
-  private calculateAlertThreshold(escrowBalance: number): number | undefined {
-    if (!Number.isFinite(escrowBalance) || escrowBalance <= 0) return undefined;
-    const threshold = Math.ceil(DEPLOYMENT_BALANCE_ALERT_THRESHOLD_RATIO * escrowBalance);
-    if (!Number.isFinite(threshold) || threshold <= 0) return undefined;
-    return threshold;
-  }
-
-  private async upsertDeploymentBalanceAlert(input: { userId: string; walletAddress: string; dseq: string; channelId: string; threshold: number }) {
+  private async upsertDeploymentClosedAlert(input: { userId: string; walletAddress: string; dseq: string; channelId: string }) {
     await backOff(
       () =>
         this.notificationsApi.v1.upsertDeploymentAlert(
@@ -117,7 +104,6 @@ export class NotificationService {
             dseq: input.dseq,
             data: {
               alerts: {
-                deploymentBalance: { notificationChannelId: input.channelId, enabled: true, threshold: input.threshold },
                 deploymentClosed: { notificationChannelId: input.channelId, enabled: true }
               }
             }
@@ -138,7 +124,6 @@ export interface AutoEnableDeploymentAlertInput {
   userId: string;
   walletAddress: string;
   dseq: string;
-  escrowBalance: number;
 }
 
 export type CreateNotificationInput = NotificationsInternalOperationDefs["createNotification"]["requestBody"]["content"]["application/json"] & {

--- a/apps/deploy-web/tests/ui/managed-wallet-alerts.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-alerts.spec.ts
@@ -54,8 +54,8 @@ test.describe("Managed wallet alerts", () => {
       await expect(page.getByText("Configure Alerts")).toBeVisible({ timeout: 10_000 });
     });
 
-    await test.step("verify escrow balance alert is enabled by default", async () => {
-      await expect(alertsForm.getEscrowEnabledToggle()).toBeChecked();
+    await test.step("verify escrow balance alert is NOT enabled by default", async () => {
+      await expect(alertsForm.getEscrowEnabledToggle()).not.toBeChecked();
       await expect(alertsForm.getEscrowThresholdInput()).toBeVisible();
       await expect(alertsForm.getEscrowChannelSelect()).toBeVisible();
     });
@@ -65,7 +65,10 @@ test.describe("Managed wallet alerts", () => {
       await expect(alertsForm.getCloseChannelSelect()).toBeVisible();
     });
 
-    await test.step("update escrow threshold and save", async () => {
+    await test.step("enable escrow balance alert, update threshold, and save", async () => {
+      await alertsForm.getEscrowEnabledToggle().click();
+      await expect(alertsForm.getEscrowEnabledToggle()).toBeChecked();
+
       const originalValue = await alertsForm.getEscrowThresholdInput().inputValue();
       const newThreshold = Math.max(0.01, parseFloat(originalValue) * 0.5).toFixed(3);
 


### PR DESCRIPTION
## Why

Auto top-up is the default for managed wallets, so the deployment balance alert is redundant for the majority of users. Worse: when a user closes a batch of deployments, escrow drops below the auto-created threshold and the balance alert fires once per deployment, spamming the user with emails (and costing us money).

There is no suppression path between auto top-up and balance alerts in `apps/notifications` today — they're fully independent.

## What

- Stop auto-creating the `deploymentBalance` alert when a deployment is created. The post-deploy job now only enables `deploymentClosed` (one-shot, not noisy).
- Users who want a balance alert can still enable it manually from the deployment **Alerts** tab — the frontend form already supplies a sensible default threshold locally.
- Existing deployments with the balance alert already enabled are intentionally left untouched. They can be turned off per-deployment in the UI.
- Side benefit: removes a per-deployment chain RPC (`getDeploymentEscrowBalance`) that was only used to compute the auto-enabled threshold.

### Files changed
- `apps/api/src/notifications/services/notification/notification.service.ts` — drop balance alert from upsert; remove threshold calc; drop `escrowBalance` from input.
- `apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.ts` — drop `DeploymentHttpService` dependency and chain fetch.
- Updated unit specs to match.
- `apps/deploy-web/tests/ui/managed-wallet-alerts.spec.ts` — flip the default-state assertion (balance toggle starts off) and enable the toggle before updating the threshold.

The `chore(repo): sync package-lock.json` commit is preparatory: the lockfile on `main` was out of sync with `package.json`, causing the `npm ci --dry-run` pre-commit check to fail on any commit. Synced as a separate commit so it can be reviewed independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default state of escrow balance alert in managed wallet settings changed to disabled.

* **Refactor**
  * Simplified deployment alert flow to only auto-enable "deployment closed" alerts; removed balance-threshold calculations from automated alerts.

* **Tests**
  * Updated unit and UI tests to reflect the new alert behavior and the adjusted default toggle state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3181)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->