### PR TITLE
fix(billing): capture pre-charge balance before payment polling

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
@@ -350,6 +350,7 @@ describe(AddCreditsForm.name, () => {
     isTrialing?: boolean;
     isPolling?: boolean;
     isWalletReady?: boolean;
+    initialBalance?: number | null;
     dependencies?: Partial<typeof DEPENDENCIES>;
   };
 
@@ -383,6 +384,11 @@ describe(AddCreditsForm.name, () => {
 
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing: input.isTrialing ?? false });
 
+    const useWalletBalance: typeof DEPENDENCIES.useWalletBalance = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useWalletBalance>>({
+        balance: input.initialBalance !== undefined ? ({ totalUsd: input.initialBalance } as ReturnType<typeof DEPENDENCIES.useWalletBalance>["balance"]) : null
+      });
+
     const use3DSecure: typeof DEPENDENCIES.use3DSecure = () =>
       mock<ReturnType<typeof DEPENDENCIES.use3DSecure>>({
         isOpen: false,
@@ -408,6 +414,7 @@ describe(AddCreditsForm.name, () => {
           usePaymentMutations,
           usePaymentPolling,
           useWallet,
+          useWalletBalance,
           use3DSecure,
           handleStripeError: input.handleStripeError ?? (() => ({ message: "fallback", userAction: undefined })),
           ...input.dependencies

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
@@ -14,6 +14,7 @@ import { usePaymentPolling } from "@src/context/PaymentPollingProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { use3DSecure } from "@src/hooks/use3DSecure";
 import { useUser } from "@src/hooks/useUser";
+import { useWalletBalance } from "@src/hooks/useWalletBalance";
 import { usePaymentMutations, useSetupIntentMutation } from "@src/queries";
 import { handleStripeError } from "@src/utils/stripeErrorHandler";
 
@@ -28,6 +29,7 @@ export const DEPENDENCIES = {
   usePaymentMutations,
   usePaymentPolling,
   useWallet,
+  useWalletBalance,
   use3DSecure,
   useUser,
   handleStripeError
@@ -45,6 +47,7 @@ interface PendingCharge {
   organization?: string;
   amount: number;
   wasTrialing: boolean;
+  initialBalance: number | null;
   status: "pending" | "charging";
 }
 
@@ -61,6 +64,7 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
   const { user } = d.useUser();
   const { pollForPayment, isPolling } = d.usePaymentPolling();
   const { isTrialing } = d.useWallet();
+  const { balance: currentBalance } = d.useWalletBalance();
   const {
     confirmPayment: { mutateAsync: confirmPayment }
   } = d.usePaymentMutations();
@@ -108,6 +112,7 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
       organization: paymentMethod.organization,
       amount,
       wasTrialing: isTrialing,
+      initialBalance: currentBalance?.totalUsd ?? null,
       status: "pending"
     });
   };
@@ -121,7 +126,7 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
 
   const threeDSecure = d.use3DSecure({
     onSuccess: function onThreeDSecureSuccess() {
-      pollForPayment();
+      pollForPayment(charge?.initialBalance ?? null);
     },
     onError: function onThreeDSecureError(message) {
       finalizeFailure(message);
@@ -151,7 +156,7 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
         }
 
         if (chargeResult.success) {
-          pollForPayment();
+          pollForPayment(pending.initialBalance);
           return;
         }
 


### PR DESCRIPTION
## Why

The onboarding E2E test `onboarding-picker-unlock-trial.spec.ts` started failing at the "Payment successful!" toast assertion. Root cause: `pollForPayment` was being started **after** the charge confirmation, with no pre-payment baseline. By the time it captured `currentBalance.totalUsd` as its baseline, React Query may have already refetched the balance with the post-payment value, so the poll's "did the balance increase?" check could never fire and it timed out at 30s.

## What

- Snapshot `currentBalance?.totalUsd` in the `submit` handler (before `addPaymentMethod`, before any `await`) and store it on the `PendingCharge` as `initialBalance`.
- Pass `pending.initialBalance` into `pollForPayment(...)` at the direct-success call site (`performCharge`) and the 3DS-success call site (`use3DSecure.onSuccess` reads it from the latest `charge` state).
- `useWalletBalance` is added to the component's `DEPENDENCIES` so the spec can inject a balance.
- Spec updated to wire `useWalletBalance` into the test setup; existing 15 tests still pass.

The 3DS path is the one that exposed the bug — its extra `await` between charge confirmation and polling start gave React Query more time to refetch the balance. Direct-success is fixed by the same change.

This does **not** touch `PaymentPopup.tsx` (the legacy billing-usage flow), which has the same `pollForPayment()` no-arg pattern but a different timing profile. If it ever surfaces the same race, the fix is identical and trivially portable.

## Test plan

- [ ] `npx vitest run src/components/billing-usage/AddCreditsForm` passes (15/15)
- [ ] `tests/ui/onboarding-picker-unlock-trial.spec.ts` reaches the "Payment successful!" snackbar within the 30s timeout
- [ ] Manual smoke: fresh trialing user purchases credits via the Add Credits sheet → sees Processing → Payment successful → Welcome snackbars in order
- [ ] Manual smoke: 3DS-required card surfaces the auth modal and the polling baseline is still correct after the modal closes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for wallet balance handling in payment forms.

* **Improvements**
  * Improved wallet balance tracking during payment operations to capture balance snapshots at charge initiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->