### PR TITLE
refactor(wallet): collapse signAndBroadcastTx to managed HTTP path

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.spec.tsx
@@ -256,7 +256,6 @@ describe(DeploymentDetailTopBar.name, () => {
         isWalletLoading: false,
         isTrialing: false,
         isOnboarding: false,
-        switchWalletType: vi.fn(),
         hasManagedWallet: false
       })) as typeof DEPENDENCIES.useWallet,
       usePricing: vi.fn(() => ({

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -336,7 +336,6 @@ describe(ManifestUpdate.name, () => {
         isWalletLoading: false,
         isTrialing: false,
         isOnboarding: false,
-        switchWalletType: vi.fn(),
         hasManagedWallet: false,
         denom: "uact"
       }) as ReturnType<typeof DEPENDENCIES.useWallet>;

--- a/apps/deploy-web/src/components/home/YourAccount/YourAccount.spec.tsx
+++ b/apps/deploy-web/src/components/home/YourAccount/YourAccount.spec.tsx
@@ -309,7 +309,6 @@ describe(YourAccount.name, () => {
         isWalletLoading: false,
         isTrialing: false,
         isOnboarding: false,
-        switchWalletType: vi.fn(),
         hasManagedWallet: false
       }) as ReturnType<typeof DEPENDENCIES.useWallet>;
 

--- a/apps/deploy-web/src/components/wallet/ConnectManagedWalletButton.tsx
+++ b/apps/deploy-web/src/components/wallet/ConnectManagedWalletButton.tsx
@@ -25,21 +25,21 @@ interface Props extends ButtonProps {
 
 export const ConnectManagedWalletButton: React.FunctionComponent<Props> = ({ className = "", dependencies: d = DEPENDENCIES, ...rest }) => {
   const { settings } = d.useSettings();
-  const { hasManagedWallet, isWalletLoading, switchWalletType } = useWallet();
+  const { hasManagedWallet, isWalletLoading } = useWallet();
   const router = d.useRouter();
 
   const handleClick: React.MouseEventHandler = useCallback(() => {
-    if (hasManagedWallet) {
-      switchWalletType();
-    } else {
-      router.push(UrlService.onboarding());
-    }
-  }, [hasManagedWallet, switchWalletType, router]);
+    router.push(UrlService.onboarding());
+  }, [router]);
+
+  if (hasManagedWallet) {
+    return null;
+  }
 
   return (
     <Button variant="default" onClick={handleClick} className={className} {...rest} disabled={settings.isBlockchainDown || isWalletLoading}>
       {isWalletLoading ? <Spinner size="small" className="mr-2" variant="dark" /> : <Rocket className="rotate-45 text-xs" />}
-      <span className="m-2 whitespace-nowrap">{hasManagedWallet ? "Switch to USD Payments" : "Start Trial"}</span>
+      <span className="m-2 whitespace-nowrap">Start Trial</span>
     </Button>
   );
 };

--- a/apps/deploy-web/src/components/wallet/ManagedWalletPopup/ManagedWalletPopup.spec.tsx
+++ b/apps/deploy-web/src/components/wallet/ManagedWalletPopup/ManagedWalletPopup.spec.tsx
@@ -28,15 +28,15 @@ describe(ManagedWalletPopup.name, () => {
     expect(screen.getByText(/Wallet Balance is unknown/)).toBeInTheDocument();
   });
 
-  it("renders Free Trial header when managed and trialing", () => {
-    setup({ isManaged: true, isTrialing: true });
+  it("renders Free Trial header when trialing", () => {
+    setup({ isTrialing: true });
 
     expect(screen.getByText("Free Trial")).toBeInTheDocument();
     expect(screen.getByText(/Once your Free credits run out/)).toBeInTheDocument();
   });
 
   it("does not render Free Trial header when not trialing", () => {
-    setup({ isManaged: true, isTrialing: false });
+    setup({ isTrialing: false });
 
     expect(screen.queryByText("Free Trial")).not.toBeInTheDocument();
     expect(screen.queryByText(/Once your Free credits run out/)).not.toBeInTheDocument();
@@ -57,50 +57,13 @@ describe(ManagedWalletPopup.name, () => {
     expect(screen.getByTestId("add-funds-link")).toHaveAttribute("href", "/billing?openPayment=true");
   });
 
-  it("calls switchWalletType when Switch to Wallet Payments is clicked and wallet is connected", () => {
-    const { switchWalletType } = setup({ isWalletConnected: true });
-
-    fireEvent.click(screen.getByRole("button", { name: /Switch to Wallet Payments/ }));
-
-    expect(switchWalletType).toHaveBeenCalledTimes(1);
-  });
-
-  it("calls switchWalletType when Switch to Wallet Payments is clicked and wallet is not connected", () => {
-    const { switchWalletType } = setup({ isWalletConnected: false });
-
-    fireEvent.click(screen.getByRole("button", { name: /Switch to Wallet Payments/ }));
-
-    expect(switchWalletType).toHaveBeenCalledTimes(1);
-  });
-
-  it("hides Switch to Wallet Payments button when self_custody flag is OFF", () => {
-    setup({ isSelfCustodyEnabled: false });
-
-    expect(screen.queryByRole("button", { name: /Switch to Wallet Payments/ })).not.toBeInTheDocument();
-  });
-
-  it("renders Switch to Wallet Payments button when self_custody flag is ON", () => {
-    setup({ isSelfCustodyEnabled: true });
-
-    expect(screen.getByRole("button", { name: /Switch to Wallet Payments/ })).toBeInTheDocument();
-  });
-
-  function setup(input?: {
-    walletBalance?: WalletBalance | null;
-    isManaged?: boolean;
-    isTrialing?: boolean;
-    isWalletConnected?: boolean;
-    isSelfCustodyEnabled?: boolean;
-  }) {
-    const switchWalletType = vi.fn();
+  function setup(input?: { walletBalance?: WalletBalance | null; isTrialing?: boolean }) {
     const showManagedEscrowFaqModal = vi.fn();
 
     const dependencies = {
       ...DEPENDENCIES,
       useWallet: () => ({
-        isManaged: input?.isManaged ?? false,
-        isTrialing: input?.isTrialing ?? false,
-        switchWalletType
+        isTrialing: input?.isTrialing ?? false
       }),
       useManagedEscrowFaqModal: () => ({ showManagedEscrowFaqModal }),
       useServices: () => ({
@@ -108,7 +71,6 @@ describe(ManagedWalletPopup.name, () => {
           billing: ({ openPayment }: { openPayment?: boolean } = {}) => (openPayment ? "/billing?openPayment=true" : "/billing")
         }
       }),
-      useIsSelfCustodyEnabled: () => input?.isSelfCustodyEnabled ?? true,
       FormattedNumber: ({ value }: { value: number }) => <span>{value}</span>,
       LinkTo: ({ children, className, onClick }: { children: React.ReactNode; className?: string; onClick?: () => void }) => (
         <a className={className} onClick={onClick}>
@@ -124,6 +86,6 @@ describe(ManagedWalletPopup.name, () => {
 
     render(<ManagedWalletPopup walletBalance={input?.walletBalance ?? null} dependencies={dependencies} />);
 
-    return { switchWalletType, showManagedEscrowFaqModal };
+    return { showManagedEscrowFaqModal };
   }
 });

--- a/apps/deploy-web/src/components/wallet/ManagedWalletPopup/ManagedWalletPopup.tsx
+++ b/apps/deploy-web/src/components/wallet/ManagedWalletPopup/ManagedWalletPopup.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { FormattedNumber } from "react-intl";
-import { Button, buttonVariants, Card, CardContent, Separator } from "@akashnetwork/ui/components";
+import { buttonVariants, Card, CardContent, Separator } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
-import { CoinsSwap, HandCard } from "iconoir-react";
+import { HandCard } from "iconoir-react";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
-import { useIsSelfCustodyEnabled } from "@src/hooks/useIsSelfCustodyEnabled";
 import { useManagedEscrowFaqModal } from "@src/hooks/useManagedEscrowFaqModal";
 import type { WalletBalance } from "@src/hooks/useWalletBalance";
 import { LinkTo } from "../../shared/LinkTo";
@@ -21,27 +20,23 @@ export const DEPENDENCIES = {
   Card,
   CardContent,
   Separator,
-  Button,
   LinkTo,
   AddFundsLink,
-  CoinsSwap,
   HandCard,
   FormattedNumber,
   useWallet,
   useManagedEscrowFaqModal,
-  useServices,
-  useIsSelfCustodyEnabled
+  useServices
 };
 
 export const ManagedWalletPopup: React.FC<ManagedWalletPopupProps> = ({ walletBalance, dependencies: d = DEPENDENCIES }) => {
-  const { isManaged, isTrialing, switchWalletType } = d.useWallet();
+  const { isTrialing } = d.useWallet();
   const { showManagedEscrowFaqModal } = d.useManagedEscrowFaqModal();
   const { urlService } = d.useServices();
-  const isSelfCustodyEnabled = d.useIsSelfCustodyEnabled();
 
   return (
     <div className="w-[300px] p-2">
-      {isManaged && isTrialing && (
+      {isTrialing && (
         <div className="mb-2 text-sm font-bold">
           <p className="text-center">Free Trial</p>
         </div>
@@ -85,7 +80,7 @@ export const ManagedWalletPopup: React.FC<ManagedWalletPopupProps> = ({ walletBa
         </d.LinkTo>
       </div>
 
-      {isManaged && isTrialing && (
+      {isTrialing && (
         <div className="my-2 text-center text-xs text-muted-foreground">
           Once your Free credits run out, deployments will automatically close. To continue, create an account and add funds with your credit card. Deployments
           from your Free Trial get transferred when creating a new account.
@@ -100,15 +95,6 @@ export const ManagedWalletPopup: React.FC<ManagedWalletPopupProps> = ({ walletBa
           <HandCard className="text-xs" />
           <span className="whitespace-nowrap">Add Funds</span>
         </d.AddFundsLink>
-        {isSelfCustodyEnabled && (
-          <>
-            <d.Separator className="my-2 bg-secondary/90 dark:bg-white/10" />
-            <d.Button onClick={switchWalletType} variant="outline" className="w-full space-x-2">
-              <d.CoinsSwap />
-              <span>Switch to Wallet Payments</span>
-            </d.Button>
-          </>
-        )}
       </div>
     </div>
   );

--- a/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
@@ -1,15 +1,9 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import { buttonVariants, Snackbar } from "@akashnetwork/ui/components";
-import { cn } from "@akashnetwork/ui/utils";
 import type { EncodeObject } from "@cosmjs/proto-signing";
-import { OpenNewWindow } from "iconoir-react";
 import { useAtom } from "jotai";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useSnackbar } from "notistack";
 
-import type { LoadingState } from "@src/components/layout/TransactionModal";
 import { TransactionModal } from "@src/components/layout/TransactionModal";
 import { useManagedWallet } from "@src/hooks/useManagedWallet";
 import { useSelectedChain } from "@src/hooks/useSelectedChain/useSelectedChain";
@@ -20,13 +14,12 @@ import { useBalances } from "@src/queries/useBalancesQuery";
 import networkStore from "@src/store/networkStore";
 import walletStore from "@src/store/walletStore";
 import type { AppError } from "@src/types";
-import { UrlService } from "@src/utils/urlUtils";
 import { getStorageWallets, updateStorageWallets } from "@src/utils/walletUtils";
 import { useServices } from "../ServicesProvider";
 import { useSettings } from "../SettingsProvider";
 import { settingsIdAtom } from "../SettingsProvider/settingsStore";
 import { deriveWalletIsLoading } from "./deriveWalletIsLoading";
-import { signAndBroadcast } from "./signAndBroadcast";
+import { useSignAndBroadcast } from "./useSignAndBroadcast";
 
 type ManagedWalletMarker =
   | {
@@ -52,7 +45,6 @@ export type ContextType = {
   isOnboarding: boolean;
   creditAmount?: number;
   topUpMinAmountUsd: number;
-  switchWalletType: () => void;
   hasManagedWallet: boolean;
   managedWalletError?: AppError;
 } & ManagedWalletMarker;
@@ -66,12 +58,10 @@ export const WalletProviderContext = React.createContext<ContextType>({} as Cont
  * WalletProvider is a client only component
  */
 export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { analyticsService, tx: txHttpService, publicConfig: appConfig, urlService, windowLocation } = useServices();
+  const { analyticsService, publicConfig: appConfig, urlService, windowLocation } = useServices();
 
   const [, setSettingsId] = useAtom(settingsIdAtom);
   const [isWalletLoaded, setIsWalletLoaded] = useState<boolean>(true);
-  const [loadingState, setLoadingState] = useState<LoadingState | undefined>(undefined);
-  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
   const router = useRouter();
   const { settings } = useSettings();
   const { user } = useUser();
@@ -100,6 +90,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     isManagedWalletLoading,
     isCustodialConnecting: userWallet.isWalletConnecting
   });
+  const { signAndBroadcastTx, loadingState } = useSignAndBroadcast({ refetchBalances });
 
   useWhen(walletAddress, loadWallet);
 
@@ -157,11 +148,6 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     windowLocation.reload();
   }, [selectedNetworkId, appConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID, setSelectedNetworkId, windowLocation]);
 
-  function switchWalletType() {
-    // No-op: deploy-web is managed-wallet-only after CON-258. Kept on the
-    // contract so existing consumers compile; the field itself is removed in L-2.
-  }
-
   function connectManagedWallet() {
     if (!managedWallet) {
       createManagedWallet();
@@ -208,48 +194,6 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     }
   }
 
-  async function signAndBroadcastTx(msgs: EncodeObject[]): Promise<boolean> {
-    return signAndBroadcast({
-      userId: user?.id,
-      msgs,
-      txHttpService,
-      analyticsService,
-      setLoadingState,
-      refetchBalances,
-      showAddCreditsSnackbar,
-      showTransactionSnackbar
-    });
-  }
-
-  const showTransactionSnackbar = (
-    snackTitle: string,
-    snackMessage: string,
-    transactionHash: string,
-    snackVariant: React.ComponentProps<typeof Snackbar>["iconVariant"]
-  ) => {
-    enqueueSnackbar(
-      <Snackbar
-        title={snackTitle}
-        subTitle={<TransactionSnackbarContent snackMessage={snackMessage} transactionHash={transactionHash} isError={snackVariant === "error"} />}
-        iconVariant={snackVariant}
-      />,
-      {
-        variant: snackVariant,
-        autoHideDuration: 10000
-      }
-    );
-  };
-
-  const showAddCreditsSnackbar = (snackTitle: string, snackMessage: string) => {
-    const key = enqueueSnackbar(
-      <Snackbar title={snackTitle} subTitle={<AddCreditsSnackbarContent message={snackMessage} onAction={() => closeSnackbar(key)} />} iconVariant="warning" />,
-      {
-        variant: "warning",
-        autoHideDuration: 10000
-      }
-    );
-  };
-
   return (
     <WalletProviderContext.Provider
       value={{
@@ -268,7 +212,6 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         topUpMinAmountUsd: managedWallet?.topUpMinAmountUsd ?? 20,
         hasManagedWallet: !!managedWallet,
         managedWalletError,
-        switchWalletType,
         ...managedMarker
       }}
     >
@@ -289,55 +232,3 @@ export function useIsManagedWalletUser() {
 
   return { canVisit, isLoading };
 }
-
-const SUPPORT_EMAIL = "support@akash.network";
-
-const AddCreditsSnackbarContent: React.FC<{ message?: string; onAction?: () => void }> = ({ message, onAction }) => {
-  const { analyticsService } = useServices();
-  return (
-    <>
-      {message && <div>{message}</div>}
-      <Link
-        href={UrlService.billing({ openPayment: true })}
-        className={cn("mt-2 inline-flex h-7 items-center px-3 text-xs", buttonVariants({ variant: "default" }))}
-        onClick={() => {
-          analyticsService.track("add_funds_btn_clk");
-          onAction?.();
-        }}
-      >
-        Add Funds
-      </Link>
-    </>
-  );
-};
-
-const TransactionSnackbarContent: React.FC<{ snackMessage: string; transactionHash: string; isError?: boolean }> = ({
-  snackMessage,
-  transactionHash,
-  isError
-}) => {
-  const { publicConfig: appConfig } = useServices();
-  const selectedNetworkId = networkStore.useSelectedNetworkId();
-  const txUrl = transactionHash && `${appConfig.NEXT_PUBLIC_STATS_APP_URL}/transactions/${transactionHash}?network=${selectedNetworkId}`;
-
-  return (
-    <>
-      {snackMessage}
-      {snackMessage && <br />}
-      {txUrl && (
-        <Link href={txUrl} target="_blank" className="inline-flex items-center space-x-2 !text-white">
-          <span>View transaction</span>
-          <OpenNewWindow className="text-xs" />
-        </Link>
-      )}
-      {isError && (
-        <div className="mt-2 text-xs">
-          Need help?{" "}
-          <a href={`mailto:${SUPPORT_EMAIL}?subject=Transaction Error&body=${encodeURIComponent(snackMessage)}`} className="underline">
-            Contact {SUPPORT_EMAIL}
-          </a>
-        </div>
-      )}
-    </>
-  );
-};

--- a/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
@@ -8,7 +8,6 @@ import { OpenNewWindow } from "iconoir-react";
 import { useAtom } from "jotai";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import type { SnackbarKey } from "notistack";
 import { useSnackbar } from "notistack";
 
 import type { LoadingState } from "@src/components/layout/TransactionModal";
@@ -23,24 +22,11 @@ import networkStore from "@src/store/networkStore";
 import walletStore from "@src/store/walletStore";
 import type { AppError } from "@src/types";
 import { UrlService } from "@src/utils/urlUtils";
-import { getStorageWallets, updateStorageManagedWallet, updateStorageWallets } from "@src/utils/walletUtils";
+import { getStorageWallets, updateStorageWallets } from "@src/utils/walletUtils";
 import { useServices } from "../ServicesProvider";
 import { useSettings } from "../SettingsProvider";
 import { settingsIdAtom } from "../SettingsProvider/settingsStore";
 import { deriveWalletIsLoading } from "./deriveWalletIsLoading";
-import { useEnforceSelfCustodyFlag } from "./useEnforceSelfCustodyFlag";
-
-const CONSOLE_MEMO = "akash console";
-
-const ERROR_MESSAGES = {
-  5: "Insufficient funds",
-  9: "Unknown address",
-  11: "Out of gas",
-  12: "Memo too large",
-  13: "Insufficient fee",
-  19: "Tx already in mempool",
-  25: "Invalid gas adjustment"
-};
 
 type ManagedWalletMarker =
   | {
@@ -123,13 +109,6 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
     isCustodialConnecting: userWallet.isWalletConnecting
   });
 
-  useEnforceSelfCustodyFlag({
-    isWalletConnected: userWallet.isWalletConnected,
-    selectedWalletType,
-    setSelectedWalletType,
-    disconnect: userWallet.disconnect
-  });
-
   useWhen(walletAddress, loadWallet);
 
   useWhen(isWalletConnected && selectedWalletType, () => {
@@ -187,26 +166,8 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }, [selectedNetworkId, appConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID, setSelectedNetworkId, windowLocation]);
 
   function switchWalletType() {
-    if (selectedWalletType === "custodial" && !managedWallet) {
-      userWallet.disconnect();
-    }
-
-    if (selectedWalletType === "custodial" && typeof window !== "undefined") {
-      window.localStorage.removeItem(CURRENT_WALLET_KEY);
-    }
-
-    if (selectedWalletType === "managed" && !userWallet.isWalletConnected) {
-      userWallet.connect();
-    }
-
-    if (selectedWalletType === "managed" && managedWallet) {
-      updateStorageManagedWallet({
-        ...managedWallet,
-        selected: false
-      });
-    }
-
-    setSelectedWalletType(prev => (prev === "custodial" ? "managed" : "custodial"));
+    // No-op: deploy-web is managed-wallet-only after CON-258. Kept on the
+    // contract so existing consumers compile; the field itself is removed in L-2.
   }
 
   function connectManagedWallet() {
@@ -256,42 +217,23 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }
 
   async function signAndBroadcastTx(msgs: EncodeObject[]): Promise<boolean> {
-    let pendingSnackbarKey: SnackbarKey | null = null;
     let txResult: TxOutput;
 
+    if (!user?.id) {
+      throw new Error("Cannot broadcast transaction: user is not authenticated");
+    }
+
     try {
-      if (!!user?.id && isManaged) {
-        const mainMessage = msgs.find(msg => msg.typeUrl in MESSAGE_STATES);
+      const mainMessage = msgs.find(msg => msg.typeUrl in MESSAGE_STATES);
 
-        if (mainMessage) {
-          setLoadingState(MESSAGE_STATES[mainMessage.typeUrl]);
-        }
-
-        txResult = await txHttpService.signAndBroadcastTx({ userId: user.id, messages: msgs });
-      } else {
-        const enqueueTxSnackbar = () => {
-          pendingSnackbarKey = enqueueSnackbar(<Snackbar title="Broadcasting transaction..." subTitle="Please wait a few seconds" showLoading />, {
-            variant: "info",
-            autoHideDuration: null
-          });
-        };
-        setLoadingState("waitingForApproval");
-        const estimatedFees = await userWallet.estimateFee(msgs, undefined, CONSOLE_MEMO);
-        const txRaw = await userWallet.sign(msgs, estimatedFees, CONSOLE_MEMO);
-
-        setLoadingState("broadcasting");
-        enqueueTxSnackbar();
-        txResult = await userWallet.broadcast(txRaw);
-
-        setLoadingState(undefined);
+      if (mainMessage) {
+        setLoadingState(MESSAGE_STATES[mainMessage.typeUrl]);
       }
+
+      txResult = await txHttpService.signAndBroadcastTx({ userId: user.id, messages: msgs });
 
       if (txResult.code !== 0) {
         throw new Error(txResult.rawLog);
-      }
-
-      if (!managedWallet) {
-        showTransactionSnackbar("Transaction success!", "", txResult.transactionHash, "success");
       }
 
       analyticsService.track("successful_tx", {
@@ -311,51 +253,22 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
           showTransactionSnackbar(title || message || "Error", message, "", "error");
         }
       } else {
-        const transactionHash = err.txHash;
         let errorMsg = "An error has occurred";
-
         if (err.message?.includes("was submitted but was not yet found on the chain")) {
           errorMsg = "Transaction timeout";
-        } else if (err.message) {
-          try {
-            const reg = /Broadcasting transaction failed with code (.+?) \(codespace: (.+?)\)/i;
-            const match = err.message.match(reg);
-            const log = err.message.substring(err.message.indexOf("Log"), err.message.length);
-
-            if (match) {
-              const code = parseInt(match[1]);
-              const codeSpace = match[2];
-
-              if (codeSpace === "sdk" && code in ERROR_MESSAGES) {
-                errorMsg = ERROR_MESSAGES[code as keyof typeof ERROR_MESSAGES];
-              }
-            }
-
-            if (log) {
-              errorMsg += `. ${log}`;
-            }
-          } catch (err) {
-            console.error(err);
-          }
         }
 
-        if (!errorMsg.includes("Request rejected")) {
-          analyticsService.track("failed_tx", {
-            category: "transactions",
-            label: "Failed transaction"
-          });
-        }
+        analyticsService.track("failed_tx", {
+          category: "transactions",
+          label: "Failed transaction"
+        });
 
-        showTransactionSnackbar("Transaction has failed...", errorMsg, transactionHash, "error");
+        showTransactionSnackbar("Transaction has failed...", errorMsg, "", "error");
       }
 
       return false;
     } finally {
       refetchBalances();
-      if (pendingSnackbarKey) {
-        closeSnackbar(pendingSnackbarKey);
-      }
-
       setLoadingState(undefined);
     }
   }

--- a/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
@@ -1,6 +1,5 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
-import { isHttpError, type TxOutput } from "@akashnetwork/http-sdk";
 import { buttonVariants, Snackbar } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import type { EncodeObject } from "@cosmjs/proto-signing";
@@ -27,6 +26,7 @@ import { useServices } from "../ServicesProvider";
 import { useSettings } from "../SettingsProvider";
 import { settingsIdAtom } from "../SettingsProvider/settingsStore";
 import { deriveWalletIsLoading } from "./deriveWalletIsLoading";
+import { signAndBroadcast } from "./signAndBroadcast";
 
 type ManagedWalletMarker =
   | {
@@ -61,14 +61,6 @@ export type ContextType = {
  * @private for testing only
  */
 export const WalletProviderContext = React.createContext<ContextType>({} as ContextType);
-
-const MESSAGE_STATES: Record<string, LoadingState> = {
-  "/akash.deployment.v1beta4.MsgCloseDeployment": "closingDeployment",
-  "/akash.deployment.v1beta4.MsgCreateDeployment": "searchingProviders",
-  "/akash.market.v1beta5.MsgCreateLease": "creatingDeployment",
-  "/akash.deployment.v1beta4.MsgUpdateDeployment": "updatingDeployment",
-  "/akash.escrow.v1.MsgAccountDeposit": "depositingDeployment"
-};
 
 /**
  * WalletProvider is a client only component
@@ -217,60 +209,16 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   }
 
   async function signAndBroadcastTx(msgs: EncodeObject[]): Promise<boolean> {
-    let txResult: TxOutput;
-
-    if (!user?.id) {
-      throw new Error("Cannot broadcast transaction: user is not authenticated");
-    }
-
-    try {
-      const mainMessage = msgs.find(msg => msg.typeUrl in MESSAGE_STATES);
-
-      if (mainMessage) {
-        setLoadingState(MESSAGE_STATES[mainMessage.typeUrl]);
-      }
-
-      txResult = await txHttpService.signAndBroadcastTx({ userId: user.id, messages: msgs });
-
-      if (txResult.code !== 0) {
-        throw new Error(txResult.rawLog);
-      }
-
-      analyticsService.track("successful_tx", {
-        category: "transactions",
-        label: "Successful transaction"
-      });
-
-      return true;
-    } catch (err: any) {
-      console.error(err);
-
-      if (isHttpError(err) && err.response?.status !== 500) {
-        const [title, message] = err.response?.data?.message?.split(": ") ?? [];
-        if (err.response?.status === 402) {
-          showAddCreditsSnackbar(title || message || "Add credits to continue", message);
-        } else {
-          showTransactionSnackbar(title || message || "Error", message, "", "error");
-        }
-      } else {
-        let errorMsg = "An error has occurred";
-        if (err.message?.includes("was submitted but was not yet found on the chain")) {
-          errorMsg = "Transaction timeout";
-        }
-
-        analyticsService.track("failed_tx", {
-          category: "transactions",
-          label: "Failed transaction"
-        });
-
-        showTransactionSnackbar("Transaction has failed...", errorMsg, "", "error");
-      }
-
-      return false;
-    } finally {
-      refetchBalances();
-      setLoadingState(undefined);
-    }
+    return signAndBroadcast({
+      userId: user?.id,
+      msgs,
+      txHttpService,
+      analyticsService,
+      setLoadingState,
+      refetchBalances,
+      showAddCreditsSnackbar,
+      showTransactionSnackbar
+    });
   }
 
   const showTransactionSnackbar = (

--- a/apps/deploy-web/src/context/WalletProvider/signAndBroadcast.spec.ts
+++ b/apps/deploy-web/src/context/WalletProvider/signAndBroadcast.spec.ts
@@ -34,7 +34,7 @@ describe("signAndBroadcast", () => {
     expect(setLoadingState).toHaveBeenCalledWith(MESSAGE_STATES["/akash.deployment.v1beta4.MsgCloseDeployment"]);
   });
 
-  it("returns false and skips loading state when message type is unknown", async () => {
+  it("skips setting a typed loading state when message type is unknown", async () => {
     const { input, setLoadingState } = setup({
       msgs: [{ typeUrl: "/akash.unknown.MsgFoo", value: new Uint8Array() }],
       txResult: { code: 0, transactionHash: "tx-hash", rawLog: "" }

--- a/apps/deploy-web/src/context/WalletProvider/signAndBroadcast.spec.ts
+++ b/apps/deploy-web/src/context/WalletProvider/signAndBroadcast.spec.ts
@@ -8,7 +8,7 @@ import { MESSAGE_STATES, signAndBroadcast, type SignAndBroadcastInput } from "./
 
 describe("signAndBroadcast", () => {
   it("calls txHttpService with userId and messages and returns true on success", async () => {
-    const { input, txHttpService, analyticsService, showTransactionSnackbar } = setup({
+    const { input, txHttpService, analyticsService, showTransactionErrorSnackbar } = setup({
       txResult: { code: 0, transactionHash: "tx-hash", rawLog: "" }
     });
 
@@ -20,7 +20,7 @@ describe("signAndBroadcast", () => {
       messages: input.msgs
     });
     expect(analyticsService.track).toHaveBeenCalledWith("successful_tx", expect.objectContaining({ category: "transactions" }));
-    expect(showTransactionSnackbar).not.toHaveBeenCalled();
+    expect(showTransactionErrorSnackbar).not.toHaveBeenCalled();
   });
 
   it("sets loading state from MESSAGE_STATES when a known message type is present", async () => {
@@ -47,19 +47,19 @@ describe("signAndBroadcast", () => {
   });
 
   it("returns false and surfaces the chain rawLog as the error message when txResult.code is non-zero", async () => {
-    const { input, showTransactionSnackbar, analyticsService } = setup({
+    const { input, showTransactionErrorSnackbar, analyticsService } = setup({
       txResult: { code: 5, transactionHash: "", rawLog: "0uakt < 1000uakt: insufficient funds" }
     });
 
     const result = await signAndBroadcast(input);
 
     expect(result).toBe(false);
-    expect(showTransactionSnackbar).toHaveBeenCalledWith("Transaction has failed...", "0uakt < 1000uakt: insufficient funds", "", "error");
+    expect(showTransactionErrorSnackbar).toHaveBeenCalledWith("Transaction has failed...", "0uakt < 1000uakt: insufficient funds");
     expect(analyticsService.track).toHaveBeenCalledWith("failed_tx", expect.objectContaining({ category: "transactions" }));
   });
 
   it("returns false and shows add-credits snackbar when txHttpService responds with HTTP 402", async () => {
-    const { input, showAddCreditsSnackbar, showTransactionSnackbar } = setup({
+    const { input, showAddCreditsSnackbar, showTransactionErrorSnackbar } = setup({
       txError: buildHttpError(402, "Out of credits: please top up your account")
     });
 
@@ -67,52 +67,52 @@ describe("signAndBroadcast", () => {
 
     expect(result).toBe(false);
     expect(showAddCreditsSnackbar).toHaveBeenCalledWith("Out of credits", "please top up your account");
-    expect(showTransactionSnackbar).not.toHaveBeenCalled();
+    expect(showTransactionErrorSnackbar).not.toHaveBeenCalled();
   });
 
   it("returns false and shows generic error snackbar on HTTP 400-class error", async () => {
-    const { input, showTransactionSnackbar, showAddCreditsSnackbar } = setup({
+    const { input, showTransactionErrorSnackbar, showAddCreditsSnackbar } = setup({
       txError: buildHttpError(400, "Validation failed: bad message")
     });
 
     const result = await signAndBroadcast(input);
 
     expect(result).toBe(false);
-    expect(showTransactionSnackbar).toHaveBeenCalledWith("Validation failed", "bad message", "", "error");
+    expect(showTransactionErrorSnackbar).toHaveBeenCalledWith("Validation failed", "bad message");
     expect(showAddCreditsSnackbar).not.toHaveBeenCalled();
   });
 
   it("returns false and surfaces err.message on HTTP 5xx (treated like network error)", async () => {
-    const { input, showTransactionSnackbar, analyticsService } = setup({
+    const { input, showTransactionErrorSnackbar, analyticsService } = setup({
       txError: buildHttpError(500, "Internal server error")
     });
 
     const result = await signAndBroadcast(input);
 
     expect(result).toBe(false);
-    expect(showTransactionSnackbar).toHaveBeenCalledWith("Transaction has failed...", "Internal server error", "", "error");
+    expect(showTransactionErrorSnackbar).toHaveBeenCalledWith("Transaction has failed...", "Internal server error");
     expect(analyticsService.track).toHaveBeenCalledWith("failed_tx", expect.objectContaining({ category: "transactions" }));
   });
 
   it("returns false and surfaces 'Transaction timeout' message when chain timeout error is thrown", async () => {
-    const { input, showTransactionSnackbar } = setup({
+    const { input, showTransactionErrorSnackbar } = setup({
       txError: new Error("Tx was submitted but was not yet found on the chain after 30s")
     });
 
     const result = await signAndBroadcast(input);
 
     expect(result).toBe(false);
-    expect(showTransactionSnackbar).toHaveBeenCalledWith("Transaction has failed...", "Transaction timeout", "", "error");
+    expect(showTransactionErrorSnackbar).toHaveBeenCalledWith("Transaction has failed...", "Transaction timeout");
   });
 
   it("returns false when userId is missing without calling txHttpService", async () => {
-    const { input, txHttpService, showTransactionSnackbar } = setup({ userId: undefined });
+    const { input, txHttpService, showTransactionErrorSnackbar } = setup({ userId: undefined });
 
     const result = await signAndBroadcast(input);
 
     expect(result).toBe(false);
     expect(txHttpService.signAndBroadcastTx).not.toHaveBeenCalled();
-    expect(showTransactionSnackbar).toHaveBeenCalledWith("Transaction has failed...", "Cannot broadcast transaction: user is not authenticated", "", "error");
+    expect(showTransactionErrorSnackbar).toHaveBeenCalledWith("Transaction has failed...", "Cannot broadcast transaction: user is not authenticated");
   });
 
   it("always refetches balances and resets loading state in finally", async () => {
@@ -150,7 +150,7 @@ describe("signAndBroadcast", () => {
     const setLoadingState = vi.fn();
     const refetchBalances = vi.fn();
     const showAddCreditsSnackbar = vi.fn();
-    const showTransactionSnackbar = vi.fn();
+    const showTransactionErrorSnackbar = vi.fn();
 
     return {
       input: {
@@ -161,14 +161,14 @@ describe("signAndBroadcast", () => {
         setLoadingState,
         refetchBalances,
         showAddCreditsSnackbar,
-        showTransactionSnackbar
+        showTransactionErrorSnackbar
       } satisfies SignAndBroadcastInput,
       txHttpService,
       analyticsService,
       setLoadingState,
       refetchBalances,
       showAddCreditsSnackbar,
-      showTransactionSnackbar
+      showTransactionErrorSnackbar
     };
   }
 });

--- a/apps/deploy-web/src/context/WalletProvider/signAndBroadcast.spec.ts
+++ b/apps/deploy-web/src/context/WalletProvider/signAndBroadcast.spec.ts
@@ -1,0 +1,174 @@
+import type { TxHttpService, TxOutput } from "@akashnetwork/http-sdk";
+import { AxiosError, AxiosHeaders, type AxiosResponse } from "axios";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+import { MESSAGE_STATES, signAndBroadcast, type SignAndBroadcastInput } from "./signAndBroadcast";
+
+describe("signAndBroadcast", () => {
+  it("calls txHttpService with userId and messages and returns true on success", async () => {
+    const { input, txHttpService, analyticsService, showTransactionSnackbar } = setup({
+      txResult: { code: 0, transactionHash: "tx-hash", rawLog: "" }
+    });
+
+    const result = await signAndBroadcast(input);
+
+    expect(result).toBe(true);
+    expect(txHttpService.signAndBroadcastTx).toHaveBeenCalledWith({
+      userId: "user-123",
+      messages: input.msgs
+    });
+    expect(analyticsService.track).toHaveBeenCalledWith("successful_tx", expect.objectContaining({ category: "transactions" }));
+    expect(showTransactionSnackbar).not.toHaveBeenCalled();
+  });
+
+  it("sets loading state from MESSAGE_STATES when a known message type is present", async () => {
+    const { input, setLoadingState } = setup({
+      msgs: [{ typeUrl: "/akash.deployment.v1beta4.MsgCloseDeployment", value: new Uint8Array() }],
+      txResult: { code: 0, transactionHash: "tx-hash", rawLog: "" }
+    });
+
+    await signAndBroadcast(input);
+
+    expect(setLoadingState).toHaveBeenCalledWith(MESSAGE_STATES["/akash.deployment.v1beta4.MsgCloseDeployment"]);
+  });
+
+  it("returns false and skips loading state when message type is unknown", async () => {
+    const { input, setLoadingState } = setup({
+      msgs: [{ typeUrl: "/akash.unknown.MsgFoo", value: new Uint8Array() }],
+      txResult: { code: 0, transactionHash: "tx-hash", rawLog: "" }
+    });
+
+    await signAndBroadcast(input);
+
+    expect(setLoadingState).not.toHaveBeenCalledWith(expect.stringMatching(/Deployment|creatingDeployment|searchingProviders/));
+    expect(setLoadingState).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it("returns false and surfaces the chain rawLog as the error message when txResult.code is non-zero", async () => {
+    const { input, showTransactionSnackbar, analyticsService } = setup({
+      txResult: { code: 5, transactionHash: "", rawLog: "0uakt < 1000uakt: insufficient funds" }
+    });
+
+    const result = await signAndBroadcast(input);
+
+    expect(result).toBe(false);
+    expect(showTransactionSnackbar).toHaveBeenCalledWith("Transaction has failed...", "0uakt < 1000uakt: insufficient funds", "", "error");
+    expect(analyticsService.track).toHaveBeenCalledWith("failed_tx", expect.objectContaining({ category: "transactions" }));
+  });
+
+  it("returns false and shows add-credits snackbar when txHttpService responds with HTTP 402", async () => {
+    const { input, showAddCreditsSnackbar, showTransactionSnackbar } = setup({
+      txError: buildHttpError(402, "Out of credits: please top up your account")
+    });
+
+    const result = await signAndBroadcast(input);
+
+    expect(result).toBe(false);
+    expect(showAddCreditsSnackbar).toHaveBeenCalledWith("Out of credits", "please top up your account");
+    expect(showTransactionSnackbar).not.toHaveBeenCalled();
+  });
+
+  it("returns false and shows generic error snackbar on HTTP 400-class error", async () => {
+    const { input, showTransactionSnackbar, showAddCreditsSnackbar } = setup({
+      txError: buildHttpError(400, "Validation failed: bad message")
+    });
+
+    const result = await signAndBroadcast(input);
+
+    expect(result).toBe(false);
+    expect(showTransactionSnackbar).toHaveBeenCalledWith("Validation failed", "bad message", "", "error");
+    expect(showAddCreditsSnackbar).not.toHaveBeenCalled();
+  });
+
+  it("returns false and surfaces err.message on HTTP 5xx (treated like network error)", async () => {
+    const { input, showTransactionSnackbar, analyticsService } = setup({
+      txError: buildHttpError(500, "Internal server error")
+    });
+
+    const result = await signAndBroadcast(input);
+
+    expect(result).toBe(false);
+    expect(showTransactionSnackbar).toHaveBeenCalledWith("Transaction has failed...", "Internal server error", "", "error");
+    expect(analyticsService.track).toHaveBeenCalledWith("failed_tx", expect.objectContaining({ category: "transactions" }));
+  });
+
+  it("returns false and surfaces 'Transaction timeout' message when chain timeout error is thrown", async () => {
+    const { input, showTransactionSnackbar } = setup({
+      txError: new Error("Tx was submitted but was not yet found on the chain after 30s")
+    });
+
+    const result = await signAndBroadcast(input);
+
+    expect(result).toBe(false);
+    expect(showTransactionSnackbar).toHaveBeenCalledWith("Transaction has failed...", "Transaction timeout", "", "error");
+  });
+
+  it("returns false when userId is missing without calling txHttpService", async () => {
+    const { input, txHttpService, showTransactionSnackbar } = setup({ userId: undefined });
+
+    const result = await signAndBroadcast(input);
+
+    expect(result).toBe(false);
+    expect(txHttpService.signAndBroadcastTx).not.toHaveBeenCalled();
+    expect(showTransactionSnackbar).toHaveBeenCalledWith("Transaction has failed...", "Cannot broadcast transaction: user is not authenticated", "", "error");
+  });
+
+  it("always refetches balances and resets loading state in finally", async () => {
+    const { input, refetchBalances, setLoadingState } = setup({
+      txError: new Error("boom")
+    });
+
+    await signAndBroadcast(input);
+
+    expect(refetchBalances).toHaveBeenCalledTimes(1);
+    expect(setLoadingState).toHaveBeenLastCalledWith(undefined);
+  });
+
+  function buildHttpError(status: number, message: string): AxiosError {
+    const headers = new AxiosHeaders();
+    const response = {
+      data: { message },
+      status,
+      statusText: "",
+      headers,
+      config: { headers }
+    } as AxiosResponse;
+    const error = new AxiosError(message, String(status), { headers }, undefined, response);
+    return error;
+  }
+
+  function setup(input?: { userId?: string; msgs?: SignAndBroadcastInput["msgs"]; txResult?: TxOutput; txError?: unknown }) {
+    const txHttpService = mock<Pick<TxHttpService, "signAndBroadcastTx">>();
+    if (input?.txError) {
+      txHttpService.signAndBroadcastTx.mockRejectedValue(input.txError);
+    } else if (input?.txResult) {
+      txHttpService.signAndBroadcastTx.mockResolvedValue(input.txResult);
+    }
+    const analyticsService = mock<Pick<AnalyticsService, "track">>();
+    const setLoadingState = vi.fn();
+    const refetchBalances = vi.fn();
+    const showAddCreditsSnackbar = vi.fn();
+    const showTransactionSnackbar = vi.fn();
+
+    return {
+      input: {
+        userId: "userId" in (input ?? {}) ? input?.userId : "user-123",
+        msgs: input?.msgs ?? [{ typeUrl: "/akash.market.v1beta5.MsgCreateLease", value: new Uint8Array() }],
+        txHttpService,
+        analyticsService,
+        setLoadingState,
+        refetchBalances,
+        showAddCreditsSnackbar,
+        showTransactionSnackbar
+      } satisfies SignAndBroadcastInput,
+      txHttpService,
+      analyticsService,
+      setLoadingState,
+      refetchBalances,
+      showAddCreditsSnackbar,
+      showTransactionSnackbar
+    };
+  }
+});

--- a/apps/deploy-web/src/context/WalletProvider/signAndBroadcast.ts
+++ b/apps/deploy-web/src/context/WalletProvider/signAndBroadcast.ts
@@ -22,8 +22,8 @@ export type SignAndBroadcastInput = {
   analyticsService: Pick<AnalyticsService, "track">;
   setLoadingState: (state: LoadingState | undefined) => void;
   refetchBalances: () => void;
-  showAddCreditsSnackbar: (title: string, message: string) => void;
-  showTransactionErrorSnackbar: (title: string, message: string) => void;
+  showAddCreditsSnackbar: (title: string, message?: string) => void;
+  showTransactionErrorSnackbar: (title: string, message?: string) => void;
 };
 
 export async function signAndBroadcast({

--- a/apps/deploy-web/src/context/WalletProvider/signAndBroadcast.ts
+++ b/apps/deploy-web/src/context/WalletProvider/signAndBroadcast.ts
@@ -1,0 +1,90 @@
+import { isHttpError, type TxHttpService, type TxOutput } from "@akashnetwork/http-sdk";
+import type { EncodeObject } from "@cosmjs/proto-signing";
+
+import type { LoadingState } from "@src/components/layout/TransactionModal";
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+
+export const MESSAGE_STATES: Record<string, LoadingState> = {
+  "/akash.deployment.v1beta4.MsgCloseDeployment": "closingDeployment",
+  "/akash.deployment.v1beta4.MsgCreateDeployment": "searchingProviders",
+  "/akash.market.v1beta5.MsgCreateLease": "creatingDeployment",
+  "/akash.deployment.v1beta4.MsgUpdateDeployment": "updatingDeployment",
+  "/akash.escrow.v1.MsgAccountDeposit": "depositingDeployment"
+};
+
+export type SignAndBroadcastInput = {
+  userId: string | undefined;
+  msgs: EncodeObject[];
+  txHttpService: Pick<TxHttpService, "signAndBroadcastTx">;
+  analyticsService: Pick<AnalyticsService, "track">;
+  setLoadingState: (state: LoadingState | undefined) => void;
+  refetchBalances: () => void;
+  showAddCreditsSnackbar: (title: string, message: string) => void;
+  showTransactionSnackbar: (title: string, message: string, transactionHash: string, variant: "success" | "error" | "warning") => void;
+};
+
+export async function signAndBroadcast({
+  userId,
+  msgs,
+  txHttpService,
+  analyticsService,
+  setLoadingState,
+  refetchBalances,
+  showAddCreditsSnackbar,
+  showTransactionSnackbar
+}: SignAndBroadcastInput): Promise<boolean> {
+  let txResult: TxOutput;
+
+  try {
+    if (!userId) {
+      throw new Error("Cannot broadcast transaction: user is not authenticated");
+    }
+
+    const mainMessage = msgs.find(msg => msg.typeUrl in MESSAGE_STATES);
+
+    if (mainMessage) {
+      setLoadingState(MESSAGE_STATES[mainMessage.typeUrl]);
+    }
+
+    txResult = await txHttpService.signAndBroadcastTx({ userId, messages: msgs });
+
+    if (txResult.code !== 0) {
+      throw new Error(txResult.rawLog);
+    }
+
+    analyticsService.track("successful_tx", {
+      category: "transactions",
+      label: "Successful transaction"
+    });
+
+    return true;
+  } catch (err: any) {
+    console.error(err);
+
+    if (isHttpError(err) && err.response?.status !== 500) {
+      const [title, message] = err.response?.data?.message?.split(": ") ?? [];
+      if (err.response?.status === 402) {
+        showAddCreditsSnackbar(title || message || "Add credits to continue", message);
+      } else {
+        showTransactionSnackbar(title || message || "Error", message, "", "error");
+      }
+    } else {
+      let errorMsg = err.message || "An error has occurred";
+      if (err.message?.includes("was submitted but was not yet found on the chain")) {
+        errorMsg = "Transaction timeout";
+      }
+
+      analyticsService.track("failed_tx", {
+        category: "transactions",
+        label: "Failed transaction"
+      });
+
+      showTransactionSnackbar("Transaction has failed...", errorMsg, "", "error");
+    }
+
+    return false;
+  } finally {
+    refetchBalances();
+    setLoadingState(undefined);
+  }
+}

--- a/apps/deploy-web/src/context/WalletProvider/signAndBroadcast.ts
+++ b/apps/deploy-web/src/context/WalletProvider/signAndBroadcast.ts
@@ -1,8 +1,11 @@
 import { isHttpError, type TxHttpService, type TxOutput } from "@akashnetwork/http-sdk";
+import { LoggerService } from "@akashnetwork/logging";
 import type { EncodeObject } from "@cosmjs/proto-signing";
 
 import type { LoadingState } from "@src/components/layout/TransactionModal";
 import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+
+const logger = new LoggerService({ name: "signAndBroadcast" });
 
 export const MESSAGE_STATES: Record<string, LoadingState> = {
   "/akash.deployment.v1beta4.MsgCloseDeployment": "closingDeployment",
@@ -59,7 +62,7 @@ export async function signAndBroadcast({
 
     return true;
   } catch (err: any) {
-    console.error(err);
+    logger.error({ event: "SIGN_AND_BROADCAST_TX_FAILED", error: err });
 
     if (isHttpError(err) && err.response?.status !== 500) {
       const [title, message] = err.response?.data?.message?.split(": ") ?? [];

--- a/apps/deploy-web/src/context/WalletProvider/signAndBroadcast.ts
+++ b/apps/deploy-web/src/context/WalletProvider/signAndBroadcast.ts
@@ -23,7 +23,7 @@ export type SignAndBroadcastInput = {
   setLoadingState: (state: LoadingState | undefined) => void;
   refetchBalances: () => void;
   showAddCreditsSnackbar: (title: string, message: string) => void;
-  showTransactionSnackbar: (title: string, message: string, transactionHash: string, variant: "success" | "error" | "warning") => void;
+  showTransactionErrorSnackbar: (title: string, message: string) => void;
 };
 
 export async function signAndBroadcast({
@@ -34,7 +34,7 @@ export async function signAndBroadcast({
   setLoadingState,
   refetchBalances,
   showAddCreditsSnackbar,
-  showTransactionSnackbar
+  showTransactionErrorSnackbar
 }: SignAndBroadcastInput): Promise<boolean> {
   let txResult: TxOutput;
 
@@ -69,7 +69,7 @@ export async function signAndBroadcast({
       if (err.response?.status === 402) {
         showAddCreditsSnackbar(title || message || "Add credits to continue", message);
       } else {
-        showTransactionSnackbar(title || message || "Error", message, "", "error");
+        showTransactionErrorSnackbar(title || message || "Error", message);
       }
     } else {
       let errorMsg = err.message || "An error has occurred";
@@ -82,7 +82,7 @@ export async function signAndBroadcast({
         label: "Failed transaction"
       });
 
-      showTransactionSnackbar("Transaction has failed...", errorMsg, "", "error");
+      showTransactionErrorSnackbar("Transaction has failed...", errorMsg);
     }
 
     return false;

--- a/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.tsx
@@ -29,14 +29,14 @@ export function useSignAndBroadcast({ refetchBalances }: UseSignAndBroadcastInpu
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
   const [loadingState, setLoadingState] = useState<LoadingState | undefined>(undefined);
 
-  const showTransactionErrorSnackbar = (snackTitle: string, snackMessage: string) => {
+  const showTransactionErrorSnackbar = (snackTitle: string, snackMessage?: string) => {
     enqueueSnackbar(<Snackbar title={snackTitle} subTitle={<TransactionErrorSnackbarContent message={snackMessage} />} iconVariant="error" />, {
       variant: "error",
       autoHideDuration: 10000
     });
   };
 
-  const showAddCreditsSnackbar = (snackTitle: string, snackMessage: string) => {
+  const showAddCreditsSnackbar = (snackTitle: string, snackMessage?: string) => {
     const key = enqueueSnackbar(
       <Snackbar title={snackTitle} subTitle={<AddCreditsSnackbarContent message={snackMessage} onAction={() => closeSnackbar(key)} />} iconVariant="warning" />,
       {
@@ -80,15 +80,18 @@ const AddCreditsSnackbarContent: React.FC<{ message?: string; onAction?: () => v
   );
 };
 
-const TransactionErrorSnackbarContent: React.FC<{ message: string }> = ({ message }) => (
-  <>
-    {message}
-    {message && <br />}
-    <div className="mt-2 text-xs">
-      Need help?{" "}
-      <a href={`mailto:${SUPPORT_EMAIL}?subject=Transaction Error&body=${encodeURIComponent(message)}`} className="underline">
-        Contact {SUPPORT_EMAIL}
-      </a>
-    </div>
-  </>
-);
+const TransactionErrorSnackbarContent: React.FC<{ message?: string }> = ({ message }) => {
+  const safeMessage = message?.trim() || "An error has occurred";
+  return (
+    <>
+      {safeMessage}
+      <br />
+      <div className="mt-2 text-xs">
+        Need help?{" "}
+        <a href={`mailto:${SUPPORT_EMAIL}?subject=Transaction Error&body=${encodeURIComponent(safeMessage)}`} className="underline">
+          Contact {SUPPORT_EMAIL}
+        </a>
+      </div>
+    </>
+  );
+};

--- a/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.tsx
@@ -1,0 +1,126 @@
+"use client";
+import React, { useState } from "react";
+import { buttonVariants, Snackbar } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
+import type { EncodeObject } from "@cosmjs/proto-signing";
+import { OpenNewWindow } from "iconoir-react";
+import Link from "next/link";
+import { useSnackbar } from "notistack";
+
+import type { LoadingState } from "@src/components/layout/TransactionModal";
+import { useUser } from "@src/hooks/useUser";
+import networkStore from "@src/store/networkStore";
+import { UrlService } from "@src/utils/urlUtils";
+import { useServices } from "../ServicesProvider";
+import { signAndBroadcast } from "./signAndBroadcast";
+
+export type UseSignAndBroadcastInput = {
+  refetchBalances: () => void;
+};
+
+export type UseSignAndBroadcastReturn = {
+  signAndBroadcastTx: (msgs: EncodeObject[]) => Promise<boolean>;
+  loadingState: LoadingState | undefined;
+};
+
+export function useSignAndBroadcast({ refetchBalances }: UseSignAndBroadcastInput): UseSignAndBroadcastReturn {
+  const { tx: txHttpService, analyticsService } = useServices();
+  const { user } = useUser();
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+  const [loadingState, setLoadingState] = useState<LoadingState | undefined>(undefined);
+
+  const showTransactionSnackbar = (
+    snackTitle: string,
+    snackMessage: string,
+    transactionHash: string,
+    snackVariant: React.ComponentProps<typeof Snackbar>["iconVariant"]
+  ) => {
+    enqueueSnackbar(
+      <Snackbar
+        title={snackTitle}
+        subTitle={<TransactionSnackbarContent snackMessage={snackMessage} transactionHash={transactionHash} isError={snackVariant === "error"} />}
+        iconVariant={snackVariant}
+      />,
+      {
+        variant: snackVariant,
+        autoHideDuration: 10000
+      }
+    );
+  };
+
+  const showAddCreditsSnackbar = (snackTitle: string, snackMessage: string) => {
+    const key = enqueueSnackbar(
+      <Snackbar title={snackTitle} subTitle={<AddCreditsSnackbarContent message={snackMessage} onAction={() => closeSnackbar(key)} />} iconVariant="warning" />,
+      {
+        variant: "warning",
+        autoHideDuration: 10000
+      }
+    );
+  };
+
+  const signAndBroadcastTx = (msgs: EncodeObject[]) =>
+    signAndBroadcast({
+      userId: user?.id,
+      msgs,
+      txHttpService,
+      analyticsService,
+      setLoadingState,
+      refetchBalances,
+      showAddCreditsSnackbar,
+      showTransactionSnackbar
+    });
+
+  return { signAndBroadcastTx, loadingState };
+}
+
+const SUPPORT_EMAIL = "support@akash.network";
+
+const AddCreditsSnackbarContent: React.FC<{ message?: string; onAction?: () => void }> = ({ message, onAction }) => {
+  const { analyticsService } = useServices();
+  return (
+    <>
+      {message && <div>{message}</div>}
+      <Link
+        href={UrlService.billing({ openPayment: true })}
+        className={cn("mt-2 inline-flex h-7 items-center px-3 text-xs", buttonVariants({ variant: "default" }))}
+        onClick={() => {
+          analyticsService.track("add_funds_btn_clk");
+          onAction?.();
+        }}
+      >
+        Add Funds
+      </Link>
+    </>
+  );
+};
+
+const TransactionSnackbarContent: React.FC<{ snackMessage: string; transactionHash: string; isError?: boolean }> = ({
+  snackMessage,
+  transactionHash,
+  isError
+}) => {
+  const { publicConfig: appConfig } = useServices();
+  const selectedNetworkId = networkStore.useSelectedNetworkId();
+  const txUrl = transactionHash && `${appConfig.NEXT_PUBLIC_STATS_APP_URL}/transactions/${transactionHash}?network=${selectedNetworkId}`;
+
+  return (
+    <>
+      {snackMessage}
+      {snackMessage && <br />}
+      {txUrl && (
+        <Link href={txUrl} target="_blank" className="inline-flex items-center space-x-2 !text-white">
+          <span>View transaction</span>
+          <OpenNewWindow className="text-xs" />
+        </Link>
+      )}
+      {isError && (
+        <div className="mt-2 text-xs">
+          Need help?{" "}
+          <a href={`mailto:${SUPPORT_EMAIL}?subject=Transaction Error&body=${encodeURIComponent(snackMessage)}`} className="underline">
+            Contact {SUPPORT_EMAIL}
+          </a>
+        </div>
+      )}
+    </>
+  );
+};

--- a/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.tsx
@@ -3,13 +3,11 @@ import React, { useState } from "react";
 import { buttonVariants, Snackbar } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import type { EncodeObject } from "@cosmjs/proto-signing";
-import { OpenNewWindow } from "iconoir-react";
 import Link from "next/link";
 import { useSnackbar } from "notistack";
 
 import type { LoadingState } from "@src/components/layout/TransactionModal";
 import { useUser } from "@src/hooks/useUser";
-import networkStore from "@src/store/networkStore";
 import { UrlService } from "@src/utils/urlUtils";
 import { useServices } from "../ServicesProvider";
 import { signAndBroadcast } from "./signAndBroadcast";
@@ -23,29 +21,19 @@ export type UseSignAndBroadcastReturn = {
   loadingState: LoadingState | undefined;
 };
 
+const SUPPORT_EMAIL = "support@akash.network";
+
 export function useSignAndBroadcast({ refetchBalances }: UseSignAndBroadcastInput): UseSignAndBroadcastReturn {
   const { tx: txHttpService, analyticsService } = useServices();
   const { user } = useUser();
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();
   const [loadingState, setLoadingState] = useState<LoadingState | undefined>(undefined);
 
-  const showTransactionSnackbar = (
-    snackTitle: string,
-    snackMessage: string,
-    transactionHash: string,
-    snackVariant: React.ComponentProps<typeof Snackbar>["iconVariant"]
-  ) => {
-    enqueueSnackbar(
-      <Snackbar
-        title={snackTitle}
-        subTitle={<TransactionSnackbarContent snackMessage={snackMessage} transactionHash={transactionHash} isError={snackVariant === "error"} />}
-        iconVariant={snackVariant}
-      />,
-      {
-        variant: snackVariant,
-        autoHideDuration: 10000
-      }
-    );
+  const showTransactionErrorSnackbar = (snackTitle: string, snackMessage: string) => {
+    enqueueSnackbar(<Snackbar title={snackTitle} subTitle={<TransactionErrorSnackbarContent message={snackMessage} />} iconVariant="error" />, {
+      variant: "error",
+      autoHideDuration: 10000
+    });
   };
 
   const showAddCreditsSnackbar = (snackTitle: string, snackMessage: string) => {
@@ -67,13 +55,11 @@ export function useSignAndBroadcast({ refetchBalances }: UseSignAndBroadcastInpu
       setLoadingState,
       refetchBalances,
       showAddCreditsSnackbar,
-      showTransactionSnackbar
+      showTransactionErrorSnackbar
     });
 
   return { signAndBroadcastTx, loadingState };
 }
-
-const SUPPORT_EMAIL = "support@akash.network";
 
 const AddCreditsSnackbarContent: React.FC<{ message?: string; onAction?: () => void }> = ({ message, onAction }) => {
   const { analyticsService } = useServices();
@@ -94,33 +80,15 @@ const AddCreditsSnackbarContent: React.FC<{ message?: string; onAction?: () => v
   );
 };
 
-const TransactionSnackbarContent: React.FC<{ snackMessage: string; transactionHash: string; isError?: boolean }> = ({
-  snackMessage,
-  transactionHash,
-  isError
-}) => {
-  const { publicConfig: appConfig } = useServices();
-  const selectedNetworkId = networkStore.useSelectedNetworkId();
-  const txUrl = transactionHash && `${appConfig.NEXT_PUBLIC_STATS_APP_URL}/transactions/${transactionHash}?network=${selectedNetworkId}`;
-
-  return (
-    <>
-      {snackMessage}
-      {snackMessage && <br />}
-      {txUrl && (
-        <Link href={txUrl} target="_blank" className="inline-flex items-center space-x-2 !text-white">
-          <span>View transaction</span>
-          <OpenNewWindow className="text-xs" />
-        </Link>
-      )}
-      {isError && (
-        <div className="mt-2 text-xs">
-          Need help?{" "}
-          <a href={`mailto:${SUPPORT_EMAIL}?subject=Transaction Error&body=${encodeURIComponent(snackMessage)}`} className="underline">
-            Contact {SUPPORT_EMAIL}
-          </a>
-        </div>
-      )}
-    </>
-  );
-};
+const TransactionErrorSnackbarContent: React.FC<{ message: string }> = ({ message }) => (
+  <>
+    {message}
+    {message && <br />}
+    <div className="mt-2 text-xs">
+      Need help?{" "}
+      <a href={`mailto:${SUPPORT_EMAIL}?subject=Transaction Error&body=${encodeURIComponent(message)}`} className="underline">
+        Contact {SUPPORT_EMAIL}
+      </a>
+    </div>
+  </>
+);

--- a/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.spec.tsx
+++ b/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.spec.tsx
@@ -187,7 +187,6 @@ describe(useProviderJwt.name, () => {
                 isTrialing: false,
                 isOnboarding: false,
                 creditAmount: 0,
-                switchWalletType: vi.fn(),
                 hasManagedWallet: false,
                 managedWalletError: undefined,
                 ...input?.wallet


### PR DESCRIPTION
## Why

Fixes CON-258 (L-1 of the [Self-custody wallet extraction](https://linear.app/ovrclk/project/self-custody-wallet-extraction-eaf9443d407d/overview) project).

`WalletProvider.signAndBroadcastTx` had two signing paths: a cosmos-kit `userWallet.sign/broadcast` flow for self-custody users, and an HTTP `txHttpService.signAndBroadcastTx` flow for managed users. After CON-260 (universal auth gate) merged, every code path through `WalletProvider` is authenticated + managed, so the cosmos-kit branch is dead weight and is what blocks CON-259 (cosmos-kit dep removal).

This PR collapses the signing layer to managed-only. The wallet-store atom, `walletUtils` dual-mode helpers, and the `useWallet()` contract trim (removing `isCustodial` / `isManaged` / `switchWalletType` from consumers) are deferred to L-2 (CON-408) so this PR stays narrowly focused on the signing collapse.

## What

- Drop the cosmos-kit branch from `signAndBroadcastTx` and the cosmos-kit-specific error parsing.
- Remove the `useEnforceSelfCustodyFlag` callsite — the auth gate from CON-260 supersedes it.
- Reduce `switchWalletType` to a no-op (the field stays on the contract so consumers compile; it's removed entirely in L-2).
- Drop dead imports (`CONSOLE_MEMO`, `ERROR_MESSAGES`, `SnackbarKey`, `updateStorageManagedWallet`).

Net diff: 17 insertions / 104 deletions, single file (`WalletProvider.tsx`).

The `selectedWalletType` atom, `walletUtils` dual-mode helpers, and the `useWallet()` contract trim are explicitly out of scope here — see CON-408 for the L-2 follow-up that handles them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Centralized transaction signing/broadcasting for consistent success/failure handling and loading-state reset.
  * Loading indicators now reflect recognized transaction types.

* **Changes**
  * Wallet-type switching UI/flow removed; trial/onboarding actions simplified (buttons now show “Start Trial”).
  * Managed-wallet popup simplified; action area reduced and free-trial messaging based on trial state.

* **Bug Fixes**
  * Clearer user messages for out-of-credits, validation errors, timeouts, and network failures.

* **Tests**
  * Added comprehensive tests covering signing/broadcasting flows, error cases, analytics, and balance refetching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/akash-network/console/pull/3239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->