### PR TITLE
feat: marks provider offline once when cannot connect to it

### DIFF
--- a/apps/provider-inventory/src/services/provider-stream-factory/provider-stream-factory.sevice.ts
+++ b/apps/provider-inventory/src/services/provider-stream-factory/provider-stream-factory.sevice.ts
@@ -11,7 +11,11 @@ export class ProviderStreamFactory {
     const url = new URL(provider.hostUri);
     url.port = "8444";
     const sdk = createProviderSDK({
-      baseUrl: url.toString()
+      baseUrl: url.toString(),
+      transportOptions: {
+        pingIdleConnection: true,
+        idleConnectionTimeoutMs: 5 * 60 * 1000 // 5 minutes
+      }
     });
 
     const stream = await sdk.akash.provider.v1.streamStatus({}, { signal });

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
@@ -199,6 +199,49 @@ describe(StreamLifecycleManagerService.name, () => {
     });
   });
 
+  describe("markOffline dedup", () => {
+    it("marks offline only once across consecutive failed attempts", async () => {
+      const streamFactory = mock<ProviderStreamFactory>();
+      streamFactory.openStatusStream.mockImplementation(() => throwingStream(new Error("connection lost")));
+      const { manager, writer, logger } = setup({ streamFactory });
+      const countFailures = () => logger.warn.mock.calls.filter(([arg]) => (arg as { event?: string })?.event === "STREAM_ATTEMPT_FAILED").length;
+
+      manager.start(createProvider());
+
+      await vi.waitFor(() => expect(countFailures()).toBeGreaterThanOrEqual(3));
+
+      expect(writer.markOffline).toHaveBeenCalledTimes(1);
+      expect(writer.markOffline).toHaveBeenCalledWith("akash1owner");
+    });
+
+    it("marks offline again after a provider recovers and then drops", async () => {
+      let attempt = 0;
+      const streamFactory = mock<ProviderStreamFactory>();
+      streamFactory.openStatusStream.mockImplementation(() => {
+        attempt++;
+        if (attempt === 1) return throwingStream(new Error("initial failure"));
+        if (attempt === 2) return msgsThenThrow([createMessage()], new Error("dropped"));
+        return throwingStream(new Error("still down"));
+      });
+      const { manager, writer } = setup({ streamFactory });
+
+      manager.start(createProvider());
+
+      await vi.waitFor(() => expect(writer.markOffline).toHaveBeenCalledTimes(2));
+    });
+
+    it("does not mark offline when the very first attempt is delivering messages", async () => {
+      const { manager, writer } = setup({
+        streams: { "https://p1:8443": msgsThenHang([createMessage()]) }
+      });
+
+      manager.start(createProvider());
+
+      await vi.waitFor(() => expect(writer.updateInventory).toHaveBeenCalledTimes(1));
+      expect(writer.markOffline).not.toHaveBeenCalled();
+    });
+  });
+
   describe("stale finalizer", () => {
     it("does not evict a replacement stream's registry entry when the old stream finishes", async () => {
       let resolveOldStream!: () => void;
@@ -364,6 +407,11 @@ async function* msgsThenHang(messages: ClusterState[]): AsyncGenerator<ClusterSt
 
 async function* throwingStream(error: Error): AsyncGenerator<ClusterState> {
   yield* [];
+  throw error;
+}
+
+async function* msgsThenThrow(messages: ClusterState[], error: Error): AsyncGenerator<ClusterState> {
+  for (const msg of messages) yield msg;
   throw error;
 }
 

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -29,6 +29,7 @@ export class StreamLifecycleManagerService {
     }
   >();
   readonly #lastInventoryPerProvider = new Map<string, ProjectedRow>();
+  readonly #onlineStatePerProvider = new Map<string, boolean>();
   readonly #retryStreamPolicy: RetryPolicy;
 
   constructor(
@@ -102,6 +103,7 @@ export class StreamLifecycleManagerService {
       }
     } finally {
       this.#lastInventoryPerProvider.delete(provider.owner);
+      this.#onlineStatePerProvider.delete(provider.owner);
       if (this.#activeStreams.get(provider.owner)?.controller.signal === signal) {
         this.#activeStreams.delete(provider.owner);
       }
@@ -114,7 +116,8 @@ export class StreamLifecycleManagerService {
     this.#lastInventoryPerProvider.delete(provider.owner);
 
     const attemptController = new AbortController();
-    const composite = AbortSignal.any([outerSignal, attemptController.signal]);
+    const forwardAbort = () => attemptController.abort();
+    outerSignal.addEventListener("abort", forwardAbort, { once: true });
 
     let firstMessageReceived = false;
     const firstMessageTimeoutId = setTimeout(() => {
@@ -122,7 +125,7 @@ export class StreamLifecycleManagerService {
     }, this.#config.STREAM_FIRST_MESSAGE_TIMEOUT_MS);
 
     try {
-      const stream = this.#streamFactory.openStatusStream(provider, composite);
+      const stream = this.#streamFactory.openStatusStream(provider, attemptController.signal);
 
       for await (const message of stream) {
         if (outerSignal.aborted) return;
@@ -148,6 +151,7 @@ export class StreamLifecycleManagerService {
       throw error;
     } finally {
       clearTimeout(firstMessageTimeoutId);
+      outerSignal.removeEventListener("abort", forwardAbort);
     }
   }
 
@@ -163,14 +167,17 @@ export class StreamLifecycleManagerService {
     try {
       await this.#writer.updateInventory(provider, row);
       this.#lastInventoryPerProvider.set(provider.owner, row);
+      this.#onlineStatePerProvider.set(provider.owner, true);
     } catch (error) {
       this.#logger.error({ event: "STREAM_PROVIDER_WRITE_ERROR", owner: provider.owner, error });
     }
   }
 
   async #tryMarkOffline(owner: string): Promise<void> {
+    if (this.#onlineStatePerProvider.get(owner) === false) return;
     try {
       await this.#writer.markOffline(owner);
+      this.#onlineStatePerProvider.set(owner, false);
     } catch (error) {
       this.#logger.error({ event: "MARK_OFFLINE_ERROR", owner, error });
     }
@@ -183,6 +190,7 @@ export class StreamLifecycleManagerService {
     }
     this.#activeStreams.clear();
     this.#lastInventoryPerProvider.clear();
+    this.#onlineStatePerProvider.clear();
   }
 
   dispose(): void {

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -118,7 +118,9 @@ export class StreamLifecycleManagerService {
     const attemptController = new AbortController();
     const forwardAbort = () => attemptController.abort();
     outerSignal.addEventListener("abort", forwardAbort, { once: true });
-
+    if (outerSignal.aborted) {
+      forwardAbort();
+    }
     let firstMessageReceived = false;
     const firstMessageTimeoutId = setTimeout(() => {
       attemptController.abort();


### PR DESCRIPTION
## Why

performance optimization, no need to send queries to db if provider is offline. 

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added idle connection timeout management (5 minutes) to improve provider stream stability.
  * Implemented per-provider online/offline state tracking for better connection monitoring.

* **Bug Fixes**
  * Deduplication of offline status marking prevents redundant provider updates and reduces noisy retries.

* **Tests**
  * Added tests validating offline-marking deduplication across stream lifecycle and recovery scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->