### PR TITLE
feat(deployment): flag-gated /new-deployment/configure three-pane shell

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.tsx
@@ -1,0 +1,14 @@
+import type { FC } from "react";
+
+export const ConfigurationPane: FC = () => {
+  return (
+    <section aria-labelledby="configure-configuration-pane-heading" className="flex h-full min-h-0 flex-col">
+      <header className="hidden h-[52px] shrink-0 items-center gap-2 border-b border-zinc-300 px-4 md:flex dark:border-zinc-700">
+        <h2 id="configure-configuration-pane-heading" className="font-mono text-sm font-medium uppercase text-muted-foreground">
+          2. Configuration
+        </h2>
+      </header>
+      <div className="flex-1 overflow-y-auto" />
+    </section>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentContainer/ConfigureDeploymentContainer.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentContainer/ConfigureDeploymentContainer.tsx
@@ -1,0 +1,21 @@
+"use client";
+import type { FC } from "react";
+import { NextSeo } from "next-seo";
+
+import Layout from "@src/components/layout/Layout";
+import { ConfigureDeploymentHeader } from "../ConfigureDeploymentHeader/ConfigureDeploymentHeader";
+import { ConfigureDeploymentPanes } from "../ConfigureDeploymentPanes/ConfigureDeploymentPanes";
+
+export const ConfigureDeploymentContainer: FC = () => {
+  return (
+    <Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col">
+      <NextSeo title="Configure your deployment" />
+      <div className="px-6 pt-6">
+        <ConfigureDeploymentHeader />
+      </div>
+      <div className="mt-6 flex min-h-0 flex-1">
+        <ConfigureDeploymentPanes />
+      </div>
+    </Layout>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
@@ -1,0 +1,44 @@
+import type { FC } from "react";
+import { Button } from "@akashnetwork/ui/components";
+import { Send } from "iconoir-react";
+
+export const ConfigureDeploymentHeader: FC = () => {
+  return (
+    <header className="flex flex-row items-center justify-between gap-3 md:items-end">
+      <div className="flex min-w-0 flex-1 flex-col gap-1 md:gap-2">
+        <h1 className="text-xl font-bold leading-tight tracking-tight md:text-3xl md:leading-9">Configure your deployment</h1>
+        <p className="hidden text-base text-muted-foreground md:block">
+          Adjust your deployment spec to refine available providers in the compute marketplace. Request official quotes when you&apos;re ready.
+        </p>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-3 md:gap-6">
+        <DeploymentSummaryBlock label="Deployment" value="—" />
+        <div className="hidden h-12 w-px self-stretch bg-border md:block" aria-hidden="true" />
+        <DeploymentSummaryBlock label="Cost" value="—" suffix="/hr" />
+        <Button disabled className="h-9 shrink-0 px-3 md:h-10 md:px-8">
+          <Send className="h-4 w-4 md:hidden" aria-label="Request quotes" />
+          <span className="hidden md:inline">Request quotes</span>
+        </Button>
+      </div>
+    </header>
+  );
+};
+
+interface DeploymentSummaryBlockProps {
+  label: string;
+  value: string;
+  suffix?: string;
+}
+
+function DeploymentSummaryBlock({ label, value, suffix }: DeploymentSummaryBlockProps) {
+  return (
+    <div className="flex flex-col items-end">
+      <span className="font-mono text-[10px] uppercase text-muted-foreground md:text-sm">{label}</span>
+      <div className="flex items-baseline gap-1">
+        <span className="font-mono text-base font-semibold leading-tight md:text-xl md:leading-8">{value}</span>
+        {suffix ? <span className="font-mono text-xs text-muted-foreground md:text-base">{suffix}</span> : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DEPENDENCIES } from "./ConfigureDeploymentPanes";
+import { ConfigureDeploymentPanes } from "./ConfigureDeploymentPanes";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe("ConfigureDeploymentPanes", () => {
+  it("marks the Deployment tab active by default", () => {
+    setup();
+
+    expect(screen.getByRole("button", { name: "1. Deployment" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("button", { name: "2. Configuration" })).not.toHaveAttribute("aria-current");
+    expect(screen.getByRole("button", { name: "3. Marketplace" })).not.toHaveAttribute("aria-current");
+  });
+
+  it("activates Configuration when its tab is clicked", async () => {
+    setup();
+
+    await userEvent.click(screen.getByRole("button", { name: "2. Configuration" }));
+
+    expect(screen.getByRole("button", { name: "1. Deployment" })).not.toHaveAttribute("aria-current");
+    expect(screen.getByRole("button", { name: "2. Configuration" })).toHaveAttribute("aria-current", "page");
+    expect(screen.getByRole("button", { name: "3. Marketplace" })).not.toHaveAttribute("aria-current");
+  });
+
+  it("activates Marketplace when its tab is clicked", async () => {
+    setup();
+
+    await userEvent.click(screen.getByRole("button", { name: "3. Marketplace" }));
+
+    expect(screen.getByRole("button", { name: "1. Deployment" })).not.toHaveAttribute("aria-current");
+    expect(screen.getByRole("button", { name: "2. Configuration" })).not.toHaveAttribute("aria-current");
+    expect(screen.getByRole("button", { name: "3. Marketplace" })).toHaveAttribute("aria-current", "page");
+  });
+
+  it("keeps only the active pane wrapper visible on mobile", async () => {
+    setup();
+
+    const deploymentRegion = screen.getByTestId("deployment-pane-mock").parentElement as HTMLElement;
+    const configurationRegion = screen.getByTestId("configuration-pane-mock").parentElement as HTMLElement;
+    const marketplaceRegion = screen.getByTestId("marketplace-pane-mock").parentElement as HTMLElement;
+
+    expect(deploymentRegion).not.toHaveClass("hidden");
+    expect(configurationRegion).toHaveClass("hidden");
+    expect(marketplaceRegion).toHaveClass("hidden");
+
+    await userEvent.click(screen.getByRole("button", { name: "3. Marketplace" }));
+
+    expect(deploymentRegion).toHaveClass("hidden");
+    expect(configurationRegion).toHaveClass("hidden");
+    expect(marketplaceRegion).not.toHaveClass("hidden");
+  });
+
+  function setup() {
+    const dependencies: typeof DEPENDENCIES = {
+      DeploymentPane: vi.fn(() => <div data-testid="deployment-pane-mock" />),
+      ConfigurationPane: vi.fn(() => <div data-testid="configuration-pane-mock" />),
+      MarketplacePane: vi.fn(() => <div data-testid="marketplace-pane-mock" />)
+    };
+    return render(<ConfigureDeploymentPanes dependencies={dependencies} />);
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
@@ -1,0 +1,65 @@
+import type { FC } from "react";
+import { useState } from "react";
+import { cn } from "@akashnetwork/ui/utils";
+
+import { ConfigurationPane } from "../ConfigurationPane/ConfigurationPane";
+import { DeploymentPane } from "../DeploymentPane/DeploymentPane";
+import { MarketplacePane } from "../MarketplacePane/MarketplacePane";
+
+type ActivePane = "deployment" | "configuration" | "marketplace";
+
+export const DEPENDENCIES = { DeploymentPane, ConfigurationPane, MarketplacePane };
+
+type Props = {
+  dependencies?: typeof DEPENDENCIES;
+};
+
+export const ConfigureDeploymentPanes: FC<Props> = ({ dependencies: d = DEPENDENCIES }) => {
+  const [activePane, setActivePane] = useState<ActivePane>("deployment");
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      <div className="grid min-h-0 flex-1 grid-rows-1 md:grid-cols-[auto_320px_1fr] md:divide-x md:divide-zinc-300 md:border-t md:border-zinc-300 md:dark:divide-zinc-700 md:dark:border-zinc-700">
+        <div className={cn("min-h-0 md:block", { hidden: activePane !== "deployment" })}>
+          <d.DeploymentPane />
+        </div>
+        <div className={cn("min-h-0 md:block", { hidden: activePane !== "configuration" })}>
+          <d.ConfigurationPane />
+        </div>
+        <div className={cn("min-h-0 md:block", { hidden: activePane !== "marketplace" })}>
+          <d.MarketplacePane />
+        </div>
+      </div>
+
+      <nav aria-label="Pane navigation" className="flex shrink-0 border-t border-zinc-300 md:hidden dark:border-zinc-700">
+        <PaneTab label="1. Deployment" value="deployment" activeValue={activePane} onSelect={setActivePane} />
+        <PaneTab label="2. Configuration" value="configuration" activeValue={activePane} onSelect={setActivePane} />
+        <PaneTab label="3. Marketplace" value="marketplace" activeValue={activePane} onSelect={setActivePane} />
+      </nav>
+    </div>
+  );
+};
+
+interface PaneTabProps {
+  label: string;
+  value: ActivePane;
+  activeValue: ActivePane;
+  onSelect: (value: ActivePane) => void;
+}
+
+function PaneTab({ label, value, activeValue, onSelect }: PaneTabProps) {
+  const isActive = activeValue === value;
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(value)}
+      aria-current={isActive ? "page" : undefined}
+      className={cn("flex-1 px-3 py-3 font-mono text-xs font-medium uppercase tracking-wide transition-colors", {
+        "border-t-2 border-foreground text-foreground": isActive,
+        "border-t-2 border-transparent text-muted-foreground": !isActive
+      })}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.spec.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { DeploymentPane } from "./DeploymentPane";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe("DeploymentPane", () => {
+  it("renders expanded with the title and a hide button by default", () => {
+    setup();
+
+    expect(screen.getByRole("heading", { name: "1. Deployment" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Hide deployment pane" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Show deployment pane" })).not.toBeInTheDocument();
+  });
+
+  it("minimizes when the hide button is clicked", async () => {
+    setup();
+
+    await userEvent.click(screen.getByRole("button", { name: "Hide deployment pane" }));
+
+    expect(screen.queryByRole("heading", { name: "1. Deployment" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Hide deployment pane" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Show deployment pane" })).toBeInTheDocument();
+  });
+
+  it("restores the expanded view when the show button is clicked", async () => {
+    setup();
+
+    await userEvent.click(screen.getByRole("button", { name: "Hide deployment pane" }));
+    await userEvent.click(screen.getByRole("button", { name: "Show deployment pane" }));
+
+    expect(screen.getByRole("heading", { name: "1. Deployment" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Hide deployment pane" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Show deployment pane" })).not.toBeInTheDocument();
+  });
+
+  function setup() {
+    return render(<DeploymentPane />);
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
@@ -1,0 +1,42 @@
+import type { FC } from "react";
+import { useState } from "react";
+import { SidebarCollapse, SidebarExpand } from "iconoir-react";
+
+export const DeploymentPane: FC = () => {
+  const [minimized, setMinimized] = useState(false);
+  const toggle = () => setMinimized(prev => !prev);
+
+  if (minimized) {
+    return (
+      <aside aria-label="Deployment pane (minimized)" className="hidden h-full min-h-0 md:flex md:w-[48px] md:flex-col md:items-center md:pt-2">
+        <button
+          type="button"
+          onClick={toggle}
+          aria-label="Show deployment pane"
+          className="flex h-8 w-8 items-center justify-center rounded text-foreground hover:bg-accent"
+        >
+          <SidebarExpand className="h-5 w-5" />
+        </button>
+      </aside>
+    );
+  }
+
+  return (
+    <section aria-labelledby="configure-deployment-pane-heading" className="flex h-full min-h-0 flex-col md:w-[231px]">
+      <header className="hidden h-[52px] shrink-0 items-center justify-between gap-2 border-b border-zinc-300 px-4 md:flex dark:border-zinc-700">
+        <h2 id="configure-deployment-pane-heading" className="font-mono text-sm font-medium uppercase text-muted-foreground">
+          1. Deployment
+        </h2>
+        <button
+          type="button"
+          onClick={toggle}
+          aria-label="Hide deployment pane"
+          className="flex h-8 w-8 items-center justify-center rounded text-foreground hover:bg-accent"
+        >
+          <SidebarCollapse className="h-5 w-5" />
+        </button>
+      </header>
+      <div className="flex-1 overflow-y-auto" />
+    </section>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
@@ -1,0 +1,14 @@
+import type { FC } from "react";
+
+export const MarketplacePane: FC = () => {
+  return (
+    <section aria-labelledby="configure-marketplace-pane-heading" className="flex h-full min-h-0 flex-col">
+      <header className="hidden h-[52px] shrink-0 items-center border-b border-zinc-300 px-4 md:flex dark:border-zinc-700">
+        <h2 id="configure-marketplace-pane-heading" className="font-mono text-sm font-medium uppercase text-muted-foreground">
+          3. Compute Marketplace
+        </h2>
+      </header>
+      <div className="flex-1 overflow-y-auto" />
+    </section>
+  );
+};

--- a/apps/deploy-web/src/components/layout/Layout.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.tsx
@@ -24,10 +24,11 @@ type Props = {
   isUsingWallet?: boolean;
   disableContainer?: boolean;
   containerClassName?: string;
+  background?: "default" | "white";
   children?: ReactNode;
 };
 
-const Layout: React.FunctionComponent<Props> = ({ children, isLoading, isUsingSettings, isUsingWallet, disableContainer, containerClassName }) => {
+const Layout: React.FunctionComponent<Props> = ({ children, isLoading, isUsingSettings, isUsingWallet, disableContainer, containerClassName, background }) => {
   const [locale, setLocale] = useState("en-US");
 
   useEffect(() => {
@@ -44,6 +45,7 @@ const Layout: React.FunctionComponent<Props> = ({ children, isLoading, isUsingSe
         isUsingWallet={isUsingWallet}
         disableContainer={disableContainer}
         containerClassName={containerClassName}
+        background={background}
       >
         {children}
       </LayoutApp>
@@ -51,7 +53,15 @@ const Layout: React.FunctionComponent<Props> = ({ children, isLoading, isUsingSe
   );
 };
 
-const LayoutApp: React.FunctionComponent<Props> = ({ children, isLoading, isUsingSettings, isUsingWallet, disableContainer, containerClassName = "" }) => {
+const LayoutApp: React.FunctionComponent<Props> = ({
+  children,
+  isLoading,
+  isUsingSettings,
+  isUsingWallet,
+  disableContainer,
+  containerClassName = "",
+  background = "default"
+}) => {
   const muiTheme = useMuiTheme();
   const smallScreen = useMediaQuery(muiTheme.breakpoints.down("md"));
   const [isNavOpen, setIsNavOpen] = useState(() => {
@@ -93,7 +103,7 @@ const LayoutApp: React.FunctionComponent<Props> = ({ children, isLoading, isUsin
   };
 
   return (
-    <div className="flex h-full flex-col">
+    <div className={cn("flex h-full flex-col", { "min-h-screen bg-white text-foreground": background === "white" })}>
       <TopBanner />
 
       <div className="w-full flex-1" style={{ marginTop: `${ACCOUNT_BAR_HEIGHT + (hasBanner ? 40 : 0)}px` }}>

--- a/apps/deploy-web/src/pages/new-deployment/configure.tsx
+++ b/apps/deploy-web/src/pages/new-deployment/configure.tsx
@@ -1,0 +1,10 @@
+import { ConfigureDeploymentContainer } from "@src/components/deployments/ConfigureDeployment/ConfigureDeploymentContainer/ConfigureDeploymentContainer";
+import { defineServerSideProps } from "@src/lib/nextjs/defineServerSideProps/defineServerSideProps";
+import { isFeatureEnabled } from "@src/lib/nextjs/pageGuards/pageGuards";
+
+export default ConfigureDeploymentContainer;
+
+export const getServerSideProps = defineServerSideProps({
+  route: "/new-deployment/configure",
+  if: async context => isFeatureEnabled("bid_screening", context)
+});

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -9,4 +9,5 @@ export type FeatureFlag =
   | "console_embedded_login"
   | "self_custody"
   | "console_auth_redesign"
-  | "console_onboarding_redesign";
+  | "console_onboarding_redesign"
+  | "bid_screening";


### PR DESCRIPTION
## Why

Closes CON-412. Lays the foundation for the redesigned deployment-creation flow (CON-411): a flag-gated screen at `/new-deployment/configure` (behind `bid_screening`) with the page header and three-pane layout (Deployment · Configuration · Compute Marketplace) that every downstream child issue (CON-415..425) drops content into. Shipping the shell first means later PRs are additive — no churn to layout, routing, or flag wiring. The legacy `/new-deployment` wizard is untouched.

## What

- New page module at `apps/deploy-web/src/pages/new-deployment/configure.tsx` with SSR flag-gate via `defineServerSideProps`. Flag off → `notFound`; flag on → renders the new shell.
- Adds `"bid_screening"` to the `FeatureFlag` union in `apps/deploy-web/src/types/feature-flags.ts` (the key already exists server-side in `apps/api/src/core/services/feature-flags/feature-flags.ts`).
- New component cluster under `apps/deploy-web/src/components/deployments/ConfigureDeployment/`, one directory per component:
  - `ConfigureDeploymentContainer/` — wraps `<Layout>` and renders the page composition.
  - `ConfigureDeploymentHeader/` — title, subtitle (desktop-only), two summary blocks with em-dash placeholders, disabled `Request quotes` CTA (icon-only on mobile via iconoir `Send`).
  - `ConfigureDeploymentPanes/` — grid with `md:grid-cols-[auto_320px_1fr]`; on mobile collapses to single column with bottom-tab navigation.
  - `DeploymentPane/` — owns its own minimize state; collapses to a 48px strip with an expand button on desktop.
  - `ConfigurationPane/`, `MarketplacePane/` — labeled empty sections with internal scrolling.
- `<Layout>` gains a `background?: "default" | "white"` prop that switches the outer surface to `min-h-screen bg-white text-foreground` for redesign pages. Legacy consumers are unaffected.
- Specs added for `ConfigureDeploymentPanes` (tab switching + pane visibility) and `DeploymentPane` (minimize toggle). 7 tests, all passing.

Pane bodies are intentionally empty — they ship in child issues. No new backend calls. No form/context/provider plumbing.

## Test plan

- [ ] `npm run lint -- --quiet`, `npx tsc --noEmit`, `npm test` pass under `apps/deploy-web`
- [ ] With `bid_screening` off (or `NEXT_PUBLIC_UNLEASH_ENABLE_ALL=false`), `GET /new-deployment/configure` returns 404
- [ ] With `bid_screening` on, `/new-deployment/configure` renders the redesign — page header (title, em-dash summary blocks, disabled CTA) + three labeled panes
- [ ] Click the Deployment pane's collapse icon → pane collapses to a 48px strip with an expand button; click the expand button → pane restores
- [ ] On mobile width, only the active pane renders; bottom tabs switch the active pane
- [ ] Legacy `/new-deployment` wizard loads and behaves identically

https://github.com/user-attachments/assets/9aafccd1-143c-4b1e-9096-323896ca3aae



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new deployment configuration page with collapsible panes for Deployment, Configuration, and Marketplace settings.
  * Responsive layout: tab navigation on mobile, multi-column view on desktop.
  * Header displays deployment summary with cost information and quote request option.
  * Expand/collapse functionality for better space management.

* **Tests**
  * Added comprehensive test coverage for configuration components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->