### PR TITLE
fix(billing): return 400 instead of 500 on malformed sign-tx payloads

### DIFF
--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -18,6 +18,7 @@ import type { ChainErrorService } from "@src/billing/services/chain-error/chain-
 import type { ManagedUserWalletService } from "@src/billing/services/managed-user-wallet/managed-user-wallet.service";
 import type { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
 import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
+import type { LoggerService } from "@src/core";
 import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import type { FeatureFlagValue } from "@src/core/services/feature-flags/feature-flags";
 import type { UserOutput, UserRepository } from "@src/user/repositories";
@@ -453,6 +454,34 @@ describe(ManagedSignerService.name, () => {
 
       expect(walletReloadJobService.scheduleImmediate).not.toHaveBeenCalled();
     });
+
+    it("throws 400 with message index and typeUrl when a message fails to decode", async () => {
+      const decodeError = new Error("illegal tag: field no 0 wire type 7");
+      const badMessage = {
+        typeUrl: "/akash.deployment.v1beta4.MsgCreateDeployment",
+        value: Buffer.from("not a real proto").toString("base64")
+      };
+
+      const { service, logger } = setup({
+        decode: jest.fn().mockImplementation(() => {
+          throw decodeError;
+        })
+      });
+
+      await expect(service.executeDerivedEncodedTxByUserId("user-123", [badMessage])).rejects.toMatchObject({
+        status: 400,
+        message: expect.stringContaining("/akash.deployment.v1beta4.MsgCreateDeployment")
+      });
+
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "TX_MESSAGE_DECODE_FAILED",
+          index: 0,
+          typeUrl: "/akash.deployment.v1beta4.MsgCreateDeployment",
+          error: decodeError
+        })
+      );
+    });
   });
 
   describe("executeFundingTx", () => {
@@ -569,6 +598,10 @@ describe(ManagedSignerService.name, () => {
       }),
       managedUserWalletService: mock<ManagedUserWalletService>({
         refillWalletFees: jest.fn()
+      }),
+      logger: mock<LoggerService>({
+        setContext: jest.fn(),
+        error: jest.fn()
       })
     };
 
@@ -589,7 +622,8 @@ describe(ManagedSignerService.name, () => {
       mocks.domainEvents,
       mocks.leaseHttpService,
       mocks.walletReloadJobService,
-      mocks.managedUserWalletService
+      mocks.managedUserWalletService,
+      mocks.logger
     );
 
     return { service, registry: registryMock, ...mocks };

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -6,6 +6,7 @@ import { EncodeObject, Registry } from "@cosmjs/proto-signing";
 import { IndexedTx } from "@cosmjs/stargate";
 import { context, trace } from "@opentelemetry/api";
 import assert from "http-assert";
+import { BadRequest } from "http-errors";
 import pick from "lodash/pick";
 import { singleton } from "tsyringe";
 
@@ -17,6 +18,7 @@ import { type UserWalletOutput, UserWalletRepository } from "@src/billing/reposi
 import { ManagedUserWalletService } from "@src/billing/services/managed-user-wallet/managed-user-wallet.service";
 import { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
 import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
+import { LoggerService } from "@src/core";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { Trace, withSpan } from "@src/core/services/tracing/tracing.service";
 import { UserRepository } from "@src/user/repositories";
@@ -44,8 +46,11 @@ export class ManagedSignerService {
     private readonly domainEvents: DomainEventsService,
     private readonly leaseHttpService: LeaseHttpService,
     private readonly walletReloadJobService: WalletReloadJobService,
-    private readonly managedUserWalletService: ManagedUserWalletService
-  ) {}
+    private readonly managedUserWalletService: ManagedUserWalletService,
+    private readonly logger: LoggerService
+  ) {
+    this.logger.setContext(ManagedSignerService.name);
+  }
 
   @Trace()
   async executeDerivedTx(walletIndex: number, messages: readonly EncodeObject[]) {
@@ -198,14 +203,26 @@ export class ManagedSignerService {
   }
 
   private decodeMessages(messages: StringifiedEncodeObject[]): EncodeObject[] {
-    return messages.map(message => {
+    return messages.map((message, index) => {
       const value = new Uint8Array(Buffer.from(message.value, "base64"));
-      const decoded = this.registry.decode({ value, typeUrl: message.typeUrl });
 
-      return {
-        typeUrl: message.typeUrl,
-        value: decoded
-      };
+      try {
+        return {
+          typeUrl: message.typeUrl,
+          value: this.registry.decode({ value, typeUrl: message.typeUrl })
+        };
+      } catch (error) {
+        this.logger.error({
+          event: "TX_MESSAGE_DECODE_FAILED",
+          index,
+          typeUrl: message.typeUrl,
+          valueLength: value.length,
+          bytePrefix: Buffer.from(value.subarray(0, 8)).toString("hex"),
+          error
+        });
+
+        throw new BadRequest(`Failed to decode message at index ${index} (typeUrl: ${message.typeUrl})`);
+      }
     });
   }
 }


### PR DESCRIPTION
**Why**
A malformed protobuf payload sent to POST /sign-tx was bubbling up to the client as a 500 because ManagedSignerService.decodeMessages had no error handling around Registry.decode. The decoder threw illegal tag: field no 0 wire type 7 (wire format equivalent of "these bytes aren't a valid protobuf message at all") — a client-side encoding/schema problem presenting as a server error with no useful diagnostic info in the logs.

Hit in production with typeUrl: /akash.deployment.v1beta4.MsgCreateDeployment — symptoms of schema-version or encoding skew between client and server. The fix doesn't try to guess the cause; it makes the failure mode correct and diagnosable.

**What**
In ManagedSignerService.decodeMessages:

- Wrap each Registry.decode call in a try/catch so the failing message's index is known.
- Throw BadRequest (400) from http-errors with the offending index and typeUrl in the message.
- Log a structured TX_MESSAGE_DECODE_FAILED event with index, typeUrl, valueLength, the first 8 bytes as hex, and the original decoder error. The hex prefix is the single most useful field for diagnosing protobuf decode failures: a valid Akash deployment message almost always starts with 0a (field 1, wire type 2). Anything else immediately tells you it's a wrong-schema or wrong-encoding problem.
- Inject LoggerService via the constructor, matching the pattern in TxManagerService, ExternalSignerHttpSdkService, etc.

Decode stays in apps/api because business validation (balance, lease-provider, trial-allowance) needs the decoded objects. tx-signer never sees these requests because apps/api rejects them first, so no tx-signer change is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for message decode failures with detailed diagnostics including message index and type information for better troubleshooting.

* **Tests**
  * Added test coverage for message decode failure scenarios to validate error logging and diagnostic reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->