### PR TITLE
fix(managed-wallet): persist derived wallet sequence and surface on-chain failures

### DIFF
--- a/apps/tx-signer/src/lib/batch-signing-client/batch-signing-client.service.spec.ts
+++ b/apps/tx-signer/src/lib/batch-signing-client/batch-signing-client.service.spec.ts
@@ -1,9 +1,9 @@
 import { TxRaw } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import { sha256 } from "@cosmjs/crypto";
 import { toHex } from "@cosmjs/encoding";
-import type { EncodeObject } from "@cosmjs/proto-signing";
+import type { AccountData, EncodeObject, GeneratedType } from "@cosmjs/proto-signing";
 import { Registry } from "@cosmjs/proto-signing";
-import type { Account, DeliverTxResponse, IndexedTx,SigningStargateClient } from "@cosmjs/stargate";
+import type { Account, DeliverTxResponse, IndexedTx, SigningStargateClient } from "@cosmjs/stargate";
 import { faker } from "@faker-js/faker";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
@@ -65,9 +65,9 @@ describe(BatchSigningClientService.name, () => {
     );
 
     const allTestData = [...successfulTestData, erroredTestData];
-    const { service, client } = setup(allTestData);
+    const { service, client, simulateMock } = setup(allTestData);
 
-    client.simulate.mockResolvedValueOnce(erroredTestData.gasEstimate);
+    simulateMock.mockResolvedValueOnce({ gasInfo: { gasUsed: BigInt(erroredTestData.gasEstimate) } });
     client.sign.mockResolvedValueOnce(erroredTestData.signedMessage);
     client.broadcastTx.mockResolvedValueOnce({ transactionHash: hash } as DeliverTxResponse);
     client.getTx.mockResolvedValueOnce(erroredTestData.tx);
@@ -91,6 +91,71 @@ describe(BatchSigningClientService.name, () => {
 
     await expect(service.signAndBroadcast(testData.messages)).rejects.toThrow("Invalid argument");
     expect(client.getTx).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when the recovered tx has a non-zero code, including rawLog so chain-error mapping works", async () => {
+    const testData = createTransactionTestData();
+    testData.tx = { ...testData.tx, code: 17, rawLog: "deployment exists" };
+
+    const { service } = setup([testData]);
+
+    await expect(service.signAndBroadcast(testData.messages)).rejects.toThrow(/deployment exists/i);
+  });
+
+  it("caches account info and sequence across sequential calls so getAccount is fetched only once", async () => {
+    const calls = [createTransactionTestData(), createTransactionTestData(), createTransactionTestData()];
+    const { service, client, simulateMock } = setup([]);
+
+    for (const data of calls) {
+      simulateMock.mockResolvedValueOnce({ gasInfo: { gasUsed: BigInt(data.gasEstimate) } });
+      client.broadcastTx.mockResolvedValueOnce({ transactionHash: data.hash } as DeliverTxResponse);
+      client.sign.mockResolvedValueOnce(data.signedMessage);
+      client.getTx.mockResolvedValueOnce(data.tx);
+      await service.signAndBroadcast(data.messages);
+    }
+
+    expect(client.getAccount).toHaveBeenCalledTimes(1);
+    const signCalls = client.sign.mock.calls;
+    expect(signCalls).toHaveLength(calls.length);
+    expect(signCalls[0][4]?.sequence).toBe(1);
+    expect(signCalls[1][4]?.sequence).toBe(2);
+    expect(signCalls[2][4]?.sequence).toBe(3);
+  });
+
+  it("passes the local sequence explicitly to the tx.simulate query", async () => {
+    const data = createTransactionTestData();
+    const { service, simulateMock } = setup([data]);
+
+    await service.signAndBroadcast(data.messages);
+
+    expect(simulateMock).toHaveBeenCalledTimes(1);
+    const [, memo, pubkey, sequence] = simulateMock.mock.calls[0];
+    expect(memo).toBe("akash console");
+    expect(pubkey).toBeDefined();
+    expect(sequence).toBe(1);
+  });
+
+  it("recovers from sequence mismatch by parsing the expected sequence from the error and retrying without a fresh chain fetch", async () => {
+    const data = createTransactionTestData();
+    const { service, client, simulateMock } = setup([data]);
+
+    const mismatchError = new Error(
+      "Query failed with (6): rpc error: code = Unknown desc = account sequence mismatch, expected 42, got 1: incorrect account sequence"
+    );
+
+    client.broadcastTx.mockReset();
+    client.broadcastTx.mockRejectedValueOnce(mismatchError).mockResolvedValueOnce({ transactionHash: data.hash } as DeliverTxResponse);
+
+    simulateMock.mockResolvedValueOnce({ gasInfo: { gasUsed: BigInt(data.gasEstimate) } });
+    client.sign.mockResolvedValueOnce(data.signedMessage);
+
+    const result = await service.signAndBroadcast(data.messages);
+
+    expect(result).toEqual(data.tx);
+    expect(client.getAccount).toHaveBeenCalledTimes(1);
+    const sequencesUsed = client.sign.mock.calls.map(call => call[4]?.sequence);
+    expect(sequencesUsed[0]).toBe(1);
+    expect(sequencesUsed[1]).toBe(42);
   });
 
   function createTransactionTestData(): TransactionTestData {
@@ -132,8 +197,18 @@ describe(BatchSigningClientService.name, () => {
   }
 
   function setup(testData: TransactionTestData[]) {
+    const address = createAkashAddress();
+    const compressedPubkey = new Uint8Array(33);
+    compressedPubkey[0] = 0x02;
+    for (let i = 1; i < 33; i++) compressedPubkey[i] = (i * 7) & 0xff;
+    const accountData: AccountData = {
+      address,
+      algo: "secp256k1",
+      pubkey: compressedPubkey
+    };
     const wallet = mock<Wallet>({
-      getFirstAddress: vi.fn(() => Promise.resolve(createAkashAddress()))
+      getFirstAddress: vi.fn(() => Promise.resolve(address)),
+      getAccounts: vi.fn(() => Promise.resolve([accountData]))
     });
 
     const billingConfigService = mock<AppConfigService>({
@@ -148,15 +223,24 @@ describe(BatchSigningClientService.name, () => {
       })
     });
 
-    const registry = new Registry();
+    const stubType = {
+      encode: () => ({ finish: () => new Uint8Array() }),
+      decode: () => ({}),
+      fromPartial: (v: unknown) => v
+    } as unknown as GeneratedType;
+    const registry = new Registry([["/test.MsgTest", stubType]]);
+    const simulateMock = vi.fn();
+    const queryClient = { tx: { simulate: simulateMock } };
 
     const client = mock<SigningStargateClient>({
       getChainId: vi.fn(async () => "test-chain"),
-      getAccount: vi.fn(async (address: string) => ({ accountNumber: 0, sequence: 1, address }) as Account)
+      getAccount: vi.fn(async (queriedAddress: string) => ({ accountNumber: 0, sequence: 1, address: queriedAddress }) as Account),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      forceGetQueryClient: vi.fn(() => queryClient as any)
     });
 
     testData.forEach((data, index) => {
-      client.simulate.mockResolvedValueOnce(data.gasEstimate);
+      simulateMock.mockResolvedValueOnce({ gasInfo: { gasUsed: BigInt(data.gasEstimate) } });
       client.sign.mockResolvedValueOnce(data.signedMessage);
 
       if (index < testData.length - 1) {
@@ -181,6 +265,6 @@ describe(BatchSigningClientService.name, () => {
     const createClientWithSigner = vi.fn(() => client);
     const service = new BatchSigningClientService(billingConfigService, wallet, registry, createClientWithSigner);
 
-    return { service, client };
+    return { service, client, simulateMock };
   }
 });

--- a/apps/tx-signer/src/lib/batch-signing-client/batch-signing-client.service.ts
+++ b/apps/tx-signer/src/lib/batch-signing-client/batch-signing-client.service.ts
@@ -1,5 +1,7 @@
 import { TxRaw } from "@akashnetwork/chain-sdk/private-types/cosmos.v1beta1";
 import { createOtelLogger } from "@akashnetwork/logging/otel";
+import type { Pubkey } from "@cosmjs/amino";
+import { encodeSecp256k1Pubkey } from "@cosmjs/amino";
 import { sha256 } from "@cosmjs/crypto";
 import { toHex } from "@cosmjs/encoding";
 import type { EncodeObject, Registry } from "@cosmjs/proto-signing";
@@ -28,16 +30,40 @@ interface SignAndBroadcastBatchOptions {
   options?: SignAndBroadcastOptions;
 }
 
+interface AccountState {
+  accountNumber: number;
+  sequence: number;
+  pubkey: Pubkey;
+  lastSyncedAt: number;
+}
+
+interface SimulateQueryClient {
+  tx: {
+    simulate: (
+      messages: readonly ReturnType<Registry["encodeAsAny"]>[],
+      memo: string | undefined,
+      signer: Pubkey,
+      sequence: number
+    ) => Promise<{ gasInfo?: { gasUsed: bigint | number | string } }>;
+  };
+}
+
+const SEQUENCE_MISMATCH_PATTERN = /account sequence mismatch, expected (\d+)/;
+
 export class BatchSigningClientService {
   private readonly MEMO = "akash console";
 
   private readonly FEES_DENOM = "uakt";
+
+  private readonly ACCOUNT_STATE_TTL_MS = 30_000;
 
   private client: SigningStargateClient;
 
   private readonly semaphore = new Sema(1);
 
   private activeBatches = 0;
+
+  private accountState: AccountState | null = null;
 
   private signAndBroadcastLoader = new DataLoader(
     async (batchedInputs: readonly SignAndBroadcastBatchOptions[]) => {
@@ -114,6 +140,16 @@ export class BatchSigningClientService {
       throw error;
     }
 
+    if (tx.code !== 0) {
+      this.logger.error({
+        event: "TX_LANDED_WITH_NON_ZERO_CODE",
+        txHash,
+        code: tx.code,
+        rawLog: tx.rawLog
+      });
+      throw new Error(`tx ${txHash} failed on-chain (code ${tx.code}): ${tx.rawLog ?? "unknown error"}`);
+    }
+
     this.logger.debug({
       event: "SIGN_AND_BROADCAST_SUCCESS",
       txHash,
@@ -127,10 +163,35 @@ export class BatchSigningClientService {
     await this.semaphore.acquire();
     this.activeBatches++;
     try {
-      return await this.executeAndBroadcastBatch(inputs);
+      const results = await this.executeAndBroadcastBatch(inputs);
+      this.applySequenceMismatchRecovery(results);
+      return results;
     } finally {
       this.semaphore.release();
       this.activeBatches--;
+    }
+  }
+
+  private applySequenceMismatchRecovery(results: readonly Result<string, unknown>[]): void {
+    for (const result of results) {
+      if (result.ok) continue;
+      const message = result.val instanceof Error ? result.val.message : String(result.val ?? "");
+      if (!message.includes("account sequence mismatch")) continue;
+
+      const match = SEQUENCE_MISMATCH_PATTERN.exec(message);
+      if (match && this.accountState) {
+        const expected = Number(match[1]);
+        this.logger.warn({
+          event: "SEQUENCE_MISMATCH_RECOVERED_FROM_ERROR",
+          previousSequence: this.accountState.sequence,
+          expectedSequence: expected
+        });
+        this.accountState = { ...this.accountState, sequence: expected, lastSyncedAt: Date.now() };
+      } else {
+        this.logger.warn({ event: "SEQUENCE_MISMATCH_CACHE_INVALIDATED", message });
+        this.accountState = null;
+      }
+      return;
     }
   }
 
@@ -142,23 +203,18 @@ export class BatchSigningClientService {
   }
 
   private async signBatch(inputs: readonly SignAndBroadcastBatchOptions[]): Promise<Result<TxRaw, unknown>[]> {
-    const [address, chainId] = await Promise.all([this.getAddress(), this.getChainId()]);
-    const accountInfo = await this.client.getAccount(address);
-
-    if (!accountInfo) {
-      throw new Error("Failed to get account info");
-    }
+    const [address, chainId, accountState] = await Promise.all([this.getAddress(), this.getChainId(), this.getOrFetchAccountState()]);
 
     const results: Result<TxRaw, unknown>[] = [];
-    let currentSequence = accountInfo.sequence;
+    let currentSequence = accountState.sequence;
 
     for (const input of inputs) {
       try {
         const { messages, options } = input;
-        const fee = await this.estimateFee(messages, this.FEES_DENOM, options?.fee?.granter);
+        const fee = await this.estimateFee(messages, accountState.pubkey, currentSequence, this.FEES_DENOM, options?.fee?.granter);
 
-        const signedTx = await this.client.sign(accountInfo.address, messages, fee, this.MEMO, {
-          accountNumber: accountInfo.accountNumber,
+        const signedTx = await this.client.sign(address, messages, fee, this.MEMO, {
+          accountNumber: accountState.accountNumber,
           sequence: currentSequence,
           chainId
         });
@@ -170,7 +226,41 @@ export class BatchSigningClientService {
       }
     }
 
+    this.accountState = { ...accountState, sequence: currentSequence, lastSyncedAt: Date.now() };
+
     return results;
+  }
+
+  private async getOrFetchAccountState(): Promise<AccountState> {
+    if (this.accountState && Date.now() - this.accountState.lastSyncedAt < this.ACCOUNT_STATE_TTL_MS) {
+      return this.accountState;
+    }
+
+    const address = await this.getAddress();
+    const [accountInfo, signerAccounts] = await Promise.all([this.client.getAccount(address), this.wallet.getAccounts()]);
+
+    if (!accountInfo) {
+      throw new Error("Failed to get account info");
+    }
+
+    const signerAccount = signerAccounts.find(account => account.address === address);
+    if (!signerAccount) {
+      throw new Error("Failed to retrieve account from signer");
+    }
+    const pubkey = encodeSecp256k1Pubkey(signerAccount.pubkey);
+
+    const cachedSequence = this.accountState?.sequence;
+    const chainSequence = accountInfo.sequence;
+    const sequence = cachedSequence !== undefined && cachedSequence > chainSequence ? cachedSequence : chainSequence;
+
+    this.accountState = {
+      accountNumber: accountInfo.accountNumber,
+      sequence,
+      pubkey,
+      lastSyncedAt: Date.now()
+    };
+
+    return this.accountState;
   }
 
   private async broadcastBatch(signResults: Result<TxRaw, unknown>[]): Promise<Result<string, unknown>[]> {
@@ -218,9 +308,17 @@ export class BatchSigningClientService {
     });
   }
 
-  private async estimateFee(messages: readonly EncodeObject[], denom: string, granter?: string) {
-    const gasEstimation = await this.client.simulate(await this.getAddress(), messages, this.MEMO);
-    const estimatedGas = Math.ceil(gasEstimation * this.config.get("GAS_SAFETY_MULTIPLIER"));
+  private async estimateFee(messages: readonly EncodeObject[], pubkey: Pubkey, sequence: number, denom: string, granter?: string) {
+    const anyMsgs = messages.map(m => this.registry.encodeAsAny(m));
+    const queryClient = (this.client as unknown as { forceGetQueryClient(): SimulateQueryClient }).forceGetQueryClient();
+    const { gasInfo } = await queryClient.tx.simulate(anyMsgs, this.MEMO, pubkey, sequence);
+
+    if (!gasInfo) {
+      throw new Error("Failed to simulate transaction: no gas info returned");
+    }
+
+    const gasUsed = Number(gasInfo.gasUsed);
+    const estimatedGas = Math.ceil(gasUsed * this.config.get("GAS_SAFETY_MULTIPLIER"));
 
     const fee = calculateFee(estimatedGas, GasPrice.fromString(`${this.config.get("AVERAGE_GAS_PRICE")}${denom}`));
 

--- a/apps/tx-signer/src/services/tx-manager/tx-manager.service.spec.ts
+++ b/apps/tx-signer/src/services/tx-manager/tx-manager.service.spec.ts
@@ -82,78 +82,67 @@ describe(TxManagerService.name, () => {
       expect(result).toEqual(txResult);
     });
 
-    it("cleans up client when no pending transactions", async () => {
+    it("reuses cached derived wallet client across consecutive calls", async () => {
       const derivationIndex = 1;
       const address = createAkashAddress();
-      const messages: EncodeObject[] = [
-        {
-          typeUrl: "/test.MsgTest",
-          value: {}
-        }
-      ];
-      const txResult = mock<IndexedTx>({
-        code: 0,
-        hash: "tx-hash",
-        rawLog: "success"
-      });
+      const messages: EncodeObject[] = [{ typeUrl: "/test.MsgTest", value: {} }];
+      const txResult = mock<IndexedTx>({ code: 0, hash: "tx-hash", rawLog: "success" });
 
-      const { service, logger } = setup({
+      const { service, batchSigningClientServiceFactory } = setup({
         derivedWalletAddress: address,
         derivedSignAndBroadcast: vi.fn().mockResolvedValue(txResult),
         hasPendingTransactions: false
       });
 
       await service.signAndBroadcastWithDerivedWallet(derivationIndex, messages);
-
-      expect(logger.debug).toHaveBeenCalledWith({ event: "DEDUPE_SIGNING_CLIENT_CLEAN_UP", derivationIndex });
-    });
-
-    it("keeps client when has pending transactions", async () => {
-      const derivationIndex = 1;
-      const address = createAkashAddress();
-      const messages: EncodeObject[] = [
-        {
-          typeUrl: "/test.MsgTest",
-          value: {}
-        }
-      ];
-      const txResult = mock<IndexedTx>({
-        code: 0,
-        hash: "tx-hash",
-        rawLog: "success"
-      });
-
-      const { service, logger } = setup({
-        derivedWalletAddress: address,
-        derivedSignAndBroadcast: vi.fn().mockResolvedValue(txResult),
-        hasPendingTransactions: true
-      });
-
+      await service.signAndBroadcastWithDerivedWallet(derivationIndex, messages);
       await service.signAndBroadcastWithDerivedWallet(derivationIndex, messages);
 
-      expect(logger.debug).not.toHaveBeenCalledWith({ event: "DEDUPE_SIGNING_CLIENT_CLEAN_UP", derivationIndex });
+      expect(batchSigningClientServiceFactory).toHaveBeenCalledTimes(1);
     });
 
-    it("cleans up client even when transaction fails", async () => {
+    it("evicts idle clients after the TTL elapses and rebuilds them on next use", async () => {
+      vi.useFakeTimers();
+      try {
+        const derivationIndex = 1;
+        const address = createAkashAddress();
+        const messages: EncodeObject[] = [{ typeUrl: "/test.MsgTest", value: {} }];
+        const txResult = mock<IndexedTx>({ code: 0, hash: "tx-hash", rawLog: "success" });
+
+        const { service, batchSigningClientServiceFactory } = setup({
+          derivedWalletAddress: address,
+          derivedSignAndBroadcast: vi.fn().mockResolvedValue(txResult),
+          hasPendingTransactions: false
+        });
+
+        await service.signAndBroadcastWithDerivedWallet(derivationIndex, messages);
+        expect(batchSigningClientServiceFactory).toHaveBeenCalledTimes(1);
+
+        vi.advanceTimersByTime(6 * 60 * 1000);
+
+        await service.signAndBroadcastWithDerivedWallet(derivationIndex, messages);
+        expect(batchSigningClientServiceFactory).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("keeps the cached client when transaction throws so the local sequence state survives the retry", async () => {
       const derivationIndex = 1;
       const address = createAkashAddress();
-      const messages: EncodeObject[] = [
-        {
-          typeUrl: "/test.MsgTest",
-          value: {}
-        }
-      ];
+      const messages: EncodeObject[] = [{ typeUrl: "/test.MsgTest", value: {} }];
       const error = new Error("Transaction failed");
 
-      const { service, logger } = setup({
+      const { service, batchSigningClientServiceFactory } = setup({
         derivedWalletAddress: address,
         derivedSignAndBroadcast: vi.fn().mockRejectedValue(error),
         hasPendingTransactions: false
       });
 
       await expect(service.signAndBroadcastWithDerivedWallet(derivationIndex, messages)).rejects.toThrow("Transaction failed");
+      await expect(service.signAndBroadcastWithDerivedWallet(derivationIndex, messages)).rejects.toThrow("Transaction failed");
 
-      expect(logger.debug).toHaveBeenCalledWith({ event: "DEDUPE_SIGNING_CLIENT_CLEAN_UP", derivationIndex });
+      expect(batchSigningClientServiceFactory).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/tx-signer/src/services/tx-manager/tx-manager.service.ts
+++ b/apps/tx-signer/src/services/tx-manager/tx-manager.service.ts
@@ -56,7 +56,10 @@ container.register(WALLET_RESOURCES, {
 type CachedClient = {
   address: string;
   client: BatchSigningClientService;
+  lastUsedAt: number;
 };
+
+const DERIVED_CLIENT_IDLE_TTL_MS = 5 * 60 * 1000;
 
 @singleton()
 export class TxManagerService {
@@ -88,15 +91,11 @@ export class TxManagerService {
   }
 
   async signAndBroadcastWithDerivedWallet(derivationIndex: number, messages: readonly EncodeObject[], options?: SignAndBroadcastOptions) {
-    const { client } = await this.#getClient(derivationIndex);
-
+    const cached = await this.#getClient(derivationIndex);
     try {
-      return await client.signAndBroadcast(messages, options);
+      return await cached.client.signAndBroadcast(messages, options);
     } finally {
-      if (!client.hasPendingTransactions && this.#clientsByDerivationIndex.has(derivationIndex)) {
-        this.logger.debug({ event: "DEDUPE_SIGNING_CLIENT_CLEAN_UP", derivationIndex });
-        this.#clientsByDerivationIndex.delete(derivationIndex);
-      }
+      cached.lastUsedAt = Date.now();
     }
   }
 
@@ -105,18 +104,34 @@ export class TxManagerService {
   }
 
   async #getClient(derivationIndex: number): Promise<CachedClient> {
-    if (!this.#clientsByDerivationIndex.has(derivationIndex)) {
-      const wallet = this.getDerivedWallet(derivationIndex);
-      const address = await wallet.getFirstAddress();
+    this.#evictIdleClients();
 
-      this.logger.debug({ event: "DERIVED_SIGNING_CLIENT_CREATE", derivationIndex });
-      this.#clientsByDerivationIndex.set(derivationIndex, {
-        address,
-        client: this.batchSigningClientServiceFactory(wallet)
-      });
+    const existing = this.#clientsByDerivationIndex.get(derivationIndex);
+    if (existing) {
+      return existing;
     }
 
-    return this.#clientsByDerivationIndex.get(derivationIndex)!;
+    const wallet = this.getDerivedWallet(derivationIndex);
+    const address = await wallet.getFirstAddress();
+
+    this.logger.debug({ event: "DERIVED_SIGNING_CLIENT_CREATE", derivationIndex });
+    const cached: CachedClient = {
+      address,
+      client: this.batchSigningClientServiceFactory(wallet),
+      lastUsedAt: Date.now()
+    };
+    this.#clientsByDerivationIndex.set(derivationIndex, cached);
+    return cached;
+  }
+
+  #evictIdleClients() {
+    const now = Date.now();
+    for (const [index, cached] of this.#clientsByDerivationIndex) {
+      if (cached.client.hasPendingTransactions) continue;
+      if (now - cached.lastUsedAt < DERIVED_CLIENT_IDLE_TTL_MS) continue;
+      this.logger.debug({ event: "DERIVED_SIGNING_CLIENT_EVICT_IDLE", derivationIndex: index });
+      this.#clientsByDerivationIndex.delete(index);
+    }
   }
 
   getDerivedWallet(index: number) {


### PR DESCRIPTION
## Why

Mainnet incident on 2026-05-23 ~18:15 UTC: a single user's derived wallet produced a burst of failed transactions out of `tx-signer-mainnet`. Grafana showed repeated `account sequence mismatch, expected 3928, got 3927` errors with traces pointing to `SigningStargateClient.simulate` inside `BatchSigningClientService.estimateFee`. The 5-attempt retry policy (~12 s total) was unable to recover.

Three compounding causes in tx-signer:

1. **No persistent sequence cache for derived wallets.** Each user's `BatchSigningClientService` was destroyed after every request via aggressive cleanup in [tx-manager.service.ts:96-99](https://github.com/akash-network/console/blob/main/apps/tx-signer/src/services/tx-manager/tx-manager.service.ts#L96-L99). The next request created a fresh client and re-fetched `client.getAccount(address)`, which reflects last *committed* state — a tx still in mempool from a prior request was invisible.
2. **`simulate` re-queries chain sequence and runs ante.** cosmjs's `SigningStargateClient.simulate` fetches the sequence from chain inside the simulate call. Cosmos SDK ≥ v0.50 runs sigverify ante during simulate, producing `expected N+1, got N` whenever a mempool tx is ahead of the RPC's auth.Account view.
3. **Retry refetches the same stale sequence.** The existing retry executor reruns `signBatch` → `getAccount` → same stale chain state, so all 5 attempts return the same `Err`.

Separately: when the broadcast did land but with a non-zero code (e.g. `deployment exists`), `signAndBroadcast` returned the `IndexedTx` as if successful and the failure propagated silently through the API layer.

## What

- Persist account state (`sequence`, `accountNumber`, `pubkey`) per `BatchSigningClientService` instance with a 30 s TTL. `signBatch` advances the cached sequence in-memory; consecutive requests reuse it without re-fetching from chain.
- Estimate fees via `client.forceGetQueryClient().tx.simulate(anyMsgs, memo, pubkey, sequence)` with the **explicit local sequence** instead of cosmjs's `client.simulate`. Breaks the dependency on chain-side freshness for gas estimation.
- Parse `expected (\d+)` out of `account sequence mismatch` errors and reset `accountState.sequence` to the expected value before the retry executor reattempts. If the parse fails, invalidate the cache to force a refetch.
- Replace immediate `finally`-block cleanup of derived wallet clients with lazy TTL eviction (5 min idle), so the sequence cache survives across back-to-back requests from the same user.
- Throw when `tryRecoverTransaction` returns a tx with non-zero code, embedding `rawLog` so the existing `ChainErrorService` substring matcher maps `deployment exists` / `deployment closed` / `bid not open` / `insufficient funds` / … to a proper 4xx.

## Test plan

- [ ] `cd apps/tx-signer && npm test` — 60 tests pass (unit + functional)
- [ ] `npm run lint -- --quiet` — clean
- [ ] `npx tsc --noEmit` — no new errors
- [ ] Manual staging smoke: 2 deployments from the same managed wallet within 3 s — both succeed, no sequence mismatch in logs
- [ ] After deploy, watch Loki `{app="tx-signer-mainnet"} |= "account sequence mismatch"` → expected near-zero, with any survivors recovered in 1 retry
- [ ] After deploy, watch for new `TX_LANDED_WITH_NON_ZERO_CODE` events and confirm they correlate 1:1 with console-api 4xx responses

Related to CON-296.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from account sequence mismatch errors with automatic retry
  * Enhanced transaction verification to detect and report on-chain failures

* **Performance**
  * Added account state caching with automatic expiration for batch signing operations
  * Implemented idle timeout mechanism for derived wallet clients (5-minute TTL) to optimize resource usage
  * Optimized signing client reuse across consecutive operations for faster execution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->