### PR TITLE
fix(deploy-web): show billing charge dates in UTC

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.spec.tsx
@@ -30,13 +30,13 @@ describe(BillingView.name, () => {
   it("renders table with billing data", () => {
     const { data } = setup();
     expect(screen.getByText("History")).toBeInTheDocument();
-    expect(screen.getByText("Date")).toBeInTheDocument();
+    expect(screen.getByText("Date (UTC)")).toBeInTheDocument();
     expect(screen.getByText("Amount")).toBeInTheDocument();
     expect(screen.getByText("Account source")).toBeInTheDocument();
     expect(screen.getByText("Status")).toBeInTheDocument();
     expect(screen.getByText("Receipt")).toBeInTheDocument();
 
-    expect(screen.getByText(new Date(data[0].created * 1000).toLocaleDateString())).toBeInTheDocument();
+    expect(screen.getByText(new Date(data[0].created * 1000).toLocaleDateString(undefined, { timeZone: "UTC" }))).toBeInTheDocument();
     expect(screen.getByText((data[0].amount / 100).toFixed(2))).toBeInTheDocument();
     expect(screen.getByText(new RegExp(data[0].paymentMethod.card?.last4 || ""))).toBeInTheDocument();
     expect(screen.getByText(/Succeeded|Pending|Failed/i)).toBeInTheDocument();

--- a/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
@@ -76,8 +76,10 @@ export const BillingView: React.FC<BillingViewProps> = ({
 
   const columns = [
     columnHelper.accessor("created", {
-      header: "Date",
-      cell: info => new Date(info.getValue() * 1000).toLocaleDateString()
+      header: "Date (UTC)",
+      // Render in UTC so the displayed day matches the Stripe charge timestamp
+      // regardless of the viewer's local timezone (see akash-network/console#2010).
+      cell: info => new Date(info.getValue() * 1000).toLocaleDateString(undefined, { timeZone: "UTC" })
     }),
     columnHelper.accessor("amount", {
       header: "Amount",


### PR DESCRIPTION
Hi, and thanks for the work on Console.

Fixes #2010. The billing history table rendered the Stripe charge date with `toLocaleDateString()`, which formats in the viewer's local timezone. Stripe receipts use the charge's UTC date, so for users far from UTC the Console could show a day that differs from the receipt.

This renders the date with `{ timeZone: "UTC" }` and labels the column `Date (UTC)` so it is unambiguous and matches the receipt regardless of where the viewer is. The `created` value is a Stripe Unix timestamp, so UTC is its canonical basis.

Changed `BillingView.tsx` (the `created` column) and updated its spec to match.

### Note on local testing
The repo targets Node 24 / npm 11, and the committed lockfile is currently out of sync (`npm ci` fails on missing esbuild entries unrelated to this change), so I could not run the vitest suite locally without rewriting the lockfile. This is a one-line formatting change and the spec was updated to mirror it, so CI should cover it. Happy to tweak the column label or approach if you would prefer something else.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the billing table to display all dates in UTC timezone. The "Date" column header now indicates "(UTC)" to clarify the timezone standard being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->