### PR TITLE
feat(deployment): add hidden sdl preview panel to configure screen

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentContainer/ConfigureDeploymentContainer.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentContainer/ConfigureDeploymentContainer.spec.tsx
@@ -1,0 +1,46 @@
+import { createStore, Provider as JotaiStoreProvider } from "jotai";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import sdlStore from "@src/store/sdlStore";
+import type { TemplateCreation } from "@src/types";
+import type { DEPENDENCIES } from "./ConfigureDeploymentContainer";
+import { ConfigureDeploymentContainer } from "./ConfigureDeploymentContainer";
+
+import { render } from "@testing-library/react";
+
+describe("ConfigureDeploymentContainer", () => {
+  it("seeds the panes with the carried-in template SDL", () => {
+    const { ConfigureDeploymentPanes } = setup({
+      deploySdl: mock<TemplateCreation>({ content: 'version: "2.0"' })
+    });
+
+    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ sdl: 'version: "2.0"' }), expect.anything());
+  });
+
+  it("passes an empty SDL when no template was carried in", () => {
+    const { ConfigureDeploymentPanes } = setup({ deploySdl: null });
+
+    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ sdl: "" }), expect.anything());
+  });
+
+  function setup(input: { deploySdl: TemplateCreation | null }) {
+    const ConfigureDeploymentPanes = vi.fn(() => <div data-testid="panes-mock" />);
+    const dependencies: typeof DEPENDENCIES = {
+      Layout: vi.fn(({ children }) => <div data-testid="layout-mock">{children}</div>) as never,
+      NextSeo: vi.fn(() => null) as never,
+      ConfigureDeploymentHeader: vi.fn(() => <div data-testid="header-mock" />),
+      ConfigureDeploymentPanes: ConfigureDeploymentPanes as never
+    };
+    const store = createStore();
+    store.set(sdlStore.deploySdl, input.deploySdl);
+
+    render(
+      <JotaiStoreProvider store={store}>
+        <ConfigureDeploymentContainer dependencies={dependencies} />
+      </JotaiStoreProvider>
+    );
+
+    return { ConfigureDeploymentPanes };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentContainer/ConfigureDeploymentContainer.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentContainer/ConfigureDeploymentContainer.tsx
@@ -1,21 +1,38 @@
 "use client";
 import type { FC } from "react";
+import { useState } from "react";
+import { useAtomValue } from "jotai";
 import { NextSeo } from "next-seo";
 
 import Layout from "@src/components/layout/Layout";
+import sdlStore from "@src/store/sdlStore";
 import { ConfigureDeploymentHeader } from "../ConfigureDeploymentHeader/ConfigureDeploymentHeader";
 import { ConfigureDeploymentPanes } from "../ConfigureDeploymentPanes/ConfigureDeploymentPanes";
 
-export const ConfigureDeploymentContainer: FC = () => {
+export const DEPENDENCIES = { Layout, NextSeo, ConfigureDeploymentHeader, ConfigureDeploymentPanes };
+
+type Props = {
+  dependencies?: typeof DEPENDENCIES;
+};
+
+export const ConfigureDeploymentContainer: FC<Props> = ({ dependencies: d = DEPENDENCIES }) => {
+  const deploySdl = useAtomValue(sdlStore.deploySdl);
+  /**
+   * Lifted SDL state, mirroring the legacy NewDeploymentContainer#editedManifest pattern:
+   * seeded once from the carried-in template; the future ConfigurationPane form becomes
+   * the producer that writes generateSdl() output into it.
+   */
+  const [sdl] = useState(() => deploySdl?.content ?? "");
+
   return (
-    <Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col">
-      <NextSeo title="Configure your deployment" />
+    <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col">
+      <d.NextSeo title="Configure your deployment" />
       <div className="px-6 pt-6">
-        <ConfigureDeploymentHeader />
+        <d.ConfigureDeploymentHeader />
       </div>
       <div className="mt-6 flex min-h-0 flex-1">
-        <ConfigureDeploymentPanes />
+        <d.ConfigureDeploymentPanes sdl={sdl} />
       </div>
-    </Layout>
+    </d.Layout>
   );
 };

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
@@ -1,3 +1,4 @@
+import { createStore, Provider as JotaiStoreProvider } from "jotai";
 import { describe, expect, it, vi } from "vitest";
 
 import type { DEPENDENCIES } from "./ConfigureDeploymentPanes";
@@ -53,12 +54,66 @@ describe("ConfigureDeploymentPanes", () => {
     expect(marketplaceRegion).not.toHaveClass("hidden");
   });
 
-  function setup() {
+  it("does not render the SDL preview pane when the flag is disabled", () => {
+    const { SdlPreviewPane } = setup({ isSdlPreviewEnabled: false });
+
+    expect(SdlPreviewPane).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("sdl-preview-pane-mock")).not.toBeInTheDocument();
+  });
+
+  it("renders the preview pane closed with the sdl when the flag is enabled", () => {
+    const { SdlPreviewPane } = setup({ isSdlPreviewEnabled: true, sdl: 'version: "2.0"' });
+
+    expect(SdlPreviewPane).toHaveBeenCalledWith(expect.objectContaining({ isOpen: false, sdl: 'version: "2.0"' }), expect.anything());
+  });
+
+  it("opens the preview pane when it requests opening and closes it back", async () => {
+    const { SdlPreviewPane } = setup({ isSdlPreviewEnabled: true });
+
+    await userEvent.click(screen.getByRole("button", { name: "Open SDL preview mock" }));
+    expect(SdlPreviewPane).toHaveBeenLastCalledWith(expect.objectContaining({ isOpen: true }), expect.anything());
+
+    await userEvent.click(screen.getByRole("button", { name: "Close SDL preview mock" }));
+    expect(SdlPreviewPane).toHaveBeenLastCalledWith(expect.objectContaining({ isOpen: false }), expect.anything());
+  });
+
+  it("restores the open state from a previous session", async () => {
+    const first = setup({ isSdlPreviewEnabled: true });
+    await userEvent.click(screen.getByRole("button", { name: "Open SDL preview mock" }));
+    first.unmount();
+
+    const second = setup({ isSdlPreviewEnabled: true, preserveStorage: true });
+
+    await vi.waitFor(() => {
+      expect(second.SdlPreviewPane).toHaveBeenLastCalledWith(expect.objectContaining({ isOpen: true }), expect.anything());
+    });
+  });
+
+  function setup(input: { isSdlPreviewEnabled?: boolean; sdl?: string; preserveStorage?: boolean } = {}) {
+    const SdlPreviewPane = vi.fn(({ isOpen, onOpen, onClose }: { isOpen: boolean; onOpen: () => void; onClose: () => void }) => (
+      <div data-testid="sdl-preview-pane-mock" data-open={isOpen}>
+        <button type="button" aria-label="Open SDL preview mock" onClick={onOpen} />
+        <button type="button" aria-label="Close SDL preview mock" onClick={onClose} />
+      </div>
+    ));
     const dependencies: typeof DEPENDENCIES = {
       DeploymentPane: vi.fn(() => <div data-testid="deployment-pane-mock" />),
       ConfigurationPane: vi.fn(() => <div data-testid="configuration-pane-mock" />),
-      MarketplacePane: vi.fn(() => <div data-testid="marketplace-pane-mock" />)
+      MarketplacePane: vi.fn(() => <div data-testid="marketplace-pane-mock" />),
+      SdlPreviewPane: SdlPreviewPane as never,
+      useFlag: (() => input.isSdlPreviewEnabled ?? false) as never
     };
-    return render(<ConfigureDeploymentPanes dependencies={dependencies} />);
+
+    if (!input.preserveStorage) {
+      localStorage.clear();
+    }
+
+    const { unmount } = render(
+      <JotaiStoreProvider store={createStore()}>
+        <ConfigureDeploymentPanes sdl={input.sdl ?? ""} dependencies={dependencies} />
+      </JotaiStoreProvider>
+    );
+
+    return { SdlPreviewPane, unmount };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
@@ -1,25 +1,32 @@
 import type { FC } from "react";
 import { useState } from "react";
 import { cn } from "@akashnetwork/ui/utils";
+import { useAtom } from "jotai";
 
+import { useFlag } from "@src/hooks/useFlag";
+import sdlStore from "@src/store/sdlStore";
 import { ConfigurationPane } from "../ConfigurationPane/ConfigurationPane";
 import { DeploymentPane } from "../DeploymentPane/DeploymentPane";
 import { MarketplacePane } from "../MarketplacePane/MarketplacePane";
+import { SdlPreviewPane } from "../SdlPreviewPane/SdlPreviewPane";
 
 type ActivePane = "deployment" | "configuration" | "marketplace";
 
-export const DEPENDENCIES = { DeploymentPane, ConfigurationPane, MarketplacePane };
+export const DEPENDENCIES = { DeploymentPane, ConfigurationPane, MarketplacePane, SdlPreviewPane, useFlag };
 
 type Props = {
+  sdl: string;
   dependencies?: typeof DEPENDENCIES;
 };
 
-export const ConfigureDeploymentPanes: FC<Props> = ({ dependencies: d = DEPENDENCIES }) => {
+export const ConfigureDeploymentPanes: FC<Props> = ({ sdl, dependencies: d = DEPENDENCIES }) => {
   const [activePane, setActivePane] = useState<ActivePane>("deployment");
+  const [isSdlPreviewOpen, setIsSdlPreviewOpen] = useAtom(sdlStore.sdlPreviewOpen);
+  const isSdlPreviewEnabled = d.useFlag("ui_sdl_preview_panel");
 
   return (
     <div className="flex h-full w-full flex-col">
-      <div className="grid min-h-0 flex-1 grid-rows-1 md:grid-cols-[auto_320px_1fr] md:divide-x md:divide-zinc-300 md:border-t md:border-zinc-300 md:dark:divide-zinc-700 md:dark:border-zinc-700">
+      <div className="grid min-h-0 flex-1 grid-rows-1 md:auto-cols-fr md:grid-flow-col md:grid-cols-[auto_320px_1fr] md:divide-x md:divide-zinc-300 md:border-t md:border-zinc-300 md:dark:divide-zinc-700 md:dark:border-zinc-700">
         <div className={cn("min-h-0 md:block", { hidden: activePane !== "deployment" })}>
           <d.DeploymentPane />
         </div>
@@ -29,6 +36,9 @@ export const ConfigureDeploymentPanes: FC<Props> = ({ dependencies: d = DEPENDEN
         <div className={cn("min-h-0 md:block", { hidden: activePane !== "marketplace" })}>
           <d.MarketplacePane />
         </div>
+        {isSdlPreviewEnabled && (
+          <d.SdlPreviewPane sdl={sdl} isOpen={isSdlPreviewOpen} onOpen={() => setIsSdlPreviewOpen(true)} onClose={() => setIsSdlPreviewOpen(false)} />
+        )}
       </div>
 
       <nav aria-label="Pane navigation" className="flex shrink-0 border-t border-zinc-300 md:hidden dark:border-zinc-700">

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlPreviewPane/SdlPreviewPane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlPreviewPane/SdlPreviewPane.spec.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { DEPENDENCIES } from "./SdlPreviewPane";
+import { SdlPreviewPane } from "./SdlPreviewPane";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe("SdlPreviewPane", () => {
+  it("renders nothing when closed", () => {
+    setup({ isOpen: false });
+
+    expect(screen.queryByTestId("sdl-editor-mock")).not.toBeInTheDocument();
+  });
+
+  it("renders the SDL in a read-only editor when open", () => {
+    const { SDLEditor } = setup({ isOpen: true, sdl: 'version: "2.0"' });
+
+    expect(SDLEditor).toHaveBeenCalledWith(expect.objectContaining({ value: 'version: "2.0"', readonly: true }), expect.anything());
+  });
+
+  it("requests opening on mod+shift+Y when closed", async () => {
+    const { onOpen, onClose } = setup({ isOpen: false });
+
+    await userEvent.keyboard("{Control>}{Shift>}[KeyY]{/Shift}{/Control}");
+
+    expect(onOpen).toHaveBeenCalledOnce();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("requests closing on mod+shift+Y when open", async () => {
+    const { onOpen, onClose } = setup({ isOpen: true });
+
+    await userEvent.keyboard("{Control>}{Shift>}[KeyY]{/Shift}{/Control}");
+
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("ignores the key without both modifiers", async () => {
+    const { onOpen, onClose } = setup({ isOpen: false });
+
+    await userEvent.keyboard("{Control>}[KeyY]{/Control}");
+    await userEvent.keyboard("{Shift>}[KeyY]{/Shift}");
+
+    expect(onOpen).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("requests closing when the close button is clicked", async () => {
+    const { onClose } = setup({ isOpen: true });
+
+    await userEvent.click(screen.getByRole("button", { name: "Close SDL preview" }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  function setup(input: { isOpen: boolean; sdl?: string }) {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    const SDLEditor = vi.fn(() => <div data-testid="sdl-editor-mock" />);
+    const dependencies: typeof DEPENDENCIES = {
+      SDLEditor: SDLEditor as never
+    };
+
+    render(<SdlPreviewPane sdl={input.sdl ?? ""} isOpen={input.isOpen} onOpen={onOpen} onClose={onClose} dependencies={dependencies} />);
+
+    return { onOpen, onClose, SDLEditor };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlPreviewPane/SdlPreviewPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlPreviewPane/SdlPreviewPane.tsx
@@ -1,0 +1,66 @@
+import type { FC } from "react";
+import { useEffect } from "react";
+import { Xmark } from "iconoir-react";
+
+import { SDLEditor } from "@src/components/sdl/SDLEditor/SDLEditor";
+
+export const DEPENDENCIES = { SDLEditor };
+
+type Props = {
+  sdl: string;
+  isOpen: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+export const SdlPreviewPane: FC<Props> = ({ sdl, isOpen, onOpen, onClose, dependencies: d = DEPENDENCIES }) => {
+  useEffect(
+    function bindSdlPreviewHotkey() {
+      const toggleSdlPreview = (event: KeyboardEvent) => {
+        if ((event.metaKey || event.ctrlKey) && event.shiftKey && event.code === "KeyY") {
+          event.preventDefault();
+          if (isOpen) {
+            onClose();
+          } else {
+            onOpen();
+          }
+        }
+      };
+
+      window.addEventListener("keydown", toggleSdlPreview);
+      return function unbindSdlPreviewHotkey() {
+        window.removeEventListener("keydown", toggleSdlPreview);
+      };
+    },
+    [isOpen, onOpen, onClose]
+  );
+
+  if (!isOpen) return null;
+
+  return (
+    <section aria-labelledby="sdl-preview-pane-heading" className="hidden h-full min-h-0 flex-col border-l-4 border-l-amber-500 md:flex">
+      <header className="flex h-[52px] shrink-0 items-center justify-between gap-2 border-b border-zinc-300 bg-amber-500/10 px-4 dark:border-zinc-700">
+        <div className="flex items-center gap-2">
+          <h2 id="sdl-preview-pane-heading" className="font-mono text-sm font-medium uppercase text-muted-foreground">
+            SDL Preview
+          </h2>
+          <span className="rounded bg-amber-500/20 px-1.5 py-0.5 font-mono text-[10px] font-semibold uppercase tracking-wide text-amber-600 dark:text-amber-400">
+            Debug
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close SDL preview"
+          className="flex h-8 w-8 items-center justify-center rounded text-foreground hover:bg-accent"
+        >
+          <Xmark className="h-5 w-5" />
+        </button>
+      </header>
+      <div className="min-h-0 flex-1">
+        <d.SDLEditor value={sdl} readonly height="100%" />
+      </div>
+    </section>
+  );
+};

--- a/apps/deploy-web/src/components/sdl/SDLEditor/SDLEditor.spec.tsx
+++ b/apps/deploy-web/src/components/sdl/SDLEditor/SDLEditor.spec.tsx
@@ -33,6 +33,19 @@ describe(SDLEditor.name || "SDLEditor", () => {
     );
   });
 
+  it("renders validation decorations when readonly", () => {
+    const { Editor } = setup({ readonly: true });
+
+    expect(Editor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          renderValidationDecorations: "on"
+        })
+      }),
+      expect.anything()
+    );
+  });
+
   it("passes readonly as false when readonly prop is false", () => {
     const { Editor } = setup({ readonly: false });
 

--- a/apps/deploy-web/src/components/sdl/SDLEditor/SDLEditor.tsx
+++ b/apps/deploy-web/src/components/sdl/SDLEditor/SDLEditor.tsx
@@ -154,6 +154,7 @@ export const SDLEditor = forwardRef<SdlEditorRefType, Props>(({ onChange, onVali
         ...props.options,
         readOnly: !!props.readonly,
         domReadOnly: !!props.readonly,
+        ...(props.readonly && { renderValidationDecorations: "on" as const }),
         hover: {
           enabled: true,
           ...(props.options?.hover as Record<string, unknown>)

--- a/apps/deploy-web/src/store/sdlStore.ts
+++ b/apps/deploy-web/src/store/sdlStore.ts
@@ -1,13 +1,16 @@
 import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
 
 import type { SdlBuilderFormValuesType, TemplateCreation } from "@src/types";
 
 const deploySdl = atom<TemplateCreation | null>(null);
 const sdlBuilderSdl = atom<SdlBuilderFormValuesType | null>(null);
 const selectedSdlEditMode = atom<"yaml" | "builder">("yaml");
+const sdlPreviewOpen = atomWithStorage<boolean>("sdlPreviewPaneOpen", false);
 
 export default {
   deploySdl,
   sdlBuilderSdl,
-  selectedSdlEditMode
+  selectedSdlEditMode,
+  sdlPreviewOpen
 };

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -10,4 +10,5 @@ export type FeatureFlag =
   | "self_custody"
   | "console_auth_redesign"
   | "console_onboarding_redesign"
-  | "bid_screening";
+  | "bid_screening"
+  | "ui_sdl_preview_panel";


### PR DESCRIPTION
## Why

The `/new-deployment/configure` redesign needs a way to inspect the SDL the screen will generate while its panes are still being built out. A hidden, read-only SDL preview gives developers (and later power users) the same visibility the legacy builder's YAML view provides, without exposing an unfinished surface to regular users.

## What

- New `SdlPreviewPane` on the configure screen: read-only Monaco `SDLEditor` with debug-tool styling (amber border + "Debug" badge), non-sequential to the three numbered panes — no number, no mobile tab, desktop-only.
- **Hidden behind the `ui_sdl_preview_panel` feature flag**; when the flag is off the pane is not rendered at all.
- **Toggled with **mod+shift+Y**** (Cmd+Shift+Y on macOS, Ctrl+Shift+Y elsewhere) or closed via the header close button; open state persists in `sdlStore.sdlPreviewOpen` (localStorage).
- `ConfigureDeploymentContainer` seeds the SDL once from `sdlStore.deploySdl` and passes it down; no setter is exposed — the future ConfigurationPane form becomes the producer.
- `SDLEditor` readonly fix: sets `renderValidationDecorations: "on"` when `readonly`, so validation markers show in read-only editors (also benefits `PreviewSdl`).

https://github.com/user-attachments/assets/2bcd854d-742b-4459-a856-95b47878ffe0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an SDL preview panel accessible via keyboard shortcut (Ctrl/Cmd + Shift + Y). The panel displays SDL content in read-only mode and automatically preserves its open/closed state across sessions.

* **Improvements**
  * Enhanced read-only SDL editor display with validation decorations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->