### PR TITLE
fix(deployment): enforce max page size on GET /v1/deployments

### DIFF
--- a/apps/api/src/deployment/http-schemas/deployment.schema.ts
+++ b/apps/api/src/deployment/http-schemas/deployment.schema.ts
@@ -131,9 +131,11 @@ export const UpdateDeploymentResponseSchema = z.object({
   data: DeploymentResponseSchema
 });
 
+export const deploymentListMaxLimit = 100;
+
 export const ListDeploymentsQuerySchema = z.object({
   skip: z.coerce.number().min(0).optional(),
-  limit: z.coerce.number().min(1).default(1000).optional()
+  limit: z.coerce.number().min(1).max(deploymentListMaxLimit).default(deploymentListMaxLimit).optional()
 });
 
 export const ListDeploymentsResponseSchema = z.object({
@@ -147,8 +149,6 @@ export const ListDeploymentsResponseSchema = z.object({
     })
   })
 });
-
-export const deploymentListMaxLimit = 100;
 
 export const ListWithResourcesParamsSchema = z.object({
   address: AkashAddressSchema.openapi({

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -6238,7 +6238,8 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "name": "limit",
             "required": false,
             "schema": {
-              "default": 1000,
+              "default": 100,
+              "maximum": 100,
               "minimum": 1,
               "type": "number",
             },


### PR DESCRIPTION
## Why
Fixes #2586
The `GET /v1/deployments` list endpoint had a default limit of 1000 but no upper bound enforced. This PR brings the endpoint in line with other list endpoints by enforcing a maximum page size of 100.

## What
- Moved `deploymentListMaxLimit` above `ListDeploymentsQuerySchema` in `apps/api/src/deployment/http-schemas/deployment.schema.ts` to prevent ReferenceErrors.
- Added `.max(deploymentListMaxLimit)` constraint to the `limit` query parameter schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the deployment list query to enforce an upper bound on the `limit` parameter (capped at 100).
  * Adjusted the default `limit` to align with the same cap, improving consistency and helping prevent excessively large responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->