### PR TITLE
feat(billing): require $100 top-up minimum for trial users

### DIFF
--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -36,6 +36,7 @@ export const envSchema = z.object({
     .string()
     .default(AUDITOR)
     .transform(val => (val ? val.split(",").map(addr => addr.trim()) : [])),
+  MANAGED_WALLET_TRIAL_MIN_TOP_UP_AMOUNT: z.number({ coerce: true }).default(100),
   MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: z
     .string()
     .default("nvidia/b300,nvidia/b200,nvidia/h200,nvidia/h100,nvidia/pro6000se,nvidia/pro6000we,nvidia/a100,nvidia/rtx5090,nvidia/rtx4090,nvidia/rtx3090")

--- a/apps/api/src/billing/config/env.config.ts
+++ b/apps/api/src/billing/config/env.config.ts
@@ -36,7 +36,7 @@ export const envSchema = z.object({
     .string()
     .default(AUDITOR)
     .transform(val => (val ? val.split(",").map(addr => addr.trim()) : [])),
-  MANAGED_WALLET_TRIAL_MIN_TOP_UP_AMOUNT: z.number({ coerce: true }).default(100),
+  MANAGED_WALLET_TRIAL_MIN_TOP_UP_AMOUNT: z.number({ coerce: true }).min(20).default(100),
   MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: z
     .string()
     .default("nvidia/b300,nvidia/b200,nvidia/h200,nvidia/h100,nvidia/pro6000se,nvidia/pro6000we,nvidia/a100,nvidia/rtx5090,nvidia/rtx4090,nvidia/rtx3090")

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -8,6 +8,7 @@ import type { UserWalletOutput, UserWalletRepository } from "@src/billing/reposi
 import type { PayingUser } from "@src/billing/services/paying-user/paying-user";
 import type { StripeService } from "@src/billing/services/stripe/stripe.service";
 import type { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
+import type { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
 import { StripeController } from "./stripe.controller";
 
 import { generateDatabaseStripeTransaction } from "@test/seeders/database-stripe-transaction.seeder";
@@ -73,6 +74,70 @@ describe(StripeController.name, () => {
           transactionStatus: "succeeded"
         }
       });
+    });
+
+    it("invokes trial-min validation before contacting Stripe", async () => {
+      const { controller, stripe, userWalletRepository, trialValidationService, user } = setup();
+      const wallet = mock<UserWalletOutput>({ isTrialing: true });
+      userWalletRepository.findOneByUserId.mockResolvedValue(wallet);
+      stripe.hasPaymentMethod.mockResolvedValue(true);
+      stripe.createPaymentIntent.mockResolvedValue({
+        success: true,
+        paymentIntentId: faker.string.uuid(),
+        transactionId: faker.string.uuid(),
+        transactionStatus: "pending"
+      });
+
+      await controller.confirmPayment({
+        userId: user.id,
+        paymentMethodId: faker.string.uuid(),
+        amount: 100,
+        currency: "usd"
+      });
+
+      expect(trialValidationService.validateTopUpAmount).toHaveBeenCalledWith(wallet, 100);
+    });
+
+    it("propagates the trial-min rejection without ever calling Stripe", async () => {
+      const { controller, stripe, userWalletRepository, trialValidationService, user } = setup();
+      const wallet = mock<UserWalletOutput>({ isTrialing: true });
+      userWalletRepository.findOneByUserId.mockResolvedValue(wallet);
+      const trialError = Object.assign(new Error("First top-up must be at least $100 while on the free trial."), { status: 402 });
+      trialValidationService.validateTopUpAmount.mockImplementation(() => {
+        throw trialError;
+      });
+
+      await expect(
+        controller.confirmPayment({
+          userId: user.id,
+          paymentMethodId: faker.string.uuid(),
+          amount: 50,
+          currency: "usd"
+        })
+      ).rejects.toBe(trialError);
+      expect(stripe.hasPaymentMethod).not.toHaveBeenCalled();
+      expect(stripe.createPaymentIntent).not.toHaveBeenCalled();
+    });
+
+    it("forwards an undefined wallet to trial-min validation when no wallet exists", async () => {
+      const { controller, userWalletRepository, trialValidationService, stripe, user } = setup();
+      userWalletRepository.findOneByUserId.mockResolvedValue(undefined);
+      stripe.hasPaymentMethod.mockResolvedValue(true);
+      stripe.createPaymentIntent.mockResolvedValue({
+        success: true,
+        paymentIntentId: faker.string.uuid(),
+        transactionId: faker.string.uuid(),
+        transactionStatus: "pending"
+      });
+
+      await controller.confirmPayment({
+        userId: user.id,
+        paymentMethodId: faker.string.uuid(),
+        amount: 50,
+        currency: "usd"
+      });
+
+      expect(trialValidationService.validateTopUpAmount).toHaveBeenCalledWith(undefined, 50);
     });
 
     it("returns 3DS data with transactionId and transactionStatus", async () => {
@@ -225,7 +290,8 @@ describe(StripeController.name, () => {
     authService.getCurrentPayingUser.mockReturnValue(payingUser);
     const stripeErrorService = mock<StripeErrorService>();
     const userWalletRepository = mock<UserWalletRepository>();
-    const controller = new StripeController(stripe, authService, stripeErrorService, userWalletRepository);
+    const trialValidationService = mock<TrialValidationService>();
+    const controller = new StripeController(stripe, authService, stripeErrorService, userWalletRepository, trialValidationService);
     container.register(AuthService, { useValue: authService });
 
     return {
@@ -234,6 +300,7 @@ describe(StripeController.name, () => {
       authService,
       stripeErrorService,
       userWalletRepository,
+      trialValidationService,
       user
     };
   }

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -22,13 +22,15 @@ import type { StripeTransactionOutput } from "@src/billing/repositories";
 import { UserWalletRepository } from "@src/billing/repositories";
 import { StripeService } from "@src/billing/services/stripe/stripe.service";
 import { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
+import { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
 @singleton()
 export class StripeController {
   constructor(
     private readonly stripe: StripeService,
     private readonly authService: AuthService,
     private readonly stripeErrorService: StripeErrorService,
-    private readonly userWalletRepository: UserWalletRepository
+    private readonly userWalletRepository: UserWalletRepository,
+    private readonly trialValidationService: TrialValidationService
   ) {}
 
   @Protected([{ action: "read", subject: "StripePayment" }])
@@ -84,6 +86,9 @@ export class StripeController {
     const currentUser = this.authService.getCurrentPayingUser({ strict: false });
 
     assert(currentUser, 500, "Payment account not properly configured. Please contact support.");
+
+    const userWallet = await this.userWalletRepository.findOneByUserId(currentUser.id);
+    this.trialValidationService.validateTopUpAmount(userWallet, params.amount);
 
     try {
       assert(await this.stripe.hasPaymentMethod(params.paymentMethodId, currentUser), 403, "Payment method does not belong to the user");

--- a/apps/api/src/billing/controllers/wallet/wallet.controller.spec.ts
+++ b/apps/api/src/billing/controllers/wallet/wallet.controller.spec.ts
@@ -11,6 +11,7 @@ import { BalancesService } from "@src/billing/services/balances/balances.service
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { RefillService } from "@src/billing/services/refill/refill.service";
 import { StripeService } from "@src/billing/services/stripe/stripe.service";
+import { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
 import { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
 import type { UserOutput } from "@src/user/repositories";
 import { UserRepository } from "@src/user/repositories";
@@ -166,6 +167,7 @@ describe("WalletController", () => {
         denom: "uakt",
         creditAmount: 0,
         isTrialing: false,
+        topUpMinAmountUsd: 20,
         createdAt: null,
         requires3DS: true,
         clientSecret: "test_client_secret",
@@ -229,7 +231,7 @@ describe("WalletController", () => {
       const result = await walletController.getWallets({ userId });
 
       expect(result).toEqual({
-        data: wallets.map(wallet => ({ ...wallet, denom: "uakt" }))
+        data: wallets.map(wallet => ({ ...wallet, denom: "uakt", topUpMinAmountUsd: wallet.isTrialing ? 100 : 20 }))
       });
       expect(container.resolve(WalletReaderService).getWallets).toHaveBeenCalledWith({ userId });
     });
@@ -352,6 +354,11 @@ describe("WalletController", () => {
     });
     rootContainer.register(UserWalletRepository, {
       useValue: mock<UserWalletRepository>()
+    });
+    rootContainer.register(TrialValidationService, {
+      useValue: mock<TrialValidationService>({
+        getTopUpMinAmountUsd: jest.fn(wallet => (wallet?.isTrialing ? 100 : 20))
+      })
     });
 
     return rootContainer;

--- a/apps/api/src/billing/controllers/wallet/wallet.controller.ts
+++ b/apps/api/src/billing/controllers/wallet/wallet.controller.ts
@@ -15,6 +15,7 @@ import { ManagedSignerService } from "@src/billing/services/managed-signer/manag
 import { RefillService } from "@src/billing/services/refill/refill.service";
 import { StripeService } from "@src/billing/services/stripe/stripe.service";
 import { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
+import { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
 import { GetWalletOptions, WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
 import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
 import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
@@ -34,7 +35,8 @@ export class WalletController {
     private readonly stripeErrorService: StripeErrorService,
     private readonly featureFlagsService: FeatureFlagsService,
     private readonly userRepository: UserRepository,
-    private readonly billingConfigService: BillingConfigService
+    private readonly billingConfigService: BillingConfigService,
+    private readonly trialValidationService: TrialValidationService
   ) {}
 
   @Protected([{ action: "create", subject: "UserWallet" }])
@@ -75,6 +77,7 @@ export class WalletController {
             denom: this.billingConfigService.get("DEPLOYMENT_GRANT_DENOM"),
             creditAmount: 0,
             isTrialing: false,
+            topUpMinAmountUsd: this.trialValidationService.getTopUpMinAmountUsd({ isTrialing: false }),
             createdAt: null,
             requires3DS: true,
             clientSecret: validationResult.clientSecret || null,
@@ -92,9 +95,10 @@ export class WalletController {
     }
 
     const denom = this.billingConfigService.get("DEPLOYMENT_GRANT_DENOM");
+    const wallet = await this.walletInitializer.initializeAndGrantTrialLimits(userId);
 
     return {
-      data: { ...(await this.walletInitializer.initializeAndGrantTrialLimits(userId)), denom }
+      data: { ...wallet, denom, topUpMinAmountUsd: this.trialValidationService.getTopUpMinAmountUsd(wallet) }
     };
   }
 
@@ -104,7 +108,7 @@ export class WalletController {
     const wallets = await this.walletReaderService.getWallets(query as GetWalletOptions);
 
     return {
-      data: wallets.map(wallet => ({ ...wallet, denom }))
+      data: wallets.map(wallet => ({ ...wallet, denom, topUpMinAmountUsd: this.trialValidationService.getTopUpMinAmountUsd(wallet) }))
     };
   }
 

--- a/apps/api/src/billing/http-schemas/wallet.schema.ts
+++ b/apps/api/src/billing/http-schemas/wallet.schema.ts
@@ -7,6 +7,7 @@ const WalletOutputSchema = z.object({
   address: z.string().nullable().openapi({}),
   denom: z.string().openapi({}),
   isTrialing: z.boolean(),
+  topUpMinAmountUsd: z.number().openapi({ description: "Minimum USD amount accepted by the next paid top-up for this wallet." }),
   createdAt: z.coerce.date().nullable().openapi({})
 });
 

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -121,7 +121,6 @@ describe(ManagedSignerService.name, () => {
       await service.executeDerivedDecodedTxByUserId("user-123", messages);
 
       expect(anonymousValidateService.validateLeaseProviders).not.toHaveBeenCalled();
-      expect(anonymousValidateService.validateTrialLimit).not.toHaveBeenCalled();
     });
 
     it("executes transaction successfully and returns result", async () => {
@@ -542,7 +541,6 @@ describe(ManagedSignerService.name, () => {
     currentUser?: UserOutput;
     enabledFeatures?: FeatureFlagValue[];
     validateLeaseProviders?: TrialValidationService["validateLeaseProviders"];
-    validateTrialLimit?: TrialValidationService["validateTrialLimit"];
     validateLeaseProvidersAuditors?: TrialValidationService["validateLeaseProvidersAuditors"];
     signAndBroadcastWithDerivedWallet?: TxManagerService["signAndBroadcastWithDerivedWallet"];
     signAndBroadcastWithFundingWallet?: TxManagerService["signAndBroadcastWithFundingWallet"];

--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
@@ -206,10 +206,17 @@ describe(TrialValidationService.name, () => {
       expect(() => service.validateTopUpAmount(undefined, 1)).not.toThrow();
     });
 
-    it("resolves for non-trial users regardless of amount", () => {
+    it("resolves for non-trial users paying at or above the standard minimum", () => {
       const { service } = setupTopUp({ trialMin: 100 });
       const wallet = createUserWallet({ isTrialing: false });
-      expect(() => service.validateTopUpAmount(wallet, 1)).not.toThrow();
+      expect(() => service.validateTopUpAmount(wallet, 20)).not.toThrow();
+      expect(() => service.validateTopUpAmount(wallet, 1000)).not.toThrow();
+    });
+
+    it("throws 402 for non-trial users paying below the standard minimum", () => {
+      const { service } = setupTopUp({ trialMin: 100 });
+      const wallet = createUserWallet({ isTrialing: false });
+      expect(() => service.validateTopUpAmount(wallet, 5)).toThrow(expect.objectContaining({ status: 402, message: "Top-up must be at least $20." }));
     });
 
     it("resolves for trial users paying at or above the trial minimum", () => {

--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
@@ -6,7 +6,6 @@ import { mock } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
-import type { DeploymentReaderService } from "@src/deployment/services/deployment-reader/deployment-reader.service";
 import type { ProviderRepository } from "@src/provider/repositories/provider/provider.repository";
 import { TrialValidationService } from "./trial-validation.service";
 
@@ -15,61 +14,6 @@ import { createBid } from "@test/seeders/bid.seeder";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(TrialValidationService.name, () => {
-  describe("validateTrialLimit", () => {
-    it("queries active deployments only when wallet is trialing and message is a deployment", async () => {
-      const wallet = createUserWallet({ isTrialing: true });
-      const { service, deploymentReaderService } = setup({ count: 0 });
-
-      await service.validateTrialLimit(createDeploymentMessage(), wallet);
-
-      expect(deploymentReaderService.listWithResources).toHaveBeenCalledWith({
-        address: wallet.address,
-        status: "active",
-        limit: 1
-      });
-    });
-
-    it("allows the deployment when active count is below the trial limit", async () => {
-      const wallet = createUserWallet({ isTrialing: true });
-      const { service } = setup({ count: 4 });
-
-      await expect(service.validateTrialLimit(createDeploymentMessage(), wallet)).resolves.toBeUndefined();
-    });
-
-    it("rejects with 402 when active count has reached the trial limit", async () => {
-      const wallet = createUserWallet({ isTrialing: true });
-      const { service } = setup({ count: 5 });
-
-      await expect(service.validateTrialLimit(createDeploymentMessage(), wallet)).rejects.toMatchObject({
-        status: 402,
-        message: "Trial limit reached. Add funds to your account to deploy more."
-      });
-    });
-
-    it("skips the check when wallet is not trialing", async () => {
-      const wallet = createUserWallet({ isTrialing: false });
-      const { service, deploymentReaderService } = setup({ count: 99 });
-
-      await service.validateTrialLimit(createDeploymentMessage(), wallet);
-
-      expect(deploymentReaderService.listWithResources).not.toHaveBeenCalled();
-    });
-
-    it("skips the check when message is not a deployment creation", async () => {
-      const wallet = createUserWallet({ isTrialing: true });
-      const { service, deploymentReaderService } = setup({ count: 99 });
-
-      const leaseMessage: EncodeObject = {
-        typeUrl: `/${MsgCreateLease.$type}`,
-        value: MsgCreateLease.fromPartial({})
-      };
-
-      await service.validateTrialLimit(leaseMessage, wallet);
-
-      expect(deploymentReaderService.listWithResources).not.toHaveBeenCalled();
-    });
-  });
-
   describe("validateLeaseGpuModels", () => {
     it("skips validation when wallet is not trialing", async () => {
       const wallet = createUserWallet({ isTrialing: false });
@@ -239,19 +183,63 @@ describe(TrialValidationService.name, () => {
     return bid;
   }
 
-  function setup(input: { count: number }) {
-    const deploymentReaderService = mock<DeploymentReaderService>();
-    deploymentReaderService.listWithResources.mockResolvedValue({ count: input.count, results: [] });
-    const config = mock<BillingConfigService>();
+  describe("getTopUpMinAmountUsd", () => {
+    it("returns the standard $20 floor when the wallet is not trialing", () => {
+      const { service } = setupTopUp({ trialMin: 100 });
+      expect(service.getTopUpMinAmountUsd({ isTrialing: false })).toBe(20);
+    });
+
+    it("returns the configured trial minimum when the wallet is trialing", () => {
+      const { service } = setupTopUp({ trialMin: 100 });
+      expect(service.getTopUpMinAmountUsd({ isTrialing: true })).toBe(100);
+    });
+
+    it("honors a custom trial minimum from config", () => {
+      const { service } = setupTopUp({ trialMin: 250 });
+      expect(service.getTopUpMinAmountUsd({ isTrialing: true })).toBe(250);
+    });
+  });
+
+  describe("validateTopUpAmount", () => {
+    it("resolves when no wallet is provided", () => {
+      const { service } = setupTopUp({ trialMin: 100 });
+      expect(() => service.validateTopUpAmount(undefined, 1)).not.toThrow();
+    });
+
+    it("resolves for non-trial users regardless of amount", () => {
+      const { service } = setupTopUp({ trialMin: 100 });
+      const wallet = createUserWallet({ isTrialing: false });
+      expect(() => service.validateTopUpAmount(wallet, 1)).not.toThrow();
+    });
+
+    it("resolves for trial users paying at or above the trial minimum", () => {
+      const { service } = setupTopUp({ trialMin: 100 });
+      const wallet = createUserWallet({ isTrialing: true });
+      expect(() => service.validateTopUpAmount(wallet, 100)).not.toThrow();
+      expect(() => service.validateTopUpAmount(wallet, 250)).not.toThrow();
+    });
+
+    it("throws 402 for trial users paying below the trial minimum", () => {
+      const { service } = setupTopUp({ trialMin: 100 });
+      const wallet = createUserWallet({ isTrialing: true });
+      expect(() => service.validateTopUpAmount(wallet, 50)).toThrow(
+        expect.objectContaining({ status: 402, message: "First top-up must be at least $100 while on the free trial." })
+      );
+    });
+  });
+
+  function setupTopUp(input: { trialMin: number }) {
     const providerRepository = mock<ProviderRepository>();
     const bidHttpService = mock<BidHttpService>();
     const blockedGpuService = mock<BlockedGpuService>();
-    const service = new TrialValidationService(deploymentReaderService, config, providerRepository, bidHttpService, blockedGpuService);
-    return { service, deploymentReaderService, config, providerRepository, bidHttpService, blockedGpuService };
+    const config = mockConfigService<BillingConfigService>({
+      MANAGED_WALLET_TRIAL_MIN_TOP_UP_AMOUNT: input.trialMin
+    });
+    const service = new TrialValidationService(config, providerRepository, bidHttpService, blockedGpuService);
+    return { service };
   }
 
   function setupGpu(input: { blockedGpuModels: string[]; bid?: ReturnType<typeof createBid> }) {
-    const deploymentReaderService = mock<DeploymentReaderService>();
     const config = mock<BillingConfigService>();
     const providerRepository = mock<ProviderRepository>();
     const bidHttpService = mock<BidHttpService>();
@@ -260,7 +248,7 @@ describe(TrialValidationService.name, () => {
       MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS: input.blockedGpuModels
     });
     const blockedGpuService = new BlockedGpuService(blockedGpuConfig);
-    const service = new TrialValidationService(deploymentReaderService, config, providerRepository, bidHttpService, blockedGpuService);
-    return { service, deploymentReaderService, config, providerRepository, bidHttpService, blockedGpuService };
+    const service = new TrialValidationService(config, providerRepository, bidHttpService, blockedGpuService);
+    return { service, config, providerRepository, bidHttpService, blockedGpuService };
   }
 });

--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.ts
@@ -75,9 +75,13 @@ export class TrialValidationService {
   }
 
   validateTopUpAmount(userWallet: Pick<UserWalletOutput, "isTrialing"> | undefined, amountUsd: number) {
-    if (!userWallet?.isTrialing) return;
+    if (!userWallet) return;
     const min = this.getTopUpMinAmountUsd(userWallet);
-    assert(amountUsd >= min, 402, `First top-up must be at least $${min} while on the free trial.`);
+    assert(
+      amountUsd >= min,
+      402,
+      userWallet.isTrialing ? `First top-up must be at least $${min} while on the free trial.` : `Top-up must be at least $${min}.`
+    );
   }
 
   @Trace()

--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.ts
@@ -10,32 +10,19 @@ import { BillingConfigService } from "@src/billing/services/billing-config/billi
 import { Trace } from "@src/core/services/tracing/tracing.service";
 import { AUDITOR, TRIAL_ATTRIBUTE, TRIAL_REGISTERED_ATTRIBUTE } from "@src/deployment/config/provider.config";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";
-import { DeploymentReaderService } from "@src/deployment/services/deployment-reader/deployment-reader.service";
 import { ProviderRepository } from "@src/provider/repositories/provider/provider.repository";
 import type { UserOutput } from "@src/user/repositories";
 
-const TRIAL_DEPLOYMENT_LIMIT = 5;
+const STANDARD_TOP_UP_MIN_AMOUNT_USD = 20;
 
 @singleton()
 export class TrialValidationService {
   constructor(
-    private readonly deploymentReaderService: DeploymentReaderService,
     private readonly config: BillingConfigService,
     private readonly providerRepository: ProviderRepository,
     private readonly bidHttpService: BidHttpService,
     private readonly blockedGpuService: BlockedGpuService
   ) {}
-
-  async validateTrialLimit(decoded: EncodeObject, userWallet: UserWalletOutput) {
-    if (userWallet.isTrialing && decoded.typeUrl === `/${MsgCreateDeployment.$type}`) {
-      const deployments = await this.deploymentReaderService.listWithResources({
-        address: userWallet.address!,
-        status: "active",
-        limit: 1
-      });
-      assert(deployments.count < TRIAL_DEPLOYMENT_LIMIT, 402, "Trial limit reached. Add funds to your account to deploy more.");
-    }
-  }
 
   async validateLeaseProviders(decoded: EncodeObject, userWallet: UserWalletOutput, user: UserOutput) {
     if (decoded.typeUrl === `/${MsgCreateDeployment.$type}`) {
@@ -81,6 +68,16 @@ export class TrialValidationService {
 
       assert(isAuditedByAllowedAuditor, 403, `Provider not authorized.`);
     }
+  }
+
+  getTopUpMinAmountUsd(userWallet: Pick<UserWalletOutput, "isTrialing">): number {
+    return userWallet.isTrialing ? this.config.get("MANAGED_WALLET_TRIAL_MIN_TOP_UP_AMOUNT") : STANDARD_TOP_UP_MIN_AMOUNT_USD;
+  }
+
+  validateTopUpAmount(userWallet: Pick<UserWalletOutput, "isTrialing"> | undefined, amountUsd: number) {
+    if (!userWallet?.isTrialing) return;
+    const min = this.getTopUpMinAmountUsd(userWallet);
+    assert(amountUsd >= min, 402, `First top-up must be at least $${min} while on the free trial.`);
   }
 
   @Trace()

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -13122,6 +13122,10 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "requires3DS": {
                           "type": "boolean",
                         },
+                        "topUpMinAmountUsd": {
+                          "description": "Minimum USD amount accepted by the next paid top-up for this wallet.",
+                          "type": "number",
+                        },
                         "userId": {
                           "nullable": true,
                           "type": "string",
@@ -13134,6 +13138,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "address",
                         "denom",
                         "isTrialing",
+                        "topUpMinAmountUsd",
                         "createdAt",
                       ],
                       "type": "object",
@@ -13192,6 +13197,10 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "requires3DS": {
                           "type": "boolean",
                         },
+                        "topUpMinAmountUsd": {
+                          "description": "Minimum USD amount accepted by the next paid top-up for this wallet.",
+                          "type": "number",
+                        },
                         "userId": {
                           "nullable": true,
                           "type": "string",
@@ -13204,6 +13213,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                         "address",
                         "denom",
                         "isTrialing",
+                        "topUpMinAmountUsd",
                         "createdAt",
                       ],
                       "type": "object",
@@ -16324,6 +16334,10 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "requires3DS": {
                             "type": "boolean",
                           },
+                          "topUpMinAmountUsd": {
+                            "description": "Minimum USD amount accepted by the next paid top-up for this wallet.",
+                            "type": "number",
+                          },
                           "userId": {
                             "nullable": true,
                             "type": "string",
@@ -16336,6 +16350,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "address",
                           "denom",
                           "isTrialing",
+                          "topUpMinAmountUsd",
                           "createdAt",
                         ],
                         "type": "object",

--- a/apps/deploy-web/src/components/billing-usage/PaymentPopup/PaymentPopup.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentPopup/PaymentPopup.spec.tsx
@@ -50,7 +50,7 @@ const MockFormField = ({ control, name, render }: any) => {
   return render({ field });
 };
 
-const MockFormInput = ({ label, type, placeholder, onChange, value, ...rest }: any) => {
+const MockFormInput = ({ label, type, placeholder, onChange, value, description, ...rest }: any) => {
   const inputId = `input-${rest.name}`;
   // Remove onChange from rest to avoid conflicts
   const { onChange: _omit, ...otherProps } = rest;
@@ -58,6 +58,7 @@ const MockFormInput = ({ label, type, placeholder, onChange, value, ...rest }: a
     <div>
       <label htmlFor={inputId}>{label}</label>
       <input id={inputId} data-testid={inputId} type={type} placeholder={placeholder} value={value} {...otherProps} onChange={onChange} />
+      {description && <p data-testid={`${inputId}-description`}>{description}</p>}
     </div>
   );
 };
@@ -217,6 +218,16 @@ describe(PaymentPopup.name, () => {
       });
 
       expect(paymentForm.getValues("amount")).toBe(25);
+    });
+
+    it("renders the wallet-provided minimum in the input description", () => {
+      setup({ open: true, topUpMinAmountUsd: 100 });
+      expect(screen.getByText("Minimum amount is $100")).toBeInTheDocument();
+    });
+
+    it("falls back to the established $20 minimum description when wallet reports it", () => {
+      setup({ open: true, topUpMinAmountUsd: 20 });
+      expect(screen.getByText("Minimum amount is $20")).toBeInTheDocument();
     });
   });
 
@@ -867,6 +878,7 @@ function setup(
     stripeErrorResponse?: any;
     mockUse3DSecure?: Mock;
     paymentMethods?: any[];
+    topUpMinAmountUsd?: number;
   } = {}
 ) {
   const mockOnClose = input.onClose || vi.fn();
@@ -1029,7 +1041,8 @@ function setup(
     })),
     handleCouponError: mockHandleCouponError,
     handleStripeError: mockHandleStripeError,
-    useServices: vi.fn(() => ({ errorHandler: mockErrorHandler, urlService: { paymentMethods: () => "/payment-methods" } }))
+    useServices: vi.fn(() => ({ errorHandler: mockErrorHandler, urlService: { paymentMethods: () => "/payment-methods" } })),
+    useWallet: vi.fn(() => ({ topUpMinAmountUsd: input.topUpMinAmountUsd ?? 20 }))
   };
 
   const props: React.ComponentProps<typeof PaymentPopup> = {

--- a/apps/deploy-web/src/components/billing-usage/PaymentPopup/PaymentPopup.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentPopup/PaymentPopup.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { FormattedNumber } from "react-intl";
 import {
@@ -33,6 +33,7 @@ import { getPaymentMethodDisplay } from "@src/components/shared/PaymentMethodCar
 import { ThreeDSecurePopup } from "@src/components/shared/PaymentMethodForm/ThreeDSecurePopup";
 import { usePaymentPolling } from "@src/context/PaymentPollingProvider";
 import { useServices } from "@src/context/ServicesProvider";
+import { useWallet } from "@src/context/WalletProvider";
 import { use3DSecure } from "@src/hooks/use3DSecure";
 import { useUser } from "@src/hooks/useUser";
 import { usePaymentMethodsQuery, usePaymentMutations } from "@src/queries";
@@ -73,19 +74,19 @@ export const DEPENDENCIES = {
   handleCouponError,
   handleStripeError,
   useServices,
+  useWallet,
   ThreeDSecurePopup
 };
 
-const MINIMUM_PAYMENT_AMOUNT = 20;
-
-const paymentFormSchema = z.object({
-  amount: z.coerce
-    .number({
-      invalid_type_error: "Amount must be a number"
-    })
-    .positive("Amount must be greater than $0")
-    .min(MINIMUM_PAYMENT_AMOUNT, `Minimum amount is $${MINIMUM_PAYMENT_AMOUNT}`)
-});
+const buildPaymentFormSchema = (minimumAmount: number) =>
+  z.object({
+    amount: z.coerce
+      .number({
+        invalid_type_error: "Amount must be a number"
+      })
+      .positive("Amount must be greater than $0")
+      .min(minimumAmount, `Minimum amount is $${minimumAmount}`)
+  });
 
 const couponFormSchema = z.object({
   coupon: z.string().min(1, "Coupon code is required")
@@ -114,6 +115,7 @@ export const PaymentPopup: React.FC<PaymentPopupProps> = ({
   const [errorAction, setErrorAction] = useState<string>();
   const submittedAmountRef = useRef<string>("");
   const { user } = d.useUser();
+  const { topUpMinAmountUsd } = d.useWallet();
   const { data: paymentMethods, isLoading: isLoadingPaymentMethods } = d.usePaymentMethodsQuery();
   const {
     confirmPayment: { isPending: isConfirmingPayment, mutateAsync: confirmPayment },
@@ -121,7 +123,9 @@ export const PaymentPopup: React.FC<PaymentPopupProps> = ({
   } = d.usePaymentMutations();
   const { pollForPayment, isPolling } = d.usePaymentPolling();
 
-  const paymentForm = d.useForm<z.infer<typeof paymentFormSchema>>({
+  const paymentFormSchema = useMemo(() => buildPaymentFormSchema(topUpMinAmountUsd), [topUpMinAmountUsd]);
+
+  const paymentForm = d.useForm<z.infer<ReturnType<typeof buildPaymentFormSchema>>>({
     defaultValues: {
       amount: 0
     },
@@ -153,7 +157,7 @@ export const PaymentPopup: React.FC<PaymentPopupProps> = ({
     }
   };
 
-  const onPayment = async ({ amount }: z.infer<typeof paymentFormSchema>) => {
+  const onPayment = async ({ amount }: z.infer<ReturnType<typeof buildPaymentFormSchema>>) => {
     if (!user?.id) {
       errorHandler.reportError({
         message: "Payment attempted without a user id",
@@ -307,10 +311,11 @@ export const PaymentPopup: React.FC<PaymentPopupProps> = ({
                       <d.FormInput
                         {...field}
                         type="number"
-                        min="0"
+                        min={topUpMinAmountUsd}
                         step="0.01"
                         placeholder="0.00"
                         label="Amount (USD)"
+                        description={`Minimum amount is $${topUpMinAmountUsd}`}
                         autoFocus
                         onChange={e => {
                           field.onChange(e);

--- a/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
@@ -66,6 +66,7 @@ export type ContextType = {
   isTrialing: boolean;
   isOnboarding: boolean;
   creditAmount?: number;
+  topUpMinAmountUsd: number;
   switchWalletType: () => void;
   hasManagedWallet: boolean;
   managedWalletError?: AppError;
@@ -399,6 +400,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         isTrialing: isManaged && !!managedWallet?.isTrialing,
         isOnboarding: !!user?.userId && isManaged && !!managedWallet?.isTrialing,
         creditAmount: isManaged ? managedWallet?.creditAmount : 0,
+        topUpMinAmountUsd: managedWallet?.topUpMinAmountUsd ?? 20,
         hasManagedWallet: !!managedWallet,
         managedWalletError,
         switchWalletType,

--- a/packages/http-sdk/src/managed-wallet-http/managed-wallet-http.service.ts
+++ b/packages/http-sdk/src/managed-wallet-http/managed-wallet-http.service.ts
@@ -9,6 +9,7 @@ export interface ApiWalletOutput {
   denom: string;
   creditAmount: number;
   isTrialing: boolean;
+  topUpMinAmountUsd: number;
   createdAt: Date;
 }
 


### PR DESCRIPTION
## Why

Trial accounts get $100 of free credits up front. With the existing $20 Stripe top-up floor, a trial user could pay $20, convert to a paying account, and keep the $100 trial credit forever — a net ~$80 loss per such account. Raising the first paid top-up to $100 (matching the trial grant) makes the worst case break-even.

## What

While the user is still on the free trial (`userWallet.isTrialing === true`), the Stripe top-up minimum is **$100**. Once they convert to a paying account, the existing **$20** minimum applies. The transition flips automatically inside the Stripe webhook (`BalancesService.refreshUserWalletLimits({ endTrial: true })`), so gating on `isTrialing` captures "first paid top-up" without needing a separate flag.

**Backend**
- New `MANAGED_WALLET_TRIAL_MIN_TOP_UP_AMOUNT` env var (default `100`).
- `TrialValidationService.getTopUpMinAmountUsd(wallet)` — single source of truth for the minimum (trial → env, otherwise $20).
- `TrialValidationService.validateTopUpAmount(wallet, amount)` — throws 402 with a dynamic message; called from `StripeController.confirmPayment` **before** any Stripe call so a $50 trial top-up never reaches Stripe.
- Wallet response now carries `topUpMinAmountUsd` so the frontend always shows the effective minimum without a duplicate env var.

**Frontend**
- `PaymentPopup` rebuilds its zod schema from `useWallet().topUpMinAmountUsd` and surfaces the active minimum in the input description ("Minimum amount is $100").
- `WalletProvider` exposes `topUpMinAmountUsd` (defaults to `20` when no managed wallet).

**Cleanup**
- Removed the dead `validateTrialLimit` + `TRIAL_DEPLOYMENT_LIMIT` path from `TrialValidationService` — no longer called anywhere — plus the now-orphaned `DeploymentReaderService` constructor dep and related spec scaffolding.

**Tests**
- New `validateTopUpAmount` + `getTopUpMinAmountUsd` specs.
- New `StripeController.confirmPayment` specs covering: trial-min gate is called, rejection short-circuits Stripe, undefined-wallet path.
- `PaymentPopup` spec: dynamic minimum is rendered from the wallet context.
- `WalletController` spec updated to assert the new `topUpMinAmountUsd` field on `getWallets` and the 3DS path.
- All 64 touched API tests + 40 deploy-web tests pass; lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payment top-up enforces and displays a configurable minimum: trial wallets use a trial-specific minimum (configurable, defaults to $100), standard wallets use a $20 minimum.

* **Refactor**
  * Trial validation reorganized to focus on top-up minimum logic and removed legacy trial-deployment limit checks.

* **Tests**
  * Expanded tests to cover top-up minimum behavior and updated wallet/payment UI tests to reflect the new minimum field.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->