### PR TITLE
chore: fixes local build platform arch

### DIFF
--- a/.github/workflows/reusable-build-image.yml
+++ b/.github/workflows/reusable-build-image.yml
@@ -120,6 +120,7 @@ jobs:
           GIT_COMMIT_HASH: ${{ github.sha }}
           APP_PATH: "apps/${{ env.app }}"
           APP_VERSION: ${{ steps.determine.outputs.base_tag }}
+          TARGET_PLATFORM: linux/amd64
         run: |
           if [[ -n "${{ env.force_build }}" ]]; then
             force_build="${{ env.force_build }}"

--- a/packages/docker/Dockerfile.nextjs
+++ b/packages/docker/Dockerfile.nextjs
@@ -17,6 +17,8 @@ ENV DEPLOYMENT_ENV $DEPLOYMENT_ENV
 ARG SENTRY_AUTH_TOKEN
 ARG GIT_COMMIT_HASH
 
+ARG TARGETARCH
+
 ENV NEXT_TELEMETRY_DISABLED 1
 
 WORKDIR /app
@@ -40,7 +42,7 @@ RUN apk add --no-cache libc6-compat
 
 COPY --from=prepare /app .
 
-RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm run safe-install
+RUN --mount=type=cache,id=npm-cache-${TARGETARCH},target=/root/.npm npm run safe-install
 
 COPY $WORKSPACE ./$WORKSPACE
 COPY /packages /app/packages

--- a/packages/docker/Dockerfile.node
+++ b/packages/docker/Dockerfile.node
@@ -5,6 +5,7 @@ FROM node:24.14.1-alpine AS base
 # see https://r1ch.net/blog/node-v20-aggregateeerror-etimedout-happy-eyeballs and https://github.com/nodejs/node/issues/54359
 ARG NODE_OPTIONS="--no-network-family-autoselection --enable-source-maps"
 ARG GITHUB_PAT
+ARG TARGETARCH
 ARG WORKSPACE
 ENV WORKSPACE $WORKSPACE
 ENV HUSKY 0
@@ -28,7 +29,7 @@ FROM base AS development
 
 COPY --from=prepare /app .
 
-RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm run safe-install -- --workspace $WORKSPACE
+RUN --mount=type=cache,id=npm-cache-${TARGETARCH},target=/root/.npm npm run safe-install -- --workspace $WORKSPACE
 COPY $WORKSPACE ./$WORKSPACE
 COPY packages ./packages
 
@@ -52,7 +53,7 @@ RUN addgroup --system --gid $APP_GROUP_ID $APP_GROUP \
 
 COPY --from=prepare /app .
 # webpack built apps are not fully bundled, so we need to install dependencies separately
-RUN --mount=type=cache,id=npm-cache,target=/root/.npm npm run safe-install -- --workspace $WORKSPACE --omit=dev
+RUN --mount=type=cache,id=npm-cache-${TARGETARCH},target=/root/.npm npm run safe-install -- --workspace $WORKSPACE --omit=dev
 
 COPY --from=builder /app/package*.json /app/
 COPY --from=builder /app/$WORKSPACE/package.json /app/$WORKSPACE/

--- a/packages/docker/script/dc.sh
+++ b/packages/docker/script/dc.sh
@@ -60,9 +60,15 @@ docker_buildx_bake() {
     done
   fi
 
-  echo "docker buildx bake $(printf -- " --file %q" "${COMPOSE_FILES[@]}") --set *.cache-from="type=gha,scope=${BUILDKIT_CACHE_SCOPE}" --set *.cache-from="type=gha,scope=${BUILDKIT_CACHE_FALLBACK_SCOPE}" --set *.cache-to="type=gha,mode=max,scope=${BUILDKIT_CACHE_FALLBACK_SCOPE}" --load ${targets[@]}"
+  local platform_args=()
+  if [[ -n "$TARGET_PLATFORM" ]]; then
+    platform_args=(--set "*.platform=${TARGET_PLATFORM}")
+  fi
+
+  echo "docker buildx bake $(printf -- " --file %q" "${COMPOSE_FILES[@]}") --set *.platform=${TARGET_PLATFORM} --set *.cache-from="type=gha,scope=${BUILDKIT_CACHE_SCOPE}" --set *.cache-from="type=gha,scope=${BUILDKIT_CACHE_FALLBACK_SCOPE}" --set *.cache-to="type=gha,mode=max,scope=${BUILDKIT_CACHE_FALLBACK_SCOPE}" --load ${targets[@]}"
   docker buildx bake \
     $(printf -- " --file %q" "${COMPOSE_FILES[@]}") \
+    "${platform_args[@]}" \
     --set *.cache-from="type=gha,scope=${BUILDKIT_CACHE_SCOPE}" \
     --set *.cache-from="type=gha,scope=${BUILDKIT_CACHE_FALLBACK_SCOPE}" \
     --set *.cache-to="type=gha,mode=max,scope=${BUILDKIT_CACHE_FALLBACK_SCOPE}" \
@@ -98,6 +104,9 @@ COMMAND=$1
 shift
 
 USE_BUILDKIT="${USE_DOCKER_BUILDKIT:-0}"
+TARGET_PLATFORM="${TARGET_PLATFORM:-}"
+# Ensures the plain `docker compose build` path also targets amd64 (not the host arch, e.g. arm64)
+export DOCKER_DEFAULT_PLATFORM="${TARGET_PLATFORM}"
 BUILDKIT_CACHE_SCOPE="${DOCKER_BUILDKIT_CACHE_SCOPE:-main}"
 BUILDKIT_CACHE_SCOPE="${BUILDKIT_CACHE_SCOPE// /-}"
 # uses cache fallback scope in case package-lock.json changed in a branch PR


### PR DESCRIPTION
## Why

building and pushing docker images locally via `act` doesn't currently work. Because the final image is built for arm64 arch but we need amd64. 

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker build process with architecture-specific npm dependency caching.
  * Added platform targeting support to build workflows for improved multi-architecture container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->