### PR TITLE
fix(jwt): harden provider JWT caching and refresh

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Alert, AlertDescription, AlertTitle, Button, Skeleton, Spinner } from "@akashnetwork/ui/components";
+import { Alert, AlertDescription, AlertTitle, Button, Spinner } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import { WarningCircle } from "iconoir-react";
 
@@ -16,6 +16,7 @@ import type { LeaseDto } from "@src/types/deployment";
 import { LeaseShellCode } from "@src/types/shell";
 import { forEachGeneratedItem } from "@src/utils/array";
 import { LeaseSelect } from "./LeaseSelect";
+import { useProviderAuthGate } from "./ProviderAuthGate";
 import { ServiceSelect } from "./ServiceSelect";
 import { ShellDownloadModal } from "./ShellDownloadModal";
 
@@ -37,10 +38,7 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
   const [isChangingSocket, setIsChangingSocket] = useState(false);
   const { data: providers } = useProviderList();
   const providerCredentials = useProviderCredentials();
-  const [hasShellAccess, setHasShellAccess] = useState(false);
-  useEffect(() => {
-    if (providerCredentials.details.usable) setHasShellAccess(true);
-  }, [providerCredentials.details.usable]);
+  const { hasAccess: hasShellAccess, fallback: authFallback } = useProviderAuthGate(providerCredentials);
   const providerInfo = providers?.find(p => p.owner === selectedLease?.provider);
   const {
     data: leaseStatus,
@@ -94,6 +92,7 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
       conn,
       abortController
     };
+    // ensureToken is intentionally omitted: it changes on every JWT rotation, which would tear down the live shell session
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [providerInfo, hasShellAccess, selectedLease, selectedService]);
 
@@ -235,20 +234,7 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
         <ShellDownloadModal onCloseClick={onCloseDownloadClick} selectedLease={selectedLease} providerInfo={providerInfo} selectedService={selectedService} />
       )}
 
