### PR TITLE
fix(alert): page through alerts list to find new dseq row in e2e

### DIFF
--- a/apps/deploy-web/tests/ui/managed-wallet-alerts.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-alerts.spec.ts
@@ -87,11 +87,7 @@ test.describe("Managed wallet alerts", () => {
       await alertsPage.openAlertsTab();
     });
 
-    const deploymentAlertRow = page.getByRole("row").filter({ hasText: dseq });
-
-    await test.step("wait for alert row for new deployment", async () => {
-      await expect(deploymentAlertRow).toBeVisible({ timeout: 30_000 });
-    });
+    const deploymentAlertRow = await alertsPage.findAlertRowByDseq(dseq!);
 
     await test.step("toggle alert from alerts list", async () => {
       const toggle = alertsPage.getAlertToggle(deploymentAlertRow);

--- a/apps/deploy-web/tests/ui/pages/AlertsPage.ts
+++ b/apps/deploy-web/tests/ui/pages/AlertsPage.ts
@@ -26,9 +26,9 @@ export class AlertsPage {
   async findAlertRowByDseq(dseq: string, options: { timeout?: number } = {}) {
     const { timeout = 30_000 } = options;
     const deadline = Date.now() + timeout;
-    // Each deployment renders two rows on /alerts (Escrow Threshold + Deployment Close),
-    // both containing the same DSEQ — scope to the first to avoid strict-mode violations
-    // on downstream toggle/link actions.
+    // A deployment can render up to one row per configured alert type (Escrow Threshold,
+    // Deployment Close), all sharing the same DSEQ. Scope to the first match so downstream
+    // toggle/link actions stay strict-mode-safe regardless of how many are configured.
     const row = this.page.getByRole("row").filter({ hasText: dseq }).first();
     const nextButton = this.page.getByRole("link", { name: /go to next page/i });
 

--- a/apps/deploy-web/tests/ui/pages/AlertsPage.ts
+++ b/apps/deploy-web/tests/ui/pages/AlertsPage.ts
@@ -22,4 +22,29 @@ export class AlertsPage {
   getAlertToggle(row: Locator) {
     return row.getByRole("checkbox", { name: /toggle alert/i });
   }
+
+  async findAlertRowByDseq(dseq: string, options: { timeout?: number } = {}) {
+    const { timeout = 30_000 } = options;
+    const deadline = Date.now() + timeout;
+    const row = this.page.getByRole("row").filter({ hasText: dseq });
+    const nextButton = this.page.getByRole("link", { name: /go to next page/i });
+
+    while (Date.now() < deadline) {
+      try {
+        await row.waitFor({ state: "visible", timeout: 2_000 });
+        return row;
+      } catch {
+        // not on this page; fall through and try the next one
+      }
+
+      const nextVisible = await nextButton.isVisible().catch(() => false);
+      if (!nextVisible) break;
+      const ariaDisabled = await nextButton.getAttribute("aria-disabled").catch(() => null);
+      if (ariaDisabled === "true") break;
+
+      await nextButton.click();
+    }
+
+    throw new Error(`Alert row for DSEQ ${dseq} not found in alerts list`);
+  }
 }

--- a/apps/deploy-web/tests/ui/pages/AlertsPage.ts
+++ b/apps/deploy-web/tests/ui/pages/AlertsPage.ts
@@ -26,7 +26,10 @@ export class AlertsPage {
   async findAlertRowByDseq(dseq: string, options: { timeout?: number } = {}) {
     const { timeout = 30_000 } = options;
     const deadline = Date.now() + timeout;
-    const row = this.page.getByRole("row").filter({ hasText: dseq });
+    // Each deployment renders two rows on /alerts (Escrow Threshold + Deployment Close),
+    // both containing the same DSEQ — scope to the first to avoid strict-mode violations
+    // on downstream toggle/link actions.
+    const row = this.page.getByRole("row").filter({ hasText: dseq }).first();
     const nextButton = this.page.getByRole("link", { name: /go to next page/i });
 
     while (Date.now() < deadline) {


### PR DESCRIPTION
## Why

After [#3256](https://github.com/akash-network/console/pull/3256), the `Managed wallet alerts` E2E still failed at the new `wait for alert row for new deployment` step:

```
Error: expect(locator).toBeVisible() failed
Error: element(s) not found
```

[apps/deploy-web/src/components/alerts/AlertsListContainer/AlertsListContainer.tsx#L36-L41](https://github.com/akash-network/console/blob/main/apps/deploy-web/src/components/alerts/AlertsListContainer/AlertsListContainer.tsx#L36-L41) hardcodes `page = 1, limit = 10`. The test uses `userType: "existing"` and prior failed runs left two orphan alerts per crashed deployment (Escrow + Close, never cleaned up because the close step never ran). Those orphans push the newly created alert off page 1, so the locator can never find it no matter how long we wait.

## What

- Add `AlertsPage#findAlertRowByDseq(dseq)` that pages forward via the `Go to next page` link until the row appears, or the next button is disabled / missing.
- Replace the page-1-only `expect(...).toBeVisible` wait in `managed-wallet-alerts.spec.ts` with that helper.

Test-only; no app changes. Cleaning up the orphan-alert backlog itself (proper `beforeAll`/teardown deleting prior alerts and deployments for the test user) is a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced UI test infrastructure for deployment alert management with improved row discovery and pagination handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->