### PR TITLE
feat(deployment): stop auto-top-up for reclaimed leases

### DIFF
--- a/apps/api/src/deployment/repositories/lease/lease.repository.ts
+++ b/apps/api/src/deployment/repositories/lease/lease.repository.ts
@@ -11,6 +11,13 @@ export interface DrainingDeploymentOutput {
   blockRate: number;
   predictedClosedHeight: number;
   closedHeight?: number;
+  /**
+   * True when every lease of the deployment has reached a terminal state (closed or reclaiming).
+   * A reclaiming lease is terminal because a provider-initiated reclamation cannot be cancelled,
+   * so reclamation always proceeds to close. Treated like a closed deployment for auto-top-up.
+   * Only populated by the RPC source; the DB source lacks reclaim state and leaves it undefined.
+   */
+  isTerminal?: boolean;
 }
 
 export interface DatabaseLeaseListParams {

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
@@ -191,6 +191,92 @@ describe(DrainingDeploymentRpcService.name, () => {
       expect(result).toHaveLength(1);
       expect(result[0].closedHeight).toBe(input.leases[0].closedHeight);
     });
+
+    it("marks a deployment as terminal when its lease is reclaiming", async () => {
+      const input = {
+        leases: [{ blockRate: 50, state: "reclaiming" }],
+        deployment: {
+          createdHeight: 995000,
+          funds: 40000,
+          transferred: 20000
+        }
+      };
+
+      const { service, owner, dseqs, closureHeight } = setup({
+        inputs: [input]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].isTerminal).toBe(true);
+    });
+
+    it("does not mark a deployment as terminal when only some of its leases are reclaiming", async () => {
+      const input = {
+        leases: [
+          { blockRate: 30, gseq: 0, state: "reclaiming" },
+          { blockRate: 20, gseq: 1, state: "active" }
+        ],
+        deployment: {
+          createdHeight: 995000,
+          funds: 40000,
+          transferred: 20000
+        }
+      };
+
+      const { service, owner, dseqs, closureHeight } = setup({
+        inputs: [input]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].isTerminal).toBe(false);
+    });
+
+    it("marks a deployment as terminal when all its leases are reclaiming or closed", async () => {
+      const input = {
+        leases: [
+          { blockRate: 30, gseq: 0, state: "reclaiming" },
+          { blockRate: 20, gseq: 1, state: "closed", closedHeight: 999000 }
+        ],
+        deployment: {
+          createdHeight: 995000,
+          funds: 40000,
+          transferred: 20000
+        }
+      };
+
+      const { service, owner, dseqs, closureHeight } = setup({
+        inputs: [input]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].isTerminal).toBe(true);
+    });
+
+    it("marks an active deployment as not terminal", async () => {
+      const input = {
+        leases: [{ blockRate: 50, state: "active" }],
+        deployment: {
+          createdHeight: 995000,
+          funds: 40000,
+          transferred: 20000
+        }
+      };
+
+      const { service, owner, dseqs, closureHeight } = setup({
+        inputs: [input]
+      });
+
+      const result = await service.findManyByDseqAndOwner(closureHeight, owner, dseqs);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].isTerminal).toBe(false);
+    });
   });
 
   function setup({

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.ts
@@ -5,6 +5,13 @@ import { LoggerService } from "@src/core";
 import { DrainingDeploymentOutput } from "@src/deployment/repositories/lease/lease.repository";
 import { DrainingDeploymentLeaseSource, RpcDeploymentInfo } from "@src/deployment/types/draining-deployment";
 
+/**
+ * REST serializes Lease_State via lease_StateToJSON; reclaiming (=4) maps to "reclaiming".
+ * A reclaiming lease is terminal: a provider-initiated reclamation cannot be cancelled,
+ * so reclamation always proceeds to close. We stop topping such deployments up.
+ */
+const RECLAIMING_LEASE_STATE = "reclaiming";
+
 @singleton()
 export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSource {
   constructor(
@@ -131,12 +138,17 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
       const denom = rpcLease.escrow_payment.state.rate.denom;
       const rateAmount = Number(rpcLease.escrow_payment.state.rate.amount);
       const closedHeight = rpcLease.lease.closed_on && rpcLease.lease.closed_on !== "0" ? Number(rpcLease.lease.closed_on) : undefined;
+      const isLeaseTerminal = !!closedHeight || rpcLease.lease.state === RECLAIMING_LEASE_STATE;
 
       const existing = leaseMap.get(dseq);
       if (existing) {
         existing.blockRate += rateAmount;
+        // A dseq stays active (not closed/terminal) as long as any of its leases is still active.
         if (!closedHeight) {
           existing.closedHeight = undefined;
+        }
+        if (!isLeaseTerminal) {
+          existing.isTerminal = false;
         }
       } else {
         leaseMap.set(dseq, {
@@ -144,7 +156,8 @@ export class DrainingDeploymentRpcService implements DrainingDeploymentLeaseSour
           owner,
           denom,
           blockRate: rateAmount,
-          closedHeight
+          closedHeight,
+          isTerminal: isLeaseTerminal
         });
       }
     }

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -106,6 +106,60 @@ describe(DrainingDeploymentService.name, () => {
         );
       });
     });
