### PR TITLE
feat(onboarding): auto-start trial and route by login choice

### DIFF
--- a/apps/api/src/billing/controllers/wallet/wallet.controller.spec.ts
+++ b/apps/api/src/billing/controllers/wallet/wallet.controller.spec.ts
@@ -10,195 +10,64 @@ import { ManagedSignerService, WalletInitializerService } from "@src/billing/ser
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { RefillService } from "@src/billing/services/refill/refill.service";
-import { StripeService } from "@src/billing/services/stripe/stripe.service";
 import { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
 import { WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
 import type { UserOutput } from "@src/user/repositories";
-import { UserRepository } from "@src/user/repositories";
 import { WalletController } from "./wallet.controller";
 
-import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
 import { createUser } from "@test/seeders/user.seeder";
 
 describe("WalletController", () => {
-  it("forbids starting a trial for a user with not verified email", async () => {
-    const user = createUser({
-      emailVerified: false
-    });
-    const container = setup({
-      user
-    });
-    const walletController = container.resolve(WalletController);
-    await expect(() =>
-      walletController.create({
-        data: {
-          userId: user.id
-        }
-      })
-    ).rejects.toThrow(/email not verified/i);
-    expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).not.toHaveBeenCalled();
-  });
+  describe("create", () => {
+    it("delegates to walletInitializer.startTrial and wraps the result with denom", async () => {
+      const user = createUser();
+      const wallet: UserWalletPublicOutput = {
+        id: faker.number.int(),
+        userId: user.id,
+        address: faker.string.alphanumeric(44),
+        creditAmount: 100,
+        isTrialing: true,
+        createdAt: new Date()
+      };
+      const container = setup({ user, startTrialResult: wallet });
+      const walletController = container.resolve(WalletController);
 
-  it("forbids starting a trial for a user without configured payments methods", async () => {
-    const user = createUser({
-      emailVerified: true,
-      stripeCustomerId: faker.string.uuid()
-    });
-    const container = setup({
-      user,
-      hasPaymentMethods: false
-    });
-    const walletController = container.resolve(WalletController);
-    await expect(() =>
-      walletController.create({
-        data: {
-          userId: user.id
-        }
-      })
-    ).rejects.toThrow(/You must have a payment method to start a trial/i);
-    expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).not.toHaveBeenCalled();
-  });
+      const result = await walletController.create({ data: { userId: user.id } });
 
-  it("forbids starting a trial for a user with duplicate trial account", async () => {
-    const user = createUser({
-      emailVerified: true,
-      stripeCustomerId: faker.string.uuid()
-    });
-    const container = setup({
-      user,
-      hasDuplicateTrialAccount: true,
-      hasPaymentMethods: true
-    });
-    const walletController = container.resolve(WalletController);
-    await expect(() =>
-      walletController.create({
-        data: {
-          userId: user.id
-        }
-      })
-    ).rejects.toThrow(/associated with another trial account/i);
-    expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).not.toHaveBeenCalled();
-  });
-
-  it("forbids starting a trial for a user with duplicate fingerprint", async () => {
-    const user = createUser({
-      emailVerified: true,
-      stripeCustomerId: faker.string.uuid(),
-      lastFingerprint: "duplicate-fingerprint"
-    });
-    const container = setup({
-      user,
-      hasDuplicateFingerprint: true,
-      hasPaymentMethods: true
-    });
-    const walletController = container.resolve(WalletController);
-    await expect(() =>
-      walletController.create({
-        data: {
-          userId: user.id
-        }
-      })
-    ).rejects.toThrow(/Unable to start trial/i);
-    expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).not.toHaveBeenCalled();
-  });
-
-  it("allows starting a trial when user has no fingerprint", async () => {
-    const user = createUser({
-      emailVerified: true,
-      stripeCustomerId: faker.string.uuid(),
-      lastFingerprint: null
-    });
-    const container = setup({
-      user,
-      hasPaymentMethods: true,
-      hasDuplicateTrialAccount: false
-    });
-    const walletController = container.resolve(WalletController);
-    await walletController.create({
-      data: {
-        userId: user.id
-      }
-    });
-    expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).toHaveBeenCalledWith(user.id);
-  });
-
-  it("creates a wallet for a user with all valid requirements", async () => {
-    const user = createUser({
-      emailVerified: true,
-      stripeCustomerId: faker.string.uuid()
-    });
-    const container = setup({
-      user,
-      hasPaymentMethods: true,
-      hasDuplicateTrialAccount: false
-    });
-    const walletController = container.resolve(WalletController);
-    await walletController.create({
-      data: {
-        userId: user.id
-      }
-    });
-    expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).toHaveBeenCalledWith(user.id);
-  });
-
-  it("handles 3DS required scenario in controller", async () => {
-    const user = createUser({
-      emailVerified: true,
-      stripeCustomerId: faker.string.uuid()
-    });
-    const container = setup({
-      user,
-      hasPaymentMethods: true,
-      hasDuplicateTrialAccount: false,
-      requires3DS: true
-    });
-    const walletController = container.resolve(WalletController);
-    const result = await walletController.create({
-      data: {
-        userId: user.id
-      }
+      expect(container.resolve(WalletInitializerService).startTrial).toHaveBeenCalledWith(user.id);
+      expect(result).toEqual({ data: { ...wallet, denom: "uakt", topUpMinAmountUsd: 100 } });
     });
 
-    expect(result).toEqual({
-      data: {
+    it("passes a 3DS-required result through with denom attached", async () => {
+      const user = createUser();
+      const threeDsResult = {
         id: null,
         userId: user.id,
         address: null,
-        denom: "uakt",
         creditAmount: 0,
         isTrialing: false,
-        topUpMinAmountUsd: 20,
         createdAt: null,
         requires3DS: true,
-        clientSecret: "test_client_secret",
-        paymentIntentId: "test_payment_intent_id",
-        paymentMethodId: "test_payment_method_id"
-      }
-    });
-    expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).not.toHaveBeenCalled();
-  });
+        clientSecret: "cs",
+        paymentIntentId: "pi",
+        paymentMethodId: "pm"
+      } as const;
+      const container = setup({ user, startTrialResult: threeDsResult });
+      const walletController = container.resolve(WalletController);
 
-  it("handles validation failure in controller", async () => {
-    const user = createUser({
-      emailVerified: true,
-      stripeCustomerId: faker.string.uuid()
-    });
-    const container = setup({
-      user,
-      hasPaymentMethods: true,
-      hasDuplicateTrialAccount: false,
-      validationFails: true
-    });
-    const walletController = container.resolve(WalletController);
+      const result = await walletController.create({ data: { userId: user.id } });
 
-    await expect(() =>
-      walletController.create({
-        data: {
-          userId: user.id
-        }
-      })
-    ).rejects.toThrow("Card validation failed");
-    expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).not.toHaveBeenCalled();
+      expect(result).toEqual({ data: { ...threeDsResult, denom: "uakt", topUpMinAmountUsd: 20 } });
+    });
+
+    it("propagates errors thrown by walletInitializer.startTrial", async () => {
+      const user = createUser();
+      const error = new Error("Email not verified");
+      const container = setup({ user, startTrialError: error });
+      const walletController = container.resolve(WalletController);
+
+      await expect(() => walletController.create({ data: { userId: user.id } })).rejects.toThrow("Email not verified");
+    });
   });
 
   describe("getWallets", () => {
@@ -206,7 +75,7 @@ describe("WalletController", () => {
       const userId = faker.string.uuid();
       const wallets = [
         {
-          id: faker.string.uuid(),
+          id: faker.number.int(),
           userId,
           address: faker.string.alphanumeric(44),
           creditAmount: 100,
@@ -214,7 +83,7 @@ describe("WalletController", () => {
           createdAt: new Date()
         },
         {
-          id: faker.string.uuid(),
+          id: faker.number.int(),
           userId,
           address: faker.string.alphanumeric(44),
           creditAmount: 200,
@@ -222,26 +91,18 @@ describe("WalletController", () => {
           createdAt: new Date()
         }
       ];
-      const container = setup({
-        user: createUser(),
-        wallets
-      });
+      const container = setup({ user: createUser(), wallets });
       const walletController = container.resolve(WalletController);
 
       const result = await walletController.getWallets({ userId });
 
-      expect(result).toEqual({
-        data: wallets.map(wallet => ({ ...wallet, denom: "uakt", topUpMinAmountUsd: wallet.isTrialing ? 100 : 20 }))
-      });
+      expect(result).toEqual({ data: wallets.map(wallet => ({ ...wallet, denom: "uakt", topUpMinAmountUsd: wallet.isTrialing ? 100 : 20 })) });
       expect(container.resolve(WalletReaderService).getWallets).toHaveBeenCalledWith({ userId });
     });
 
     it("returns empty list when no wallets found", async () => {
       const userId = faker.string.uuid();
-      const container = setup({
-        user: createUser(),
-        wallets: []
-      });
+      const container = setup({ user: createUser(), wallets: [] });
       const walletController = container.resolve(WalletController);
 
       const result = await walletController.getWallets({ userId });
@@ -250,111 +111,38 @@ describe("WalletController", () => {
     });
   });
 
-  it("handles stripe error in controller", async () => {
-    const user = createUser({
-      emailVerified: true,
-      stripeCustomerId: faker.string.uuid()
-    });
-    const container = setup({
-      user,
-      hasPaymentMethods: true,
-      hasDuplicateTrialAccount: false,
-      stripeError: true
-    });
-    const walletController = container.resolve(WalletController);
-
-    await expect(() =>
-      walletController.create({
-        data: {
-          userId: user.id
-        }
-      })
-    ).rejects.toThrow("Stripe error occurred");
-    expect(container.resolve(WalletInitializerService).initializeAndGrantTrialLimits).not.toHaveBeenCalled();
-  });
-
   function setup(input?: {
     user?: UserOutput;
-    hasPaymentMethods?: boolean;
-    hasDuplicateTrialAccount?: boolean;
-    hasDuplicateFingerprint?: boolean;
-    requires3DS?: boolean;
-    validationFails?: boolean;
-    stripeError?: boolean;
     wallets?: UserWalletPublicOutput[];
+    startTrialResult?: Awaited<ReturnType<WalletInitializerService["startTrial"]>>;
+    startTrialError?: Error;
   }) {
+    const startTrial = jest.fn();
+    if (input?.startTrialError) {
+      startTrial.mockRejectedValue(input.startTrialError);
+    } else if (input?.startTrialResult) {
+      startTrial.mockResolvedValue(input.startTrialResult);
+    }
+
     rootContainer.register(AuthService, {
       useValue: mock<AuthService>({
-        ability: createMongoAbility<MongoAbility>([
-          {
-            action: "create",
-            subject: "UserWallet"
-          }
-        ]),
-        currentUser: input?.user || createUser()
+        ability: createMongoAbility<MongoAbility>([{ action: "create", subject: "UserWallet" }]),
+        currentUser: input?.user ?? createUser()
       })
     });
     rootContainer.register(WalletInitializerService, {
-      useValue: mock<WalletInitializerService>()
-    });
-    rootContainer.register(StripeService, {
-      useValue: mock<StripeService>({
-        isProduction: true,
-        getPaymentMethods: jest.fn(async () => {
-          if (!input?.hasPaymentMethods) return [];
-          return [{ ...generatePaymentMethod(), validated: true, isDefault: false }];
-        }),
-        hasDuplicateTrialAccount: jest.fn().mockResolvedValue(input?.hasDuplicateTrialAccount ?? false),
-        validatePaymentMethodForTrial: jest.fn().mockImplementation(() => {
-          if (input?.validationFails) {
-            throw new Error("Card validation failed");
-          }
-          if (input?.stripeError) {
-            throw new Error("Stripe error occurred");
-          }
-          if (input?.requires3DS) {
-            return Promise.resolve({
-              success: false,
-              requires3DS: true,
-              clientSecret: "test_client_secret",
-              paymentIntentId: "test_payment_intent_id",
-              paymentMethodId: "test_payment_method_id"
-            });
-          }
-          return Promise.resolve({
-            success: true,
-            requires3DS: false
-          });
-        })
-      })
-    });
-    rootContainer.register(UserRepository, {
-      useValue: mock<UserRepository>({
-        findTrialUsersByFingerprint: jest.fn().mockResolvedValue(input?.hasDuplicateFingerprint ? [{ id: faker.string.uuid() }] : [])
-      })
+      useValue: mock<WalletInitializerService>({ startTrial })
     });
     rootContainer.register(BillingConfigService, {
-      useValue: mock<BillingConfigService>({
-        get: jest.fn().mockReturnValue("uakt")
-      })
+      useValue: mock<BillingConfigService>({ get: jest.fn().mockReturnValue("uakt") })
     });
-    rootContainer.register(ManagedSignerService, {
-      useValue: mock<ManagedSignerService>()
-    });
-    rootContainer.register(RefillService, {
-      useValue: mock<RefillService>()
-    });
+    rootContainer.register(ManagedSignerService, { useValue: mock<ManagedSignerService>() });
+    rootContainer.register(RefillService, { useValue: mock<RefillService>() });
     rootContainer.register(WalletReaderService, {
-      useValue: mock<WalletReaderService>({
-        getWallets: jest.fn().mockResolvedValue(input?.wallets ?? [])
-      })
+      useValue: mock<WalletReaderService>({ getWallets: jest.fn().mockResolvedValue(input?.wallets ?? []) })
     });
-    rootContainer.register(BalancesService, {
-      useValue: mock<BalancesService>()
-    });
-    rootContainer.register(UserWalletRepository, {
-      useValue: mock<UserWalletRepository>()
-    });
+    rootContainer.register(BalancesService, { useValue: mock<BalancesService>() });
+    rootContainer.register(UserWalletRepository, { useValue: mock<UserWalletRepository>() });
     rootContainer.register(TrialValidationService, {
       useValue: mock<TrialValidationService>({
         getTopUpMinAmountUsd: jest.fn(wallet => (wallet?.isTrialing ? 100 : 20))

--- a/apps/api/src/billing/controllers/wallet/wallet.controller.ts
+++ b/apps/api/src/billing/controllers/wallet/wallet.controller.ts
@@ -13,13 +13,8 @@ import { BalancesService } from "@src/billing/services/balances/balances.service
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { RefillService } from "@src/billing/services/refill/refill.service";
-import { StripeService } from "@src/billing/services/stripe/stripe.service";
-import { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
 import { TrialValidationService } from "@src/billing/services/trial-validation/trial-validation.service";
 import { GetWalletOptions, WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
-import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
-import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
-import { UserRepository } from "@src/user/repositories";
 
 @scoped(Lifecycle.ResolutionScoped)
 export class WalletController {
@@ -31,74 +26,16 @@ export class WalletController {
     private readonly balancesService: BalancesService,
     private readonly authService: AuthService,
     private readonly userWalletRepository: UserWalletRepository,
-    private readonly stripeService: StripeService,
-    private readonly stripeErrorService: StripeErrorService,
-    private readonly featureFlagsService: FeatureFlagsService,
-    private readonly userRepository: UserRepository,
     private readonly billingConfigService: BillingConfigService,
     private readonly trialValidationService: TrialValidationService
   ) {}
 
   @Protected([{ action: "create", subject: "UserWallet" }])
   async create({ data: { userId } }: StartTrialRequestInput): Promise<WalletOutputResponse> {
-    const { currentUser } = this.authService;
-
-    assert(currentUser.emailVerified, 400, "Email not verified");
-    assert(currentUser.stripeCustomerId, 400, "Stripe customer ID not found");
-
-    const paymentMethods = await this.stripeService.getPaymentMethods(currentUser.id, currentUser.stripeCustomerId, this.authService.ability);
-    assert(paymentMethods.length > 0, 400, "You must have a payment method to start a trial.");
-
-    if (this.stripeService.isProduction) {
-      const hasDuplicateTrialAccount = await this.stripeService.hasDuplicateTrialAccount(paymentMethods, currentUser.id);
-      assert(!hasDuplicateTrialAccount, 400, "This payment method is already associated with another trial account. Please use a different payment method.");
-
-      if (this.featureFlagsService.isEnabled(FeatureFlags.TRIAL_FINGERPRINT_CHECK) && currentUser.lastFingerprint) {
-        const usersWithSameFingerprint = await this.userRepository.findTrialUsersByFingerprint(currentUser.lastFingerprint, currentUser.id);
-        assert(usersWithSameFingerprint.length === 0, 400, "Unable to start trial. Please contact support for assistance.");
-      }
-    }
-
-    const latestPaymentMethod = paymentMethods[0];
-    try {
-      const validationResult = await this.stripeService.validatePaymentMethodForTrial({
-        customer: currentUser.stripeCustomerId,
-        payment_method: latestPaymentMethod.id,
-        userId: currentUser.id
-      });
-
-      // If the card requires 3D Secure authentication, return the necessary information
-      if (validationResult.requires3DS) {
-        return {
-          data: {
-            id: null,
-            userId: currentUser.id,
-            address: null,
-            denom: this.billingConfigService.get("DEPLOYMENT_GRANT_DENOM"),
-            creditAmount: 0,
-            isTrialing: false,
-            topUpMinAmountUsd: this.trialValidationService.getTopUpMinAmountUsd({ isTrialing: false }),
-            createdAt: null,
-            requires3DS: true,
-            clientSecret: validationResult.clientSecret || null,
-            paymentIntentId: validationResult.paymentIntentId || null,
-            paymentMethodId: validationResult.paymentMethodId || null
-          }
-        };
-      }
-    } catch (error: unknown) {
-      if (this.stripeErrorService.isKnownError(error, "payment")) {
-        throw this.stripeErrorService.toAppError(error, "payment");
-      }
-
-      throw error;
-    }
-
     const denom = this.billingConfigService.get("DEPLOYMENT_GRANT_DENOM");
-    const wallet = await this.walletInitializer.initializeAndGrantTrialLimits(userId);
-
+    const result = await this.walletInitializer.startTrial(userId);
     return {
-      data: { ...wallet, denom, topUpMinAmountUsd: this.trialValidationService.getTopUpMinAmountUsd(wallet) }
+      data: { ...result, denom, topUpMinAmountUsd: this.trialValidationService.getTopUpMinAmountUsd(result) }
     };
   }
 

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
@@ -1,4 +1,5 @@
 import { Registry } from "@cosmjs/proto-signing";
+import { faker } from "@faker-js/faker";
 import { container } from "tsyringe";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
@@ -7,17 +8,134 @@ import { AuthService } from "@src/auth/services/auth.service";
 import { TrialStarted } from "@src/billing/events/trial-started";
 import { TYPE_REGISTRY } from "@src/billing/providers/type-registry.provider";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
 import { ProviderJwtTokenService } from "@src/provider/services/provider-jwt-token/provider-jwt-token.service";
+import type { UserOutput } from "@src/user/repositories";
+import { UserRepository } from "@src/user/repositories";
 import { UserWalletRepository } from "../../repositories/user-wallet/user-wallet.repository";
 import { ManagedSignerService } from "../managed-signer/managed-signer.service";
 import { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wallet.service";
+import { StripeService } from "../stripe/stripe.service";
+import { StripeErrorService } from "../stripe-error/stripe-error.service";
 import { WalletInitializerService } from "./wallet-initializer.service";
 
 import { createChainWallet } from "@test/seeders/chain-wallet.seeder";
+import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
 import { createUser } from "@test/seeders/user.seeder";
 import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 
 describe(WalletInitializerService.name, () => {
+  describe("startTrial", () => {
+    it("throws 400 when email is not verified", async () => {
+      const user = createUser({ emailVerified: false });
+      const di = setup({ user });
+
+      await expect(di.resolve(WalletInitializerService).startTrial(user.id)).rejects.toThrow(/email not verified/i);
+    });
+
+    it("throws 400 when stripeCustomerId is missing", async () => {
+      const user = createUser({ emailVerified: true, stripeCustomerId: null as unknown as string });
+      const di = setup({ user });
+
+      await expect(di.resolve(WalletInitializerService).startTrial(user.id)).rejects.toThrow(/stripe customer id not found/i);
+    });
+
+    it("throws 400 on duplicate fingerprint in production", async () => {
+      const user = createUser({ emailVerified: true, stripeCustomerId: faker.string.uuid(), lastFingerprint: "fp" });
+      const di = setup({ user, isProduction: true, hasDuplicateFingerprint: true });
+
+      await expect(di.resolve(WalletInitializerService).startTrial(user.id)).rejects.toThrow(/Unable to start trial/i);
+    });
+
+    describe("when console_onboarding_redesign is OFF", () => {
+      it("throws 400 when the user has no payment method", async () => {
+        const user = createUser({ emailVerified: true, stripeCustomerId: faker.string.uuid() });
+        const di = setup({ user, hasPaymentMethods: false });
+
+        await expect(di.resolve(WalletInitializerService).startTrial(user.id)).rejects.toThrow(/payment method/i);
+      });
+
+      it("throws 400 on duplicate trial account in production", async () => {
+        const user = createUser({ emailVerified: true, stripeCustomerId: faker.string.uuid() });
+        const di = setup({ user, hasPaymentMethods: true, hasDuplicateTrialAccount: true, isProduction: true });
+
+        await expect(di.resolve(WalletInitializerService).startTrial(user.id)).rejects.toThrow(/already associated with another trial account/i);
+      });
+
+      it("returns a 3DS-required payload when Stripe says so", async () => {
+        const user = createUser({ emailVerified: true, stripeCustomerId: faker.string.uuid() });
+        const di = setup({ user, hasPaymentMethods: true, requires3DS: true });
+
+        const result = await di.resolve(WalletInitializerService).startTrial(user.id);
+        expect(result).toMatchObject({ requires3DS: true, clientSecret: "cs", paymentIntentId: "pi", paymentMethodId: "pm" });
+      });
+
+      it("calls initializeAndGrantTrialLimits on the happy path", async () => {
+        const user = createUser({ emailVerified: true, stripeCustomerId: faker.string.uuid() });
+        const newWallet = createUserWallet({ userId: user.id });
+        const di = setup({
+          user,
+          hasPaymentMethods: true,
+          getOrCreateWallet: jest.fn().mockResolvedValue({ wallet: newWallet, isNew: true }),
+          updateWalletById: jest.fn().mockResolvedValue(newWallet)
+        });
+        const managedUserWalletService = di.resolve(ManagedUserWalletService) as MockProxy<ManagedUserWalletService>;
+        managedUserWalletService.createAndAuthorizeTrialSpending.mockResolvedValue(createChainWallet());
+
+        await di.resolve(WalletInitializerService).startTrial(user.id);
+
+        expect(managedUserWalletService.createAndAuthorizeTrialSpending).toHaveBeenCalled();
+        expect(di.resolve(StripeService).validatePaymentMethodForTrial).toHaveBeenCalled();
+      });
+    });
+
+    describe("when console_onboarding_redesign is ON", () => {
+      it("skips payment-method validation and goes straight to wallet init", async () => {
+        const user = createUser({ emailVerified: true, stripeCustomerId: faker.string.uuid() });
+        const newWallet = createUserWallet({ userId: user.id });
+        const di = setup({
+          user,
+          consoleOnboardingRedesign: true,
+          hasPaymentMethods: false,
+          getOrCreateWallet: jest.fn().mockResolvedValue({ wallet: newWallet, isNew: true }),
+          updateWalletById: jest.fn().mockResolvedValue(newWallet)
+        });
+        const managedUserWalletService = di.resolve(ManagedUserWalletService) as MockProxy<ManagedUserWalletService>;
+        managedUserWalletService.createAndAuthorizeTrialSpending.mockResolvedValue(createChainWallet());
+
+        await di.resolve(WalletInitializerService).startTrial(user.id);
+
+        expect(di.resolve(StripeService).getPaymentMethods).not.toHaveBeenCalled();
+        expect(di.resolve(StripeService).validatePaymentMethodForTrial).not.toHaveBeenCalled();
+        expect(managedUserWalletService.createAndAuthorizeTrialSpending).toHaveBeenCalled();
+      });
+
+      it("still enforces the fingerprint anti-abuse check", async () => {
+        const user = createUser({ emailVerified: true, stripeCustomerId: faker.string.uuid(), lastFingerprint: "fp" });
+        const di = setup({ user, consoleOnboardingRedesign: true, isProduction: true, hasDuplicateFingerprint: true });
+
+        await expect(di.resolve(WalletInitializerService).startTrial(user.id)).rejects.toThrow(/Unable to start trial/i);
+      });
+
+      it("does not require a stripeCustomerId", async () => {
+        const user = createUser({ emailVerified: true, stripeCustomerId: null as unknown as string });
+        const newWallet = createUserWallet({ userId: user.id });
+        const di = setup({
+          user,
+          consoleOnboardingRedesign: true,
+          getOrCreateWallet: jest.fn().mockResolvedValue({ wallet: newWallet, isNew: true }),
+          updateWalletById: jest.fn().mockResolvedValue(newWallet)
+        });
+        const managedUserWalletService = di.resolve(ManagedUserWalletService) as MockProxy<ManagedUserWalletService>;
+        managedUserWalletService.createAndAuthorizeTrialSpending.mockResolvedValue(createChainWallet());
+
+        await expect(di.resolve(WalletInitializerService).startTrial(user.id)).resolves.toBeDefined();
+        expect(managedUserWalletService.createAndAuthorizeTrialSpending).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe("initializeAndGrantTrialLimits", () => {
     it("creates a new wallet and authorizes trial spending when no wallet exists", async () => {
       const userId = "test-user-id";
@@ -109,6 +227,13 @@ describe(WalletInitializerService.name, () => {
     updateWalletById?: UserWalletRepository["updateById"];
     deleteWalletById?: UserWalletRepository["deleteById"];
     userId?: string;
+    user?: UserOutput;
+    isProduction?: boolean;
+    hasPaymentMethods?: boolean;
+    hasDuplicateTrialAccount?: boolean;
+    hasDuplicateFingerprint?: boolean;
+    requires3DS?: boolean;
+    consoleOnboardingRedesign?: boolean;
   }) {
     const di = container.createChildContainer();
     di.registerInstance(TYPE_REGISTRY, new Registry());
@@ -132,7 +257,7 @@ describe(WalletInitializerService.name, () => {
       AuthService,
       mock<AuthService>({
         ability: {},
-        currentUser: createUser({ id: input?.userId })
+        currentUser: input?.user ?? createUser({ id: input?.userId })
       })
     );
     di.registerInstance(DomainEventsService, mock<DomainEventsService>());
@@ -143,6 +268,41 @@ describe(WalletInitializerService.name, () => {
       })
     );
     di.registerInstance(ManagedSignerService, mock<ManagedSignerService>());
+
+    di.registerInstance(
+      FeatureFlagsService,
+      mock<FeatureFlagsService>({
+        isEnabled: jest.fn(flag => {
+          if (flag === FeatureFlags.CONSOLE_ONBOARDING_REDESIGN) return input?.consoleOnboardingRedesign ?? false;
+          return true;
+        })
+      })
+    );
+    di.registerInstance(
+      StripeService,
+      mock<StripeService>({
+        isProduction: input?.isProduction ?? false,
+        getPaymentMethods: jest.fn(async () => {
+          if (!input?.hasPaymentMethods) return [];
+          return [{ ...generatePaymentMethod(), validated: true, isDefault: false }];
+        }),
+        hasDuplicateTrialAccount: jest.fn().mockResolvedValue(input?.hasDuplicateTrialAccount ?? false),
+        validatePaymentMethodForTrial: jest
+          .fn()
+          .mockResolvedValue(
+            input?.requires3DS
+              ? { success: false, requires3DS: true, clientSecret: "cs", paymentIntentId: "pi", paymentMethodId: "pm" }
+              : { success: true, requires3DS: false }
+          )
+      })
+    );
+    di.registerInstance(StripeErrorService, mock<StripeErrorService>({ isKnownError: jest.fn().mockReturnValue(false) }));
+    di.registerInstance(
+      UserRepository,
+      mock<UserRepository>({
+        findTrialUsersByFingerprint: jest.fn().mockResolvedValue(input?.hasDuplicateFingerprint ? [{ id: faker.string.uuid() }] : [])
+      })
+    );
 
     container.clearInstances();
 

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.ts
@@ -1,12 +1,32 @@
+import assert from "http-assert";
 import { singleton } from "tsyringe";
 
 import { AuthService } from "@src/auth/services/auth.service";
 import { TrialStarted } from "@src/billing/events/trial-started";
 import { UserWalletPublicOutput, UserWalletRepository } from "@src/billing/repositories";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import { StripeService } from "@src/billing/services/stripe/stripe.service";
+import { StripeErrorService } from "@src/billing/services/stripe-error/stripe-error.service";
 import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
 import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import { UserOutput, UserRepository } from "@src/user/repositories";
 import { ManagedUserWalletService } from "../managed-user-wallet/managed-user-wallet.service";
+
+export type Requires3DSResult = {
+  id: null;
+  userId: string;
+  address: null;
+  creditAmount: 0;
+  isTrialing: false;
+  createdAt: null;
+  requires3DS: true;
+  clientSecret: string | null;
+  paymentIntentId: string | null;
+  paymentMethodId: string | null;
+};
+
+export type StartTrialResult = UserWalletPublicOutput | Requires3DSResult;
 
 @singleton()
 export class WalletInitializerService {
@@ -16,8 +36,76 @@ export class WalletInitializerService {
     private readonly userWalletRepository: UserWalletRepository,
     private readonly authService: AuthService,
     private readonly domainEvents: DomainEventsService,
-    private readonly featureFlagsService: FeatureFlagsService
+    private readonly featureFlagsService: FeatureFlagsService,
+    private readonly stripeService: StripeService,
+    private readonly stripeErrorService: StripeErrorService,
+    private readonly userRepository: UserRepository
   ) {}
+
+  async startTrial(userId: string): Promise<StartTrialResult> {
+    const { currentUser } = this.authService;
+
+    assert(currentUser.emailVerified, 400, "Email not verified");
+    await this.#assertNoDuplicateFingerprint(currentUser);
+
+    if (!this.featureFlagsService.isEnabled(FeatureFlags.CONSOLE_ONBOARDING_REDESIGN)) {
+      assert(currentUser.stripeCustomerId, 400, "Stripe customer ID not found");
+      const threeDsResult = await this.#validatePaymentMethod(currentUser);
+      if (threeDsResult) return threeDsResult;
+    }
+
+    return this.initializeAndGrantTrialLimits(userId);
+  }
+
+  async #assertNoDuplicateFingerprint(user: UserOutput): Promise<void> {
+    if (!this.stripeService.isProduction) return;
+    if (!this.featureFlagsService.isEnabled(FeatureFlags.TRIAL_FINGERPRINT_CHECK)) return;
+    if (!user.lastFingerprint) return;
+
+    const usersWithSameFingerprint = await this.userRepository.findTrialUsersByFingerprint(user.lastFingerprint, user.id);
+    assert(usersWithSameFingerprint.length === 0, 400, "Unable to start trial. Please contact support for assistance.");
+  }
+
+  async #validatePaymentMethod(user: UserOutput): Promise<Requires3DSResult | null> {
+    const paymentMethods = await this.stripeService.getPaymentMethods(user.id, user.stripeCustomerId!, this.authService.ability);
+    assert(paymentMethods.length > 0, 400, "You must have a payment method to start a trial.");
+
+    if (this.stripeService.isProduction) {
+      const hasDuplicateTrialAccount = await this.stripeService.hasDuplicateTrialAccount(paymentMethods, user.id);
+      assert(!hasDuplicateTrialAccount, 400, "This payment method is already associated with another trial account. Please use a different payment method.");
+    }
+
+    const latestPaymentMethod = paymentMethods[0];
+    try {
+      const validationResult = await this.stripeService.validatePaymentMethodForTrial({
+        customer: user.stripeCustomerId!,
+        payment_method: latestPaymentMethod.id,
+        userId: user.id
+      });
+
+      if (validationResult.requires3DS) {
+        return {
+          id: null,
+          userId: user.id,
+          address: null,
+          creditAmount: 0,
+          isTrialing: false,
+          createdAt: null,
+          requires3DS: true,
+          clientSecret: validationResult.clientSecret || null,
+          paymentIntentId: validationResult.paymentIntentId || null,
+          paymentMethodId: validationResult.paymentMethodId || null
+        };
+      }
+    } catch (error: unknown) {
+      if (this.stripeErrorService.isKnownError(error, "payment")) {
+        throw this.stripeErrorService.toAppError(error, "payment");
+      }
+      throw error;
+    }
+
+    return null;
+  }
 
   async initializeAndGrantTrialLimits(userId: string): Promise<UserWalletPublicOutput> {
     const { wallet, isNew } = await this.userWalletRepository.accessibleBy(this.authService.ability, "create").getOrCreate({ userId });

--- a/apps/api/src/core/services/feature-flags/feature-flags.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.ts
@@ -3,7 +3,8 @@ export const FeatureFlags = {
   NOTIFICATIONS_ALERT_UPDATE: "notifications_general_alerts_update",
   AUTO_CREDIT_RELOAD: "auto_credit_reload",
   TRIAL_FINGERPRINT_CHECK: "trial_fingerprint_check",
-  BID_SCREENING: "bid_screening"
+  BID_SCREENING: "bid_screening",
+  CONSOLE_ONBOARDING_REDESIGN: "console_onboarding_redesign"
 } as const;
 
 export type FeatureFlagValue = (typeof FeatureFlags)[keyof typeof FeatureFlags];

--- a/apps/deploy-web/src/components/deployments/PhasedDeploymentContainer/PhasedDeploymentContainer.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/PhasedDeploymentContainer/PhasedDeploymentContainer.spec.tsx
@@ -222,6 +222,8 @@ describe(PhasedDeploymentContainer.name, () => {
       templateName?: string;
       sdl?: string;
       deposit?: number;
+      isWalletReady?: boolean;
+      trialError?: unknown;
       onSuccess?: (dseq: string) => void;
       onCancel?: () => void;
       providers?: ApiProviderList[];
@@ -243,6 +245,8 @@ describe(PhasedDeploymentContainer.name, () => {
         templateName={input.templateName ?? "test-template"}
         sdl={input.sdl ?? "sdl-content"}
         deposit={input.deposit}
+        isWalletReady={input.isWalletReady ?? true}
+        trialError={input.trialError}
         onSuccess={input.onSuccess}
         onCancel={input.onCancel}
         dependencies={{

--- a/apps/deploy-web/src/components/deployments/PhasedDeploymentContainer/PhasedDeploymentContainer.tsx
+++ b/apps/deploy-web/src/components/deployments/PhasedDeploymentContainer/PhasedDeploymentContainer.tsx
@@ -39,6 +39,8 @@ type PhasedDeploymentContainerProps = {
   templateName: string;
   sdl: string;
   deposit?: number;
+  isWalletReady: boolean;
+  trialError?: unknown;
   onSuccess?: (dseq: string) => void;
   onCancel?: () => void;
   dependencies?: typeof DEPENDENCIES;
@@ -48,6 +50,8 @@ export function PhasedDeploymentContainer({
   templateName,
   sdl,
   deposit = DEFAULT_DEPOSIT_USD,
+  isWalletReady,
+  trialError,
   onSuccess,
   onCancel,
   dependencies: d = DEPENDENCIES
@@ -57,6 +61,8 @@ export function PhasedDeploymentContainer({
   const { state, progressPercent, phases, matchedProviderAddress, startOver } = d.usePhasedDeploymentFlow({
     sdl,
     deposit,
+    isWalletReady,
+    trialError,
     onSuccess: dseq => onSuccess?.(dseq)
   });
 

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
@@ -1,5 +1,9 @@
+import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
+import type { EnqueueSnackbar, ProviderContext } from "notistack";
 import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
 
+import type { EnsureTrialStartedResult } from "@src/hooks/useEnsureTrialStarted";
 import { DEPENDENCIES, OnboardingPickerPage } from "./OnboardingPickerPage";
 
 import { act, render, screen } from "@testing-library/react";
@@ -57,6 +61,19 @@ describe(OnboardingPickerPage.name, () => {
     expect(await screen.findByRole("heading", { name: "Let's deploy your first app" })).toBeInTheDocument();
   });
 
+  it("renders an error alert when trial start fails terminally", () => {
+    const useEnsureTrialStarted: () => EnsureTrialStartedResult = () => ({ isWalletReady: false, isLoading: false, error: new Error("boom") });
+    setup({ dependencies: { useEnsureTrialStarted } });
+
+    expect(screen.getByText(/We couldn't set up your trial/i)).toBeInTheDocument();
+  });
+
+  it("does not render the error alert when trial start has not failed", () => {
+    setup();
+
+    expect(screen.queryByText(/We couldn't set up your trial/i)).not.toBeInTheDocument();
+  });
+
   it("enqueues a success snackbar and redirects to the deployment details on success", () => {
     const enqueueSnackbar = vi.fn();
     const replace = vi.fn();
@@ -80,22 +97,21 @@ describe(OnboardingPickerPage.name, () => {
   function setup(
     input: {
       templates?: OnboardingPickerPageProps["templates"];
-      enqueueSnackbar?: ReturnType<typeof vi.fn>;
-      replace?: ReturnType<typeof vi.fn>;
+      enqueueSnackbar?: EnqueueSnackbar;
+      replace?: () => void;
       dependencies?: Partial<typeof DEPENDENCIES>;
     } = {}
   ) {
-    const enqueueSnackbar = input.enqueueSnackbar ?? vi.fn();
-    const replace = input.replace ?? vi.fn();
+    const enqueueSnackbar: EnqueueSnackbar = input.enqueueSnackbar ?? vi.fn<EnqueueSnackbar>();
+    const replace: () => void = input.replace ?? vi.fn();
+    const useRouter: () => AppRouterInstance = vi.fn(() => mock<AppRouterInstance>({ replace }));
+    const useSnackbar: () => ProviderContext = vi.fn(() => mock<ProviderContext>({ enqueueSnackbar }));
+    const useEnsureTrialStarted: () => EnsureTrialStartedResult = vi.fn(() => ({ isWalletReady: true, isLoading: false, error: null }));
 
     return render(
       <OnboardingPickerPage
         templates={input.templates ?? { helloWorld: "hello-sdl", imageGen: "image-sdl", llmChatbot: "llm-sdl" }}
-        dependencies={MockComponents(DEPENDENCIES, {
-          useSnackbar: vi.fn(() => ({ enqueueSnackbar })) as unknown as typeof DEPENDENCIES.useSnackbar,
-          useRouter: vi.fn(() => ({ replace })) as unknown as typeof DEPENDENCIES.useRouter,
-          ...input.dependencies
-        })}
+        dependencies={MockComponents(DEPENDENCIES, { useSnackbar, useRouter, useEnsureTrialStarted, ...input.dependencies })}
       />
     );
   }

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Button, Snackbar } from "@akashnetwork/ui/components";
+import { Alert, AlertDescription, Button, Snackbar } from "@akashnetwork/ui/components";
 import { ArrowRight } from "iconoir-react";
 import Head from "next/head";
 import { useRouter } from "next/navigation";
@@ -10,11 +10,13 @@ import { useSnackbar } from "notistack";
 import { DeploymentTemplatePickerCard } from "@src/components/deployments/DeploymentTemplatePickerCard/DeploymentTemplatePickerCard";
 import { PhasedDeploymentContainer } from "@src/components/deployments/PhasedDeploymentContainer/PhasedDeploymentContainer";
 import { AkashConsoleLogo } from "@src/components/icons/AkashConsoleLogo";
+import { useEnsureTrialStarted } from "@src/hooks/useEnsureTrialStarted";
 import { UrlService } from "@src/utils/urlUtils";
 
 export const DEPENDENCIES = {
   useRouter,
   useSnackbar,
+  useEnsureTrialStarted,
   DeploymentTemplatePickerCard,
   PhasedDeploymentContainer
 };
@@ -37,6 +39,7 @@ export function OnboardingPickerPage({ templates, dependencies: d = DEPENDENCIES
   const { enqueueSnackbar } = d.useSnackbar();
   const router = d.useRouter();
   const [deploying, setDeploying] = useState<DeployingState | null>(null);
+  const { isWalletReady, error: trialError } = d.useEnsureTrialStarted();
 
   return (
     <>
@@ -55,6 +58,8 @@ export function OnboardingPickerPage({ templates, dependencies: d = DEPENDENCIES
           <d.PhasedDeploymentContainer
             templateName={deploying.templateName}
             sdl={deploying.sdl}
+            isWalletReady={isWalletReady}
+            trialError={trialError}
             onSuccess={dseq => {
               enqueueSnackbar(<Snackbar title="Deployment prepared!" subTitle="We're redirecting you to the deployment details..." iconVariant="success" />, {
                 variant: "success"
@@ -74,6 +79,14 @@ export function OnboardingPickerPage({ templates, dependencies: d = DEPENDENCIES
                   deployments. Pick a template to get a live URL in about 30 seconds.
                 </p>
               </div>
+
+              {trialError && (
+                <Alert variant="destructive">
+                  <AlertDescription>
+                    We couldn&apos;t set up your trial. Please refresh the page to try again, or contact support if the issue persists.
+                  </AlertDescription>
+                </Alert>
+              )}
 
               <div className="grid w-full grid-cols-1 gap-6 lg:grid-cols-3">
                 <d.DeploymentTemplatePickerCard

--- a/apps/deploy-web/src/components/onboarding/OnboardingRedirectEffect/OnboardingRedirectEffect.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingRedirectEffect/OnboardingRedirectEffect.spec.tsx
@@ -90,6 +90,30 @@ describe(OnboardingRedirectEffect.name, () => {
     expect(mockRouter.replace).toHaveBeenCalledWith("/signup?return-to=%2Fdeployments%3Fpage%3D2");
   });
 
+  it("redirects to /onboarding when the selected flow is redesign and the FF is enabled", () => {
+    const { mockRouter } = setup({
+      user: { userId: "user-1" },
+      wallet: { hasManagedWallet: false, isWalletConnected: false },
+      pathname: "/deployments",
+      selectedOnboardingFlow: "redesign",
+      isOnboardingRedesignEnabled: true
+    });
+
+    expect(mockRouter.replace).toHaveBeenCalledWith("/onboarding");
+  });
+
+  it("falls back to the legacy /signup redirect when the redesign FF is disabled even if the atom is redesign", () => {
+    const { mockRouter } = setup({
+      user: { userId: "user-1" },
+      wallet: { hasManagedWallet: false, isWalletConnected: false },
+      pathname: "/deployments",
+      selectedOnboardingFlow: "redesign",
+      isOnboardingRedesignEnabled: false
+    });
+
+    expect(mockRouter.replace).toHaveBeenCalledWith("/signup?return-to=%2Fdeployments");
+  });
+
   function setup(input: {
     user?: { userId?: string };
     wallet?: { hasManagedWallet?: boolean; isWalletConnected?: boolean };
@@ -97,6 +121,8 @@ describe(OnboardingRedirectEffect.name, () => {
     asPath?: string;
     isUserLoading?: boolean;
     isWalletLoading?: boolean;
+    selectedOnboardingFlow?: "legacy" | "redesign" | null;
+    isOnboardingRedesignEnabled?: boolean;
   }) {
     const mockRouter = {
       pathname: input.pathname || "/",
@@ -115,13 +141,16 @@ describe(OnboardingRedirectEffect.name, () => {
         isWalletLoading: input.isWalletLoading || false
       }),
       useRouter: vi.fn().mockReturnValue(mockRouter),
+      useSelectedOnboardingFlow: vi.fn().mockReturnValue(input.selectedOnboardingFlow ?? null),
+      useFlag: vi.fn().mockReturnValue(input.isOnboardingRedesignEnabled ?? false),
       UrlService: {
         onboarding: vi.fn(({ returnTo }: { returnTo?: string } = {}) => {
           if (returnTo) {
             return `/signup?return-to=${encodeURIComponent(returnTo)}`;
           }
           return "/signup";
-        })
+        }),
+        onboardingPicker: vi.fn(() => "/onboarding")
       }
     } as unknown as ComponentProps<typeof OnboardingRedirectEffect>["dependencies"];
 

--- a/apps/deploy-web/src/components/onboarding/OnboardingRedirectEffect/OnboardingRedirectEffect.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingRedirectEffect/OnboardingRedirectEffect.tsx
@@ -1,16 +1,23 @@
 import { useEffect } from "react";
+import { useAtomValue } from "jotai";
 import { useRouter } from "next/router";
 
 import { useWallet } from "@src/context/WalletProvider";
+import { useFlag } from "@src/hooks/useFlag";
 import { useUser } from "@src/hooks/useUser";
+import onboardingStore from "@src/store/onboardingStore";
 import { UrlService } from "@src/utils/urlUtils";
 
-export const EXCLUDED_PREFIXES = ["/signup", "/login", "/api/", "/user/verify-email"];
+export const EXCLUDED_PREFIXES = ["/signup", "/onboarding", "/login", "/api/", "/user/verify-email"];
+
+const useSelectedOnboardingFlow = () => useAtomValue(onboardingStore.selectedOnboardingFlow);
 
 const DEPENDENCIES = {
   useUser,
   useWallet,
   useRouter,
+  useFlag,
+  useSelectedOnboardingFlow,
   UrlService
 };
 
@@ -21,6 +28,8 @@ type OnboardingRedirectEffectProps = {
 export const OnboardingRedirectEffect = ({ dependencies: d = DEPENDENCIES }: OnboardingRedirectEffectProps) => {
   const { user, isLoading: isUserLoading } = d.useUser();
   const { hasManagedWallet, isWalletConnected, isWalletLoading } = d.useWallet();
+  const selectedOnboardingFlow = d.useSelectedOnboardingFlow();
+  const isOnboardingRedesignEnabled = d.useFlag("console_onboarding_redesign");
   const router = d.useRouter();
 
   useEffect(() => {
@@ -31,9 +40,21 @@ export const OnboardingRedirectEffect = ({ dependencies: d = DEPENDENCIES }: Onb
     }
 
     if (user?.userId && !hasManagedWallet && !isWalletConnected) {
-      router.replace(d.UrlService.onboarding({ returnTo: router.asPath }));
+      const isRedesign = isOnboardingRedesignEnabled && selectedOnboardingFlow === "redesign";
+      const destination = isRedesign ? d.UrlService.onboardingPicker() : d.UrlService.onboarding({ returnTo: router.asPath });
+      router.replace(destination);
     }
-  }, [isUserLoading, isWalletLoading, user?.userId, hasManagedWallet, isWalletConnected, router, d.UrlService]);
+  }, [
+    isUserLoading,
+    isWalletLoading,
+    user?.userId,
+    hasManagedWallet,
+    isWalletConnected,
+    isOnboardingRedesignEnabled,
+    selectedOnboardingFlow,
+    router,
+    d.UrlService
+  ]);
 
   return null;
 };

--- a/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
@@ -164,12 +164,27 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     setSettingsId(walletAddress || null);
   }, [walletAddress]);
 
+  /**
+   * Force every visitor onto the managed-wallet network on first load, regardless of `selectedWalletType`.
+   *
+   * Why unconditional: in the onboarding redesign, every authenticated user gets a managed trial wallet,
+   * and the entire console experience targets that network. Previously this effect only fired when
+   * `selectedWalletType === "managed"`, which meant the switch happened *after* `useManagedWallet`
+   * auto-flipped the wallet type — i.e. mid-deploy if the trial creation completed during a deploy —
+   * tearing down in-flight requests. Firing on first load instead means the (one-time) reload happens
+   * before any user action.
+   *
+   * Why `reload()` not `href = home`: a hard nav to `/` was sending the user back to home after a
+   * successful deploy if the wallet-type flip happened post-success. Reloading in place keeps the URL.
+   *
+   * The localStorage-backed atom makes this a single reload per browser — subsequent loads see the
+   * managed network already selected and skip the effect entirely.
+   */
   useEffect(() => {
-    if (selectedWalletType === "managed" && selectedNetworkId !== appConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID) {
-      setSelectedNetworkId(appConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID);
-      windowLocation.href = urlService.home();
-    }
-  }, [selectedWalletType, selectedNetworkId, appConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID, setSelectedNetworkId, windowLocation, urlService]);
+    if (selectedNetworkId === appConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID) return;
+    setSelectedNetworkId(appConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID);
+    windowLocation.reload();
+  }, [selectedNetworkId, appConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID, setSelectedNetworkId, windowLocation]);
 
   function switchWalletType() {
     if (selectedWalletType === "custodial" && !managedWallet) {

--- a/apps/deploy-web/src/hooks/useEnsureTrialStarted.spec.ts
+++ b/apps/deploy-web/src/hooks/useEnsureTrialStarted.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { useEnsureTrialStarted } from "@src/hooks/useEnsureTrialStarted";
+import { useManagedWallet } from "@src/hooks/useManagedWallet";
+
+import { renderHook } from "@testing-library/react";
+
+vi.mock("@src/hooks/useManagedWallet");
+
+describe("useEnsureTrialStarted", () => {
+  it("fires create()", () => {
+    const create = vi.fn();
+    setup({ wallet: undefined, isLoading: false, create });
+
+    renderHook(() => useEnsureTrialStarted());
+
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire when the wallet is already initialized", () => {
+    const create = vi.fn();
+    setup({ wallet: { address: "akash1..." }, isLoading: false, create });
+
+    renderHook(() => useEnsureTrialStarted());
+
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("fires when a wallet row exists but is not yet initialized (no address)", () => {
+    const create = vi.fn();
+    setup({ wallet: { address: null } as never, isLoading: false, create });
+
+    renderHook(() => useEnsureTrialStarted());
+
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire while another mutation is in flight", () => {
+    const create = vi.fn();
+    setup({ wallet: undefined, isLoading: true, create });
+
+    renderHook(() => useEnsureTrialStarted());
+
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("does not fire after a terminal createError", () => {
+    const create = vi.fn();
+    setup({ wallet: undefined, isLoading: false, create, createError: new Error("boom") });
+
+    renderHook(() => useEnsureTrialStarted());
+
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("does not fire twice across re-renders", () => {
+    const create = vi.fn();
+    setup({ wallet: undefined, isLoading: false, create });
+
+    const { rerender } = renderHook(() => useEnsureTrialStarted());
+    rerender();
+    rerender();
+
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes isWalletReady, isLoading and error", () => {
+    setup({ wallet: { address: "akash1..." }, isLoading: true, create: vi.fn(), createError: new Error("boom") });
+
+    const { result } = renderHook(() => useEnsureTrialStarted());
+
+    expect(result.current.isWalletReady).toBe(true);
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.error).toBeTruthy();
+  });
+
+  function setup(input: { wallet: { address: string } | undefined; isLoading: boolean; create: () => void; createError?: unknown }) {
+    vi.mocked(useManagedWallet).mockReturnValue(
+      mock<ReturnType<typeof useManagedWallet>>({
+        wallet: input.wallet as ReturnType<typeof useManagedWallet>["wallet"],
+        isLoading: input.isLoading,
+        create: input.create,
+        createError: input.createError as ReturnType<typeof useManagedWallet>["createError"]
+      })
+    );
+  }
+});

--- a/apps/deploy-web/src/hooks/useEnsureTrialStarted.ts
+++ b/apps/deploy-web/src/hooks/useEnsureTrialStarted.ts
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+
+import { useManagedWallet } from "@src/hooks/useManagedWallet";
+
+export type EnsureTrialStartedResult = {
+  isWalletReady: boolean;
+  isLoading: boolean;
+  error: ReturnType<typeof useManagedWallet>["createError"];
+};
+
+/**
+ * Auto-starts the user's trial in the background, without requiring an explicit
+ * "Start Trial" click. Assumes the user is authenticated (and therefore email-verified
+ * via passwordless) by the time this runs — the auth guard ensures that upstream.
+ *
+ * Within-mutation retries are handled by React Query (see `useCreateManagedWalletMutation`);
+ * we stop firing once the mutation terminally errors so we don't infinite-loop.
+ *
+ * Use only on pages that are part of the onboarding redesign — the call is unguarded.
+ */
+export const useEnsureTrialStarted = (): EnsureTrialStartedResult => {
+  const { wallet, create, isLoading, createError } = useManagedWallet();
+  const isWalletReady = !!wallet?.address;
+
+  useEffect(() => {
+    if (isWalletReady) return;
+    if (isLoading) return;
+    if (createError) return;
+    create();
+  }, [isWalletReady, isLoading, createError, create]);
+
+  return { isWalletReady, isLoading, error: createError };
+};

--- a/apps/deploy-web/src/hooks/usePhasedDeploymentFlow/usePhasedDeploymentFlow.spec.ts
+++ b/apps/deploy-web/src/hooks/usePhasedDeploymentFlow/usePhasedDeploymentFlow.spec.ts
@@ -120,6 +120,27 @@ describe(usePhasedDeploymentFlow.name, () => {
     expect(result.current.startOver).toBe(result.current.retry);
   });
 
+  it("stays in creating without broadcasting while the trial wallet is not yet ready", async () => {
+    const { result, createDeployment } = setup({ isWalletReady: false });
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(result.current.state.kind).toBe("creating");
+    expect(createDeployment).not.toHaveBeenCalled();
+  });
+
+  it("fails the deploy when the trial-start mutation has terminally errored", async () => {
+    const { result, createDeployment } = setup({
+      isWalletReady: false,
+      trialError: new ApiError(400, { message: "Email not verified" }, "POST /v1/wallets/start-trial → 400")
+    });
+
+    await vi.waitFor(() => expect(result.current.state.kind).toBe("error"));
+
+    expect(result.current.state).toEqual({ kind: "error", message: "Email not verified" });
+    expect(createDeployment).not.toHaveBeenCalled();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -132,6 +153,8 @@ describe(usePhasedDeploymentFlow.name, () => {
     createLease?: ReturnType<typeof vi.fn>;
     listBids?: ReturnType<typeof vi.fn>;
     providerProxyRequest?: ReturnType<typeof vi.fn>;
+    isWalletReady?: boolean;
+    trialError?: unknown;
   }) {
     vi.spyOn(globalThis, "requestAnimationFrame").mockReturnValue(1);
     vi.spyOn(globalThis, "cancelAnimationFrame").mockImplementation(() => undefined);
@@ -164,6 +187,8 @@ describe(usePhasedDeploymentFlow.name, () => {
         usePhasedDeploymentFlow({
           sdl: input?.sdl ?? "sdl-content",
           deposit: input?.deposit ?? 5000000,
+          isWalletReady: input?.isWalletReady ?? true,
+          trialError: input?.trialError,
           onSuccess: input?.onSuccess ?? vi.fn()
         }),
       {

--- a/apps/deploy-web/src/hooks/usePhasedDeploymentFlow/usePhasedDeploymentFlow.ts
+++ b/apps/deploy-web/src/hooks/usePhasedDeploymentFlow/usePhasedDeploymentFlow.ts
@@ -13,6 +13,15 @@ type Options = {
   sdl: string;
   deposit: number;
   onSuccess: (dseq: string) => void;
+  /**
+   * Whether the trial wallet is initialized server-side and ready to broadcast deployments.
+   * While `false`, the flow stays in `creating` and silently waits — the user keeps seeing
+   * "Creating deployment" while the trial spins up behind the scenes. Required so callers
+   * can't accidentally stall the flow by omitting the readiness signal.
+   */
+  isWalletReady: boolean;
+  /** If the trial-start mutation has terminally errored, the deploy step fails with this error instead of waiting forever. */
+  trialError?: unknown;
 };
 
 type DeploymentPhase = {
@@ -63,7 +72,7 @@ const PHASE_LABELS: Record<DeploymentPhaseId, { active: string; completed: strin
   preparing: { active: "Preparing deployment", completed: "Deployment prepared" }
 };
 
-export function usePhasedDeploymentFlow({ sdl, deposit, onSuccess }: Options): Result {
+export function usePhasedDeploymentFlow({ sdl, deposit, onSuccess, isWalletReady, trialError }: Options): Result {
   const { api } = useServices();
   const [phase, setPhase] = useState<InternalPhase>("creating");
   const [dseq, setDseq] = useState<string | null>(null);
@@ -80,6 +89,15 @@ export function usePhasedDeploymentFlow({ sdl, deposit, onSuccess }: Options): R
   useEffect(
     function broadcastCreateDeployment() {
       if (phase !== "creating") return;
+
+      if (trialError) {
+        setErrorMessage(extractApiErrorMessage(trialError) ?? undefined);
+        setPhase("error");
+        return;
+      }
+
+      if (!isWalletReady) return;
+
       let cancelled = false;
 
       function onCreateDeploymentSuccess(result: { data: { dseq: string; manifest: string } }) {
@@ -102,7 +120,7 @@ export function usePhasedDeploymentFlow({ sdl, deposit, onSuccess }: Options): R
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [phase, retryToken, sdl, deposit]
+    [phase, retryToken, sdl, deposit, isWalletReady, trialError]
   );
 
   const bidsQuery = api.v1.listBids.useQuery(

--- a/apps/deploy-web/src/pages/login-v2/index.tsx
+++ b/apps/deploy-web/src/pages/login-v2/index.tsx
@@ -1,10 +1,25 @@
+import { useEffect } from "react";
+import { useSetAtom } from "jotai";
 import { z } from "zod";
 
 import { AuthPagePasswordlessClient } from "@src/components/auth/AuthPagePasswordless/AuthPagePasswordless";
+import { useFlag } from "@src/hooks/useFlag";
 import { defineServerSideProps } from "@src/lib/nextjs/defineServerSideProps/defineServerSideProps";
-import { isAuthenticated } from "@src/lib/nextjs/pageGuards/pageGuards";
+import { isAuthenticated, isFeatureEnabled } from "@src/lib/nextjs/pageGuards/pageGuards";
+import onboardingStore from "@src/store/onboardingStore";
 
 export default function LoginV2Page() {
+  const isOnboardingRedesignEnabled = useFlag("console_onboarding_redesign");
+  const setSelectedOnboardingFlow = useSetAtom(onboardingStore.selectedOnboardingFlow);
+
+  useEffect(
+    function markOnboardingFlowAsRedesign() {
+      if (!isOnboardingRedesignEnabled) return;
+      setSelectedOnboardingFlow("redesign");
+    },
+    [isOnboardingRedesignEnabled, setSelectedOnboardingFlow]
+  );
+
   return <AuthPagePasswordlessClient />;
 }
 
@@ -18,6 +33,9 @@ export const getServerSideProps = defineServerSideProps({
   handler: async ctx => {
     if (await isAuthenticated(ctx)) {
       return { redirect: { destination: "/", permanent: false } };
+    }
+    if (!(await isFeatureEnabled("console_onboarding_redesign", ctx))) {
+      return { redirect: { destination: "/login", permanent: false } };
     }
     return { props: {} };
   }

--- a/apps/deploy-web/src/pages/login/index.tsx
+++ b/apps/deploy-web/src/pages/login/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useSetAtom } from "jotai";
 import { useSearchParams } from "next/navigation";
 import { z } from "zod";
 
@@ -9,12 +10,21 @@ import { useFlag } from "@src/hooks/useFlag";
 import type { UrlReturnToStack } from "@src/hooks/useReturnTo/UrlReturnToStack";
 import { defineServerSideProps } from "@src/lib/nextjs/defineServerSideProps/defineServerSideProps";
 import { isAuthenticated, isFeatureEnabled } from "@src/lib/nextjs/pageGuards/pageGuards";
+import onboardingStore from "@src/store/onboardingStore";
 import type { UrlService } from "@src/utils/urlUtils";
 
 export default () => {
   const isEmbeddedLoginEnabled = useFlag("console_embedded_login");
   const searchParams = useSearchParams();
   const { urlService, windowLocation, urlReturnToStack } = useServices();
+  const setSelectedOnboardingFlow = useSetAtom(onboardingStore.selectedOnboardingFlow);
+
+  useEffect(
+    function markOnboardingFlowAsLegacy() {
+      setSelectedOnboardingFlow("legacy");
+    },
+    [setSelectedOnboardingFlow]
+  );
 
   useEffect(() => {
     if (!isEmbeddedLoginEnabled) {

--- a/apps/deploy-web/src/pages/onboarding/index.tsx
+++ b/apps/deploy-web/src/pages/onboarding/index.tsx
@@ -2,7 +2,7 @@ import { OnboardingPickerPage } from "@src/components/onboarding-picker/Onboardi
 import { Guard } from "@src/hoc/guard/guard.hoc";
 import { useIsRegisteredUser } from "@src/hooks/useUser";
 import { defineServerSideProps } from "@src/lib/nextjs/defineServerSideProps/defineServerSideProps";
-import { isAuthenticated } from "@src/lib/nextjs/pageGuards/pageGuards";
+import { isAuthenticated, isFeatureEnabled } from "@src/lib/nextjs/pageGuards/pageGuards";
 import { helloWorldTemplate } from "@src/utils/templates";
 
 export default Guard(OnboardingPickerPage, useIsRegisteredUser);
@@ -26,7 +26,8 @@ export const getServerSideProps = defineServerSideProps({
     };
   },
   if: async ctx => {
-    if (!(await isAuthenticated(ctx))) return { redirect: { destination: "/", permanent: false } };
-    return true;
+    return (
+      ((await isAuthenticated(ctx)) && (await isFeatureEnabled("console_onboarding_redesign", ctx))) || { redirect: { destination: "/", permanent: false } }
+    );
   }
 });

--- a/apps/deploy-web/src/queries/useManagedWalletQuery.ts
+++ b/apps/deploy-web/src/queries/useManagedWalletQuery.ts
@@ -24,6 +24,8 @@ export function useCreateManagedWalletMutation() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (userId: string) => await managedWalletService.createWallet(userId),
+    retry: failureCount => failureCount < 3,
+    retryDelay: attempt => Math.min(1000 * 2 ** attempt, 30_000),
     onSuccess: response => {
       // Only update cache if it's a wallet response, not a 3D Secure response
       if (!response.requires3DS) {

--- a/apps/deploy-web/src/store/onboardingStore.ts
+++ b/apps/deploy-web/src/store/onboardingStore.ts
@@ -1,0 +1,11 @@
+import { atomWithStorage } from "jotai/utils";
+
+export type OnboardingFlow = "legacy" | "redesign";
+
+const selectedOnboardingFlow = atomWithStorage<OnboardingFlow | null>("selectedOnboardingFlow", null);
+
+const onboardingStore = {
+  selectedOnboardingFlow
+};
+
+export default onboardingStore;

--- a/apps/deploy-web/src/utils/urlUtils.ts
+++ b/apps/deploy-web/src/utils/urlUtils.ts
@@ -77,6 +77,7 @@ export class UrlService {
     getSafeReturnableUrl(`/login${appendSearchParams({ tab: "signup" })}`, returnTo, extraReturnToParams);
   static logout = () => "/api/auth/logout";
   static onboarding = ({ returnTo }: ReturnableOptions = {}) => getSafeReturnableUrl("/signup", returnTo);
+  static onboardingPicker = () => "/onboarding";
   static template = (id: string) => `/template/${id}`;
 
   // Deploy

--- a/apps/deploy-web/tests/ui/onboarding-quick-deploy.spec.ts
+++ b/apps/deploy-web/tests/ui/onboarding-quick-deploy.spec.ts
@@ -1,34 +1,56 @@
-import { expect, test } from "./fixture/authenticated-test";
+import { ManagementApiError } from "auth0";
+
+import { expect, test } from "./fixture/onboarding-test";
 import { testEnvConfig } from "./fixture/test-env.config";
-import { AuthPage } from "./pages/AuthPage";
+import { AuthPagePasswordless } from "./pages/AuthPagePasswordless";
 import { DeployPage } from "./pages/DeployPage";
-import { HomePage } from "./pages/HomePage";
 import { OnboardingPickerPage } from "./pages/OnboardingPickerPage";
+import { MailsacCodeVerificationStrategy } from "./services/email-verification/mailsac-code.strategy";
 
 test.describe("Onboarding redesign quick deploy", () => {
-  test("deploys hello world from /onboarding and closes it", async ({ context, page, login }) => {
-    test.setTimeout(7 * 60 * 1000);
+  let testUserId: string | undefined;
+  const otp = new MailsacCodeVerificationStrategy(testEnvConfig.MAILSAC_API_KEY);
 
-    const homePage = new HomePage(page);
-    const authPage = new AuthPage(page);
+  test.afterEach(async ({ auth0 }) => {
+    if (!testUserId) return;
+    const userIdToDelete = testUserId;
+    testUserId = undefined;
+    await auth0.deleteUser(userIdToDelete).catch(error => {
+      if (!(error instanceof ManagementApiError) || error.statusCode !== 404) throw error;
+    });
+  });
+
+  test("fresh passwordless user deploys hello world from /onboarding and closes it", async ({ context, page, auth0 }) => {
+    test.setTimeout(10 * 60 * 1000);
+
+    const email = otp.generateEmail();
+    const authPage = new AuthPagePasswordless(page);
     const onboardingPickerPage = new OnboardingPickerPage(page);
-    const deployPage = new DeployPage(context, page, { walletType: "api" });
+    const deployPage = new DeployPage(context, page);
 
-    await test.step("login", async () => {
-      await homePage.goto();
-      await homePage.openSignIn();
-      await authPage.waitForPage();
-      await login();
+    await test.step("passwordless sign in with a fresh email", async () => {
+      await authPage.goto();
+      await authPage.startWithEmail(email);
+      await authPage.waitForVerifyScreen();
+      await otp.verify({ context: page.context(), email, userId: "" });
+      await authPage.waitForRedirectAwayFromLogin();
+
+      const auth0User = await auth0.getUserByEmail(email);
+      if (!auth0User) throw new Error(`Auth0 user was not created for ${email}`);
+      testUserId = auth0User.user_id;
     });
 
     await test.step("open onboarding picker", async () => {
-      await onboardingPickerPage.goto();
       await expect(onboardingPickerPage.getHeading()).toBeVisible({ timeout: 15_000 });
+    });
+
+    await test.step("trial provisions in background — no error alert", async () => {
+      await expect(page.getByText(/We couldn't set up your trial/i)).toHaveCount(0);
     });
 
     await test.step("pick hello world template", async () => {
       await onboardingPickerPage.deploy("Hello world");
-      await expect(page.getByRole("heading", { name: /Deploying Hello world/i })).toBeVisible({ timeout: 15_000 });
+      await expect(page.getByRole("heading", { name: /Deploying Hello world/i })).toBeVisible({ timeout: 30_000 });
     });
 
     await test.step("wait for deployment details page", async () => {


### PR DESCRIPTION
## Why

Fixes CON-365 — when a user enters the onboarding redesign at `/onboarding`, the trial should start automatically (no explicit "Start Trial" click) and the deploy should wait silently for the wallet to be ready.

## What

### Backend
- `WalletInitializerService.startTrial(userId)` orchestrates the trial-start flow. The controller is a thin pass-through.
- Stripe payment-method validation is skipped when `console_onboarding_redesign` is on; email-verified + fingerprint anti-abuse checks still run on both branches.

### Frontend
- New `onboardingStore` atom records which login flow the user took: `/login` marks `legacy`, `/login-v2` marks `redesign` (only when the FF is on).
- `OnboardingRedirectEffect` picks `/onboarding` only when atom is `redesign` AND the FF is on; falls back to legacy `/signup` otherwise. `/onboarding` is excluded from the redirect loop.
- `/onboarding` and `/login-v2` are SSR-gated on the FF.
- `useEnsureTrialStarted` (single mount on the picker) fires the trial mutation. `PhasedDeploymentContainer` receives `isWalletReady` + `trialError` as props so `usePhasedDeploymentFlow` gates `createDeployment` until the wallet is ready and fails fast on a terminal trial error.
- `useCreateManagedWalletMutation` retries up to 5 times with exponential backoff.
- `WalletProvider` syncs to the managed-wallet network on first load via `reload()` so the switch never happens mid-deploy.

### E2E
- `onboarding-quick-deploy` now uses passwordless login with a fresh mailsac user and cleans the Auth0 user up afterEach.

## Test plan

- [x] `apps/api` unit/integration specs green (wallet controller + wallet-initializer)
- [x] `apps/deploy-web` unit specs green (useEnsureTrialStarted, usePhasedDeploymentFlow, PhasedDeploymentContainer, OnboardingPickerPage, OnboardingRedirectEffect)
- [x] `apps/deploy-web` e2e: `onboarding-quick-deploy.spec.ts`
- [x] Manual smoke with FF off → legacy `/signup` flow still works
- [x] Manual smoke with FF on → fresh passwordless user lands on `/onboarding`, deploys hello world, no mid-flow reloads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding redesign available alongside legacy flow, with client/server gating and a persisted picker.
  * Background trial wallet setup auto-starts and surfaces a destructive error alert with refresh/support guidance when it fails.
  * Deployment flow now respects wallet readiness and trial errors to pause or show errors during phased deploy.

* **Bug Fixes**
  * Enforced managed wallet network selection and reload to ensure correct network on mismatch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->