### PR TITLE
perf: improve perf of bin packing alg

### DIFF
--- a/apps/provider-inventory/src/lib/groupspec-mapper/groupspec-mapper.ts
+++ b/apps/provider-inventory/src/lib/groupspec-mapper/groupspec-mapper.ts
@@ -35,7 +35,7 @@ export function mapGroupSpecToResourceUnits(request: GroupSpecJSON): RequestedRe
   });
 }
 
-function getAttributeFingerprint(attributes: ResourceAttribute[] | undefined): string | null {
+export function getAttributeFingerprint(attributes: ResourceAttribute[] | undefined): string | null {
   if (!attributes || attributes.length === 0) return null;
   return attributes
     .map(a => `${a.key}=${a.value}`)

--- a/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.spec.ts
+++ b/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { parseGPUAttributes } from "@src/lib/gpu-attribute-parser/gpu-attribute-parser";
+import { getAttributeFingerprint } from "@src/lib/groupspec-mapper/groupspec-mapper";
 import { ResourcePair } from "@src/lib/resource-pair/resource-pair";
 import { parseStorageAttributes } from "@src/lib/storage-attribute-parser/storage-attribute-parser";
 import type { ClusterState, CpuInfo, GpuInfo, NodeState, RequestedResourceUnit, ResourceAttribute } from "../../types/inventory.types";
@@ -1079,19 +1080,11 @@ function buildResourceUnit(input: {
   return {
     id: input.id,
     resources: {
-      cpu: { units: input.cpu, fingerprint: fingerprintAttrs(input.cpuAttributes) },
+      cpu: { units: input.cpu, fingerprint: getAttributeFingerprint(input.cpuAttributes) },
       gpu: { units: input.gpuUnits ?? 0n, attributes: parseGPUAttributes(input.gpuAttributes ?? []) },
       memory: { quantity: input.memory },
       storage: input.storage.map(s => ({ name: s.name, quantity: s.quantity, attributes: parseStorageAttributes(s.attributes) }))
     },
     count: input.count
   };
-}
-
-function fingerprintAttrs(attributes: ResourceAttribute[] | undefined): string | null {
-  if (!attributes || attributes.length === 0) return null;
-  return attributes
-    .map(a => `${a.key}=${a.value}`)
-    .sort()
-    .join(",");
 }

--- a/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.ts
+++ b/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.ts
@@ -3,24 +3,20 @@ import { singleton } from "tsyringe";
 import { matchesGPU, type ParsedGPUAttributes } from "../../lib/gpu-attribute-parser/gpu-attribute-parser";
 import type { ClusterState, MatchResult, NodeState, RequestedResourceUnit } from "../../types/inventory.types";
 
-interface CanonicalHardware {
-  gpuSpecs: ParsedGPUAttributes | null;
-  cpuFingerprint: string | null;
-}
-
-const FAIL_NODE = Object.freeze({ nodeOk: false, clusterOk: true });
-const FAIL_CLUSTER = Object.freeze({ nodeOk: false, clusterOk: false });
-const GPU_CHECK_FAIL = Object.freeze({ ok: false });
+const FAIL_NODE = Object.freeze({ nodeOk: false, clusterOk: true } as const);
+const FAIL_CLUSTER = Object.freeze({ nodeOk: false, clusterOk: false } as const);
+const GPU_CHECK_FAIL = Object.freeze({ ok: false } as const);
 const NO_CAPACITY = Object.freeze({ matched: false, error: "INSUFFICIENT_CAPACITY" } as MatchResult);
 const GROUP_MISMATCH = Object.freeze({ matched: false, error: "GROUP_RESOURCE_MISMATCH" } as MatchResult);
 
 @singleton()
 export class ClusterInventoryMatcherService {
   match(cluster: ClusterState, resourceUnits: RequestedResourceUnit[]): MatchResult {
-    return this.#adjust(cloneCluster(cluster), resourceUnits);
-  }
-
-  #adjust(cluster: ClusterState, resourceUnits: RequestedResourceUnit[]): MatchResult {
+    const nodeDeltas: NodeDelta[] = new Array(cluster.nodes.length);
+    for (let i = 0; i < cluster.nodes.length; i++) {
+      nodeDeltas[i] = { cpu: 0n, mem: 0n, eph: 0n, gpu: 0n };
+    }
+    const storageDeltas: Record<string, bigint> = Object.create(null);
     let canonical: CanonicalHardware = { gpuSpecs: null, cpuFingerprint: null };
 
     for (let i = resourceUnits.length - 1; i >= 0; i--) {
@@ -34,13 +30,21 @@ export class ClusterInventoryMatcherService {
       let remaining = group.count;
 
       for (let nodeIdx = 0; nodeIdx < cluster.nodes.length && remaining > 0; ) {
-        const result = this.#tryAdjust(cluster.nodes[nodeIdx], group, cluster.storage, canonical);
+        const result = this.#tryAdjust(cluster.nodes[nodeIdx], nodeDeltas[nodeIdx], cluster.storage, storageDeltas, group, canonical);
         if (!result.clusterOk) return NO_CAPACITY;
 
-        if (result.nodeOk === true) {
-          cluster.nodes[nodeIdx] = result.newNode ?? cluster.nodes[nodeIdx];
-          cluster.storage = result.newClusterStorage ?? cluster.storage;
-          canonical = result.canonical ?? canonical;
+        if (result.nodeOk) {
+          const delta = nodeDeltas[nodeIdx];
+          delta.cpu += result.stageCpu;
+          delta.mem += result.stageMem;
+          delta.eph += result.stageEph;
+          delta.gpu += result.stageGpu;
+          if (result.stageStorage) {
+            for (const s of result.stageStorage) {
+              storageDeltas[s.class] = (storageDeltas[s.class] ?? 0n) + s.quantity;
+            }
+          }
+          canonical = result.canonical;
           remaining--;
         } else {
           // increment node index only if the current node cannot allocate resources for the resource unit
@@ -62,38 +66,59 @@ export class ClusterInventoryMatcherService {
 
   #tryAdjust(
     node: NodeState,
-    group: RequestedResourceUnit,
+    baseDelta: NodeDelta,
     clusterStorage: ClusterState["storage"],
+    storageDeltas: Record<string, bigint>,
+    group: RequestedResourceUnit,
     canonical: CanonicalHardware
-  ): {
-    nodeOk: boolean;
-    clusterOk: boolean;
-    canonical?: CanonicalHardware;
-    newNode?: NodeState;
-    newClusterStorage?: ClusterState["storage"];
-  } {
-    if (!node.cpu.canAllocate(group.resources.cpu.units)) return FAIL_NODE;
-    if (!node.memory.canAllocate(group.resources.memory.quantity)) return FAIL_NODE;
-    if (!node.gpu.quantity.canAllocate(group.resources.gpu.units)) return FAIL_NODE;
+  ): AttemptResult {
+    if (!node.cpu.canAllocateWithDelta(group.resources.cpu.units, baseDelta.cpu)) return FAIL_NODE;
+    if (!node.memory.canAllocateWithDelta(group.resources.memory.quantity, baseDelta.mem)) return FAIL_NODE;
+    if (!node.gpu.quantity.canAllocateWithDelta(group.resources.gpu.units, baseDelta.gpu)) return FAIL_NODE;
 
-    const nodeCopy = copyNode(node);
-    nodeCopy.cpu.allocate(group.resources.cpu.units);
-    nodeCopy.memory.allocate(group.resources.memory.quantity);
-
-    const storageCopies = Object.values(clusterStorage).reduce<ClusterState["storage"]>((acc, storage) => {
-      acc[storage.class] = { ...storage, quantity: storage.quantity.clone() };
-      return acc;
-    }, Object.create(null));
+    let stageMem = group.resources.memory.quantity;
+    let stageEph = 0n;
+    let stageStorage: StorageStage[] | null = null;
 
     for (const vol of group.resources.storage) {
-      const storageResult = this.#tryAdjustStorage(nodeCopy, vol, storageCopies);
-      if (!storageResult.nodeOk) return storageResult;
+      const attrs = vol.attributes;
+
+      if (attrs.classification === "ram") {
+        const next = stageMem + vol.quantity;
+        if (!node.memory.canAllocateWithDelta(next, baseDelta.mem)) return FAIL_NODE;
+        stageMem = next;
+        continue;
+      }
+
+      if (attrs.classification === "ephemeral") {
+        const next = stageEph + vol.quantity;
+        if (!node.ephemeralStorage.canAllocateWithDelta(next, baseDelta.eph)) return FAIL_NODE;
+        stageEph = next;
+        continue;
+      }
+
+      if (attrs.classification === "persistent") {
+        if (!node.storageClasses.includes(attrs.class)) return FAIL_NODE;
+        const pool = clusterStorage[attrs.class];
+        if (!pool) return FAIL_CLUSTER;
+
+        const existing = stageStorage?.find(s => s.class === attrs.class);
+        const classDelta = (storageDeltas[attrs.class] ?? 0n) + (existing?.quantity ?? 0n);
+        if (!pool.quantity.canAllocateWithDelta(vol.quantity, classDelta)) return FAIL_CLUSTER;
+
+        if (existing) {
+          existing.quantity += vol.quantity;
+        } else {
+          if (!stageStorage) stageStorage = [];
+          stageStorage.push({ class: attrs.class, quantity: vol.quantity });
+        }
+      }
     }
 
     let resolvedGpuSpecs: ParsedGPUAttributes | undefined;
     if (group.resources.gpu.units > 0n) {
       const effectiveSpecs = canonical.gpuSpecs ? [canonical.gpuSpecs] : group.resources.gpu.attributes;
-      const gpuResult = this.#tryAdjustGPU(nodeCopy, group.resources.gpu.units, effectiveSpecs);
+      const gpuResult = this.#tryAdjustGPU(node, group.resources.gpu.units, effectiveSpecs);
       if (!gpuResult.ok) return FAIL_NODE;
       resolvedGpuSpecs = gpuResult.resolved;
     }
@@ -101,45 +126,17 @@ export class ClusterInventoryMatcherService {
     return {
       nodeOk: true,
       clusterOk: true,
-      canonical: {
-        gpuSpecs: resolvedGpuSpecs ?? canonical.gpuSpecs,
-        cpuFingerprint: canonical.cpuFingerprint
-      },
-      newNode: nodeCopy,
-      newClusterStorage: storageCopies
+      canonical: resolvedGpuSpecs ? { ...canonical, gpuSpecs: resolvedGpuSpecs } : canonical,
+      stageCpu: group.resources.cpu.units,
+      stageMem,
+      stageEph,
+      stageGpu: group.resources.gpu.units,
+      stageStorage
     };
-  }
-
-  #tryAdjustStorage(
-    node: NodeState,
-    vol: RequestedResourceUnit["resources"]["storage"][0],
-    clusterStorage: ClusterState["storage"]
-  ): { nodeOk: boolean; clusterOk: boolean } {
-    const parsed = vol.attributes;
-
-    if (parsed.classification === "ram") {
-      if (!node.memory.allocate(vol.quantity)) return FAIL_NODE;
-      return { nodeOk: true, clusterOk: true };
-    }
-
-    if (parsed.classification === "ephemeral") {
-      if (!node.ephemeralStorage.allocate(vol.quantity)) return FAIL_NODE;
-      return { nodeOk: true, clusterOk: true };
-    }
-
-    if (parsed.classification === "persistent") {
-      if (!node.storageClasses.includes(parsed.class)) return FAIL_NODE;
-      const pool = clusterStorage[parsed.class];
-      if (!pool?.quantity.allocate(vol.quantity)) return FAIL_CLUSTER;
-      return { nodeOk: true, clusterOk: true };
-    }
-
-    return { nodeOk: true, clusterOk: true };
   }
 
   #tryAdjustGPU(node: NodeState, requestedUnits: bigint, gpuSpecs: ParsedGPUAttributes[]): { ok: boolean; resolved?: ParsedGPUAttributes } {
     if (node.gpu.info.length === 0) return GPU_CHECK_FAIL;
-    if (!node.gpu.quantity.canAllocate(requestedUnits)) return GPU_CHECK_FAIL;
 
     if (gpuSpecs.length === 0) {
       const first = node.gpu.info[0];
@@ -177,8 +174,6 @@ export class ClusterInventoryMatcherService {
 
     if (remaining > 0) return GPU_CHECK_FAIL;
 
-    if (!node.gpu.quantity.allocate(requestedUnits)) return GPU_CHECK_FAIL;
-
     return {
       ok: true,
       resolved: pinnedSpec!
@@ -186,27 +181,32 @@ export class ClusterInventoryMatcherService {
   }
 }
 
-function cloneCluster(cluster: ClusterState): ClusterState {
-  return {
-    nodes: cluster.nodes.map(copyNode),
-    storage: Object.values(cluster.storage).reduce<ClusterState["storage"]>((acc, pool) => {
-      acc[pool.class] = { class: pool.class, quantity: pool.quantity.clone() };
-      return acc;
-    }, Object.create(null))
-  };
+interface CanonicalHardware {
+  gpuSpecs: ParsedGPUAttributes | null;
+  cpuFingerprint: string | null;
 }
 
-function copyNode(node: NodeState): NodeState {
-  return {
-    name: node.name,
-    cpu: node.cpu.clone(),
-    memory: node.memory.clone(),
-    ephemeralStorage: node.ephemeralStorage.clone(),
-    gpu: {
-      quantity: node.gpu.quantity.clone(),
-      info: node.gpu.info.map(g => ({ ...g }))
-    },
-    storageClasses: [...node.storageClasses],
-    cpus: node.cpus.map(c => ({ ...c }))
-  };
+interface NodeDelta {
+  cpu: bigint;
+  mem: bigint;
+  eph: bigint;
+  gpu: bigint;
 }
+
+interface StorageStage {
+  class: string;
+  quantity: bigint;
+}
+
+type AttemptResult =
+  | { nodeOk: false; clusterOk: boolean }
+  | {
+      nodeOk: true;
+      clusterOk: true;
+      canonical: CanonicalHardware;
+      stageCpu: bigint;
+      stageMem: bigint;
+      stageEph: bigint;
+      stageGpu: bigint;
+      stageStorage: StorageStage[] | null;
+    };


### PR DESCRIPTION
## Why

The previous algorithm cloned the full `ClusterState` (every `NodeState`, every storage pool's `ResourcePair`) on entry and then produced another fresh `nodeCopy` + cloned storage map for every placement attempt. With realistic clusters this dominates runtime through allocation churn and GC pressure on a hot path called per-bid.

Delta accounting does the same arithmetic — `available - sum(deltas) >= request` — without producing any new node, pool, or resource-pair objects per attempt. Behavior is unchanged: deltas are only folded in on a successful placement, mirroring the old "commit the copies" semantics, and storage staging within a single resource unit is tracked locally before being merged into storageDeltas.

Ref CON-406

## What

Reworks the bin-packing loop in `ClusterInventoryMatcherService.match` to use delta-based capacity accounting instead of clone-and-mutate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized internal cluster inventory matching algorithm to use delta-based calculations instead of state cloning, improving memory efficiency and performance. No changes to matching behavior or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->