+
+    it("marks terminal (reclaiming) deployments as closed and excludes them from top-up", async () => {
+      const { service, deploymentSettingRepository, currentHeight } = setup();
+      const deploymentSettings = createManyAutoTopUpDeployments(2);
+      const addresses = deploymentSettings.map(s => s.address);
+      const dseqs = deploymentSettings.map(s => Number(s.dseq));
+
+      const activeBatch: DrainingDeploymentOutput[] = [
+        {
+          dseq: dseqs[0],
+          owner: addresses[0],
+          denom: "uakt",
+          blockRate: faker.number.int({ min: 50, max: 100 }),
+          predictedClosedHeight: faker.number.int({ min: 900000, max: 1000000 }),
+          isTerminal: false
+        }
+      ];
+
+      const terminalBatch: DrainingDeploymentOutput[] = [
+        {
+          dseq: dseqs[1],
+          owner: addresses[1],
+          denom: "uakt",
+          blockRate: faker.number.int({ min: 50, max: 100 }),
+          predictedClosedHeight: currentHeight + 1000,
+          isTerminal: true
+        }
+      ];
+
+      jest.spyOn(service, "findLeases").mockResolvedValueOnce(activeBatch).mockResolvedValueOnce(terminalBatch);
+
+      const deploymentSettingsByAddress = groupBy(deploymentSettings, "address");
+      deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
+        (async function* () {
+          for (const [address, settings] of Object.entries(deploymentSettingsByAddress)) {
+            yield { address, deploymentSettings: settings };
+          }
+        })()
+      );
+
+      const callback = jest.fn();
+      for await (const result of service.findDrainingDeploymentsByOwner()) {
+        callback(result);
+      }
+
+      expect(deploymentSettingRepository.updateManyById).toHaveBeenCalledWith(expect.arrayContaining([deploymentSettings[1].id]), { closed: true });
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: addresses[0],
+          deployments: expect.arrayContaining([expect.objectContaining({ dseq: dseqs[0].toString() })])
+        })
+      );
+    });
   });
 
   describe("findLeases", () => {

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -62,7 +62,8 @@ export class DrainingDeploymentService {
               return acc;
             }
 
-            if (deployment.closedHeight) {
+            // A reclaiming/paused deployment is terminal: stop topping it up, same as an already-closed one.
+            if (deployment.closedHeight || deployment.isTerminal) {
               acc[1].push(deploymentSetting.id);
             } else {
               acc[0].push({


### PR DESCRIPTION
## Why

Part of CON-376.

With AEP-82 resource reclamation (v2.1.0, mainnet June 11), a provider can reclaim a lease. The lease enters the `reclaiming` state and reclamation **always proceeds to close** — a tenant cannot cancel it. Today auto-top-up keeps funding such deployments right up until the chain closes them, wasting tenant funds on a deployment that is going away.

> **Scope note:** CON-376 originally also called for a deploy-web "paused group" status + a **"Restart group"** action signing `MsgStartGroup`. That premise turned out to be wrong — reclamation is terminal and there is no tenant restart path (recovery is close & redeploy). The frontend portion has been dropped from this PR; CON-376 needs re-scoping for the read-only paused-status + redeploy guidance. This PR ships only the backend behavior, which is correct regardless of how the UI surfaces it.

## What

- Add an optional `isTerminal` flag to `DrainingDeploymentOutput`. It is `true` only when **every** lease of a deployment is terminal (closed **or** `reclaiming`). Populated by the RPC source only; the DB source lacks reclaim state and leaves it `undefined`.
- `DrainingDeploymentRpcService` now treats a `reclaiming` lease as terminal (named constant `RECLAIMING_LEASE_STATE`), aggregated so a deployment with a mix of reclaiming + still-active leases keeps being topped up.
- `DrainingDeploymentService` excludes terminal deployments from top-up and marks their setting `closed: true`, exactly as it already does for closed leases.

The exact REST state string (`"reclaiming"`) was confirmed against the chain-sdk serializer (`lease_StateToJSON`).

### Tests
- `draining-deployment-rpc.service.spec.ts`: reclaiming → terminal; partial reclaiming → not terminal; all-terminal (reclaiming + closed) → terminal; active → not terminal.
- `draining-deployment.service.spec.ts`: a terminal (reclaiming) deployment is marked closed and excluded from top-up batches.

All affected api specs pass (36), lint clean, build type-check clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced lease state tracking to properly identify and handle terminal deployments with reclaiming leases.

* **Tests**
  * Added comprehensive test coverage for terminal lease state determination based on lease conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->