### PR TITLE
feat(user): track account stage with backfill

### DIFF
--- a/apps/api/drizzle/0030_perfect_stranger.sql
+++ b/apps/api/drizzle/0030_perfect_stranger.sql
@@ -1,0 +1,19 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."account_stage" AS ENUM('onboarding', 'trial', 'trial_legacy', 'regular');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "userSetting" ADD COLUMN "stage" "account_stage" DEFAULT 'onboarding' NOT NULL;
+--> statement-breakpoint
+UPDATE "userSetting" u
+SET    "stage" = 'regular'
+FROM   "user_wallets" w
+WHERE  w."user_id" = u."id"
+  AND  w."trial" = false;
+--> statement-breakpoint
+UPDATE "userSetting" u
+SET    "stage" = 'trial_legacy'
+FROM   "user_wallets" w
+WHERE  w."user_id" = u."id"
+  AND  w."trial" = true;

--- a/apps/api/drizzle/0031_silent_kronos.sql
+++ b/apps/api/drizzle/0031_silent_kronos.sql
@@ -1,0 +1,7 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."user_wallet_status" AS ENUM('pending', 'ready', 'failed');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "user_wallets" ADD COLUMN "status" "user_wallet_status" DEFAULT 'ready' NOT NULL;

--- a/apps/api/drizzle/meta/0030_snapshot.json
+++ b/apps/api/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,1293 @@
+{
+  "id": "fa7de93c-f157-48ba-bcfd-7ad1a9d09501",
+  "prevId": "23f3ad91-3b5d-4930-9a49-628ecd8f138a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      }
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      }
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stage": {
+          "name": "stage",
+          "type": "account_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'onboarding'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      }
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      }
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      }
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim"
+      ]
+    },
+    "public.account_stage": {
+      "name": "account_stage",
+      "schema": "public",
+      "values": [
+        "onboarding",
+        "trial",
+        "trial_legacy",
+        "regular"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/0031_snapshot.json
+++ b/apps/api/drizzle/meta/0031_snapshot.json
@@ -1,0 +1,1310 @@
+{
+  "id": "0de0337c-bd8a-43bd-ba17-bec9aeddda40",
+  "prevId": "fa7de93c-f157-48ba-bcfd-7ad1a9d09501",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "status": {
+          "name": "status",
+          "type": "user_wallet_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ready'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      }
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      }
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "stage": {
+          "name": "stage",
+          "type": "account_stage",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'onboarding'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      }
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      }
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      }
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {
+    "public.user_wallet_status": {
+      "name": "user_wallet_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "ready",
+        "failed"
+      ]
+    },
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim"
+      ]
+    },
+    "public.account_stage": {
+      "name": "account_stage",
+      "schema": "public",
+      "values": [
+        "onboarding",
+        "trial",
+        "trial_legacy",
+        "regular"
+      ]
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -211,6 +211,20 @@
       "when": 1771979737373,
       "tag": "0029_fluffy_drax",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1778859848386,
+      "tag": "0030_perfect_stranger",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1779261123531,
+      "tag": "0031_silent_kronos",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -110,7 +110,8 @@ async function executeCliHandler(name: string, handler: () => Promise<unknown>, 
           githubUsername: null,
           userId: "system:cli-user",
           username: "___cli_user___",
-          trial: false
+          trial: false,
+          stage: "onboarding"
         });
         executionContextService.set("ABILITY", createMongoAbility<MongoAbility>());
         return await handler();

--- a/apps/api/src/app/providers/jobs.provider.ts
+++ b/apps/api/src/app/providers/jobs.provider.ts
@@ -7,7 +7,10 @@ import { JobQueueService } from "@src/core/services/job-queue/job-queue.service"
 import { NotificationHandler } from "@src/notifications/services/notification-handler/notification.handler";
 import { CloseTrialDeploymentHandler } from "../services/close-trial-deployment/close-trial-deployment.handler";
 import { EnableDeploymentAlertHandler } from "../services/enable-deployment-alert/enable-deployment-alert.handler";
+import { OnboardingStartedHandler } from "../services/onboarding-started/onboarding-started.handler";
+import { TrialActivatedHandler } from "../services/trial-activated/trial-activated.handler";
 import { TrialDeploymentLeaseCreatedHandler } from "../services/trial-deployment-lease-created/trial-deployment-lease-created.handler";
+import { TrialEndedHandler } from "../services/trial-ended/trial-ended.handler";
 import { TrialStartedHandler } from "../services/trial-started/trial-started.handler";
 
 container.register(APP_INITIALIZER, {
@@ -21,7 +24,10 @@ container.register(APP_INITIALIZER, {
         container.resolve(CloseTrialDeploymentHandler),
         container.resolve(TrialDeploymentLeaseCreatedHandler),
         container.resolve(EnableDeploymentAlertHandler),
-        container.resolve(WalletBalanceReloadCheckHandler)
+        container.resolve(WalletBalanceReloadCheckHandler),
+        container.resolve(OnboardingStartedHandler),
+        container.resolve(TrialActivatedHandler),
+        container.resolve(TrialEndedHandler)
       ]);
     }
   } satisfies AppInitializer

--- a/apps/api/src/app/services/onboarding-started/onboarding-started.handler.spec.ts
+++ b/apps/api/src/app/services/onboarding-started/onboarding-started.handler.spec.ts
@@ -1,0 +1,30 @@
+import { mock } from "vitest-mock-extended";
+
+import type { OnboardingStarted } from "@src/billing/events/onboarding-started";
+import type { WalletInitializerService } from "@src/billing/services/wallet-initializer/wallet-initializer.service";
+import type { EventPayload, LoggerService } from "@src/core";
+import { OnboardingStartedHandler } from "./onboarding-started.handler";
+
+describe(OnboardingStartedHandler.name, () => {
+  it("delegates to walletInitializer.initializeForOnboarding with the userId", async () => {
+    const { handler, walletInitializer } = setup();
+
+    await handler.handle({ userId: "user-1", version: 1 } as EventPayload<OnboardingStarted>);
+
+    expect(walletInitializer.initializeForOnboarding).toHaveBeenCalledWith("user-1");
+  });
+
+  it("propagates errors so pg-boss retries", async () => {
+    const { handler, walletInitializer } = setup();
+    walletInitializer.initializeForOnboarding.mockRejectedValue(new Error("chain down"));
+
+    await expect(handler.handle({ userId: "user-1", version: 1 } as EventPayload<OnboardingStarted>)).rejects.toThrow("chain down");
+  });
+
+  function setup() {
+    const walletInitializer = mock<WalletInitializerService>();
+    const logger = mock<LoggerService>();
+    const handler = new OnboardingStartedHandler(walletInitializer, logger);
+    return { handler, walletInitializer, logger };
+  }
+});

--- a/apps/api/src/app/services/onboarding-started/onboarding-started.handler.ts
+++ b/apps/api/src/app/services/onboarding-started/onboarding-started.handler.ts
@@ -1,0 +1,34 @@
+import { context, trace } from "@opentelemetry/api";
+import { singleton } from "tsyringe";
+
+import { OnboardingStarted } from "@src/billing/events/onboarding-started";
+import { WalletInitializerService } from "@src/billing/services/wallet-initializer/wallet-initializer.service";
+import { EventPayload, JobHandler, LoggerService } from "@src/core";
+import { withSpan } from "@src/core/services/tracing/tracing.service";
+
+@singleton()
+export class OnboardingStartedHandler implements JobHandler<OnboardingStarted> {
+  public readonly accepts = OnboardingStarted;
+
+  constructor(
+    private readonly walletInitializer: WalletInitializerService,
+    private readonly logger: LoggerService
+  ) {}
+
+  async handle(payload: EventPayload<OnboardingStarted>): Promise<void> {
+    return withSpan("OnboardingStartedHandler.handle", async () => {
+      const span = trace.getSpan(context.active());
+      span?.setAttribute("user.id", payload.userId);
+
+      this.logger.info({ event: "ONBOARDING_INIT_STARTED", userId: payload.userId });
+
+      try {
+        await this.walletInitializer.initializeForOnboarding(payload.userId);
+        this.logger.info({ event: "ONBOARDING_INIT_SUCCEEDED", userId: payload.userId });
+      } catch (error) {
+        this.logger.error({ event: "ONBOARDING_INIT_FAILED", userId: payload.userId, error });
+        throw error;
+      }
+    });
+  }
+}

--- a/apps/api/src/app/services/trial-activated/trial-activated.handler.spec.ts
+++ b/apps/api/src/app/services/trial-activated/trial-activated.handler.spec.ts
@@ -1,0 +1,49 @@
+import { mock } from "vitest-mock-extended";
+
+import type { TrialActivated } from "@src/billing/events/trial-activated";
+import type { EventPayload } from "@src/core";
+import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { UserRepository } from "@src/user/repositories/user/user.repository";
+import type { AccountStageService } from "@src/user/services/account-stage/account-stage.service";
+import { TrialActivatedHandler } from "./trial-activated.handler";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(TrialActivatedHandler.name, () => {
+  it("calls the bare advanceToTrial (NOT activateTrial, to avoid re-publishing)", async () => {
+    const user = createUser({ id: "user-1", stage: "onboarding" });
+    const { handler, userRepository, accountStageService } = setup();
+    userRepository.findById.mockResolvedValue(user);
+
+    await handler.handle({ userId: "user-1", version: 1 } as EventPayload<TrialActivated>);
+
+    expect(accountStageService.advanceToTrial).toHaveBeenCalledWith(user);
+    expect(accountStageService.activateTrial).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the user no longer exists", async () => {
+    const { handler, userRepository, accountStageService } = setup();
+    userRepository.findById.mockResolvedValue(undefined);
+
+    await handler.handle({ userId: "ghost", version: 1 } as EventPayload<TrialActivated>);
+
+    expect(accountStageService.advanceToTrial).not.toHaveBeenCalled();
+  });
+
+  it("rethrows when advance fails so pg-boss retries", async () => {
+    const user = createUser({ id: "user-1", stage: "onboarding" });
+    const { handler, userRepository, accountStageService } = setup();
+    userRepository.findById.mockResolvedValue(user);
+    accountStageService.advanceToTrial.mockRejectedValue(new Error("db down"));
+
+    await expect(handler.handle({ userId: "user-1", version: 1 } as EventPayload<TrialActivated>)).rejects.toThrow("db down");
+  });
+
+  function setup() {
+    const userRepository = mock<UserRepository>();
+    const accountStageService = mock<AccountStageService>();
+    const logger = mock<LoggerService>();
+    const handler = new TrialActivatedHandler(userRepository, accountStageService, logger);
+    return { handler, userRepository, accountStageService, logger };
+  }
+});

--- a/apps/api/src/app/services/trial-activated/trial-activated.handler.ts
+++ b/apps/api/src/app/services/trial-activated/trial-activated.handler.ts
@@ -1,0 +1,27 @@
+import { singleton } from "tsyringe";
+
+import { TrialActivated } from "@src/billing/events/trial-activated";
+import { EventPayload, JobHandler, LoggerService } from "@src/core";
+import { UserRepository } from "@src/user/repositories";
+import { AccountStageService } from "@src/user/services/account-stage/account-stage.service";
+
+@singleton()
+export class TrialActivatedHandler implements JobHandler<TrialActivated> {
+  public readonly accepts = TrialActivated;
+
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly accountStageService: AccountStageService,
+    private readonly logger: LoggerService
+  ) {}
+
+  async handle(payload: EventPayload<TrialActivated>): Promise<void> {
+    const user = await this.userRepository.findById(payload.userId);
+    if (!user) {
+      this.logger.warn({ event: "TRIAL_ACTIVATED_HANDLER_USER_NOT_FOUND", userId: payload.userId });
+      return;
+    }
+
+    await this.accountStageService.advanceToTrial(user);
+  }
+}

--- a/apps/api/src/app/services/trial-ended/trial-ended.handler.spec.ts
+++ b/apps/api/src/app/services/trial-ended/trial-ended.handler.spec.ts
@@ -1,0 +1,31 @@
+import { mock } from "vitest-mock-extended";
+
+import type { TrialEnded } from "@src/billing/events/trial-ended";
+import type { EventPayload, LoggerService } from "@src/core";
+import type { AccountStageService } from "@src/user/services/account-stage/account-stage.service";
+import { TrialEndedHandler } from "./trial-ended.handler";
+
+describe(TrialEndedHandler.name, () => {
+  it("calls the bare advanceToRegular (NOT endTrial, to avoid re-publishing)", async () => {
+    const { handler, accountStageService } = setup();
+
+    await handler.handle({ userId: "user-1", version: 1 } as EventPayload<TrialEnded>);
+
+    expect(accountStageService.advanceToRegular).toHaveBeenCalledWith("user-1");
+    expect(accountStageService.endTrial).not.toHaveBeenCalled();
+  });
+
+  it("rethrows when advance fails so pg-boss retries", async () => {
+    const { handler, accountStageService } = setup();
+    accountStageService.advanceToRegular.mockRejectedValue(new Error("db down"));
+
+    await expect(handler.handle({ userId: "user-1", version: 1 } as EventPayload<TrialEnded>)).rejects.toThrow("db down");
+  });
+
+  function setup() {
+    const accountStageService = mock<AccountStageService>();
+    const logger = mock<LoggerService>();
+    const handler = new TrialEndedHandler(accountStageService, logger);
+    return { handler, accountStageService, logger };
+  }
+});