-      {!hasShellAccess && !providerCredentials.details.error && (
-        <div className="mt-4 space-y-2">
-          <Skeleton className="h-[56px] w-full" />
-          <Skeleton className="h-[400px] w-full" />
-        </div>
-      )}
-
-      {!hasShellAccess && providerCredentials.details.error && (
-        <Alert variant="warning" className="mt-4 p-4">
-          <WarningCircle className="h-4 w-4" />
-          <AlertTitle className="mb-1 text-sm">Could not authorize with the provider</AlertTitle>
-          <AlertDescription className="text-xs text-muted-foreground">Please retry once the network has recovered.</AlertDescription>
-        </Alert>
-      )}
+      {authFallback}
 
       {hasShellAccess && (
         <>

--- a/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
@@ -16,7 +16,7 @@ import type { LeaseDto } from "@src/types/deployment";
 import { LeaseShellCode } from "@src/types/shell";
 import { forEachGeneratedItem } from "@src/utils/array";
 import { LeaseSelect } from "./LeaseSelect";
-import { useProviderAuthGate } from "./ProviderAuthGate";
+import { ProviderAuthFallback, useProviderAccess } from "./ProviderAuthGate";
 import { ServiceSelect } from "./ServiceSelect";
 import { ShellDownloadModal } from "./ShellDownloadModal";
 
@@ -38,7 +38,7 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
   const [isChangingSocket, setIsChangingSocket] = useState(false);
   const { data: providers } = useProviderList();
   const providerCredentials = useProviderCredentials();
-  const { hasAccess: hasShellAccess, fallback: authFallback } = useProviderAuthGate(providerCredentials);
+  const hasShellAccess = useProviderAccess(providerCredentials);
   const providerInfo = providers?.find(p => p.owner === selectedLease?.provider);
   const {
     data: leaseStatus,
@@ -234,7 +234,7 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
         <ShellDownloadModal onCloseClick={onCloseDownloadClick} selectedLease={selectedLease} providerInfo={providerInfo} selectedService={selectedService} />
       )}
 
-      {authFallback}
+      <ProviderAuthFallback hasAccess={hasShellAccess} error={providerCredentials.details.error} />
 
       {hasShellAccess && (
         <>

--- a/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
@@ -41,6 +41,11 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
   const providerCredentials = useProviderCredentials();
   const hasShellAccess = useProviderAccess(providerCredentials);
   const providerInfo = providers?.find(p => p.owner === selectedLease?.provider);
+  const providerHostUri = providerInfo?.hostUri;
+  const providerAddress = providerInfo?.owner;
+  const dseq = selectedLease?.dseq;
+  const gseq = selectedLease?.gseq;
+  const oseq = selectedLease?.oseq;
   const {
     data: leaseStatus,
     refetch: getLeaseStatus,
@@ -73,16 +78,16 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
   }, [selectedLease, providerInfo, getLeaseStatus]);
 
   const shellSession = useMemo(() => {
-    if (!providerInfo || !hasShellAccess || !selectedLease || !selectedService) return null;
+    if (!providerHostUri || !providerAddress || !hasShellAccess || !dseq || gseq === undefined || oseq === undefined || !selectedService) return null;
 
     const abortController = new AbortController();
     const conn = providerProxy.connectToShell({
-      providerBaseUrl: providerInfo.hostUri,
-      providerAddress: providerInfo.owner,
+      providerBaseUrl: providerHostUri,
+      providerAddress,
       ensureToken: providerCredentials.ensureToken,
-      dseq: selectedLease.dseq,
-      gseq: selectedLease.gseq,
-      oseq: selectedLease.oseq,
+      dseq,
+      gseq,
+      oseq,
       service: selectedService,
       useStdIn: true,
       useTTY: true,
@@ -93,7 +98,7 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
       conn,
       abortController
     };
-  }, [providerInfo, hasShellAccess, selectedLease, selectedService, providerCredentials.ensureToken]);
+  }, [providerHostUri, providerAddress, hasShellAccess, dseq, gseq, oseq, selectedService, providerCredentials.ensureToken]);
 
   useEffect(() => {
     if (!shellSession) return;

--- a/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
@@ -6,6 +6,7 @@ import { WarningCircle } from "iconoir-react";
 
 import { ViewPanel } from "@src/components/shared/ViewPanel";
 import { useServices } from "@src/context/ServicesProvider";
+import { useProviderAccess } from "@src/hooks/useProviderAccess/useProviderAccess";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { XTerm } from "@src/lib/XTerm";
 import type { XTermRefType } from "@src/lib/XTerm/XTerm";
@@ -16,7 +17,7 @@ import type { LeaseDto } from "@src/types/deployment";
 import { LeaseShellCode } from "@src/types/shell";
 import { forEachGeneratedItem } from "@src/utils/array";
 import { LeaseSelect } from "./LeaseSelect";
-import { ProviderAuthFallback, useProviderAccess } from "./ProviderAuthGate";
+import { ProviderAuthFallback } from "./ProviderAuthGate";
 import { ServiceSelect } from "./ServiceSelect";
 import { ShellDownloadModal } from "./ShellDownloadModal";
 

--- a/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Alert, AlertDescription, AlertTitle, Button, Spinner } from "@akashnetwork/ui/components";
+import { Alert, AlertDescription, AlertTitle, Button, Skeleton, Spinner } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import { WarningCircle } from "iconoir-react";
 
@@ -37,6 +37,10 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
   const [isChangingSocket, setIsChangingSocket] = useState(false);
   const { data: providers } = useProviderList();
   const providerCredentials = useProviderCredentials();
+  const [hasShellAccess, setHasShellAccess] = useState(false);
+  useEffect(() => {
+    if (providerCredentials.details.usable) setHasShellAccess(true);
+  }, [providerCredentials.details.usable]);
   const providerInfo = providers?.find(p => p.owner === selectedLease?.provider);
   const {
     data: leaseStatus,
@@ -70,13 +74,13 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
   }, [selectedLease, providerInfo, getLeaseStatus]);
 
   const shellSession = useMemo(() => {
-    if (!providerInfo || !providerCredentials.details.usable || !selectedLease || !selectedService) return null;
+    if (!providerInfo || !hasShellAccess || !selectedLease || !selectedService) return null;
 
     const abortController = new AbortController();
     const conn = providerProxy.connectToShell({
       providerBaseUrl: providerInfo.hostUri,
       providerAddress: providerInfo.owner,
-      providerCredentials: providerCredentials.details,
+      ensureToken: providerCredentials.ensureToken,
       dseq: selectedLease.dseq,
       gseq: selectedLease.gseq,
       oseq: selectedLease.oseq,
@@ -90,7 +94,8 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
       conn,
       abortController
     };
-  }, [providerInfo, providerCredentials.details, selectedLease, selectedService]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [providerInfo, hasShellAccess, selectedLease, selectedService]);
 
   useEffect(() => {
     if (!shellSession) return;
@@ -230,7 +235,22 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
         <ShellDownloadModal onCloseClick={onCloseDownloadClick} selectedLease={selectedLease} providerInfo={providerInfo} selectedService={selectedService} />
       )}
 
-      {providerCredentials.details.usable && (
+      {!hasShellAccess && !providerCredentials.details.error && (
+        <div className="mt-4 space-y-2">
+          <Skeleton className="h-[56px] w-full" />
+          <Skeleton className="h-[400px] w-full" />
+        </div>
+      )}
+
+      {!hasShellAccess && providerCredentials.details.error && (
+        <Alert variant="warning" className="mt-4 p-4">
+          <WarningCircle className="h-4 w-4" />
+          <AlertTitle className="mb-1 text-sm">Could not authorize with the provider</AlertTitle>
+          <AlertDescription className="text-xs text-muted-foreground">Please retry once the network has recovered.</AlertDescription>
+        </Alert>
+      )}
+
+      {hasShellAccess && (
         <>
           {selectedLease && (
             <>

--- a/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLeaseShell.tsx
@@ -93,9 +93,7 @@ export const DeploymentLeaseShell: React.FunctionComponent<Props> = ({ leases })
       conn,
       abortController
     };
-    // ensureToken is intentionally omitted: it changes on every JWT rotation, which would tear down the live shell session
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [providerInfo, hasShellAccess, selectedLease, selectedService]);
+  }, [providerInfo, hasShellAccess, selectedLease, selectedService, providerCredentials.ensureToken]);
 
   useEffect(() => {
     if (!shellSession) return;

--- a/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
@@ -1,23 +1,11 @@
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-  Button,
-  Checkbox,
-  CheckboxWithLabel,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-  Skeleton,
-  Spinner
-} from "@akashnetwork/ui/components";
+import { Button, Checkbox, CheckboxWithLabel, DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, Spinner } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import type { Monaco } from "@monaco-editor/react";
 import { useTheme as useMuiTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import { Download, MoreHoriz, WarningCircle } from "iconoir-react";
+import { Download, MoreHoriz } from "iconoir-react";
 import type { editor } from "monaco-editor";
 
 import { CustomDropdownLinkItem } from "@src/components/shared/CustomDropdownLinkItem";
@@ -36,6 +24,7 @@ import type { K8sEventMessage, LogEntryMessage, ProviderProxyMessage } from "@sr
 import type { LeaseDto } from "@src/types/deployment";
 import { forEachGeneratedItem } from "@src/utils/array";
 import { LeaseSelect } from "./LeaseSelect";
+import { useProviderAuthGate } from "./ProviderAuthGate";
 
 export type LOGS_MODE = "logs" | "events";
 
@@ -57,10 +46,7 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
   const [selectedLease, setSelectedLease] = useState<LeaseDto | null>(null);
   const { data: providers } = useProviderList();
   const providerCredentials = useProviderCredentials();
-  const [hasLogsAccess, setHasLogsAccess] = useState(false);
-  useEffect(() => {
-    if (providerCredentials.details.usable) setHasLogsAccess(true);
-  }, [providerCredentials.details.usable]);
+  const { hasAccess: hasLogsAccess, fallback: authFallback } = useProviderAuthGate(providerCredentials);
   const { downloadLogs } = useProviderApiActions();
   const monacoEditorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<Monaco | null>(null);
@@ -231,20 +217,7 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
 
   return (
     <div>
-      {!hasLogsAccess && !providerCredentials.details.error && (
-        <div className="mt-4 space-y-2">
-          <Skeleton className="h-[56px] w-full" />
-          <Skeleton className="h-[400px] w-full" />
-        </div>
-      )}
-
-      {!hasLogsAccess && providerCredentials.details.error && (
-        <Alert variant="warning" className="mt-4 p-4">
-          <WarningCircle className="h-4 w-4" />
-          <AlertTitle className="mb-1 text-sm">Could not authorize with the provider</AlertTitle>
-          <AlertDescription className="text-xs text-muted-foreground">Please retry once the network has recovered.</AlertDescription>
-        </Alert>
-      )}
+      {authFallback}
 
       {hasLogsAccess && (
         <>

--- a/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
@@ -14,6 +14,7 @@ import { LinearLoadingSkeleton } from "@src/components/shared/LinearLoadingSkele
 import { SelectCheckbox } from "@src/components/shared/SelectCheckbox";
 import { ViewPanel } from "@src/components/shared/ViewPanel";
 import { useServices } from "@src/context/ServicesProvider";
+import { useProviderAccess } from "@src/hooks/useProviderAccess/useProviderAccess";
 import { useProviderApiActions } from "@src/hooks/useProviderApiActions";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 import { useThrottledCallback } from "@src/hooks/useThrottle";
@@ -24,7 +25,7 @@ import type { K8sEventMessage, LogEntryMessage, ProviderProxyMessage } from "@sr
 import type { LeaseDto } from "@src/types/deployment";
 import { forEachGeneratedItem } from "@src/utils/array";
 import { LeaseSelect } from "./LeaseSelect";
-import { ProviderAuthFallback, useProviderAccess } from "./ProviderAuthGate";
+import { ProviderAuthFallback } from "./ProviderAuthGate";
 
 export type LOGS_MODE = "logs" | "events";
 

--- a/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
@@ -1,11 +1,23 @@
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Button, Checkbox, CheckboxWithLabel, DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, Spinner } from "@akashnetwork/ui/components";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  Checkbox,
+  CheckboxWithLabel,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  Skeleton,
+  Spinner
+} from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import type { Monaco } from "@monaco-editor/react";
 import { useTheme as useMuiTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import { Download, MoreHoriz } from "iconoir-react";
+import { Download, MoreHoriz, WarningCircle } from "iconoir-react";
 import type { editor } from "monaco-editor";
 
 import { CustomDropdownLinkItem } from "@src/components/shared/CustomDropdownLinkItem";
@@ -45,6 +57,10 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
   const [selectedLease, setSelectedLease] = useState<LeaseDto | null>(null);
   const { data: providers } = useProviderList();
   const providerCredentials = useProviderCredentials();
+  const [hasLogsAccess, setHasLogsAccess] = useState(false);
+  useEffect(() => {
+    if (providerCredentials.details.usable) setHasLogsAccess(true);
+  }, [providerCredentials.details.usable]);
   const { downloadLogs } = useProviderApiActions();
   const monacoEditorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<Monaco | null>(null);
@@ -113,7 +129,7 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
   }, [selectedLease, providerInfo, getLeaseStatus]);
 
   useEffect(() => {
-    if (!providerInfo || !providerCredentials.details.usable || !selectedLease || !services?.length || !selectedServices?.length) return;
+    if (!providerInfo || !hasLogsAccess || !selectedLease || !services?.length || !selectedServices?.length) return;
 
     logs.current = [];
 
@@ -123,7 +139,7 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
       providerProxy.getLogsStream({
         providerBaseUrl: providerInfo.hostUri,
         providerAddress: providerInfo.owner,
-        providerCredentials: providerCredentials.details,
+        ensureToken: providerCredentials.ensureToken,
         dseq: selectedLease.dseq,
         gseq: selectedLease.gseq,
         oseq: selectedLease.oseq,
@@ -150,7 +166,7 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
       setIsLoadingLogs(false);
       setIsConnectionEstablished(false);
     };
-  }, [providerCredentials.details, selectedLogsMode, selectedLease, selectedServices, services?.length, providerInfo?.owner, providerInfo?.hostUri]);
+  }, [hasLogsAccess, selectedLogsMode, selectedLease, selectedServices, services?.length, providerInfo?.owner, providerInfo?.hostUri]);
 
   function onLogReceived(proxyMessage: ProviderProxyMessage<LogEntryMessage> | ProviderProxyMessage<K8sEventMessage>) {
     if (proxyMessage.closed) return;
@@ -215,7 +231,22 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
 
   return (
     <div>
-      {providerCredentials.details.usable && (
+      {!hasLogsAccess && !providerCredentials.details.error && (
+        <div className="mt-4 space-y-2">
+          <Skeleton className="h-[56px] w-full" />
+          <Skeleton className="h-[400px] w-full" />
+        </div>
+      )}
+
+      {!hasLogsAccess && providerCredentials.details.error && (
+        <Alert variant="warning" className="mt-4 p-4">
+          <WarningCircle className="h-4 w-4" />
+          <AlertTitle className="mb-1 text-sm">Could not authorize with the provider</AlertTitle>
+          <AlertDescription className="text-xs text-muted-foreground">Please retry once the network has recovered.</AlertDescription>
+        </Alert>
+      )}
+
+      {hasLogsAccess && (
         <>
           {selectedLease && (
             <>

--- a/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
@@ -24,7 +24,7 @@ import type { K8sEventMessage, LogEntryMessage, ProviderProxyMessage } from "@sr
 import type { LeaseDto } from "@src/types/deployment";
 import { forEachGeneratedItem } from "@src/utils/array";
 import { LeaseSelect } from "./LeaseSelect";
-import { useProviderAuthGate } from "./ProviderAuthGate";
+import { ProviderAuthFallback, useProviderAccess } from "./ProviderAuthGate";
 
 export type LOGS_MODE = "logs" | "events";
 
@@ -46,7 +46,7 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
   const [selectedLease, setSelectedLease] = useState<LeaseDto | null>(null);
   const { data: providers } = useProviderList();
   const providerCredentials = useProviderCredentials();
-  const { hasAccess: hasLogsAccess, fallback: authFallback } = useProviderAuthGate(providerCredentials);
+  const hasLogsAccess = useProviderAccess(providerCredentials);
   const { downloadLogs } = useProviderApiActions();
   const monacoEditorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<Monaco | null>(null);
@@ -217,7 +217,7 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
 
   return (
     <div>
-      {authFallback}
+      <ProviderAuthFallback hasAccess={hasLogsAccess} error={providerCredentials.details.error} />
 
       {hasLogsAccess && (
         <>

--- a/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentLogs.tsx
@@ -6,6 +6,7 @@ import type { Monaco } from "@monaco-editor/react";
 import { useTheme as useMuiTheme } from "@mui/material/styles";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import { Download, MoreHoriz } from "iconoir-react";
+import { isEqual } from "lodash";
 import type { editor } from "monaco-editor";
 
 import { CustomDropdownLinkItem } from "@src/components/shared/CustomDropdownLinkItem";
@@ -52,6 +53,11 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
   const monacoEditorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<Monaco | null>(null);
   const providerInfo = providers?.find(p => p.owner === selectedLease?.provider);
+  const providerHostUri = providerInfo?.hostUri;
+  const providerAddress = providerInfo?.owner;
+  const dseq = selectedLease?.dseq;
+  const gseq = selectedLease?.gseq;
+  const oseq = selectedLease?.oseq;
   const {
     data: leaseStatus,
     refetch: getLeaseStatus,
@@ -86,11 +92,8 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
   }, [monacoEditorRef.current]);
 
   useEffect(() => {
-    if (leaseStatus) {
-      setSelectedServices(Object.keys(leaseStatus.services));
-    } else {
-      setSelectedServices([]);
-    }
+    const next = leaseStatus ? Object.keys(leaseStatus.services) : [];
+    setSelectedServices(prev => (isEqual(prev, next) ? prev : next));
   }, [leaseStatus]);
 
   const updateLogText = useThrottledCallback(
@@ -116,7 +119,17 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
   }, [selectedLease, providerInfo, getLeaseStatus]);
 
   useEffect(() => {
-    if (!providerInfo || !hasLogsAccess || !selectedLease || !services?.length || !selectedServices?.length) return;
+    if (
+      !providerHostUri ||
+      !providerAddress ||
+      !hasLogsAccess ||
+      !dseq ||
+      gseq === undefined ||
+      oseq === undefined ||
+      !services?.length ||
+      !selectedServices?.length
+    )
+      return;
 
     logs.current = [];
 
@@ -124,12 +137,12 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
     const abortController = new AbortController();
     forEachGeneratedItem(
       providerProxy.getLogsStream({
-        providerBaseUrl: providerInfo.hostUri,
-        providerAddress: providerInfo.owner,
+        providerBaseUrl: providerHostUri,
+        providerAddress,
         ensureToken: providerCredentials.ensureToken,
-        dseq: selectedLease.dseq,
-        gseq: selectedLease.gseq,
-        oseq: selectedLease.oseq,
+        dseq,
+        gseq,
+        oseq,
         type: selectedLogsMode,
         follow: true,
         services: selectedServices.length < services.length ? selectedServices : undefined,
@@ -153,7 +166,18 @@ export const DeploymentLogs: React.FunctionComponent<Props> = ({ leases, selecte
       setIsLoadingLogs(false);
       setIsConnectionEstablished(false);
     };
-  }, [hasLogsAccess, selectedLogsMode, selectedLease, selectedServices, services?.length, providerInfo?.owner, providerInfo?.hostUri]);
+  }, [
+    hasLogsAccess,
+    selectedLogsMode,
+    dseq,
+    gseq,
+    oseq,
+    selectedServices,
+    services?.length,
+    providerHostUri,
+    providerAddress,
+    providerCredentials.ensureToken
+  ]);
 
   function onLogReceived(proxyMessage: ProviderProxyMessage<LogEntryMessage> | ProviderProxyMessage<K8sEventMessage>) {
     if (proxyMessage.closed) return;

--- a/apps/deploy-web/src/components/deployments/LeaseRow.tsx
+++ b/apps/deploy-web/src/components/deployments/LeaseRow.tsx
@@ -120,7 +120,7 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(
       try {
         const manifest = deploymentData.getManifest(parsedManifest);
 
-        await providerProxy.sendManifest(provider, manifest, { dseq, credentials: providerCredentials.details });
+        await providerProxy.sendManifest(provider, manifest, { dseq, ensureToken: providerCredentials.ensureToken });
 
         enqueueSnackbar(<Snackbar title="Manifest sent!" iconVariant="success" />, { variant: "success", autoHideDuration: 10_000 });
 

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -111,7 +111,7 @@ describe(ManifestUpdate.name, () => {
     const ButtonMock = vi.fn(ComponentMock);
     setup({
       providerCredentials: {
-        details: { usable: false, isExpired: true, type: "jwt" as const, value: null }
+        details: { usable: false, isExpired: true, type: "jwt" as const, value: null, error: null }
       },
       dependencies: {
         Button: ButtonMock
@@ -310,7 +310,7 @@ describe(ManifestUpdate.name, () => {
     onManifestChange?: (value: string) => void;
     providers?: Array<Partial<{ owner: string; hostUri: string }>>;
     wallet?: Partial<{ address: string; signAndBroadcastTx: ReturnType<typeof vi.fn>; isManaged: boolean }>;
-    providerCredentials?: Partial<{ details: { usable: boolean; isExpired: boolean; type: "jwt"; value: string | null } }>;
+    providerCredentials?: Partial<{ details: { usable: boolean; isExpired: boolean; type: "jwt"; value: string | null; error: Error | null } }>;
     deploymentLocalStorage?: Partial<{ get: ReturnType<typeof vi.fn>; update: ReturnType<typeof vi.fn> }>;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
@@ -351,7 +351,8 @@ describe(ManifestUpdate.name, () => {
         usable: true,
         isExpired: false,
         type: "jwt" as const,
-        value: "test-token"
+        value: "test-token",
+        error: null
       },
       ensureToken: vi.fn().mockResolvedValue("test-token")
     });

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.tsx
@@ -117,7 +117,7 @@ export const ManifestUpdate: React.FunctionComponent<Props> = ({
     try {
       return await providerProxy.sendManifest(providerInfo, manifest, {
         dseq: deployment.dseq,
-        credentials: providerCredentials.details
+        ensureToken: providerCredentials.ensureToken
       });
     } catch (err) {
       enqueueSnackbar(<d.ManifestErrorSnackbar err={err} />, { variant: "error", autoHideDuration: null });

--- a/apps/deploy-web/src/components/deployments/ProviderAuthGate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ProviderAuthGate.spec.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { ProviderAuthFallback } from "./ProviderAuthGate";
+
+import { render, screen } from "@testing-library/react";
+
+const ERROR_TITLE = "Could not authorize with the provider";
+
+describe(ProviderAuthFallback.name, () => {
+  it("renders nothing when access is granted and no error is present", () => {
+    const { container } = setup({ hasAccess: true, error: null });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the skeleton while access is pending and no error is present", () => {
+    const { container } = setup({ hasAccess: false, error: null });
+
+    expect(container).not.toBeEmptyDOMElement();
+    expect(screen.queryByText(ERROR_TITLE)).not.toBeInTheDocument();
+  });
+
+  it("renders the error alert when credentials report an error", () => {
+    setup({ hasAccess: false, error: new Error("boom") });
+
+    expect(screen.queryByText(ERROR_TITLE)).toBeInTheDocument();
+  });
+
+  it("renders the error alert even when access was previously granted", () => {
+    setup({ hasAccess: true, error: new Error("boom") });
+
+    expect(screen.queryByText(ERROR_TITLE)).toBeInTheDocument();
+  });
+
+  function setup(input: { hasAccess: boolean; error: Error | null }) {
+    return render(<ProviderAuthFallback hasAccess={input.hasAccess} error={input.error} />);
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ProviderAuthGate.tsx
+++ b/apps/deploy-web/src/components/deployments/ProviderAuthGate.tsx
@@ -14,24 +14,30 @@ export function useProviderAuthGate(providerCredentials: ReturnType<typeof usePr
     if (providerCredentials.details.usable) setHasAccess(true);
   }, [providerCredentials.details.usable]);
 
-  if (hasAccess) {
-    return { hasAccess: true, fallback: null };
+  const { error } = providerCredentials.details;
+
+  if (error) {
+    return { hasAccess, fallback: <ProviderAuthErrorAlert /> };
   }
 
-  return { hasAccess: false, fallback: <ProviderAuthFallback error={providerCredentials.details.error} /> };
+  if (!hasAccess) {
+    return { hasAccess: false, fallback: <ProviderAuthSkeleton /> };
+  }
+
+  return { hasAccess: true, fallback: null };
 }
 
-function ProviderAuthFallback({ error }: { error: Error | null }) {
-  if (error) {
-    return (
-      <Alert variant="warning" className="mt-4 p-4">
-        <WarningCircle className="h-4 w-4" />
-        <AlertTitle className="mb-1 text-sm">Could not authorize with the provider</AlertTitle>
-        <AlertDescription className="text-xs text-muted-foreground">Please retry once the network has recovered.</AlertDescription>
-      </Alert>
-    );
-  }
+function ProviderAuthErrorAlert() {
+  return (
+    <Alert variant="warning" className="mt-4 p-4">
+      <WarningCircle className="h-4 w-4" />
+      <AlertTitle className="mb-1 text-sm">Could not authorize with the provider</AlertTitle>
+      <AlertDescription className="text-xs text-muted-foreground">Please retry once the network has recovered.</AlertDescription>
+    </Alert>
+  );
+}
 
+function ProviderAuthSkeleton() {
   return (
     <div className="mt-4 space-y-2">
       <Skeleton className="h-[56px] w-full" />

--- a/apps/deploy-web/src/components/deployments/ProviderAuthGate.tsx
+++ b/apps/deploy-web/src/components/deployments/ProviderAuthGate.tsx
@@ -1,18 +1,5 @@
-import { useEffect, useState } from "react";
 import { Alert, AlertDescription, AlertTitle, Skeleton } from "@akashnetwork/ui/components";
 import { WarningCircle } from "iconoir-react";
-
-import type { UseProviderCredentialsResult } from "@src/hooks/useProviderCredentials/useProviderCredentials";
-
-export function useProviderAccess(providerCredentials: UseProviderCredentialsResult): boolean {
-  const [hasAccess, setHasAccess] = useState(false);
-
-  useEffect(() => {
-    if (providerCredentials.details.usable) setHasAccess(true);
-  }, [providerCredentials.details.usable]);
-
-  return hasAccess;
-}
 
 export function ProviderAuthFallback({ hasAccess, error }: { hasAccess: boolean; error: Error | null }) {
   if (error) return <ProviderAuthErrorAlert />;

--- a/apps/deploy-web/src/components/deployments/ProviderAuthGate.tsx
+++ b/apps/deploy-web/src/components/deployments/ProviderAuthGate.tsx
@@ -1,30 +1,23 @@
-import { type ReactNode, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { Alert, AlertDescription, AlertTitle, Skeleton } from "@akashnetwork/ui/components";
 import { WarningCircle } from "iconoir-react";
 
-import type { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
+import type { UseProviderCredentialsResult } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 
-export function useProviderAuthGate(providerCredentials: ReturnType<typeof useProviderCredentials>): {
-  hasAccess: boolean;
-  fallback: ReactNode;
-} {
+export function useProviderAccess(providerCredentials: UseProviderCredentialsResult): boolean {
   const [hasAccess, setHasAccess] = useState(false);
 
   useEffect(() => {
     if (providerCredentials.details.usable) setHasAccess(true);
   }, [providerCredentials.details.usable]);
 
-  const { error } = providerCredentials.details;
+  return hasAccess;
+}
 
-  if (error) {
-    return { hasAccess, fallback: <ProviderAuthErrorAlert /> };
-  }
-
-  if (!hasAccess) {
-    return { hasAccess: false, fallback: <ProviderAuthSkeleton /> };
-  }
-
-  return { hasAccess: true, fallback: null };
+export function ProviderAuthFallback({ hasAccess, error }: { hasAccess: boolean; error: Error | null }) {
+  if (error) return <ProviderAuthErrorAlert />;
+  if (!hasAccess) return <ProviderAuthSkeleton />;
+  return null;
 }
 
 function ProviderAuthErrorAlert() {

--- a/apps/deploy-web/src/components/deployments/ProviderAuthGate.tsx
+++ b/apps/deploy-web/src/components/deployments/ProviderAuthGate.tsx
@@ -1,0 +1,41 @@
+import { type ReactNode, useEffect, useState } from "react";
+import { Alert, AlertDescription, AlertTitle, Skeleton } from "@akashnetwork/ui/components";
+import { WarningCircle } from "iconoir-react";
+
+import type { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
+
+export function useProviderAuthGate(providerCredentials: ReturnType<typeof useProviderCredentials>): {
+  hasAccess: boolean;
+  fallback: ReactNode;
+} {
+  const [hasAccess, setHasAccess] = useState(false);
+
+  useEffect(() => {
+    if (providerCredentials.details.usable) setHasAccess(true);
+  }, [providerCredentials.details.usable]);
+
+  if (hasAccess) {
+    return { hasAccess: true, fallback: null };
+  }
+
+  return { hasAccess: false, fallback: <ProviderAuthFallback error={providerCredentials.details.error} /> };
+}
+
+function ProviderAuthFallback({ error }: { error: Error | null }) {
+  if (error) {
+    return (
+      <Alert variant="warning" className="mt-4 p-4">
+        <WarningCircle className="h-4 w-4" />
+        <AlertTitle className="mb-1 text-sm">Could not authorize with the provider</AlertTitle>
+        <AlertDescription className="text-xs text-muted-foreground">Please retry once the network has recovered.</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <div className="mt-4 space-y-2">
+      <Skeleton className="h-[56px] w-full" />
+      <Skeleton className="h-[400px] w-full" />
+    </div>
+  );
+}

--- a/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.spec.tsx
@@ -131,13 +131,9 @@ describe(CreateLease.name, () => {
             typeUrl: `/${MsgCreateLease.$type}`
           })
         ]);
-        expect(ensureToken).toHaveBeenCalled();
         expect(sendManifest).toHaveBeenCalledWith(selectedProvider, expect.any(Array), {
           dseq,
-          credentials: {
-            type: "jwt",
-            value: "jwt-token"
-          }
+          ensureToken
         });
       });
     });
@@ -174,13 +170,9 @@ describe(CreateLease.name, () => {
 
       await userEvent.click(screen.getByRole<HTMLButtonElement>("button", { name: /Re-send Manifest/i }));
       await vi.waitFor(() => {
-        expect(ensureToken).toHaveBeenCalled();
         expect(sendManifest).toHaveBeenCalledWith(selectedProvider, expect.any(Array), {
           dseq,
-          credentials: {
-            type: "jwt",
-            value: "refreshed-token"
-          }
+          ensureToken
         });
       });
     });

--- a/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
@@ -203,12 +203,11 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
       });
 
     try {
-      const token = await providerCredentials.ensureToken();
       const yamlJson = yaml.load(localDeploymentData.manifest);
       const mani = deploymentData.getManifest(yamlJson);
       const options: SendManifestToProviderOptions = {
         dseq,
-        credentials: { type: "jwt", value: token }
+        ensureToken: providerCredentials.ensureToken
       };
 
       for (let i = 0; i < bidKeys.length; i++) {

--- a/apps/deploy-web/src/hooks/useProviderAccess/useProviderAccess.spec.ts
+++ b/apps/deploy-web/src/hooks/useProviderAccess/useProviderAccess.spec.ts
@@ -38,12 +38,15 @@ describe(useProviderAccess.name, () => {
   });
 
   function buildCredentials(input: { usable: boolean }) {
-    return mock<UseProviderCredentialsResult>({
-      details: mock<UseProviderCredentialsResult["details"]>({
-        usable: input.usable,
-        error: null
-      })
-    });
+    const credentials = mock<UseProviderCredentialsResult>();
+    credentials.details = {
+      type: "jwt",
+      value: input.usable ? "fresh-token" : null,
+      isExpired: !input.usable,
+      usable: input.usable,
+      error: null
+    };
+    return credentials;
   }
 
   function setup(input: { usable: boolean }) {

--- a/apps/deploy-web/src/hooks/useProviderAccess/useProviderAccess.spec.ts
+++ b/apps/deploy-web/src/hooks/useProviderAccess/useProviderAccess.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { UseProviderCredentialsResult } from "@src/hooks/useProviderCredentials/useProviderCredentials";
+import { useProviderAccess } from "./useProviderAccess";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useProviderAccess.name, () => {
+  it("returns false while credentials are not usable", () => {
+    const { result } = setup({ usable: false });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true when credentials are usable from the start", () => {
+    const { result } = setup({ usable: true });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("flips to true once credentials become usable", () => {
+    const { result, rerender } = setup({ usable: false });
+    expect(result.current).toBe(false);
+
+    rerender({ credentials: buildCredentials({ usable: true }) });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("stays true after credentials become unusable again", () => {
+    const { result, rerender } = setup({ usable: true });
+    expect(result.current).toBe(true);
+
+    rerender({ credentials: buildCredentials({ usable: false }) });
+
+    expect(result.current).toBe(true);
+  });
+
+  function buildCredentials(input: { usable: boolean }) {
+    return mock<UseProviderCredentialsResult>({
+      details: mock<UseProviderCredentialsResult["details"]>({
+        usable: input.usable,
+        error: null
+      })
+    });
+  }
+
+  function setup(input: { usable: boolean }) {
+    return renderHook(({ credentials }) => useProviderAccess(credentials), {
+      initialProps: { credentials: buildCredentials(input) }
+    });
+  }
+});

--- a/apps/deploy-web/src/hooks/useProviderAccess/useProviderAccess.ts
+++ b/apps/deploy-web/src/hooks/useProviderAccess/useProviderAccess.ts
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import type { UseProviderCredentialsResult } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 
 export function useProviderAccess(providerCredentials: UseProviderCredentialsResult): boolean {
-  const [hasAccess, setHasAccess] = useState(false);
+  const [hasAccess, setHasAccess] = useState(() => providerCredentials.details.usable);
 
   useEffect(() => {
     if (providerCredentials.details.usable) setHasAccess(true);

--- a/apps/deploy-web/src/hooks/useProviderAccess/useProviderAccess.ts
+++ b/apps/deploy-web/src/hooks/useProviderAccess/useProviderAccess.ts
@@ -1,13 +1,9 @@
-import { useEffect, useState } from "react";
+import { useRef } from "react";
 
 import type { UseProviderCredentialsResult } from "@src/hooks/useProviderCredentials/useProviderCredentials";
 
 export function useProviderAccess(providerCredentials: UseProviderCredentialsResult): boolean {
-  const [hasAccess, setHasAccess] = useState(() => providerCredentials.details.usable);
-
-  useEffect(() => {
-    if (providerCredentials.details.usable) setHasAccess(true);
-  }, [providerCredentials.details.usable]);
-
-  return hasAccess;
+  const hasAccessRef = useRef(providerCredentials.details.usable);
+  if (providerCredentials.details.usable) hasAccessRef.current = true;
+  return hasAccessRef.current;
 }

--- a/apps/deploy-web/src/hooks/useProviderAccess/useProviderAccess.ts
+++ b/apps/deploy-web/src/hooks/useProviderAccess/useProviderAccess.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from "react";
+
+import type { UseProviderCredentialsResult } from "@src/hooks/useProviderCredentials/useProviderCredentials";
+
+export function useProviderAccess(providerCredentials: UseProviderCredentialsResult): boolean {
+  const [hasAccess, setHasAccess] = useState(false);
+
+  useEffect(() => {
+    if (providerCredentials.details.usable) setHasAccess(true);
+  }, [providerCredentials.details.usable]);
+
+  return hasAccess;
+}

--- a/apps/deploy-web/src/hooks/useProviderApiActions.tsx
+++ b/apps/deploy-web/src/hooks/useProviderApiActions.tsx
@@ -61,7 +61,7 @@ export const useProviderApiActions = (): ProviderApiActions => {
         const result = await providerProxy.downloadLogs({
           providerBaseUrl: provider.hostUri,
           providerAddress: provider.owner,
-          providerCredentials: providerCredentials.details,
+          ensureToken: providerCredentials.ensureToken,
           dseq,
           gseq,
           oseq,
@@ -90,7 +90,7 @@ export const useProviderApiActions = (): ProviderApiActions => {
         const result = await providerProxy.downloadFileFromShell({
           providerBaseUrl: provider.hostUri,
           providerAddress: provider.owner,
-          providerCredentials: providerCredentials.details,
+          ensureToken: providerCredentials.ensureToken,
           dseq,
           gseq,
           oseq,

--- a/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.spec.ts
+++ b/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.spec.ts
@@ -2,9 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { useWallet } from "@src/context/WalletProvider";
+import type { useNotificator } from "@src/hooks/useNotificator";
 import type { UseProviderJwtResult } from "../useProviderJwt/useProviderJwt";
 import { DEPENDENCIES, useProviderCredentials } from "./useProviderCredentials";
 
+import { act } from "@testing-library/react";
 import { setupQuery } from "@tests/unit/query-client";
 
 describe(useProviderCredentials.name, () => {
@@ -18,7 +20,8 @@ describe(useProviderCredentials.name, () => {
       type: "jwt",
       value: "fresh-token",
       isExpired: false,
-      usable: true
+      usable: true,
+      error: null
     });
   });
 
@@ -101,7 +104,96 @@ describe(useProviderCredentials.name, () => {
     expect(generateToken).toHaveBeenCalledTimes(1);
   });
 
-  function setup(input?: { wallet?: Partial<ReturnType<typeof useWallet>>; providerJwt?: Partial<UseProviderJwtResult> }) {
+  it("does not auto-generate while not hydrated", async () => {
+    const generateToken = vi.fn().mockResolvedValue("new-token");
+
+    setup({
+      wallet: { isWalletConnected: true },
+      providerJwt: { accessToken: null, isTokenExpired: false, generateToken, isHydrated: false }
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(generateToken).not.toHaveBeenCalled();
+  });
+
+  it("auto-generates after hydration completes with a missing token", async () => {
+    const generateToken = vi.fn().mockResolvedValue("new-token");
+
+    setup({
+      wallet: { isWalletConnected: true },
+      providerJwt: { accessToken: null, isTokenExpired: false, generateToken, isHydrated: true }
+    });
+
+    await vi.waitFor(() => expect(generateToken).toHaveBeenCalledTimes(1));
+  });
+
+  it("retries generateToken on transient failure and surfaces no toast when it eventually succeeds", async () => {
+    const generateToken = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("blip 1"))
+      .mockRejectedValueOnce(new Error("blip 2"))
+      .mockResolvedValueOnce("recovered-token");
+    const notificatorError = vi.fn();
+
+    const { result } = setup({
+      wallet: { isWalletConnected: true },
+      providerJwt: { accessToken: null, isTokenExpired: false, generateToken },
+      notificator: { error: notificatorError }
+    });
+
+    const token = await result.current.ensureToken();
+
+    expect(token).toBe("recovered-token");
+    expect(generateToken).toHaveBeenCalledTimes(3);
+    expect(notificatorError).not.toHaveBeenCalled();
+    expect(result.current.details.error).toBeNull();
+  });
+
+  it("surfaces toast and populates details.error after retry exhaustion", async () => {
+    const generateToken = vi.fn().mockRejectedValue(new Error("permanent failure"));
+    const notificatorError = vi.fn();
+
+    const { result } = setup({
+      wallet: { isWalletConnected: true },
+      providerJwt: { accessToken: null, isTokenExpired: false, generateToken },
+      notificator: { error: notificatorError }
+    });
+
+    await expect(result.current.ensureToken()).rejects.toThrow(/permanent failure/);
+
+    expect(generateToken.mock.calls.length).toBeGreaterThanOrEqual(3);
+    expect(notificatorError).toHaveBeenCalledTimes(1);
+    expect(notificatorError.mock.calls[0][0]).toMatch(/Failed to authorize with the provider/i);
+    await vi.waitFor(() => expect(result.current.details.error).toBeInstanceOf(Error));
+  });
+
+  it("clears details.error when the wallet address changes", async () => {
+    const generateToken = vi.fn().mockRejectedValue(new Error("permanent failure"));
+    const addressRef = { current: "akash1aaa" };
+
+    const { result, rerender } = setup({
+      wallet: { isWalletConnected: true },
+      providerJwt: { accessToken: null, isTokenExpired: false, generateToken },
+      addressRef
+    });
+
+    await expect(result.current.ensureToken()).rejects.toThrow();
+    await vi.waitFor(() => expect(result.current.details.error).toBeInstanceOf(Error));
+
+    addressRef.current = "akash1bbb";
+    await act(async () => {
+      rerender();
+    });
+
+    expect(result.current.details.error).toBeNull();
+  });
+
+  function setup(input?: {
+    wallet?: Partial<ReturnType<typeof useWallet>>;
+    providerJwt?: Partial<UseProviderJwtResult>;
+    notificator?: Partial<ReturnType<typeof useNotificator>>;
+    addressRef?: { current: string };
+  }) {
     return setupQuery(() =>
       useProviderCredentials({
         dependencies: {
@@ -109,14 +201,22 @@ describe(useProviderCredentials.name, () => {
           useWallet: () =>
             mock<ReturnType<typeof useWallet>>({
               isWalletConnected: true,
-              ...input?.wallet
+              ...input?.wallet,
+              address: input?.addressRef?.current ?? input?.wallet?.address ?? "akash1aaa"
             }),
           useProviderJwt: () =>
             mock<UseProviderJwtResult>({
               accessToken: null,
               isTokenExpired: false,
+              isHydrated: true,
               generateToken: vi.fn().mockResolvedValue("generated-token"),
               ...input?.providerJwt
+            }),
+          useNotificator: () =>
+            mock<ReturnType<typeof useNotificator>>({
+              error: vi.fn(),
+              success: vi.fn(),
+              ...input?.notificator
             })
         }
       })

--- a/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
+++ b/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ExponentialBackoff, handleAll, retry } from "cockatiel";
-import { atom, getDefaultStore } from "jotai";
+import { getDefaultStore } from "jotai";
 
 import { useWallet } from "@src/context/WalletProvider";
 import { useNotificator } from "@src/hooks/useNotificator";
 import type { ProviderCredentials } from "@src/services/provider-proxy/provider-proxy.service";
+import providerCredentialsStore from "@src/store/providerCredentialsStore";
 import { useProviderJwt } from "../useProviderJwt/useProviderJwt";
 
 export const DEPENDENCIES = {
@@ -27,7 +28,7 @@ const GENERATE_TOKEN_FAILURE_MESSAGE = "Failed to authorize with the provider. P
 // ensureToken on their auto-trigger effect, they all await the same promise
 // instead of issuing parallel generateToken requests (which for self-custodial
 // wallets would spawn N signArbitrary popups).
-const IN_FLIGHT_TOKEN_REQUEST_ATOM = atom<{ address: string; promise: Promise<string> } | null>(null);
+const { inFlightTokenRequest } = providerCredentialsStore;
 
 export type UseProviderCredentialsResult = {
   details: ProviderCredentials & {
@@ -57,9 +58,9 @@ export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UsePr
   useEffect(() => {
     setError(null);
     const store = getDefaultStore();
-    const current = store.get(IN_FLIGHT_TOKEN_REQUEST_ATOM);
+    const current = store.get(inFlightTokenRequest);
     if (current && current.address !== address) {
-      store.set(IN_FLIGHT_TOKEN_REQUEST_ATOM, null);
+      store.set(inFlightTokenRequest, null);
     }
   }, [address]);
 
@@ -67,7 +68,7 @@ export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UsePr
     const { accessToken, isTokenExpired, generateToken, notificator, address } = stateRef.current;
     if (accessToken && !isTokenExpired) return accessToken;
     const store = getDefaultStore();
-    const current = store.get(IN_FLIGHT_TOKEN_REQUEST_ATOM);
+    const current = store.get(inFlightTokenRequest);
     if (current && current.address === address) {
       return current.promise;
     }
@@ -84,11 +85,11 @@ export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UsePr
         throw normalizedError;
       })
       .finally(() => {
-        if (store.get(IN_FLIGHT_TOKEN_REQUEST_ATOM)?.promise === promise) {
-          store.set(IN_FLIGHT_TOKEN_REQUEST_ATOM, null);
+        if (store.get(inFlightTokenRequest)?.promise === promise) {
+          store.set(inFlightTokenRequest, null);
         }
       });
-    store.set(IN_FLIGHT_TOKEN_REQUEST_ATOM, { address, promise });
+    store.set(inFlightTokenRequest, { address, promise });
     return promise;
   }, []);
 

--- a/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
+++ b/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ExponentialBackoff, handleAll, retry } from "cockatiel";
 
 import { useWallet } from "@src/context/WalletProvider";
@@ -22,6 +22,10 @@ const GENERATE_TOKEN_RETRY_POLICY = retry(handleAll, {
 
 const GENERATE_TOKEN_FAILURE_MESSAGE = "Failed to authorize with the provider. Please retry.";
 
+// Module-scoped so concurrent ensureToken calls from multiple hook instances
+// share the same in-flight request. A per-hook ref can't survive remount
+// mid-request, and a context provider would be a heavier rewiring; revisit if
+// the cross-instance coupling becomes a problem.
 const inFlightTracker: { current: { address: string; promise: Promise<string> } | null } = { current: null };
 
 export type UseProviderCredentialsResult = {
@@ -46,6 +50,9 @@ export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UsePr
 
   const [error, setError] = useState<Error | null>(null);
 
+  const stateRef = useRef({ accessToken, isTokenExpired, generateToken, notificator, address });
+  stateRef.current = { accessToken, isTokenExpired, generateToken, notificator, address };
+
   useEffect(() => {
     setError(null);
     if (inFlightTracker.current && inFlightTracker.current.address !== address) {
@@ -54,6 +61,7 @@ export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UsePr
   }, [address]);
 
   const ensureToken = useCallback(async (): Promise<string> => {
+    const { accessToken, isTokenExpired, generateToken, notificator, address } = stateRef.current;
     if (accessToken && !isTokenExpired) return accessToken;
     if (inFlightTracker.current && inFlightTracker.current.address === address) {
       return inFlightTracker.current.promise;
@@ -77,10 +85,10 @@ export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UsePr
       });
     inFlightTracker.current = { address, promise };
     return promise;
-  }, [accessToken, isTokenExpired, generateToken, notificator, address]);
+  }, []);
 
   useEffect(() => {
-    if (!isWalletConnected || !isHydrated || isUsable || error || inFlightTracker.current) return;
+    if (!isWalletConnected || !isHydrated || isUsable || error) return;
     ensureToken().catch(() => {});
   }, [isWalletConnected, isHydrated, isUsable, error, ensureToken]);
 

--- a/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
+++ b/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ExponentialBackoff, handleAll, retry } from "cockatiel";
+import { atom, getDefaultStore } from "jotai";
 
 import { useWallet } from "@src/context/WalletProvider";
 import { useNotificator } from "@src/hooks/useNotificator";
@@ -22,11 +23,11 @@ const GENERATE_TOKEN_RETRY_POLICY = retry(handleAll, {
 
 const GENERATE_TOKEN_FAILURE_MESSAGE = "Failed to authorize with the provider. Please retry.";
 
-// Module-scoped so concurrent ensureToken calls from multiple hook instances
-// share the same in-flight request. A per-hook ref can't survive remount
-// mid-request, and a context provider would be a heavier rewiring; revisit if
-// the cross-instance coupling becomes a problem.
-const inFlightTracker: { current: { address: string; promise: Promise<string> } | null } = { current: null };
+// Cross-instance dedup: when multiple components mount and each calls
+// ensureToken on their auto-trigger effect, they all await the same promise
+// instead of issuing parallel generateToken requests (which for self-custodial
+// wallets would spawn N signArbitrary popups).
+const IN_FLIGHT_TOKEN_REQUEST_ATOM = atom<{ address: string; promise: Promise<string> } | null>(null);
 
 export type UseProviderCredentialsResult = {
   details: ProviderCredentials & {
@@ -55,16 +56,20 @@ export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UsePr
 
   useEffect(() => {
     setError(null);
-    if (inFlightTracker.current && inFlightTracker.current.address !== address) {
-      inFlightTracker.current = null;
+    const store = getDefaultStore();
+    const current = store.get(IN_FLIGHT_TOKEN_REQUEST_ATOM);
+    if (current && current.address !== address) {
+      store.set(IN_FLIGHT_TOKEN_REQUEST_ATOM, null);
     }
   }, [address]);
 
   const ensureToken = useCallback(async (): Promise<string> => {
     const { accessToken, isTokenExpired, generateToken, notificator, address } = stateRef.current;
     if (accessToken && !isTokenExpired) return accessToken;
-    if (inFlightTracker.current && inFlightTracker.current.address === address) {
-      return inFlightTracker.current.promise;
+    const store = getDefaultStore();
+    const current = store.get(IN_FLIGHT_TOKEN_REQUEST_ATOM);
+    if (current && current.address === address) {
+      return current.promise;
     }
 
     const promise = GENERATE_TOKEN_RETRY_POLICY.execute(() => generateToken())
@@ -79,11 +84,11 @@ export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UsePr
         throw normalizedError;
       })
       .finally(() => {
-        if (inFlightTracker.current?.promise === promise) {
-          inFlightTracker.current = null;
+        if (store.get(IN_FLIGHT_TOKEN_REQUEST_ATOM)?.promise === promise) {
+          store.set(IN_FLIGHT_TOKEN_REQUEST_ATOM, null);
         }
       });
-    inFlightTracker.current = { address, promise };
+    store.set(IN_FLIGHT_TOKEN_REQUEST_ATOM, { address, promise });
     return promise;
   }, []);
 

--- a/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
+++ b/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
@@ -81,9 +81,7 @@ export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UsePr
 
   useEffect(() => {
     if (!isWalletConnected || !isHydrated || isUsable || error || inFlightTracker.current) return;
-    ensureToken().catch(() => {
-      // Error already surfaced via notificator + details.error inside ensureToken
-    });
+    ensureToken().catch(() => {});
   }, [isWalletConnected, isHydrated, isUsable, error, ensureToken]);
 
   const credentials = useMemo(

--- a/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
+++ b/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
@@ -1,18 +1,34 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ExponentialBackoff, handleAll, retry } from "cockatiel";
 
 import { useWallet } from "@src/context/WalletProvider";
+import { useNotificator } from "@src/hooks/useNotificator";
 import type { ProviderCredentials } from "@src/services/provider-proxy/provider-proxy.service";
 import { useProviderJwt } from "../useProviderJwt/useProviderJwt";
 
 export const DEPENDENCIES = {
   useWallet,
-  useProviderJwt
+  useProviderJwt,
+  useNotificator
 };
+
+const GENERATE_TOKEN_RETRY_POLICY = retry(handleAll, {
+  maxAttempts: 3,
+  backoff: new ExponentialBackoff({
+    initialDelay: 500,
+    maxDelay: 5000
+  })
+});
+
+const GENERATE_TOKEN_FAILURE_MESSAGE = "Failed to authorize with the provider. Please retry.";
+
+const inFlightTracker: { current: { address: string; promise: Promise<string> } | null } = { current: null };
 
 export type UseProviderCredentialsResult = {
   details: ProviderCredentials & {
     isExpired: boolean;
     usable: boolean;
+    error: Error | null;
   };
   ensureToken: () => Promise<string>;
 };
@@ -22,30 +38,53 @@ export type UseProviderCredentialsDependencies = {
 };
 
 export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UseProviderCredentialsDependencies = {}): UseProviderCredentialsResult {
-  const { isWalletConnected } = d.useWallet();
-  const { accessToken, generateToken, isTokenExpired } = d.useProviderJwt();
+  const { isWalletConnected, address } = d.useWallet();
+  const { accessToken, generateToken, isTokenExpired, isHydrated } = d.useProviderJwt();
+  const notificator = d.useNotificator();
 
   const isUsable = !!accessToken && !isTokenExpired;
 
-  const inFlightRef = useRef<Promise<string> | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    setError(null);
+    if (inFlightTracker.current && inFlightTracker.current.address !== address) {
+      inFlightTracker.current = null;
+    }
+  }, [address]);
 
   const ensureToken = useCallback(async (): Promise<string> => {
     if (accessToken && !isTokenExpired) return accessToken;
-    if (inFlightRef.current) return inFlightRef.current;
+    if (inFlightTracker.current && inFlightTracker.current.address === address) {
+      return inFlightTracker.current.promise;
+    }
 
-    const promise = generateToken().finally(() => {
-      inFlightRef.current = null;
-    });
-    inFlightRef.current = promise;
+    const promise = GENERATE_TOKEN_RETRY_POLICY.execute(() => generateToken())
+      .then(token => {
+        setError(null);
+        return token;
+      })
+      .catch((err: unknown) => {
+        const normalizedError = err instanceof Error ? err : new Error(String(err));
+        setError(normalizedError);
+        notificator.error(GENERATE_TOKEN_FAILURE_MESSAGE);
+        throw normalizedError;
+      })
+      .finally(() => {
+        if (inFlightTracker.current?.promise === promise) {
+          inFlightTracker.current = null;
+        }
+      });
+    inFlightTracker.current = { address, promise };
     return promise;
-  }, [accessToken, isTokenExpired, generateToken]);
+  }, [accessToken, isTokenExpired, generateToken, notificator, address]);
 
   useEffect(() => {
-    if (!isWalletConnected || isUsable || inFlightRef.current) return;
+    if (!isWalletConnected || !isHydrated || isUsable || error || inFlightTracker.current) return;
     ensureToken().catch(() => {
-      // Auto-refresh failures are surfaced by downstream provider calls
+      // Error already surfaced via notificator + details.error inside ensureToken
     });
-  }, [isWalletConnected, isUsable, ensureToken]);
+  }, [isWalletConnected, isHydrated, isUsable, error, ensureToken]);
 
   const credentials = useMemo(
     () =>
@@ -53,9 +92,10 @@ export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UsePr
         type: "jwt",
         value: accessToken,
         isExpired: isTokenExpired,
-        usable: isUsable
+        usable: isUsable,
+        error
       }) as const,
-    [accessToken, isTokenExpired, isUsable]
+    [accessToken, isTokenExpired, isUsable, error]
   );
 
   return useMemo(

--- a/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
+++ b/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ExponentialBackoff, handleAll, retry } from "cockatiel";
-import { getDefaultStore } from "jotai";
+import { useSetAtom } from "jotai";
 
 import { useWallet } from "@src/context/WalletProvider";
 import { useNotificator } from "@src/hooks/useNotificator";
@@ -24,11 +24,6 @@ const GENERATE_TOKEN_RETRY_POLICY = retry(handleAll, {
 
 const GENERATE_TOKEN_FAILURE_MESSAGE = "Failed to authorize with the provider. Please retry.";
 
-// Cross-instance dedup: when multiple components mount and each calls
-// ensureToken on their auto-trigger effect, they all await the same promise
-// instead of issuing parallel generateToken requests (which for self-custodial
-// wallets would spawn N signArbitrary popups).
-
 export type UseProviderCredentialsResult = {
   details: ProviderCredentials & {
     isExpired: boolean;
@@ -51,46 +46,43 @@ export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UsePr
 
   const [error, setError] = useState<Error | null>(null);
 
+  const claimInFlight = useSetAtom(providerCredentialsStore.claimInFlightTokenRequest);
+  const releaseInFlight = useSetAtom(providerCredentialsStore.releaseInFlightTokenRequest);
+  const clearInFlightForOtherAddress = useSetAtom(providerCredentialsStore.clearInFlightTokenRequestForOtherAddress);
+
   const stateRef = useRef({ accessToken, isTokenExpired, generateToken, notificator, address });
   stateRef.current = { accessToken, isTokenExpired, generateToken, notificator, address };
 
   useEffect(() => {
     setError(null);
-    const store = getDefaultStore();
-    const current = store.get(providerCredentialsStore.inFlightTokenRequest);
-    if (current && current.address !== address) {
-      store.set(providerCredentialsStore.inFlightTokenRequest, null);
-    }
-  }, [address]);
+    clearInFlightForOtherAddress(address);
+  }, [address, clearInFlightForOtherAddress]);
 
   const ensureToken = useCallback(async (): Promise<string> => {
     const { accessToken, isTokenExpired, generateToken, notificator, address } = stateRef.current;
     if (accessToken && !isTokenExpired) return accessToken;
-    const store = getDefaultStore();
-    const current = store.get(providerCredentialsStore.inFlightTokenRequest);
-    if (current && current.address === address) {
-      return current.promise;
-    }
 
-    const promise = GENERATE_TOKEN_RETRY_POLICY.execute(() => generateToken())
-      .then(token => {
-        setError(null);
-        return token;
-      })
-      .catch((err: unknown) => {
-        const normalizedError = err instanceof Error ? err : new Error(String(err));
-        setError(normalizedError);
-        notificator.error(GENERATE_TOKEN_FAILURE_MESSAGE);
-        throw normalizedError;
-      })
-      .finally(() => {
-        if (store.get(providerCredentialsStore.inFlightTokenRequest)?.promise === promise) {
-          store.set(providerCredentialsStore.inFlightTokenRequest, null);
-        }
-      });
-    store.set(providerCredentialsStore.inFlightTokenRequest, { address, promise });
-    return promise;
-  }, []);
+    return claimInFlight({
+      address,
+      createPromise: () => {
+        const createdPromise: Promise<string> = GENERATE_TOKEN_RETRY_POLICY.execute(() => generateToken())
+          .then(token => {
+            setError(null);
+            return token;
+          })
+          .catch((err: unknown) => {
+            const normalizedError = err instanceof Error ? err : new Error(String(err));
+            setError(normalizedError);
+            notificator.error(GENERATE_TOKEN_FAILURE_MESSAGE);
+            throw normalizedError;
+          })
+          .finally(() => {
+            releaseInFlight(createdPromise);
+          });
+        return createdPromise;
+      }
+    });
+  }, [claimInFlight, releaseInFlight]);
 
   useEffect(() => {
     if (!isWalletConnected || !isHydrated || isUsable || error) return;

--- a/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
+++ b/apps/deploy-web/src/hooks/useProviderCredentials/useProviderCredentials.ts
@@ -28,7 +28,6 @@ const GENERATE_TOKEN_FAILURE_MESSAGE = "Failed to authorize with the provider. P
 // ensureToken on their auto-trigger effect, they all await the same promise
 // instead of issuing parallel generateToken requests (which for self-custodial
 // wallets would spawn N signArbitrary popups).
-const { inFlightTokenRequest } = providerCredentialsStore;
 
 export type UseProviderCredentialsResult = {
   details: ProviderCredentials & {
@@ -58,9 +57,9 @@ export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UsePr
   useEffect(() => {
     setError(null);
     const store = getDefaultStore();
-    const current = store.get(inFlightTokenRequest);
+    const current = store.get(providerCredentialsStore.inFlightTokenRequest);
     if (current && current.address !== address) {
-      store.set(inFlightTokenRequest, null);
+      store.set(providerCredentialsStore.inFlightTokenRequest, null);
     }
   }, [address]);
 
@@ -68,7 +67,7 @@ export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UsePr
     const { accessToken, isTokenExpired, generateToken, notificator, address } = stateRef.current;
     if (accessToken && !isTokenExpired) return accessToken;
     const store = getDefaultStore();
-    const current = store.get(inFlightTokenRequest);
+    const current = store.get(providerCredentialsStore.inFlightTokenRequest);
     if (current && current.address === address) {
       return current.promise;
     }
@@ -85,11 +84,11 @@ export function useProviderCredentials({ dependencies: d = DEPENDENCIES }: UsePr
         throw normalizedError;
       })
       .finally(() => {
-        if (store.get(inFlightTokenRequest)?.promise === promise) {
-          store.set(inFlightTokenRequest, null);
+        if (store.get(providerCredentialsStore.inFlightTokenRequest)?.promise === promise) {
+          store.set(providerCredentialsStore.inFlightTokenRequest, null);
         }
       });
-    store.set(inFlightTokenRequest, { address, promise });
+    store.set(providerCredentialsStore.inFlightTokenRequest, { address, promise });
     return promise;
   }, []);
 

--- a/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.spec.tsx
+++ b/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.spec.tsx
@@ -8,7 +8,7 @@ import type { ContextType as WalletContext } from "@src/context/WalletProvider";
 import type { ChainContext as CustodialWallet } from "@src/lib/cosmos-kit-jotai";
 import type * as storedWalletsService from "@src/utils/walletUtils";
 import type { useSelectedChain } from "../useSelectedChain/useSelectedChain";
-import { DEPENDENCIES, useProviderJwt } from "./useProviderJwt";
+import { DEPENDENCIES, REFRESH_SKEW_SECONDS, useProviderJwt } from "./useProviderJwt";
 
 import { act } from "@testing-library/react";
 import type { RenderAppHookOptions } from "@tests/unit/query-client";
@@ -76,7 +76,7 @@ describe(useProviderJwt.name, () => {
         ttl: 1800, // 30 * 60
         leases: {
           access: "scoped",
-          scope: ["status", "shell", "events", "logs"]
+          scope: ["status", "shell", "events", "logs", "send-manifest", "get-manifest"]
         }
       }
     });
@@ -159,6 +159,34 @@ describe(useProviderJwt.name, () => {
     });
 
     expect(result.current.isTokenExpired).toBe(false);
+  });
+
+  it("treats token within refresh skew window as expired", () => {
+    const nearExpiry = Math.floor(Date.now() / 1000) + REFRESH_SKEW_SECONDS - 5;
+
+    const { result } = setup({
+      initialToken: genFakeToken({ exp: nearExpiry })
+    });
+
+    expect(result.current.isTokenExpired).toBe(true);
+  });
+
+  it("treats token outside refresh skew window as valid", () => {
+    const beyondSkew = Math.floor(Date.now() / 1000) + REFRESH_SKEW_SECONDS + 60;
+
+    const { result } = setup({
+      initialToken: genFakeToken({ exp: beyondSkew })
+    });
+
+    expect(result.current.isTokenExpired).toBe(false);
+  });
+
+  it("marks isHydrated true after the storage read completes", () => {
+    const { result } = setup({
+      initialToken: genFakeToken()
+    });
+
+    expect(result.current.isHydrated).toBe(true);
   });
 
   function setup(input?: {

--- a/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.ts
+++ b/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.ts
@@ -25,7 +25,6 @@ export function useProviderJwt({ dependencies: d = DEPENDENCIES }: { dependencie
   const [isHydrated, setIsHydrated] = useState(false);
 
   useEffect(() => {
-    setIsHydrated(false);
     const token = storedWalletsService.getStorageWallets(selectedNetworkId).find(w => w.address === address)?.token;
     setAccessToken(token || null);
     setIsHydrated(true);

--- a/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.ts
+++ b/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { JwtTokenManager, type JwtTokenPayload } from "@akashnetwork/chain-sdk/web";
 import { atom, useAtom } from "jotai";
 
@@ -7,6 +7,8 @@ import { useWallet } from "@src/context/WalletProvider";
 import { useSelectedChain } from "../useSelectedChain/useSelectedChain";
 
 const JWT_TOKEN_ATOM = atom<string | null>(null);
+
+export const REFRESH_SKEW_SECONDS = 60;
 
 export const DEPENDENCIES = {
   useSelectedChain,
@@ -20,10 +22,13 @@ export function useProviderJwt({ dependencies: d = DEPENDENCIES }: { dependencie
   const selectedChain = d.useSelectedChain();
   const selectedNetworkId = networkStore.useSelectedNetworkId();
   const [accessToken, setAccessToken] = useAtom(JWT_TOKEN_ATOM);
+  const [isHydrated, setIsHydrated] = useState(false);
 
   useEffect(() => {
+    setIsHydrated(false);
     const token = storedWalletsService.getStorageWallets(selectedNetworkId).find(w => w.address === address)?.token;
     setAccessToken(token || null);
+    setIsHydrated(true);
   }, [storedWalletsService, selectedNetworkId, address]);
 
   const jwtTokenManager = useMemo(
@@ -49,7 +54,7 @@ export function useProviderJwt({ dependencies: d = DEPENDENCIES }: { dependencie
 
     const leasesAccess: JwtTokenPayload["leases"] = {
       access: "scoped",
-      scope: ["status", "shell", "events", "logs"]
+      scope: ["status", "shell", "events", "logs", "send-manifest", "get-manifest"]
     };
     const tokenLifetimeInSeconds = 30 * 60;
     let token: string;
@@ -80,12 +85,13 @@ export function useProviderJwt({ dependencies: d = DEPENDENCIES }: { dependencie
   return useMemo(
     () => ({
       get isTokenExpired() {
-        return !!parsedToken && parsedToken.exp <= Math.floor(Date.now() / 1000);
+        return !!parsedToken && parsedToken.exp - REFRESH_SKEW_SECONDS <= Math.floor(Date.now() / 1000);
       },
       accessToken,
-      generateToken
+      generateToken,
+      isHydrated
     }),
-    [accessToken, generateToken]
+    [accessToken, generateToken, isHydrated]
   );
 }
 
@@ -93,4 +99,5 @@ export interface UseProviderJwtResult {
   isTokenExpired: boolean;
   accessToken: string | null;
   generateToken: () => Promise<string>;
+  isHydrated: boolean;
 }

--- a/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
@@ -279,7 +279,8 @@ describe("useLeaseQuery", () => {
           type: "jwt",
           value: null,
           isExpired: false,
-          usable: false
+          usable: false,
+          error: null
         },
         services: {
           providerProxy: () => mock<ProviderProxyService>()
@@ -330,7 +331,8 @@ describe("useLeaseQuery", () => {
           type: "jwt",
           value: "jwt-token",
           isExpired: false,
-          usable: true
+          usable: true,
+          error: null
         },
         services: {
           providerProxy: () => providerProxy
@@ -364,7 +366,8 @@ describe("useLeaseQuery", () => {
             type: "jwt",
             value: "jwt-token",
             isExpired: false,
-            usable: true
+            usable: true,
+            error: null
           },
           ensureToken: vi.fn().mockResolvedValue("jwt-token")
         })

--- a/apps/deploy-web/src/queries/useLeaseQuery.ts
+++ b/apps/deploy-web/src/queries/useLeaseQuery.ts
@@ -85,9 +85,10 @@ export function useLeaseStatus(
     queryFn: async () => {
       if (lease?.state !== "active" || !providerCredentials.details.usable) return null;
 
+      const token = await providerCredentials.ensureToken();
       const response = await fetchProviderUrl<LeaseStatusDto>(`/lease/${lease.dseq}/${lease.gseq}/${lease.oseq}/status`, {
         method: "GET",
-        credentials: providerCredentials.details
+        credentials: { type: "jwt", value: token }
       }).catch(error => {
         if (isHttpError(error) && error.response?.status === 404) {
           return { data: null };

--- a/apps/deploy-web/src/services/provider-proxy/RotatingShellSession.ts
+++ b/apps/deploy-web/src/services/provider-proxy/RotatingShellSession.ts
@@ -35,6 +35,7 @@ export class RotatingShellSession {
   }
 
   private async openNextSession(): Promise<void> {
+    if (this.isDisconnected || this.options.signal?.aborted) return;
     const token = await this.options.ensureToken();
     if (this.isDisconnected || this.options.signal?.aborted) return;
     const sessionAbort = new AbortController();

--- a/apps/deploy-web/src/services/provider-proxy/RotatingShellSession.ts
+++ b/apps/deploy-web/src/services/provider-proxy/RotatingShellSession.ts
@@ -1,0 +1,111 @@
+import type { LoggerService } from "@akashnetwork/logging";
+
+import type { WebsocketSession } from "@src/lib/websocket/WebsocketSession";
+import { isTokenExpiredMessage, mergeSignals, RotationTracker } from "./ws-rotation";
+
+export interface ReceivedShellMessage {
+  message?: {
+    data: number[];
+  };
+  error?: string;
+  closed?: boolean;
+}
+
+export class RotatingShellSession {
+  private static readonly OUTBOUND_QUEUE_CAP = 256;
+  private currentSession?: WebsocketSession<Uint8Array, ReceivedShellMessage>;
+  private currentSessionAbort?: AbortController;
+  private outboundQueue: Uint8Array[] = [];
+  private readonly tracker: RotationTracker;
+  private isDisconnected = false;
+  private sessionReady: Promise<void>;
+
+  constructor(
+    private readonly options: {
+      ensureToken: () => Promise<string>;
+      createSession: (token: string, signal: AbortSignal) => WebsocketSession<Uint8Array, ReceivedShellMessage>;
+      logger: LoggerService;
+      url: string;
+      signal?: AbortSignal;
+    }
+  ) {
+    this.tracker = new RotationTracker(options.logger, options.url);
+    this.sessionReady = this.openNextSession();
+    this.sessionReady.catch(() => {});
+  }
+
+  private async openNextSession(): Promise<void> {
+    const token = await this.options.ensureToken();
+    if (this.isDisconnected || this.options.signal?.aborted) return;
+    const sessionAbort = new AbortController();
+    const session = this.options.createSession(token, mergeSignals(this.options.signal, sessionAbort.signal));
+    this.currentSession = session;
+    this.currentSessionAbort = sessionAbort;
+    while (this.outboundQueue.length > 0) {
+      session.send(this.outboundQueue.shift()!);
+    }
+  }
+
+  send(message: Uint8Array): void {
+    if (this.isDisconnected) return;
+    if (this.currentSession) {
+      this.currentSession.send(message);
+      return;
+    }
+    if (this.outboundQueue.length >= RotatingShellSession.OUTBOUND_QUEUE_CAP) {
+      this.options.logger.warn({ event: "SHELL_OUTBOUND_QUEUE_OVERFLOW", url: this.options.url, dropped: 1 });
+      this.outboundQueue.shift();
+    }
+    this.outboundQueue.push(message);
+  }
+
+  async disconnect(): Promise<void> {
+    this.isDisconnected = true;
+    this.outboundQueue = [];
+    this.currentSessionAbort?.abort();
+    if (this.currentSession) {
+      await this.currentSession.disconnect();
+      this.currentSession = undefined;
+    }
+  }
+
+  async *receive(): AsyncGenerator<ReceivedShellMessage> {
+    while (!this.isDisconnected && !this.options.signal?.aborted) {
+      try {
+        await this.sessionReady;
+      } catch {
+        yield { closed: true } as ReceivedShellMessage;
+        return;
+      }
+      const session = this.currentSession;
+      const sessionAbort = this.currentSessionAbort;
+      if (!session) return;
+
+      let rotate = false;
+      try {
+        for await (const message of session.receive()) {
+          if (isTokenExpiredMessage(message)) {
+            rotate = true;
+            break;
+          }
+          yield message;
+        }
+      } finally {
+        sessionAbort?.abort();
+        await session.disconnect();
+        if (this.currentSession === session) {
+          this.currentSession = undefined;
+          this.currentSessionAbort = undefined;
+        }
+      }
+
+      if (!rotate) return;
+      if (!this.tracker.allowRotation()) {
+        yield { closed: true } as ReceivedShellMessage;
+        return;
+      }
+      this.sessionReady = this.openNextSession();
+      this.sessionReady.catch(() => {});
+    }
+  }
+}

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
@@ -19,7 +19,7 @@ describe(ProviderProxyService.name, () => {
   describe("sendManifest", () => {
     it("does nothing if provider is undefined", () => {
       const { service, httpClient } = setup();
-      service.sendManifest(undefined, [] as Manifest, { dseq: "1" });
+      service.sendManifest(undefined, [] as Manifest, { dseq: "1", ensureToken: () => Promise.resolve("noop") });
       expect(httpClient.post).not.toHaveBeenCalled();
     });
 
@@ -79,7 +79,7 @@ describe(ProviderProxyService.name, () => {
         }
       ];
       const credentials: ProviderCredentials = { type: "jwt", value: "jwt-token" };
-      const promise = service.sendManifest(provider, manifest, { dseq, credentials });
+      const promise = service.sendManifest(provider, manifest, { dseq, ensureToken: () => Promise.resolve(credentials.value as string) });
 
       const [result] = await Promise.all([promise, vi.runAllTimersAsync()]);
 

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
@@ -791,7 +791,7 @@ describe(ProviderProxyService.name, () => {
       await dispatchWsEvent(secondSocket, new Event("close"));
     });
 
-    it("stops rotating after exceeding the rotation cap and logs WS_ROTATION_LIMIT_EXCEEDED", async () => {
+    it("stops rotating after exceeding the rotation cap, yields a closed message, and logs WS_ROTATION_LIMIT_EXCEEDED", async () => {
       const { service, createWebSocket, logger } = setupWithSocketSequence(4);
       const ensureToken = vi.fn().mockResolvedValue("any-token");
 
@@ -821,10 +821,34 @@ describe(ProviderProxyService.name, () => {
         await dispatchWsEvent(socket, new MessageEvent("message", { data: JSON.stringify({ type: "websocket", error: "tokenExpired" }) }));
       }
 
-      await consumePromise;
+      const messages = await consumePromise;
 
       expect(createWebSocket).toHaveBeenCalledTimes(4);
       expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "WS_ROTATION_LIMIT_EXCEEDED" }));
+      expect(messages.at(-1)).toEqual({ closed: true });
+    });
+
+    it("yields a closed message when ensureToken rejects", async () => {
+      const { service } = setup();
+      const ensureToken = vi.fn().mockRejectedValue(new Error("token unavailable"));
+
+      const stream = service.getLogsStream({
+        providerBaseUrl: "https://provider.akash.network",
+        providerAddress: "akash1provider",
+        ensureToken,
+        dseq: "333",
+        gseq: 1,
+        oseq: 1,
+        type: "logs" as const,
+        follow: true
+      });
+
+      const messages = [];
+      for await (const message of stream) {
+        messages.push(message);
+      }
+
+      expect(messages).toEqual([{ closed: true }]);
     });
   });
 

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
@@ -108,7 +108,7 @@ describe(ProviderProxyService.name, () => {
         type: "logs" as const,
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "123",
         gseq: 1,
         oseq: 1
@@ -160,7 +160,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "456",
         gseq: 2,
         oseq: 3,
@@ -202,7 +202,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "token123" },
+        ensureToken: () => Promise.resolve("token123"),
         dseq: "789",
         gseq: 1,
         oseq: 1,
@@ -227,7 +227,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "111",
         gseq: 1,
         oseq: 1,
@@ -269,7 +269,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "222",
         gseq: 1,
         oseq: 1,
@@ -295,7 +295,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "111",
         gseq: 1,
         oseq: 1,
@@ -323,7 +323,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "123",
         gseq: 1,
         oseq: 1,
@@ -366,7 +366,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "456",
         gseq: 2,
         oseq: 3,
@@ -405,7 +405,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "token123" },
+        ensureToken: () => Promise.resolve("token123"),
         dseq: "789",
         gseq: 1,
         oseq: 1,
@@ -438,7 +438,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "999",
         gseq: 1,
         oseq: 1,
@@ -464,7 +464,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "111",
         gseq: 1,
         oseq: 1,
@@ -497,7 +497,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "222",
         gseq: 1,
         oseq: 1,
@@ -538,7 +538,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "123",
         gseq: 1,
         oseq: 1,
@@ -582,7 +582,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "token123" },
+        ensureToken: () => Promise.resolve("token123"),
         dseq: "456",
         gseq: 2,
         oseq: 3,
@@ -628,7 +628,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "789",
         gseq: 1,
         oseq: 1,
@@ -682,7 +682,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "999",
         gseq: 1,
         oseq: 1,
@@ -693,11 +693,10 @@ describe(ProviderProxyService.name, () => {
       const stream = service.getLogsStream(input);
 
       await dispatchWsEvent(websocket, new Event("open"));
-
-      const [result] = await Promise.all([stream.next(), abortController.abort()]);
+      abortController.abort();
+      const result = await stream.next();
 
       expect(result.done).toBe(true);
-      expect(websocket.close).toHaveBeenCalled();
     });
 
     it("includes `tail`, `services` and `follow` parameters in request", async () => {
@@ -705,7 +704,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "111",
         gseq: 1,
         oseq: 1,
@@ -732,7 +731,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "111",
         gseq: 1,
         oseq: 1,
@@ -751,6 +750,82 @@ describe(ProviderProxyService.name, () => {
 
       expect(createWebSocket).toHaveBeenCalledTimes(1);
     });
+
+    it("rotates the websocket when the server emits a tokenExpired payload", async () => {
+      const { service, createWebSocket } = setupWithSocketSequence(2);
+      const ensureToken = vi.fn().mockResolvedValueOnce("stale-token").mockResolvedValueOnce("fresh-token");
+
+      const stream = service.getLogsStream({
+        providerBaseUrl: "https://provider.akash.network",
+        providerAddress: "akash1provider",
+        ensureToken,
+        dseq: "111",
+        gseq: 1,
+        oseq: 1,
+        type: "logs" as const,
+        follow: true
+      });
+
+      const firstMessagePromise = stream.next();
+
+      await vi.waitFor(() => expect(createWebSocket).toHaveBeenCalledTimes(1));
+      const firstSocket = (createWebSocket as Mock).mock.results[0].value as WebSocket;
+      await dispatchWsEvent(firstSocket, new Event("open"));
+      await dispatchWsEvent(firstSocket, new MessageEvent("message", { data: JSON.stringify({ type: "websocket", error: "tokenExpired" }) }));
+
+      await vi.waitFor(() => expect(createWebSocket).toHaveBeenCalledTimes(2));
+
+      const secondSocket = (createWebSocket as Mock).mock.results[1].value as WebSocket;
+      await dispatchWsEvent(secondSocket, new Event("open"));
+
+      const logMessage: LogEntryMessage = { name: "web-1", message: "after rotation", service: "web" };
+      await dispatchWsEvent(secondSocket, new MessageEvent("message", { data: JSON.stringify({ message: JSON.stringify(logMessage) }) }));
+
+      const result = await firstMessagePromise;
+
+      expect(result.value).toEqual({ message: logMessage });
+      expect(ensureToken).toHaveBeenCalledTimes(2);
+      const secondHandshake = JSON.parse((secondSocket.send as Mock).mock.calls[0][0]);
+      expect(secondHandshake.auth).toEqual({ type: "jwt", token: "fresh-token" });
+
+      await dispatchWsEvent(secondSocket, new Event("close"));
+    });
+
+    it("stops rotating after exceeding the rotation cap and logs WS_ROTATION_LIMIT_EXCEEDED", async () => {
+      const { service, createWebSocket, logger } = setupWithSocketSequence(4);
+      const ensureToken = vi.fn().mockResolvedValue("any-token");
+
+      const stream = service.getLogsStream({
+        providerBaseUrl: "https://provider.akash.network",
+        providerAddress: "akash1provider",
+        ensureToken,
+        dseq: "222",
+        gseq: 1,
+        oseq: 1,
+        type: "logs" as const,
+        follow: true
+      });
+
+      const consumePromise = (async () => {
+        const messages = [];
+        for await (const message of stream) {
+          messages.push(message);
+        }
+        return messages;
+      })();
+
+      for (let attempt = 0; attempt < 4; attempt++) {
+        await vi.waitFor(() => expect(createWebSocket).toHaveBeenCalledTimes(attempt + 1));
+        const socket = (createWebSocket as Mock).mock.results[attempt].value as WebSocket;
+        await dispatchWsEvent(socket, new Event("open"));
+        await dispatchWsEvent(socket, new MessageEvent("message", { data: JSON.stringify({ type: "websocket", error: "tokenExpired" }) }));
+      }
+
+      await consumePromise;
+
+      expect(createWebSocket).toHaveBeenCalledTimes(4);
+      expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "WS_ROTATION_LIMIT_EXCEEDED" }));
+    });
   });
 
   describe("connectToShell", () => {
@@ -759,7 +834,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.example.com",
         providerAddress: "akash1test",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "100",
         gseq: 2,
         oseq: 3,
@@ -781,7 +856,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "456",
         gseq: 1,
         oseq: 1,
@@ -803,7 +878,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "789",
         gseq: 1,
         oseq: 1,
@@ -826,7 +901,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "333",
         gseq: 1,
         oseq: 1,
@@ -849,7 +924,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "token123" },
+        ensureToken: () => Promise.resolve("token123"),
         dseq: "555",
         gseq: 1,
         oseq: 1,
@@ -872,7 +947,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "666",
         gseq: 1,
         oseq: 1,
@@ -893,7 +968,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "777",
         gseq: 1,
         oseq: 1,
@@ -914,7 +989,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "888",
         gseq: 1,
         oseq: 1,
@@ -936,7 +1011,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "1000",
         gseq: 1,
         oseq: 1,
@@ -964,7 +1039,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "1111",
         gseq: 1,
         oseq: 1,
@@ -1005,7 +1080,7 @@ describe(ProviderProxyService.name, () => {
       const input = {
         providerBaseUrl: "https://provider.akash.network",
         providerAddress: "akash1provider",
-        providerCredentials: { type: "jwt" as const, value: "jwt-token" },
+        ensureToken: () => Promise.resolve("jwt-token"),
         dseq: "1111",
         gseq: 1,
         oseq: 1,
@@ -1039,5 +1114,16 @@ describe(ProviderProxyService.name, () => {
     const createWebSocket = vi.fn(() => websocket);
     const service = new ProviderProxyService(httpClient, logger, createWebSocket, saveFile);
     return { service, httpClient, logger, saveFile, websocket, createWebSocket };
+  }
+
+  function setupWithSocketSequence(count: number) {
+    const httpClient = mock<HttpClient>();
+    const logger = mock<LoggerService>();
+    const saveFile = vi.fn();
+    const sockets = Array.from({ length: count }, () => createWebsocketMock());
+    const createWebSocket = vi.fn();
+    sockets.forEach(socket => createWebSocket.mockReturnValueOnce(socket));
+    const service = new ProviderProxyService(httpClient, logger, createWebSocket, saveFile);
+    return { service, httpClient, logger, saveFile, sockets, createWebSocket };
   }
 });

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
@@ -9,6 +9,10 @@ import type { ApiProviderList } from "@src/types/provider";
 import { toBase64 } from "@src/utils/encoding";
 import { wait } from "@src/utils/timer";
 import { formatK8sEvent, formatLogMessage } from "./logFormatters";
+import { type ReceivedShellMessage, RotatingShellSession } from "./RotatingShellSession";
+import { isTokenExpiredMessage, mergeSignals, RotationTracker } from "./ws-rotation";
+
+export type { ReceivedShellMessage } from "./RotatingShellSession";
 
 // @see https://www.rfc-editor.org/rfc/rfc6455.html#page-46
 export const WS_ERRORS = {
@@ -331,151 +335,9 @@ export class ProviderProxyService {
   }
 }
 
-class RotationTracker {
-  private static readonly WINDOW_MS = 60_000;
-  private static readonly MAX_PER_WINDOW = 3;
-  private readonly timestamps: number[] = [];
-
-  constructor(
-    private readonly logger: LoggerService,
-    private readonly url: string
-  ) {}
-
-  allowRotation(): boolean {
-    const now = Date.now();
-    while (this.timestamps.length > 0 && this.timestamps[0] < now - RotationTracker.WINDOW_MS) {
-      this.timestamps.shift();
-    }
-    this.timestamps.push(now);
-    if (this.timestamps.length > RotationTracker.MAX_PER_WINDOW) {
-      this.logger.error({ event: "WS_ROTATION_LIMIT_EXCEEDED", url: this.url });
-      return false;
-    }
-    return true;
-  }
-}
-
-export class RotatingShellSession {
-  private static readonly OUTBOUND_QUEUE_CAP = 256;
-  private currentSession?: WebsocketSession<Uint8Array, ReceivedShellMessage>;
-  private currentSessionAbort?: AbortController;
-  private outboundQueue: Uint8Array[] = [];
-  private readonly tracker: RotationTracker;
-  private isDisconnected = false;
-  private sessionReady: Promise<void>;
-
-  constructor(
-    private readonly options: {
-      ensureToken: () => Promise<string>;
-      createSession: (token: string, signal: AbortSignal) => WebsocketSession<Uint8Array, ReceivedShellMessage>;
-      logger: LoggerService;
-      url: string;
-      signal?: AbortSignal;
-    }
-  ) {
-    this.tracker = new RotationTracker(options.logger, options.url);
-    this.sessionReady = this.openNextSession();
-    this.sessionReady.catch(() => {});
-  }
-
-  private async openNextSession(): Promise<void> {
-    const token = await this.options.ensureToken();
-    if (this.isDisconnected || this.options.signal?.aborted) return;
-    const sessionAbort = new AbortController();
-    const session = this.options.createSession(token, mergeSignals(this.options.signal, sessionAbort.signal));
-    this.currentSession = session;
-    this.currentSessionAbort = sessionAbort;
-    while (this.outboundQueue.length > 0) {
-      session.send(this.outboundQueue.shift()!);
-    }
-  }
-
-  send(message: Uint8Array): void {
-    if (this.isDisconnected) return;
-    if (this.currentSession) {
-      this.currentSession.send(message);
-      return;
-    }
-    if (this.outboundQueue.length >= RotatingShellSession.OUTBOUND_QUEUE_CAP) {
-      this.options.logger.warn({ event: "SHELL_OUTBOUND_QUEUE_OVERFLOW", url: this.options.url, dropped: 1 });
-      this.outboundQueue.shift();
-    }
-    this.outboundQueue.push(message);
-  }
-
-  async disconnect(): Promise<void> {
-    this.isDisconnected = true;
-    this.outboundQueue = [];
-    this.currentSessionAbort?.abort();
-    if (this.currentSession) {
-      await this.currentSession.disconnect();
-      this.currentSession = undefined;
-    }
-  }
-
-  async *receive(): AsyncGenerator<ReceivedShellMessage> {
-    while (!this.isDisconnected && !this.options.signal?.aborted) {
-      try {
-        await this.sessionReady;
-      } catch {
-        yield { closed: true } as ReceivedShellMessage;
-        return;
-      }
-      const session = this.currentSession;
-      const sessionAbort = this.currentSessionAbort;
-      if (!session) return;
-
-      let rotate = false;
-      try {
-        for await (const message of session.receive()) {
-          if (isTokenExpiredMessage(message)) {
-            rotate = true;
-            break;
-          }
-          yield message;
-        }
-      } finally {
-        sessionAbort?.abort();
-        await session.disconnect();
-        if (this.currentSession === session) {
-          this.currentSession = undefined;
-          this.currentSessionAbort = undefined;
-        }
-      }
-
-      if (!rotate) return;
-      if (!this.tracker.allowRotation()) {
-        yield { closed: true } as ReceivedShellMessage;
-        return;
-      }
-      this.sessionReady = this.openNextSession();
-      this.sessionReady.catch(() => {});
-    }
-  }
-}
-
-function isTokenExpiredMessage(message: unknown): boolean {
-  return typeof message === "object" && message !== null && (message as { error?: string }).error === "tokenExpired";
-}
-
-function mergeSignals(...signals: Array<AbortSignal | undefined>): AbortSignal {
-  const defined = signals.filter((s): s is AbortSignal => !!s);
-  if (defined.length === 0) return new AbortController().signal;
-  if (defined.length === 1) return defined[0];
-  return AbortSignal.any(defined);
-}
-
 function providerLeaseUrl(input: { providerBaseUrl: string; dseq: string; gseq: number; oseq: number; type: "logs" | "events" | "shell" }): string {
   const type = input.type === "events" ? "kubeevents" : input.type;
   return `${input.providerBaseUrl}/lease/${input.dseq}/${input.gseq}/${input.oseq}/${type}`;
-}
-
-export interface ReceivedShellMessage {
-  message?: {
-    data: number[];
-  };
-  error?: string;
-  closed?: boolean;
 }
 
 export interface ProviderProxyPayload {

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
@@ -48,13 +48,13 @@ export class ProviderProxyService {
     await wait(ProviderProxyService.BEFORE_SEND_MANIFEST_DELAY);
 
     const serializedManifest = manifestToSortedJSON(manifest);
+    const credentials: ProviderCredentials = { type: "jwt", value: await options.ensureToken() };
     let response: AxiosResponse | undefined;
 
     for (let i = 1; i <= 3 && !response; i++) {
       this.logger.info({ event: "ATTEMPT_SEND_MANIFEST", attempt: i, providerAddress: providerInfo.owner, dseq: options.dseq });
       try {
         if (!response) {
-          const credentials = options.ensureToken ? ({ type: "jwt", value: await options.ensureToken() } satisfies ProviderCredentials) : options.credentials;
           response = await this.request(`/deployment/${options.dseq}/manifest`, {
             method: "PUT",
             credentials,
@@ -275,10 +275,8 @@ export class ProviderProxyService {
           yield message;
         }
       } finally {
-        if (rotate) {
-          rotationAbort.abort();
-          await session.disconnect();
-        }
+        rotationAbort.abort();
+        await session.disconnect();
       }
 
       if (!rotate || !tracker.allowRotation()) return;
@@ -358,6 +356,7 @@ class RotationTracker {
 }
 
 export class RotatingShellSession {
+  private static readonly OUTBOUND_QUEUE_CAP = 256;
   private currentSession?: WebsocketSession<Uint8Array, ReceivedShellMessage>;
   private currentSessionAbort?: AbortController;
   private outboundQueue: Uint8Array[] = [];
@@ -376,6 +375,7 @@ export class RotatingShellSession {
   ) {
     this.tracker = new RotationTracker(options.logger, options.url);
     this.sessionReady = this.openNextSession();
+    this.sessionReady.catch(() => {});
   }
 
   private async openNextSession(): Promise<void> {
@@ -395,6 +395,10 @@ export class RotatingShellSession {
     if (this.currentSession) {
       this.currentSession.send(message);
       return;
+    }
+    if (this.outboundQueue.length >= RotatingShellSession.OUTBOUND_QUEUE_CAP) {
+      this.options.logger.warn({ event: "SHELL_OUTBOUND_QUEUE_OVERFLOW", url: this.options.url, dropped: 1 });
+      this.outboundQueue.shift();
     }
     this.outboundQueue.push(message);
   }
@@ -431,10 +435,8 @@ export class RotatingShellSession {
           yield message;
         }
       } finally {
-        if (rotate) {
-          sessionAbort?.abort();
-          await session.disconnect();
-        }
+        sessionAbort?.abort();
+        await session.disconnect();
         if (this.currentSession === session) {
           this.currentSession = undefined;
           this.currentSessionAbort = undefined;
@@ -447,6 +449,7 @@ export class RotatingShellSession {
         return;
       }
       this.sessionReady = this.openNextSession();
+      this.sessionReady.catch(() => {});
     }
   }
 }
@@ -490,8 +493,7 @@ export interface ProviderIdentity {
 
 export interface SendManifestToProviderOptions {
   dseq: string;
-  credentials?: ProviderCredentials | null;
-  ensureToken?: () => Promise<string>;
+  ensureToken: () => Promise<string>;
 }
 
 export type ProviderCredentials = {

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
@@ -54,9 +54,10 @@ export class ProviderProxyService {
       this.logger.info({ event: "ATTEMPT_SEND_MANIFEST", attempt: i, providerAddress: providerInfo.owner, dseq: options.dseq });
       try {
         if (!response) {
+          const credentials = options.ensureToken ? ({ type: "jwt", value: await options.ensureToken() } satisfies ProviderCredentials) : options.credentials;
           response = await this.request(`/deployment/${options.dseq}/manifest`, {
             method: "PUT",
-            credentials: options.credentials,
+            credentials,
             body: serializedManifest,
             timeout: 60_000,
             providerIdentity: providerInfo
@@ -89,7 +90,7 @@ export class ProviderProxyService {
   async downloadLogs(input: {
     providerBaseUrl: string;
     providerAddress: string;
-    providerCredentials: ProviderCredentials;
+    ensureToken: () => Promise<string>;
     dseq: string;
     gseq: number;
     oseq: number;
@@ -139,7 +140,7 @@ export class ProviderProxyService {
   async downloadFileFromShell(input: {
     providerBaseUrl: string;
     providerAddress: string;
-    providerCredentials: ProviderCredentials;
+    ensureToken: () => Promise<string>;
     dseq: string;
     gseq: number;
     oseq: number;
@@ -220,7 +221,7 @@ export class ProviderProxyService {
   async *getLogsStream<T extends "logs" | "events">(input: {
     providerBaseUrl: string;
     providerAddress: string;
-    providerCredentials: ProviderCredentials;
+    ensureToken: () => Promise<string>;
     dseq: string;
     gseq: number;
     oseq: number;
@@ -232,38 +233,62 @@ export class ProviderProxyService {
   }): AsyncGenerator<T extends "logs" ? ProviderProxyMessage<LogEntryMessage> : ProviderProxyMessage<K8sEventMessage>> {
     const tail = input.tail ? `&tail=${input.tail}` : "";
     const url = `${providerLeaseUrl(input)}?follow=${input.follow ? "true" : "false"}${tail}${input.services ? `&service=${input.services.join(",")}` : ""}`;
+    const tracker = new RotationTracker(this.logger, url);
 
-    const session = new WebsocketSession<undefined, T extends "logs" ? ProviderProxyMessage<LogEntryMessage> : ProviderProxyMessage<K8sEventMessage>>({
-      websocketFactory: this.createWebSocket,
-      shouldRetry: error => !error.cause || !isInvalidProviderCertificate(error.cause as CloseEvent),
-      signal: input.signal,
-      transformSentMessage: () =>
-        JSON.stringify({
-          type: "websocket",
-          url,
-          auth: providerCredentialsToApiCredentials(input.providerCredentials),
-          providerAddress: input.providerAddress
-        }),
-      transformReceivedMessage: rawMessage => {
-        const message = JSON.parse(rawMessage as string);
-        if (!message.message) return message;
+    type LogStreamMessage = T extends "logs" ? ProviderProxyMessage<LogEntryMessage> : ProviderProxyMessage<K8sEventMessage>;
 
-        return {
-          ...message,
-          message: JSON.parse(message.message)
-        };
+    while (!input.signal?.aborted) {
+      const token = await input.ensureToken();
+      if (input.signal?.aborted) return;
+      const rotationAbort = new AbortController();
+      const session = new WebsocketSession<undefined, LogStreamMessage>({
+        websocketFactory: this.createWebSocket,
+        shouldRetry: error => !error.cause || !isInvalidProviderCertificate(error.cause as CloseEvent),
+        signal: mergeSignals(input.signal, rotationAbort.signal),
+        transformSentMessage: () =>
+          JSON.stringify({
+            type: "websocket",
+            url,
+            auth: { type: "jwt", token } satisfies ProviderApiCredentials,
+            providerAddress: input.providerAddress
+          }),
+        transformReceivedMessage: rawMessage => {
+          const message = JSON.parse(rawMessage as string);
+          if (!message.message) return message;
+
+          return {
+            ...message,
+            message: JSON.parse(message.message)
+          };
+        }
+      });
+
+      session.send(undefined);
+
+      let rotate = false;
+      try {
+        for await (const message of session.receive()) {
+          if (isTokenExpiredMessage(message)) {
+            rotate = true;
+            break;
+          }
+          yield message;
+        }
+      } finally {
+        if (rotate) {
+          rotationAbort.abort();
+          await session.disconnect();
+        }
       }
-    });
 
-    session.send(undefined);
-
-    return yield* session.receive();
+      if (!rotate || !tracker.allowRotation()) return;
+    }
   }
 
   connectToShell(input: {
     providerBaseUrl: string;
     providerAddress: string;
-    providerCredentials: ProviderCredentials;
+    ensureToken: () => Promise<string>;
     dseq: string;
     gseq: number;
     oseq: number;
@@ -272,32 +297,169 @@ export class ProviderProxyService {
     useTTY?: boolean;
     command?: string[];
     signal?: AbortSignal;
-  }): WebsocketSession<Uint8Array, ReceivedShellMessage> {
+  }): RotatingShellSession {
     const argv = input.command ?? ["sh", "-c", "command -v bash >/dev/null 2>&1 && exec bash || exec sh"];
     const command = argv.map((c, i) => `cmd${i}=${encodeURIComponent(c)}`).join("&");
     const url = `${providerLeaseUrl({ ...input, type: "shell" })}?stdin=${input.useStdIn ? "1" : "0"}&tty=${input.useTTY ? "1" : "0"}&podIndex=0&${command}&service=${encodeURIComponent(input.service)}`;
+    const createWebSocket = this.createWebSocket;
 
-    return new WebsocketSession<Uint8Array, ReceivedShellMessage>({
-      websocketFactory: this.createWebSocket,
-      shouldRetry: error => !error.cause || !isInvalidProviderCertificate(error.cause as CloseEvent),
+    return new RotatingShellSession({
+      ensureToken: input.ensureToken,
       signal: input.signal,
-      transformSentMessage: message => {
-        const remoteMessage: Record<string, unknown> = {
-          type: "websocket",
-          url,
-          auth: providerCredentialsToApiCredentials(input.providerCredentials),
-          providerAddress: input.providerAddress,
-          isBase64: true
-        };
+      logger: this.logger,
+      url,
+      createSession: (token, sessionSignal) =>
+        new WebsocketSession<Uint8Array, ReceivedShellMessage>({
+          websocketFactory: createWebSocket,
+          shouldRetry: error => !error.cause || !isInvalidProviderCertificate(error.cause as CloseEvent),
+          signal: sessionSignal,
+          transformSentMessage: message => {
+            const remoteMessage: Record<string, unknown> = {
+              type: "websocket",
+              url,
+              auth: { type: "jwt", token } satisfies ProviderApiCredentials,
+              providerAddress: input.providerAddress,
+              isBase64: true
+            };
 
-        if (message.length > 0) {
-          remoteMessage.data = toBase64(message);
-        }
+            if (message.length > 0) {
+              remoteMessage.data = toBase64(message);
+            }
 
-        return JSON.stringify(remoteMessage);
-      }
+            return JSON.stringify(remoteMessage);
+          }
+        })
     });
   }
+}
+
+class RotationTracker {
+  private static readonly WINDOW_MS = 60_000;
+  private static readonly MAX_PER_WINDOW = 3;
+  private readonly timestamps: number[] = [];
+
+  constructor(
+    private readonly logger: LoggerService,
+    private readonly url: string
+  ) {}
+
+  allowRotation(): boolean {
+    const now = Date.now();
+    while (this.timestamps.length > 0 && this.timestamps[0] < now - RotationTracker.WINDOW_MS) {
+      this.timestamps.shift();
+    }
+    this.timestamps.push(now);
+    if (this.timestamps.length > RotationTracker.MAX_PER_WINDOW) {
+      this.logger.error({ event: "WS_ROTATION_LIMIT_EXCEEDED", url: this.url });
+      return false;
+    }
+    return true;
+  }
+}
+
+export class RotatingShellSession {
+  private currentSession?: WebsocketSession<Uint8Array, ReceivedShellMessage>;
+  private currentSessionAbort?: AbortController;
+  private outboundQueue: Uint8Array[] = [];
+  private readonly tracker: RotationTracker;
+  private isDisconnected = false;
+  private sessionReady: Promise<void>;
+
+  constructor(
+    private readonly options: {
+      ensureToken: () => Promise<string>;
+      createSession: (token: string, signal: AbortSignal) => WebsocketSession<Uint8Array, ReceivedShellMessage>;
+      logger: LoggerService;
+      url: string;
+      signal?: AbortSignal;
+    }
+  ) {
+    this.tracker = new RotationTracker(options.logger, options.url);
+    this.sessionReady = this.openNextSession();
+  }
+
+  private async openNextSession(): Promise<void> {
+    const token = await this.options.ensureToken();
+    if (this.isDisconnected || this.options.signal?.aborted) return;
+    const sessionAbort = new AbortController();
+    const session = this.options.createSession(token, mergeSignals(this.options.signal, sessionAbort.signal));
+    this.currentSession = session;
+    this.currentSessionAbort = sessionAbort;
+    while (this.outboundQueue.length > 0) {
+      session.send(this.outboundQueue.shift()!);
+    }
+  }
+
+  send(message: Uint8Array): void {
+    if (this.isDisconnected) return;
+    if (this.currentSession) {
+      this.currentSession.send(message);
+      return;
+    }
+    this.outboundQueue.push(message);
+  }
+
+  async disconnect(): Promise<void> {
+    this.isDisconnected = true;
+    this.outboundQueue = [];
+    this.currentSessionAbort?.abort();
+    if (this.currentSession) {
+      await this.currentSession.disconnect();
+      this.currentSession = undefined;
+    }
+  }
+
+  async *receive(): AsyncGenerator<ReceivedShellMessage> {
+    while (!this.isDisconnected && !this.options.signal?.aborted) {
+      try {
+        await this.sessionReady;
+      } catch {
+        yield { closed: true } as ReceivedShellMessage;
+        return;
+      }
+      const session = this.currentSession;
+      const sessionAbort = this.currentSessionAbort;
+      if (!session) return;
+
+      let rotate = false;
+      try {
+        for await (const message of session.receive()) {
+          if (isTokenExpiredMessage(message)) {
+            rotate = true;
+            break;
+          }
+          yield message;
+        }
+      } finally {
+        if (rotate) {
+          sessionAbort?.abort();
+          await session.disconnect();
+        }
+        if (this.currentSession === session) {
+          this.currentSession = undefined;
+          this.currentSessionAbort = undefined;
+        }
+      }
+
+      if (!rotate) return;
+      if (!this.tracker.allowRotation()) {
+        yield { closed: true } as ReceivedShellMessage;
+        return;
+      }
+      this.sessionReady = this.openNextSession();
+    }
+  }
+}
+
+function isTokenExpiredMessage(message: unknown): boolean {
+  return typeof message === "object" && message !== null && (message as { error?: string }).error === "tokenExpired";
+}
+
+function mergeSignals(...signals: Array<AbortSignal | undefined>): AbortSignal {
+  const defined = signals.filter((s): s is AbortSignal => !!s);
+  if (defined.length === 0) return new AbortController().signal;
+  if (defined.length === 1) return defined[0];
+  return AbortSignal.any(defined);
 }
 
 function providerLeaseUrl(input: { providerBaseUrl: string; dseq: string; gseq: number; oseq: number; type: "logs" | "events" | "shell" }): string {
@@ -329,6 +491,7 @@ export interface ProviderIdentity {
 export interface SendManifestToProviderOptions {
   dseq: string;
   credentials?: ProviderCredentials | null;
+  ensureToken?: () => Promise<string>;
 }
 
 export type ProviderCredentials = {

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
@@ -242,7 +242,13 @@ export class ProviderProxyService {
     type LogStreamMessage = T extends "logs" ? ProviderProxyMessage<LogEntryMessage> : ProviderProxyMessage<K8sEventMessage>;
 
     while (!input.signal?.aborted) {
-      const token = await input.ensureToken();
+      let token: string;
+      try {
+        token = await input.ensureToken();
+      } catch {
+        yield { closed: true } as LogStreamMessage;
+        return;
+      }
       if (input.signal?.aborted) return;
       const rotationAbort = new AbortController();
       const session = new WebsocketSession<undefined, LogStreamMessage>({
@@ -283,7 +289,11 @@ export class ProviderProxyService {
         await session.disconnect();
       }
 
-      if (!rotate || !tracker.allowRotation()) return;
+      if (!rotate) return;
+      if (!tracker.allowRotation()) {
+        yield { closed: true } as LogStreamMessage;
+        return;
+      }
     }
   }
 

--- a/apps/deploy-web/src/services/provider-proxy/ws-rotation.ts
+++ b/apps/deploy-web/src/services/provider-proxy/ws-rotation.ts
@@ -15,11 +15,11 @@ export class RotationTracker {
     while (this.timestamps.length > 0 && this.timestamps[0] < now - RotationTracker.WINDOW_MS) {
       this.timestamps.shift();
     }
-    this.timestamps.push(now);
-    if (this.timestamps.length > RotationTracker.MAX_PER_WINDOW) {
+    if (this.timestamps.length >= RotationTracker.MAX_PER_WINDOW) {
       this.logger.error({ event: "WS_ROTATION_LIMIT_EXCEEDED", url: this.url });
       return false;
     }
+    this.timestamps.push(now);
     return true;
   }
 }

--- a/apps/deploy-web/src/services/provider-proxy/ws-rotation.ts
+++ b/apps/deploy-web/src/services/provider-proxy/ws-rotation.ts
@@ -1,0 +1,36 @@
+import type { LoggerService } from "@akashnetwork/logging";
+
+export class RotationTracker {
+  private static readonly WINDOW_MS = 60_000;
+  private static readonly MAX_PER_WINDOW = 3;
+  private readonly timestamps: number[] = [];
+
+  constructor(
+    private readonly logger: LoggerService,
+    private readonly url: string
+  ) {}
+
+  allowRotation(): boolean {
+    const now = Date.now();
+    while (this.timestamps.length > 0 && this.timestamps[0] < now - RotationTracker.WINDOW_MS) {
+      this.timestamps.shift();
+    }
+    this.timestamps.push(now);
+    if (this.timestamps.length > RotationTracker.MAX_PER_WINDOW) {
+      this.logger.error({ event: "WS_ROTATION_LIMIT_EXCEEDED", url: this.url });
+      return false;
+    }
+    return true;
+  }
+}
+
+export function isTokenExpiredMessage(message: unknown): boolean {
+  return typeof message === "object" && message !== null && (message as { error?: string }).error === "tokenExpired";
+}
+
+export function mergeSignals(...signals: Array<AbortSignal | undefined>): AbortSignal {
+  const defined = signals.filter((s): s is AbortSignal => !!s);
+  if (defined.length === 0) return new AbortController().signal;
+  if (defined.length === 1) return defined[0];
+  return AbortSignal.any(defined);
+}

--- a/apps/deploy-web/src/store/providerCredentialsStore.spec.ts
+++ b/apps/deploy-web/src/store/providerCredentialsStore.spec.ts
@@ -1,0 +1,124 @@
+import { createStore } from "jotai";
+import { describe, expect, it, vi } from "vitest";
+
+import providerCredentialsStore from "./providerCredentialsStore";
+
+describe("providerCredentialsStore", () => {
+  describe("claimInFlightTokenRequest", () => {
+    it("creates and stores a new promise when nothing is in flight", () => {
+      const { store } = setup();
+      const promise = Promise.resolve("token-1");
+      const createPromise = vi.fn().mockReturnValue(promise);
+
+      const result = store.set(providerCredentialsStore.claimInFlightTokenRequest, { address: "akash1aaa", createPromise });
+
+      expect(result).toBe(promise);
+      expect(createPromise).toHaveBeenCalledTimes(1);
+      expect(store.get(providerCredentialsStore.inFlightTokenRequest)).toEqual({ address: "akash1aaa", promise });
+    });
+
+    it("returns the existing promise when the address matches", () => {
+      const { store } = setup();
+      const existing = Promise.resolve("existing-token");
+      store.set(providerCredentialsStore.inFlightTokenRequest, { address: "akash1aaa", promise: existing });
+      const createPromise = vi.fn();
+
+      const result = store.set(providerCredentialsStore.claimInFlightTokenRequest, { address: "akash1aaa", createPromise });
+
+      expect(result).toBe(existing);
+      expect(createPromise).not.toHaveBeenCalled();
+    });
+
+    it("creates a new promise and overwrites when the address differs", () => {
+      const { store } = setup();
+      const existing = Promise.resolve("existing-token");
+      store.set(providerCredentialsStore.inFlightTokenRequest, { address: "akash1aaa", promise: existing });
+      const newPromise = Promise.resolve("new-token");
+      const createPromise = vi.fn().mockReturnValue(newPromise);
+
+      const result = store.set(providerCredentialsStore.claimInFlightTokenRequest, { address: "akash1bbb", createPromise });
+
+      expect(result).toBe(newPromise);
+      expect(createPromise).toHaveBeenCalledTimes(1);
+      expect(store.get(providerCredentialsStore.inFlightTokenRequest)).toEqual({ address: "akash1bbb", promise: newPromise });
+    });
+
+    it("only calls createPromise once for parallel claims at the same address", () => {
+      const { store } = setup();
+      const promise = Promise.resolve("token");
+      const createPromise = vi.fn().mockReturnValue(promise);
+
+      const first = store.set(providerCredentialsStore.claimInFlightTokenRequest, { address: "akash1aaa", createPromise });
+      const second = store.set(providerCredentialsStore.claimInFlightTokenRequest, { address: "akash1aaa", createPromise });
+
+      expect(first).toBe(second);
+      expect(createPromise).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("releaseInFlightTokenRequest", () => {
+    it("clears the in-flight entry when the released promise matches", () => {
+      const { store } = setup();
+      const promise = Promise.resolve("token");
+      store.set(providerCredentialsStore.inFlightTokenRequest, { address: "akash1aaa", promise });
+
+      store.set(providerCredentialsStore.releaseInFlightTokenRequest, promise);
+
+      expect(store.get(providerCredentialsStore.inFlightTokenRequest)).toBeNull();
+    });
+
+    it("leaves the in-flight entry intact when a different promise is released", () => {
+      const { store } = setup();
+      const currentPromise = Promise.resolve("current");
+      const otherPromise = Promise.resolve("other");
+      const current = { address: "akash1aaa", promise: currentPromise };
+      store.set(providerCredentialsStore.inFlightTokenRequest, current);
+
+      store.set(providerCredentialsStore.releaseInFlightTokenRequest, otherPromise);
+
+      expect(store.get(providerCredentialsStore.inFlightTokenRequest)).toEqual(current);
+    });
+
+    it("is a no-op when nothing is in flight", () => {
+      const { store } = setup();
+      const promise = Promise.resolve("token");
+
+      store.set(providerCredentialsStore.releaseInFlightTokenRequest, promise);
+
+      expect(store.get(providerCredentialsStore.inFlightTokenRequest)).toBeNull();
+    });
+  });
+
+  describe("clearInFlightTokenRequestForOtherAddress", () => {
+    it("clears the in-flight entry when the stored address differs", () => {
+      const { store } = setup();
+      store.set(providerCredentialsStore.inFlightTokenRequest, { address: "akash1aaa", promise: Promise.resolve("token") });
+
+      store.set(providerCredentialsStore.clearInFlightTokenRequestForOtherAddress, "akash1bbb");
+
+      expect(store.get(providerCredentialsStore.inFlightTokenRequest)).toBeNull();
+    });
+
+    it("preserves the in-flight entry when the stored address matches", () => {
+      const { store } = setup();
+      const current = { address: "akash1aaa", promise: Promise.resolve("token") };
+      store.set(providerCredentialsStore.inFlightTokenRequest, current);
+
+      store.set(providerCredentialsStore.clearInFlightTokenRequestForOtherAddress, "akash1aaa");
+
+      expect(store.get(providerCredentialsStore.inFlightTokenRequest)).toEqual(current);
+    });
+
+    it("is a no-op when nothing is in flight", () => {
+      const { store } = setup();
+
+      store.set(providerCredentialsStore.clearInFlightTokenRequestForOtherAddress, "akash1aaa");
+
+      expect(store.get(providerCredentialsStore.inFlightTokenRequest)).toBeNull();
+    });
+  });
+
+  function setup() {
+    return { store: createStore() };
+  }
+});

--- a/apps/deploy-web/src/store/providerCredentialsStore.ts
+++ b/apps/deploy-web/src/store/providerCredentialsStore.ts
@@ -1,7 +1,36 @@
 import { atom } from "jotai";
 
-const inFlightTokenRequest = atom<{ address: string; promise: Promise<string> } | null>(null);
+type InFlightTokenRequest = { address: string; promise: Promise<string> } | null;
+
+const inFlightTokenRequest = atom<InFlightTokenRequest>(null);
+
+const claimInFlightTokenRequest = atom(null, (get, set, payload: { address: string; createPromise: () => Promise<string> }): Promise<string> => {
+  const current = get(inFlightTokenRequest);
+  if (current && current.address === payload.address) {
+    return current.promise;
+  }
+  const promise = payload.createPromise();
+  set(inFlightTokenRequest, { address: payload.address, promise });
+  return promise;
+});
+
+const releaseInFlightTokenRequest = atom(null, (get, set, promise: Promise<string>) => {
+  const current = get(inFlightTokenRequest);
+  if (current?.promise === promise) {
+    set(inFlightTokenRequest, null);
+  }
+});
+
+const clearInFlightTokenRequestForOtherAddress = atom(null, (get, set, address: string) => {
+  const current = get(inFlightTokenRequest);
+  if (current && current.address !== address) {
+    set(inFlightTokenRequest, null);
+  }
+});
 
 export default {
-  inFlightTokenRequest
+  inFlightTokenRequest,
+  claimInFlightTokenRequest,
+  releaseInFlightTokenRequest,
+  clearInFlightTokenRequestForOtherAddress
 };

--- a/apps/deploy-web/src/store/providerCredentialsStore.ts
+++ b/apps/deploy-web/src/store/providerCredentialsStore.ts
@@ -1,0 +1,7 @@
+import { atom } from "jotai";
+
+const inFlightTokenRequest = atom<{ address: string; promise: Promise<string> } | null>(null);
+
+export default {
+  inFlightTokenRequest
+};

--- a/apps/provider-proxy/src/services/WebsocketServer.spec.ts
+++ b/apps/provider-proxy/src/services/WebsocketServer.spec.ts
@@ -1,0 +1,141 @@
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import WebSocket from "ws";
+import { z } from "zod";
+
+import { emitVerifiedWhenOpen, isJwtExpiredError } from "./WebsocketServer";
+
+describe("emitVerifiedWhenOpen", () => {
+  it("emits 'verified' synchronously when the socket is already OPEN", () => {
+    const { ws } = setup({ readyState: WebSocket.OPEN });
+    const listener = vi.fn();
+    ws.on("verified", listener);
+
+    emitVerifiedWhenOpen(ws);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits 'verified' only after the socket transitions to OPEN", () => {
+    const { ws } = setup({ readyState: WebSocket.CONNECTING });
+    const listener = vi.fn();
+    ws.on("verified", listener);
+
+    emitVerifiedWhenOpen(ws);
+
+    expect(listener).not.toHaveBeenCalled();
+
+    ws.emit("open");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("attaches a one-shot listener so subsequent 'open' events do not re-emit", () => {
+    const { ws } = setup({ readyState: WebSocket.CONNECTING });
+    const listener = vi.fn();
+    ws.on("verified", listener);
+
+    emitVerifiedWhenOpen(ws);
+    ws.emit("open");
+    ws.emit("open");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  function setup(input: { readyState: number }) {
+    const emitter = new EventEmitter();
+    const ws = mock<WebSocket>({
+      readyState: input.readyState as WebSocket["readyState"],
+      emit: emitter.emit.bind(emitter) as WebSocket["emit"],
+      on: emitter.on.bind(emitter) as WebSocket["on"],
+      once: emitter.once.bind(emitter) as WebSocket["once"]
+    });
+    return { ws };
+  }
+});
+
+describe("isJwtExpiredError", () => {
+  it("returns true for a custom issue on auth.token with 'Token has expired'", () => {
+    const error = buildZodError([
+      {
+        code: z.ZodIssueCode.custom,
+        path: ["auth", "token"],
+        message: "is not a valid JWT token",
+        params: { errors: ["Token has expired"] }
+      }
+    ]);
+
+    expect(isJwtExpiredError(error)).toBe(true);
+  });
+
+  it("returns false when the issue path is not auth.token", () => {
+    const error = buildZodError([
+      {
+        code: z.ZodIssueCode.custom,
+        path: ["auth", "certPem"],
+        message: "is not a valid certificate",
+        params: { errors: ["Token has expired"] }
+      }
+    ]);
+
+    expect(isJwtExpiredError(error)).toBe(false);
+  });
+
+  it("returns false when the issue code is not custom", () => {
+    const error = buildZodError([
+      {
+        code: z.ZodIssueCode.invalid_type,
+        path: ["auth", "token"],
+        message: "Required",
+        expected: "string",
+        received: "undefined"
+      }
+    ]);
+
+    expect(isJwtExpiredError(error)).toBe(false);
+  });
+
+  it("returns false when params.errors does not include the expired marker", () => {
+    const error = buildZodError([
+      {
+        code: z.ZodIssueCode.custom,
+        path: ["auth", "token"],
+        message: "is not a valid JWT token",
+        params: { errors: ["Invalid token"] }
+      }
+    ]);
+
+    expect(isJwtExpiredError(error)).toBe(false);
+  });
+
+  it("returns false when params is missing", () => {
+    const error = buildZodError([
+      {
+        code: z.ZodIssueCode.custom,
+        path: ["auth", "token"],
+        message: "is not a valid JWT token"
+      }
+    ]);
+
+    expect(isJwtExpiredError(error)).toBe(false);
+  });
+
+  it("returns true when at least one issue in the list matches", () => {
+    const error = buildZodError([
+      { code: z.ZodIssueCode.custom, path: ["url"], message: "bad url" },
+      {
+        code: z.ZodIssueCode.custom,
+        path: ["auth", "token"],
+        message: "is not a valid JWT token",
+        params: { errors: ["Token has expired"] }
+      }
+    ]);
+
+    expect(isJwtExpiredError(error)).toBe(true);
+  });
+
+  function buildZodError(issues: z.ZodIssue[]) {
+    return new z.ZodError(issues);
+  }
+});

--- a/apps/provider-proxy/src/services/WebsocketServer.ts
+++ b/apps/provider-proxy/src/services/WebsocketServer.ts
@@ -276,7 +276,7 @@ export class WebsocketServer {
         if (socket?.authorized) {
           // CA validation is successful, so certificate is not self-signed
           wsDetails.verification = "finished";
-          pws.emit("verified");
+          emitVerifiedWhenOpen(pws);
           return;
         }
 
@@ -451,6 +451,14 @@ interface CreateProviderSocketOptions {
   wsId: string;
   auth?: z.infer<typeof providerRequestSchema>["auth"];
   providerAddress: string;
+}
+
+function emitVerifiedWhenOpen(ws: WebSocket): void {
+  if (ws.readyState === WebSocket.OPEN) {
+    ws.emit("verified");
+    return;
+  }
+  ws.once("open", () => ws.emit("verified"));
 }
 
 function isJwtExpiredError(error: z.ZodError): boolean {

--- a/apps/provider-proxy/src/services/WebsocketServer.ts
+++ b/apps/provider-proxy/src/services/WebsocketServer.ts
@@ -114,6 +114,14 @@ export class WebsocketServer {
                 message: "Message doesn't match expected schema",
                 error: parsedMessage.error
               });
+              if (isJwtExpiredError(parsedMessage.error)) {
+                return ws.send(
+                  JSON.stringify({
+                    type: "websocket",
+                    error: "tokenExpired"
+                  })
+                );
+              }
               return ws.send(
                 JSON.stringify({
                   type: "websocket",
@@ -443,6 +451,15 @@ interface CreateProviderSocketOptions {
   wsId: string;
   auth?: z.infer<typeof providerRequestSchema>["auth"];
   providerAddress: string;
+}
+
+function isJwtExpiredError(error: z.ZodError): boolean {
+  return error.errors.some(issue => {
+    if (issue.code !== z.ZodIssueCode.custom) return false;
+    if (issue.path[0] !== "auth" || issue.path[1] !== "token") return false;
+    const params = (issue as { params?: { errors?: unknown } }).params;
+    return Array.isArray(params?.errors) && params.errors.includes("Token has expired");
+  });
 }
 
 function getWebSocketUsage(message: any): WebSocketUsage {

--- a/apps/provider-proxy/src/services/WebsocketServer.ts
+++ b/apps/provider-proxy/src/services/WebsocketServer.ts
@@ -453,7 +453,7 @@ interface CreateProviderSocketOptions {
   providerAddress: string;
 }
 
-function emitVerifiedWhenOpen(ws: WebSocket): void {
+export function emitVerifiedWhenOpen(ws: WebSocket): void {
   if (ws.readyState === WebSocket.OPEN) {
     ws.emit("verified");
     return;
@@ -461,7 +461,7 @@ function emitVerifiedWhenOpen(ws: WebSocket): void {
   ws.once("open", () => ws.emit("verified"));
 }
 
-function isJwtExpiredError(error: z.ZodError): boolean {
+export function isJwtExpiredError(error: z.ZodError): boolean {
   return error.errors.some(issue => {
     if (issue.code !== z.ZodIssueCode.custom) return false;
     if (issue.path[0] !== "auth" || issue.path[1] !== "token") return false;

--- a/apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts
@@ -409,7 +409,7 @@ describe("Provider proxy ws", () => {
       version: "v1",
       leases: { access: "full" }
     };
-    const encoded = Buffer.from(JSON.stringify(expiredPayload)).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    const encoded = Buffer.from(JSON.stringify(expiredPayload)).toString("base64url");
     return `${header}.${encoded}.${signature}`;
   }
 

--- a/apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts
+++ b/apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts
@@ -358,6 +358,61 @@ describe("Provider proxy ws", () => {
     );
   });
 
+  it("emits a structured tokenExpired payload when the client sends an expired JWT", async () => {
+    const providerAddress = generateBech32();
+    const certPair = await createX509CertPair({ commonName: providerAddress });
+    const chainServer = await startChainApiServer([certPair.cert]);
+    const { providerUrl } = await startProviderServer({
+      certPair,
+      websocketServer: { enable: true, onConnection: pws => pws.send("connected") }
+    });
+    const proxyServerUrl = await startServer({ REST_API_NODE_URL: chainServer.url });
+    const ws = new WebSocket(`${proxyServerUrl}/ws`);
+
+    await new Promise(resolve => ws.once("open", resolve));
+
+    const wallet = await Secp256k1HdWallet.generate(24, { prefix: "akash" });
+    const tokenManager = new JwtTokenManager(wallet);
+    const issuer = (await wallet.getAccounts())[0].address;
+    const validToken = await tokenManager.generateToken({
+      iss: issuer,
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      version: "v1",
+      leases: { access: "full" }
+    });
+    const expiredToken = withExpiredPayload(validToken, issuer);
+
+    ws.send(
+      JSON.stringify(
+        ourMessage("hello", providerUrl, {
+          providerAddress,
+          auth: { type: "jwt", token: expiredToken }
+        })
+      )
+    );
+
+    expect(await waitForMessage(ws)).toEqual({
+      type: "websocket",
+      error: "tokenExpired"
+    });
+  });
+
+  function withExpiredPayload(token: string, issuer: string): string {
+    const [header, , signature] = token.split(".");
+    const now = Math.floor(Date.now() / 1000);
+    const expiredPayload = {
+      iss: issuer,
+      iat: now - 7200,
+      nbf: now - 7200,
+      exp: now - 60,
+      version: "v1",
+      leases: { access: "full" }
+    };
+    const encoded = Buffer.from(JSON.stringify(expiredPayload)).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+    return `${header}.${encoded}.${signature}`;
+  }
+
   function providerMessage<T>(message: T, extra?: Record<string, any>) {
     return {
       ...extra,


### PR DESCRIPTION
## Why

Fixes CON-371. PR #3217 (CON-268) switched managed `deploy-web` to a JWT-only provider auth flow with a cache-first `ensureToken()` (jotai atom + localStorage, 30 min TTL). The cache works on the happy path but several edge cases reduced its value or stranded users:

- Mount-time race regenerated a perfectly good stored token on every refresh.
- WS streams (shell / logs / events) snapshot the token once at handshake, so mid-session expiry left a dead connection with no recovery.
- No proactive refresh or clock-skew tolerance — a stream opened seconds before `exp` died almost immediately.
- Auto-gen failures were swallowed silently.
- Multiple credential-using hook instances raced on mount, each firing its own `POST /v1/create-jwt-token`.
- Provider JWT scope was missing `send-manifest` / `get-manifest`, so PUT /manifest returned 401 in production paths after CON-268 — caught during smoke and bundled in.
- `sendManifest`'s internal retry loop snapshotted the token at call time; long flows (lease-not-found backoff) could outlive the cached token.

## What

Client (`apps/deploy-web`):
- `useProviderJwt`: hydrated flag + skew-aware `isTokenExpired` (`REFRESH_SKEW_SECONDS = 60`), JWT scope extended to include `send-manifest` / `get-manifest`.
- `useProviderCredentials`: cockatiel retry inside `ensureToken`, toast on exhaustion via `useNotificator`, `details.error` exposed, in-flight tracker promoted to module scope so all hook instances dedup against the same POST. Cleared on `address` change.
- `provider-proxy.service.ts`: WS rotation loop in `getLogsStream` and a new `RotatingShellSession` that swap the underlying WebsocketSession on `tokenExpired`, capped at 3 rotations within 60s. Per-session inner AbortController so cockatiel doesn't retry on intentional rotation disconnects. Emits a synthetic `closed: true` when the cap is exceeded or auth-gen fails, so the existing "unavailable" panel surfaces. `sendManifest` calls `ensureToken` per attempt inside its internal retry loop.
- `DeploymentLeaseShell` / `DeploymentLogs`: sticky `hasShellAccess` / `hasLogsAccess` state so the panes survive transient `usable` flips during refresh; skeleton-loading placeholder while credentials load; warning alert when auth-gen ultimately fails.
- `useLeaseStatus`, `ManifestUpdate`, `LeaseRow`, `CreateLease`, `useProviderApiActions`: switched from snapshot `providerCredentials.details` to `ensureToken` flow where the request is auth-bearing.

Server (`apps/provider-proxy`):
- `WebsocketServer`: when the schema-validation failure is specifically "Token has expired", emit `{ type: "websocket", error: "tokenExpired" }` (stable contract) instead of the generic `Invalid message format` shape. Other schema failures unchanged.

Specs:
- `useProviderJwt.spec.tsx`, `useProviderCredentials.spec.ts`, `provider-proxy.service.spec.ts`, `useLeaseQuery.spec.tsx`, `ManifestUpdate.spec.tsx` updated for the new contract and new behaviors. Added functional case in `apps/provider-proxy/test/functional/provider-proxy-ws.spec.ts` asserting the structured `tokenExpired` payload.

## Verification

- `npm run lint -- --quiet` clean in `apps/deploy-web` and `apps/provider-proxy`.
- `npx tsc --noEmit` delta is 0 (17 pre-existing `ManifestUpdate.spec.tsx` errors unrelated to this PR).
- `npm run test:unit` green in both apps.
- Manual smoke run under a shortened 90s TTL (then reverted):
  - AC1: no `POST /v1/create-jwt-token` on hard refresh while the cached token is in-window.
  - AC2: opening logs/shell while the token is in the 60s skew window triggers exactly one refresh POST.
  - AC3: token expires mid-shell → DevTools shows the structured `{ error: "tokenExpired" }` frame, a new WS handshake fires with a fresh `Authorization: Bearer …`, the XTerm stays mounted (no remount on refresh).
  - AC3b: `/v1/create-jwt-token` blocked → after the auth-gen retries exhaust, the synthetic close yields the "Shell access unavailable" alert.
  - AC4: wallet reconnect with `/v1/create-jwt-token` blocked → 4 attempts (1 + 3 retries, ~3.5s), error toast appears, no infinite retry; skeleton shows during the retry window so the pane isn't blank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now shows an explicit auth fallback (error alert or loading skeleton) and gates shell/log actions until provider access is granted.
  * Long-running shell and log sessions automatically rotate credentials to stay connected; queued shell output is preserved across rotations.

* **Bug Fixes**
  * More accurate token-expiry detection and clearer "token expired" websocket messaging.
  * Actions (send manifest, downloads, log streaming) obtain fresh tokens on demand with retry behavior and clearer failure notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->