### PR TITLE
feat(template): bump Hello Akash World image to official ghcr image

### DIFF
--- a/apps/api/test/mocks/hello-world-sdl-update.yml
+++ b/apps/api/test/mocks/hello-world-sdl-update.yml
@@ -2,7 +2,7 @@
 version: "2.0"
 services:
   web:
-    image: baktun/hello-akash-world:1.0.0
+    image: ghcr.io/akash-network/hello-akash-world:2.1.0
     env:
       - NEW_FEATURE=enabled
     expose:

--- a/apps/api/test/mocks/hello-world-sdl.yml
+++ b/apps/api/test/mocks/hello-world-sdl.yml
@@ -2,7 +2,7 @@
 version: "2.0"
 services:
   web:
-    image: baktun/hello-akash-world:1.0.0
+    image: ghcr.io/akash-network/hello-akash-world:2.1.0
     expose:
       - port: 3000
         as: 80

--- a/apps/api/test/mocks/invalid-sdl.yml
+++ b/apps/api/test/mocks/invalid-sdl.yml
@@ -2,7 +2,7 @@
 version: "2.0"
 services:
   web:
-    image: baktun/hello-akash-world:1.0.0
+    image: ghcr.io/akash-network/hello-akash-world:2.1.0
     expose:
       - port: 3000
         as: 80

--- a/apps/deploy-web/src/utils/templates.ts
+++ b/apps/deploy-web/src/utils/templates.ts
@@ -29,7 +29,7 @@ services:
   # The name of the service "web"
   web:
     # The docker container image with version. You must specify a version, the "latest" tag doesn't work.
-    image: baktun/hello-akash-world:1.0.0
+    image: ghcr.io/akash-network/hello-akash-world:2.1.0
     # You can map ports here https://akash.network/docs/getting-started/stack-definition-language/#servicesexpose
     expose:
       - port: 3000

--- a/apps/deploy-web/tests/mocks/two-services-sdl.yml
+++ b/apps/deploy-web/tests/mocks/two-services-sdl.yml
@@ -2,7 +2,7 @@
 version: "2.0"
 services:
   web:
-    image: baktun/hello-akash-world:1.0.0
+    image: ghcr.io/akash-network/hello-akash-world:2.1.0
     expose:
       - port: 3000
         as: 80

--- a/apps/deploy-web/tests/seeders/manifest.ts
+++ b/apps/deploy-web/tests/seeders/manifest.ts
@@ -4,7 +4,7 @@ export const helloWorldManifest = `
 
   services:
     web:
-      image: baktun/hello-akash-world:1.0.0
+      image: ghcr.io/akash-network/hello-akash-world:2.1.0
       expose:
         - port: 3000
           as: 80


### PR DESCRIPTION
## Why

The Hello Akash World deployment template (the default template users see in onboarding and the SDL Builder) was pinned to `baktun/hello-akash-world:1.0.0`, a personal Docker Hub image. The Akash org now publishes an official image at [`ghcr.io/akash-network/hello-akash-world`](https://github.com/akash-network/hello-akash-world/pkgs/container/hello-akash-world), so the console should point at that.

## What

- Bump the image in [`apps/deploy-web/src/utils/templates.ts`](apps/deploy-web/src/utils/templates.ts) from `baktun/hello-akash-world:1.0.0` to `ghcr.io/akash-network/hello-akash-world:2.1.0`.
- Bump the same image string in matching test fixtures and seeders so they stay aligned with the live template:
  - `apps/api/test/mocks/hello-world-sdl.yml`
  - `apps/api/test/mocks/hello-world-sdl-update.yml`
  - `apps/api/test/mocks/invalid-sdl.yml`
  - `apps/deploy-web/tests/mocks/two-services-sdl.yml`
  - `apps/deploy-web/tests/seeders/manifest.ts`

No behavior change beyond the image. Tag pinned to `2.1.0` per upstream guidance (Akash docs explicitly note that `latest` doesn't work for SDL).

## Test plan

- [x] `cd apps/deploy-web && NODE_ENV=test DEPLOYMENT_ENV=staging npx vitest run` — 1591/1592 pass (one pre-existing date-dependent failure in `TrendIndicator.spec.tsx`, unrelated)
- [x] `npx eslint --quiet` on changed files — clean
- [ ] Smoke-test onboarding "Hello World" template end-to-end in sandbox (not done in this PR — reviewer can verify or do via QA)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures, mock configurations, and example deployment templates to reference the latest version of the hello-akash-world container image across multiple test suites.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3199?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->