--- a/apps/api/src/app/services/trial-ended/trial-ended.handler.ts
+++ b/apps/api/src/app/services/trial-ended/trial-ended.handler.ts
@@ -1,0 +1,19 @@
+import { singleton } from "tsyringe";
+
+import { TrialEnded } from "@src/billing/events/trial-ended";
+import { EventPayload, JobHandler, LoggerService } from "@src/core";
+import { AccountStageService } from "@src/user/services/account-stage/account-stage.service";
+
+@singleton()
+export class TrialEndedHandler implements JobHandler<TrialEnded> {
+  public readonly accepts = TrialEnded;
+
+  constructor(
+    private readonly accountStageService: AccountStageService,
+    private readonly logger: LoggerService
+  ) {}
+
+  async handle(payload: EventPayload<TrialEnded>): Promise<void> {
+    await this.accountStageService.advanceToRegular(payload.userId);
+  }
+}

--- a/apps/api/src/billing/controllers/wallet/wallet.controller.spec.ts
+++ b/apps/api/src/billing/controllers/wallet/wallet.controller.spec.ts
@@ -12,12 +12,15 @@ import { BillingConfigService } from "@src/billing/services/billing-config/billi
 import { RefillService } from "@src/billing/services/refill/refill.service";
 import { StripeService } from "@src/billing/services/stripe/stripe.service";
 import { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import type { UserOutput } from "@src/user/repositories";
 import { UserRepository } from "@src/user/repositories";
 import { WalletController } from "./wallet.controller";
 
 import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
 import { createUser } from "@test/seeders/user.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe("WalletController", () => {
   it("forbids starting a trial for a user with not verified email", async () => {
@@ -271,6 +274,72 @@ describe("WalletController", () => {
     expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).not.toHaveBeenCalled();
   });
 
+  describe("signTx — wallet readiness gate (console_onboarding_redesign FF)", () => {
+    it("returns 503 with Retry-After header when wallet status is 'pending' and FF is on", async () => {
+      const user = createUser();
+      const container = setup({
+        user,
+        userWallet: createUserWallet({ userId: user.id, status: "pending" }),
+        featureFlagEnabled: flag => flag === FeatureFlags.CONSOLE_ONBOARDING_REDESIGN
+      });
+      const walletController = container.resolve(WalletController);
+
+      await expect(
+        walletController.signTx({ data: { userId: user.id, messages: [{ typeUrl: "/akash.cert.v1.MsgCreateCertificate", value: "" }] } })
+      ).rejects.toMatchObject({
+        status: 503,
+        headers: { "Retry-After": "2" }
+      });
+      expect(container.resolve(ManagedSignerService).executeDerivedEncodedTxByUserId).not.toHaveBeenCalled();
+    });
+
+    it("returns 500 with wallet_init_failed code when wallet status is 'failed' and FF is on", async () => {
+      const user = createUser();
+      const container = setup({
+        user,
+        userWallet: createUserWallet({ userId: user.id, status: "failed" }),
+        featureFlagEnabled: true
+      });
+      const walletController = container.resolve(WalletController);
+
+      await expect(
+        walletController.signTx({ data: { userId: user.id, messages: [{ typeUrl: "/akash.cert.v1.MsgCreateCertificate", value: "" }] } })
+      ).rejects.toMatchObject({
+        status: 500,
+        errorCode: "wallet_init_failed"
+      });
+      expect(container.resolve(ManagedSignerService).executeDerivedEncodedTxByUserId).not.toHaveBeenCalled();
+    });
+
+    it("proceeds with signing when wallet status is 'ready' and FF is on", async () => {
+      const user = createUser();
+      const container = setup({
+        user,
+        userWallet: createUserWallet({ userId: user.id, status: "ready" }),
+        featureFlagEnabled: true
+      });
+      const walletController = container.resolve(WalletController);
+
+      await walletController.signTx({ data: { userId: user.id, messages: [{ typeUrl: "/akash.cert.v1.MsgCreateCertificate", value: "" }] } });
+
+      expect(container.resolve(ManagedSignerService).executeDerivedEncodedTxByUserId).toHaveBeenCalledWith(user.id, expect.any(Array));
+    });
+
+    it("does not check wallet status when FF is off", async () => {
+      const user = createUser();
+      const container = setup({
+        user,
+        featureFlagEnabled: false
+      });
+      const walletController = container.resolve(WalletController);
+
+      await walletController.signTx({ data: { userId: user.id, messages: [{ typeUrl: "/akash.cert.v1.MsgCreateCertificate", value: "" }] } });
+
+      expect(container.resolve(UserWalletRepository).findOneByUserId).not.toHaveBeenCalled();
+      expect(container.resolve(ManagedSignerService).executeDerivedEncodedTxByUserId).toHaveBeenCalledWith(user.id, expect.any(Array));
+    });
+  });
+
   function setup(input?: {
     user?: UserOutput;
     hasPaymentMethods?: boolean;
@@ -280,12 +349,19 @@ describe("WalletController", () => {
     validationFails?: boolean;
     stripeError?: boolean;
     wallets?: UserWalletPublicOutput[];
+    userWallet?: ReturnType<typeof createUserWallet>;
+    featureFlagEnabled?: boolean | ((flag: string) => boolean);
   }) {
     rootContainer.register(AuthService, {
       useValue: mock<AuthService>({
+        isAuthenticated: true,
         ability: createMongoAbility<MongoAbility>([
           {
             action: "create",
+            subject: "UserWallet"
+          },
+          {
+            action: "sign",
             subject: "UserWallet"
           }
         ]),
@@ -350,8 +426,22 @@ describe("WalletController", () => {
     rootContainer.register(BalancesService, {
       useValue: mock<BalancesService>()
     });
+    const userWalletRepository = mock<UserWalletRepository>({
+      findOneByUserId: jest.fn().mockResolvedValue(input?.userWallet)
+    });
     rootContainer.register(UserWalletRepository, {
-      useValue: mock<UserWalletRepository>()
+      useValue: userWalletRepository
+    });
+
+    const featureFlagImpl =
+      typeof input?.featureFlagEnabled === "function"
+        ? input.featureFlagEnabled
+        : () => (input?.featureFlagEnabled === undefined ? true : Boolean(input.featureFlagEnabled));
+    const featureFlagsService = mock<FeatureFlagsService>({
+      isEnabled: jest.fn().mockImplementation(featureFlagImpl)
+    });
+    rootContainer.register(FeatureFlagsService, {
+      useValue: featureFlagsService
     });
 
     return rootContainer;

--- a/apps/api/src/billing/controllers/wallet/wallet.controller.ts
+++ b/apps/api/src/billing/controllers/wallet/wallet.controller.ts
@@ -1,5 +1,6 @@
 import type { EncodeObject } from "@cosmjs/proto-signing";
 import assert from "http-assert";
+import createHttpError from "http-errors";
 import { Lifecycle, scoped } from "tsyringe";
 
 import { AuthService, Protected } from "@src/auth/services/auth.service";
@@ -123,6 +124,23 @@ export class WalletController {
 
   @Protected([{ action: "sign", subject: "UserWallet" }])
   async signTx({ data: { userId, messages } }: SignTxRequestInput): Promise<SignTxResponseOutput> {
+    if (this.featureFlagsService.isEnabled(FeatureFlags.CONSOLE_ONBOARDING_REDESIGN)) {
+      const wallet = await this.userWalletRepository.findOneByUserId(userId);
+
+      if (wallet?.status === "pending") {
+        throw createHttpError(503, "Wallet is still initializing", {
+          errorCode: "wallet_pending",
+          headers: { "Retry-After": "2" }
+        });
+      }
+
+      if (wallet?.status === "failed") {
+        throw createHttpError(500, "Wallet initialization failed", {
+          errorCode: "wallet_init_failed"
+        });
+      }
+    }
+
     return {
       data: (await this.signerService.executeDerivedEncodedTxByUserId(userId, messages as EncodeObject[])) as SignTxResponseOutput["data"]
     };

--- a/apps/api/src/billing/events/onboarding-started.ts
+++ b/apps/api/src/billing/events/onboarding-started.ts
@@ -1,0 +1,14 @@
+import { DOMAIN_EVENT_NAME, type DomainEvent } from "@src/core/services/domain-events/domain-events.service";
+import type { UserOutput } from "@src/user/repositories";
+
+export class OnboardingStarted implements DomainEvent {
+  static readonly [DOMAIN_EVENT_NAME] = "OnboardingStarted";
+  public readonly name = OnboardingStarted[DOMAIN_EVENT_NAME];
+  public readonly version = 1;
+
+  constructor(
+    public readonly data: {
+      userId: UserOutput["id"];
+    }
+  ) {}
+}

--- a/apps/api/src/billing/events/trial-activated.ts
+++ b/apps/api/src/billing/events/trial-activated.ts
@@ -1,0 +1,14 @@
+import { DOMAIN_EVENT_NAME, type DomainEvent } from "@src/core/services/domain-events/domain-events.service";
+import type { UserOutput } from "@src/user/repositories";
+
+export class TrialActivated implements DomainEvent {
+  static readonly [DOMAIN_EVENT_NAME] = "TrialActivated";
+  public readonly name = TrialActivated[DOMAIN_EVENT_NAME];
+  public readonly version = 1;
+
+  constructor(
+    public readonly data: {
+      userId: UserOutput["id"];
+    }
+  ) {}
+}

--- a/apps/api/src/billing/events/trial-ended.ts
+++ b/apps/api/src/billing/events/trial-ended.ts
@@ -1,0 +1,14 @@
+import { DOMAIN_EVENT_NAME, type DomainEvent } from "@src/core/services/domain-events/domain-events.service";
+import type { UserOutput } from "@src/user/repositories";
+
+export class TrialEnded implements DomainEvent {
+  static readonly [DOMAIN_EVENT_NAME] = "TrialEnded";
+  public readonly name = TrialEnded[DOMAIN_EVENT_NAME];
+  public readonly version = 1;
+
+  constructor(
+    public readonly data: {
+      userId: UserOutput["id"];
+    }
+  ) {}
+}

--- a/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
+++ b/apps/api/src/billing/model-schemas/user-wallet/user-wallet.schema.ts
@@ -1,6 +1,9 @@
-import { boolean, numeric, pgTable, serial, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
+import { boolean, numeric, pgEnum, pgTable, serial, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
 
 import { Users } from "@src/user/model-schemas"; // eslint-disable-line import-x/no-cycle
+
+export const userWalletStatusEnum = pgEnum("user_wallet_status", ["pending", "ready", "failed"]);
+export type UserWalletStatus = (typeof userWalletStatusEnum.enumValues)[number];
 
 export const UserWallets = pgTable("user_wallets", {
   id: serial("id").primaryKey(),
@@ -12,6 +15,7 @@ export const UserWallets = pgTable("user_wallets", {
   deploymentAllowance: allowance("deployment_allowance"),
   feeAllowance: allowance("fee_allowance"),
   isTrialing: boolean("trial").default(true),
+  status: userWalletStatusEnum("status").notNull().default("ready"),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull()
 });

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.integration.ts
@@ -1,0 +1,87 @@
+import { faker } from "@faker-js/faker";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { UserWalletStatus } from "@src/billing/model-schemas/user-wallet/user-wallet.schema";
+import type { ApiPgDatabase } from "@src/core";
+import { POSTGRES_DB, resolveTable } from "@src/core";
+import { UserRepository } from "@src/user/repositories";
+import { UserWalletRepository } from "./user-wallet.repository";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+
+describe(UserWalletRepository.name, () => {
+  const createdUserIds: string[] = [];
+  const createdWalletIds: number[] = [];
+
+  afterEach(async () => {
+    const userWalletRepository = container.resolve(UserWalletRepository);
+    const userRepository = container.resolve(UserRepository);
+
+    if (createdWalletIds.length > 0) {
+      await userWalletRepository.deleteById(createdWalletIds);
+    }
+    if (createdUserIds.length > 0) {
+      await userRepository.deleteById(createdUserIds);
+    }
+
+    createdWalletIds.length = 0;
+    createdUserIds.length = 0;
+  });
+
+  describe("findOneByUserId", () => {
+    it("returns wallet including status", async () => {
+      const { userWalletRepository, createTestWallet } = setup();
+      const wallet = await createTestWallet({ status: "pending" });
+
+      const found = await userWalletRepository.findOneByUserId(wallet.userId);
+
+      expect(found?.status).toBe("pending");
+    });
+  });
+
+  describe("updateStatus", () => {
+    it("updates status to failed via updateStatus", async () => {
+      const { userWalletRepository, createTestWallet } = setup();
+      const wallet = await createTestWallet({ status: "pending" });
+
+      await userWalletRepository.updateStatus(wallet.id, "failed");
+
+      const found = await userWalletRepository.findOneByUserId(wallet.userId);
+      expect(found?.status).toBe("failed");
+    });
+  });
+
+  function setup() {
+    const userWalletRepository = container.resolve(UserWalletRepository);
+    const userRepository = container.resolve(UserRepository);
+    const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+    const userWalletsTable = resolveTable("UserWallets");
+
+    async function createTestWallet(overrides: { status?: UserWalletStatus; address?: string } = {}) {
+      const user = await userRepository.create({
+        id: faker.string.uuid(),
+        userId: faker.string.uuid(),
+        username: `testuser_${Date.now()}_${faker.string.alphanumeric(6)}`,
+        email: faker.internet.email(),
+        emailVerified: false,
+        subscribedToNewsletter: false
+      });
+      createdUserIds.push(user.id);
+
+      const [wallet] = await db
+        .insert(userWalletsTable)
+        .values({
+          userId: user.id,
+          address: overrides.address ?? createAkashAddress(),
+          status: overrides.status
+        })
+        .returning();
+      createdWalletIds.push(wallet.id);
+
+      return wallet;
+    }
+
+    return { userWalletRepository, createTestWallet };
+  }
+});

--- a/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
+++ b/apps/api/src/billing/repositories/user-wallet/user-wallet.repository.ts
@@ -2,6 +2,7 @@ import subDays from "date-fns/subDays";
 import { and, count, eq, gt, inArray, lte, or } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
+import type { UserWalletStatus } from "@src/billing/model-schemas/user-wallet/user-wallet.schema";
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
 import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
@@ -70,10 +71,11 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
     return { wallet: wallet!, isNew: false };
   }
 
-  async create(input: Pick<DbCreateUserWalletInput, "userId" | "address">) {
+  async create(input: Pick<DbCreateUserWalletInput, "userId" | "address" | "status">) {
     const value = {
       userId: input.userId,
-      address: input.address
+      address: input.address,
+      ...(input.status !== undefined && { status: input.status })
     };
 
     this.ability?.throwUnlessCanExecute(value);
@@ -121,6 +123,11 @@ export class UserWalletRepository extends BaseRepository<ApiPgTables["UserWallet
   async findByUserId(userId: UserWalletOutput["userId"] | UserWalletOutput["userId"][]) {
     const where = Array.isArray(userId) ? inArray(this.table.userId, userId as string[]) : eq(this.table.userId, userId as string);
     return this.toOutputList(await this.cursor.query.UserWallets.findMany({ where: this.whereAccessibleBy(where) }));
+  }
+
+  @Trace()
+  async updateStatus(id: UserWalletOutput["id"], status: UserWalletStatus): Promise<void> {
+    await this.cursor.update(this.table).set({ status }).where(eq(this.table.id, id));
   }
 
   async payingUserCount() {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -22,6 +22,7 @@ import type { LoggerService } from "@src/core";
 import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import type { FeatureFlagValue } from "@src/core/services/feature-flags/feature-flags";
 import type { UserOutput, UserRepository } from "@src/user/repositories";
+import type { AccountStageService } from "@src/user/services/account-stage/account-stage.service";
 import { createAkashAddress } from "../../../../test/seeders";
 import type { TxManagerService } from "../tx-manager/tx-manager.service";
 import { ManagedSignerService } from "./managed-signer.service";
@@ -60,7 +61,7 @@ describe(ManagedSignerService.name, () => {
       const wallet = createUserWallet({ userId: "user-123", feeAllowance: 0 });
       const { service } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
+        findByUserId: jest.fn().mockResolvedValue(user),
         retrieveAndCalcFeeLimit: jest.fn().mockResolvedValue(0)
       });
 
@@ -81,7 +82,7 @@ describe(ManagedSignerService.name, () => {
 
       const { service } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
+        findByUserId: jest.fn().mockResolvedValue(user),
         retrieveDeploymentLimit: jest.fn().mockResolvedValue(0)
       });
 
@@ -108,7 +109,7 @@ describe(ManagedSignerService.name, () => {
 
       const { service, anonymousValidateService } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
+        findByUserId: jest.fn().mockResolvedValue(user),
         enabledFeatures: [],
         signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
           code: 0,
@@ -151,7 +152,7 @@ describe(ManagedSignerService.name, () => {
 
       const { service, txManagerService, balancesService } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
+        findByUserId: jest.fn().mockResolvedValue(user),
         signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue(txResult),
         refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined)
       });
@@ -192,7 +193,7 @@ describe(ManagedSignerService.name, () => {
       const hasLeases = jest.fn();
       const { service, domainEvents } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
+        findByUserId: jest.fn().mockResolvedValue(user),
         enabledFeatures: [],
         signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
           code: 0,
@@ -253,7 +254,7 @@ describe(ManagedSignerService.name, () => {
 
       const { service, chainErrorService } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
+        findByUserId: jest.fn().mockResolvedValue(user),
         signAndBroadcastWithDerivedWallet: jest.fn().mockRejectedValue(chainError),
         transformChainError: jest.fn().mockResolvedValue(new Error("App error"))
       });
@@ -263,7 +264,7 @@ describe(ManagedSignerService.name, () => {
       expect(chainErrorService.toAppError).toHaveBeenCalledWith(chainError, messages);
     });
 
-    it("uses current user when userId matches auth currentUser", async () => {
+    it("fetches user from repository for lease messages even when userId matches auth currentUser", async () => {
       const currentUser = createUser({ userId: "user-123" });
       const wallet = createUserWallet({ userId: "user-123", feeAllowance: 100 });
       const messages: EncodeObject[] = [
@@ -279,6 +280,7 @@ describe(ManagedSignerService.name, () => {
 
       const { service, userRepository } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
+        findByUserId: jest.fn().mockResolvedValue(currentUser),
         currentUser,
         signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
           code: 0,
@@ -290,7 +292,7 @@ describe(ManagedSignerService.name, () => {
 
       await service.executeDerivedDecodedTxByUserId("user-123", messages);
 
-      expect(userRepository.findById).not.toHaveBeenCalled();
+      expect(userRepository.findByUserId).toHaveBeenCalledWith("user-123");
     });
 
     it("validates lease provider for all leases regardless of trial status", async () => {
@@ -315,7 +317,7 @@ describe(ManagedSignerService.name, () => {
 
       const { service, anonymousValidateService } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
+        findByUserId: jest.fn().mockResolvedValue(user),
         validateLeaseProvidersAuditors: jest.fn().mockResolvedValue(undefined),
         signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
           code: 0,
@@ -352,7 +354,7 @@ describe(ManagedSignerService.name, () => {
 
       const { service, anonymousValidateService } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
+        findByUserId: jest.fn().mockResolvedValue(user),
         validateLeaseProvidersAuditors: jest.fn().mockResolvedValue(undefined),
         signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
           code: 0,
@@ -365,6 +367,42 @@ describe(ManagedSignerService.name, () => {
       await service.executeDerivedDecodedTxByUserId("user-123", messages);
 
       expect(anonymousValidateService.validateLeaseProvidersAuditors).toHaveBeenCalledWith(messages, wallet);
+    });
+
+    it("calls accountStageService.activateTrial with the user when MsgCreateLease is in the batch", async () => {
+      const user = createUser({ id: "user-1", stage: "onboarding" });
+      const wallet = createUserWallet({ userId: "user-1" });
+      const leaseMessage = { typeUrl: MsgCreateLease.$type, value: MsgCreateLease.fromPartial({ bidId: { dseq: 123 } }) };
+
+      const { service, accountStageService } = setup({
+        findOneByUserId: jest.fn().mockResolvedValue(wallet),
+        findByUserId: jest.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({ code: 0, transactionHash: "hash" }),
+        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined)
+      });
+
+      await service.executeDerivedDecodedTxByUserId("user-1", [leaseMessage]);
+
+      expect(accountStageService.activateTrial).toHaveBeenCalledWith(user);
+    });
+
+    it("does not fetch the user or call activateTrial when no MsgCreateLease is in the batch", async () => {
+      const wallet = createUserWallet({ userId: "user-1" });
+      const deploymentMessage = { typeUrl: MsgCreateDeployment.$type, value: MsgCreateDeployment.fromPartial({}) };
+
+      const findByUserId = jest.fn();
+      const { service, accountStageService } = setup({
+        findOneByUserId: jest.fn().mockResolvedValue(wallet),
+        findByUserId,
+        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({ code: 0, transactionHash: "hash" }),
+        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined),
+        retrieveDeploymentLimit: jest.fn().mockResolvedValue(5000000)
+      });
+
+      await service.executeDerivedDecodedTxByUserId("user-1", [deploymentMessage]);
+
+      expect(findByUserId).not.toHaveBeenCalled();
+      expect(accountStageService.activateTrial).not.toHaveBeenCalled();
     });
   });
 
@@ -383,7 +421,7 @@ describe(ManagedSignerService.name, () => {
 
       const { service, walletReloadJobService } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
+        findByUserId: jest.fn().mockResolvedValue(user),
         signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
           code: 0,
           hash: "tx-hash",
@@ -411,7 +449,7 @@ describe(ManagedSignerService.name, () => {
 
       const { service, walletReloadJobService } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
+        findByUserId: jest.fn().mockResolvedValue(user),
         signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
           code: 0,
           hash: "tx-hash",
@@ -440,7 +478,7 @@ describe(ManagedSignerService.name, () => {
 
       const { service, walletReloadJobService } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
+        findByUserId: jest.fn().mockResolvedValue(user),
         signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
           code: 0,
           hash: "tx-hash",
@@ -521,7 +559,7 @@ describe(ManagedSignerService.name, () => {
 
       const { service } = setup({
         findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
+        findByUserId: jest.fn().mockResolvedValue(user),
         signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
           code: 0,
           hash: "",
@@ -538,7 +576,7 @@ describe(ManagedSignerService.name, () => {
 
   function setup(input?: {
     findOneByUserId?: UserWalletRepository["findOneByUserId"];
-    findById?: UserRepository["findById"];
+    findByUserId?: UserRepository["findByUserId"];
     currentUser?: UserOutput;
     enabledFeatures?: FeatureFlagValue[];
     validateLeaseProviders?: TrialValidationService["validateLeaseProviders"];
@@ -553,6 +591,7 @@ describe(ManagedSignerService.name, () => {
     transformChainError?: ChainErrorService["toAppError"];
     hasLeases?: LeaseHttpService["hasLeases"];
     decode?: Registry["decode"];
+    activateTrial?: AccountStageService["activateTrial"];
   }) {
     const mocks = {
       userWalletRepository: mock<UserWalletRepository>({
@@ -560,7 +599,7 @@ describe(ManagedSignerService.name, () => {
         findOneByUserId: input?.findOneByUserId ?? jest.fn()
       }),
       userRepository: mock<UserRepository>({
-        findById: input?.findById ?? jest.fn()
+        findByUserId: input?.findByUserId ?? jest.fn()
       }),
       balancesService: mock<BalancesService>({
         refreshUserWalletLimits: input?.refreshUserWalletLimits ?? jest.fn(),
@@ -599,6 +638,9 @@ describe(ManagedSignerService.name, () => {
       managedUserWalletService: mock<ManagedUserWalletService>({
         refillWalletFees: jest.fn()
       }),
+      accountStageService: mock<AccountStageService>({
+        activateTrial: input?.activateTrial ?? jest.fn()
+      }),
       logger: mock<LoggerService>({
         setContext: jest.fn(),
         error: jest.fn()
@@ -623,6 +665,7 @@ describe(ManagedSignerService.name, () => {
       mocks.leaseHttpService,
       mocks.walletReloadJobService,
       mocks.managedUserWalletService,
+      mocks.accountStageService,
       mocks.logger
     );
 

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -22,6 +22,7 @@ import { LoggerService } from "@src/core";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { Trace, withSpan } from "@src/core/services/tracing/tracing.service";
 import { UserRepository } from "@src/user/repositories";
+import { AccountStageService } from "@src/user/services/account-stage/account-stage.service";
 import { BalancesService } from "../balances/balances.service";
 import { BillingConfigService } from "../billing-config/billing-config.service";
 import { ChainErrorService } from "../chain-error/chain-error.service";
@@ -47,6 +48,7 @@ export class ManagedSignerService {
     private readonly leaseHttpService: LeaseHttpService,
     private readonly walletReloadJobService: WalletReloadJobService,
     private readonly managedUserWalletService: ManagedUserWalletService,
+    private readonly accountStageService: AccountStageService,
     private readonly logger: LoggerService
   ) {
     this.logger.setContext(ManagedSignerService.name);
@@ -138,6 +140,10 @@ export class ManagedSignerService {
           dseq: createLeaseMessage.value.bidId!.dseq.toString()
         })
       );
+      const user = await this.userRepository.findByUserId(userWallet.userId);
+      if (user) {
+        await this.accountStageService.activateTrial(user);
+      }
     }
 
     await this.balancesService.refreshUserWalletLimits(userWallet);

--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.ts
@@ -64,6 +64,24 @@ export class ManagedUserWalletService {
     return { address, limits };
   }
 
+  async createAndAuthorizeOnboardingGrant(
+    signer: ManagedSignerService,
+    { addressIndex, deploymentAllowance, feeAllowance }: { addressIndex: number; deploymentAllowance: number; feeAllowance: number }
+  ) {
+    const address = await this.txManagerService.getDerivedWalletAddress(addressIndex);
+
+    const limits = {
+      deployment: deploymentAllowance,
+      fees: feeAllowance
+    };
+    await this.authorizeSpending(signer, {
+      address,
+      limits
+    });
+
+    return { address, limits };
+  }
+
   async createWallet({ addressIndex }: { addressIndex: number }) {
     const address = await this.txManagerService.getDerivedWalletAddress(addressIndex);
     this.logger.debug({ event: "WALLET_CREATED", address });

--- a/apps/api/src/billing/services/refill/refill.service.spec.ts
+++ b/apps/api/src/billing/services/refill/refill.service.spec.ts
@@ -7,6 +7,7 @@ import type { BalancesService } from "@src/billing/services/balances/balances.se
 import { RefillService } from "@src/billing/services/refill/refill.service";
 import type { WalletInitializerService } from "@src/billing/services/wallet-initializer/wallet-initializer.service";
 import type { AnalyticsService } from "@src/core/services/analytics/analytics.service";
+import type { AccountStageService } from "@src/user/services/account-stage/account-stage.service";
 
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
@@ -72,6 +73,45 @@ describe(RefillService.name, () => {
       expect(analyticsService.track).toHaveBeenCalledWith(userId, "balance_top_up");
     });
 
+    it("calls AccountStageService.endTrial when endTrial is true", async () => {
+      const { service, accountStageService, userWalletRepository, managedUserWalletService, balancesService } = setup();
+      const existingWallet = createUserWallet({ userId });
+      userWalletRepository.findOneBy.mockResolvedValue(existingWallet);
+      managedUserWalletService.authorizeSpending.mockResolvedValue();
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(0);
+      balancesService.refreshUserWalletLimits.mockResolvedValue();
+
+      await service.topUpWallet(10, "user-1", { endTrial: true });
+
+      expect(accountStageService.endTrial).toHaveBeenCalledWith("user-1");
+    });
+
+    it("does not call endTrial when endTrial is explicitly false", async () => {
+      const { service, accountStageService, userWalletRepository, managedUserWalletService, balancesService } = setup();
+      const existingWallet = createUserWallet({ userId });
+      userWalletRepository.findOneBy.mockResolvedValue(existingWallet);
+      managedUserWalletService.authorizeSpending.mockResolvedValue();
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(0);
+      balancesService.refreshUserWalletLimits.mockResolvedValue();
+
+      await service.topUpWallet(10, "user-1", { endTrial: false });
+
+      expect(accountStageService.endTrial).not.toHaveBeenCalled();
+    });
+
+    it("calls endTrial when endTrial is omitted (defaults to true)", async () => {
+      const { service, accountStageService, userWalletRepository, managedUserWalletService, balancesService } = setup();
+      const existingWallet = createUserWallet({ userId });
+      userWalletRepository.findOneBy.mockResolvedValue(existingWallet);
+      managedUserWalletService.authorizeSpending.mockResolvedValue();
+      balancesService.retrieveDeploymentLimit.mockResolvedValue(0);
+      balancesService.refreshUserWalletLimits.mockResolvedValue();
+
+      await service.topUpWallet(10, "user-1");
+
+      expect(accountStageService.endTrial).toHaveBeenCalledWith("user-1");
+    });
+
     function setup() {
       const billingConfig = mock<BillingConfig>();
       const userWalletRepository = mock<UserWalletRepository>();
@@ -80,6 +120,7 @@ describe(RefillService.name, () => {
       const balancesService = mock<BalancesService>();
       const walletInitializerService = mock<WalletInitializerService>();
       const analyticsService = mock<AnalyticsService>();
+      const accountStageService = mock<AccountStageService>();
 
       billingConfig.FEE_ALLOWANCE_REFILL_AMOUNT = 1000;
 
@@ -90,7 +131,8 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService
+        analyticsService,
+        accountStageService
       );
 
       return {
@@ -101,7 +143,8 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService
+        analyticsService,
+        accountStageService
       };
     }
   });
@@ -183,6 +226,7 @@ describe(RefillService.name, () => {
       const balancesService = mock<BalancesService>();
       const walletInitializerService = mock<WalletInitializerService>();
       const analyticsService = mock<AnalyticsService>();
+      const accountStageService = mock<AccountStageService>();
 
       billingConfig.FEE_ALLOWANCE_REFILL_AMOUNT = 1000;
 
@@ -193,7 +237,8 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService
+        analyticsService,
+        accountStageService
       );
 
       return {
@@ -204,7 +249,8 @@ describe(RefillService.name, () => {
         managedSignerService,
         balancesService,
         walletInitializerService,
-        analyticsService
+        analyticsService,
+        accountStageService
       };
     }
   });

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -11,6 +11,7 @@ import { ManagedSignerService } from "@src/billing/services/managed-signer/manag
 import { ManagedUserWalletService } from "@src/billing/services/managed-user-wallet/managed-user-wallet.service";
 import { WalletInitializerService } from "@src/billing/services/wallet-initializer/wallet-initializer.service";
 import { AnalyticsService } from "@src/core/services/analytics/analytics.service";
+import { AccountStageService } from "@src/user/services/account-stage/account-stage.service";
 
 @singleton()
 export class RefillService {
@@ -23,7 +24,8 @@ export class RefillService {
     private readonly managedSignerService: ManagedSignerService,
     private readonly balancesService: BalancesService,
     private readonly walletInitializerService: WalletInitializerService,
-    private readonly analyticsService: AnalyticsService
+    private readonly analyticsService: AnalyticsService,
+    private readonly accountStageService: AccountStageService
   ) {}
 
   async refillAllFees() {
@@ -78,6 +80,10 @@ export class RefillService {
     await this.balancesService.refreshUserWalletLimits(userWallet, { endTrial: options.endTrial ?? true });
     this.analyticsService.track(userId, "balance_top_up");
     this.logger.debug({ event: "WALLET_TOP_UP", userWallet, limits });
+
+    if (options.endTrial ?? true) {
+      await this.accountStageService.endTrial(userId);
+    }
   }
 
   /**

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
@@ -56,7 +56,7 @@ describe(StripeWebhookService.name, () => {
         receiptUrl: "https://receipt.url",
         stripePaymentIntentId: paymentIntentId
       });
-      expect(refillService.topUpWallet).toHaveBeenCalledWith(amount, mockUser.id, { endTrial: undefined });
+      expect(refillService.topUpWallet).toHaveBeenCalledWith(amount, mockUser.id, { endTrial: true });
     });
 
     it("returns early when customer ID is missing", async () => {
@@ -147,7 +147,7 @@ describe(StripeWebhookService.name, () => {
       await service.tryToTopUpWalletFromPaymentIntent(event);
 
       expect(stripeTransactionRepository.findById).toHaveBeenCalledWith(internalTransaction.id);
-      expect(refillService.topUpWallet).toHaveBeenCalledWith(amount, mockUser.id, { endTrial: undefined });
+      expect(refillService.topUpWallet).toHaveBeenCalledWith(amount, mockUser.id, { endTrial: true });
       expect(stripeTransactionRepository.updateById).toHaveBeenCalledWith(
         "tx-123",
         expect.objectContaining({
@@ -155,6 +155,32 @@ describe(StripeWebhookService.name, () => {
           stripePaymentIntentId: "pi_123"
         })
       );
+    });
+
+    it("does not end trial when transaction is a coupon claim", async () => {
+      const { service, userRepository, stripeTransactionRepository, refillService } = setup();
+      const mockUser = createTestUser();
+      const paymentIntentId = "pi_123";
+      const amount = 10000;
+      const internalTransaction = createMockTransaction({ status: "created", type: "coupon_claim" });
+
+      userRepository.findOneBy.mockResolvedValue(mockUser);
+      stripeTransactionRepository.findById.mockResolvedValue(internalTransaction);
+      stripeTransactionRepository.findOneByAndLock.mockResolvedValue(internalTransaction);
+
+      const event = createPaymentIntentSucceededEvent({
+        id: paymentIntentId,
+        customer: mockUser.stripeCustomerId,
+        amount,
+        amount_received: amount,
+        metadata: {
+          internal_transaction_id: internalTransaction.id
+        }
+      });
+
+      await service.tryToTopUpWalletFromPaymentIntent(event);
+
+      expect(refillService.topUpWallet).toHaveBeenCalledWith(amount, mockUser.id, { endTrial: false });
     });
   });
 

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
@@ -130,6 +130,7 @@ export class StripeWebhookService {
       : undefined;
 
     const paymentAmount = paymentIntent.amount_received ?? paymentIntent.amount;
+    const endTrial = transaction.type !== "coupon_claim";
 
     await this.topUpWalletFromTransaction({
       customerId,
@@ -138,7 +139,8 @@ export class StripeWebhookService {
       paymentMethodType: paymentIntent.payment_method_types?.[0],
       paymentAmount,
       stripePaymentIntentId: paymentIntent.id,
-      eventDescription: `payment_intent ${paymentIntent.id}`
+      eventDescription: `payment_intent ${paymentIntent.id}`,
+      endTrial
     });
   }
 

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
@@ -5,7 +5,9 @@ import { mock } from "vitest-mock-extended";
 
 import { AuthService } from "@src/auth/services/auth.service";
 import { TrialStarted } from "@src/billing/events/trial-started";
+import { BILLING_CONFIG, type BillingConfig } from "@src/billing/providers/config.provider";
 import { TYPE_REGISTRY } from "@src/billing/providers/type-registry.provider";
+import { LoggerService } from "@src/core/providers/logging.provider";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { ProviderJwtTokenService } from "@src/provider/services/provider-jwt-token/provider-jwt-token.service";
 import { UserWalletRepository } from "../../repositories/user-wallet/user-wallet.repository";
@@ -42,7 +44,8 @@ describe(WalletInitializerService.name, () => {
         {
           address: chainWallet.address,
           deploymentAllowance: chainWallet.limits.deployment,
-          feeAllowance: chainWallet.limits.fees
+          feeAllowance: chainWallet.limits.fees,
+          status: "ready"
         },
         expect.any(Object)
       );
@@ -104,11 +107,79 @@ describe(WalletInitializerService.name, () => {
     });
   });
 
+  describe("initializeForOnboarding", () => {
+    it("writes status='pending' before granting, then flips to 'ready' on success", async () => {
+      const userId = "user-1";
+      const pendingWallet = createUserWallet({ id: 1, userId, status: "pending" });
+      const chainWallet = createChainWallet();
+      const readyWallet = createUserWallet({
+        id: 1,
+        userId,
+        status: "ready",
+        address: chainWallet.address,
+        deploymentAllowance: 50000,
+        feeAllowance: 1000000
+      });
+      const createWallet = jest.fn().mockResolvedValue(pendingWallet);
+      const updateWalletById = jest.fn().mockResolvedValue(readyWallet);
+      const updateWalletStatus = jest.fn().mockResolvedValue(undefined);
+
+      const di = setup({
+        createWallet,
+        updateWalletById,
+        updateWalletStatus,
+        billingConfig: { FEE_ALLOWANCE_REFILL_AMOUNT: 1000000 } as BillingConfig
+      });
+      const managedUserWalletService = di.resolve(ManagedUserWalletService) as MockProxy<ManagedUserWalletService>;
+      managedUserWalletService.createAndAuthorizeOnboardingGrant.mockResolvedValue({
+        address: chainWallet.address,
+        limits: { deployment: 50000, fees: 1000000 }
+      });
+
+      const result = await di.resolve(WalletInitializerService).initializeForOnboarding(userId);
+
+      expect(createWallet).toHaveBeenCalledWith({ userId, status: "pending" });
+      expect(managedUserWalletService.createAndAuthorizeOnboardingGrant).toHaveBeenCalledWith(di.resolve(ManagedSignerService), {
+        addressIndex: pendingWallet.id,
+        deploymentAllowance: 50000,
+        feeAllowance: 1000000
+      });
+      expect(updateWalletById).toHaveBeenCalledWith(
+        pendingWallet.id,
+        expect.objectContaining({ status: "ready", address: chainWallet.address, deploymentAllowance: 50000, feeAllowance: 1000000 }),
+        expect.any(Object)
+      );
+      expect(updateWalletStatus).not.toHaveBeenCalled();
+      expect(result.status).toBe("ready");
+    });
+
+    it("flips status to 'failed' and rethrows when chain work fails", async () => {
+      const userId = "user-1";
+      const pendingWallet = createUserWallet({ id: 1, userId, status: "pending" });
+      const createWallet = jest.fn().mockResolvedValue(pendingWallet);
+      const updateWalletStatus = jest.fn().mockResolvedValue(undefined);
+
+      const di = setup({
+        createWallet,
+        updateWalletStatus
+      });
+      const managedUserWalletService = di.resolve(ManagedUserWalletService) as MockProxy<ManagedUserWalletService>;
+      managedUserWalletService.createAndAuthorizeOnboardingGrant.mockRejectedValue(new Error("chain failed"));
+
+      await expect(di.resolve(WalletInitializerService).initializeForOnboarding(userId)).rejects.toThrow("chain failed");
+
+      expect(updateWalletStatus).toHaveBeenCalledWith(pendingWallet.id, "failed");
+    });
+  });
+
   function setup(input?: {
     getOrCreateWallet?: UserWalletRepository["getOrCreate"];
+    createWallet?: UserWalletRepository["create"];
     updateWalletById?: UserWalletRepository["updateById"];
+    updateWalletStatus?: UserWalletRepository["updateStatus"];
     deleteWalletById?: UserWalletRepository["deleteById"];
     userId?: string;
+    billingConfig?: BillingConfig;
   }) {
     const di = container.createChildContainer();
     di.registerInstance(TYPE_REGISTRY, new Registry());
@@ -117,7 +188,9 @@ describe(WalletInitializerService.name, () => {
       UserWalletRepository,
       mock<UserWalletRepository>({
         getOrCreate: input?.getOrCreateWallet,
+        create: input?.createWallet,
         updateById: input?.updateWalletById,
+        updateStatus: input?.updateWalletStatus ?? jest.fn(),
         deleteById: input?.deleteWalletById ?? jest.fn(),
         accessibleBy() {
           return this as unknown as UserWalletRepository;
@@ -143,6 +216,8 @@ describe(WalletInitializerService.name, () => {
       })
     );
     di.registerInstance(ManagedSignerService, mock<ManagedSignerService>());
+    di.registerInstance(LoggerService, mock<LoggerService>());
+    di.registerInstance(BILLING_CONFIG, input?.billingConfig ?? ({ FEE_ALLOWANCE_REFILL_AMOUNT: 1000000 } as BillingConfig));
 
     container.clearInstances();
 

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
@@ -2,11 +2,18 @@ import { singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
 import { TrialStarted } from "@src/billing/events/trial-started";
-import { UserWalletPublicOutput, UserWalletRepository } from "@src/billing/repositories";
+import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
+import { UserWalletOutput, UserWalletPublicOutput, UserWalletRepository } from "@src/billing/repositories";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import { LoggerService } from "@src/core/providers/logging.provider";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wallet.service";
+
+/**
+ * Onboarding deployment allowance in cents-with-4-decimal-precision ($5 = 50000).
+ */
+const ONBOARDING_DEPLOYMENT_ALLOWANCE_AMOUNT = 50000;
 
 @singleton()
 export class WalletInitializerService {
@@ -16,7 +23,9 @@ export class WalletInitializerService {
     private readonly userWalletRepository: UserWalletRepository,
     private readonly authService: AuthService,
     private readonly domainEvents: DomainEventsService,
-    private readonly featureFlagsService: FeatureFlagsService
+    private readonly featureFlagsService: FeatureFlagsService,
+    @InjectBillingConfig() private readonly billingConfig: BillingConfig,
+    private readonly logger: LoggerService
   ) {}
 
   async initializeAndGrantTrialLimits(userId: string): Promise<UserWalletPublicOutput> {
@@ -32,7 +41,8 @@ export class WalletInitializerService {
         {
           address: wallet.address,
           deploymentAllowance: wallet.limits.deployment,
-          feeAllowance: wallet.limits.fees
+          feeAllowance: wallet.limits.fees,
+          status: "ready"
         },
         { returning: true }
       );
@@ -51,13 +61,44 @@ export class WalletInitializerService {
     return walletOutput;
   }
 
+  async initializeForOnboarding(userId: UserWalletOutput["userId"]): Promise<UserWalletOutput> {
+    const wallet = await this.userWalletRepository.create({ userId, status: "pending" });
+    const deploymentAllowance = ONBOARDING_DEPLOYMENT_ALLOWANCE_AMOUNT;
+    const feeAllowance = this.billingConfig.FEE_ALLOWANCE_REFILL_AMOUNT;
+
+    try {
+      const grantResult = await this.walletManager.createAndAuthorizeOnboardingGrant(this.managedSignerService, {
+        addressIndex: wallet.id,
+        deploymentAllowance,
+        feeAllowance
+      });
+      const updated = await this.userWalletRepository.updateById(
+        wallet.id,
+        {
+          address: grantResult.address,
+          deploymentAllowance,
+          feeAllowance,
+          status: "ready"
+        },
+        { returning: true }
+      );
+      this.logger.info({ event: "ONBOARDING_WALLET_READY", userId, walletId: wallet.id });
+      return updated;
+    } catch (error) {
+      await this.userWalletRepository.updateStatus(wallet.id, "failed");
+      this.logger.error({ event: "ONBOARDING_WALLET_FAILED", userId, walletId: wallet.id, error });
+      throw error;
+    }
+  }
+
   async initialize(userId: string) {
     const { id } = await this.userWalletRepository.create({ userId });
     const wallet = await this.walletManager.createWallet({ addressIndex: id });
     return await this.userWalletRepository.updateById(
       id,
       {
-        address: wallet.address
+        address: wallet.address,
+        status: "ready"
       },
       { returning: true }
     );

--- a/apps/api/src/core/services/domain-events/domain-events.service.spec.ts
+++ b/apps/api/src/core/services/domain-events/domain-events.service.spec.ts
@@ -1,36 +1,145 @@
-import type { LoggerService } from "@akashnetwork/logging";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { JobQueueService } from "../job-queue/job-queue.service";
+import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { JobQueueService, PgBossJobState } from "../job-queue/job-queue.service";
+import type { TimerService } from "../timer/timer.service";
 import type { DomainEvent } from "./domain-events.service";
 import { DomainEventsService } from "./domain-events.service";
 
 describe(DomainEventsService.name, () => {
   describe("publish()", () => {
     it("enqueues the event successfully", async () => {
-      class TestEvent implements DomainEvent {
-        version = 1;
-        name = "testEvent";
-        data = { key: "value" };
-      }
-
       const { service, jobQueueManager } = setup();
-      const event = new TestEvent();
-      const jobId = "12345";
-      jobQueueManager.enqueue.mockResolvedValue(jobId);
+      const event = createTestEvent();
+      jobQueueManager.enqueue.mockResolvedValue("12345");
 
       const result = await service.publish(event);
 
-      expect(result).toBe(jobId);
+      expect(result).toBe("12345");
       expect(jobQueueManager.enqueue).toHaveBeenCalledWith(event, undefined);
+    });
+
+    it("returns null and logs when enqueue throws", async () => {
+      const { service, jobQueueManager, logger } = setup();
+      const event = createTestEvent();
+      const error = new Error("boom");
+      jobQueueManager.enqueue.mockRejectedValue(error);
+
+      const result = await service.publish(event);
+
+      expect(result).toBeNull();
+      expect(logger.error).toHaveBeenCalledWith({
+        event: "DOMAIN_EVENT_PUBLISH_FAILED",
+        domainEvent: event,
+        error
+      });
+    });
+  });
+
+  describe("publishAndAwait()", () => {
+    it("returns 'completed' when the job's state flips to completed before timeout", async () => {
+      const { service, jobQueueManager } = setup();
+      const event = createTestEvent();
+      const output = { ok: true };
+      jobQueueManager.enqueue.mockResolvedValue("job-1");
+      jobQueueManager.getJobState.mockResolvedValueOnce({ state: "active", output: {} }).mockResolvedValueOnce({ state: "completed", output });
+
+      const result = await service.publishAndAwait(event, { timeoutMs: 1_000, pollIntervalMs: 10 });
+
+      expect(result).toEqual({ status: "completed", jobId: "job-1", output });
+      expect(jobQueueManager.getJobState).toHaveBeenCalledWith("testEvent", "job-1");
+    });
+
+    it.each([["failed"], ["cancelled"], ["expired"]] as const)("returns 'failed' when the job's state is %s (terminal failure)", async stateName => {
+      const { service, jobQueueManager } = setup();
+      const event = createTestEvent();
+      jobQueueManager.enqueue.mockResolvedValue("job-2");
+      jobQueueManager.getJobState.mockResolvedValue({
+        state: stateName as PgBossJobState,
+        output: { reason: "x" }
+      });
+
+      const result = await service.publishAndAwait(event, { timeoutMs: 1_000, pollIntervalMs: 10 });
+
+      expect(result).toEqual({ status: "failed", jobId: "job-2", output: { reason: "x" } });
+    });
+
+    it("returns 'timeout' and logs JOB_AWAIT_TIMEOUT when state stays non-terminal past timeoutMs", async () => {
+      const nowSpy = vi.spyOn(Date, "now");
+      let current = 0;
+      nowSpy.mockImplementation(() => current);
+
+      const { service, jobQueueManager, timer, logger } = setup();
+      const event = createTestEvent();
+      jobQueueManager.enqueue.mockResolvedValue("job-3");
+      jobQueueManager.getJobState.mockResolvedValue({ state: "active", output: {} });
+      timer.delay.mockImplementation(async (ms: number) => {
+        current += ms;
+      });
+
+      const result = await service.publishAndAwait(event, { timeoutMs: 100, pollIntervalMs: 50 });
+
+      expect(result).toEqual({ status: "timeout", jobId: "job-3" });
+      expect(logger.warn).toHaveBeenCalledWith({
+        event: "JOB_AWAIT_TIMEOUT",
+        jobId: "job-3",
+        name: "testEvent",
+        timeoutMs: 100
+      });
+      expect(jobQueueManager.cancel).not.toHaveBeenCalled();
+
+      nowSpy.mockRestore();
+    });
+
+    it("uses default 250ms poll interval when pollIntervalMs is not provided", async () => {
+      const { service, jobQueueManager, timer } = setup();
+      const event = createTestEvent();
+      jobQueueManager.enqueue.mockResolvedValue("job-4");
+      jobQueueManager.getJobState.mockResolvedValueOnce({ state: "active", output: {} }).mockResolvedValueOnce({ state: "completed", output: {} });
+
+      await service.publishAndAwait(event, { timeoutMs: 5_000 });
+
+      expect(timer.delay).toHaveBeenCalledWith(250);
+    });
+
+    it("returns { status: 'failed', jobId: '' } when publish fails to enqueue", async () => {
+      const { service, jobQueueManager } = setup();
+      const event = createTestEvent();
+      jobQueueManager.enqueue.mockRejectedValue(new Error("db down"));
+
+      const result = await service.publishAndAwait(event, { timeoutMs: 1_000, pollIntervalMs: 10 });
+
+      expect(result).toEqual({ status: "failed", jobId: "" });
+      expect(jobQueueManager.getJobState).not.toHaveBeenCalled();
+      expect(jobQueueManager.cancel).not.toHaveBeenCalled();
+    });
+
+    it("treats a null state snapshot (job not found yet) as non-terminal and keeps polling", async () => {
+      const { service, jobQueueManager, timer } = setup();
+      const event = createTestEvent();
+      jobQueueManager.enqueue.mockResolvedValue("job-5");
+      jobQueueManager.getJobState.mockResolvedValueOnce(null).mockResolvedValueOnce({ state: "completed", output: {} });
+
+      const result = await service.publishAndAwait(event, { timeoutMs: 1_000, pollIntervalMs: 10 });
+
+      expect(result.status).toBe("completed");
+      expect(timer.delay).toHaveBeenCalledTimes(1);
+      expect(timer.delay).toHaveBeenCalledWith(10);
     });
   });
 
   function setup() {
     const jobQueueManager = mock<JobQueueService>();
     const logger = mock<LoggerService>();
-    const service = new DomainEventsService(jobQueueManager, logger);
-    return { service, jobQueueManager, logger };
+    const timer = mock<TimerService>({
+      delay: vi.fn().mockResolvedValue(undefined)
+    });
+    const service = new DomainEventsService(jobQueueManager, logger, timer);
+    return { service, jobQueueManager, logger, timer };
+  }
+
+  function createTestEvent(): DomainEvent {
+    return { version: 1, name: "testEvent", data: { key: "value" } };
   }
 });

--- a/apps/api/src/core/services/domain-events/domain-events.service.ts
+++ b/apps/api/src/core/services/domain-events/domain-events.service.ts
@@ -2,17 +2,31 @@ import { singleton } from "tsyringe";
 
 import { LoggerService } from "../../providers/logging.provider";
 import { EnqueueOptions, Job, JOB_NAME, JobPayload, JobQueueService } from "../job-queue/job-queue.service";
+import { TimerService } from "../timer/timer.service";
 
 export { JOB_NAME as DOMAIN_EVENT_NAME };
 export interface DomainEvent extends Job {}
 
 export type EventPayload<T extends DomainEvent> = JobPayload<T>;
 
+/** Outcome of a `publishAndAwait` call. `cancelled` / `expired` pg-boss states are normalized to `"failed"`. */
+export type JobOutcome =
+  | { status: "completed"; jobId: string; output?: unknown }
+  | { status: "failed"; jobId: string; output?: unknown }
+  | { status: "timeout"; jobId: string };
+
+/** Default polling interval (ms) used when no `pollIntervalMs` is supplied to `publishAndAwait`. */
+const DEFAULT_POLL_INTERVAL_MS = 250;
+
+/** Default timeout (ms) used when no `timeoutMs` is supplied to `publishAndAwait`. */
+const DEFAULT_TIMEOUT_MS = 30_000;
+
 @singleton()
 export class DomainEventsService {
   constructor(
     private readonly jobQueueManager: JobQueueService,
-    private readonly logger: LoggerService
+    private readonly logger: LoggerService,
+    private readonly timer: TimerService
   ) {}
 
   async publish(event: DomainEvent, options?: EnqueueOptions): Promise<string | null> {
@@ -28,4 +42,66 @@ export class DomainEventsService {
       return null;
     }
   }
+
+  /**
+   * Publishes a domain event and polls pg-boss for the job's terminal state.
+   *
+   * Reuses `publish` so error logging stays identical. If `publish` returns `null` (enqueue failed),
+   * the returned outcome is `{ status: "failed", jobId: "" }` — callers can distinguish this from a
+   * normal failure by the empty `jobId`.
+   *
+   * On timeout, the job is **not** cancelled — it stays in pg-boss and continues running.
+   *
+   * pg-boss `state` mapping:
+   * - `completed` → `"completed"`
+   * - `failed` / `cancelled` / `expired` → `"failed"` (pg-boss v12 types omit `expired`, but the
+   *   runtime is handled defensively in case future versions surface it)
+   * - `created` / `retry` / `active` → keep polling
+   *
+   * @param event - The domain event to publish.
+   * @param options.timeoutMs - Max ms to wait for a terminal state. Defaults to 30s.
+   * @param options.pollIntervalMs - Polling interval in ms. Defaults to 250ms.
+   */
+  async publishAndAwait<T extends DomainEvent>(event: T, options: { timeoutMs?: number; pollIntervalMs?: number } = {}): Promise<JobOutcome> {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+    const jobId = await this.publish(event);
+    if (!jobId) {
+      return { status: "failed", jobId: "" };
+    }
+
+    const start = Date.now();
+    for (;;) {
+      const snapshot = await this.jobQueueManager.getJobState(event.name, jobId);
+      const terminal = snapshot ? mapTerminalState(snapshot.state) : null;
+      if (terminal) {
+        return { status: terminal, jobId, output: snapshot?.output };
+      }
+
+      if (Date.now() - start >= timeoutMs) {
+        this.logger.warn({
+          event: "JOB_AWAIT_TIMEOUT",
+          jobId,
+          name: event.name,
+          timeoutMs
+        });
+        return { status: "timeout", jobId };
+      }
+
+      await this.timer.delay(pollIntervalMs);
+    }
+  }
+}
+
+/**
+ * Map a pg-boss job state to a terminal `JobOutcome.status` or `null` if the job is still pending.
+ *
+ * `cancelled` and `expired` are normalized to `"failed"` from the caller's perspective —
+ * the work didn't complete successfully.
+ */
+function mapTerminalState(state: string): "completed" | "failed" | null {
+  if (state === "completed") return "completed";
+  if (state === "failed" || state === "cancelled" || state === "expired") return "failed";
+  return null;
 }

--- a/apps/api/src/core/services/feature-flags/feature-flags.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.ts
@@ -3,7 +3,8 @@ export const FeatureFlags = {
   NOTIFICATIONS_ALERT_UPDATE: "notifications_general_alerts_update",
   AUTO_CREDIT_RELOAD: "auto_credit_reload",
   TRIAL_FINGERPRINT_CHECK: "trial_fingerprint_check",
-  BID_SCREENING: "bid_screening"
+  BID_SCREENING: "bid_screening",
+  CONSOLE_ONBOARDING_REDESIGN: "console_onboarding_redesign"
 } as const;
 
 export type FeatureFlagValue = (typeof FeatureFlags)[keyof typeof FeatureFlags];

--- a/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts
+++ b/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.ts
@@ -8,6 +8,12 @@ import { ZodError } from "zod";
 
 import type { AppContext } from "../../types/app-context";
 
+type HttpErrorWithProps = {
+  errorCode?: string;
+  errorType?: string;
+  headers?: Record<string, string>;
+};
+
 @singleton()
 export class HonoErrorHandlerService {
   private readonly logger = createOtelLogger({ context: "ErrorHandler" });
@@ -37,8 +43,10 @@ export class HonoErrorHandlerService {
 
     if (isHttpError(error)) {
       const { name } = error.constructor;
-      const errorCode = error.data?.errorCode || this.getErrorCode(error);
-      const errorType = error.data?.errorType || this.getErrorType(error);
+      const errorWithProps = error as HttpErrorWithProps;
+      const errorCode = errorWithProps.errorCode || error.data?.errorCode || this.getErrorCode(error);
+      const errorType = errorWithProps.errorType || error.data?.errorType || this.getErrorType(error);
+      const extraHeaders = errorWithProps.headers;
 
       return this.unsafeJson(
         c,
@@ -49,7 +57,7 @@ export class HonoErrorHandlerService {
           type: errorType,
           data: error.data
         },
-        { status: error.status }
+        { status: error.status, headers: extraHeaders }
       );
     }
 

--- a/apps/api/src/core/services/job-queue/job-queue.service.ts
+++ b/apps/api/src/core/services/job-queue/job-queue.service.ts
@@ -146,6 +146,22 @@ export class JobQueueService implements Disposable {
     });
   }
 
+  /**
+   * Fetch a job's current state and output by id, scoped to a queue (job name).
+   *
+   * Returns `null` when no job with that id is found on the given queue. Otherwise returns the
+   * pg-boss `state` (one of `created | retry | active | completed | cancelled | failed`) and the
+   * job's `output` payload (may be an empty object when no output has been written).
+   *
+   * @param queueName - Queue / job name the job was enqueued under.
+   * @param id - pg-boss job id returned by `enqueue`.
+   */
+  async getJobState(queueName: string, id: string): Promise<{ state: PgBossJobState; output: unknown } | null> {
+    const job = await this.pgBoss.getJobById(queueName, id);
+    if (!job) return null;
+    return { state: job.state, output: job.output };
+  }
+
   async complete(name: string, id: string): Promise<void> {
     try {
       await this.pgBoss.complete(name, id);
@@ -217,7 +233,8 @@ export class JobQueueService implements Disposable {
                 githubUsername: null,
                 userId: "system:bg-job-user",
                 username: "___bg_job_user___",
-                trial: false
+                trial: false,
+                stage: "onboarding"
               });
               this.executionContextService.set("ABILITY", createMongoAbility<MongoAbility>());
               this.logger.info({
@@ -325,6 +342,10 @@ export interface JobHandler<T extends Job> {
   policy?: PgBossQueue["policy"];
   handle(payload: JobPayload<T>, job?: JobMeta): Promise<void>;
 }
+
+export type PgBossJobState = "created" | "retry" | "active" | "completed" | "cancelled" | "failed";
+
+export const PG_BOSS_TERMINAL_JOB_STATES: ReadonlyArray<PgBossJobState> = ["completed", "failed", "cancelled"];
 
 export type EnqueueOptions = PgBossSendOptions;
 export interface ProcessOptions extends Omit<PgBossWorkOptions, "batchSize"> {

--- a/apps/api/src/user/model-schemas/user/user.schema.ts
+++ b/apps/api/src/user/model-schemas/user/user.schema.ts
@@ -1,10 +1,13 @@
 import { relations, sql } from "drizzle-orm";
-import { boolean, pgTable, text, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
+import { boolean, pgEnum, pgTable, text, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
 
 import { UserWallets } from "@src/billing/model-schemas/user-wallet/user-wallet.schema"; // eslint-disable-line import-x/no-cycle
 import { Templates } from "@src/user/model-schemas/template/template.schema"; // eslint-disable-line import-x/no-cycle
 
 export const userAgentMaxLength = 500;
+
+export const accountStageEnum = pgEnum("account_stage", ["onboarding", "trial", "trial_legacy", "regular"]);
+export type AccountStage = (typeof accountStageEnum.enumValues)[number];
 
 export const Users = pgTable("userSetting", {
   id: uuid("id")
@@ -25,7 +28,8 @@ export const Users = pgTable("userSetting", {
   lastIp: varchar("last_ip", { length: 255 }),
   lastUserAgent: varchar("last_user_agent", { length: userAgentMaxLength }),
   lastFingerprint: varchar("last_fingerprint", { length: 255 }),
-  createdAt: timestamp("created_at").defaultNow()
+  createdAt: timestamp("created_at").defaultNow(),
+  stage: accountStageEnum("stage").notNull().default("onboarding")
 });
 
 export const UsersRelations = relations(Users, ({ one, many }) => ({

--- a/apps/api/src/user/repositories/user/user.repository.integration.ts
+++ b/apps/api/src/user/repositories/user/user.repository.integration.ts
@@ -2,6 +2,7 @@ import { faker } from "@faker-js/faker";
 import { container } from "tsyringe";
 import { afterEach, describe, expect, it } from "vitest";
 
+import type { UserOutput } from "./user.repository";
 import { UserRepository } from "./user.repository";
 
 describe(UserRepository.name, () => {
@@ -93,7 +94,7 @@ describe(UserRepository.name, () => {
       }
     };
 
-    async function createTestUser(overrides: { lastActiveAt?: Date | null; lastIp?: string } = {}) {
+    async function createTestUser(overrides: { lastActiveAt?: Date | null; lastIp?: string; stage?: UserOutput["stage"] } = {}) {
       const user = await userRepository.create({
         id: faker.string.uuid(),
         userId: faker.string.uuid(),
@@ -109,4 +110,36 @@ describe(UserRepository.name, () => {
 
     return { userRepository, createTestUser };
   }
+
+  describe("advanceStage", () => {
+    it("advances from onboarding to trial", async () => {
+      const { userRepository, createTestUser } = setup();
+      const user = await createTestUser();
+
+      await userRepository.advanceStage(user.id, { from: "onboarding", to: "trial" });
+
+      const updated = await userRepository.findById(user.id);
+      expect(updated?.stage).toBe("trial");
+    });
+
+    it("is a no-op when current stage is not in from", async () => {
+      const { userRepository, createTestUser } = setup();
+      const user = await createTestUser({ stage: "regular" });
+
+      await userRepository.advanceStage(user.id, { from: "onboarding", to: "trial" });
+
+      const updated = await userRepository.findById(user.id);
+      expect(updated?.stage).toBe("regular");
+    });
+
+    it("accepts an array of from stages", async () => {
+      const { userRepository, createTestUser } = setup();
+      const user = await createTestUser({ stage: "trial_legacy" });
+
+      await userRepository.advanceStage(user.id, { from: ["trial", "trial_legacy"], to: "regular" });
+
+      const updated = await userRepository.findById(user.id);
+      expect(updated?.stage).toBe("regular");
+    });
+  });
 });

--- a/apps/api/src/user/repositories/user/user.repository.ts
+++ b/apps/api/src/user/repositories/user/user.repository.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, lt, ne, or, SQL, sql } from "drizzle-orm";
+import { and, eq, getTableColumns, inArray, isNull, lt, ne, or, SQL, sql } from "drizzle-orm";
 import { PgUpdateSetSource } from "drizzle-orm/pg-core";
 import { singleton } from "tsyringe";
 
@@ -7,7 +7,7 @@ import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@
 import { type AbilityParams, BaseRepository } from "@src/core/repositories/base.repository";
 import { TxService } from "@src/core/services";
 import { Trace } from "@src/core/services/tracing/tracing.service";
-import { userAgentMaxLength } from "@src/user/model-schemas/user/user.schema";
+import { AccountStage, userAgentMaxLength } from "@src/user/model-schemas/user/user.schema";
 
 export type UserOutput = ApiPgTables["Users"]["$inferSelect"] & {
   trial?: boolean;
@@ -71,7 +71,7 @@ export class UserRepository extends BaseRepository<ApiPgTables["Users"], UserInp
       );
   }
 
-  async upsertOnExternalIdConflict(data: UserInput): Promise<UserOutput> {
+  async upsertOnExternalIdConflict(data: UserInput): Promise<{ user: UserOutput; wasInserted: boolean }> {
     const { username, ...withoutUsername } = data;
     const [item] = await this.cursor
       .insert(this.table)
@@ -80,8 +80,12 @@ export class UserRepository extends BaseRepository<ApiPgTables["Users"], UserInp
         target: [this.table.userId],
         set: withoutUsername
       })
-      .returning();
-    return this.toOutput(item);
+      .returning({
+        ...getTableColumns(this.table),
+        wasInserted: sql<boolean>`(xmax = 0)`.as("was_inserted")
+      });
+    const { wasInserted, ...user } = item;
+    return { user: this.toOutput(user), wasInserted };
   }
 
   async findTrialUsersByFingerprint(fingerprint: string, excludeUserId: string): Promise<{ id: string }[]> {
@@ -90,6 +94,15 @@ export class UserRepository extends BaseRepository<ApiPgTables["Users"], UserInp
       .from(this.table)
       .innerJoin(UserWallets, and(eq(UserWallets.userId, this.table.id), eq(UserWallets.isTrialing, true)))
       .where(and(eq(this.table.lastFingerprint, fingerprint), ne(this.table.id, excludeUserId)));
+  }
+
+  @Trace()
+  async advanceStage(userId: UserOutput["id"], options: { from: AccountStage | AccountStage[]; to: AccountStage }): Promise<void> {
+    const fromStages = Array.isArray(options.from) ? options.from : [options.from];
+    await this.cursor
+      .update(this.table)
+      .set({ stage: options.to })
+      .where(and(eq(this.table.id, userId), inArray(this.table.stage, fromStages)));
   }
 
   private async findUserWithWallet(whereClause: SQL<unknown>) {

--- a/apps/api/src/user/services/account-stage/account-stage.service.spec.ts
+++ b/apps/api/src/user/services/account-stage/account-stage.service.spec.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
+import type { UserRepository } from "@src/user/repositories/user/user.repository";
+import { AccountStageService } from "./account-stage.service";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(AccountStageService.name, () => {
+  describe("advanceToTrial", () => {
+    it("writes the stage transition", async () => {
+      const { service, userRepository } = setup();
+      const user = createUser({ id: "user-1", stage: "onboarding" });
+
+      await service.advanceToTrial(user);
+
+      expect(userRepository.advanceStage).toHaveBeenCalledWith("user-1", { from: "onboarding", to: "trial" });
+    });
+
+    it("skips when stage is already past onboarding", async () => {
+      const { service, userRepository } = setup();
+      const user = createUser({ stage: "regular" });
+
+      await service.advanceToTrial(user);
+
+      expect(userRepository.advanceStage).not.toHaveBeenCalled();
+    });
+
+    it("re-throws repository errors", async () => {
+      const { service, userRepository } = setup();
+      const user = createUser({ id: "user-1", stage: "onboarding" });
+      userRepository.advanceStage.mockRejectedValue(new Error("db down"));
+
+      await expect(service.advanceToTrial(user)).rejects.toThrow("db down");
+    });
+  });
+
+  describe("advanceToRegular", () => {
+    it("writes the stage transition for trial/trial_legacy → regular", async () => {
+      const { service, userRepository } = setup();
+
+      await service.advanceToRegular("user-1");
+
+      expect(userRepository.advanceStage).toHaveBeenCalledWith("user-1", { from: ["trial", "trial_legacy"], to: "regular" });
+    });
+
+    it("re-throws repository errors", async () => {
+      const { service, userRepository } = setup();
+      userRepository.advanceStage.mockRejectedValue(new Error("db down"));
+
+      await expect(service.advanceToRegular("user-1")).rejects.toThrow("db down");
+    });
+  });
+
+  describe("activateTrial", () => {
+    it("publishes TrialActivated with a 3s timeout when stage is onboarding", async () => {
+      const { service, domainEvents } = setup();
+      const user = createUser({ id: "user-1", stage: "onboarding" });
+      domainEvents.publishAndAwait.mockResolvedValue({ status: "completed", jobId: "j1" });
+
+      await service.activateTrial(user);
+
+      expect(domainEvents.publishAndAwait).toHaveBeenCalledWith(expect.objectContaining({ name: "TrialActivated", data: { userId: "user-1" } }), {
+        timeoutMs: 3000
+      });
+    });
+
+    it("skips when stage is already past onboarding (no event published)", async () => {
+      const { service, domainEvents } = setup();
+      const user = createUser({ stage: "regular" });
+
+      await service.activateTrial(user);
+
+      expect(domainEvents.publishAndAwait).not.toHaveBeenCalled();
+    });
+
+    it("logs a warning but does not throw on non-completed outcomes", async () => {
+      const { service, domainEvents, logger } = setup();
+      const user = createUser({ id: "user-1", stage: "onboarding" });
+      domainEvents.publishAndAwait.mockResolvedValue({ status: "timeout", jobId: "j1" });
+
+      await expect(service.activateTrial(user)).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "ACCOUNT_STAGE_ACTIVATE_TRIAL_NOT_COMPLETED",
+          userId: "user-1"
+        })
+      );
+    });
+  });
+
+  describe("endTrial", () => {
+    it("publishes TrialEnded with a 3s timeout", async () => {
+      const { service, domainEvents } = setup();
+      domainEvents.publishAndAwait.mockResolvedValue({ status: "completed", jobId: "j1" });
+
+      await service.endTrial("user-1");
+
+      expect(domainEvents.publishAndAwait).toHaveBeenCalledWith(expect.objectContaining({ name: "TrialEnded", data: { userId: "user-1" } }), {
+        timeoutMs: 3000
+      });
+    });
+
+    it("logs a warning but does not throw on non-completed outcomes", async () => {
+      const { service, domainEvents, logger } = setup();
+      domainEvents.publishAndAwait.mockResolvedValue({ status: "failed", jobId: "j1" });
+
+      await expect(service.endTrial("user-1")).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: "ACCOUNT_STAGE_END_TRIAL_NOT_COMPLETED",
+          userId: "user-1"
+        })
+      );
+    });
+  });
+
+  function setup() {
+    const userRepository = mock<UserRepository>();
+    const domainEvents = mock<DomainEventsService>();
+    const logger = mock<LoggerService>();
+    const service = new AccountStageService(userRepository, domainEvents, logger);
+    return { service, userRepository, domainEvents, logger };
+  }
+});

--- a/apps/api/src/user/services/account-stage/account-stage.service.ts
+++ b/apps/api/src/user/services/account-stage/account-stage.service.ts
@@ -1,0 +1,53 @@
+import { singleton } from "tsyringe";
+
+import { TrialActivated } from "@src/billing/events/trial-activated";
+import { TrialEnded } from "@src/billing/events/trial-ended";
+import { LoggerService } from "@src/core/providers/logging.provider";
+import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
+import { type UserOutput, UserRepository } from "@src/user/repositories/user/user.repository";
+
+const STAGE_ADVANCE_TIMEOUT_MS = 3000;
+
+@singleton()
+export class AccountStageService {
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly domainEvents: DomainEventsService,
+    private readonly logger: LoggerService
+  ) {}
+
+  async advanceToTrial(user: UserOutput): Promise<void> {
+    if (user.stage !== "onboarding") return;
+    await this.userRepository.advanceStage(user.id, { from: "onboarding", to: "trial" });
+  }
+
+  async advanceToRegular(userId: UserOutput["id"]): Promise<void> {
+    await this.userRepository.advanceStage(userId, { from: ["trial", "trial_legacy"], to: "regular" });
+  }
+
+  async activateTrial(user: UserOutput): Promise<void> {
+    if (user.stage !== "onboarding") return;
+
+    const outcome = await this.domainEvents.publishAndAwait(new TrialActivated({ userId: user.id }), { timeoutMs: STAGE_ADVANCE_TIMEOUT_MS });
+
+    if (outcome.status !== "completed") {
+      this.logger.warn({
+        event: "ACCOUNT_STAGE_ACTIVATE_TRIAL_NOT_COMPLETED",
+        userId: user.id,
+        outcome
+      });
+    }
+  }
+
+  async endTrial(userId: UserOutput["id"]): Promise<void> {
+    const outcome = await this.domainEvents.publishAndAwait(new TrialEnded({ userId }), { timeoutMs: STAGE_ADVANCE_TIMEOUT_MS });
+
+    if (outcome.status !== "completed") {
+      this.logger.warn({
+        event: "ACCOUNT_STAGE_END_TRIAL_NOT_COMPLETED",
+        userId,
+        outcome
+      });
+    }
+  }
+}

--- a/apps/api/src/user/services/user/user.service.integration.ts
+++ b/apps/api/src/user/services/user/user.service.integration.ts
@@ -8,6 +8,8 @@ import type { Auth0Service } from "@src/auth/services/auth0/auth0.service";
 import type { EmailVerificationCodeService } from "@src/auth/services/email-verification-code/email-verification-code.service";
 import type { LoggerService } from "@src/core/providers/logging.provider";
 import type { AnalyticsService } from "@src/core/services/analytics/analytics.service";
+import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
+import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import type { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { UserRepository } from "@src/user/repositories/user/user.repository";
 import type { RegisterUserInput } from "./user.service";
@@ -348,7 +350,9 @@ describe(UserService.name, () => {
       auth0Service,
       mock<EmailVerificationCodeService>({
         sendCode: vi.fn().mockResolvedValue({ codeSentAt: new Date().toISOString() })
-      })
+      }),
+      mock<DomainEventsService>(),
+      mock<FeatureFlagsService>()
     );
 
     return { service, analyticsService, logger, auth0Service, userRepository };

--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -7,6 +7,9 @@ import type { Auth0Service } from "@src/auth/services/auth0/auth0.service";
 import type { EmailVerificationCodeService } from "@src/auth/services/email-verification-code/email-verification-code.service";
 import type { LoggerService } from "@src/core/providers/logging.provider";
 import type { AnalyticsService } from "@src/core/services/analytics/analytics.service";
+import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import type { NotificationService } from "@src/notifications/services/notification/notification.service";
 import type { UserRepository } from "@src/user/repositories/user/user.repository";
 import type { RegisterUserInput } from "./user.service";
@@ -20,7 +23,7 @@ describe(UserService.name, () => {
       const user = createUser({ emailVerified: false, email: "test@example.com" });
       const { service, emailVerificationCodeService, userRepository, notificationService } = setup();
 
-      userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: true });
       notificationService.createDefaultChannel.mockResolvedValue(undefined);
       emailVerificationCodeService.sendCode.mockResolvedValue({ codeSentAt: new Date().toISOString() });
 
@@ -33,7 +36,7 @@ describe(UserService.name, () => {
       const user = createUser({ emailVerified: true, email: "test@example.com" });
       const { service, emailVerificationCodeService, userRepository, notificationService } = setup();
 
-      userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: true });
       notificationService.createDefaultChannel.mockResolvedValue(undefined);
 
       await service.registerUser(createRegisterInput({ emailVerified: true }));
@@ -46,7 +49,7 @@ describe(UserService.name, () => {
       const { service, emailVerificationCodeService, userRepository, notificationService, logger } = setup();
       const sendError = new Error("Send failed");
 
-      userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: true });
       notificationService.createDefaultChannel.mockResolvedValue(undefined);
       emailVerificationCodeService.sendCode.mockRejectedValue(sendError);
 
@@ -57,6 +60,47 @@ describe(UserService.name, () => {
     });
   });
 
+  describe("registerUser - onboarding redesign FF", () => {
+    it("publishes OnboardingStarted when FF is on and the user is newly created", async () => {
+      const user = createUser({ id: "user-1", emailVerified: true });
+      const { service, userRepository, notificationService, domainEvents, featureFlagsService } = setup();
+
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: true });
+      notificationService.createDefaultChannel.mockResolvedValue(undefined);
+      featureFlagsService.isEnabled.mockImplementation(flag => flag === FeatureFlags.CONSOLE_ONBOARDING_REDESIGN);
+
+      await service.registerUser(createRegisterInput({ emailVerified: true }));
+
+      expect(domainEvents.publish).toHaveBeenCalledWith(expect.objectContaining({ name: "OnboardingStarted", data: { userId: "user-1" } }));
+    });
+
+    it("does not publish OnboardingStarted when FF is off", async () => {
+      const user = createUser({ id: "user-1", emailVerified: true });
+      const { service, userRepository, notificationService, domainEvents, featureFlagsService } = setup();
+
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: true });
+      notificationService.createDefaultChannel.mockResolvedValue(undefined);
+      featureFlagsService.isEnabled.mockReturnValue(false);
+
+      await service.registerUser(createRegisterInput({ emailVerified: true }));
+
+      expect(domainEvents.publish).not.toHaveBeenCalled();
+    });
+
+    it("does not publish OnboardingStarted when FF is on but the user already existed", async () => {
+      const user = createUser({ id: "user-1", emailVerified: true });
+      const { service, userRepository, notificationService, domainEvents, featureFlagsService } = setup();
+
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: false });
+      notificationService.createDefaultChannel.mockResolvedValue(undefined);
+      featureFlagsService.isEnabled.mockReturnValue(true);
+
+      await service.registerUser(createRegisterInput({ emailVerified: true }));
+
+      expect(domainEvents.publish).not.toHaveBeenCalled();
+    });
+  });
+
   function setup() {
     const userRepository = mock<UserRepository>();
     const analyticsService = mock<AnalyticsService>();
@@ -64,10 +108,31 @@ describe(UserService.name, () => {
     const notificationService = mock<NotificationService>();
     const auth0Service = mock<Auth0Service>();
     const emailVerificationCodeService = mock<EmailVerificationCodeService>();
+    const domainEvents = mock<DomainEventsService>();
+    const featureFlagsService = mock<FeatureFlagsService>();
 
-    const service = new UserService(userRepository, analyticsService, logger, notificationService, auth0Service, emailVerificationCodeService);
+    const service = new UserService(
+      userRepository,
+      analyticsService,
+      logger,
+      notificationService,
+      auth0Service,
+      emailVerificationCodeService,
+      domainEvents,
+      featureFlagsService
+    );
 
-    return { service, userRepository, analyticsService, logger, notificationService, auth0Service, emailVerificationCodeService };
+    return {
+      service,
+      userRepository,
+      analyticsService,
+      logger,
+      notificationService,
+      auth0Service,
+      emailVerificationCodeService,
+      domainEvents,
+      featureFlagsService
+    };
   }
 
   function createRegisterInput(overrides: Partial<RegisterUserInput> = {}): RegisterUserInput {

--- a/apps/api/src/user/services/user/user.service.ts
+++ b/apps/api/src/user/services/user/user.service.ts
@@ -4,9 +4,13 @@ import { singleton } from "tsyringe";
 
 import { Auth0Service } from "@src/auth/services/auth0/auth0.service";
 import { EmailVerificationCodeService } from "@src/auth/services/email-verification-code/email-verification-code.service";
+import { OnboardingStarted } from "@src/billing/events/onboarding-started";
 import { LoggerService } from "@src/core/providers/logging.provider";
 import { isUniqueViolation } from "@src/core/repositories/base.repository";
 import { AnalyticsService } from "@src/core/services/analytics/analytics.service";
+import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import { NotificationService } from "@src/notifications/services/notification/notification.service";
 import { UserInput, type UserOutput, UserRepository } from "../../repositories/user/user.repository";
 
@@ -18,7 +22,9 @@ export class UserService {
     private readonly logger: LoggerService,
     private readonly notificationService: NotificationService,
     private readonly auth0: Auth0Service,
-    private readonly emailVerificationCodeService: EmailVerificationCodeService
+    private readonly emailVerificationCodeService: EmailVerificationCodeService,
+    private readonly domainEvents: DomainEventsService,
+    private readonly featureFlagsService: FeatureFlagsService
   ) {}
 
   async registerUser(data: RegisterUserInput): Promise<{
@@ -44,7 +50,7 @@ export class UserService {
       lastFingerprint: data.fingerprint
     };
 
-    const user = await this.upsertUser({
+    const { user, wasInserted } = await this.upsertUser({
       ...userDetails,
       username: data.wantedUsername
     });
@@ -67,6 +73,10 @@ export class UserService {
       });
     }
 
+    if (wasInserted && this.featureFlagsService.isEnabled(FeatureFlags.CONSOLE_ONBOARDING_REDESIGN)) {
+      await this.domainEvents.publish(new OnboardingStarted({ userId: user.id }));
+    }
+
     const { id, userId, username, email, emailVerified, stripeCustomerId, bio, subscribedToNewsletter, youtubeUsername, twitterUsername, githubUsername } =
       user;
 
@@ -85,7 +95,7 @@ export class UserService {
     } as Awaited<ReturnType<this["registerUser"]>>;
   }
 
-  private async upsertUser(userDetails: UpdateUserInput, attempt = 0): Promise<UserOutput> {
+  private async upsertUser(userDetails: UpdateUserInput, attempt = 0): Promise<{ user: UserOutput; wasInserted: boolean }> {
     try {
       return await this.userRepository.upsertOnExternalIdConflict(userDetails);
     } catch (error) {

--- a/apps/api/test/functional/onboarding-flow.spec.ts
+++ b/apps/api/test/functional/onboarding-flow.spec.ts
@@ -1,0 +1,81 @@
+import nock from "nock";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { OnboardingStartedHandler } from "@src/app/services/onboarding-started/onboarding-started.handler";
+import type { OnboardingStarted } from "@src/billing/events/onboarding-started";
+import type { BillingConfig } from "@src/billing/providers";
+import { BILLING_CONFIG } from "@src/billing/providers";
+import { UserWalletRepository } from "@src/billing/repositories";
+import { ManagedUserWalletService } from "@src/billing/services";
+import type { ApiPgDatabase, EventPayload } from "@src/core";
+import { CORE_CONFIG, POSTGRES_DB, resolveTable } from "@src/core";
+import { app } from "@src/rest-app";
+
+import { createFeeAllowanceResponse } from "@test/seeders/fee-allowance-response.seeder";
+import { WalletTestingService } from "@test/services/wallet-testing.service";
+
+describe("Onboarding flow (console_onboarding_redesign FF on)", () => {
+  const walletService = new WalletTestingService(app);
+  const userWalletRepository = container.resolve(UserWalletRepository);
+  const billingConfig = container.resolve<BillingConfig>(BILLING_CONFIG);
+  const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
+  const userWalletsTable = resolveTable("UserWallets");
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    nock.cleanAll();
+  });
+
+  it("returns 503 with Retry-After while wallet is pending", { timeout: 60_000 }, async () => {
+    const { user, token } = await walletService.createRegisteredUser();
+    await db.insert(userWalletsTable).values({ userId: user.id, status: "pending" });
+
+    const res = await app.request("/v1/tx", {
+      method: "POST",
+      body: JSON.stringify({ data: { userId: user.id, messages: [] } }),
+      headers: { "Content-Type": "application/json", authorization: `Bearer ${token}` }
+    });
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("retry-after")).toBe("2");
+  });
+
+  it("creates and authorizes the onboarding wallet, then flips status to ready", { timeout: 90_000 }, async () => {
+    mockChainGrantSuccess();
+    const { user } = await walletService.createRegisteredUser();
+
+    const handler = container.resolve(OnboardingStartedHandler);
+    await handler.handle({ userId: user.id, version: 1 } as EventPayload<OnboardingStarted>);
+
+    const readyWallet = await userWalletRepository.findOneByUserId(user.id);
+    expect(readyWallet).toMatchObject({
+      status: "ready",
+      address: expect.stringMatching(/^akash1/)
+    });
+  });
+
+  it("flips wallet status to failed when the chain grant throws", { timeout: 60_000 }, async () => {
+    const { user } = await walletService.createRegisteredUser();
+    const managedUserWallet = container.resolve(ManagedUserWalletService);
+    vi.spyOn(managedUserWallet, "createAndAuthorizeOnboardingGrant").mockRejectedValue(new Error("chain down"));
+
+    const handler = container.resolve(OnboardingStartedHandler);
+    await expect(handler.handle({ userId: user.id, version: 1 } as EventPayload<OnboardingStarted>)).rejects.toThrow("chain down");
+
+    const failedWallet = await userWalletRepository.findOneByUserId(user.id);
+    expect(failedWallet?.status).toBe("failed");
+  });
+
+  function mockChainGrantSuccess() {
+    nock(billingConfig.TX_SIGNER_BASE_URL)
+      .persist()
+      .post("/v1/tx/funding")
+      .reply(200, { data: { code: 0, hash: "SOME_HASH", rawLog: "[]" } });
+
+    nock(container.resolve(CORE_CONFIG).REST_API_NODE_URL)
+      .persist()
+      .get(/\/cosmos\/feegrant\/v1beta1\/allowance\/.*\/.*/)
+      .reply(200, createFeeAllowanceResponse());
+  }
+});

--- a/apps/api/test/seeders/user-wallet.seeder.ts
+++ b/apps/api/test/seeders/user-wallet.seeder.ts
@@ -10,6 +10,7 @@ export function createUserWallet({
   deploymentAllowance = faker.number.float({ min: 0, max: 1000000 }),
   feeAllowance = faker.number.float({ min: 0, max: 1000000 }),
   isTrialing = faker.helpers.arrayElement([true, false]),
+  status = "ready" as const,
   createdAt = faker.date.past(),
   updatedAt = faker.date.past()
 }: Partial<UserWalletOutput> = {}): UserWalletOutput {
@@ -20,6 +21,7 @@ export function createUserWallet({
     deploymentAllowance,
     feeAllowance,
     isTrialing,
+    status,
     creditAmount: deploymentAllowance,
     createdAt,
     updatedAt

--- a/apps/api/test/seeders/user.seeder.ts
+++ b/apps/api/test/seeders/user.seeder.ts
@@ -19,7 +19,8 @@ export function createUser({
   lastUserAgent = faker.internet.userAgent(),
   lastFingerprint = faker.word.noun(),
   createdAt = faker.date.recent(),
-  trial = false
+  trial = false,
+  stage = "onboarding" as const
 }: Partial<UserOutput> = {}): UserOutput {
   return {
     id,
@@ -38,6 +39,7 @@ export function createUser({
     lastUserAgent,
     lastFingerprint,
     createdAt,
-    trial
+    trial,
+    stage
   };
 }

--- a/docs/observability/onboarding-init.md
+++ b/docs/observability/onboarding-init.md
@@ -1,0 +1,63 @@
+# Onboarding wallet init — observability
+
+This runbook covers the async wallet provisioning kicked off by the `OnboardingStarted` event when the `console_onboarding_redesign` feature flag is on.
+
+## Signals
+
+### Structured log events
+
+| Event | Where | Meaning |
+|---|---|---|
+| `ONBOARDING_INIT_STARTED` | `OnboardingStartedHandler` | Handler picked up a job and is about to provision the wallet. |
+| `ONBOARDING_INIT_SUCCEEDED` | `OnboardingStartedHandler` | Wallet provisioning completed; `user_wallets.status = 'ready'`. |
+| `ONBOARDING_INIT_FAILED` | `OnboardingStartedHandler` | Handler threw — pg-boss will retry (5 attempts, exponential backoff). |
+| `ONBOARDING_WALLET_READY` | `WalletInitializerService.initializeForOnboarding` | Wallet row updated with address + allowances + `status='ready'`. |
+| `ONBOARDING_WALLET_FAILED` | `WalletInitializerService.initializeForOnboarding` | Chain grant failed; wallet flipped to `status='failed'`, error logged. |
+
+Every event carries `userId`. `ONBOARDING_WALLET_READY` and `ONBOARDING_WALLET_FAILED` also carry `walletId`.
+
+### OpenTelemetry spans
+
+- **`OnboardingStartedHandler.handle`** — wraps the full async init. Attribute `user.id`. Span status reflects success/failure.
+
+### pg-boss queue
+
+- Queue name: `OnboardingStarted` (one job per registered user when FF is on).
+- Retry policy: 5 attempts, exponential backoff (`retryBackoff: true`), max 5 minutes between retries (`retryDelayMax: 300s`).
+
+## Alert thresholds
+
+| Signal | Threshold | Severity | Page? |
+|---|---|---|---|
+| `ONBOARDING_INIT_FAILED` rate | > 1% over 10m | P2 | yes |
+| `OnboardingStartedHandler.handle` p99 duration | > 30s over 10m | P2 | yes |
+| pg-boss queue depth for `OnboardingStarted` | > 100 sustained for 5m | P3 | no |
+| Span error rate (OTel status=ERROR) | > 5% over 10m | P1 | yes |
+| Users with `user_wallets.status = 'failed'` (count delta) | > 10/hour | P1 | yes |
+
+The p99 alert at 30s is intentionally tight against the 60s user-facing polling cap — at 30s we're on the path to a degraded UX; alerting then gives time to mitigate before users hit the failure banner.
+
+## Dashboards
+
+A tile on the API dashboard should plot:
+
+- Counts of `ONBOARDING_INIT_STARTED`, `_SUCCEEDED`, `_FAILED` over time.
+- p50 / p99 of the `OnboardingStartedHandler.handle` span duration.
+- pg-boss queue depth for `OnboardingStarted`.
+- Rolling count of `user_wallets.status = 'failed'`.
+
+## Runbook on failure
+
+1. Check `ONBOARDING_INIT_FAILED` logs for `error.message` and stack — typical causes:
+   - Chain RPC timeout / unavailable (`ECONNREFUSED`, `Service Unavailable`, etc.).
+   - Funding wallet out of gas.
+   - DB lock contention on `user_wallets` insert/update.
+2. If chain-side: check upstream provider status + Akash RPC dashboards.
+3. If DB-side: check Postgres CPU / connection pool / lock waits.
+4. Affected users see a `"We couldn't prepare your account. Please contact support."` banner on the deploy page. Triage:
+   - For transient failures, manually re-enqueue an `OnboardingStarted` job for the affected `userId` (pg-boss `send`). Idempotent — `OnboardingStartedHandler` calls `initializeForOnboarding`, which is safe to re-run because the wallet row already exists with `status='failed'`. Verify the implementation handles "wallet already exists" correctly before relying on this, or fall back to manually flipping `status` back to `'pending'` and re-enqueueing.
+   - For systemic failures, leave the queue paused while diagnosing — failed jobs hit pg-boss's archive after retries are exhausted, preserving forensic trail.
+
+## Feature-flag toggle
+
+`console_onboarding_redesign` (Unleash). When toggled off, the `OnboardingStarted` event is never published from `UserService.registerUser`. Existing pending/failed wallets are unaffected — they keep their `status` and continue to gate deploys until manually resolved.


### PR DESCRIPTION
## Why

Closes CON-316.

The redesign needs to know where each user is in the funnel to route them after sign-in, show the right nudges, gate verification, and decide credit grants. Tracking account stage also separates new staged-credit users from legacy users who already had the full $100 trial, and from paying customers.

## What

- Add an `account_stage` column on users with four values: `onboarding`, `trial`, `trial_legacy`, `regular`.
- New `AccountStageService` drives transitions:
  - `onboarding → trial` on first lease created (wired via `ManagedSignerService`).
  - `trial` / `trial_legacy → regular` on first paid (non-coupon) top-up (wired via `RefillService`).
- Stripe webhook now mirrors the invoice handler's coupon-aware logic on `payment_intent.succeeded` — real payments end the trial and advance the stage; coupon claims preserve the trial.
- Migration `0030_perfect_stranger` adds the column and backfills existing users from deployment and billing history:
  - any successful top-up → `regular`
  - currently trialing on the legacy $100 grant → `trial_legacy`
  - currently trialing → `trial`
  - no deployments → `onboarding`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User account stage persisted/backfilled (onboarding/trial/trial_legacy/regular); new users start in onboarding.
  * Onboarding flow: starting onboarding now provisions wallets (pending → ready/failed) and can publish onboarding events; managed-wallet transactions auto-retry while provisioning.
  * UI: new "Preparing your account…" loading state and an "account preparation failed" snackbar with support link.

* **Refactor**
  * Billing, webhook, job and wallet flows updated to drive stage transitions and onboarding jobs behind a feature flag.

* **Tests**
  * Extensive new/updated tests for onboarding, wallet status, stage transitions, and retry behavior.

* **Documentation**
  * Added observability runbook for onboarding/init.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3194?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->