### PR TITLE
feat(deployment): forward SDL 2.1 reclamation into MsgCreateDeployment

### DIFF
--- a/apps/api/src/billing/services/rpc-message-service/rpc-message.service.spec.ts
+++ b/apps/api/src/billing/services/rpc-message-service/rpc-message.service.spec.ts
@@ -1,4 +1,4 @@
-import { MsgMintACT } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { DeploymentReclamation, MsgMintACT } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
@@ -22,6 +22,34 @@ describe(RpcMessageService.name, () => {
           }
         })
       });
+    });
+  });
+
+  describe("getCreateDeploymentMsg", () => {
+    const baseOptions = {
+      owner: "akash1abc",
+      dseq: 123,
+      groups: [],
+      hash: new Uint8Array(),
+      denom: "uakt",
+      amount: 1000000
+    };
+
+    it("forwards the reclamation block into the message when the SDL declares it", () => {
+      const { service } = setup();
+      const reclamation = DeploymentReclamation.fromPartial({ minWindow: { seconds: 86400 } });
+
+      const msg = service.getCreateDeploymentMsg({ ...baseOptions, reclamation });
+
+      expect(msg.value.reclamation).toEqual(reclamation);
+    });
+
+    it("leaves reclamation unset for an SDL without a reclamation block", () => {
+      const { service } = setup();
+
+      const msg = service.getCreateDeploymentMsg(baseOptions);
+
+      expect(msg.value.reclamation).toBeUndefined();
     });
   });
 

--- a/apps/api/src/billing/services/rpc-message-service/rpc-message.service.ts
+++ b/apps/api/src/billing/services/rpc-message-service/rpc-message.service.ts
@@ -1,4 +1,5 @@
 import {
+  type DeploymentReclamation,
   DepositAuthorization,
   DepositAuthorization_Scope,
   MsgAccountDeposit,
@@ -37,6 +38,7 @@ export interface DepositDeploymentMsgOptions extends DepositDeploymentMsgOptions
 export interface CreateDeploymentMsgOptions extends DepositDeploymentMsgOptionsBase {
   groups: GroupSpec[];
   hash: Uint8Array;
+  reclamation?: DeploymentReclamation;
 }
 
 export interface CreateLeaseMsgOptions {
@@ -158,7 +160,7 @@ export class RpcMessageService {
     };
   }
 
-  getCreateDeploymentMsg({ owner, dseq, groups, hash, denom, amount }: CreateDeploymentMsgOptions) {
+  getCreateDeploymentMsg({ owner, dseq, groups, hash, denom, amount, reclamation }: CreateDeploymentMsgOptions) {
     return {
       typeUrl: `/${MsgCreateDeployment.$type}`,
       value: MsgCreateDeployment.fromPartial({
@@ -174,7 +176,8 @@ export class RpcMessageService {
             amount: amount.toString()
           },
           sources: [Source.grant]
-        }
+        },
+        reclamation
       })
     };
   }

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -1,4 +1,4 @@
-import { MsgAccountDeposit } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { DeploymentReclamation, MsgAccountDeposit } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { MsgCloseDeployment, MsgCreateDeployment, MsgUpdateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import { vi } from "vitest";
 import { mock, type MockProxy } from "vitest-mock-extended";
@@ -98,6 +98,24 @@ describe(DeploymentWriterService.name, () => {
       } as any);
 
       await expect(service.create({ userId: "user-1", sdl: "bad-sdl", deposit: 5 })).rejects.toThrow();
+    });
+
+    it("forwards the reclamation block to getCreateDeploymentMsg when the SDL declares it", async () => {
+      const { service, sdlService, rpcMessageService } = setup();
+      const reclamation = DeploymentReclamation.fromPartial({ minWindow: { seconds: 86400 } });
+      sdlService.generateManifest.mockReturnValue({ ok: true, value: { ...manifestValue, reclamation } } as any);
+
+      await service.create({ userId: "user-1", sdl: "sdl-with-reclamation", deposit: 5 });
+
+      expect(rpcMessageService.getCreateDeploymentMsg).toHaveBeenCalledWith(expect.objectContaining({ reclamation }));
+    });
+
+    it("passes reclamation as undefined for an SDL without a reclamation block", async () => {
+      const { service, rpcMessageService } = setup();
+
+      await service.create({ userId: "user-1", sdl: "sdl-2.0", deposit: 5 });
+
+      expect(rpcMessageService.getCreateDeploymentMsg.mock.calls[0][0].reclamation).toBeUndefined();
     });
   });
 

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.ts
@@ -43,7 +43,8 @@ export class DeploymentWriterService {
       groups: manifest.groupSpecs,
       denom: this.billingConfig.get("DEPLOYMENT_GRANT_DENOM"),
       amount: denomToUdenom(input.deposit),
-      hash: manifestVersion
+      hash: manifestVersion,
+      reclamation: manifest.reclamation
     });
 
     const result = await this.signerService.executeDerivedDecodedTxByUserId(wallet.userId, [message]);

