### PR TITLE
feat: implements provider stream backoff

### DIFF
--- a/apps/provider-inventory/src/config/env.config.ts
+++ b/apps/provider-inventory/src/config/env.config.ts
@@ -16,6 +16,7 @@ export const envSchema = z.object({
   STREAM_RECONNECT_INITIAL_DELAY_MS: z.number({ coerce: true }).default(60_000),
   STREAM_RECONNECT_MAX_DELAY_MS: z.number({ coerce: true }).default(5 * 60 * 1000),
   STREAM_FIRST_MESSAGE_TIMEOUT_MS: z.number({ coerce: true }).default(10_000),
+  STREAM_UPDATE_THROTTLE_MS: z.number({ coerce: true }).nonnegative().default(1000),
   REST_API_NODE_URL: z.string().url()
 });
 

--- a/apps/provider-inventory/src/lib/generators/latest-value/latest-value.spec.ts
+++ b/apps/provider-inventory/src/lib/generators/latest-value/latest-value.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { latestValue } from "./latest-value";
+
+describe("latestValue", () => {
+  it("yields a value set before iteration begins", async () => {
+    const cell = latestValue<number>();
+    cell.set(1);
+    cell.close();
+
+    const values = await collect(cell);
+
+    expect(values).toEqual([1]);
+  });
+
+  it("waits for a value to be set before yielding", async () => {
+    const cell = latestValue<number>();
+    const iterator = cell[Symbol.asyncIterator]();
+    const next = iterator.next();
+
+    cell.set(7);
+
+    await expect(next).resolves.toEqual({ value: 7, done: false });
+  });
+
+  it("drops intermediate values, keeping only the latest between reads", async () => {
+    const cell = latestValue<number>();
+    cell.set(1);
+    cell.set(2);
+    cell.set(3);
+    cell.close();
+
+    const values = await collect(cell);
+
+    expect(values).toEqual([3]);
+  });
+
+  it("consumes the value so a second read waits for a fresh one", async () => {
+    const cell = latestValue<number>();
+    const iterator = cell[Symbol.asyncIterator]();
+
+    cell.set(1);
+    await iterator.next();
+    const pending = iterator.next();
+    cell.set(2);
+
+    await expect(pending).resolves.toEqual({ value: 2, done: false });
+  });
+
+  it("ends iteration when closed with no pending value", async () => {
+    const cell = latestValue<number>();
+    cell.close();
+
+    const values = await collect(cell);
+
+    expect(values).toEqual([]);
+  });
+
+  it("flushes a pending value before ending when closed", async () => {
+    const cell = latestValue<number>();
+    cell.set(1);
+    cell.set(2);
+    cell.close();
+
+    const values = await collect(cell);
+
+    expect(values).toEqual([2]);
+  });
+
+  it("throws the failure after iteration is closed with fail", async () => {
+    const cell = latestValue<number>();
+    cell.fail(new Error("boom"));
+
+    await expect(collect(cell)).rejects.toThrow("boom");
+  });
+
+  it("ignores values set after the cell is closed", async () => {
+    const cell = latestValue<number>();
+    cell.close();
+    cell.set(99);
+
+    const values = await collect(cell);
+
+    expect(values).toEqual([]);
+  });
+
+  it("ends iteration promptly once the signal is aborted", async () => {
+    const controller = new AbortController();
+    const cell = latestValue<number>({ signal: controller.signal });
+    const iterator = cell[Symbol.asyncIterator]();
+    const next = iterator.next();
+
+    controller.abort();
+
+    await expect(next).resolves.toEqual({ value: undefined, done: true });
+  });
+
+  async function collect<T>(cell: AsyncIterable<T>) {
+    const values: T[] = [];
+    for await (const value of cell) values.push(value);
+    return values;
+  }
+});

