### PR TITLE
refactor: removes otel instrumentation for net

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45022,7 +45022,6 @@
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^2.5.1",
         "@opentelemetry/instrumentation-http": "^0.212.0",
-        "@opentelemetry/instrumentation-net": "^0.56.0",
         "@opentelemetry/instrumentation-pg": "^0.64.0",
         "@opentelemetry/instrumentation-pino": "^0.58.0",
         "@opentelemetry/instrumentation-runtime-node": "^0.25.0",
@@ -45319,22 +45318,6 @@
         "@opentelemetry/instrumentation": "0.212.0",
         "@opentelemetry/semantic-conventions": "^1.29.0",
         "forwarded-parse": "2.1.2"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "packages/instrumentation/node_modules/@opentelemetry/instrumentation-net": {
-      "version": "0.56.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.56.0.tgz",
-      "integrity": "sha512-h69x7U6f86mP3gGWWTaMkQZk0K3tBvpVMIU7E0q2kkVw6eZ5TqFm9rkaEy38moQmixiDFQ9j/2/cwxG9P7ZEeA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.212.0",
-        "@opentelemetry/semantic-conventions": "^1.33.0"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"

--- a/packages/instrumentation/package.json
+++ b/packages/instrumentation/package.json
@@ -24,7 +24,6 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/core": "^2.5.1",
     "@opentelemetry/instrumentation-http": "^0.212.0",
-    "@opentelemetry/instrumentation-net": "^0.56.0",
     "@opentelemetry/instrumentation-pg": "^0.64.0",
     "@opentelemetry/instrumentation-pino": "^0.58.0",
     "@opentelemetry/instrumentation-runtime-node": "^0.25.0",

--- a/packages/instrumentation/src/instrumentation.ts
+++ b/packages/instrumentation/src/instrumentation.ts
@@ -1,5 +1,4 @@
 import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
-import { NetInstrumentation } from "@opentelemetry/instrumentation-net";
 import { PgInstrumentation } from "@opentelemetry/instrumentation-pg";
 import { PinoInstrumentation } from "@opentelemetry/instrumentation-pino";
 import { RuntimeNodeInstrumentation } from "@opentelemetry/instrumentation-runtime-node";
@@ -18,7 +17,6 @@ export const sdk = new NodeSDK({
     new PinoInstrumentation({
       disableLogSending: true
     }),
-    new NetInstrumentation(),
     new UndiciInstrumentation()
   ],
   resourceDetectors: [containerDetector, processDetector, envDetector, hostDetector]


### PR DESCRIPTION
## Why

otel net instrumentation is noisy in distributed tracing and doesn't give us additional value

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed Net network instrumentation from the instrumentation package to reduce dependencies and streamline the instrumentation setup.
  * No changes to exported/public interfaces or other instrumentations; remaining instrumentation behavior preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->