--- a/apps/deploy-web/src/types/deployment.ts
+++ b/apps/deploy-web/src/types/deployment.ts
@@ -1,3 +1,4 @@
+import type { DeploymentReclamation } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import type { GroupSpec } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import type { Bid, DeploymentResource } from "@akashnetwork/http-sdk";
 
@@ -337,4 +338,5 @@ export interface NewDeploymentData {
   leaseId: unknown[];
   deposit: DepositParams;
   hash: Uint8Array;
+  reclamation?: DeploymentReclamation;
 }

--- a/apps/deploy-web/src/utils/TransactionMessageData.spec.ts
+++ b/apps/deploy-web/src/utils/TransactionMessageData.spec.ts
@@ -1,0 +1,41 @@
+import { DeploymentReclamation } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { describe, expect, it } from "vitest";
+
+import type { NewDeploymentData } from "@src/types/deployment";
+import { TransactionMessageData } from "./TransactionMessageData";
+
+describe(TransactionMessageData.name, () => {
+  describe("getCreateDeploymentMsg", () => {
+    it("forwards the reclamation block into the message when present", () => {
+      const reclamation = DeploymentReclamation.fromPartial({ minWindow: { seconds: 86400 } });
+      const deploymentData = setup({ reclamation });
+
+      const msg = TransactionMessageData.getCreateDeploymentMsg(deploymentData);
+
+      expect(msg.value.reclamation).toEqual(reclamation);
+    });
+
+    it("leaves reclamation unset when the deployment has none", () => {
+      const deploymentData = setup({ reclamation: undefined });
+
+      const msg = TransactionMessageData.getCreateDeploymentMsg(deploymentData);
+
+      expect(msg.value.reclamation).toBeUndefined();
+    });
+  });
+
+  function setup(input: { reclamation?: NewDeploymentData["reclamation"] }) {
+    const deploymentData: NewDeploymentData = {
+      sdl: {},
+      manifest: {},
+      groups: [],
+      deploymentId: { owner: "akash1abc", dseq: "123" },
+      orderId: [],
+      leaseId: [],
+      deposit: { denom: "uakt", amount: "1000000" },
+      hash: new Uint8Array(),
+      reclamation: input.reclamation
+    };
+    return deploymentData;
+  }
+});

--- a/apps/deploy-web/src/utils/TransactionMessageData.ts
+++ b/apps/deploy-web/src/utils/TransactionMessageData.ts
@@ -31,7 +31,8 @@ export class TransactionMessageData {
         deposit: {
           amount: deploymentData.deposit,
           sources: [Source.grant, Source.balance]
-        }
+        },
+        reclamation: deploymentData.reclamation
       })
     };
   }

--- a/apps/deploy-web/src/utils/deploymentData/v1beta3.spec.ts
+++ b/apps/deploy-web/src/utils/deploymentData/v1beta3.spec.ts
@@ -1,7 +1,8 @@
+import { DeploymentReclamation } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import yaml from "js-yaml";
 import { describe, expect, it } from "vitest";
 