--- a/apps/provider-inventory/src/lib/generators/latest-value/latest-value.ts
+++ b/apps/provider-inventory/src/lib/generators/latest-value/latest-value.ts
@@ -1,0 +1,79 @@
+export interface Signal<T> {
+  set(value: T): void;
+  close(): void;
+  fail(error: unknown): void;
+  [Symbol.asyncIterator](): AsyncIterableIterator<T>;
+}
+
+export interface SignalOptions {
+  signal?: AbortSignal;
+}
+
+/**
+ * A single-slot, latest-wins cell bridging a fast producer to a slower consumer.
+ *
+ * Writers call {@link Signal.set} to overwrite the stored value; a single consumer iterates the cell
+ * and receives only the most recent value, consuming it. Values written between reads are dropped, so
+ * memory stays bounded to one value no matter how fast it is written — a provider pushing inventory
+ * several times per second can never make the consumer accumulate a backlog.
+ *
+ * The producer signals completion with {@link Signal.close} (graceful) or {@link Signal.fail} (error).
+ * A value still pending when the cell closes is flushed to the consumer before iteration ends, and an
+ * aborted signal ends iteration promptly.
+ */
+export function latestValue<T>(options?: SignalOptions): Signal<T> {
+  let slot: { value: T } | undefined;
+  let closed = false;
+  let failure: { error: unknown } | undefined;
+  let notify: (() => void) | null = null;
+
+  const wake = () => {
+    notify?.();
+    notify = null;
+  };
+
+  return {
+    set(value) {
+      if (closed) return;
+      slot = { value };
+      wake();
+    },
+    close() {
+      closed = true;
+      wake();
+    },
+    fail(error) {
+      if (closed) return;
+      failure = { error };
+      closed = true;
+      wake();
+    },
+    async *[Symbol.asyncIterator]() {
+      const { signal } = options ?? {};
+      signal?.addEventListener("abort", wake, { once: true });
+      try {
+        while (true) {
+          while (!slot && !closed && !signal?.aborted) {
+            const { promise, resolve } = Promise.withResolvers<void>();
+            notify = resolve;
+            await promise;
+          }
+
+          if (signal?.aborted) return;
+
+          if (slot) {
+            const { value } = slot;
+            slot = undefined;
+            yield value;
+            continue;
+          }
+
+          if (failure) throw failure.error;
+          return;
+        }
+      } finally {
+        signal?.removeEventListener("abort", wake);
+      }
+    }
+  };
+}

