### PR TITLE
fix(deployment): bump dseq on collision and surface non-zero tx code

### DIFF
--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -231,6 +231,36 @@ describe(ManagedSignerService.name, () => {
       });
     });
 
+    it("throws and skips side-effects when the broadcast tx lands on-chain with a non-zero code", async () => {
+      const wallet = createUserWallet({ userId: "user-123", feeAllowance: 100, deploymentAllowance: 100, isTrialing: true });
+      const user = createUser({ userId: "user-123" });
+      const deploymentMessage: EncodeObject = {
+        typeUrl: MsgCreateLease.$type,
+        value: MsgCreateLease.fromPartial({
+          bidId: { dseq: 123, owner: "akash1test", gseq: 1, oseq: 1, provider: "akash1test" }
+        })
+      };
+
+      const { service, domainEvents, balancesService, walletReloadJobService, chainErrorService } = setup({
+        findOneByUserId: jest.fn().mockResolvedValue(wallet),
+        findById: jest.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
+          code: 17,
+          hash: "tx-hash",
+          rawLog: "deployment exists"
+        }),
+        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined),
+        transformChainError: jest.fn().mockResolvedValue(new Error("Deployment with provided dseq and owner already exists"))
+      });
+
+      await expect(service.executeDerivedDecodedTxByUserId("user-123", [deploymentMessage])).rejects.toThrow("Deployment with provided dseq");
+
+      expect(chainErrorService.toAppError).toHaveBeenCalledWith(expect.objectContaining({ message: "deployment exists" }), [deploymentMessage]);
+      expect(domainEvents.publish).not.toHaveBeenCalled();
+      expect(balancesService.refreshUserWalletLimits).not.toHaveBeenCalled();
+      expect(walletReloadJobService.scheduleImmediate).not.toHaveBeenCalled();
+    });
+
     it("handles chain errors properly", async () => {
       const wallet = createUserWallet({
         userId: "user-123",

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -22,6 +22,7 @@ import { LoggerService } from "@src/core";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { Trace, withSpan } from "@src/core/services/tracing/tracing.service";
 import { UserRepository } from "@src/user/repositories";
+import { COSMOS_TX_CODE_OK } from "@src/utils/constants";
 import { BalancesService } from "../balances/balances.service";
 import { BillingConfigService } from "../billing-config/billing-config.service";
 import { ChainErrorService } from "../chain-error/chain-error.service";
@@ -119,7 +120,7 @@ export class ManagedSignerService {
 
     const tx = await this.executeDerivedTx(userWallet.id, messages);
 
-    if (tx.code !== 0) {
+    if (tx.code !== COSMOS_TX_CODE_OK) {
       this.logger.error({ event: "TX_LANDED_WITH_NON_ZERO_CODE", txHash: tx.hash, code: tx.code, rawLog: tx.rawLog });
       throw await this.chainErrorService.toAppError(new Error(tx.rawLog || `tx ${tx.hash} failed on-chain with code ${tx.code}`), messages);
     }

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -119,6 +119,11 @@ export class ManagedSignerService {
 
     const tx = await this.executeDerivedTx(userWallet.id, messages);
 
+    if (tx.code !== 0) {
+      this.logger.error({ event: "TX_LANDED_WITH_NON_ZERO_CODE", txHash: tx.hash, code: tx.code, rawLog: tx.rawLog });
+      throw await this.chainErrorService.toAppError(new Error(tx.rawLog || `tx ${tx.hash} failed on-chain with code ${tx.code}`), messages);
+    }
+
     if (hasCreateTrialLeaseMessage) {
       await this.domainEvents.publish(
         new TrialDeploymentLeaseCreated({

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -1,11 +1,10 @@
-import type { BlockHttpService, DeploymentHttpService } from "@akashnetwork/http-sdk";
+import { vi } from "vitest";
 import { mock, type MockProxy } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import type { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc-message.service";
 import type { WalletInitialized, WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
-import type { LoggerService } from "@src/core";
 import type { GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
 import type { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import type { ProviderService } from "@src/provider/services/provider/provider.service";
@@ -59,12 +58,15 @@ describe(DeploymentWriterService.name, () => {
     }
   };
 
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   describe("create", () => {
-    it("creates a deployment and returns dseq, manifest, and signTx", async () => {
-      const { service, blockHttpService, signerService, rpcMessageService, deploymentHttpService } = setup();
-      const dseq = 200;
-      blockHttpService.getCurrentHeight.mockResolvedValue(dseq);
-      deploymentHttpService.findByOwnerAndDseq.mockResolvedValue({ code: 5, message: "deployment not found" } as any);
+    it("creates a deployment with a millisecond-timestamp dseq", async () => {
+      const { service, signerService, rpcMessageService } = setup();
+      const dseq = 1748400000000;
+      vi.spyOn(Date, "now").mockReturnValue(dseq);
       const txResult = { code: 0, transactionHash: "tx-hash" };
       signerService.executeDerivedDecodedTxByUserId.mockResolvedValue(txResult);
       const createMsg = { typeUrl: "/create", value: {} };
@@ -72,7 +74,7 @@ describe(DeploymentWriterService.name, () => {
 
       const result = await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 });
 
-      expect(result.dseq).toBe("200");
+      expect(result.dseq).toBe("1748400000000");
       expect(result.signTx).toBe(txResult);
       expect(rpcMessageService.getCreateDeploymentMsg).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -84,33 +86,6 @@ describe(DeploymentWriterService.name, () => {
         })
       );
       expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledWith("user-1", [createMsg]);
-    });
-
-    it("bumps the dseq when the current block height collides with an existing deployment on-chain", async () => {
-      const { service, blockHttpService, signerService, rpcMessageService, deploymentHttpService } = setup();
-      const baseHeight = 200;
-      blockHttpService.getCurrentHeight.mockResolvedValue(baseHeight);
-      deploymentHttpService.findByOwnerAndDseq
-        .mockResolvedValueOnce(deploymentData as any)
-        .mockResolvedValueOnce({ code: 5, message: "deployment not found" } as any);
-      signerService.executeDerivedDecodedTxByUserId.mockResolvedValue({ code: 0, hash: "tx-hash", transactionHash: "tx-hash", rawLog: "" });
-      const createMsg = { typeUrl: "/create", value: {} };
-      rpcMessageService.getCreateDeploymentMsg.mockReturnValue(createMsg);
-
-      const result = await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 });
-
-      expect(result.dseq).toBe("201");
-      expect(rpcMessageService.getCreateDeploymentMsg).toHaveBeenCalledWith(expect.objectContaining({ dseq: baseHeight + 1 }));
-      expect(deploymentHttpService.findByOwnerAndDseq).toHaveBeenCalledWith(wallet.address, "200");
-      expect(deploymentHttpService.findByOwnerAndDseq).toHaveBeenCalledWith(wallet.address, "201");
-    });
-
-    it("throws 409 when no free dseq can be found within the collision budget", async () => {
-      const { service, blockHttpService, deploymentHttpService } = setup();
-      blockHttpService.getCurrentHeight.mockResolvedValue(200);
-      deploymentHttpService.findByOwnerAndDseq.mockResolvedValue(deploymentData as any);
-
-      await expect(service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 })).rejects.toMatchObject({ status: 409 });
     });
 
     it("throws 400 when SDL is invalid", async () => {
@@ -223,8 +198,6 @@ describe(DeploymentWriterService.name, () => {
   });
 
   function setup() {
-    const blockHttpService = mock<BlockHttpService>();
-    const deploymentHttpService = mock<DeploymentHttpService>();
     const signerService = mock<ManagedSignerService>();
     const rpcMessageService = mock<RpcMessageService>();
     const sdlService = mock<SdlService>();
@@ -234,39 +207,31 @@ describe(DeploymentWriterService.name, () => {
     const providerService = mock<ProviderService>();
     const deploymentReaderService = mock<DeploymentReaderService>();
     const walletReaderService = mock<WalletReaderService>();
-    const logger = mock<LoggerService>();
 
     walletReaderService.getWalletByUserId.mockResolvedValue(wallet);
     sdlService.generateManifest.mockReturnValue({ ok: true, value: manifestValue } as any);
     sdlService.generateManifestVersion.mockResolvedValue(new Uint8Array([4, 5, 6]));
     deploymentReaderService.findByWalletAndDseq.mockResolvedValue(deploymentData);
-    deploymentHttpService.findByOwnerAndDseq.mockResolvedValue({ code: 5, message: "deployment not found" } as any);
 
     const service = new DeploymentWriterService(
-      blockHttpService,
-      deploymentHttpService,
       signerService,
       rpcMessageService,
       sdlService,
       billingConfig,
       providerService,
       deploymentReaderService,
-      walletReaderService,
-      logger
+      walletReaderService
     );
 
     return {
       service,
-      blockHttpService,
-      deploymentHttpService,
       signerService,
       rpcMessageService,
       sdlService,
       billingConfig,
       providerService,
       deploymentReaderService,
-      walletReaderService,
-      logger
+      walletReaderService
     };
   }
 });

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -1,10 +1,11 @@
-import type { BlockHttpService } from "@akashnetwork/http-sdk";
+import type { BlockHttpService, DeploymentHttpService } from "@akashnetwork/http-sdk";
 import { mock, type MockProxy } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import type { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc-message.service";
 import type { WalletInitialized, WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
+import type { LoggerService } from "@src/core";
 import type { GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
 import type { SdlService } from "@src/deployment/services/sdl/sdl.service";
 import type { ProviderService } from "@src/provider/services/provider/provider.service";
@@ -60,9 +61,10 @@ describe(DeploymentWriterService.name, () => {
 
   describe("create", () => {
     it("creates a deployment and returns dseq, manifest, and signTx", async () => {
-      const { service, blockHttpService, signerService, rpcMessageService } = setup();
+      const { service, blockHttpService, signerService, rpcMessageService, deploymentHttpService } = setup();
       const dseq = 200;
       blockHttpService.getCurrentHeight.mockResolvedValue(dseq);
+      deploymentHttpService.findByOwnerAndDseq.mockResolvedValue({ code: 5, message: "deployment not found" } as any);
       const txResult = { code: 0, transactionHash: "tx-hash" };
       signerService.executeDerivedDecodedTxByUserId.mockResolvedValue(txResult);
       const createMsg = { typeUrl: "/create", value: {} };
@@ -82,6 +84,33 @@ describe(DeploymentWriterService.name, () => {
         })
       );
       expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledWith("user-1", [createMsg]);
+    });
+
+    it("bumps the dseq when the current block height collides with an existing deployment on-chain", async () => {
+      const { service, blockHttpService, signerService, rpcMessageService, deploymentHttpService } = setup();
+      const baseHeight = 200;
+      blockHttpService.getCurrentHeight.mockResolvedValue(baseHeight);
+      deploymentHttpService.findByOwnerAndDseq
+        .mockResolvedValueOnce(deploymentData as any)
+        .mockResolvedValueOnce({ code: 5, message: "deployment not found" } as any);
+      signerService.executeDerivedDecodedTxByUserId.mockResolvedValue({ code: 0, hash: "tx-hash", transactionHash: "tx-hash", rawLog: "" });
+      const createMsg = { typeUrl: "/create", value: {} };
+      rpcMessageService.getCreateDeploymentMsg.mockReturnValue(createMsg);
+
+      const result = await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 });
+
+      expect(result.dseq).toBe("201");
+      expect(rpcMessageService.getCreateDeploymentMsg).toHaveBeenCalledWith(expect.objectContaining({ dseq: baseHeight + 1 }));
+      expect(deploymentHttpService.findByOwnerAndDseq).toHaveBeenCalledWith(wallet.address, "200");
+      expect(deploymentHttpService.findByOwnerAndDseq).toHaveBeenCalledWith(wallet.address, "201");
+    });
+
+    it("throws 409 when no free dseq can be found within the collision budget", async () => {
+      const { service, blockHttpService, deploymentHttpService } = setup();
+      blockHttpService.getCurrentHeight.mockResolvedValue(200);
+      deploymentHttpService.findByOwnerAndDseq.mockResolvedValue(deploymentData as any);
+
+      await expect(service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 })).rejects.toMatchObject({ status: 409 });
     });
 
     it("throws 400 when SDL is invalid", async () => {
@@ -195,6 +224,7 @@ describe(DeploymentWriterService.name, () => {
 
   function setup() {
     const blockHttpService = mock<BlockHttpService>();
+    const deploymentHttpService = mock<DeploymentHttpService>();
     const signerService = mock<ManagedSignerService>();
     const rpcMessageService = mock<RpcMessageService>();
     const sdlService = mock<SdlService>();
@@ -204,33 +234,39 @@ describe(DeploymentWriterService.name, () => {
     const providerService = mock<ProviderService>();
     const deploymentReaderService = mock<DeploymentReaderService>();
     const walletReaderService = mock<WalletReaderService>();
+    const logger = mock<LoggerService>();
 
     walletReaderService.getWalletByUserId.mockResolvedValue(wallet);
     sdlService.generateManifest.mockReturnValue({ ok: true, value: manifestValue } as any);
     sdlService.generateManifestVersion.mockResolvedValue(new Uint8Array([4, 5, 6]));
     deploymentReaderService.findByWalletAndDseq.mockResolvedValue(deploymentData);
+    deploymentHttpService.findByOwnerAndDseq.mockResolvedValue({ code: 5, message: "deployment not found" } as any);
 
     const service = new DeploymentWriterService(
       blockHttpService,
+      deploymentHttpService,
       signerService,
       rpcMessageService,
       sdlService,
       billingConfig,
       providerService,
       deploymentReaderService,
-      walletReaderService
+      walletReaderService,
+      logger
     );
 
     return {
       service,
       blockHttpService,
+      deploymentHttpService,
       signerService,
       rpcMessageService,
       sdlService,
       billingConfig,
       providerService,
       deploymentReaderService,
-      walletReaderService
+      walletReaderService,
+      logger
     };
   }
 });

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -1,5 +1,4 @@
 import { manifestToSortedJSON } from "@akashnetwork/chain-sdk";
-import { BlockHttpService, DeploymentHttpService } from "@akashnetwork/http-sdk";
 import assert from "http-assert";
 import { singleton } from "tsyringe";
 
@@ -8,7 +7,6 @@ import { BillingConfigService } from "@src/billing/services/billing-config/billi
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc-message.service";
 import { WalletInitialized, WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
-import { LoggerService } from "@src/core";
 import {
   CreateDeploymentRequest,
   CreateDeploymentResponse,
@@ -20,35 +18,24 @@ import { ProviderService } from "@src/provider/services/provider/provider.servic
 import { denomToUdenom } from "@src/utils/math";
 import { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
 
-const MAX_DSEQ_COLLISION_BUMPS = 5;
-
 @singleton()
 export class DeploymentWriterService {
   constructor(
-    private readonly blockHttpService: BlockHttpService,
-    private readonly deploymentHttpService: DeploymentHttpService,
     private readonly signerService: ManagedSignerService,
     private readonly rpcMessageService: RpcMessageService,
     private readonly sdlService: SdlService,
     private readonly billingConfig: BillingConfigService,
     private readonly providerService: ProviderService,
     private readonly deploymentReaderService: DeploymentReaderService,
-    private readonly walletReaderService: WalletReaderService,
-    private readonly logger: LoggerService
-  ) {
-    this.logger.setContext(DeploymentWriterService.name);
-  }
+    private readonly walletReaderService: WalletReaderService
+  ) {}
 
   public async create(input: CreateDeploymentRequest["data"] & { userId: string }): Promise<CreateDeploymentResponse["data"]> {
     const wallet = await this.walletReaderService.getWalletByUserId(input.userId);
     const manifest = this.#parseManifest(input.sdl, { isTrialing: !!wallet.isTrialing });
 
-    const [baseHeight, manifestVersion] = await Promise.all([
-      this.blockHttpService.getCurrentHeight(),
-      this.sdlService.generateManifestVersion(manifest.groups)
-    ]);
-
-    const dseq = await this.#findAvailableDseq(wallet.address, baseHeight);
+    const dseq = Date.now();
+    const manifestVersion = await this.sdlService.generateManifestVersion(manifest.groups);
 
     const message = this.rpcMessageService.getCreateDeploymentMsg({
       owner: wallet.address,
@@ -65,33 +52,6 @@ export class DeploymentWriterService {
       manifest: manifestToSortedJSON(manifest.groups),
       signTx: result
     };
-  }
-
-  async #findAvailableDseq(owner: string, baseHeight: number): Promise<number> {
-    for (let offset = 0; offset <= MAX_DSEQ_COLLISION_BUMPS; offset++) {
-      const candidate = baseHeight + offset;
-      if (!(await this.#deploymentExists(owner, candidate))) {
-        if (offset > 0) {
-          this.logger.warn({ event: "DSEQ_COLLISION_BUMPED", owner, baseHeight, finalDseq: candidate, offset });
-        }
-        return candidate;
-      }
-    }
-    this.logger.error({ event: "DSEQ_COLLISION_EXHAUSTED", owner, baseHeight });
-    assert(false, 409, "Could not allocate a free dseq for deployment, please retry");
-  }
-
-  async #deploymentExists(owner: string, dseq: number): Promise<boolean> {
-    try {
-      const response = await this.deploymentHttpService.findByOwnerAndDseq(owner, dseq.toString());
-      if (response && "code" in response) {
-        return !response.message?.toLowerCase().includes("not found");
-      }
-      return !!response;
-    } catch (error) {
-      this.logger.warn({ event: "DSEQ_EXISTENCE_CHECK_FAILED", owner, dseq, error });
-      return false;
-    }
   }
 
   public async closeByUserIdAndDseq(userId: string, dseq: string): Promise<void> {

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -1,5 +1,5 @@
 import { manifestToSortedJSON } from "@akashnetwork/chain-sdk";
-import { BlockHttpService } from "@akashnetwork/http-sdk";
+import { BlockHttpService, DeploymentHttpService } from "@akashnetwork/http-sdk";
 import assert from "http-assert";
 import { singleton } from "tsyringe";
 
@@ -8,6 +8,7 @@ import { BillingConfigService } from "@src/billing/services/billing-config/billi
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { RpcMessageService } from "@src/billing/services/rpc-message-service/rpc-message.service";
 import { WalletInitialized, WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
+import { LoggerService } from "@src/core";
 import {
   CreateDeploymentRequest,
   CreateDeploymentResponse,
@@ -19,24 +20,35 @@ import { ProviderService } from "@src/provider/services/provider/provider.servic
 import { denomToUdenom } from "@src/utils/math";
 import { DeploymentReaderService } from "../deployment-reader/deployment-reader.service";
 
+const MAX_DSEQ_COLLISION_BUMPS = 5;
+
 @singleton()
 export class DeploymentWriterService {
   constructor(
     private readonly blockHttpService: BlockHttpService,
+    private readonly deploymentHttpService: DeploymentHttpService,
     private readonly signerService: ManagedSignerService,
     private readonly rpcMessageService: RpcMessageService,
     private readonly sdlService: SdlService,
     private readonly billingConfig: BillingConfigService,
     private readonly providerService: ProviderService,
     private readonly deploymentReaderService: DeploymentReaderService,
-    private readonly walletReaderService: WalletReaderService
-  ) {}
+    private readonly walletReaderService: WalletReaderService,
+    private readonly logger: LoggerService
+  ) {
+    this.logger.setContext(DeploymentWriterService.name);
+  }
 
   public async create(input: CreateDeploymentRequest["data"] & { userId: string }): Promise<CreateDeploymentResponse["data"]> {
     const wallet = await this.walletReaderService.getWalletByUserId(input.userId);
     const manifest = this.#parseManifest(input.sdl, { isTrialing: !!wallet.isTrialing });
 
-    const [dseq, manifestVersion] = await Promise.all([this.blockHttpService.getCurrentHeight(), this.sdlService.generateManifestVersion(manifest.groups)]);
+    const [baseHeight, manifestVersion] = await Promise.all([
+      this.blockHttpService.getCurrentHeight(),
+      this.sdlService.generateManifestVersion(manifest.groups)
+    ]);
+
+    const dseq = await this.#findAvailableDseq(wallet.address, baseHeight);
 
     const message = this.rpcMessageService.getCreateDeploymentMsg({
       owner: wallet.address,
@@ -53,6 +65,33 @@ export class DeploymentWriterService {
       manifest: manifestToSortedJSON(manifest.groups),
       signTx: result
     };
+  }
+
+  async #findAvailableDseq(owner: string, baseHeight: number): Promise<number> {
+    for (let offset = 0; offset <= MAX_DSEQ_COLLISION_BUMPS; offset++) {
+      const candidate = baseHeight + offset;
+      if (!(await this.#deploymentExists(owner, candidate))) {
+        if (offset > 0) {
+          this.logger.warn({ event: "DSEQ_COLLISION_BUMPED", owner, baseHeight, finalDseq: candidate, offset });
+        }
+        return candidate;
+      }
+    }
+    this.logger.error({ event: "DSEQ_COLLISION_EXHAUSTED", owner, baseHeight });
+    assert(false, 409, "Could not allocate a free dseq for deployment, please retry");
+  }
+
+  async #deploymentExists(owner: string, dseq: number): Promise<boolean> {
+    try {
+      const response = await this.deploymentHttpService.findByOwnerAndDseq(owner, dseq.toString());
+      if (response && "code" in response) {
+        return !response.message?.toLowerCase().includes("not found");
+      }
+      return !!response;
+    } catch (error) {
+      this.logger.warn({ event: "DSEQ_EXISTENCE_CHECK_FAILED", owner, dseq, error });
+      return false;
+    }
   }
 
   public async closeByUserIdAndDseq(userId: string, dseq: string): Promise<void> {

--- a/apps/api/src/utils/constants.ts
+++ b/apps/api/src/utils/constants.ts
@@ -18,3 +18,5 @@ export const openApiExampleValidatorAddress = "akashvaloper14mt78hz73d9tdwpdvkd5
 export const certVersion = "v1";
 export const deploymentVersion = "v1beta4";
 export const marketVersion = "v1beta5";
+
+export const COSMOS_TX_CODE_OK = 0;

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -65,7 +65,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
   onManifestChange,
   dependencies: d = DEPENDENCIES
 }) => {
-  const { providerProxy, analyticsService, chainApiHttpClient, deploymentLocalStorage } = useServices();
+  const { providerProxy, analyticsService, deploymentLocalStorage } = useServices();
   const [parsingError, setParsingError] = useState<string | null>(null);
   const [deploymentVersion, setDeploymentVersion] = useState<string | null>(null);
   const [showOutsideDeploymentMessage, setShowOutsideDeploymentMessage] = useState(false);
@@ -131,7 +131,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     try {
       const doc = yaml.load(editedManifest);
 
-      const dd = await d.deploymentData.NewDeploymentData(chainApiHttpClient, editedManifest, deployment.dseq, address); // TODO Flags
+      const dd = await d.deploymentData.NewDeploymentData(editedManifest, deployment.dseq, address); // TODO Flags
       const mani = d.deploymentData.getManifest(doc);
 
       // If it's actual update, send a transaction, else just send the manifest

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -131,7 +131,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     try {
       const doc = yaml.load(editedManifest);
 
-      const dd = await d.deploymentData.NewDeploymentData(editedManifest, deployment.dseq, address); // TODO Flags
+      const dd = await d.deploymentData.NewDeploymentData(editedManifest, deployment.dseq, address);
       const mani = d.deploymentData.getManifest(doc);
 
       // If it's actual update, send a transaction, else just send the manifest

--- a/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
+++ b/apps/deploy-web/src/components/new-deployment/ManifestEdit/ManifestEdit.tsx
@@ -110,7 +110,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
     }
   }, [editedManifest]);
 
-  const { analyticsService, chainApiHttpClient, publicConfig: appConfig, deploymentLocalStorage } = d.useServices();
+  const { analyticsService, publicConfig: appConfig, deploymentLocalStorage } = d.useServices();
   const { settings } = d.useSettings();
   const { address, signAndBroadcastTx, isManaged, isTrialing } = d.useWallet();
   const router = d.useRouter();
@@ -179,7 +179,7 @@ export const ManifestEdit: React.FunctionComponent<Props> = ({
     try {
       if (!yamlStr) return null;
 
-      const dd = await deploymentData.NewDeploymentData(chainApiHttpClient, yamlStr, dseq, address, deposit);
+      const dd = await deploymentData.NewDeploymentData(yamlStr, dseq, address, deposit);
       validateDeploymentData(dd, selectedTemplate);
       setParsingError(null);
 

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
@@ -287,10 +287,6 @@ describe("OnboardingContainer", () => {
       newDeployment: vi.fn(() => "/deployments/new")
     };
 
-    const mockChainApiHttpClient = {
-      get: vi.fn()
-    };
-
     const mockDeploymentLocalStorage = {
       update: vi.fn()
     };
@@ -318,7 +314,6 @@ describe("OnboardingContainer", () => {
       analyticsService: mockAnalyticsService,
       urlService: mockUrlService,
       authService,
-      chainApiHttpClient: mockChainApiHttpClient,
       deploymentLocalStorage: mockDeploymentLocalStorage,
       publicConfig: mockAppConfig,
       errorHandler: mockErrorHandler,
@@ -451,7 +446,6 @@ describe("OnboardingContainer", () => {
       mockNavigateWithReturnTo,
       mockLocalStorage,
       mockSignAndBroadcastTx,
-      mockChainApiHttpClient,
       mockDeploymentLocalStorage,
       mockNewDeploymentData,
       mockValidateDeploymentData,

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
@@ -176,7 +176,7 @@ describe("OnboardingContainer", () => {
       await onComplete("hello-akash");
     });
 
-    const sdlArgument = mockNewDeploymentData.mock.calls[0][1];
+    const sdlArgument = mockNewDeploymentData.mock.calls[0][0];
     expect(sdlArgument).not.toContain("uakt");
   });
 
@@ -190,7 +190,7 @@ describe("OnboardingContainer", () => {
       await onComplete("hello-akash");
     });
 
-    const sdlArgument = mockNewDeploymentData.mock.calls[0][1];
+    const sdlArgument = mockNewDeploymentData.mock.calls[0][0];
     expect(sdlArgument).toBe("mock-sdl-content");
   });
 
@@ -230,7 +230,7 @@ describe("OnboardingContainer", () => {
       await onComplete("hello-akash");
     });
 
-    const sdlArgument = mockNewDeploymentData.mock.calls[0][1];
+    const sdlArgument = mockNewDeploymentData.mock.calls[0][0];
     expect(sdlArgument).toBe("mock-sdl-content");
     expect(sdlArgument).not.toContain("undefined");
   });

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.tsx
@@ -77,7 +77,6 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
   const {
     analyticsService,
     urlService,
-    chainApiHttpClient,
     deploymentLocalStorage,
     errorHandler,
     windowLocation,
@@ -280,7 +279,7 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
 
         const minDepositAmount = wallet.denom === "uact" ? minDeposit.act : wallet.denom !== "uakt" && wallet.isManaged ? minDeposit.act : minDeposit.akt;
         const deposit = d.denomToUdenom(minDepositAmount);
-        const dd = await d.deploymentData.NewDeploymentData(chainApiHttpClient, sdl, null, wallet.address, deposit);
+        const dd = await d.deploymentData.NewDeploymentData(sdl, null, wallet.address, deposit);
         d.validateDeploymentData(dd, null);
 
         if (!dd) {
@@ -318,7 +317,6 @@ export const OnboardingContainer: React.FunctionComponent<OnboardingContainerPro
       urlService,
       wallet,
       templateService,
-      chainApiHttpClient,
       minDeposit,
       deploymentLocalStorage,
       analyticsService,

--- a/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
+++ b/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
@@ -2,7 +2,6 @@ import type { Attribute } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import type { GroupSpec } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import type { Manifest as AkashManifest, SDLInput } from "@akashnetwork/chain-sdk/web";
 import { generateManifestVersion } from "@akashnetwork/chain-sdk/web";
-import type { HttpClient } from "@akashnetwork/http-sdk";
 import yaml from "js-yaml";
 
 import { browserEnvConfig } from "@src/config/browser-env.config";
@@ -176,7 +175,6 @@ ${result}`;
 }
 
 export async function NewDeploymentData(
-  chainApiHttpClient: HttpClient,
   yamlStr: string,
   dseq: string | null,
   fromAddress: string,
@@ -191,11 +189,7 @@ export async function NewDeploymentData(
     const version = await generateManifestVersion(manifest.groups);
     const _deposit = (Array.isArray(deposit) && deposit.find(d => d.denom === denom)) || { denom, amount: deposit.toString() };
 
-    let finalDseq: string = dseq || "";
-    if (!finalDseq) {
-      const response = await chainApiHttpClient.get("/cosmos/base/tendermint/v1beta1/blocks/latest");
-      finalDseq = response.data.block.header.height;
-    }
+    const finalDseq: string = dseq || Date.now().toString();
 
     return {
       sdl: sdlInput,

--- a/packages/database/dbSchemas/akash/deployment.ts
+++ b/packages/database/dbSchemas/akash/deployment.ts
@@ -35,7 +35,7 @@ export class Deployment extends Model {
   @Required @Column owner!: string;
   /**
    * The dseq of the deployment (unique identifier for the deployment on the blockchain)
-   * It can be any uint64 chosen by the deployer. Historically derived from the block height at creation; managed-wallet deploys today derive it from a millisecond timestamp.
+   * It can be any uint64 chosen by the deployer (commonly a block height or millisecond timestamp).
    * Unique Identifier: DSEQ is a unique identifier assigned to each deployment on the Akash Network, enabling precise tracking and management of deployments
    * Order Sequence Number (OSEQ): DSEQ is associated with an Order Sequence Number (OSEQ), which indicates the order in which deployments are created and managed within the network
    * Deployment Management: DSEQ facilitates the management of deployments by providing a specific reference point for each deployment instance, ensuring clarity and organization in the deployment process

--- a/packages/database/dbSchemas/akash/deployment.ts
+++ b/packages/database/dbSchemas/akash/deployment.ts
@@ -35,7 +35,7 @@ export class Deployment extends Model {
   @Required @Column owner!: string;
   /**
    * The dseq of the deployment (unique identifier for the deployment on the blockchain)
-   * It can be any string, but ususally it's the block height at which the deployment was created.
+   * It can be any uint64 chosen by the deployer. Historically derived from the block height at creation; managed-wallet deploys today derive it from a millisecond timestamp.
    * Unique Identifier: DSEQ is a unique identifier assigned to each deployment on the Akash Network, enabling precise tracking and management of deployments
    * Order Sequence Number (OSEQ): DSEQ is associated with an Order Sequence Number (OSEQ), which indicates the order in which deployments are created and managed within the network
    * Deployment Management: DSEQ facilitates the management of deployments by providing a specific reference point for each deployment instance, ensuring clarity and organization in the deployment process


### PR DESCRIPTION
## Why

Closes CON-85

Mainnet incident on 2026-05-23 — two failed `MsgCreateDeployment` transactions landed on-chain (heights 26955138 and 26955799), both for the same user's derived wallet. The deployment creation flow had two latent bugs that made these failures harmful instead of recoverable:

1. **DSeq generated from current block height with no idempotency.** [DeploymentWriterService.create:39](https://github.com/akash-network/console/blob/main/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts#L39) did `dseq = await this.blockHttpService.getCurrentHeight()`. Two POST `/v1/deployments` requests in the same Akash block (~6 s) generated the *same* dseq; the second landed on-chain with `deployment exists`.
2. **Non-zero tx codes propagated silently.** In [ManagedSignerService.executeDecodedTxByUserWallet](https://github.com/akash-network/console/blob/main/apps/api/src/billing/services/managed-signer/managed-signer.service.ts#L120-L144), the code path after `executeDerivedTx` didn't check `tx.code`. A transaction that landed with `code !== 0` still triggered side effects: `TrialDeploymentLeaseCreated`, `EnableDeploymentAlertCommand`, `balancesService.refreshUserWalletLimits`, `walletReloadJobService.scheduleImmediate`. Alerts and trial events were created for deployments that don't exist on-chain.

## What

- **DSeq from millisecond timestamp in `DeploymentWriterService.create`**: replace block-height-derived dseq with `Date.now()`. dseq is uint64 on-chain and stored as a string, so ms timestamps (~1.7e12) fit safely. This eliminates the same-block collision class entirely. The vanishingly rare same-millisecond case (two POSTs from the same user inside one ms) is cleanly handled by defense (2) — returns a 4xx, no orphan side effects.
- **Defense-in-depth `code !== 0` assertion in `ManagedSignerService.executeDecodedTxByUserWallet`**: immediately after `executeDerivedTx`, check `tx.code === 0` and throw through `ChainErrorService.toAppError(new Error(tx.rawLog), messages)` if not. This guarantees side effects (domain events, balance refresh, reload schedule) only fire on transactions that succeeded on-chain. The existing `ChainErrorService` pattern matcher already maps `deployment exists` / `deployment closed` / etc. to the right 4xx — no new mappings needed.

Note: the self-custodial frontend deploy path in [apps/deploy-web/src/utils/deploymentData/v1beta3.ts](https://github.com/akash-network/console/blob/main/apps/deploy-web/src/utils/deploymentData/v1beta3.ts) still uses block height. A single user firing two browser deploys in the same ~6 s block is far rarer than the managed-wallet server case; leaving it out keeps this PR tight. Can follow up separately if needed.

Companion to #PR_TX_SIGNER (tx-signer-side throw on `code !== 0`). This PR's defense-in-depth makes the api side robust independently — works whether the tx-signer PR has shipped or not.

## Test plan

- [ ] `cd apps/api && npm run test:unit src/billing/services/managed-signer src/deployment/services/deployment-writer` — 28 tests pass
- [ ] `npm run lint -- --quiet` — clean
- [ ] `npx tsc --noEmit` — no new errors (7 deployment-writer spec errors remain, all pre-existing patterns; count went down from 9 since the two collision tests were removed)
- [ ] Manual staging smoke: hand-craft a duplicate dseq POST `/v1/deployments` → API returns 400 `"Deployment with provided dseq and owner already exists"`, no `TrialDeploymentLeaseCreated` in logs
- [ ] Trigger two rapid deployments → both succeed with distinct ms-timestamp dseqs (~13 digits) matching what landed on-chain
- [ ] After deploy, monitor for orphaned alerts/events; should drop to zero

Related to CON-296.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for on-chain transactions that land with errors: clear app errors are thrown and downstream side effects are skipped.

* **Performance Improvements**
  * Deployment creation now uses client-side timestamps to avoid extra network calls.

* **Refactor**
  * Removed dependence on the chain API client from deployment flows and UI components.

* **Tests**
  * Updated tests and mocks to match timestamp behavior and added mock cleanup.

* **Documentation**
  * Clarified dseq description to allow millisecond timestamps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->