### PR TITLE
chore(deployment): update chain-sdk to alpha.34

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -24,7 +24,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -20,7 +20,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
@@ -527,7 +527,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -2388,7 +2388,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
@@ -2766,7 +2766,7 @@
       "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -3911,7 +3911,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4251,7 +4251,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4428,7 +4428,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -5193,7 +5193,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -5420,9 +5420,9 @@
       }
     },
     "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.33",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.33.tgz",
-      "integrity": "sha512-ahiX8+dBzQDjIPOM5Mrqf8PuKdH7SAMB+oPrUIXyFNd64RYAP6gZQDG0we7LcHpoWHRiba5ox4xU16YHY4CrvQ==",
+      "version": "1.0.0-alpha.34",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.34.tgz",
+      "integrity": "sha512-DaDWVI7QnCS9OWH3zS/WaHPGTl5OYO5UBLMGgqed7Sl0cWKcge4J4LMcYpupBlEqhdS4ywbnYUa5+fLq+qTmVg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -21683,6 +21683,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-8yQrvS6sMpSwIovhPOwfyNf2Wz6v/B62LFSVYQ85+Rq3tLsBIG7rP5geMxaijTUxSkrO6RzN/IRuIAADYQsleA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -45523,7 +45524,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       }

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.33",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.34",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   }


### PR DESCRIPTION
## Why

Keep all workspaces on the latest `@akashnetwork/chain-sdk` alpha release. Bumps every consumer from `1.0.0-alpha.33` to `1.0.0-alpha.34`.

alpha.34 changes:
- feat(ts): surface SDL reclamation from `generateManifest` (chain-sdk #318) — additive to `generateManifest` output
- fix(ts): resolve grpc-gateway path field from `{field=**}` templates (chain-sdk #323) — internal to the SDK REST client

## What

- Bumped `@akashnetwork/chain-sdk` to `1.0.0-alpha.34` in all 9 workspace `package.json` files (`api`, `deploy-web`, `indexer`, `notifications`, `provider-inventory`, `provider-proxy`, `stats-web`, `tx-signer`, `network-store`) + `package-lock.json`. No source changes — mirrors prior bumps (#3261, #3229).

**Verification**
- `tsc -p tsconfig.build.json` (src) clean for `api`; no chain-sdk/`generateManifest` type errors in `deploy-web`.
- `generateManifest`/`generateManifestVersion` consumer tests pass: `api` 40/40 (sdl, deployment-writer, gpu-bids-creator), `deploy-web` 13/13 (deploymentData).

> [!NOTE]
> alpha.34 was published <7 days ago, so it does not yet satisfy the repo's `min-release-age=7` cooldown in `.npmrc`. The lockfile was updated with the cooldown bypassed **for this one install only** — `.npmrc` is unchanged and the version will satisfy the policy organically around 2026-06-12.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped core chain SDK to v1.0.0-alpha.34 across all applications and packages to ensure dependency consistency and maintain platform reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->