### PR TITLE
docs(repo): add Console Air pointer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 **Akash Console** is a powerful application that allows you to deploy any [Docker container](https://www.docker.com/) on the [Akash Network](https://akash.network) with just a few clicks. 🚀
 
+> Looking for self-custody (Keplr / Leap / your own wallet)? See [Akash Console Air](https://github.com/akash-network/console-air). This repository powers the managed Console at [console.akash.network](https://console.akash.network).
+
 For an indept understanding of the code [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/akash-network/console)
 
 [![release](https://img.shields.io/github/v/release/akash-network/console.svg)](https://github.com/akash-network/console/releases)


### PR DESCRIPTION
## Why

The Akash Console / Console Air split (AEP-84) is live. The root README still describes Console without acknowledging that self-custody users belong in Console Air now. A one-line pointer near the top of the README routes readers to the right product before they get any further into the repo.

Ref CON-267

## What

Adds a single blockquote line under the project description linking to [akash-network/console-air](https://github.com/akash-network/console-air) for self-custody users and clarifying that this repo powers the managed Console at `console.akash.network`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that this repository powers the managed Console at `console.akash.network`
  * Added guidance directing users interested in self-custody options to the Akash Console Air repository

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->