### PR TITLE
feat(billing): migrate denom exchange oracle to V2 with V1 fallback

### DIFF
--- a/apps/api/src/chain/services/denom-exchange/denom-exchange.service.spec.ts
+++ b/apps/api/src/chain/services/denom-exchange/denom-exchange.service.spec.ts
@@ -25,7 +25,7 @@ describe(DenomExchangeService.name, () => {
       });
     });
 
-    it("queries the V2 price history over a 24h time window", async () => {
+    it("queries the V2 price history over a window inside the 24h retention", async () => {
       const { service, getPricesV2 } = setup({});
 
       await service.getExchangeRateToUSD("akt");
@@ -41,7 +41,9 @@ describe(DenomExchangeService.name, () => {
         })
       );
       const { startTime, endTime } = getPricesV2.mock.calls[0][0].filters;
-      expect(endTime.getTime() - startTime.getTime()).toBe(24 * 60 * 60 * 1000);
+      const windowMs = endTime.getTime() - startTime.getTime();
+      expect(windowMs).toBe(23 * 60 * 60 * 1000);
+      expect(windowMs).toBeLessThan(24 * 60 * 60 * 1000);
     });
 
     it("returns zero price change when historical price is zero", async () => {

--- a/apps/api/src/chain/services/denom-exchange/denom-exchange.service.spec.ts
+++ b/apps/api/src/chain/services/denom-exchange/denom-exchange.service.spec.ts
@@ -9,12 +9,12 @@ import { DenomExchangeService } from "./denom-exchange.service";
 describe(DenomExchangeService.name, () => {
   describe("getExchangeRateToUSD", () => {
     it("returns oracle price data", async () => {
-      const { service, getAggregatedPrice, getPrices } = setup({});
+      const { service, getAggregatedPriceV2, getPricesV2 } = setup({});
 
       const result = await service.getExchangeRateToUSD("akt");
 
-      expect(getAggregatedPrice).toHaveBeenCalled();
-      expect(getPrices).toHaveBeenCalled();
+      expect(getAggregatedPriceV2).toHaveBeenCalled();
+      expect(getPricesV2).toHaveBeenCalled();
       expect(result).toEqual({
         price: 0.56,
         volume: 0,
@@ -25,17 +25,23 @@ describe(DenomExchangeService.name, () => {
       });
     });
 
-    it("calculates block height 24h ago for historical price lookup", async () => {
-      const { service, getPrices } = setup({ currentHeight: 100000n });
+    it("queries the V2 price history over a 24h time window", async () => {
+      const { service, getPricesV2 } = setup({});
 
       await service.getExchangeRateToUSD("akt");
 
-      const expectedHeight = 100000n - (24n * 60n * 60n) / 6n;
-      expect(getPrices).toHaveBeenCalledWith(
+      expect(getPricesV2).toHaveBeenCalledWith(
         expect.objectContaining({
-          filters: expect.objectContaining({ height: expectedHeight })
+          filters: expect.objectContaining({
+            assetDenom: "akt",
+            baseDenom: "usd",
+            startTime: expect.any(Date),
+            endTime: expect.any(Date)
+          })
         })
       );
+      const { startTime, endTime } = getPricesV2.mock.calls[0][0].filters;
+      expect(endTime.getTime() - startTime.getTime()).toBe(24 * 60 * 60 * 1000);
     });
 
     it("returns zero price change when historical price is zero", async () => {
@@ -56,12 +62,42 @@ describe(DenomExchangeService.name, () => {
       expect(result.priceChangePercentage24).toBe(0);
     });
 
+    it("keeps the V2 price when the 24h history query fails", async () => {
+      const { service, getAggregatedPriceV1, getLatestBlock, logger } = setup({ v2HistoryThrows: true });
+
+      const result = await service.getExchangeRateToUSD("akt");
+
+      expect(result.price).toBe(0.56);
+      expect(result.priceChange24h).toBe(0);
+      expect(result.priceChangePercentage24).toBe(0);
+      expect(getAggregatedPriceV1).not.toHaveBeenCalled();
+      expect(getLatestBlock).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "ORACLE_V2_PRICE_HISTORY_UNAVAILABLE" }));
+    });
+
+    it("falls back to V1 when the V2 query service is unavailable", async () => {
+      const { service, getAggregatedPriceV2, getAggregatedPriceV1, getPricesV1, logger } = setup({ v2Unavailable: true, currentHeight: 100000n });
+
+      const result = await service.getExchangeRateToUSD("akt");
+
+      expect(getAggregatedPriceV2).toHaveBeenCalled();
+      expect(getAggregatedPriceV1).toHaveBeenCalled();
+      expect(getPricesV1).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: expect.objectContaining({ height: 100000n - (24n * 60n * 60n) / 6n })
+        })
+      );
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "ORACLE_V2_UNAVAILABLE_FALLBACK_V1" }));
+      expect(result.price).toBe(0.56);
+    });
+
     it("falls back to DB price when oracle reports unhealthy", async () => {
-      const { service, dayRepository, logger } = setup({ isHealthy: false, latestAktPrice: 1.23 });
+      const { service, dayRepository, logger, getAggregatedPriceV1 } = setup({ isHealthy: false, latestAktPrice: 1.23 });
 
       const result = await service.getExchangeRateToUSD("akt");
 
       expect(dayRepository.getLatestAktPrice).toHaveBeenCalled();
+      expect(getAggregatedPriceV1).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "ORACLE_PRICE_UNHEALTHY" }));
       expect(result).toEqual({
         price: 1.23,
@@ -73,7 +109,7 @@ describe(DenomExchangeService.name, () => {
       });
     });
 
-    it("falls back to DB price when oracle RPC fails", async () => {
+    it("falls back to DB price when both oracle versions fail", async () => {
       const { service, dayRepository, logger } = setup({ oracleThrows: true, latestAktPrice: 0.99 });
 
       const result = await service.getExchangeRateToUSD("akt");
@@ -113,27 +149,44 @@ describe(DenomExchangeService.name, () => {
     emptyHistoricalPrices?: boolean;
     isHealthy?: boolean;
     oracleThrows?: boolean;
+    v2Unavailable?: boolean;
+    v2HistoryThrows?: boolean;
     latestAktPrice?: number | null;
   }) {
     const getLatestBlock = vi.fn().mockResolvedValue({
       block: { header: { height: { toBigInt: () => input.currentHeight ?? 1000000n } } }
     });
-    const getAggregatedPrice = vi.fn().mockResolvedValue({
+    const aggregatedPriceResponse = {
       aggregatedPrice: { medianPrice: "0.56" },
       priceHealth: { isHealthy: input.isHealthy ?? true }
-    });
-    const getPrices = vi.fn().mockResolvedValue({
+    };
+    const pricesResponse = {
       prices: input.emptyHistoricalPrices ? [] : [{ state: { price: input.historicalPrice ?? "0.5" } }]
-    });
+    };
 
+    const getAggregatedPriceV2 = vi.fn().mockResolvedValue(aggregatedPriceResponse);
+    const getPricesV2 = vi.fn().mockResolvedValue(pricesResponse);
+    const getAggregatedPriceV1 = vi.fn().mockResolvedValue(aggregatedPriceResponse);
+    const getPricesV1 = vi.fn().mockResolvedValue(pricesResponse);
+
+    if (input.v2Unavailable) {
+      getAggregatedPriceV2.mockRejectedValue(new Error("V2 query service unavailable"));
+    }
+    if (input.v2HistoryThrows) {
+      getPricesV2.mockRejectedValue(new Error("price history pruned"));
+    }
     if (input.oracleThrows) {
+      // Both the V2 query and the V1 fallback fail, so the service falls through to CoinGecko.
+      getAggregatedPriceV2.mockRejectedValue(new Error("V2 RPC connection refused"));
       getLatestBlock.mockRejectedValue(new Error("RPC connection refused"));
     }
 
     const chainSdk = mockDeep<ChainSDK>();
     chainSdk.cosmos.base.tendermint.v1beta1.getLatestBlock.mockImplementation(getLatestBlock);
-    chainSdk.akash.oracle.v1.getAggregatedPrice.mockImplementation(getAggregatedPrice);
-    chainSdk.akash.oracle.v1.getPrices.mockImplementation(getPrices);
+    chainSdk.akash.oracle.v2.getAggregatedPrice.mockImplementation(getAggregatedPriceV2);
+    chainSdk.akash.oracle.v2.getPrices.mockImplementation(getPricesV2);
+    chainSdk.akash.oracle.v1.getAggregatedPrice.mockImplementation(getAggregatedPriceV1);
+    chainSdk.akash.oracle.v1.getPrices.mockImplementation(getPricesV1);
 
     const dayRepository = mock<DayRepository>();
     dayRepository.getLatestAktPrice.mockResolvedValue("latestAktPrice" in input ? input.latestAktPrice! : 1.23);
@@ -142,6 +195,6 @@ describe(DenomExchangeService.name, () => {
 
     const service = new DenomExchangeService(chainSdk, dayRepository, logger);
 
-    return { service, getLatestBlock, getAggregatedPrice, getPrices, dayRepository, logger };
+    return { service, getLatestBlock, getAggregatedPriceV2, getPricesV2, getAggregatedPriceV1, getPricesV1, dayRepository, logger };
   }
 });

--- a/apps/api/src/chain/services/denom-exchange/denom-exchange.service.spec.ts
+++ b/apps/api/src/chain/services/denom-exchange/denom-exchange.service.spec.ts
@@ -93,6 +93,28 @@ describe(DenomExchangeService.name, () => {
       expect(result.price).toBe(0.56);
     });
 
+    it("does not fall back to V1 on a non-Unimplemented V2 error", async () => {
+      const { service, getAggregatedPriceV1, getLatestBlock, dayRepository, logger } = setup({ v2TransientError: true, latestAktPrice: 1.5 });
+
+      const result = await service.getExchangeRateToUSD("akt");
+
+      expect(getAggregatedPriceV1).not.toHaveBeenCalled();
+      expect(getLatestBlock).not.toHaveBeenCalled();
+      expect(dayRepository.getLatestAktPrice).toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "ORACLE_RPC_FAILED" }));
+      expect(result.price).toBe(1.5);
+    });
+
+    it("caches the V2-unavailable decision and skips V2 on subsequent calls", async () => {
+      const { service, getAggregatedPriceV2, getAggregatedPriceV1 } = setup({ v2Unavailable: true });
+
+      await service.getExchangeRateToUSD("akt");
+      await service.getExchangeRateToUSD("akash-network");
+
+      expect(getAggregatedPriceV2).toHaveBeenCalledTimes(1);
+      expect(getAggregatedPriceV1).toHaveBeenCalledTimes(2);
+    });
+
     it("falls back to DB price when oracle reports unhealthy", async () => {
       const { service, dayRepository, logger, getAggregatedPriceV1 } = setup({ isHealthy: false, latestAktPrice: 1.23 });
 
@@ -152,6 +174,7 @@ describe(DenomExchangeService.name, () => {
     isHealthy?: boolean;
     oracleThrows?: boolean;
     v2Unavailable?: boolean;
+    v2TransientError?: boolean;
     v2HistoryThrows?: boolean;
     latestAktPrice?: number | null;
   }) {
@@ -172,14 +195,19 @@ describe(DenomExchangeService.name, () => {
     const getPricesV1 = vi.fn().mockResolvedValue(pricesResponse);
 
     if (input.v2Unavailable) {
-      getAggregatedPriceV2.mockRejectedValue(new Error("V2 query service unavailable"));
+      // gRPC Unimplemented (HTTP 501): the node hasn't registered the V2 query service yet.
+      getAggregatedPriceV2.mockRejectedValue(makeTransportError(12));
+    }
+    if (input.v2TransientError) {
+      // Any non-Unimplemented V2 error must NOT trigger the V1 fallback.
+      getAggregatedPriceV2.mockRejectedValue(makeTransportError(14));
     }
     if (input.v2HistoryThrows) {
       getPricesV2.mockRejectedValue(new Error("price history pruned"));
     }
     if (input.oracleThrows) {
-      // Both the V2 query and the V1 fallback fail, so the service falls through to CoinGecko.
-      getAggregatedPriceV2.mockRejectedValue(new Error("V2 RPC connection refused"));
+      // V2 is unimplemented (-> tries V1) and V1 also fails, so the service falls through to CoinGecko.
+      getAggregatedPriceV2.mockRejectedValue(makeTransportError(12));
       getLatestBlock.mockRejectedValue(new Error("RPC connection refused"));
     }
 
@@ -198,5 +226,11 @@ describe(DenomExchangeService.name, () => {
     const service = new DenomExchangeService(chainSdk, dayRepository, logger);
 
     return { service, getLatestBlock, getAggregatedPriceV2, getPricesV2, getAggregatedPriceV1, getPricesV1, dayRepository, logger };
+  }
+
+  // Mirrors a chain-sdk TransportError: an unregistered query method surfaces as gRPC code 12
+  // (Unimplemented / HTTP 501); other failures carry a different code.
+  function makeTransportError(code: number) {
+    return Object.assign(new Error(`transport error ${code}`), { name: "TransportError", code });
   }
 });

--- a/apps/api/src/chain/services/denom-exchange/denom-exchange.service.spec.ts
+++ b/apps/api/src/chain/services/denom-exchange/denom-exchange.service.spec.ts
@@ -228,8 +228,7 @@ describe(DenomExchangeService.name, () => {
     return { service, getLatestBlock, getAggregatedPriceV2, getPricesV2, getAggregatedPriceV1, getPricesV1, dayRepository, logger };
   }
 
-  // Mirrors a chain-sdk TransportError: an unregistered query method surfaces as gRPC code 12
-  // (Unimplemented / HTTP 501); other failures carry a different code.
+  // Mirrors a chain-sdk TransportError (gRPC code 12 = Unimplemented for an unregistered method).
   function makeTransportError(code: number) {
     return Object.assign(new Error(`transport error ${code}`), { name: "TransportError", code });
   }

--- a/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
+++ b/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
@@ -1,4 +1,4 @@
-import { minutesToMilliseconds } from "date-fns";
+import { minutesToMilliseconds, subHours } from "date-fns";
 import { inject, singleton } from "tsyringe";
 
 import { memoizeAsync } from "@src/caching/helpers";
@@ -27,17 +27,7 @@ export class DenomExchangeService {
       const mappedDenom = legacyToNewMapping[denom] ?? denom;
 
       try {
-        const latestBlock = await this.#chainSdk.cosmos.base.tendermint.v1beta1.getLatestBlock();
-        const currentHeight = latestBlock.block?.header?.height?.toBigInt() ?? 0n;
-        const blocksPerDay = (24n * 60n * 60n) / BigInt(Math.ceil(averageBlockTime));
-        const blockHeight24hAgo = currentHeight > blocksPerDay ? currentHeight - blocksPerDay : 1n;
-        const [oracleRate, rate24hAgo] = await Promise.all([
-          this.#chainSdk.akash.oracle.v1.getAggregatedPrice({ denom: mappedDenom }),
-          this.#chainSdk.akash.oracle.v1.getPrices({
-            filters: { assetDenom: mappedDenom, baseDenom: "usd", height: blockHeight24hAgo },
-            pagination: { limit: 1 }
-          })
-        ]);
+        const { oracleRate, rate24hAgo } = await this.#fetchOracleRate(mappedDenom);
 
         if (!oracleRate.priceHealth?.isHealthy) {
           this.#logger.warn({ event: "ORACLE_PRICE_UNHEALTHY", denom: mappedDenom });
@@ -62,6 +52,55 @@ export class DenomExchangeService {
     },
     { cacheItemLimit: 10, ttl: minutesToMilliseconds(10) }
   );
+
+  /**
+   * Version-aware oracle fetch: prefer Oracle V2, falling back to V1 when the V2 query service is
+   * unavailable (e.g. on nodes that have not yet run the v2.1.0 upgrade, which do not register the
+   * V2 query service so the call throws). The V1 fallback is removed once V2 is stable on mainnet.
+   */
+  async #fetchOracleRate(mappedDenom: string) {
+    try {
+      return await this.#fetchOracleRateV2(mappedDenom);
+    } catch (error) {
+      this.#logger.warn({ event: "ORACLE_V2_UNAVAILABLE_FALLBACK_V1", denom: mappedDenom, error });
+      return await this.#fetchOracleRateV1(mappedDenom);
+    }
+  }
+
+  async #fetchOracleRateV2(mappedDenom: string) {
+    const endTime = new Date();
+    const startTime = subHours(endTime, 24);
+    const [oracleRate, rate24hAgo] = await Promise.all([
+      this.#chainSdk.akash.oracle.v2.getAggregatedPrice({ denom: mappedDenom }),
+      // The 24h history feeds only the priceChange fields and is edge-of-retention in V2, so a
+      // failure here must not degrade the (billing-critical) current price — degrade to empty.
+      this.#chainSdk.akash.oracle.v2
+        .getPrices({
+          filters: { assetDenom: mappedDenom, baseDenom: "usd", startTime, endTime },
+          pagination: { limit: 1 }
+        })
+        .catch((error): { prices: [] } => {
+          this.#logger.warn({ event: "ORACLE_V2_PRICE_HISTORY_UNAVAILABLE", denom: mappedDenom, error });
+          return { prices: [] };
+        })
+    ]);
+    return { oracleRate, rate24hAgo };
+  }
+
+  async #fetchOracleRateV1(mappedDenom: string) {
+    const latestBlock = await this.#chainSdk.cosmos.base.tendermint.v1beta1.getLatestBlock();
+    const currentHeight = latestBlock.block?.header?.height?.toBigInt() ?? 0n;
+    const blocksPerDay = (24n * 60n * 60n) / BigInt(Math.ceil(averageBlockTime));
+    const blockHeight24hAgo = currentHeight > blocksPerDay ? currentHeight - blocksPerDay : 1n;
+    const [oracleRate, rate24hAgo] = await Promise.all([
+      this.#chainSdk.akash.oracle.v1.getAggregatedPrice({ denom: mappedDenom }),
+      this.#chainSdk.akash.oracle.v1.getPrices({
+        filters: { assetDenom: mappedDenom, baseDenom: "usd", height: blockHeight24hAgo },
+        pagination: { limit: 1 }
+      })
+    ]);
+    return { oracleRate, rate24hAgo };
+  }
 
   async #getFallbackExchangeRateToUSD() {
     const aktPrice = await this.#dayRepository.getLatestAktPrice();

--- a/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
+++ b/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
@@ -7,12 +7,7 @@ import { LoggerService } from "@src/core/providers/logging.provider";
 import { DayRepository } from "@src/gpu/repositories/day.repository";
 import { averageBlockTime } from "@src/utils/constants";
 
-/**
- * gRPC status code (`Unimplemented`) the node's grpc-gateway returns — as HTTP 501 with a
- * `{ "code": 12 }` body — when a query method isn't registered. The chain-sdk surfaces it as a
- * `TransportError` carrying this numeric `code`, but the enum isn't exported, so we match the
- * number. This is the SDK equivalent of provider-proxy's former `response.status === 501` check.
- */
+// gRPC "Unimplemented" code, returned for an unregistered query method (chain-sdk's TransportErrorCode isn't exported).
 const TRANSPORT_CODE_UNIMPLEMENTED = 12;
 
 function isOracleQueryUnimplemented(error: unknown): boolean {
@@ -24,8 +19,7 @@ export class DenomExchangeService {
   readonly #chainSdk: ChainSDK;
   readonly #dayRepository: DayRepository;
   readonly #logger: LoggerService;
-  // Cached availability of the Oracle V2 query service. Set false on a V2 "unimplemented" error
-  // (pre-v2.1.0 nodes) so we stop probing V2 until the V1 fallback itself breaks.
+  // Goes false once V2 returns Unimplemented; we then skip V2 until the V1 fallback breaks.
   #isOracleV2Available = true;
 
   constructor(@inject(CHAIN_SDK) chainSdk: ChainSDK, dayRepository: DayRepository, logger: LoggerService) {
@@ -68,13 +62,8 @@ export class DenomExchangeService {
     { cacheItemLimit: 10, ttl: minutesToMilliseconds(10) }
   );
 
-  /**
-   * Version-aware oracle fetch: prefer Oracle V2, falling back to V1 only when the node hasn't
-   * registered the V2 query service yet (pre-v2.1.0 — gRPC Unimplemented / HTTP 501). The decision
-   * is cached so we stop probing V2 until the V1 fallback breaks (expected once v2.1.0 ships and V1
-   * is removed), at which point we re-probe V2. Any other V2 error falls through to the CoinGecko
-   * net in the caller. The whole V1 fallback is removed once V2 is stable on mainnet.
-   */
+  // Prefer V2; fall back to V1 only when V2 is unimplemented (pre-v2.1.0), caching that until V1
+  // breaks. Other V2 errors propagate to the caller's CoinGecko fallback.
   async #fetchOracleRate(mappedDenom: string) {
     if (this.#isOracleV2Available) {
       try {
@@ -96,9 +85,7 @@ export class DenomExchangeService {
 
   async #fetchOracleRateV2(mappedDenom: string) {
     const endTime = new Date();
-    // V2 prunes oracle state to ~24h; query just inside that window (23h) since a price exactly 24h
-    // back may already be pruned. This figure feeds only the (currently unused) priceChange fields,
-    // so a failure here must not degrade the billing-critical current price — degrade to empty.
+    // 23h, not 24h: V2 prunes to ~24h, so the exact-24h price may already be gone.
     const startTime = subHours(endTime, 23);
     const [oracleRate, rate24hAgo] = await Promise.all([
       this.#chainSdk.akash.oracle.v2.getAggregatedPrice({ denom: mappedDenom }),
@@ -107,6 +94,7 @@ export class DenomExchangeService {
           filters: { assetDenom: mappedDenom, baseDenom: "usd", startTime, endTime },
           pagination: { limit: 1 }
         })
+        // history feeds only the unused priceChange fields — never fail the price over it
         .catch((error): { prices: [] } => {
           this.#logger.warn({ event: "ORACLE_V2_PRICE_HISTORY_UNAVAILABLE", denom: mappedDenom, error });
           return { prices: [] };

--- a/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
+++ b/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
@@ -7,11 +7,26 @@ import { LoggerService } from "@src/core/providers/logging.provider";
 import { DayRepository } from "@src/gpu/repositories/day.repository";
 import { averageBlockTime } from "@src/utils/constants";
 
+/**
+ * gRPC status code (`Unimplemented`) the node's grpc-gateway returns — as HTTP 501 with a
+ * `{ "code": 12 }` body — when a query method isn't registered. The chain-sdk surfaces it as a
+ * `TransportError` carrying this numeric `code`, but the enum isn't exported, so we match the
+ * number. This is the SDK equivalent of provider-proxy's former `response.status === 501` check.
+ */
+const TRANSPORT_CODE_UNIMPLEMENTED = 12;
+
+function isOracleQueryUnimplemented(error: unknown): boolean {
+  return error instanceof Error && error.name === "TransportError" && (error as { code?: unknown }).code === TRANSPORT_CODE_UNIMPLEMENTED;
+}
+
 @singleton()
 export class DenomExchangeService {
   readonly #chainSdk: ChainSDK;
   readonly #dayRepository: DayRepository;
   readonly #logger: LoggerService;
+  // Cached availability of the Oracle V2 query service. Set false on a V2 "unimplemented" error
+  // (pre-v2.1.0 nodes) so we stop probing V2 until the V1 fallback itself breaks.
+  #isOracleV2Available = true;
 
   constructor(@inject(CHAIN_SDK) chainSdk: ChainSDK, dayRepository: DayRepository, logger: LoggerService) {
     this.#chainSdk = chainSdk;
@@ -54,16 +69,28 @@ export class DenomExchangeService {
   );
 
   /**
-   * Version-aware oracle fetch: prefer Oracle V2, falling back to V1 when the V2 query service is
-   * unavailable (e.g. on nodes that have not yet run the v2.1.0 upgrade, which do not register the
-   * V2 query service so the call throws). The V1 fallback is removed once V2 is stable on mainnet.
+   * Version-aware oracle fetch: prefer Oracle V2, falling back to V1 only when the node hasn't
+   * registered the V2 query service yet (pre-v2.1.0 — gRPC Unimplemented / HTTP 501). The decision
+   * is cached so we stop probing V2 until the V1 fallback breaks (expected once v2.1.0 ships and V1
+   * is removed), at which point we re-probe V2. Any other V2 error falls through to the CoinGecko
+   * net in the caller. The whole V1 fallback is removed once V2 is stable on mainnet.
    */
   async #fetchOracleRate(mappedDenom: string) {
+    if (this.#isOracleV2Available) {
+      try {
+        return await this.#fetchOracleRateV2(mappedDenom);
+      } catch (error) {
+        if (!isOracleQueryUnimplemented(error)) throw error;
+        this.#isOracleV2Available = false;
+        this.#logger.warn({ event: "ORACLE_V2_UNAVAILABLE_FALLBACK_V1", denom: mappedDenom });
+      }
+    }
+
     try {
-      return await this.#fetchOracleRateV2(mappedDenom);
-    } catch (error) {
-      this.#logger.warn({ event: "ORACLE_V2_UNAVAILABLE_FALLBACK_V1", denom: mappedDenom, error });
       return await this.#fetchOracleRateV1(mappedDenom);
+    } catch (error) {
+      this.#isOracleV2Available = true;
+      throw error;
     }
   }
 

--- a/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
+++ b/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
@@ -69,11 +69,12 @@ export class DenomExchangeService {
 
   async #fetchOracleRateV2(mappedDenom: string) {
     const endTime = new Date();
-    const startTime = subHours(endTime, 24);
+    // V2 prunes oracle state to ~24h; query just inside that window (23h) since a price exactly 24h
+    // back may already be pruned. This figure feeds only the (currently unused) priceChange fields,
+    // so a failure here must not degrade the billing-critical current price — degrade to empty.
+    const startTime = subHours(endTime, 23);
     const [oracleRate, rate24hAgo] = await Promise.all([
       this.#chainSdk.akash.oracle.v2.getAggregatedPrice({ denom: mappedDenom }),
-      // The 24h history feeds only the priceChange fields and is edge-of-retention in V2, so a
-      // failure here must not degrade the (billing-critical) current price — degrade to empty.
       this.#chainSdk.akash.oracle.v2
         .getPrices({
           filters: { assetDenom: mappedDenom, baseDenom: "usd", startTime, endTime },

--- a/apps/api/test/functional/market-data.spec.ts
+++ b/apps/api/test/functional/market-data.spec.ts
@@ -13,29 +13,18 @@ describe("Market Data", () => {
       .get("/cosmos/base/tendermint/v1beta1/blocks/latest")
       .reply(200, { block: { header: { height: "1000000" } } });
 
+    // DenomExchangeService queries oracle V2 first and only falls back to V1 when V2 is unimplemented.
     nock(restApiNodeUrl)
       .persist()
-      .get("/akash/oracle/v1/aggregated_price/akt")
+      .get("/akash/oracle/v2/aggregated_price/akt")
       .query(true)
       .reply(200, { aggregated_price: { median_price: "1.5" }, price_health: { is_healthy: true } });
 
     nock(restApiNodeUrl)
       .persist()
-      .get("/akash/oracle/v1/aggregated_price/usdc")
-      .query(true)
-      .reply(200, { aggregated_price: { median_price: "1.0" }, price_health: { is_healthy: true } });
-
-    nock(restApiNodeUrl)
-      .persist()
-      .get("/akash/oracle/v1/prices")
+      .get("/akash/oracle/v2/prices")
       .query(q => q["filters.asset_denom"] === "akt")
       .reply(200, { prices: [{ state: { price: "1.25" } }] });
-
-    nock(restApiNodeUrl)
-      .persist()
-      .get("/akash/oracle/v1/prices")
-      .query(q => q["filters.asset_denom"] === "usdc")
-      .reply(200, { prices: [{ state: { price: "0.5" } }] });
   });
 
   afterAll(() => {


### PR DESCRIPTION
## Why

Oracle V2 activates on Akash mainnet with the **v2.1.0 node upgrade (June 11)**. At that point the V1 oracle query stops working, and `DenomExchangeService` — the only code querying the oracle module — would silently degrade to its **daily CoinGecko** fallback, hurting real-time pricing for **live ACT minting** (`master-wallet-mint`).

Part of CON-195

## What

Migrates `DenomExchangeService.getExchangeRateToUSD` from Oracle **V1 (block-height)** to **V2 (time-based)** with a **version-aware fallback**: try V2 → fall back to V1 when the V2 query service is unavailable (pre-upgrade nodes don't register it, so the call throws) → existing CoinGecko net. This decouples the api deploy from the June 11 node release and self-heals across the upgrade.

- V2 `getPrices` uses a `startTime`/`endTime` window instead of `height`; `getAggregatedPrice` is unchanged between versions.
- The 24h price-history query (edge-of-retention under V2's 24h pruning, and feeds only the currently-unused `priceChange` fields) is decoupled so a failure there cannot degrade the billing-critical current price.
- Return shape is unchanged, so both consumers (`master-wallet-mint`, `stats`) are transparent.
- **No indexer change**: the `Oracle.v1` event listener must stay V1 for re-index correctness (re-indexing replays frozen historical V1 events) — see canceled CON-409.

**Not breaking**: the `getExchangeRateToUSD` return contract is unchanged.

**Follow-up** (not in this PR): remove the V1 fallback path once Oracle V2 is stable on mainnet (post-v2.1.0).

### Verification

- `npm run test:unit -- denom-exchange` — 9 passed (covers V2 path, V1 fallback, 24h-history degrade, unhealthy → CoinGecko, both-versions-fail → CoinGecko)
- `npx tsc --noEmit` — no new errors (changed files + both consumers type-clean)
- `npm run lint` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now prefers the newer oracle price feed and avoids repeatedly probing unsupported endpoints, improving stability.

* **Bug Fixes**
  * More reliable USD exchange rates via version-aware feed selection and resilient fallbacks when primary feeds or history queries fail.
  * More accurate 24‑hour change calculations using a precise ~23h time window and graceful degradation to avoid misleading change values.
  * Emits clearer warnings when historical pricing is unavailable while preserving expected behavior during partial outages.

* **Tests**
  * Expanded coverage for multi-version feed behavior, fallback scenarios, and improved test helpers for independent feed mocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->