### PR TITLE
fix(alert): wait for new deployment row in alerts e2e

### DIFF
--- a/apps/deploy-web/tests/ui/managed-wallet-alerts.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-alerts.spec.ts
@@ -85,12 +85,16 @@ test.describe("Managed wallet alerts", () => {
       await sidebar.openAlerts();
       await alertsPage.waitForPage();
       await alertsPage.openAlertsTab();
-      await expect(alertsPage.getAlertRow(0)).toBeVisible({ timeout: 10_000 });
+    });
+
+    const deploymentAlertRow = page.getByRole("row").filter({ hasText: dseq });
+
+    await test.step("wait for alert row for new deployment", async () => {
+      await expect(deploymentAlertRow).toBeVisible({ timeout: 30_000 });
     });
 
     await test.step("toggle alert from alerts list", async () => {
-      const firstAlertRow = alertsPage.getAlertRow(0);
-      const toggle = alertsPage.getAlertToggle(firstAlertRow);
+      const toggle = alertsPage.getAlertToggle(deploymentAlertRow);
 
       await toggle.click();
       await expect(toggle).not.toBeChecked({ timeout: 5_000 });
@@ -100,7 +104,7 @@ test.describe("Managed wallet alerts", () => {
     });
 
     await test.step("close deployment", async () => {
-      await page.getByRole("row").filter({ hasText: dseq }).getByRole("link").first().click();
+      await deploymentAlertRow.getByRole("link").first().click();
       await deployPage.closeDeployment();
       await expect(page.getByText(/are you sure you want to close/i)).toBeVisible({ timeout: 5_000 });
       await page.getByRole("button", { name: /confirm/i }).click();


### PR DESCRIPTION
## Why

The `Managed wallet alerts` E2E (`managed-wallet-alerts.spec.ts`) was failing repeatedly on beta runs in the close-deployment step:

```
locator.click: Timeout 15000ms exceeded
  - waiting for getByRole('row').filter({ hasText: '<dseq>' }).getByRole('link').first()
```

The test uses `userType: "existing"`, so the alerts list already contains historical rows from prior runs. Previously:

- The "verify alerts on global alerts page" step only asserted `getAlertRow(0)` was visible — true even if that row is a stale alert from a prior run.
- The "toggle alert from alerts list" step then toggled row 0 — potentially a stale alert, masking propagation lag.
- The "close deployment" step finally filtered by *this run's* DSEQ — but if `notifications-chain-events` hadn't pushed the new alert to `/alerts` within the default 15s action timeout, the locator never resolved.

Locally the lag is small enough to be invisible; on CI it consistently races.

## What

Pin every alerts-list interaction (visibility check, toggle, link click) to a single locator filtered by the freshly created DSEQ, with a 30s wait for the new row to appear. This removes the dependency on `getAlertRow(0)` (non-deterministic across runs) and gives `notifications-chain-events` enough headroom to propagate before we drive the row.

No production code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for managed wallet alerts by enhancing test precision when targeting specific deployment alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->