--- a/apps/provider-inventory/src/lib/generators/paginate/paginate.spec.ts
+++ b/apps/provider-inventory/src/lib/generators/paginate/paginate.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { paginate } from "./paginate";
+
+describe("paginate", () => {
+  it("fetches a single page when the first response has no nextKey", async () => {
+    const fetchPage = vi.fn().mockResolvedValueOnce({ items: [1, 2, 3], nextKey: undefined });
+
+    const pages = await Array.fromAsync(paginate(fetchPage));
+
+    expect(pages).toEqual([[1, 2, 3]]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+    expect(fetchPage).toHaveBeenCalledWith(undefined);
+  });
+
+  it("stops when an empty Uint8Array nextKey is returned", async () => {
+    const fetchPage = vi.fn().mockResolvedValueOnce({ items: ["a"], nextKey: new Uint8Array(0) });
+
+    const pages = await Array.fromAsync(paginate(fetchPage));
+
+    expect(pages).toEqual([["a"]]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+
+  it("follows nextKey across pages, passing the previous key into the next fetch", async () => {
+    const pageOneKey = new Uint8Array([1, 2, 3]);
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [1], nextKey: pageOneKey })
+      .mockResolvedValueOnce({ items: [2], nextKey: new Uint8Array(0) });
+
+    const pages = await Array.fromAsync(paginate(fetchPage));
+
+    expect(pages).toEqual([[1], [2]]);
+    expect(fetchPage).toHaveBeenNthCalledWith(1, undefined);
+    expect(fetchPage).toHaveBeenNthCalledWith(2, pageOneKey);
+  });
+
+  it("stops fetching further pages once the signal is aborted", async () => {
+    const controller = new AbortController();
+    const fetchPage = vi.fn().mockImplementation(async () => {
+      controller.abort();
+      return { items: [1], nextKey: new Uint8Array([9]) };
+    });
+
+    const pages = await Array.fromAsync(paginate(fetchPage, { signal: controller.signal }));
+
+    expect(pages).toEqual([[1]]);
+    expect(fetchPage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/provider-inventory/src/lib/generators/paginate/paginate.ts
+++ b/apps/provider-inventory/src/lib/generators/paginate/paginate.ts
@@ -15,9 +15,10 @@ export interface Page<T> {
  */
 export async function* paginate<T>(fetchPage: (key: Uint8Array | undefined) => Promise<Page<T>>, options: { signal?: AbortSignal } = {}): AsyncGenerator<T[]> {
   let nextKey: Uint8Array | undefined = undefined;
-  do {
+  while (!options.signal?.aborted) {
     const page = await fetchPage(nextKey);
     yield page.items;
     nextKey = page.nextKey;
-  } while (nextKey && nextKey.length > 0 && !options.signal?.aborted);
+    if (!nextKey || nextKey.length === 0) break;
+  }
 }

--- a/apps/provider-inventory/src/lib/generators/paginate/paginate.ts
+++ b/apps/provider-inventory/src/lib/generators/paginate/paginate.ts
@@ -1,0 +1,23 @@
+export interface Page<T> {
+  items: T[];
+  nextKey?: Uint8Array;
+}
+
+/**
+ * Walks a cosmos-style key-paginated endpoint, yielding one page of items at a time.
+ *
+ * `fetchPage` is called with the previous page's `nextKey` (`undefined` for the first page)
+ * and must return the page items along with the `nextKey` to continue from. Iteration stops
+ * once a falsy or empty `nextKey` is returned, or when `signal` is aborted.
+ *
+ * Yielding page-by-page keeps only a single page in memory at once instead of accumulating the
+ * full result set up front.
+ */
+export async function* paginate<T>(fetchPage: (key: Uint8Array | undefined) => Promise<Page<T>>, options: { signal?: AbortSignal } = {}): AsyncGenerator<T[]> {
+  let nextKey: Uint8Array | undefined = undefined;
+  do {
+    const page = await fetchPage(nextKey);
+    yield page.items;
+    nextKey = page.nextKey;
+  } while (nextKey && nextKey.length > 0 && !options.signal?.aborted);
+}

--- a/apps/provider-inventory/src/lib/generators/throttle-latest/throttle-latest.spec.ts
+++ b/apps/provider-inventory/src/lib/generators/throttle-latest/throttle-latest.spec.ts
@@ -1,0 +1,148 @@
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, expect, it } from "vitest";
+
+import { throttleLatest } from "./throttle-latest";
+
+const INTERVAL = 50;
+// Comfortably shorter than INTERVAL: long enough for microtasks/leading emits to settle,
+// short enough to assert "nothing emitted yet" before the interval boundary.
+const SETTLE = 10;
+
+describe("throttleLatest", () => {
+  it("emits the first value immediately without waiting for the interval", async () => {
+    const { stream, push } = createPushStream<number>();
+    const collected = collect(stream);
+
+    push(1);
+    await delay(SETTLE);
+
+    expect(collected.values).toEqual([1]);
+  });
+
+  it("drops intermediate values and emits only the latest once the interval elapses", async () => {
+    const { stream, push } = createPushStream<number>();
+    const collected = collect(stream);
+
+    push(1);
+    await delay(SETTLE);
+    expect(collected.values).toEqual([1]);
+
+    push(2);
+    push(3);
+    await delay(INTERVAL / 2);
+    expect(collected.values).toEqual([1]);
+
+    await delay(INTERVAL);
+    expect(collected.values).toEqual([1, 3]);
+  });
+
+  it("emits every value when they arrive slower than the interval", async () => {
+    const { stream, push } = createPushStream<number>();
+    const collected = collect(stream);
+
+    push(1);
+    await delay(SETTLE);
+    expect(collected.values).toEqual([1]);
+
+    await delay(INTERVAL);
+    push(2);
+    await delay(SETTLE);
+    expect(collected.values).toEqual([1, 2]);
+  });
+
+  it("flushes the final pending value when the source ends mid-interval", async () => {
+    const { stream, push, end } = createPushStream<number>();
+    const collected = collect(stream);
+
+    push(1);
+    await delay(SETTLE);
+    expect(collected.values).toEqual([1]);
+
+    push(2);
+    end();
+    await delay(INTERVAL + SETTLE);
+
+    expect(collected.values).toEqual([1, 2]);
+    await expect(collected.done).resolves.toBeUndefined();
+  });
+
+  it("propagates a source error after the in-flight value", async () => {
+    const { stream, push, fail } = createPushStream<number>();
+    const collected = collect(stream);
+
+    push(1);
+    await delay(SETTLE);
+    expect(collected.values).toEqual([1]);
+
+    fail(new Error("source exploded"));
+
+    await expect(collected.done).rejects.toThrow("source exploded");
+  });
+
+  it("stops emitting once the signal is aborted", async () => {
+    const controller = new AbortController();
+    const { stream, push } = createPushStream<number>();
+    const collected = collect(stream, controller.signal);
+
+    push(1);
+    await delay(SETTLE);
+    expect(collected.values).toEqual([1]);
+
+    controller.abort();
+    push(2);
+
+    await expect(collected.done).resolves.toBeUndefined();
+    expect(collected.values).toEqual([1]);
+  });
+
+  function collect<T>(source: AsyncIterable<T>, signal?: AbortSignal) {
+    const values: T[] = [];
+    const done = (async () => {
+      for await (const value of throttleLatest(source, INTERVAL, { signal })) {
+        values.push(value);
+      }
+    })();
+    return { values, done };
+  }
+});
+
+function createPushStream<T>() {
+  const queue: T[] = [];
+  let resolveNext: (() => void) | undefined;
+  let finished = false;
+  let failure: { error: unknown } | undefined;
+
+  const wake = () => {
+    resolveNext?.();
+    resolveNext = undefined;
+  };
+
+  async function* stream(): AsyncGenerator<T> {
+    while (true) {
+      while (queue.length === 0 && !finished && !failure) {
+        await new Promise<void>(resolve => {
+          resolveNext = resolve;
+        });
+      }
+      while (queue.length > 0) yield queue.shift() as T;
+      if (failure) throw failure.error;
+      if (finished) return;
+    }
+  }
+
+  return {
+    stream: stream(),
+    push: (value: T) => {
+      queue.push(value);
+      wake();
+    },
+    end: () => {
+      finished = true;
+      wake();
+    },
+    fail: (error: unknown) => {
+      failure = { error };
+      wake();
+    }
+  };
+}

--- a/apps/provider-inventory/src/lib/generators/throttle-latest/throttle-latest.ts
+++ b/apps/provider-inventory/src/lib/generators/throttle-latest/throttle-latest.ts
@@ -1,0 +1,37 @@
+import { setTimeout as delay } from "node:timers/promises";
+
+import { latestValue, type Signal } from "../latest-value/latest-value";
+
+/**
+ * Wraps a source async iterable, eagerly draining it into a {@link latestValue} cell and re-emitting
+ * the freshest value at most once per `intervalMs`.
+ *
+ * Two loops cooperate through the cell: a producer drains the source as fast as it arrives (keeping
+ * only the newest value, so a fast producer can never build a backlog), and the consumer emits the
+ * current value and then holds off until the interval elapses. Intermediate values produced during
+ * that window are dropped — only the latest survives. Emission is leading + trailing: the first value
+ * is yielded immediately, subsequent values no sooner than `intervalMs` apart, and a value still
+ * pending when the source ends is flushed before completing. Source errors are propagated after the
+ * in-flight value; an aborted `signal` ends iteration promptly.
+ */
+export async function* throttleLatest<T>(source: AsyncIterable<T>, intervalMs: number, options: { signal?: AbortSignal } = {}): AsyncGenerator<T> {
+  const { signal } = options;
+  const latest = latestValue<T>({ signal });
+
+  pump(source, latest).catch(() => undefined);
+
+  for await (const value of latest) {
+    yield value;
+    await delay(intervalMs, undefined, { signal }).catch(() => undefined);
+    if (signal?.aborted) return;
+  }
+}
+
+async function pump<T>(source: AsyncIterable<T>, latest: Signal<T>): Promise<void> {
+  try {
+    for await (const value of source) latest.set(value);
+    latest.close();
+  } catch (error) {
+    latest.fail(error);
+  }
+}

--- a/apps/provider-inventory/src/services/chain-provider-poller/chain-provider-poller.service.spec.ts
+++ b/apps/provider-inventory/src/services/chain-provider-poller/chain-provider-poller.service.spec.ts
@@ -63,15 +63,16 @@ describe(ChainProviderPollerService.name, () => {
   it("merges signed audit attributes into providers by owner", async () => {
     const { service, getAllProvidersAttributes, getProviders } = setup();
     getAllProvidersAttributes.mockResolvedValueOnce(
-      mock<AuditResponse>({
-        providers: [
+      auditResponse(
+        [
           mock<AuditRecord>({
             owner: "akash1aaa",
             auditor: "akash1auditor",
             attributes: [{ key: "region", value: "us-west" }]
           })
-        ]
-      })
+        ],
+        new Uint8Array(0)
+      )
     );
     getProviders.mockResolvedValueOnce(providersResponse([chainProvider({ owner: "akash1aaa" }), chainProvider({ owner: "akash1bbb" })], new Uint8Array(0)));
 
@@ -81,12 +82,38 @@ describe(ChainProviderPollerService.name, () => {
     expect(batch[1].signedAttributes).toEqual([]);
   });
 
+  it("follows nextKey across multiple audit pages and merges attributes from every page", async () => {
+    const { service, getAllProvidersAttributes, getProviders } = setup();
+    const pageOneKey = new Uint8Array([1, 2, 3]);
+    getAllProvidersAttributes
+      .mockResolvedValueOnce(
+        auditResponse([mock<AuditRecord>({ owner: "akash1aaa", auditor: "akash1auditor1", attributes: [{ key: "region", value: "us-west" }] })], pageOneKey)
+      )
+      .mockResolvedValueOnce(
+        auditResponse([mock<AuditRecord>({ owner: "akash1aaa", auditor: "akash1auditor2", attributes: [{ key: "tier", value: "gpu" }] })], new Uint8Array(0))
+      );
+    getProviders.mockResolvedValueOnce(providersResponse([chainProvider({ owner: "akash1aaa" })], new Uint8Array(0)));
+
+    const [batch] = await Array.fromAsync(service.poll());
+
+    expect(getAllProvidersAttributes).toHaveBeenCalledTimes(2);
+    expect(getAllProvidersAttributes).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ pagination: expect.objectContaining({ key: pageOneKey }) }),
+      expect.anything()
+    );
+    expect(batch[0].signedAttributes).toEqual([
+      { key: "region", value: "us-west", auditor: "akash1auditor1" },
+      { key: "tier", value: "gpu", auditor: "akash1auditor2" }
+    ]);
+  });
+
   function setup() {
     const chainSDK = mockDeep<ChainNodeWebSDK>();
     const getAllProvidersAttributes = chainSDK.akash.audit.v1.getAllProvidersAttributes;
     const getProviders = chainSDK.akash.provider.v1beta4.getProviders;
 
-    getAllProvidersAttributes.mockResolvedValue(mock<AuditResponse>({ providers: [] }));
+    getAllProvidersAttributes.mockResolvedValue(auditResponse([], new Uint8Array(0)));
 
     const loggerFactory: LoggerFactory = () => mock<ReturnType<LoggerFactory>>();
     const service = new ChainProviderPollerService(chainSDK, loggerFactory);
@@ -106,4 +133,8 @@ function chainProvider(overrides: Partial<ChainSDKProvider>): ChainSDKProvider {
 
 function providersResponse(providers: ChainSDKProvider[], nextKey: Uint8Array): ProvidersResponse {
   return { providers, pagination: { nextKey } } as unknown as ProvidersResponse;
+}
+
+function auditResponse(providers: AuditRecord[], nextKey: Uint8Array): AuditResponse {
+  return { providers, pagination: { nextKey } } as unknown as AuditResponse;
 }

--- a/apps/provider-inventory/src/services/chain-provider-poller/chain-provider-poller.service.ts
+++ b/apps/provider-inventory/src/services/chain-provider-poller/chain-provider-poller.service.ts
@@ -2,6 +2,7 @@ import type { ChainNodeWebSDK } from "@akashnetwork/chain-sdk/web";
 import type { LoggerService } from "@akashnetwork/logging";
 import { inject, singleton } from "tsyringe";
 
+import { paginate } from "@src/lib/generators/paginate/paginate";
 import { CHAIN_SDK } from "@src/providers/chain-sdk.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
 import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
@@ -21,35 +22,49 @@ export class ChainProviderPollerService {
     const MAX_PROVIDERS_PER_BATCH = input.batchSize ?? 500;
     this.#logger.info({ event: "CHAIN_POLL_START" });
 
-    const auditRecords = await this.#chainSDK.akash.audit.v1.getAllProvidersAttributes({}, { signal: input.signal });
-
     const signedByOwner = new Map<string, { attributes: Array<{ key: string; value: string; auditor: string }>; auditors: Set<string> }>();
-    for (const record of auditRecords.providers) {
-      const existing = signedByOwner.get(record.owner);
-      const attributes = record.attributes.map(a => ({ key: a.key, value: a.value, auditor: record.auditor }));
-      if (existing) {
-        existing.attributes.push(...attributes);
-        existing.auditors.add(record.auditor);
-      } else {
-        signedByOwner.set(record.owner, { attributes, auditors: new Set([record.auditor]) });
+    const auditPages = paginate(
+      async key => {
+        const response = await this.#chainSDK.akash.audit.v1.getAllProvidersAttributes(
+          { pagination: { limit: MAX_PROVIDERS_PER_BATCH, key } },
+          { signal: input.signal }
+        );
+        return { items: response.providers, nextKey: response.pagination?.nextKey };
+      },
+      { signal: input.signal }
+    );
+
+    for await (const records of auditPages) {
+      for (const record of records) {
+        const existing = signedByOwner.get(record.owner);
+        const attributes = record.attributes.map(a => ({ key: a.key, value: a.value, auditor: record.auditor }));
+        if (existing) {
+          existing.attributes.push(...attributes);
+          existing.auditors.add(record.auditor);
+        } else {
+          signedByOwner.set(record.owner, { attributes, auditors: new Set([record.auditor]) });
+        }
       }
     }
 
     let providerCount = 0;
-    let nextKey: Uint8Array | undefined = undefined;
-    do {
-      this.#logger.info({ event: "CHAIN_PROVIDERS_POLL_BATCH", nextKey: nextKey ? Buffer.from(nextKey).toString("base64") : null });
+    const providerPages = paginate(
+      async key => {
+        this.#logger.info({ event: "CHAIN_PROVIDERS_POLL_BATCH", nextKey: key ? Buffer.from(key).toString("base64") : null });
+        const response = await this.#chainSDK.akash.provider.v1beta4.getProviders(
+          { pagination: { limit: MAX_PROVIDERS_PER_BATCH, key } },
+          { signal: input.signal }
+        );
+        return { items: response.providers, nextKey: response.pagination?.nextKey };
+      },
+      { signal: input.signal }
+    );
 
-      const response = await this.#chainSDK.akash.provider.v1beta4.getProviders(
-        {
-          pagination: { limit: MAX_PROVIDERS_PER_BATCH, key: nextKey }
-        },
-        { signal: input.signal }
-      );
-      providerCount += response.providers.length;
+    for await (const providers of providerPages) {
+      providerCount += providers.length;
 
       const validProviders: ChainProvider[] = [];
-      for (const provider of response.providers) {
+      for (const provider of providers) {
         if (isValidUrl(provider.hostUri)) {
           validProviders.push({
             owner: provider.owner,
@@ -66,9 +81,7 @@ export class ChainProviderPollerService {
       if (validProviders.length > 0) {
         yield validProviders;
       }
-
-      nextKey = response.pagination?.nextKey;
-    } while (nextKey && nextKey.length > 0 && !input.signal?.aborted);
+    }
 
     this.#logger.info({ event: "CHAIN_PROVIDERS_POLL_COMPLETE", providerCount });
   }

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
@@ -75,7 +75,59 @@ describe(StreamLifecycleManagerService.name, () => {
       await vi.waitFor(() => expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(2));
       expect(oldSignal.aborted).toBe(true);
       expect(streamFactory.openStatusStream).toHaveBeenLastCalledWith(updated, expect.any(AbortSignal));
+      expect(streamFactory.disposeProvider).toHaveBeenCalledWith("https://old:8443");
+      expect(streamFactory.disposeProvider).not.toHaveBeenCalledWith("https://new:8443");
       expect(writer.deleteByOwner).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("parent signal listener", () => {
+    it("keeps the parent-signal abort listener while the stream is healthy", async () => {
+      const parent = new AbortController();
+      const removeSpy = vi.spyOn(parent.signal, "removeEventListener");
+      const { manager, streamFactory } = setup({ streams: { "https://p1:8443": "hang" } });
+
+      manager.start(createProvider(), parent.signal);
+      await vi.waitFor(() => expect(streamFactory.openStatusStream).toHaveBeenCalled());
+      await delay(50);
+
+      expect(removeSpy).not.toHaveBeenCalled();
+    });
+
+    it("removes the parent-signal abort listener once the stream gives up", async () => {
+      const parent = new AbortController();
+      const addSpy = vi.spyOn(parent.signal, "addEventListener");
+      const removeSpy = vi.spyOn(parent.signal, "removeEventListener");
+      const streamFactory = mock<ProviderStreamFactory>();
+      streamFactory.disposeProvider.mockResolvedValue();
+      streamFactory.openStatusStream.mockImplementation(() => throwingStream(new Error("connection lost")));
+      const { manager } = setup({ streamFactory });
+
+      manager.start(createProvider(), parent.signal);
+
+      const handler = addSpy.mock.calls.find(([type]) => type === "abort")?.[1];
+      await vi.waitFor(() => expect(removeSpy).toHaveBeenCalledWith("abort", handler), { timeout: 5000 });
+    });
+
+    it("removes the old listener and attaches a fresh one on restart without accumulating", async () => {
+      const old = createProvider({ owner: "a", hostUri: "https://old:8443" });
+      const updated = createProvider({ owner: "a", hostUri: "https://new:8443" });
+      const parent = new AbortController();
+      const addSpy = vi.spyOn(parent.signal, "addEventListener");
+      const removeSpy = vi.spyOn(parent.signal, "removeEventListener");
+      const { manager, streamFactory } = setup({ streams: { "https://old:8443": "hang", "https://new:8443": "hang" } });
+
+      manager.start(old, parent.signal);
+      await vi.waitFor(() => expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(1));
+      const oldHandler = addSpy.mock.calls.filter(([type]) => type === "abort")[0][1];
+
+      manager.restart(updated, parent.signal);
+      await vi.waitFor(() => expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(2));
+
+      await vi.waitFor(() => expect(removeSpy).toHaveBeenCalledWith("abort", oldHandler));
+      const abortAdds = addSpy.mock.calls.filter(([type]) => type === "abort");
+      expect(abortAdds).toHaveLength(2);
+      expect(removeSpy).not.toHaveBeenCalledWith("abort", abortAdds[1][1]);
     });
   });
 
@@ -171,6 +223,21 @@ describe(StreamLifecycleManagerService.name, () => {
 
       expect(writer.updateInventory).toHaveBeenCalledWith(providerA, expect.objectContaining({ totalAvailableCpu: 1000n }));
       expect(writer.updateInventory).toHaveBeenCalledWith(providerB, expect.objectContaining({ totalAvailableCpu: 1000n }));
+      expect(writer.updateInventory).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("update throttle", () => {
+    it("coalesces a burst of updates within the window into a single write of the latest", async () => {
+      const { manager, writer } = setup({ streams: { "https://p1:8443": leadThenBurst() }, throttleMs: 1000 });
+
+      manager.start(createProvider());
+
+      await vi.waitFor(() => expect(writer.updateInventory).toHaveBeenCalledWith(createProvider(), expect.objectContaining({ totalAvailableCpu: 3000n })), {
+        timeout: 3000
+      });
+      expect(writer.updateInventory).toHaveBeenCalledWith(createProvider(), expect.objectContaining({ totalAvailableCpu: 1000n }));
+      expect(writer.updateInventory).not.toHaveBeenCalledWith(createProvider(), expect.objectContaining({ totalAvailableCpu: 2000n }));
       expect(writer.updateInventory).toHaveBeenCalledTimes(2);
     });
   });
@@ -345,7 +412,11 @@ describe(StreamLifecycleManagerService.name, () => {
     });
   });
 
-  function setup(input?: { streams?: Record<string, AsyncIterable<ClusterState> | "hang">; streamFactory?: MockProxy<ProviderStreamFactory> }) {
+  function setup(input?: {
+    streams?: Record<string, AsyncIterable<ClusterState> | "hang">;
+    streamFactory?: MockProxy<ProviderStreamFactory>;
+    throttleMs?: number;
+  }) {
     const streamFactory = input?.streamFactory ?? mock<ProviderStreamFactory>();
     streamFactory.disposeProvider.mockResolvedValue();
     const writer = mock<ProviderInventoryRepository>();
@@ -358,7 +429,8 @@ describe(StreamLifecycleManagerService.name, () => {
       MAX_CONCURRENT_STREAM_CONNECTIONS: 100,
       STREAM_RECONNECT_INITIAL_DELAY_MS: 10,
       STREAM_RECONNECT_MAX_DELAY_MS: 50,
-      STREAM_FIRST_MESSAGE_TIMEOUT_MS: 80
+      STREAM_FIRST_MESSAGE_TIMEOUT_MS: 80,
+      STREAM_UPDATE_THROTTLE_MS: input?.throttleMs ?? 0
     });
 
     if (!input?.streamFactory) {
@@ -428,6 +500,16 @@ async function* throwingStream(error: Error): AsyncGenerator<ClusterState> {
 async function* msgsThenThrow(messages: ClusterState[], error: Error): AsyncGenerator<ClusterState> {
   for (const msg of messages) yield msg;
   throw error;
+}
+
+// Emits a leading message, then — after it has been consumed — a rapid burst within the throttle
+// window, so the burst coalesces to its latest value (3000) while the leading value (1000) survives.
+async function* leadThenBurst(): AsyncGenerator<ClusterState> {
+  yield createMessage({ cpu: 1000n });
+  await delay(20);
+  yield createMessage({ cpu: 2000n });
+  yield createMessage({ cpu: 3000n });
+  await new Promise<never>(() => undefined);
 }
 
 function hangingStream(signal?: AbortSignal): AsyncIterable<ClusterState> {

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -75,6 +75,11 @@ export class StreamLifecycleManagerService {
   }
 
   start(provider: ChainProvider, signal?: AbortSignal): void {
+    if (signal?.aborted) {
+      this.#logger.warn({ event: "STREAM_START_ABORTED", owner: provider.owner, reason: "Received already aborted signal" });
+      return;
+    }
+
     const controller = new AbortController();
     const abortProviderStream = () => controller.abort();
     this.#activeStreams.set(provider.owner, { controller, hostUri: provider.hostUri });

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -6,6 +6,7 @@ import Dataloader from "dataloader";
 import once from "lodash/once";
 import { inject, singleton } from "tsyringe";
 
+import { throttleLatest } from "@src/lib/generators/throttle-latest/throttle-latest";
 import { projectRow } from "@src/lib/project-row/project-row";
 import { projectedRowsEqual } from "@src/lib/projected-row-equals/projected-row-equals";
 import type { EnvConfig } from "@src/providers/app-config.provider";
@@ -75,18 +76,27 @@ export class StreamLifecycleManagerService {
 
   start(provider: ChainProvider, signal?: AbortSignal): void {
     const controller = new AbortController();
+    const abortProviderStream = () => controller.abort();
     this.#activeStreams.set(provider.owner, { controller, hostUri: provider.hostUri });
-    signal?.addEventListener("abort", () => controller.abort(), { once: true });
+    signal?.addEventListener("abort", abortProviderStream, { once: true });
 
     const firstAttempt = Promise.withResolvers<void>();
     this.#pendingFirstAttempts.add(firstAttempt.promise);
-    firstAttempt.promise.finally(() => this.#pendingFirstAttempts.delete(firstAttempt.promise));
+    firstAttempt.promise.finally(() => {
+      this.#pendingFirstAttempts.delete(firstAttempt.promise);
+    });
 
-    void this.#runStream(provider, controller.signal, firstAttempt.resolve);
+    void this.#runStream(provider, controller.signal, firstAttempt.resolve).finally(() => signal?.removeEventListener("abort", abortProviderStream));
   }
 
   restart(provider: ChainProvider, signal?: AbortSignal): void {
+    const previousHostUri = this.#activeStreams.get(provider.owner)?.hostUri;
     this.#abortIfActive(provider.owner, "STREAM_STOPPED_HOSTURI_CHANGE");
+    if (previousHostUri && previousHostUri !== provider.hostUri) {
+      void this.#streamFactory.disposeProvider(previousHostUri).catch(error => {
+        this.#logger.error({ event: "DISPOSE_STREAM_ERROR", owner: provider.owner, hostUri: previousHostUri, error });
+      });
+    }
     this.start(provider, signal);
   }
 
@@ -165,8 +175,9 @@ export class StreamLifecycleManagerService {
 
     try {
       const stream = this.#streamFactory.openStatusStream(provider, attemptController.signal);
+      const throttled = throttleLatest(stream, this.#config.STREAM_UPDATE_THROTTLE_MS, { signal: attemptController.signal });
 
-      for await (const message of stream) {
+      for await (const message of throttled) {
         this.#logger.debug({ event: "STREAM_MESSAGE_RECEIVED", owner: provider.owner });
         if (outerSignal.aborted) return;
         releasePermit();

--- a/apps/provider-inventory/test/functional/discovery-pipeline.spec.ts
+++ b/apps/provider-inventory/test/functional/discovery-pipeline.spec.ts
@@ -125,6 +125,7 @@ describe("DiscoveryScheduler pipeline", () => {
     );
 
     const streamFactory = mock<ProviderStreamFactory>();
+    streamFactory.disposeProvider.mockResolvedValue();
     streamFactory.openStatusStream.mockImplementation((provider: ChainProvider, signal: AbortSignal) => {
       openedHosts.push(provider.hostUri);
       signal.addEventListener("abort", () => abortedHosts.push(provider.hostUri), { once: true });


### PR DESCRIPTION
## Why

The provider-inventory service has two unbounded-memory hazards:

1. Fast producers / slow consumers. A provider can push status/inventory updates several times per second over its stream. The consumer (DB projection + diffing) is slower, so messages pile up into an ever-growing backlog → memory leak.
2. Loading full result sets up front. Chain polling fetched all provider audit attributes and all providers into memory before processing

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable stream update throttling (default 1000ms)
  * Pagination helper for paged fetches
  * "Latest-wins" signal and throttle-latest stream operator for coalescing updates

* **Improvements**
  * Enhanced stream cleanup with provider disposal on restart
  * Improved abort signal handling and safer start/stop lifecycle
  * Status streams are now rate-limited using the throttle setting

* **Tests**
  * Added comprehensive tests for throttling, pagination, latest-value behavior, and stream lifecycle
<!-- end of auto-generated comment: release notes by coderabbit.ai -->