### PR TITLE
fix: allow different services to request different gpus

### DIFF
--- a/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.spec.ts
+++ b/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.spec.ts
@@ -669,6 +669,148 @@ describe(ClusterInventoryMatcherService.name, () => {
     });
   });
 
+  describe("cross-service canonical scope (AC9)", () => {
+    it("places two services with disjoint GPU model requests independently in the same placement group", () => {
+      const service = new ClusterInventoryMatcherService();
+      const cluster = makeCluster([
+        {
+          cpu: 8000n,
+          memory: 17179869184n,
+          ephemeral: 107374182400n,
+          gpuCount: 1n,
+          gpuInfo: [{ vendor: "nvidia", name: "a100", modelId: "2235", interface: "PCIe", memorySize: "80Gi" }]
+        },
+        {
+          cpu: 8000n,
+          memory: 17179869184n,
+          ephemeral: 107374182400n,
+          gpuCount: 1n,
+          gpuInfo: [{ vendor: "nvidia", name: "h100", modelId: "2330", interface: "PCIe", memorySize: "80Gi" }]
+        }
+      ]);
+      const serviceA = buildResourceUnit({
+        id: 1,
+        cpu: 1000n,
+        memory: 1073741824n,
+        gpuUnits: 1n,
+        gpuAttributes: [{ key: "vendor/nvidia/model/a100", value: "true" }],
+        storage: [{ name: "default", quantity: 1073741824n, attributes: [{ key: "persistent", value: "false" }] }],
+        count: 1
+      });
+      const serviceB = buildResourceUnit({
+        id: 2,
+        cpu: 1000n,
+        memory: 1073741824n,
+        gpuUnits: 1n,
+        gpuAttributes: [{ key: "vendor/nvidia/model/h100", value: "true" }],
+        storage: [{ name: "default", quantity: 1073741824n, attributes: [{ key: "persistent", value: "false" }] }],
+        count: 1
+      });
+
+      expect(service.match(cluster, [serviceA, serviceB]).matched).toBe(true);
+    });
+
+    it("does not leak a wildcard-pinned GPU model from one service to another in the same placement group", () => {
+      const service = new ClusterInventoryMatcherService();
+      const cluster = makeCluster([
+        {
+          cpu: 8000n,
+          memory: 17179869184n,
+          ephemeral: 107374182400n,
+          gpuCount: 1n,
+          gpuInfo: [{ vendor: "nvidia", name: "a100", modelId: "2235", interface: "PCIe", memorySize: "80Gi" }]
+        },
+        {
+          cpu: 8000n,
+          memory: 17179869184n,
+          ephemeral: 107374182400n,
+          gpuCount: 1n,
+          gpuInfo: [{ vendor: "nvidia", name: "h100", modelId: "2330", interface: "PCIe", memorySize: "80Gi" }]
+        }
+      ]);
+      const wildcardService = buildResourceUnit({
+        id: 1,
+        cpu: 1000n,
+        memory: 1073741824n,
+        gpuUnits: 1n,
+        gpuAttributes: [{ key: "vendor/nvidia", value: "true" }],
+        storage: [{ name: "default", quantity: 1073741824n, attributes: [{ key: "persistent", value: "false" }] }],
+        count: 1
+      });
+      const h100Service = buildResourceUnit({
+        id: 2,
+        cpu: 1000n,
+        memory: 1073741824n,
+        gpuUnits: 1n,
+        gpuAttributes: [{ key: "vendor/nvidia/model/h100", value: "true" }],
+        storage: [{ name: "default", quantity: 1073741824n, attributes: [{ key: "persistent", value: "false" }] }],
+        count: 1
+      });
+
+      expect(service.match(cluster, [wildcardService, h100Service]).matched).toBe(true);
+    });
+
+    it("places two services with different non-empty CPU fingerprints independently", () => {
+      const service = new ClusterInventoryMatcherService();
+      const cluster = makeCluster([
+        { cpu: 8000n, memory: 17179869184n, ephemeral: 107374182400n },
+        { cpu: 8000n, memory: 17179869184n, ephemeral: 107374182400n }
+      ]);
+      const intelService = buildResourceUnit({
+        id: 1,
+        cpu: 1000n,
+        cpuAttributes: [{ key: "vendor", value: "intel" }],
+        memory: 1073741824n,
+        storage: [{ name: "default", quantity: 1073741824n, attributes: [{ key: "persistent", value: "false" }] }],
+        count: 1
+      });
+      const amdService = buildResourceUnit({
+        id: 2,
+        cpu: 1000n,
+        cpuAttributes: [{ key: "vendor", value: "amd" }],
+        memory: 1073741824n,
+        storage: [{ name: "default", quantity: 1073741824n, attributes: [{ key: "persistent", value: "false" }] }],
+        count: 1
+      });
+
+      const result = service.match(cluster, [intelService, amdService]);
+      expect(result.matched).toBe(true);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("returns INSUFFICIENT_CAPACITY (not GROUP_RESOURCE_MISMATCH) when a wildcard-pinned replica cannot find a second matching GPU within the same service", () => {
+      const service = new ClusterInventoryMatcherService();
+      const cluster = makeCluster([
+        {
+          cpu: 8000n,
+          memory: 17179869184n,
+          ephemeral: 107374182400n,
+          gpuCount: 1n,
+          gpuInfo: [{ vendor: "nvidia", name: "a100", modelId: "2235", interface: "PCIe", memorySize: "80Gi" }]
+        },
+        {
+          cpu: 8000n,
+          memory: 17179869184n,
+          ephemeral: 107374182400n,
+          gpuCount: 1n,
+          gpuInfo: [{ vendor: "nvidia", name: "h100", modelId: "2330", interface: "PCIe", memorySize: "80Gi" }]
+        }
+      ]);
+      const units = makeResourceUnits({
+        cpu: 1000n,
+        memory: 1073741824n,
+        ephemeral: 1073741824n,
+        count: 2,
+        gpuUnits: 1n,
+        gpuAttributes: [{ key: "vendor/nvidia", value: "true" }]
+      });
+
+      const result = service.match(cluster, units);
+      expect(result.matched).toBe(false);
+      expect(result.error).toBe("INSUFFICIENT_CAPACITY");
+    });
+  });
+
   describe("nodes with existing allocations", () => {
     it("matches when remaining capacity after allocation is sufficient", () => {
       const service = new ClusterInventoryMatcherService();

--- a/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.ts
+++ b/apps/provider-inventory/src/services/cluster-inventory-matcher/cluster-inventory-matcher.service.ts
@@ -7,7 +7,6 @@ const FAIL_NODE = Object.freeze({ nodeOk: false, clusterOk: true } as const);
 const FAIL_CLUSTER = Object.freeze({ nodeOk: false, clusterOk: false } as const);
 const GPU_CHECK_FAIL = Object.freeze({ ok: false } as const);
 const NO_CAPACITY = Object.freeze({ matched: false, error: "INSUFFICIENT_CAPACITY" } as MatchResult);
-const GROUP_MISMATCH = Object.freeze({ matched: false, error: "GROUP_RESOURCE_MISMATCH" } as MatchResult);
 
 @singleton()
 export class ClusterInventoryMatcherService {
@@ -17,15 +16,10 @@ export class ClusterInventoryMatcherService {
       nodeDeltas[i] = { cpu: 0n, mem: 0n, eph: 0n, gpu: 0n };
     }
     const storageDeltas: Record<string, bigint> = Object.create(null);
-    let canonical: CanonicalHardware = { gpuSpecs: null, cpuFingerprint: null };
 
     for (let i = resourceUnits.length - 1; i >= 0; i--) {
       const group = resourceUnits[i];
-
-      const groupCpuFingerprint = group.resources.cpu.fingerprint;
-      if (canonical.cpuFingerprint && groupCpuFingerprint && canonical.cpuFingerprint !== groupCpuFingerprint) {
-        return GROUP_MISMATCH;
-      }
+      let canonical: CanonicalHardware = { gpuSpecs: null, cpuFingerprint: group.resources.cpu.fingerprint };
 
       let remaining = group.count;
 
@@ -54,10 +48,6 @@ export class ClusterInventoryMatcherService {
 
       if (remaining > 0) {
         return NO_CAPACITY;
-      }
-
-      if (canonical.cpuFingerprint === null) {
-        canonical = { ...canonical, cpuFingerprint: groupCpuFingerprint };
       }
     }
 


### PR DESCRIPTION
## Why

The previous logic treated the whole placement group as a single canonical-hardware unit: once any service in the group locked in a CPU fingerprint or a wildcard-resolved GPU model, every later service had to match it or the match failed with `GROUP_RESOURCE_MISMATCH`. That over-constrained legitimate deployments — e.g. one service asking for an A100 and another for an H100 in the same group.

The new tests pin down the intended semantics:

- two services with disjoint GPU models can co-place,
- a wildcard-pinned GPU model in service A doesn't leak into service B, but within a single service's replicas, a wildcard still has to resolve consistently — when it can't, the failure is INSUFFICIENT_CAPACITY


## What

In cluster-inventory-matcher.service.ts the canonical hardware accumulator was moved inside the per-group loop instead of being carried across all groups. The cross-group CPU fingerprint check and the GROUP_RESOURCE_MISMATCH early return were removed (the constant too). Canonical state — including GPU specs pinned by wildcards — is now scoped to a single service/group, not the whole placement. Added 4 specs covering the AC9 "cross-service canonical scope" cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test cases verifying cluster placement isolation across multiple services with different GPU and CPU requirements.

* **Bug Fixes**
  * Improved CPU fingerprint constraint application and GPU request isolation between services in placement matching logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->