### PR TITLE
chore(deployment): align registry + specs to chain-sdk alpha.32

### DIFF
--- a/apps/api/src/billing/services/balances/balances.service.spec.ts
+++ b/apps/api/src/billing/services/balances/balances.service.spec.ts
@@ -114,7 +114,7 @@ describe(BalancesService.name, () => {
 
   function setup(input?: { limitsUpdate?: Partial<UserWalletInput>; deploymentLimit?: number; fiatAmount?: number; denom?: string }) {
     const billingConfig = mock<BillingConfig>();
-    billingConfig.DEPLOYMENT_GRANT_DENOM = input?.denom ?? "uakt";
+    billingConfig.DEPLOYMENT_GRANT_DENOM = (input?.denom ?? "uakt") as "uakt" | "uact";
     const userWalletRepository = mock<UserWalletRepository>();
     const txManagerService = mock<TxManagerService>();
     const authzHttpService = mock<AuthzHttpService>();

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -1,3 +1,5 @@
+import { MsgAccountDeposit } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { MsgCloseDeployment, MsgCreateDeployment, MsgUpdateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { vi } from "vitest";
 import { mock, type MockProxy } from "vitest-mock-extended";
 
@@ -67,9 +69,9 @@ describe(DeploymentWriterService.name, () => {
       const { service, signerService, rpcMessageService } = setup();
       const dseq = 1748400000000;
       vi.spyOn(Date, "now").mockReturnValue(dseq);
-      const txResult = { code: 0, transactionHash: "tx-hash" };
+      const txResult = { code: 0, transactionHash: "tx-hash", hash: "tx-hash", rawLog: "" };
       signerService.executeDerivedDecodedTxByUserId.mockResolvedValue(txResult);
-      const createMsg = { typeUrl: "/create", value: {} };
+      const createMsg = { typeUrl: "/create", value: MsgCreateDeployment.fromPartial({}) };
       rpcMessageService.getCreateDeploymentMsg.mockReturnValue(createMsg);
 
       const result = await service.create({ userId: "user-1", sdl: "valid-sdl", deposit: 5 });
@@ -102,7 +104,7 @@ describe(DeploymentWriterService.name, () => {
   describe("closeByUserIdAndDseq", () => {
     it("fetches wallet and closes deployment", async () => {
       const { service, signerService, rpcMessageService } = setup();
-      const closeMsg = { typeUrl: "/close", value: {} };
+      const closeMsg = { typeUrl: "/close", value: MsgCloseDeployment.fromPartial({}) };
       rpcMessageService.getCloseDeploymentMsg.mockReturnValue(closeMsg);
 
       await service.closeByUserIdAndDseq("user-1", "100");
@@ -115,7 +117,7 @@ describe(DeploymentWriterService.name, () => {
   describe("close", () => {
     it("closes deployment by wallet and dseq", async () => {
       const { service, signerService, rpcMessageService } = setup();
-      const closeMsg = { typeUrl: "/close", value: {} };
+      const closeMsg = { typeUrl: "/close", value: MsgCloseDeployment.fromPartial({}) };
       rpcMessageService.getCloseDeploymentMsg.mockReturnValue(closeMsg);
 
       await service.close(wallet, "100");
@@ -130,7 +132,7 @@ describe(DeploymentWriterService.name, () => {
       const { service, rpcMessageService, signerService, deploymentReaderService } = setup();
       const updatedDeployment = { ...deploymentData };
       deploymentReaderService.findByWalletAndDseq.mockResolvedValue(updatedDeployment);
-      const depositMsg = { typeUrl: "/deposit", value: {} };
+      const depositMsg = { typeUrl: "/deposit", value: MsgAccountDeposit.fromPartial({}) };
       rpcMessageService.getDepositDeploymentMsg.mockReturnValue(depositMsg);
 
       const result = await service.deposit({ userId: "user-1", dseq: "100", amount: 3 });
@@ -155,7 +157,7 @@ describe(DeploymentWriterService.name, () => {
         deployment: { ...deploymentData.deployment, hash: "stale-hash" }
       };
       deploymentReaderService.findByWalletAndDseq.mockResolvedValueOnce(staleDeployment).mockResolvedValueOnce(deploymentData);
-      const updateMsg = { typeUrl: "/update", value: {} };
+      const updateMsg = { typeUrl: "/update", value: MsgUpdateDeployment.fromPartial({}) };
       rpcMessageService.getUpdateDeploymentMsg.mockReturnValue(updateMsg);
 
       const result = await service.updateByUserIdAndDseq("user-1", "100", { sdl: "valid-sdl" });
@@ -187,7 +189,7 @@ describe(DeploymentWriterService.name, () => {
         ]
       };
       deploymentReaderService.findByWalletAndDseq.mockResolvedValueOnce(deploymentWithMultipleLeases).mockResolvedValueOnce(deploymentData);
-      providerService.toProviderAuth.mockResolvedValue({ certPem: "cert", keyPem: "key" });
+      providerService.toProviderAuth.mockResolvedValue({ type: "jwt", token: "test-token" });
 
       await service.updateByUserIdAndDseq("user-1", "100", { sdl: "valid-sdl" });
 

--- a/apps/tx-signer/src/providers/type-registry.provider.spec.ts
+++ b/apps/tx-signer/src/providers/type-registry.provider.spec.ts
@@ -1,0 +1,27 @@
+import { MsgLeaseStartReclaim } from "@akashnetwork/chain-sdk/private-types/akash.v1beta5";
+import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
+
+import { TYPE_REGISTRY } from "./type-registry.provider";
+
+describe("TYPE_REGISTRY", () => {
+  it("registers MsgLeaseStartReclaim and round-trips a populated value", () => {
+    const registry = container.resolve(TYPE_REGISTRY);
+    const typeUrl = "/akash.market.v1beta5.MsgLeaseStartReclaim";
+
+    expect(registry.lookupType(typeUrl)).toBeDefined();
+
+    const value = MsgLeaseStartReclaim.fromPartial({
+      id: { owner: "akash1test", dseq: "100", gseq: 1, oseq: 1, provider: "akash1prov" },
+      reason: 1
+    });
+    const bytes = registry.encode({ typeUrl, value });
+    const decoded = registry.decode({ typeUrl, value: bytes }) as MsgLeaseStartReclaim;
+
+    expect(decoded.id?.owner).toBe("akash1test");
+    expect(decoded.id?.provider).toBe("akash1prov");
+    expect(decoded.id?.gseq).toBe(1);
+    expect(decoded.id?.oseq).toBe(1);
+    expect(decoded.reason).toBe(1);
+  });
+});

--- a/apps/tx-signer/src/providers/type-registry.provider.spec.ts
+++ b/apps/tx-signer/src/providers/type-registry.provider.spec.ts
@@ -20,6 +20,7 @@ describe("TYPE_REGISTRY", () => {
 
     expect(decoded.id?.owner).toBe("akash1test");
     expect(decoded.id?.provider).toBe("akash1prov");
+    expect(String(decoded.id?.dseq)).toBe("100");
     expect(decoded.id?.gseq).toBe(1);
     expect(decoded.id?.oseq).toBe(1);
     expect(decoded.reason).toBe(1);


### PR DESCRIPTION
## Why

PR #3229 bumped `@akashnetwork/chain-sdk` to `1.0.0-alpha.32`, which ships the AEP-82 lease reclamation primitives and tightens several existing proto shapes. The new types were silently picked up by all three Cosmos type registries (`apps/api`, `apps/tx-signer`, `apps/notifications`) via the existing `Object.values(v1beta5)` wildcard spread — `MsgLeaseStartReclaim` is already registered today. However, several test mocks in `apps/api` were left passing values that no longer satisfy the tightened proto contracts, so `npx tsc --noEmit` failed there.

This PR closes out CON-286 by:
1. Adding a defensive registry round-trip test that locks in the registration contract for `MsgLeaseStartReclaim`.
2. Updating the spec mocks in `apps/api` so the type-check is clean against the new proto shapes.

Closes CON-286

## What

- **New test** — [apps/tx-signer/src/providers/type-registry.provider.spec.ts](apps/tx-signer/src/providers/type-registry.provider.spec.ts). Resolves the registry, looks up `/akash.market.v1beta5.MsgLeaseStartReclaim`, populates an instance via `fromPartial`, and round-trips through `registry.encode` → `registry.decode` to confirm fields are preserved.
- **Spec fixes** in [apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts](apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts):
  - `typeUrl`/`value` pairs use `MsgCreateDeployment.fromPartial({})` / `MsgCloseDeployment.fromPartial({})` / `MsgUpdateDeployment.fromPartial({})` / `MsgAccountDeposit.fromPartial({})` so they satisfy the strict Msg shapes (e.g., `MsgCreateDeployment` now requires `reclamation`).
  - `txResult` mock includes `hash` and `rawLog` to match the `ManagedSignerService` return signature.
  - `toProviderAuth` mock returns `{ type: "jwt", token }` after #3217 removed `certPem` from `ProviderAuth`.
- **Spec fix** in [apps/api/src/billing/services/balances/balances.service.spec.ts](apps/api/src/billing/services/balances/balances.service.spec.ts) — casts `denom` at the assignment site so the deliberate IBC-denom test still compiles against the `"uakt" | "uact"` zod enum.

### Scope note

The `certPem` and `balances.spec` denom edits are pre-existing main drift, not strictly chain-sdk alpha.32 fallout (the `denom` literal-type tightening and the `ProviderAuth` reshape from #3217 predate the bump). They were bundled in because they sat in the same files that needed the CON-286 proto-shape fixes, and tsc isn't per-line — clearing the CON-286 errors required clearing the surrounding noise to keep the verification signal clean. Happy to split them out into a separate commit if reviewers prefer.

The remaining ~50 tsc errors in `apps/api` (vitest globals not in scope, internal cosmjs/http-sdk import paths, tsup `import.meta`) are pre-existing infra issues unrelated to v2.1.0 and out of CON-286 scope.

## Test plan

- [x] `npx tsc --noEmit` in `apps/api`, `apps/tx-signer`, `apps/notifications`, `apps/indexer` — no CON-286-attributable errors
- [x] `npm run lint -- --quiet` in `apps/api` and `apps/tx-signer` — clean
- [x] `npm run test:unit` in `apps/api` — 945/945 pass
- [x] `npm test` in `apps/tx-signer` — 56/56 pass (includes new registry round-trip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test coverage and type safety for billing, deployment, and transaction services.
  * Deployment tests now use strongly-typed transaction messages and validate provider auth handling.
  * Added a registry round‑trip unit test to verify message encoding/decoding and key field integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->