### PR TITLE
feat: persist new total_available_leased_ip count in provider inventory

### DIFF
--- a/apps/provider-inventory/drizzle/0001_add_leased_ip_column.sql
+++ b/apps/provider-inventory/drizzle/0001_add_leased_ip_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "provider_inventory" ADD COLUMN "total_available_leased_ip" bigint DEFAULT 0 NOT NULL;

--- a/apps/provider-inventory/drizzle/meta/0001_snapshot.json
+++ b/apps/provider-inventory/drizzle/meta/0001_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "00000000-0000-0000-0000-000000000000",
-  "prevId": "",
+  "id": "b5bc1ea9-e4f7-46f1-8cb8-43cb58b9ba51",
+  "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -70,6 +70,13 @@
         },
         "total_available_persistent": {
           "name": "total_available_persistent",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_leased_ip": {
+          "name": "total_available_leased_ip",
           "type": "bigint",
           "primaryKey": false,
           "notNull": true,
@@ -167,6 +174,10 @@
   },
   "enums": {},
   "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
   "_meta": {
     "columns": {},
     "schemas": {},

--- a/apps/provider-inventory/drizzle/meta/_journal.json
+++ b/apps/provider-inventory/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1746662400000,
       "tag": "0000_initial_provider_inventory",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1780549868503,
+      "tag": "0001_add_leased_ip_column",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/provider-inventory/src/domain/is-equal-cluster-state/is-equal-cluster-state.ts
+++ b/apps/provider-inventory/src/domain/is-equal-cluster-state/is-equal-cluster-state.ts
@@ -1,8 +1,10 @@
 import type { ClusterState, CpuInfo, GpuInfo, NodeState, RawPair } from "@src/types/inventory";
 
+const EMPTY_PAIR: RawPair = { allocatable: 0n, allocated: 0n };
+
 export function isEqualClusterState(a: ClusterState, b: ClusterState): boolean {
   if (a === b) return true;
-  return clusterStorageEqual(a.storage, b.storage) && nodesEqual(a.nodes, b.nodes);
+  return clusterStorageEqual(a.storage, b.storage) && nodesEqual(a.nodes, b.nodes) && pairEqual(a.leasedIp ?? EMPTY_PAIR, b.leasedIp ?? EMPTY_PAIR);
 }
 
 function nodesEqual(a: readonly NodeState[] | undefined, b: readonly NodeState[] | undefined): boolean {

--- a/apps/provider-inventory/src/lib/generators/paginate/paginate.ts
+++ b/apps/provider-inventory/src/lib/generators/paginate/paginate.ts
@@ -1,6 +1,6 @@
-export interface Page<T> {
+export interface Page<T, TKey extends string | Uint8Array = string> {
   items: T[];
-  nextKey?: Uint8Array;
+  nextKey?: TKey;
 }
 
 /**
@@ -13,8 +13,11 @@ export interface Page<T> {
  * Yielding page-by-page keeps only a single page in memory at once instead of accumulating the
  * full result set up front.
  */
-export async function* paginate<T>(fetchPage: (key: Uint8Array | undefined) => Promise<Page<T>>, options: { signal?: AbortSignal } = {}): AsyncGenerator<T[]> {
-  let nextKey: Uint8Array | undefined = undefined;
+export async function* paginate<T, TKey extends string | Uint8Array = Uint8Array>(
+  fetchPage: (key: TKey | undefined) => Promise<Page<T, TKey>>,
+  options: { signal?: AbortSignal } = {}
+): AsyncGenerator<T[]> {
+  let nextKey: TKey | undefined = undefined;
   while (!options.signal?.aborted) {
     const page = await fetchPage(nextKey);
     yield page.items;

--- a/apps/provider-inventory/src/model-schemas/provider-inventory/provider-inventory.schema.ts
+++ b/apps/provider-inventory/src/model-schemas/provider-inventory/provider-inventory.schema.ts
@@ -13,14 +13,33 @@ export const providerInventory = pgTable(
 
     inventory: jsonbBigint("inventory").notNull().default({}),
 
-    totalAvailableCpu: bigint("total_available_cpu", { mode: "bigint" }).notNull().default(BigInt(0)),
-    totalAvailableMemory: bigint("total_available_memory", { mode: "bigint" }).notNull().default(BigInt(0)),
-    totalAvailableGpu: bigint("total_available_gpu", { mode: "bigint" }).notNull().default(BigInt(0)),
-    totalAvailableEph: bigint("total_available_eph", { mode: "bigint" }).notNull().default(BigInt(0)),
-    totalAvailablePersistent: bigint("total_available_persistent", { mode: "bigint" }).notNull().default(BigInt(0)),
-    maxNodeFreeCpu: bigint("max_node_free_cpu", { mode: "bigint" }).notNull().default(BigInt(0)),
-    maxNodeFreeMemory: bigint("max_node_free_memory", { mode: "bigint" }).notNull().default(BigInt(0)),
-    maxNodeFreeGpu: bigint("max_node_free_gpu", { mode: "bigint" }).notNull().default(BigInt(0)),
+    totalAvailableCpu: bigint("total_available_cpu", { mode: "bigint" })
+      .notNull()
+      .default(sql`0`),
+    totalAvailableMemory: bigint("total_available_memory", { mode: "bigint" })
+      .notNull()
+      .default(sql`0`),
+    totalAvailableGpu: bigint("total_available_gpu", { mode: "bigint" })
+      .notNull()
+      .default(sql`0`),
+    totalAvailableEph: bigint("total_available_eph", { mode: "bigint" })
+      .notNull()
+      .default(sql`0`),
+    totalAvailablePersistent: bigint("total_available_persistent", { mode: "bigint" })
+      .notNull()
+      .default(sql`0`),
+    totalAvailableLeasedIp: bigint("total_available_leased_ip", { mode: "bigint" })
+      .notNull()
+      .default(sql`0`),
+    maxNodeFreeCpu: bigint("max_node_free_cpu", { mode: "bigint" })
+      .notNull()
+      .default(sql`0`),
+    maxNodeFreeMemory: bigint("max_node_free_memory", { mode: "bigint" })
+      .notNull()
+      .default(sql`0`),
+    maxNodeFreeGpu: bigint("max_node_free_gpu", { mode: "bigint" })
+      .notNull()
+      .default(sql`0`),
 
     gpuModels: text("gpu_models").array().notNull().default([]),
     storageClasses: text("storage_classes").array().notNull().default([]),

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
@@ -4,6 +4,7 @@ import { and, eq, gt, inArray, sql as rawSql } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { inject, singleton } from "tsyringe";
 
+import { paginate } from "@src/lib/generators/paginate/paginate";
 import { providerInventory } from "@src/model-schemas/provider-inventory/provider-inventory.schema";
 import { DRIZZLE_DB } from "@src/providers/drizzle.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
@@ -33,24 +34,21 @@ export class ProviderInventoryRepository {
 
   async *streamOnlineProviders(options?: { batchSize?: number }): AsyncGenerator<Pick<ProviderInventory, "owner" | "hostUri">> {
     const batchSize = options?.batchSize ?? DEFAULT_ONLINE_STREAM_BATCH_SIZE;
-    let cursor: string | undefined;
     const baseQuery = this.#db
       .select({ owner: providerInventory.owner, hostUri: providerInventory.hostUri })
       .from(providerInventory)
       .orderBy(providerInventory.owner)
       .limit(batchSize);
 
-    while (true) {
-      const where =
-        cursor === undefined ? eq(providerInventory.isOnline, true) : and(eq(providerInventory.isOnline, true), gt(providerInventory.owner, cursor));
+    const allProviders = paginate<Pick<ProviderInventory, "owner" | "hostUri">, string>(async key => {
+      const where = key === undefined ? eq(providerInventory.isOnline, true) : and(eq(providerInventory.isOnline, true), gt(providerInventory.owner, key));
+      const items = await baseQuery.where(where);
+      const nextKey = items.length === batchSize ? items[items.length - 1].owner : undefined;
+      return { items, nextKey };
+    });
 
-      const batch = await baseQuery.where(where);
-      if (batch.length === 0) return;
-
+    for await (const batch of allProviders) {
       for (const row of batch) yield row;
-
-      if (batch.length < batchSize) return;
-      cursor = batch[batch.length - 1].owner;
     }
   }
 
@@ -81,6 +79,7 @@ export class ProviderInventoryRepository {
         totalAvailableMemory: row.totalAvailableMemory,
         totalAvailableGpu: row.totalAvailableGpu,
         totalAvailableEph: row.totalAvailableEph,
+        totalAvailableLeasedIp: row.totalAvailableLeasedIp,
         totalAvailablePersistent: row.totalAvailablePersistent,
         maxNodeFreeCpu: row.maxNodeFreeCpu,
         maxNodeFreeMemory: row.maxNodeFreeMemory,

--- a/apps/provider-inventory/src/repositories/provider-inventory/stored-cluster-state-mapper/stored-cluster-state-mapper.spec.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/stored-cluster-state-mapper/stored-cluster-state-mapper.spec.ts
@@ -14,6 +14,7 @@ describe(mapToStoredClusterState.name, () => {
       totalAvailableGpu: 0n,
       totalAvailableEph: 0n,
       totalAvailablePersistent: 0n,
+      totalAvailableLeasedIp: 0n,
       maxNodeFreeCpu: 0n,
       maxNodeFreeMemory: 0n,
       maxNodeFreeGpu: 0n,
@@ -45,7 +46,8 @@ describe(mapToStoredClusterState.name, () => {
             storageClasses: ["beta2"]
           })
         ],
-        storage: { beta2: { class: "beta2", quantity: pair(500_000_000_000n) } }
+        storage: { beta2: { class: "beta2", quantity: pair(500_000_000_000n) } },
+        leasedIp: pair(10n)
       })
     );
 
@@ -54,6 +56,7 @@ describe(mapToStoredClusterState.name, () => {
     expect(result.totalAvailableGpu).toBe(2n);
     expect(result.totalAvailableEph).toBe(100_000_000_000n);
     expect(result.totalAvailablePersistent).toBe(500_000_000_000n);
+    expect(result.totalAvailableLeasedIp).toBe(10n);
     expect(result.maxNodeFreeCpu).toBe(4000n);
     expect(result.maxNodeFreeMemory).toBe(8_000_000_000n);
     expect(result.maxNodeFreeGpu).toBe(2n);
@@ -196,6 +199,7 @@ function buildNode(overrides?: Partial<NodeState>): NodeState {
 
 function buildCluster(overrides?: Partial<ClusterState>): ClusterState {
   return {
+    ...overrides,
     nodes: overrides?.nodes ?? [],
     storage: overrides?.storage ?? Object.create(null)
   };

--- a/apps/provider-inventory/src/repositories/provider-inventory/stored-cluster-state-mapper/stored-cluster-state-mapper.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/stored-cluster-state-mapper/stored-cluster-state-mapper.ts
@@ -7,6 +7,7 @@ export function mapToStoredClusterState(cluster: ClusterState): StoredClusterSta
   let totalAvailableGpu = 0n;
   let totalAvailableEph = 0n;
   let totalAvailablePersistent = 0n;
+  let totalAvailableLeasedIp = 0n;
   let maxNodeFreeCpu = 0n;
   let maxNodeFreeMemory = 0n;
   let maxNodeFreeGpu = 0n;
@@ -52,6 +53,10 @@ export function mapToStoredClusterState(cluster: ClusterState): StoredClusterSta
     }
   }
 
+  if (cluster.leasedIp) {
+    totalAvailableLeasedIp += availableCapacity(cluster.leasedIp);
+  }
+
   return {
     cluster,
     totalAvailableCpu,
@@ -59,6 +64,7 @@ export function mapToStoredClusterState(cluster: ClusterState): StoredClusterSta
     totalAvailableGpu,
     totalAvailableEph,
     totalAvailablePersistent,
+    totalAvailableLeasedIp,
     maxNodeFreeCpu,
     maxNodeFreeMemory,
     maxNodeFreeGpu,
@@ -73,6 +79,7 @@ export interface StoredClusterState {
   totalAvailableGpu: bigint;
   totalAvailableEph: bigint;
   totalAvailablePersistent: bigint;
+  totalAvailableLeasedIp: bigint;
   maxNodeFreeCpu: bigint;
   maxNodeFreeMemory: bigint;
   maxNodeFreeGpu: bigint;

--- a/apps/provider-inventory/src/services/provider-stream-factory/provider-stream-factory.sevice.ts
+++ b/apps/provider-inventory/src/services/provider-stream-factory/provider-stream-factory.sevice.ts
@@ -3,7 +3,7 @@ import { inject, singleton } from "tsyringe";
 
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
 import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
-import { mapClusterToStreamStatus } from "@src/services/provider-stream-factory/stream-status-mapper";
+import { mapInventoryToClusterState } from "@src/services/provider-stream-factory/stream-status-mapper";
 import { ChainProvider } from "@src/types/chain-provider";
 import type { ClusterState } from "@src/types/inventory";
 
@@ -36,7 +36,7 @@ export class ProviderStreamFactory {
     this.#logger.debug({ event: "STREAM_OPENED", owner: provider.owner, msSinceCreate: Date.now() - openedAt });
 
     for await (const status of stream) {
-      const inventory = status.cluster?.inventory?.cluster;
+      const inventory = status.cluster?.inventory;
       this.#logger.debug({
         event: "STREAM_RAW_ENVELOPE",
         owner: provider.owner,
@@ -44,7 +44,7 @@ export class ProviderStreamFactory {
         hasInventoryCluster: !!inventory
       });
       if (inventory) {
-        yield mapClusterToStreamStatus(inventory);
+        yield mapInventoryToClusterState(inventory);
       }
     }
   }

--- a/apps/provider-inventory/src/services/provider-stream-factory/stream-status-mapper.spec.ts
+++ b/apps/provider-inventory/src/services/provider-stream-factory/stream-status-mapper.spec.ts
@@ -1,6 +1,18 @@
+import type {
+  Cluster,
+  CPUInfo,
+  GPU,
+  GPUInfo,
+  Inventory,
+  Node as SdkNode,
+  NodeCapabilities,
+  ResourcePair as SdkResourcePair,
+  Storage as SdkStorage,
+  StorageInfo
+} from "@akashnetwork/chain-sdk/private-types/provider.akash.v1";
 import { describe, expect, it } from "vitest";
 
-import { parseQuantity } from "./stream-status-mapper";
+import { mapInventoryToClusterState, parseQuantity } from "./stream-status-mapper";
 
 describe(parseQuantity.name, () => {
   describe("empty / unparseable input", () => {
@@ -155,4 +167,238 @@ describe(parseQuantity.name, () => {
       expect(parseQuantity({ string: "5e-3" }, 1000n)).toBe(5n);
     });
   });
+});
+
+describe(mapInventoryToClusterState.name, () => {
+  describe("nodes", () => {
+    it("returns undefined nodes when the cluster is missing", () => {
+      const result = mapInventoryToClusterState(buildInventory({ cluster: undefined }));
+
+      expect(result.nodes).toBeUndefined();
+    });
+
+    it("maps every node in the cluster", () => {
+      const inventory = buildInventory({
+        cluster: buildCluster({ nodes: [buildNode({ name: "node-a" }), buildNode({ name: "node-b" })] })
+      });
+
+      const result = mapInventoryToClusterState(inventory);
+
+      expect(result.nodes?.map(node => node.name)).toEqual(["node-a", "node-b"]);
+    });
+
+    it("scales cpu quantities to millicores via the 1000n multiplier", () => {
+      const inventory = buildInventory({
+        cluster: buildCluster({ nodes: [buildNode({ cpu: buildPair({ allocatable: "2", allocated: "1.5" }) })] })
+      });
+
+      const result = mapInventoryToClusterState(inventory);
+
+      expect(result.nodes?.[0].cpu).toEqual({ allocatable: 2000n, allocated: 1500n });
+    });
+
+    it("maps memory and ephemeral storage without scaling", () => {
+      const inventory = buildInventory({
+        cluster: buildCluster({
+          nodes: [
+            buildNode({
+              memory: buildPair({ allocatable: "32Gi", allocated: "1Gi" }),
+              ephemeralStorage: buildPair({ allocatable: "100Gi", allocated: "0" })
+            })
+          ]
+        })
+      });
+
+      const result = mapInventoryToClusterState(inventory);
+
+      expect(result.nodes?.[0].memory).toEqual({ allocatable: 34359738368n, allocated: 1073741824n });
+      expect(result.nodes?.[0].ephemeralStorage).toEqual({ allocatable: 107374182400n, allocated: 0n });
+    });
+
+    it("maps the gpu quantity pair and info", () => {
+      const inventory = buildInventory({
+        cluster: buildCluster({
+          nodes: [
+            buildNode({
+              gpu: buildGpu({
+                allocatable: "4",
+                allocated: "1",
+                info: [
+                  {
+                    vendor: "nvidia",
+                    vendorId: "10de",
+                    name: "a100",
+                    modelid: "20b0",
+                    interface: "pcie",
+                    memorySize: "40Gi"
+                  }
+                ]
+              })
+            })
+          ]
+        })
+      });
+
+      const result = mapInventoryToClusterState(inventory);
+
+      expect(result.nodes?.[0].gpu).toEqual({
+        quantity: { allocatable: 4n, allocated: 1n },
+        info: [{ vendor: "nvidia", name: "a100", modelId: "20b0", interface: "pcie", memorySize: "40Gi" }]
+      });
+    });
+
+    it("defaults gpu info to an empty array when absent", () => {
+      const inventory = buildInventory({
+        cluster: buildCluster({ nodes: [buildNode({ gpu: buildGpu({ info: undefined }) })] })
+      });
+
+      const result = mapInventoryToClusterState(inventory);
+
+      expect(result.nodes?.[0].gpu.info).toEqual([]);
+    });
+
+    it("maps cpu info entries", () => {
+      const inventory = buildInventory({
+        cluster: buildCluster({
+          nodes: [buildNode({ cpus: [{ vendor: "amd", model: "epyc" } as CPUInfo] })]
+        })
+      });
+
+      const result = mapInventoryToClusterState(inventory);
+
+      expect(result.nodes?.[0].cpus).toEqual([{ vendor: "amd", model: "epyc" }]);
+    });
+
+    it("defaults cpu info to an empty array when absent", () => {
+      const inventory = buildInventory({
+        cluster: buildCluster({ nodes: [buildNode({ cpus: undefined })] })
+      });
+
+      const result = mapInventoryToClusterState(inventory);
+
+      expect(result.nodes?.[0].cpus).toEqual([]);
+    });
+
+    it("maps the node storage classes", () => {
+      const inventory = buildInventory({
+        cluster: buildCluster({ nodes: [buildNode({ storageClasses: ["beta2", "beta3"] })] })
+      });
+
+      const result = mapInventoryToClusterState(inventory);
+
+      expect(result.nodes?.[0].storageClasses).toEqual(["beta2", "beta3"]);
+    });
+
+    it("defaults storage classes to an empty array when capabilities are missing", () => {
+      const inventory = buildInventory({
+        cluster: buildCluster({ nodes: [buildNode({ capabilities: undefined })] })
+      });
+
+      const result = mapInventoryToClusterState(inventory);
+
+      expect(result.nodes?.[0].storageClasses).toEqual([]);
+    });
+  });
+
+  describe("storage", () => {
+    it("returns undefined when the cluster is missing", () => {
+      const result = mapInventoryToClusterState(buildInventory({ cluster: undefined }));
+
+      expect(result.storage).toBeUndefined();
+    });
+
+    it("returns undefined when the cluster has no storage", () => {
+      const result = mapInventoryToClusterState(buildInventory({ cluster: buildCluster({ storage: undefined }) }));
+
+      expect(result.storage).toBeUndefined();
+    });
+
+    it("keys each pool by its storage class", () => {
+      const inventory = buildInventory({
+        cluster: buildCluster({
+          storage: [
+            buildStorage({ class: "beta2", allocatable: "100Gi", allocated: "10Gi" }),
+            buildStorage({ class: "beta3", allocatable: "200Gi", allocated: "0" })
+          ]
+        })
+      });
+
+      const result = mapInventoryToClusterState(inventory);
+
+      expect(result.storage).toEqual({
+        beta2: { class: "beta2", quantity: { allocatable: 107374182400n, allocated: 10737418240n } },
+        beta3: { class: "beta3", quantity: { allocatable: 214748364800n, allocated: 0n } }
+      });
+    });
+
+    it("falls back to an empty-string class when the pool info is missing", () => {
+      const inventory = buildInventory({
+        cluster: buildCluster({ storage: [buildStorage({ class: undefined, allocatable: "50Gi", allocated: "0" })] })
+      });
+
+      const result = mapInventoryToClusterState(inventory);
+
+      expect(result.storage?.[""]).toEqual({ class: "", quantity: { allocatable: 53687091200n, allocated: 0n } });
+    });
+  });
+
+  describe("leasedIp", () => {
+    it("maps the leased ip pair", () => {
+      const inventory = buildInventory({ leasedIp: buildPair({ allocatable: "10", allocated: "3" }) });
+
+      const result = mapInventoryToClusterState(inventory);
+
+      expect(result.leasedIp).toEqual({ allocatable: 10n, allocated: 3n });
+    });
+
+    it("defaults to a zero pair when leasedIp is missing", () => {
+      const result = mapInventoryToClusterState(buildInventory({ leasedIp: undefined }));
+
+      expect(result.leasedIp).toEqual({ allocatable: 0n, allocated: 0n });
+    });
+  });
+
+  function buildInventory(overrides: Partial<Inventory>): Inventory {
+    return { cluster: undefined, leasedIp: undefined, ...overrides } as Inventory;
+  }
+
+  function buildCluster(overrides: { nodes?: SdkNode[]; storage?: SdkStorage[] }): Cluster {
+    return { nodes: overrides.nodes ?? [], storage: overrides.storage } as Cluster;
+  }
+
+  function buildPair(input: { allocatable?: string; allocated?: string }) {
+    return { allocatable: { string: input.allocatable }, allocated: { string: input.allocated } } as SdkResourcePair;
+  }
+
+  function buildGpu(input: { allocatable?: string; allocated?: string; info?: GPUInfo[] }) {
+    return { quantity: buildPair(input), info: input.info } as GPU;
+  }
+
+  function buildStorage(input: { class?: string; allocatable?: string; allocated?: string }) {
+    return { quantity: buildPair(input), info: input.class === undefined ? undefined : ({ class: input.class } as StorageInfo) } as SdkStorage;
+  }
+
+  function buildNode(
+    input: {
+      name?: string;
+      cpu?: SdkResourcePair;
+      memory?: SdkResourcePair;
+      ephemeralStorage?: SdkResourcePair;
+      gpu?: GPU;
+      cpus?: CPUInfo[];
+      storageClasses?: string[];
+      capabilities?: NodeCapabilities;
+    } = {}
+  ) {
+    return {
+      name: input.name ?? "node-1",
+      resources: {
+        cpu: { quantity: input.cpu ?? buildPair({ allocatable: "1", allocated: "0" }), info: input.cpus ?? [] },
+        memory: { quantity: input.memory ?? buildPair({ allocatable: "1Gi", allocated: "0" }) },
+        ephemeralStorage: input.ephemeralStorage ?? buildPair({ allocatable: "1Gi", allocated: "0" }),
+        gpu: input.gpu ?? buildGpu({ allocatable: "0", allocated: "0", info: [] })
+      },
+      capabilities: "capabilities" in input ? input.capabilities : { storageClasses: input.storageClasses ?? [] }
+    } as SdkNode;
+  }
 });

--- a/apps/provider-inventory/src/services/provider-stream-factory/stream-status-mapper.ts
+++ b/apps/provider-inventory/src/services/provider-stream-factory/stream-status-mapper.ts
@@ -1,7 +1,7 @@
 import type {
-  Cluster,
   CPUInfo,
   GPUInfo,
+  Inventory,
   Node as SdkNode,
   ResourcePair as SdkResourcePair,
   Storage as SdkStorage
@@ -102,7 +102,9 @@ function mapNode(node: SdkNode): NodeState {
   };
 }
 
-function mapClusterStorage(storage: SdkStorage[]): ClusterState["storage"] {
+function mapClusterStorage(storage: SdkStorage[] | undefined): ClusterState["storage"] {
+  if (!storage) return;
+
   const result: Exclude<ClusterState["storage"], undefined> = Object.create(null);
   for (const pool of storage) {
     const cls = pool.info?.class ?? "";
@@ -111,9 +113,10 @@ function mapClusterStorage(storage: SdkStorage[]): ClusterState["storage"] {
   return result;
 }
 
-export function mapClusterToStreamStatus(cluster: Cluster): ClusterState {
+export function mapInventoryToClusterState(inventory: Inventory): ClusterState {
   return {
-    nodes: cluster.nodes.map(mapNode),
-    storage: mapClusterStorage(cluster.storage)
+    nodes: inventory.cluster?.nodes.map(mapNode),
+    storage: mapClusterStorage(inventory.cluster?.storage),
+    leasedIp: pairFromSdk(inventory.leasedIp)
   };
 }

--- a/apps/provider-inventory/src/types/inventory.ts
+++ b/apps/provider-inventory/src/types/inventory.ts
@@ -29,6 +29,7 @@ export interface NodeState {
 export interface ClusterState {
   nodes?: NodeState[];
   storage?: Record<string, { class: string; quantity: RawPair }>;
+  leasedIp?: RawPair;
 }
 
 export interface RequestedStorage {


### PR DESCRIPTION
## Why

ref CON-431

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added leased IP capacity tracking and surfaced it in provider status streams.

* **Improvements**
  * Provider state comparison and inventory mappings now include leased IP metrics.
  * Pagination helper generalized to support different key types.

* **Tests**
  * Expanded test coverage to validate leased IP rollups and inventory-to-cluster mappings.

* **Chores**
  * Database schema and migration metadata updated to store leased IP totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->