### PR TITLE
refactor: excludes stripe-webhook from openapi docs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -63,9 +63,11 @@ jobs:
             ]);
             const totalChangedLines = files.reduce((total, file) => {
               const path = file.filename ?? "";
-              if (excludedLockfiles.has(path) || (path.includes("/drizzle/meta/") && path.endsWith('.json'))) {
-                return total;
-              }
+              const isIgnoredFile = excludedLockfiles.has(path) ||
+                (path.includes("/drizzle/meta/") && path.endsWith('.json')) || path.endsWith('.md') ||
+                path.endsWith(".gen.ts") ||
+                path.includes("/generated/");
+              if (isIgnoredFile) return total;
               return total + (file.additions ?? 0) + (file.deletions ?? 0);
             }, 0);
 

--- a/apps/api/src/billing/routes/stripe-webhook/stripe-webhook.router.ts
+++ b/apps/api/src/billing/routes/stripe-webhook/stripe-webhook.router.ts
@@ -14,6 +14,7 @@ const route = createRoute({
   summary: "Stripe Webhook Handler",
   tags: ["Payment"],
   security: SECURITY_NONE,
+  hiddenInOpenApiDocs: true,
   additionalContentTypes: ["application/json"],
   request: {
     body: {

--- a/apps/api/src/caching/helpers.ts
+++ b/apps/api/src/caching/helpers.ts
@@ -113,12 +113,16 @@ export async function cacheResponse<T>(seconds: number, key: string, refreshRequ
 
 export function memoizeAsync<A extends unknown[], R>(
   fn: (...args: A) => Promise<R>,
-  options?: { cacheItemLimit: number; ttl?: number }
+  options?: {
+    cacheItemLimit: number;
+    ttl?: number;
+    getCacheKey?: (...args: A) => string;
+  }
 ): (...args: A) => Promise<R> {
   const cache = new LRUCache<string, Promise<R>>({ max: options?.cacheItemLimit ?? 100, ttl: options?.ttl });
 
   return (...args: A) => {
-    const key = JSON.stringify(args);
+    const key = options?.getCacheKey ? options.getCacheKey(...args) : JSON.stringify(args);
 
     const cached = cache.get(key);
     if (cached) {

--- a/apps/api/src/core/lib/create-route/create-route.ts
+++ b/apps/api/src/core/lib/create-route/create-route.ts
@@ -23,15 +23,27 @@ export interface ExtendedRouteConfig<R extends RouteConfig> {
 
 const NO_CACHE = cacheControlMiddleware({ maxAge: 0 });
 
+/**
+ * OpenAPI vendor extension used to mark a route as hidden from generated
+ * documentation. Operations carrying this extension are stripped by
+ * `OpenApiDocsService.generateDocs` before the spec is returned.
+ */
+export const HIDDEN_ROUTES = new Set<string>();
+
 export function createRoute<
   R extends Omit<RouteConfig, "security"> & {
     security: Required<RouteConfig>["security"];
     cache?: CacheConfig;
     bodyLimit?: Parameters<typeof bodyLimit>[0];
     additionalContentTypes?: string[];
+    /**
+     * Hide this route from the generated OpenAPI document and Swagger UI.
+     * The route is still mounted and reachable — only documentation is suppressed.
+     */
+    hiddenInOpenApiDocs?: boolean;
   }
 >(routeConfig: R) {
-  const { cache, bodyLimit: bodyLimitOptions, additionalContentTypes, ...openApiConfig } = routeConfig;
+  const { cache, bodyLimit: bodyLimitOptions, additionalContentTypes, hiddenInOpenApiDocs, ...openApiConfig } = routeConfig;
   let middlewares: MiddlewareHandler[] = [];
 
   if (routeConfig.method !== "get" && routeConfig.method !== "head") {
@@ -69,5 +81,9 @@ export function createRoute<
     openApiConfig.middleware = middlewares;
   }
 
-  return createOpenApiRoute(openApiConfig as Omit<R, "cache">);
+  if (hiddenInOpenApiDocs) {
+    HIDDEN_ROUTES.add(openApiConfig.operationId ?? `${openApiConfig.method?.toUpperCase() || "UNKNOWN"} ${openApiConfig.path}`);
+  }
+
+  return createOpenApiRoute(openApiConfig as Omit<R, "cache" | "hiddenInOpenApiDocs">);
 }

--- a/apps/api/src/core/services/openapi-docs/openapi-docs.service.spec.ts
+++ b/apps/api/src/core/services/openapi-docs/openapi-docs.service.spec.ts
@@ -1,16 +1,23 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { OpenApiDocsService } from "./openapi-docs.service";
 
-vi.mock("axios", () => ({
-  default: { get: vi.fn() }
-}));
-
 describe("OpenApiDocsService", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    fetchMock.mockReset();
+  });
+
   it("loads the notifications spec from disk when source = file", async () => {
     const notificationsSpec = {
       openapi: "3.0.0",
@@ -56,22 +63,19 @@ describe("OpenApiDocsService", () => {
   });
 
   it("defaults to source = http when no source is specified", async () => {
-    const axiosModule = await import("axios");
-    const axiosGet = vi.mocked(axiosModule.default.get);
-    vi.clearAllMocks();
-    axiosGet.mockResolvedValueOnce({
-      data: {
+    fetchMock.mockResolvedValueOnce({
+      json: async () => ({
         openapi: "3.0.0",
         info: { title: "Notif", version: "1.0.0" },
         paths: {},
         components: { schemas: {} }
-      }
+      })
     });
 
     const { service } = setup({ notificationsSwaggerPath: "/should-not-be-read" });
     await service.generateDocs([], { scope: "full" });
 
-    expect(axiosGet).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it("returns docs without external paths when NOTIFICATIONS_SWAGGER_PATH is missing", async () => {
@@ -82,15 +86,12 @@ describe("OpenApiDocsService", () => {
   });
 
   it("returns docs without external paths when the HTTP fetch fails", async () => {
-    const axiosModule = await import("axios");
-    const axiosGet = vi.mocked(axiosModule.default.get);
-    vi.clearAllMocks();
-    axiosGet.mockRejectedValueOnce(new Error("network down"));
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
 
     const { service } = setup({});
     const docs = await service.generateDocs([], { scope: "full", source: "http" });
 
-    expect(axiosGet).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledOnce();
     expect(docs.paths).toEqual({});
   });
 
@@ -113,11 +114,8 @@ describe("OpenApiDocsService", () => {
     );
 
     try {
-      const axiosModule = await import("axios");
-      const axiosGet = vi.mocked(axiosModule.default.get);
-      vi.clearAllMocks();
-      axiosGet.mockResolvedValueOnce({
-        data: {
+      fetchMock.mockResolvedValueOnce({
+        json: async () => ({
           openapi: "3.0.0",
           info: { title: "Notif", version: "1.0.0" },
           paths: {
@@ -126,7 +124,7 @@ describe("OpenApiDocsService", () => {
             }
           },
           components: { schemas: {} }
-        }
+        })
       });
 
       const { service } = setup({ notificationsSwaggerPath: tmpFile });
@@ -136,7 +134,7 @@ describe("OpenApiDocsService", () => {
 
       const httpDocs = await service.generateDocs([], { scope: "full", source: "http" });
       expect(httpDocs.paths["/v1/from-http"]).toBeDefined();
-      expect(axiosGet).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }

--- a/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
+++ b/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
@@ -1,9 +1,10 @@
 import { createOtelLogger } from "@akashnetwork/logging/otel";
-import axios from "axios";
 import { readFile } from "node:fs/promises";
-import type { ComponentsObject, OpenAPIObject, PathsObject, ReferenceObject } from "openapi3-ts/oas30";
+import type { ComponentsObject, OpenAPIObject, PathItemObject, PathsObject, ReferenceObject } from "openapi3-ts/oas30";
 import { inject, singleton } from "tsyringe";
 
+import { memoizeAsync } from "@src/caching/helpers";
+import { HIDDEN_ROUTES } from "@src/core/lib/create-route/create-route";
 import type { CoreConfig } from "@src/core/providers/config.provider";
 import { CORE_CONFIG } from "@src/core/providers/config.provider";
 import type { NotificationsConfig } from "@src/notifications/config/env.config";
@@ -15,7 +16,6 @@ const logger = createOtelLogger({ context: "OpenApiDocsService" });
 @singleton()
 export class OpenApiDocsService {
   readonly #serverOrigin: string;
-  #externalSpecLoadPromises: Partial<Record<"file" | "http", Promise<OpenAPIObject | null>>> = {};
 
   constructor(
     @inject(CORE_CONFIG) coreConfig: CoreConfig,
@@ -24,94 +24,97 @@ export class OpenApiDocsService {
     this.#serverOrigin = coreConfig.SERVER_ORIGIN;
   }
 
-  async generateDocs(handlers: OpenApiHonoHandler[], options: { scope: string; source?: "file" | "http" }): Promise<OpenAPIObject> {
-    const source = options.source ?? "http";
-    const version = "v1";
-    const docs: OpenAPIObject & { components: NonNullable<OpenAPIObject["components"]> } = {
-      openapi: "3.0.0",
-      servers: [{ url: this.#serverOrigin }],
-      info: {
-        title: "Akash Network Console API",
-        description: "API providing data to the Akash Network Console",
-        version: version
-      },
-      paths: {},
-      components: {
-        schemas: {},
-        securitySchemes: {
-          BearerAuth: {
-            type: "http",
-            scheme: "bearer",
-            bearerFormat: "JWT",
-            description: 'JWT token for authenticated users, sent in "Authorization: Bearer %token" header.'
-          },
-          ApiKeyAuth: {
-            type: "apiKey",
-            in: "header",
-            name: "x-api-key",
-            description: "API key for programmatic access."
+  generateDocs = memoizeAsync(
+    async (handlers: OpenApiHonoHandler[], options: { scope: string; source?: "file" | "http" }): Promise<OpenAPIObject> => {
+      const source = options.source ?? "http";
+      const version = "v1";
+      const docs: OpenAPIObject & { components: NonNullable<OpenAPIObject["components"]> } = {
+        openapi: "3.0.0",
+        servers: [{ url: this.#serverOrigin }],
+        info: {
+          title: "Akash Network Console API",
+          description: "API providing data to the Akash Network Console",
+          version: version
+        },
+        paths: {},
+        components: {
+          schemas: {},
+          securitySchemes: {
+            BearerAuth: {
+              type: "http",
+              scheme: "bearer",
+              bearerFormat: "JWT",
+              description: 'JWT token for authenticated users, sent in "Authorization: Bearer %token" header.'
+            },
+            ApiKeyAuth: {
+              type: "apiKey",
+              in: "header",
+              name: "x-api-key",
+              description: "API key for programmatic access."
+            }
+          }
+        }
+      };
+
+      for (const handler of handlers) {
+        try {
+          const handlerDocs = handler.getOpenAPIDocument({
+            openapi: "3.0.0",
+            info: {
+              title: "Unified API",
+              version: "1.0.0"
+            }
+          });
+
+          Object.assign(docs.paths, this.#stripHiddenOperations(handlerDocs.paths));
+        } catch (error) {
+          logger.error({
+            name: `Error generating OpenAPI docs for handler, example path: ${handler.routes[0]?.path || "unknown"}`,
+            error
+          });
+        }
+      }
+
+      if (options.scope === "full") {
+        const externalDocs = await this.#loadExternalNotificationsSpec(source);
+        if (externalDocs?.paths) {
+          const { filteredPaths, usedSchemaRefs } = this.#filterPrivateRoutes(externalDocs.paths);
+          Object.assign(docs.paths, filteredPaths);
+
+          if (externalDocs?.components?.schemas) {
+            const filteredSchemas = this.#filterSchemasByReferences(externalDocs.components.schemas, usedSchemaRefs);
+
+            docs.components.schemas = {
+              ...docs.components.schemas,
+              ...filteredSchemas
+            };
+            docs.components.securitySchemes = {
+              ...docs.components.securitySchemes,
+              ...(externalDocs.components.securitySchemes || {})
+            };
+          } else if (externalDocs?.components) {
+            docs.components.securitySchemes = {
+              ...docs.components.securitySchemes,
+              ...(externalDocs.components.securitySchemes || {})
+            };
           }
         }
       }
-    };
 
-    for (const handler of handlers) {
-      try {
-        const handlerDocs = handler.getOpenAPIDocument({
-          openapi: "3.0.0",
-          info: {
-            title: "Unified API",
-            version: "1.0.0"
-          }
-        });
-
-        Object.assign(docs.paths, handlerDocs.paths);
-      } catch (error) {
-        logger.error({
-          name: `Error generating OpenAPI docs for handler, example path: ${handler.routes[0]?.path || "unknown"}`,
-          error
-        });
-      }
+      return docs;
+    },
+    {
+      ttl: 60 * 60 * 1000, // 1 hour
+      cacheItemLimit: 10,
+      getCacheKey: (_, options) => `${options.scope}-${options.source ?? "http"}`
     }
-
-    if (options.scope === "full") {
-      const externalDocs = await this.#loadExternalNotificationsSpec(source);
-      if (externalDocs?.paths) {
-        const { filteredPaths, usedSchemaRefs } = this.#filterPrivateRoutes(externalDocs.paths);
-        Object.assign(docs.paths, filteredPaths);
-
-        if (externalDocs?.components?.schemas) {
-          const filteredSchemas = this.#filterSchemasByReferences(externalDocs.components.schemas, usedSchemaRefs);
-
-          docs.components.schemas = {
-            ...docs.components.schemas,
-            ...filteredSchemas
-          };
-          docs.components.securitySchemes = {
-            ...docs.components.securitySchemes,
-            ...(externalDocs.components.securitySchemes || {})
-          };
-        } else if (externalDocs?.components) {
-          docs.components.securitySchemes = {
-            ...docs.components.securitySchemes,
-            ...(externalDocs.components.securitySchemes || {})
-          };
-        }
-      }
-    }
-
-    return docs;
-  }
+  );
 
   async #loadExternalNotificationsSpec(source: "file" | "http"): Promise<OpenAPIObject | null> {
     if (!this.notificationsConfig) return null;
 
-    const cached = this.#externalSpecLoadPromises[source];
-    if (cached) return cached;
-
     const promise = source === "file" ? this.#loadNotificationsSpecFromFile() : this.#loadNotificationsSpecFromHttp();
-    this.#externalSpecLoadPromises[source] = promise;
-    return promise;
+    return await promise;
   }
 
   async #loadNotificationsSpecFromFile(): Promise<OpenAPIObject | null> {
@@ -129,12 +132,42 @@ export class OpenApiDocsService {
   async #loadNotificationsSpecFromHttp(): Promise<OpenAPIObject | null> {
     const externalOpenApiUrl = `${this.notificationsConfig!.NOTIFICATIONS_API_BASE_URL}/api-json`;
     try {
-      const response = await axios.get(externalOpenApiUrl, { timeout: 5000 });
-      return response.data;
+      const response = await fetch(externalOpenApiUrl, { signal: AbortSignal.timeout(5000) });
+      return (await response.json()) as OpenAPIObject;
     } catch (error) {
       logger.warn({ event: "EXTERNAL_OPENAPI_FETCH_ERROR", error, url: externalOpenApiUrl });
       return null;
     }
+  }
+
+  /**
+   * Removes operations marked with the `OPENAPI_HIDDEN_EXTENSION` vendor extension from a paths
+   * object. Routes opt in via `createRoute({ hiddenInOpenApiDocs: true, ... })` — e.g. webhook
+   * endpoints whose path is a shared secret and must not appear in public docs.
+   */
+  #stripHiddenOperations(paths: PathsObject | undefined): PathsObject {
+    if (!paths) return {};
+    const result: PathsObject = {};
+
+    for (const [path, pathItem] of Object.entries(paths)) {
+      if (!pathItem || typeof pathItem !== "object") continue;
+
+      let filteredItem: PathItemObject | null = null;
+      Object.keys(pathItem).forEach(key => {
+        const route = pathItem[key as keyof PathItemObject];
+        if (typeof route !== "object" || route === null) return;
+
+        const operationId = route.operationId ?? `${key.toUpperCase()} ${path}`;
+        if (!HIDDEN_ROUTES.has(operationId)) {
+          filteredItem ??= {};
+          filteredItem[key as keyof PathItemObject] = pathItem[key as keyof PathItemObject];
+        }
+      });
+      if (filteredItem) {
+        result[path] = filteredItem;
+      }
+    }
+    return result;
   }
 
   /**

--- a/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
+++ b/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
@@ -78,11 +78,11 @@ export class OpenApiDocsService {
       if (options.scope === "full") {
         const externalDocs = await this.#loadExternalNotificationsSpec(source);
         if (externalDocs?.paths) {
-          const { filteredPaths, usedSchemaRefs } = this.#filterPrivateRoutes(externalDocs.paths);
+          const filteredPaths = this.#filterPrivateRoutes(externalDocs.paths);
           Object.assign(docs.paths, filteredPaths);
 
           if (externalDocs?.components?.schemas) {
-            const filteredSchemas = this.#filterSchemasByReferences(externalDocs.components.schemas, usedSchemaRefs);
+            const filteredSchemas = this.#filterSchemasByReferences(externalDocs.components.schemas, filteredPaths);
 
             docs.components.schemas = {
               ...docs.components.schemas,
@@ -175,87 +175,58 @@ export class OpenApiDocsService {
    * Internal endpoints live under /internal/ and ship in apps/notifications/swagger.internal.json;
    * the public swagger.json should already exclude them, but we belt-and-suspender here.
    */
-  #filterPrivateRoutes(paths: PathsObject): { filteredPaths: PathsObject; usedSchemaRefs: Set<string> } {
+  #filterPrivateRoutes(paths: PathsObject): PathsObject {
     const filteredPaths: PathsObject = {};
-    const usedSchemaRefs = new Set<string>();
-
-    const extractSchemaRefs = (obj: unknown): void => {
-      if (!obj || typeof obj !== "object") {
-        return;
-      }
-
-      if (Array.isArray(obj)) {
-        obj.forEach(item => extractSchemaRefs(item));
-        return;
-      }
-
-      const objWithRef = obj as ReferenceObject | { $ref?: string };
-      if (objWithRef.$ref && typeof objWithRef.$ref === "string" && objWithRef.$ref.startsWith("#/components/schemas/")) {
-        const schemaName = objWithRef.$ref.replace("#/components/schemas/", "");
-        usedSchemaRefs.add(schemaName);
-      }
-
-      Object.values(obj).forEach(value => extractSchemaRefs(value));
-    };
 
     for (const [path, pathItem] of Object.entries(paths)) {
       if (path.startsWith("/internal/")) {
         continue;
       }
       filteredPaths[path] = pathItem;
-      extractSchemaRefs(pathItem);
     }
 
-    return { filteredPaths, usedSchemaRefs };
+    return filteredPaths;
   }
 
   /**
-   * Filters schemas to only include those referenced by the provided schema references set.
-   * Also extracts nested schema references (if SchemaA references SchemaB, includes SchemaB).
+   * Filters schemas to only those transitively referenced from `seed`. The seed can be any object
+   * containing `$ref: "#/components/schemas/..."` entries (e.g. a paths object). Walks each
+   * referenced schema's body to pull in nested refs (if SchemaA references SchemaB, includes
+   * SchemaB).
    *
    * @param schemas - All available schemas from external OpenAPI spec
-   * @param usedSchemaRefs - Set of schema names that are referenced by filtered routes
+   * @param seed - Object to scan for the initial set of `$ref`s (typically the filtered paths)
    * @returns Filtered schemas object containing only referenced schemas
    */
-  #filterSchemasByReferences(schemas: ComponentsObject["schemas"], usedSchemaRefs: Set<string>): ComponentsObject["schemas"] {
+  #filterSchemasByReferences(schemas: ComponentsObject["schemas"], seed: unknown): ComponentsObject["schemas"] {
     if (!schemas) {
       return {};
     }
 
-    const visitedSchemas = new Set<string>();
-    const extractNestedSchemaRefs = (obj: unknown): void => {
+    const usedSchemaRefs = new Set<string>();
+    const walk = (obj: unknown): void => {
       if (!obj || typeof obj !== "object") {
         return;
       }
 
       if (Array.isArray(obj)) {
-        obj.forEach(item => extractNestedSchemaRefs(item));
+        obj.forEach(walk);
         return;
       }
 
       const objWithRef = obj as ReferenceObject | { $ref?: string };
       if (objWithRef.$ref && typeof objWithRef.$ref === "string" && objWithRef.$ref.startsWith("#/components/schemas/")) {
         const schemaName = objWithRef.$ref.replace("#/components/schemas/", "");
-        if (!visitedSchemas.has(schemaName) && schemas[schemaName]) {
-          visitedSchemas.add(schemaName);
+        if (!usedSchemaRefs.has(schemaName) && schemas[schemaName]) {
           usedSchemaRefs.add(schemaName);
-          extractNestedSchemaRefs(schemas[schemaName]);
+          walk(schemas[schemaName]);
         }
       }
 
-      Object.values(obj).forEach(value => extractNestedSchemaRefs(value));
+      Object.values(obj).forEach(walk);
     };
 
-    const initialRefs = Array.from(usedSchemaRefs);
-    for (const schemaName of initialRefs) {
-      if (!visitedSchemas.has(schemaName)) {
-        visitedSchemas.add(schemaName);
-        const schema = schemas?.[schemaName];
-        if (schema) {
-          extractNestedSchemaRefs(schema);
-        }
-      }
-    }
+    walk(seed);
 
     const filteredSchemas: ComponentsObject["schemas"] = {};
     for (const [schemaName, schema] of Object.entries(schemas)) {

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -608,48 +608,6 @@
         }
       }
     },
-    "/v1/stripe-webhook": {
-      "post": {
-        "summary": "Stripe Webhook Handler",
-        "tags": [
-          "Payment"
-        ],
-        "security": [],
-        "requestBody": {
-          "content": {
-            "text/plain": {
-              "schema": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Webhook processed successfully",
-            "content": {}
-          },
-          "400": {
-            "description": "Stripe signature is required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "error"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/v1/stripe/prices": {
       "get": {
         "summary": "Get available Stripe pricing options",
@@ -1947,7 +1905,7 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "default": "2026-05-14",
+              "default": "2026-05-20",
               "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
               "example": "2024-01-31"
             },
@@ -2073,7 +2031,7 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "default": "2026-05-14",
+              "default": "2026-05-20",
               "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
               "example": "2024-01-31"
             },
@@ -16466,6 +16424,9 @@
                           "properties": {
                             "key": {
                               "type": "string",
+                              "minLength": 1,
+                              "maxLength": 128,
+                              "pattern": "^([a-zA-Z][\\w/.-]{1,126}[\\w*]?)$",
                               "description": "Attribute key",
                               "example": "persistent"
                             },
@@ -16506,9 +16467,7 @@
                                   "properties": {
                                     "val": {
                                       "type": "string",
-                                      "pattern": "^\\d+$",
-                                      "description": "String-encoded integer value",
-                                      "example": "1000"
+                                      "maxLength": 80
                                     }
                                   },
                                   "required": [
@@ -16522,6 +16481,9 @@
                                     "properties": {
                                       "key": {
                                         "type": "string",
+                                        "minLength": 1,
+                                        "maxLength": 128,
+                                        "pattern": "^([a-zA-Z][\\w/.-]{1,126}[\\w*]?)$",
                                         "description": "Attribute key",
                                         "example": "persistent"
                                       },
@@ -16539,8 +16501,7 @@
                                 }
                               },
                               "required": [
-                                "units",
-                                "attributes"
+                                "units"
                               ]
                             },
                             "memory": {
@@ -16551,9 +16512,7 @@
                                   "properties": {
                                     "val": {
                                       "type": "string",
-                                      "pattern": "^\\d+$",
-                                      "description": "String-encoded integer value",
-                                      "example": "1000"
+                                      "maxLength": 80
                                     }
                                   },
                                   "required": [
@@ -16567,6 +16526,9 @@
                                     "properties": {
                                       "key": {
                                         "type": "string",
+                                        "minLength": 1,
+                                        "maxLength": 128,
+                                        "pattern": "^([a-zA-Z][\\w/.-]{1,126}[\\w*]?)$",
                                         "description": "Attribute key",
                                         "example": "persistent"
                                       },
@@ -16584,8 +16546,7 @@
                                 }
                               },
                               "required": [
-                                "quantity",
-                                "attributes"
+                                "quantity"
                               ]
                             },
                             "gpu": {
@@ -16596,9 +16557,7 @@
                                   "properties": {
                                     "val": {
                                       "type": "string",
-                                      "pattern": "^\\d+$",
-                                      "description": "String-encoded integer value",
-                                      "example": "1000"
+                                      "maxLength": 80
                                     }
                                   },
                                   "required": [
@@ -16612,6 +16571,9 @@
                                     "properties": {
                                       "key": {
                                         "type": "string",
+                                        "minLength": 1,
+                                        "maxLength": 128,
+                                        "pattern": "^([a-zA-Z][\\w/.-]{1,126}[\\w*]?)$",
                                         "description": "Attribute key",
                                         "example": "persistent"
                                       },
@@ -16629,8 +16591,7 @@
                                 }
                               },
                               "required": [
-                                "units",
-                                "attributes"
+                                "units"
                               ]
                             },
                             "storage": {
@@ -16648,9 +16609,7 @@
                                     "properties": {
                                       "val": {
                                         "type": "string",
-                                        "pattern": "^\\d+$",
-                                        "description": "String-encoded integer value",
-                                        "example": "1000"
+                                        "maxLength": 80
                                       }
                                     },
                                     "required": [
@@ -16664,6 +16623,9 @@
                                       "properties": {
                                         "key": {
                                           "type": "string",
+                                          "minLength": 1,
+                                          "maxLength": 128,
+                                          "pattern": "^([a-zA-Z][\\w/.-]{1,126}[\\w*]?)$",
                                           "description": "Attribute key",
                                           "example": "persistent"
                                         },
@@ -16682,8 +16644,7 @@
                                 },
                                 "required": [
                                   "name",
-                                  "quantity",
-                                  "attributes"
+                                  "quantity"
                                 ]
                               }
                             },

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -13226,48 +13226,6 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
         ],
       },
     },
-    "/v1/stripe-webhook": {
-      "post": {
-        "requestBody": {
-          "content": {
-            "text/plain": {
-              "schema": {
-                "type": "string",
-              },
-            },
-          },
-        },
-        "responses": {
-          "200": {
-            "content": {},
-            "description": "Webhook processed successfully",
-          },
-          "400": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "properties": {
-                    "error": {
-                      "type": "string",
-                    },
-                  },
-                  "required": [
-                    "error",
-                  ],
-                  "type": "object",
-                },
-              },
-            },
-            "description": "Stripe signature is required",
-          },
-        },
-        "security": [],
-        "summary": "Stripe Webhook Handler",
-        "tags": [
-          "Payment",
-        ],
-      },
-    },
     "/v1/stripe/coupons/apply": {
       "post": {
         "requestBody": {


### PR DESCRIPTION
## Why

to hide /stripe-webhook a bit from client's eyes

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docs generation memoized for improved performance and supports hiding selected endpoints.

* **Documentation**
  * Stripe webhook endpoint removed from public API docs.
  * Updated pricing date defaults in OpenAPI.
  * Enhanced validation rules for pricing attribute fields and keys.
  * Generated docs now omit hidden operations.

* **Chores**
  * CI PR-size calculation now ignores Markdown and generated files.

* **Tests**
  * OpenAPI service tests updated to use fetch-based HTTP simulation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->