-import { applyTrialGpuPolicy, replaceSdlDenom } from "./v1beta3";
+import { applyTrialGpuPolicy, NewDeploymentData, replaceSdlDenom } from "./v1beta3";
 
 describe(replaceSdlDenom.name, () => {
   it("replaces denom in a single placement pricing entry", () => {
@@ -185,5 +186,36 @@ describe(applyTrialGpuPolicy.name, () => {
     };
     const profile = Object.values(sdl.profiles.compute)[0];
     return profile.resources.gpu?.attributes?.vendor?.nvidia;
+  }
+});
+
+describe(NewDeploymentData.name, () => {
+  it("forwards the reclamation block when the SDL declares one", async () => {
+    const sdl = setup({ version: "2.1", reclamation: { min_window: "24h" } });
+
+    const result = await NewDeploymentData(sdl, null, "akash1abc", 5);
+
+    expect(result.reclamation).toEqual(DeploymentReclamation.fromPartial({ minWindow: { seconds: 86400 } }));
+  });
+
+  it("omits reclamation for an SDL without a reclamation block", async () => {
+    const sdl = setup({ version: "2.0" });
+
+    const result = await NewDeploymentData(sdl, null, "akash1abc", 5);
+
+    expect(result.reclamation).toBeUndefined();
+  });
+
+  function setup(input: { version: "2.0" | "2.1"; reclamation?: { min_window: string } }) {
+    return yaml.dump({
+      version: input.version,
+      services: { web: { image: "nginx", expose: [{ port: 80, as: 80, to: [{ global: true }] }] } },
+      profiles: {
+        compute: { web: { resources: { cpu: { units: 0.5 }, memory: { size: "512Mi" }, storage: { size: "1Gi" } } } },
+        placement: { dcloud: { pricing: { web: { denom: "uakt", amount: 1000 } } } }
+      },
+      deployment: { web: { dcloud: { profile: "web", count: 1 } } },
+      ...(input.reclamation ? { reclamation: input.reclamation } : {})
+    });
   }
 });

--- a/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
+++ b/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
@@ -202,7 +202,8 @@ export async function NewDeploymentData(
       orderId: [],
       leaseId: [],
       hash: version,
-      deposit: _deposit
+      deposit: _deposit,
+      reclamation: manifest.reclamation
     };
   } catch (e: any) {
     const error = new CustomValidationError(e.message);


### PR DESCRIPTION
## Why

Closes CON-288 (network upgrade v2.1.0). AEP-82 reclamation lets deployers opt into a minimum reclamation window via SDL 2.1's `reclamation.min_window`. chain-sdk's `generateManifest()` already parses the block into a `DeploymentReclamation` (gated only on block presence, not SDL version, and outside the manifest hash), but both message builders were **discarding** it. This forwards it into `MsgCreateDeployment` so the on-chain deployment carries the tenant's reclamation requirement.

The "`min_window` editable in the visual builder" acceptance criterion was split into a follow-up (CON-440, on the new SDL builder) and CON-288 was narrowed accordingly, so this PR delivers CON-288's full (narrowed) scope: YAML-editor + message plumbing.

## What

Forward `manifest.reclamation` into `MsgCreateDeployment.fromPartial(...)` in **both** deployment-creation paths:

- **Managed-wallet (apps/api)** — `RpcMessageService.getCreateDeploymentMsg` accepts `reclamation` on `CreateDeploymentMsgOptions`; `DeploymentWriterService.create` passes `manifest.reclamation` through.
- **Self-custody / wallet-signed (apps/deploy-web)** — `NewDeploymentData` gains an optional `reclamation` field, populated from `buildManifest(...)`; `TransactionMessageData.getCreateDeploymentMsg` carries it into the message.

Notes:
- **Reclamation is optional.** SDL 2.0 (no block) is unaffected — `fromPartial` leaves `reclamation` unset.
- **No visual-builder changes** (`SdlBuilder` / `generateSdl` / `sdlImport` / form schema untouched) — deferred to the new-builder work.
- No pricing/denom changes; reclamation lives on `MsgCreateDeployment`, not in the manifest group, so the manifest hash is unaffected.

### Tests (8 new)
- **api** — `rpc-message.service.spec.ts` and `deployment-writer.service.spec.ts`: assert the block is forwarded when declared, and `undefined` for an SDL without it.
- **deploy-web** — `v1beta3.spec.ts` `NewDeploymentData` runs the **real** chain-sdk `generateManifest` over a 2.1 SDL with `min_window: "24h"` (and a 2.0 SDL); new `TransactionMessageData.spec.ts` asserts pass-through.
- Verified: api unit suite (953) + deploy-web unit suite (1603) pass; lint clean on changed files; no new type errors.
