### PR TITLE
fix(billing): treat trial flip as a payment-success signal

### DIFF
--- a/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.spec.tsx
+++ b/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.spec.tsx
@@ -206,6 +206,35 @@ describe(PaymentPollingProvider.name, () => {
     consoleSpy.mockRestore();
   });
 
+  it("signals 'Payment successful!' on trial flip and suppresses the later timeout warning", async () => {
+    const { enqueueSnackbar, setIsTrialing, advancePollCycle, cleanup } = setup({
+      isTrialing: true,
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start-polling").click();
+    });
+
+    expect(enqueueSnackbar).toHaveBeenCalledWith(snackbarWithTitle("Processing payment..."), expect.anything());
+
+    await setIsTrialing(false);
+    await advancePollCycle();
+
+    expect(enqueueSnackbar).toHaveBeenCalledWith(snackbarWithTitle("Payment successful!"), expect.objectContaining({ variant: "success" }));
+
+    await advancePollCycle(30000);
+
+    expect(enqueueSnackbar).not.toHaveBeenCalledWith(snackbarWithTitle("Payment processing timeout"), expect.anything());
+
+    cleanup();
+  });
+
+  function snackbarWithTitle(title: string) {
+    return expect.objectContaining({ props: expect.objectContaining({ title }) });
+  }
+
   function setup(input: { isTrialing: boolean; balance: { totalUsd: number } | null; isWalletBalanceLoading: boolean }) {
     vi.useFakeTimers();
 
@@ -214,33 +243,33 @@ describe(PaymentPollingProvider.name, () => {
     const analyticsService = mock<AnalyticsService>();
     const mockEnqueueSnackbar = vi.fn();
     const mockCloseSnackbar = vi.fn();
-    const wallet = buildWallet({ isTrialing: input.isTrialing });
-    const managedWallet = buildManagedWallet({ isTrialing: input.isTrialing });
-    const walletBalance = input.balance ? buildWalletBalance(input.balance) : null;
+
+    const state = {
+      isTrialing: input.isTrialing,
+      balance: input.balance
+    };
 
     const mockSnackbar = ({ title, subTitle, iconVariant, showLoading }: { title: string; subTitle: string; iconVariant?: string; showLoading?: boolean }) => (
       <div data-testid="snackbar" data-title={title} data-subtitle={subTitle} data-icon-variant={iconVariant} data-show-loading={showLoading} />
     );
 
-    const mockManagedWallet = {
-      ...managedWallet,
-      username: "Managed Wallet" as const,
-      isWalletConnected: true,
-      isWalletLoaded: true,
-      selected: true,
-      creditAmount: 0
-    };
-
     const dependencies = {
       ...DEPENDENCIES,
-      useWallet: vi.fn(() => wallet),
+      useWallet: vi.fn(() => buildWallet({ isTrialing: state.isTrialing })),
       useWalletBalance: vi.fn(() => ({
-        balance: walletBalance,
+        balance: state.balance ? buildWalletBalance(state.balance) : null,
         refetch: refetchBalance,
         isLoading: input.isWalletBalanceLoading
       })),
       useManagedWallet: vi.fn(() => ({
-        wallet: mockManagedWallet,
+        wallet: {
+          ...buildManagedWallet({ isTrialing: state.isTrialing }),
+          username: "Managed Wallet" as const,
+          isWalletConnected: true,
+          isWalletLoaded: true,
+          selected: true,
+          creditAmount: 0
+        },
         isLoading: false,
         isFetching: false,
         createError: null,
@@ -272,11 +301,12 @@ describe(PaymentPollingProvider.name, () => {
       );
     };
 
-    const { rerender, unmount } = render(
-      <PaymentPollingProvider dependencies={dependencies}>
+    const buildUi = () => (
+      <PaymentPollingProvider dependencies={{ ...dependencies }}>
         <TestComponent />
       </PaymentPollingProvider>
     );
+    const { rerender, unmount } = render(buildUi());
 
     return {
       refetchBalance,
@@ -286,6 +316,17 @@ describe(PaymentPollingProvider.name, () => {
       closeSnackbar: mockCloseSnackbar,
       rerender,
       unmount,
+      setIsTrialing: async (isTrialing: boolean) => {
+        state.isTrialing = isTrialing;
+        await act(async () => {
+          rerender(buildUi());
+        });
+      },
+      advancePollCycle: async (time: number = 2000) => {
+        await act(async () => {
+          vi.advanceTimersByTime(time);
+        });
+      },
       cleanup: () => {
         vi.useRealTimers();
       }

--- a/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.tsx
+++ b/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.tsx
@@ -58,6 +58,7 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
   const wasTrialingRef = useRef<boolean>(wasTrialing);
   const initialTrialingRef = useRef<boolean>(wasTrialing);
   const loadingSnackbarKeyRef = useRef<string | number | null>(null);
+  const hasSignaledSuccessRef = useRef<boolean>(false);
 
   const closeLoadingSnackbar = useCallback(() => {
     if (loadingSnackbarKeyRef.current) {
@@ -85,9 +86,11 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
 
     if (attemptCountRef.current > MAX_ATTEMPTS) {
       stopPolling();
-      enqueueSnackbar(<d.Snackbar title="Payment processing timeout" subTitle="Please refresh the page to check your balance" iconVariant="warning" />, {
-        variant: "warning"
-      });
+      if (!hasSignaledSuccessRef.current) {
+        enqueueSnackbar(<d.Snackbar title="Payment processing timeout" subTitle="Please refresh the page to check your balance" iconVariant="warning" />, {
+          variant: "warning"
+        });
+      }
       return;
     }
 
@@ -104,6 +107,7 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
       const balanceToUse = initialBalance ?? currentBalance?.totalUsd ?? null;
       initialBalanceRef.current = balanceToUse;
       initialTrialingRef.current = wasTrialing;
+      hasSignaledSuccessRef.current = false;
       isPollingRef.current = true;
       attemptCountRef.current = 0;
       setIsPolling(true);
@@ -156,29 +160,31 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
 
   useEffect(
     function checkForPaymentCompletion() {
-      if (!isPolling || !currentBalance || initialBalanceRef.current == null) {
+      if (!isPolling || hasSignaledSuccessRef.current) {
         return;
       }
 
-      const currentTotalBalance = currentBalance.totalUsd;
-      const initialBalanceValue = initialBalanceRef.current;
+      const balanceIncreased = currentBalance != null && initialBalanceRef.current != null && currentBalance.totalUsd > initialBalanceRef.current;
+      const trialFlipped = initialTrialingRef.current && !wasTrialing;
 
-      if (currentTotalBalance > initialBalanceValue) {
-        closeLoadingSnackbar();
-        enqueueSnackbar(<d.Snackbar title="Payment successful!" subTitle="Your balance has been updated" iconVariant="success" />, { variant: "success" });
+      if (!balanceIncreased && !trialFlipped) {
+        return;
+      }
 
-        // Track analytics for trial users after stopping polling
-        if (initialTrialingRef.current) {
-          analyticsService.track("trial_completed", {
-            category: "user",
-            label: "First payment completed"
-          });
-        } else {
-          stopPolling();
-        }
+      hasSignaledSuccessRef.current = true;
+      closeLoadingSnackbar();
+      enqueueSnackbar(<d.Snackbar title="Payment successful!" subTitle="Your balance has been updated" iconVariant="success" />, { variant: "success" });
+
+      if (initialTrialingRef.current) {
+        analyticsService.track("trial_completed", {
+          category: "user",
+          label: "First payment completed"
+        });
+      } else {
+        stopPolling();
       }
     },
-    [isPolling, currentBalance, stopPolling, enqueueSnackbar, analyticsService, d, closeLoadingSnackbar]
+    [isPolling, currentBalance, wasTrialing, stopPolling, enqueueSnackbar, analyticsService, d, closeLoadingSnackbar]
   );
 
   useEffect(


### PR DESCRIPTION
## Why

The onboarding E2E test `onboarding-picker-unlock-trial.spec.ts` fails at the `"Payment successful!"` assertion — the toast never appears within 30s, even though "Processing payment..." fires (polling starts) and the trial does eventually convert. Cause: for a fresh trialing user, the trial allowance is counted as USD in `walletBalance.totalUsd`. Quoting the gift-icon alert in `AddCreditsForm.tsx`:

> "Akash matches your first purchase dollar-dollar, up to $100."

So a $100 trial allowance is replaced by $100 of paid balance on first purchase — `totalUsd` is **net flat**. The polling effect's strict `currentTotalBalance > initialBalanceValue` check therefore never trips for trialing users, and the `"Payment successful!"` snackbar never enqueues. The separate trial-flip effect still fires `"Welcome to Akash!"`, but the test (and the user-visible flow) wants both.

## What

In `PaymentPollingProvider.tsx`'s `checkForPaymentCompletion` effect:

- Detect a successful payment via either path: a balance increase **or** a trial flip (`initialTrialingRef.current && !wasTrialing`). For trialing users in the trial-credit-matched case, only the trial flip will fire — that's the new signal.
- Add a `hasSignaledSuccessRef` ref that's reset in `pollForPayment` and set after the success snackbar fires, so the effect fires `"Payment successful!"` exactly once per poll cycle even though `currentBalance` updates may continue to trigger the effect.
- Drop the strict early-return on `initialBalanceRef.current == null` so the trial-flip path still resolves when the balance was never observed before the charge.

For non-trialing users the behavior is unchanged: balance increase fires `"Payment successful!"` and stops polling. For trialing users the new path fires `"Payment successful!"` on trial flip, tracks `trial_completed` analytics, and leaves the existing `checkForTrialStatusChange` effect to fire `"Welcome to Akash!"` and `stopPolling`. The two effects run in declaration order on the same `wasTrialing` change, so the user sees: `Processing → Payment successful! → Welcome to Akash!`.

## Test plan

- [ ] Existing `PaymentPollingProvider` unit tests pass (10/10)
- [ ] `tests/ui/onboarding-picker-unlock-trial.spec.ts` reaches the `"Payment successful!"` and `"Welcome to Akash!"` snackbars within the 30s timeouts
- [ ] Manual smoke: fresh trialing user purchases $100 via the Add Credits sheet → sees Processing → Payment successful → Welcome snackbars in order, sheet closes, LLM CTA unlocks
- [ ] Manual smoke: non-trialing user adds $20 credit (balance increases) → still sees Processing → Payment successful → no regression
- [ ] Manual smoke: 3DS-required card surfaces the auth modal; both snackbars still fire correctly after the modal closes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate “Payment successful!” notifications during polling sessions.
  * Improved completion detection to treat either a trial → non-trial transition or a USD balance increase as payment success.
  * Ensured loading snackbars are cleared and success confirmations are shown reliably.
  * Suppressed timeout warnings when success has already been signaled.

* **Tests**
  * Added a test verifying a trial → non-trial flip triggers success and prevents a later timeout warning; introduced helpers to mutate trial state and advance polling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->