### PR TITLE
fix(deployment): clear local storage when closing deployment

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.spec.tsx
@@ -231,7 +231,8 @@ describe(DeploymentDetailTopBar.name, () => {
     const track = input?.analyticsTrack ?? vi.fn();
     const deps = MockComponents(DEPENDENCIES, {
       useServices: vi.fn(() => ({
-        analyticsService: { track }
+        analyticsService: { track },
+        deploymentLocalStorage: { delete: vi.fn() }
       })) as unknown as typeof DEPENDENCIES.useServices,
       useLocalNotes: vi.fn(() => ({
         getDeploymentName: input?.localNotes?.getDeploymentName ?? (() => null),

--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.tsx
@@ -73,7 +73,7 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
   leases,
   dependencies: d = DEPENDENCIES
 }) => {
-  const { analyticsService } = d.useServices();
+  const { analyticsService, deploymentLocalStorage } = d.useServices();
   const { changeDeploymentName, getDeploymentData, getDeploymentName } = d.useLocalNotes();
   const { udenomToUsd } = d.usePricing();
   const router = d.useRouter();
@@ -105,6 +105,8 @@ export const DeploymentDetailTopBar: React.FunctionComponent<Props> = ({
     const message = TransactionMessageData.getCloseDeploymentMsg(address, deployment.dseq);
     const response = await wallet.signAndBroadcastTx([message]);
     if (response) {
+      deploymentLocalStorage.delete(address, deployment.dseq);
+
       onDeploymentClose();
       removeLeases();
       loadDeploymentDetail();

--- a/apps/deploy-web/src/components/deployments/DeploymentList.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentList.tsx
@@ -21,6 +21,7 @@ import { NextSeo } from "next-seo";
 
 import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { LinkTo } from "@src/components/shared/LinkTo";
+import { useServices } from "@src/context/ServicesProvider";
 import { useSettings } from "@src/context/SettingsProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useListSelection } from "@src/hooks/useListSelection/useListSelection";
@@ -38,6 +39,7 @@ import { DeploymentListRow } from "./DeploymentListRow";
 
 export const DeploymentList: React.FunctionComponent = () => {
   const { address, signAndBroadcastTx, isWalletLoaded, isWalletConnected } = useWallet();
+  const { deploymentLocalStorage } = useServices();
   const { data: providers, isFetching: isLoadingProviders } = useProviderList();
   const { data: deployments, isFetching: isLoadingDeployments, refetch: getDeployments } = useDeploymentList(address, { enabled: false });
   const [pageIndex, setPageIndex] = useState(0);
@@ -119,6 +121,8 @@ export const DeploymentList: React.FunctionComponent = () => {
       const messages = selectedItemIds.map(dseq => TransactionMessageData.getCloseDeploymentMsg(address, `${dseq}`));
       const response = await signAndBroadcastTx(messages);
       if (response) {
+        selectedItemIds.forEach(dseq => deploymentLocalStorage.delete(address, `${dseq}`));
+
         getDeployments();
         clearSelection();
       }

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -60,7 +60,7 @@ type Props = {
 
 export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, isSelectable, onSelectDeployment, checked, providers, refreshDeployments }) => {
   const router = useRouter();
-  const { analyticsService } = useServices();
+  const { analyticsService, deploymentLocalStorage } = useServices();
   const [open, setOpen] = useState(false);
   const [isDepositingDeployment, setIsDepositingDeployment] = useState(false);
   const { changeDeploymentName, getDeploymentData } = useLocalNotes();
@@ -136,6 +136,8 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
     const message = TransactionMessageData.getCloseDeploymentMsg(address, deployment.dseq);
     const response = await signAndBroadcastTx([message]);
     if (response) {
+      deploymentLocalStorage.delete(address, deployment.dseq);
+
       if (onSelectDeployment) {
         onSelectDeployment({ id: deployment.dseq, isShiftPressed: false });
       }


### PR DESCRIPTION
## Why
Fixes #1927
When a deployment was closed via the UI, its associated metadata (such as custom manifest/notes) persisted indefinitely in the browser's `localStorage` via `deploymentLocalStorage`, leading to accumulated stale data over time.

## What
- Destructured `deploymentLocalStorage` from `useServices()`.
- Implemented `deploymentLocalStorage.delete(address, dseq)` triggers within the success handlers of the following actions:
  - Closing a deployment from the detail view (`DeploymentDetailTopBar.tsx`).
  - Closing a deployment from a single list row action (`DeploymentListRow.tsx`).
  - Bulk-closing multiple deployments from the list selection (`DeploymentList.tsx`).
- Updated the `DeploymentDetailTopBar.spec.tsx` test suite to mock the newly introduced local storage calls.****

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed local storage not being properly cleared when deployments are closed across deployment detail, list, and list item views.

* **Tests**
  * Updated test mocking to support local storage cleanup verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->