### PR TITLE
feat(notifications): email tenant when lease enters reclaiming state

### DIFF
--- a/apps/notifications/src/common/config/event-key-registry.config.ts
+++ b/apps/notifications/src/common/config/event-key-registry.config.ts
@@ -1,5 +1,6 @@
 export const eventKeyRegistry = {
   blockCreated: "blockchain.v1.block.created",
   eventCloseDeployment: "akash.v1.deployment.deployment-closed",
+  eventLeaseReclaimStarted: "akash.v1.market.lease-reclaim-started",
   createNotification: "notifications.v1.notification.create"
 } as const;

--- a/apps/notifications/src/infrastructure/broker/services/broker/event-map.ts
+++ b/apps/notifications/src/infrastructure/broker/services/broker/event-map.ts
@@ -1,10 +1,12 @@
 import type { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import type { ChainBlockCreatedDto } from "@src/modules/alert/dto/chain-block-created.dto";
 import type { EventClosedDeploymentDto } from "@src/modules/alert/dto/event-closed-deployment.dto";
+import type { EventLeaseReclaimStartedDto } from "@src/modules/alert/dto/event-lease-reclaim-started.dto";
 import type { AlertMessage } from "@src/modules/alert/types/message-callback.type";
 
 export type EventToPayload = {
   [eventKeyRegistry.createNotification]: AlertMessage;
   [eventKeyRegistry.blockCreated]: ChainBlockCreatedDto;
   [eventKeyRegistry.eventCloseDeployment]: EventClosedDeploymentDto;
+  [eventKeyRegistry.eventLeaseReclaimStarted]: EventLeaseReclaimStartedDto;
 };

--- a/apps/notifications/src/interfaces/alert-events/handlers/chain-events/chain-events.handler.spec.ts
+++ b/apps/notifications/src/interfaces/alert-events/handlers/chain-events/chain-events.handler.spec.ts
@@ -8,8 +8,10 @@ import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import { BrokerService } from "@src/infrastructure/broker";
 import { ChainBlockCreatedDto } from "@src/modules/alert/dto/chain-block-created.dto";
 import { EventClosedDeploymentDto } from "@src/modules/alert/dto/event-closed-deployment.dto";
+import { EventLeaseReclaimStartedDto } from "@src/modules/alert/dto/event-lease-reclaim-started.dto";
 import { ChainAlertService } from "@src/modules/alert/services/chain-alert/chain-alert.service";
 import { DeploymentBalanceAlertsService } from "@src/modules/alert/services/deployment-balance-alerts/deployment-balance-alerts.service";
+import { ReclaimAlertService } from "@src/modules/alert/services/reclaim-alert/reclaim-alert.service";
 import { WalletBalanceAlertsService } from "@src/modules/alert/services/wallet-balance-alerts/wallet-balance-alerts.service";
 import { ChainEventsHandler } from "./chain-events.handler";
 
@@ -28,6 +30,21 @@ describe(ChainEventsHandler.name, () => {
       await controller.processDeploymentClosed(mockEvent);
 
       expect(chainMessageAlertService.alertFor).toHaveBeenCalledWith({ type: "CHAIN_EVENT", payload: mockEvent }, expect.any(Function));
+      expect(brokerService.publish).toHaveBeenCalledWith(eventKeyRegistry.createNotification, alertMessage);
+    });
+  });
+
+  describe("processLeaseReclaimStarted", () => {
+    it("routes the reclaim event to the reclaim alert service and publishes notifications", async () => {
+      const { controller, reclaimAlertService, brokerService } = await setup();
+
+      const mockEvent = generateMock(EventLeaseReclaimStartedDto.schema);
+      const alertMessage = generateAlertMessage({});
+      reclaimAlertService.alertFor.mockImplementation((_, callback) => callback(alertMessage));
+
+      await controller.processLeaseReclaimStarted(mockEvent);
+
+      expect(reclaimAlertService.alertFor).toHaveBeenCalledWith(mockEvent, expect.any(Function));
       expect(brokerService.publish).toHaveBeenCalledWith(eventKeyRegistry.createNotification, alertMessage);
     });
   });
@@ -55,7 +72,8 @@ describe(ChainEventsHandler.name, () => {
         ChainEventsHandler,
         MockProvider(ChainAlertService),
         MockProvider(DeploymentBalanceAlertsService),
-        MockProvider(WalletBalanceAlertsService)
+        MockProvider(WalletBalanceAlertsService),
+        MockProvider(ReclaimAlertService)
       ]
     }).compile();
 
@@ -64,6 +82,7 @@ describe(ChainEventsHandler.name, () => {
       chainMessageAlertService: module.get<MockProxy<ChainAlertService>>(ChainAlertService),
       deploymentBalanceAlertsService: module.get<MockProxy<DeploymentBalanceAlertsService>>(DeploymentBalanceAlertsService),
       walletBalanceAlertsService: module.get<MockProxy<WalletBalanceAlertsService>>(WalletBalanceAlertsService),
+      reclaimAlertService: module.get<MockProxy<ReclaimAlertService>>(ReclaimAlertService),
       brokerService: module.get<MockProxy<BrokerService>>(BrokerService)
     };
   }

--- a/apps/notifications/src/interfaces/alert-events/handlers/chain-events/chain-events.handler.ts
+++ b/apps/notifications/src/interfaces/alert-events/handlers/chain-events/chain-events.handler.ts
@@ -4,8 +4,10 @@ import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
 import { BrokerService, Handler } from "@src/infrastructure/broker";
 import { ChainBlockCreatedDto } from "@src/modules/alert/dto/chain-block-created.dto";
 import { EventClosedDeploymentDto } from "@src/modules/alert/dto/event-closed-deployment.dto";
+import { EventLeaseReclaimStartedDto } from "@src/modules/alert/dto/event-lease-reclaim-started.dto";
 import { ChainAlertService } from "@src/modules/alert/services/chain-alert/chain-alert.service";
 import { DeploymentBalanceAlertsService } from "@src/modules/alert/services/deployment-balance-alerts/deployment-balance-alerts.service";
+import { ReclaimAlertService } from "@src/modules/alert/services/reclaim-alert/reclaim-alert.service";
 import { WalletBalanceAlertsService } from "@src/modules/alert/services/wallet-balance-alerts/wallet-balance-alerts.service";
 
 @Injectable()
@@ -14,6 +16,7 @@ export class ChainEventsHandler {
     private readonly chainMessageAlertService: ChainAlertService,
     private readonly deploymentBalanceAlertsService: DeploymentBalanceAlertsService,
     private readonly walletBalanceAlertsService: WalletBalanceAlertsService,
+    private readonly reclaimAlertService: ReclaimAlertService,
     private readonly brokerService: BrokerService
   ) {}
 
@@ -45,5 +48,13 @@ export class ChainEventsHandler {
     await this.chainMessageAlertService.alertFor({ type: "CHAIN_EVENT", payload }, message =>
       this.brokerService.publish(eventKeyRegistry.createNotification, message)
     );
+  }
+
+  @Handler({
+    key: eventKeyRegistry.eventLeaseReclaimStarted,
+    dto: EventLeaseReclaimStartedDto
+  })
+  async processLeaseReclaimStarted(payload: EventLeaseReclaimStartedDto) {
+    await this.reclaimAlertService.alertFor(payload, message => this.brokerService.publish(eventKeyRegistry.createNotification, message));
   }
 }

--- a/apps/notifications/src/modules/alert/alert.module.ts
+++ b/apps/notifications/src/modules/alert/alert.module.ts
@@ -12,6 +12,7 @@ import { DbHealthzService } from "@src/infrastructure/db/services/db-healthz/db-
 import { AlertRepository } from "@src/modules/alert/repositories/alert/alert.repository";
 import { ChainAlertService } from "@src/modules/alert/services/chain-alert/chain-alert.service";
 import { DeploymentAlertService } from "@src/modules/alert/services/deployment-alert/deployment-alert.service";
+import { ReclaimAlertService } from "@src/modules/alert/services/reclaim-alert/reclaim-alert.service";
 import { WalletBalanceAlertsService } from "@src/modules/alert/services/wallet-balance-alerts/wallet-balance-alerts.service";
 import { HTTP_SDK_PROVIDERS } from "./providers/http-sdk.provider";
 import { AlertMessageService } from "./services/alert-message/alert-message.service";
@@ -34,10 +35,19 @@ import * as schema from "./model-schemas";
     DeploymentService,
     TemplateService,
     DeploymentAlertService,
+    ReclaimAlertService,
     DbHealthzService,
     ...HTTP_SDK_PROVIDERS
   ],
-  exports: [ChainAlertService, DeploymentBalanceAlertsService, WalletBalanceAlertsService, AlertRepository, DeploymentAlertService, DbHealthzService]
+  exports: [
+    ChainAlertService,
+    DeploymentBalanceAlertsService,
+    WalletBalanceAlertsService,
+    AlertRepository,
+    DeploymentAlertService,
+    ReclaimAlertService,
+    DbHealthzService
+  ]
 })
 export class AlertModule implements OnApplicationShutdown {
   constructor(@InjectDrizzle(DRIZZLE_PROVIDER_TOKEN) private readonly db: NodePgDatabase<FullSchema>) {}

--- a/apps/notifications/src/modules/alert/dto/event-lease-reclaim-started.dto.ts
+++ b/apps/notifications/src/modules/alert/dto/event-lease-reclaim-started.dto.ts
@@ -1,0 +1,17 @@
+import { createZodDto } from "nestjs-zod";
+import { z } from "zod";
+
+const EventLeaseReclaimStartedSchema = z.object({
+  module: z.literal("market"),
+  action: z.literal("lease-reclaim-started"),
+  owner: z.string(),
+  dseq: z.string(),
+  provider: z.string(),
+  // On-chain enum/Long JSON encoding is ambiguous: `reason` may be the enum
+  // number, its numeric string, or its proto name; `deadline` (a Long unix
+  // timestamp) may be a number or string. Normalization happens in the service.
+  reason: z.union([z.string(), z.number()]),
+  deadline: z.union([z.string(), z.number()])
+});
+
+export class EventLeaseReclaimStartedDto extends createZodDto(EventLeaseReclaimStartedSchema) {}

--- a/apps/notifications/src/modules/alert/repositories/alert/alert-json-fields.schema.ts
+++ b/apps/notifications/src/modules/alert/repositories/alert/alert-json-fields.schema.ts
@@ -49,7 +49,8 @@ export const walletBalanceParamsSchema = z.object({
 export const generalParamsSchema = z.object({
   dseq: dseqSchema,
   type: z.string(),
-  suppressedBySystem: z.boolean().optional()
+  suppressedBySystem: z.boolean().optional(),
+  reclaimNotifiedAt: z.string().optional()
 });
 
 export const chainMessageTypeSchema = z.literal("CHAIN_MESSAGE");

--- a/apps/notifications/src/modules/alert/repositories/alert/alert.repository.ts
+++ b/apps/notifications/src/modules/alert/repositories/alert/alert.repository.ts
@@ -180,8 +180,9 @@ export class AlertRepository {
     const alert = await this.db.query.Alert.findFirst({
       where: and(
         eq(schema.Alert.type, "CHAIN_EVENT"),
-        sql`${schema.Alert.params}->>'type' = 'DEPLOYMENT_CLOSED'`,
-        sql`${schema.Alert.params}->>'dseq' = ${dseq}`,
+        // Containment (`@>`) rather than `->>` extraction so the GIN `jsonb_path_ops`
+        // index on `params` (idx_alerts_params) is used; dseq is stored as a string.
+        sql`${schema.Alert.params} @> ${JSON.stringify({ type: "DEPLOYMENT_CLOSED", dseq })}::jsonb`,
         sql`${schema.Alert.conditions}->'value' @> ${JSON.stringify([{ field: "owner", value: owner }])}::jsonb`
       )
     });

--- a/apps/notifications/src/modules/alert/repositories/alert/alert.repository.ts
+++ b/apps/notifications/src/modules/alert/repositories/alert/alert.repository.ts
@@ -168,6 +168,49 @@ export class AlertRepository {
     );
   }
 
+  /**
+   * Finds the deployment-closed CHAIN_EVENT alert for a specific owner AND dseq.
+   *
+   * dseq is per-owner (not globally unique) and the owner is stored in the alert's
+   * `conditions.value[]` (not `params`), so both must be matched. This runs in a
+   * background/system context with no CASL ability scope, so it is intentionally
+   * not filtered by `whereAccessibleBy`.
+   */
+  async findDeploymentClosedAlertByOwnerAndDseq(owner: string, dseq: string): Promise<AlertOutput | undefined> {
+    const alert = await this.db.query.Alert.findFirst({
+      where: and(
+        eq(schema.Alert.type, "CHAIN_EVENT"),
+        sql`${schema.Alert.params}->>'type' = 'DEPLOYMENT_CLOSED'`,
+        sql`${schema.Alert.params}->>'dseq' = ${dseq}`,
+        sql`${schema.Alert.conditions}->'value' @> ${JSON.stringify([{ field: "owner", value: owner }])}::jsonb`
+      )
+    });
+
+    return alert && this.toOutput(alert);
+  }
+
+  /**
+   * Atomically claims the reclaim notification for an alert by stamping
+   * `params.reclaimNotifiedAt`, but only if it has not been claimed before.
+   * Returns the updated alert when this call won the claim, or `undefined` when
+   * it was already claimed (replay / pg-boss redelivery) — making the reclaim
+   * email exactly-once.
+   */
+  async claimReclaimNotification(id: string): Promise<AlertOutput | undefined> {
+    return this.db.transaction(async transaction => {
+      const [alert] = await transaction
+        .update(schema.Alert)
+        .set({
+          params: sql`COALESCE(${schema.Alert.params}, '{}'::jsonb) || jsonb_build_object('reclaimNotifiedAt', to_jsonb(NOW()))`,
+          updatedAt: sql`NOW()`
+        })
+        .where(and(eq(schema.Alert.id, id), sql`NOT jsonb_exists(COALESCE(${schema.Alert.params}, '{}'::jsonb), 'reclaimNotifiedAt')`))
+        .returning();
+
+      return alert && this.toOutput(alert);
+    });
+  }
+
   async deleteOneById(id: string): Promise<AlertOutput | undefined> {
     return this.db.transaction(async transaction => {
       const [alert] = await transaction

--- a/apps/notifications/src/modules/alert/services/reclaim-alert/lease-closed-reason.spec.ts
+++ b/apps/notifications/src/modules/alert/services/reclaim-alert/lease-closed-reason.spec.ts
@@ -1,0 +1,44 @@
+import { LeaseClosedReason } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { describe, expect, it } from "vitest";
+
+import { getLeaseClosedReasonText, toLeaseClosedReason } from "./lease-closed-reason";
+
+describe("toLeaseClosedReason", () => {
+  it("maps a known numeric enum value to itself", () => {
+    expect(toLeaseClosedReason(10000)).toBe(LeaseClosedReason.lease_closed_reason_unstable);
+  });
+
+  it("maps a known enum name to its numeric value", () => {
+    expect(toLeaseClosedReason("lease_closed_reason_insufficient_funds")).toBe(LeaseClosedReason.lease_closed_reason_insufficient_funds);
+  });
+
+  it("maps a numeric string to its enum value", () => {
+    expect(toLeaseClosedReason("10001")).toBe(LeaseClosedReason.lease_closed_reason_decommission);
+  });
+
+  it("returns UNRECOGNIZED for an unknown numeric value", () => {
+    expect(toLeaseClosedReason(99999)).toBe(LeaseClosedReason.UNRECOGNIZED);
+  });
+
+  it("returns UNRECOGNIZED for an unknown string value", () => {
+    expect(toLeaseClosedReason("not_a_real_reason")).toBe(LeaseClosedReason.UNRECOGNIZED);
+  });
+});
+
+describe("getLeaseClosedReasonText", () => {
+  it("returns readable text for a mapped reason", () => {
+    expect(getLeaseClosedReasonText(LeaseClosedReason.lease_closed_reason_decommission)).toBe("the provider is being decommissioned");
+  });
+
+  it("returns the fallback text for UNRECOGNIZED", () => {
+    expect(getLeaseClosedReasonText(LeaseClosedReason.UNRECOGNIZED)).toBe("an unspecified reason");
+  });
+
+  it("returns readable text for every known enum value", () => {
+    const knownValues = Object.values(LeaseClosedReason).filter((value): value is LeaseClosedReason => typeof value === "number");
+
+    for (const value of knownValues) {
+      expect(getLeaseClosedReasonText(value)).toBeTruthy();
+    }
+  });
+});

--- a/apps/notifications/src/modules/alert/services/reclaim-alert/lease-closed-reason.ts
+++ b/apps/notifications/src/modules/alert/services/reclaim-alert/lease-closed-reason.ts
@@ -1,0 +1,43 @@
+import { LeaseClosedReason } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+
+/**
+ * Normalizes a raw on-chain `reason` value into a {@link LeaseClosedReason}.
+ *
+ * The reason arrives from a Comet38 event attribute that is `JSON.parse`d, so it
+ * may be the enum's numeric value (e.g. `10000`), its numeric string (`"10000"`),
+ * or its proto name (`"lease_closed_reason_unstable"`). Anything unknown maps to
+ * `UNRECOGNIZED`.
+ */
+export function toLeaseClosedReason(raw: string | number): LeaseClosedReason {
+  if (typeof raw === "number") {
+    return raw in LeaseClosedReason ? (raw as LeaseClosedReason) : LeaseClosedReason.UNRECOGNIZED;
+  }
+
+  if (/^-?\d+$/.test(raw)) {
+    const numeric = Number(raw);
+    return numeric in LeaseClosedReason ? (numeric as LeaseClosedReason) : LeaseClosedReason.UNRECOGNIZED;
+  }
+
+  const byName = LeaseClosedReason[raw as keyof typeof LeaseClosedReason];
+  return typeof byName === "number" ? byName : LeaseClosedReason.UNRECOGNIZED;
+}
+
+const REASON_TEXT: Record<number, string> = {
+  [LeaseClosedReason.lease_closed_invalid]: "an unspecified reason",
+  [LeaseClosedReason.lease_closed_owner]: "the owner closed the lease",
+  [LeaseClosedReason.lease_closed_reason_unstable]: "the workload has been unstable",
+  [LeaseClosedReason.lease_closed_reason_decommission]: "the provider is being decommissioned",
+  [LeaseClosedReason.lease_closed_reason_unspecified]: "the provider did not specify a reason",
+  [LeaseClosedReason.lease_closed_reason_manifest_timeout]: "the manifest was not received in time",
+  [LeaseClosedReason.lease_closed_reason_insufficient_funds]: "the deployment has insufficient funds"
+};
+
+const FALLBACK_REASON_TEXT = "an unspecified reason";
+
+/**
+ * Returns human-readable text describing a {@link LeaseClosedReason}, with a
+ * safe fallback for `UNRECOGNIZED` or any value not in the map.
+ */
+export function getLeaseClosedReasonText(reason: LeaseClosedReason): string {
+  return REASON_TEXT[reason] ?? FALLBACK_REASON_TEXT;
+}

--- a/apps/notifications/src/modules/alert/services/reclaim-alert/lease-closed-reason.ts
+++ b/apps/notifications/src/modules/alert/services/reclaim-alert/lease-closed-reason.ts
@@ -9,21 +9,24 @@ import { LeaseClosedReason } from "@akashnetwork/chain-sdk/private-types/akash.v
  * `UNRECOGNIZED`.
  */
 export function toLeaseClosedReason(raw: string | number): LeaseClosedReason {
-  if (typeof raw === "number") {
-    return raw in LeaseClosedReason ? (raw as LeaseClosedReason) : LeaseClosedReason.UNRECOGNIZED;
+  // A proto name (e.g. "lease_closed_reason_unstable") resolves to its numeric
+  // value via the enum's forward lookup. A numeric string reverse-maps to a name
+  // (not a number) here, so it falls through to be parsed as a value below.
+  if (typeof raw === "string") {
+    const byName = LeaseClosedReason[raw as keyof typeof LeaseClosedReason];
+    if (typeof byName === "number") {
+      return byName;
+    }
   }
 
-  if (/^-?\d+$/.test(raw)) {
-    const numeric = Number(raw);
-    return numeric in LeaseClosedReason ? (numeric as LeaseClosedReason) : LeaseClosedReason.UNRECOGNIZED;
-  }
-
-  const byName = LeaseClosedReason[raw as keyof typeof LeaseClosedReason];
-  return typeof byName === "number" ? byName : LeaseClosedReason.UNRECOGNIZED;
+  const numeric = Number(raw);
+  return numeric in LeaseClosedReason ? (numeric as LeaseClosedReason) : LeaseClosedReason.UNRECOGNIZED;
 }
 
+const FALLBACK_REASON_TEXT = "an unspecified reason";
+
 const REASON_TEXT: Record<number, string> = {
-  [LeaseClosedReason.lease_closed_invalid]: "an unspecified reason",
+  [LeaseClosedReason.lease_closed_invalid]: FALLBACK_REASON_TEXT,
   [LeaseClosedReason.lease_closed_owner]: "the owner closed the lease",
   [LeaseClosedReason.lease_closed_reason_unstable]: "the workload has been unstable",
   [LeaseClosedReason.lease_closed_reason_decommission]: "the provider is being decommissioned",
@@ -31,8 +34,6 @@ const REASON_TEXT: Record<number, string> = {
   [LeaseClosedReason.lease_closed_reason_manifest_timeout]: "the manifest was not received in time",
   [LeaseClosedReason.lease_closed_reason_insufficient_funds]: "the deployment has insufficient funds"
 };
-
-const FALLBACK_REASON_TEXT = "an unspecified reason";
 
 /**
  * Returns human-readable text describing a {@link LeaseClosedReason}, with a

--- a/apps/notifications/src/modules/alert/services/reclaim-alert/reclaim-alert.service.spec.ts
+++ b/apps/notifications/src/modules/alert/services/reclaim-alert/reclaim-alert.service.spec.ts
@@ -1,0 +1,113 @@
+import { LeaseClosedReason } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { ConfigModule } from "@nestjs/config";
+import { Test } from "@nestjs/testing";
+import { describe, expect, it, vi } from "vitest";
+import type { MockProxy } from "vitest-mock-extended";
+
+import { LoggerService } from "@src/common/services/logger/logger.service";
+import moduleConfig from "@src/modules/alert/config";
+import { AlertRepository } from "@src/modules/alert/repositories/alert/alert.repository";
+import type { ReclaimAlertEvent } from "@src/modules/alert/services/reclaim-alert/reclaim-alert.service";
+import { ReclaimAlertService } from "@src/modules/alert/services/reclaim-alert/reclaim-alert.service";
+
+import { MockProvider } from "@test/mocks/provider.mock";
+import { mockAkashAddress } from "@test/seeders/akash-address.seeder";
+import { generateGeneralAlert } from "@test/seeders/general-alert.seeder";
+
+describe(ReclaimAlertService.name, () => {
+  describe("alertFor", () => {
+    it("skips when no deployment-closed alert exists for the owner and dseq", async () => {
+      const { service, alertRepository, onMessage } = await setup();
+      alertRepository.findDeploymentClosedAlertByOwnerAndDseq.mockResolvedValue(undefined);
+
+      await service.alertFor(generateReclaimEvent(), onMessage);
+
+      expect(alertRepository.claimReclaimNotification).not.toHaveBeenCalled();
+      expect(onMessage).not.toHaveBeenCalled();
+    });
+
+    it("skips when the deployment-closed alert is disabled (opted out)", async () => {
+      const { service, alertRepository, onMessage } = await setup();
+      alertRepository.findDeploymentClosedAlertByOwnerAndDseq.mockResolvedValue(generateGeneralAlert({ type: "CHAIN_EVENT", enabled: false }));
+
+      await service.alertFor(generateReclaimEvent(), onMessage);
+
+      expect(alertRepository.claimReclaimNotification).not.toHaveBeenCalled();
+      expect(onMessage).not.toHaveBeenCalled();
+    });
+
+    it("skips when the reclaim notification was already claimed", async () => {
+      const { service, alertRepository, onMessage } = await setup();
+      alertRepository.findDeploymentClosedAlertByOwnerAndDseq.mockResolvedValue(generateGeneralAlert({ type: "CHAIN_EVENT", enabled: true }));
+      alertRepository.claimReclaimNotification.mockResolvedValue(undefined);
+
+      await service.alertFor(generateReclaimEvent(), onMessage);
+
+      expect(onMessage).not.toHaveBeenCalled();
+    });
+
+    it("claims then sends exactly one notification to the alert's channel", async () => {
+      const { service, alertRepository, onMessage } = await setup();
+      const alert = generateGeneralAlert({ type: "CHAIN_EVENT", enabled: true });
+      alertRepository.findDeploymentClosedAlertByOwnerAndDseq.mockResolvedValue(alert);
+      alertRepository.claimReclaimNotification.mockResolvedValue(alert);
+
+      await service.alertFor(generateReclaimEvent({ dseq: "12345" }), onMessage);
+
+      expect(alertRepository.claimReclaimNotification).toHaveBeenCalledWith(alert.id);
+      expect(onMessage).toHaveBeenCalledTimes(1);
+      expect(onMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          notificationChannelId: alert.notificationChannelId,
+          payload: {
+            summary: expect.stringContaining("12345"),
+            description: expect.any(String)
+          }
+        })
+      );
+    });
+
+    it("includes the provider, reason, deadline and deep link in the message", async () => {
+      const { service, alertRepository, onMessage } = await setup();
+      const alert = generateGeneralAlert({ type: "CHAIN_EVENT", enabled: true });
+      alertRepository.findDeploymentClosedAlertByOwnerAndDseq.mockResolvedValue(alert);
+      alertRepository.claimReclaimNotification.mockResolvedValue(alert);
+      const provider = mockAkashAddress();
+
+      await service.alertFor(
+        generateReclaimEvent({ dseq: "12345", provider, reason: LeaseClosedReason.lease_closed_reason_unstable, deadline: 1749398400 }),
+        onMessage
+      );
+
+      const { description } = onMessage.mock.calls[0][0].payload;
+      expect(description).toContain(provider);
+      expect(description).toContain("the workload has been unstable");
+      expect(description).toContain("2025-06-08");
+      expect(description).toContain("/deployments/12345");
+    });
+  });
+
+  function generateReclaimEvent(overrides: Partial<ReclaimAlertEvent> = {}): ReclaimAlertEvent {
+    return {
+      owner: mockAkashAddress(),
+      dseq: "12345",
+      provider: mockAkashAddress(),
+      reason: LeaseClosedReason.lease_closed_reason_unstable,
+      deadline: 1749398400,
+      ...overrides
+    };
+  }
+
+  async function setup() {
+    const module = await Test.createTestingModule({
+      imports: [ConfigModule.forFeature(moduleConfig)],
+      providers: [ReclaimAlertService, MockProvider(AlertRepository), MockProvider(LoggerService)]
+    }).compile();
+
+    return {
+      service: module.get<ReclaimAlertService>(ReclaimAlertService),
+      alertRepository: module.get<MockProxy<AlertRepository>>(AlertRepository),
+      onMessage: vi.fn()
+    };
+  }
+});

--- a/apps/notifications/src/modules/alert/services/reclaim-alert/reclaim-alert.service.ts
+++ b/apps/notifications/src/modules/alert/services/reclaim-alert/reclaim-alert.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+
+import { LoggerService } from "@src/common/services/logger/logger.service";
+import type { AlertConfig } from "@src/modules/alert/config";
+import { AlertRepository } from "@src/modules/alert/repositories/alert/alert.repository";
+import type { AlertMessagePayload } from "@src/modules/alert/services/alert-message/alert-message.service";
+import { getLeaseClosedReasonText, toLeaseClosedReason } from "@src/modules/alert/services/reclaim-alert/lease-closed-reason";
+import { formatReclaimDeadline } from "@src/modules/alert/services/reclaim-alert/reclaim-deadline";
+import type { MessageCallback } from "@src/modules/alert/types/message-callback.type";
+
+export interface ReclaimAlertEvent {
+  owner: string;
+  dseq: string;
+  provider: string;
+  reason: string | number;
+  deadline: string | number;
+}
+
+@Injectable()
+export class ReclaimAlertService {
+  constructor(
+    private readonly alertRepository: AlertRepository,
+    private readonly configService: ConfigService<AlertConfig>,
+    private readonly loggerService: LoggerService
+  ) {
+    this.loggerService.setContext(ReclaimAlertService.name);
+  }
+
+  async alertFor(event: ReclaimAlertEvent, onMessage: MessageCallback): Promise<void> {
+    const alert = await this.alertRepository.findDeploymentClosedAlertByOwnerAndDseq(event.owner, event.dseq);
+
+    if (!alert) {
+      this.loggerService.debug({ event: "RECLAIM_ALERT_SKIPPED", reason: "NO_DEPLOYMENT_CLOSED_ALERT", owner: event.owner, dseq: event.dseq });
+      return;
+    }
+
+    if (!alert.enabled) {
+      this.loggerService.debug({ event: "RECLAIM_ALERT_SKIPPED", reason: "OPTED_OUT", alertId: alert.id });
+      return;
+    }
+
+    const claimedAlert = await this.alertRepository.claimReclaimNotification(alert.id);
+
+    if (!claimedAlert) {
+      this.loggerService.debug({ event: "RECLAIM_ALERT_SKIPPED", reason: "ALREADY_NOTIFIED", alertId: alert.id });
+      return;
+    }
+
+    await onMessage({
+      notificationChannelId: claimedAlert.notificationChannelId,
+      payload: this.buildMessage(event)
+    });
+  }
+
+  private buildMessage(event: ReclaimAlertEvent): AlertMessagePayload {
+    const reasonText = getLeaseClosedReasonText(toLeaseClosedReason(event.reason));
+    const deadline = formatReclaimDeadline(Number(event.deadline), Date.now());
+    const link = this.getConsoleLink(event.dseq);
+
+    return {
+      summary: `Deployment ${event.dseq} is being reclaimed by the provider`,
+      description:
+        `The provider ${event.provider} has started reclaiming deployment ${event.dseq} because ${reasonText}. ` +
+        `You have until ${deadline} to take action before the lease is closed. ` +
+        `Please visit ${link} to manage your deployment.`
+    };
+  }
+
+  private getConsoleLink(dseq: string): string {
+    const baseUrl = this.configService.getOrThrow("alert.CONSOLE_WEB_URL");
+    return `<a href="https://${baseUrl}/deployments/${dseq}">${baseUrl}</a>`;
+  }
+}

--- a/apps/notifications/src/modules/alert/services/reclaim-alert/reclaim-deadline.spec.ts
+++ b/apps/notifications/src/modules/alert/services/reclaim-alert/reclaim-deadline.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { formatReclaimDeadline } from "./reclaim-deadline";
+
+describe("formatReclaimDeadline", () => {
+  const HOUR_MS = 3_600_000;
+
+  it("renders the absolute UTC time and a relative window", () => {
+    const deadlineSeconds = (72 * HOUR_MS) / 1000;
+
+    expect(formatReclaimDeadline(deadlineSeconds, 0)).toBe("1970-01-04 00:00 UTC (about 72 hours from now)");
+  });
+
+  it("uses singular hour wording for a one-hour window", () => {
+    const nowMs = 0;
+    const deadlineSeconds = HOUR_MS / 1000;
+
+    expect(formatReclaimDeadline(deadlineSeconds, nowMs)).toBe("1970-01-01 01:00 UTC (about 1 hour from now)");
+  });
+
+  it("describes a sub-hour window without an hour count", () => {
+    const nowMs = 0;
+    const deadlineSeconds = (30 * 60 * 1000) / 1000;
+
+    expect(formatReclaimDeadline(deadlineSeconds, nowMs)).toBe("1970-01-01 00:30 UTC (less than an hour from now)");
+  });
+
+  it("notes when the deadline has already passed", () => {
+    const nowMs = 10 * HOUR_MS;
+    const deadlineSeconds = HOUR_MS / 1000;
+
+    expect(formatReclaimDeadline(deadlineSeconds, nowMs)).toBe("1970-01-01 01:00 UTC (the deadline has passed)");
+  });
+});

--- a/apps/notifications/src/modules/alert/services/reclaim-alert/reclaim-deadline.ts
+++ b/apps/notifications/src/modules/alert/services/reclaim-alert/reclaim-deadline.ts
@@ -1,0 +1,35 @@
+const HOUR_MS = 3_600_000;
+
+function toUtcString(ms: number): string {
+  const date = new Date(ms);
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())} UTC`;
+}
+
+function toRelative(deadlineMs: number, nowMs: number): string {
+  const diffMs = deadlineMs - nowMs;
+
+  if (diffMs <= 0) {
+    return "the deadline has passed";
+  }
+
+  if (diffMs < HOUR_MS) {
+    return "less than an hour from now";
+  }
+
+  const hours = Math.round(diffMs / HOUR_MS);
+  return `about ${hours} ${hours === 1 ? "hour" : "hours"} from now`;
+}
+
+/**
+ * Renders a reclamation deadline as an absolute UTC timestamp plus a relative
+ * window, e.g. `2026-06-08 14:00 UTC (about 71 hours from now)`. The tenant's
+ * timezone is unknown server-side, so the absolute time is always UTC.
+ *
+ * @param deadlineSeconds - unix timestamp (seconds) when the reclamation window expires
+ * @param nowMs - current time in milliseconds (injected for deterministic formatting)
+ */
+export function formatReclaimDeadline(deadlineSeconds: number, nowMs: number): string {
+  const deadlineMs = deadlineSeconds * 1000;
+  return `${toUtcString(deadlineMs)} (${toRelative(deadlineMs, nowMs)})`;
+}

--- a/apps/notifications/src/modules/alert/services/reclaim-alert/reclaim-deadline.ts
+++ b/apps/notifications/src/modules/alert/services/reclaim-alert/reclaim-deadline.ts
@@ -1,9 +1,8 @@
 const HOUR_MS = 3_600_000;
 
 function toUtcString(ms: number): string {
-  const date = new Date(ms);
-  const pad = (value: number) => String(value).padStart(2, "0");
-  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())} UTC`;
+  // toISOString is always UTC: "2025-06-08T16:00:00.000Z" -> "2025-06-08 16:00 UTC"
+  return `${new Date(ms).toISOString().slice(0, 16).replace("T", " ")} UTC`;
 }
 
 function toRelative(deadlineMs: number, nowMs: number): string {

--- a/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.spec.ts
+++ b/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.spec.ts
@@ -83,7 +83,7 @@ describe(ChainEventsPollerService.name, () => {
     ]);
   });
 
-  it("fetches lease reclaim started events from the market module", async () => {
+  it("fetches deployment and market events for a block in a single call", async () => {
     const { service, txEventsService, CURRENT_HEIGHT } = await setup();
 
     service.onApplicationBootstrap();
@@ -92,12 +92,10 @@ describe(ChainEventsPollerService.name, () => {
 
     expect(txEventsService.getBlockEvents).toHaveBeenCalledWith(
       CURRENT_HEIGHT + 1,
-      {
-        module: "market",
-        version: "v1",
-        source: "akash",
-        action: ["lease-reclaim-started"]
-      },
+      expect.arrayContaining([
+        { module: "deployment", version: "v1", source: "akash", action: ["deployment-closed"] },
+        { module: "market", version: "v1", source: "akash", action: ["lease-reclaim-started"] }
+      ]),
       expect.any(AbortSignal)
     );
   });
@@ -280,31 +278,27 @@ describe(ChainEventsPollerService.name, () => {
     });
 
     const txEventsService = module.get<MockProxy<TxEventsService>>(TxEventsService);
-    txEventsService.getBlockEvents.mockImplementation(async (_height, filter) => {
-      if (filter?.module === "market") {
-        return [
-          {
-            type: "akash.v1",
-            module: "market",
-            action: "lease-reclaim-started",
-            owner: "akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd",
-            dseq: "22350842",
-            provider: "akash1provideraddressxxxxxxxxxxxxxxxxxxxxxx",
-            reason: "lease_closed_reason_unstable",
-            deadline: "1749398400"
-          }
-        ];
+    // The poller fetches every event family in a single call, so the mock returns
+    // the deployment and market events together in one array.
+    txEventsService.getBlockEvents.mockResolvedValue([
+      {
+        type: "akash.v1",
+        module: "deployment",
+        action: "deployment-closed",
+        owner: "akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd",
+        dseq: "22350842"
+      },
+      {
+        type: "akash.v1",
+        module: "market",
+        action: "lease-reclaim-started",
+        owner: "akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd",
+        dseq: "22350842",
+        provider: "akash1provideraddressxxxxxxxxxxxxxxxxxxxxxx",
+        reason: "lease_closed_reason_unstable",
+        deadline: "1749398400"
       }
-      return [
-        {
-          type: "akash.v1",
-          module: "deployment",
-          action: "deployment-closed",
-          owner: "akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd",
-          dseq: "22350842"
-        }
-      ];
-    });
+    ]);
 
     return {
       module,

--- a/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.spec.ts
+++ b/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.spec.ts
@@ -66,8 +66,40 @@ describe(ChainEventsPollerService.name, () => {
           owner: "akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd",
           dseq: "22350842"
         }
+      },
+      {
+        eventName: eventKeyRegistry.eventLeaseReclaimStarted,
+        event: {
+          type: "akash.v1",
+          module: "market",
+          action: "lease-reclaim-started",
+          owner: "akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd",
+          dseq: "22350842",
+          provider: "akash1provideraddressxxxxxxxxxxxxxxxxxxxxxx",
+          reason: "lease_closed_reason_unstable",
+          deadline: "1749398400"
+        }
       }
     ]);
+  });
+
+  it("fetches lease reclaim started events from the market module", async () => {
+    const { service, txEventsService, CURRENT_HEIGHT } = await setup();
+
+    service.onApplicationBootstrap();
+    await delay(500);
+    service.onModuleDestroy();
+
+    expect(txEventsService.getBlockEvents).toHaveBeenCalledWith(
+      CURRENT_HEIGHT + 1,
+      {
+        module: "market",
+        version: "v1",
+        source: "akash",
+        action: ["lease-reclaim-started"]
+      },
+      expect.any(AbortSignal)
+    );
   });
 
   it("retries instead of shutting down when block processing consistently fails", async () => {
@@ -248,15 +280,31 @@ describe(ChainEventsPollerService.name, () => {
     });
 
     const txEventsService = module.get<MockProxy<TxEventsService>>(TxEventsService);
-    txEventsService.getBlockEvents.mockResolvedValue([
-      {
-        type: "akash.v1",
-        module: "deployment",
-        action: "deployment-closed",
-        owner: "akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd",
-        dseq: "22350842"
+    txEventsService.getBlockEvents.mockImplementation(async (_height, filter) => {
+      if (filter?.module === "market") {
+        return [
+          {
+            type: "akash.v1",
+            module: "market",
+            action: "lease-reclaim-started",
+            owner: "akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd",
+            dseq: "22350842",
+            provider: "akash1provideraddressxxxxxxxxxxxxxxxxxxxxxx",
+            reason: "lease_closed_reason_unstable",
+            deadline: "1749398400"
+          }
+        ];
       }
-    ]);
+      return [
+        {
+          type: "akash.v1",
+          module: "deployment",
+          action: "deployment-closed",
+          owner: "akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd",
+          dseq: "22350842"
+        }
+      ];
+    });
 
     return {
       module,

--- a/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.ts
+++ b/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.ts
@@ -145,7 +145,7 @@ export class ChainEventsPollerService implements OnApplicationBootstrap, OnModul
 
       const block = await this.blockMessageService.getMessages(nextBlockHeight, [MsgCloseDeployment["$type"], MsgCreateDeployment["$type"]], this.signal);
 
-      const chainEvents = await this.txEventsService.getBlockEvents(
+      const blockEvents = await this.txEventsService.getBlockEvents(
         nextBlockHeight,
         [
           { module: "deployment", version: "v1", source: "akash", action: ["deployment-closed"] },
@@ -165,7 +165,7 @@ export class ChainEventsPollerService implements OnApplicationBootstrap, OnModul
           eventName: message.type,
           event: message
         })),
-        ...chainEvents.map(event => ({
+        ...blockEvents.map(event => ({
           eventName: `${event.type}.${event.module}.${event.action}`,
           event: event
         }))

--- a/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.ts
+++ b/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.ts
@@ -156,6 +156,17 @@ export class ChainEventsPollerService implements OnApplicationBootstrap, OnModul
         this.signal
       );
 
+      const marketEvents = await this.txEventsService.getBlockEvents(
+        nextBlockHeight,
+        {
+          module: "market",
+          version: "v1",
+          source: "akash",
+          action: ["lease-reclaim-started"]
+        },
+        this.signal
+      );
+
       await this.brokerService.publishAll([
         {
           eventName: eventKeyRegistry.blockCreated,
@@ -167,7 +178,7 @@ export class ChainEventsPollerService implements OnApplicationBootstrap, OnModul
           eventName: message.type,
           event: message
         })),
-        ...txEvents.map(event => ({
+        ...[...txEvents, ...marketEvents].map(event => ({
           eventName: `${event.type}.${event.module}.${event.action}`,
           event: event
         }))

--- a/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.ts
+++ b/apps/notifications/src/modules/chain/services/chain-events-poller/chain-events-poller.service.ts
@@ -145,25 +145,12 @@ export class ChainEventsPollerService implements OnApplicationBootstrap, OnModul
 
       const block = await this.blockMessageService.getMessages(nextBlockHeight, [MsgCloseDeployment["$type"], MsgCreateDeployment["$type"]], this.signal);
 
-      const txEvents = await this.txEventsService.getBlockEvents(
+      const chainEvents = await this.txEventsService.getBlockEvents(
         nextBlockHeight,
-        {
-          module: "deployment",
-          version: "v1",
-          source: "akash",
-          action: ["deployment-closed"]
-        },
-        this.signal
-      );
-
-      const marketEvents = await this.txEventsService.getBlockEvents(
-        nextBlockHeight,
-        {
-          module: "market",
-          version: "v1",
-          source: "akash",
-          action: ["lease-reclaim-started"]
-        },
+        [
+          { module: "deployment", version: "v1", source: "akash", action: ["deployment-closed"] },
+          { module: "market", version: "v1", source: "akash", action: ["lease-reclaim-started"] }
+        ],
         this.signal
       );
 
@@ -178,7 +165,7 @@ export class ChainEventsPollerService implements OnApplicationBootstrap, OnModul
           eventName: message.type,
           event: message
         })),
-        ...[...txEvents, ...marketEvents].map(event => ({
+        ...chainEvents.map(event => ({
           eventName: `${event.type}.${event.module}.${event.action}`,
           event: event
         }))

--- a/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.spec.ts
+++ b/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.spec.ts
@@ -236,6 +236,63 @@ describe(TxEventsService.name, () => {
         }
       ]);
     });
+
+    it("does not emit duplicate events when overlapping filters match the same event", async () => {
+      const { module } = await setup();
+      const service = module.get<TxEventsService>(TxEventsService);
+      const cometClient = module.get<MockProxy<Comet38Client>>(Comet38Client);
+      const blockResults: comet38.BlockResultsResponse = {
+        height: 1,
+        results: [
+          {
+            code: 0,
+            codespace: "",
+            data: Uint8Array.from([]),
+            events: [
+              {
+                type: "akash.market.v1.EventLeaseReclaimStarted",
+                attributes: [
+                  {
+                    key: "id",
+                    value:
+                      '{"owner":"akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd","dseq":"22350842","gseq":1,"oseq":1,"provider":"akash1provideraddressxxxxxxxxxxxxxxxxxxxxxx"}'
+                  },
+                  { key: "reason", value: '"lease_closed_reason_unstable"' },
+                  { key: "deadline", value: '"1749398400"' },
+                  { key: "msg_index", value: "0" }
+                ]
+              }
+            ],
+            gasWanted: 100000n,
+            gasUsed: 80000n
+          }
+        ],
+        validatorUpdates: [],
+        finalizeBlockEvents: []
+      };
+      cometClient.blockResults.mockResolvedValue(blockResults);
+
+      // A specific filter and a broad one that both match the same event
+      const result = await service.getBlockEvents(1, [
+        { source: "akash", module: "market", version: "v1", action: ["lease-reclaim-started"] },
+        { source: "akash", module: "market", version: "v1" }
+      ]);
+
+      expect(result).toEqual([
+        {
+          type: "akash.v1",
+          module: "market",
+          action: "lease-reclaim-started",
+          owner: "akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd",
+          dseq: "22350842",
+          gseq: 1,
+          oseq: 1,
+          provider: "akash1provideraddressxxxxxxxxxxxxxxxxxxxxxx",
+          reason: "lease_closed_reason_unstable",
+          deadline: "1749398400"
+        }
+      ]);
+    });
   });
 
   async function setup() {

--- a/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.spec.ts
+++ b/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.spec.ts
@@ -183,6 +183,59 @@ describe(TxEventsService.name, () => {
         }
       ]);
     });
+
+    it("extracts a lease reclaim started event from the market module", async () => {
+      const { module } = await setup();
+      const service = module.get<TxEventsService>(TxEventsService);
+      const cometClient = module.get<MockProxy<Comet38Client>>(Comet38Client);
+      const blockResults: comet38.BlockResultsResponse = {
+        height: 1,
+        results: [
+          {
+            code: 0,
+            codespace: "",
+            data: Uint8Array.from([]),
+            events: [
+              {
+                type: "akash.market.v1.EventLeaseReclaimStarted",
+                attributes: [
+                  {
+                    key: "id",
+                    value:
+                      '{"owner":"akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd","dseq":"22350842","gseq":1,"oseq":1,"provider":"akash1provideraddressxxxxxxxxxxxxxxxxxxxxxx"}'
+                  },
+                  { key: "reason", value: '"lease_closed_reason_unstable"' },
+                  { key: "deadline", value: '"1749398400"' },
+                  { key: "msg_index", value: "0" }
+                ]
+              }
+            ],
+            gasWanted: 100000n,
+            gasUsed: 80000n
+          }
+        ],
+        validatorUpdates: [],
+        finalizeBlockEvents: []
+      };
+      cometClient.blockResults.mockResolvedValue(blockResults);
+
+      const result = await service.getBlockEvents(1, { source: "akash", module: "market", version: "v1", action: ["lease-reclaim-started"] });
+
+      expect(result).toEqual([
+        {
+          type: "akash.v1",
+          module: "market",
+          action: "lease-reclaim-started",
+          owner: "akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd",
+          dseq: "22350842",
+          gseq: 1,
+          oseq: 1,
+          provider: "akash1provideraddressxxxxxxxxxxxxxxxxxxxxxx",
+          reason: "lease_closed_reason_unstable",
+          deadline: "1749398400"
+        }
+      ]);
+    });
   });
 
   async function setup() {

--- a/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.spec.ts
+++ b/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.spec.ts
@@ -237,7 +237,7 @@ describe(TxEventsService.name, () => {
       ]);
     });
 
-    it("does not emit duplicate events when overlapping filters match the same event", async () => {
+    it("applies multiple filters in a single block fetch", async () => {
       const { module } = await setup();
       const service = module.get<TxEventsService>(TxEventsService);
       const cometClient = module.get<MockProxy<Comet38Client>>(Comet38Client);
@@ -250,6 +250,10 @@ describe(TxEventsService.name, () => {
             data: Uint8Array.from([]),
             events: [
               {
+                type: "akash.deployment.v1.EventDeploymentClosed",
+                attributes: [{ key: "id", value: '{"owner":"akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd","dseq":"22350843"}' }]
+              },
+              {
                 type: "akash.market.v1.EventLeaseReclaimStarted",
                 attributes: [
                   {
@@ -258,8 +262,7 @@ describe(TxEventsService.name, () => {
                       '{"owner":"akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd","dseq":"22350842","gseq":1,"oseq":1,"provider":"akash1provideraddressxxxxxxxxxxxxxxxxxxxxxx"}'
                   },
                   { key: "reason", value: '"lease_closed_reason_unstable"' },
-                  { key: "deadline", value: '"1749398400"' },
-                  { key: "msg_index", value: "0" }
+                  { key: "deadline", value: '"1749398400"' }
                 ]
               }
             ],
@@ -272,13 +275,19 @@ describe(TxEventsService.name, () => {
       };
       cometClient.blockResults.mockResolvedValue(blockResults);
 
-      // A specific filter and a broad one that both match the same event
       const result = await service.getBlockEvents(1, [
-        { source: "akash", module: "market", version: "v1", action: ["lease-reclaim-started"] },
-        { source: "akash", module: "market", version: "v1" }
+        { source: "akash", module: "deployment", version: "v1", action: ["deployment-closed"] },
+        { source: "akash", module: "market", version: "v1", action: ["lease-reclaim-started"] }
       ]);
 
       expect(result).toEqual([
+        {
+          type: "akash.v1",
+          module: "deployment",
+          action: "deployment-closed",
+          owner: "akash1qh0f0h7jlq4x5gpxghrxvps5l09y7uuvcumcyd",
+          dseq: "22350843"
+        },
         {
           type: "akash.v1",
           module: "market",

--- a/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.ts
+++ b/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.ts
@@ -62,12 +62,17 @@ export class TxEventsService {
   }
 
   /**
-   * Retrieves and processes block events filtered by type and action
+   * Retrieves and processes block events filtered by type and action.
+   *
+   * Accepts one filter or several: the block is fetched from the chain only once
+   * and every filter is applied in-memory, so callers needing multiple event
+   * families (e.g. deployment + market) don't pay for a duplicate block fetch.
+   *
    * @param blockHeight - The height of the block to process
-   * @param filter - Optional filter to apply to events
-   * @returns Array of processed events matching the filter criteria
+   * @param filter - Optional filter, or list of filters, to apply to events
+   * @returns Array of processed events matching any of the filter criteria
    */
-  async getBlockEvents(blockHeight: number, filter?: EventFilter, signal?: AbortSignal): Promise<ProcessedEvent[]> {
+  async getBlockEvents(blockHeight: number, filter?: EventFilter | EventFilter[], signal?: AbortSignal): Promise<ProcessedEvent[]> {
     try {
       const blockResults = await this.fetchBlockResultsWithRetry(blockHeight, signal);
 
@@ -77,7 +82,8 @@ export class TxEventsService {
         transactionCount: blockResults.results.length
       });
 
-      return this.extractFilteredEventsFromBlockResults(blockResults, filter);
+      const filters = Array.isArray(filter) ? filter : [filter];
+      return filters.flatMap(f => this.extractFilteredEventsFromBlockResults(blockResults, f));
     } catch (error) {
       this.loggerService.error({
         event: "BLOCK_EVENTS_PROCESSING_FAILED",

--- a/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.ts
+++ b/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.ts
@@ -18,7 +18,7 @@ interface ProcessedEvent {
 /**
  * Supported blockchain event actions
  */
-type Action = "deployment-closed" | "deployment-created";
+type Action = "deployment-closed" | "deployment-created" | "lease-reclaim-started";
 
 /**
  * Filter criteria for blockchain events
@@ -26,7 +26,7 @@ type Action = "deployment-closed" | "deployment-created";
 interface EventFilter {
   source?: "akash";
   action?: Action | Action[];
-  module?: "deployment";
+  module?: "deployment" | "market";
   version?: "v1";
 }
 
@@ -46,7 +46,8 @@ interface EventFilter {
 export class TxEventsService {
   private readonly EVENT_ACTIONS: Record<string, string> = {
     EventDeploymentClosed: "deployment-closed",
-    EventDeploymentCreated: "deployment-created"
+    EventDeploymentCreated: "deployment-created",
+    EventLeaseReclaimStarted: "lease-reclaim-started"
   };
 
   private readonly ACTION_EVENTS: Record<string, string> = Object.fromEntries(Object.entries(this.EVENT_ACTIONS).map(([k, v]) => [v, k]));

--- a/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.ts
+++ b/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.ts
@@ -83,7 +83,8 @@ export class TxEventsService {
       });
 
       const filters = Array.isArray(filter) ? filter : [filter];
-      return filters.flatMap(f => this.extractFilteredEventsFromBlockResults(blockResults, f));
+      const events = filters.flatMap(f => this.extractFilteredEventsFromBlockResults(blockResults, f));
+      return this.dedupeEvents(events);
     } catch (error) {
       this.loggerService.error({
         event: "BLOCK_EVENTS_PROCESSING_FAILED",
@@ -92,6 +93,24 @@ export class TxEventsService {
       });
       return [];
     }
+  }
+
+  /**
+   * Removes duplicate events that arise when overlapping filters match the same
+   * chain event, preserving first-seen order. Without this, a single chain event
+   * could be published — and the tenant emailed — multiple times.
+   *
+   * @param events - Events merged from all filters
+   * @returns Events with duplicates removed
+   */
+  private dedupeEvents(events: ProcessedEvent[]): ProcessedEvent[] {
+    const seen = new Set<string>();
+    return events.filter(event => {
+      const key = JSON.stringify(event);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
   }
 
   private readonly retryExecutor = retry(handleAll, {

--- a/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.ts
+++ b/apps/notifications/src/modules/chain/services/tx-events-service/tx-events.service.ts
@@ -83,8 +83,7 @@ export class TxEventsService {
       });
 
       const filters = Array.isArray(filter) ? filter : [filter];
-      const events = filters.flatMap(f => this.extractFilteredEventsFromBlockResults(blockResults, f));
-      return this.dedupeEvents(events);
+      return filters.flatMap(f => this.extractFilteredEventsFromBlockResults(blockResults, f));
     } catch (error) {
       this.loggerService.error({
         event: "BLOCK_EVENTS_PROCESSING_FAILED",
@@ -93,24 +92,6 @@ export class TxEventsService {
       });
       return [];
     }
-  }
-
-  /**
-   * Removes duplicate events that arise when overlapping filters match the same
-   * chain event, preserving first-seen order. Without this, a single chain event
-   * could be published — and the tenant emailed — multiple times.
-   *
-   * @param events - Events merged from all filters
-   * @returns Events with duplicates removed
-   */
-  private dedupeEvents(events: ProcessedEvent[]): ProcessedEvent[] {
-    const seen = new Set<string>();
-    return events.filter(event => {
-      const key = JSON.stringify(event);
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    });
   }
 
   private readonly retryExecutor = retry(handleAll, {

--- a/apps/notifications/test/functional/lease-reclaim-alert.spec.ts
+++ b/apps/notifications/test/functional/lease-reclaim-alert.spec.ts
@@ -1,0 +1,150 @@
+import { faker } from "@faker-js/faker";
+import { Test } from "@nestjs/testing";
+import { describe, expect, it, vi } from "vitest";
+
+import { eventKeyRegistry } from "@src/common/config/event-key-registry.config";
+import { BrokerService } from "@src/infrastructure/broker";
+import { DRIZZLE_PROVIDER_TOKEN } from "@src/infrastructure/db/config/db.config";
+import AlertEventsModule from "@src/interfaces/alert-events/alert-events.module";
+import { ChainEventsHandler } from "@src/interfaces/alert-events/handlers/chain-events/chain-events.handler";
+import type { EventLeaseReclaimStartedDto } from "@src/modules/alert/dto/event-lease-reclaim-started.dto";
+import * as schema from "@src/modules/alert/model-schemas";
+import { NotificationChannel } from "@src/modules/notifications/model-schemas";
+
+import { mockAkashAddress } from "@test/seeders/akash-address.seeder";
+import { generateGeneralAlert } from "@test/seeders/general-alert.seeder";
+import { generateNotificationChannel } from "@test/seeders/notification-channel.seeder";
+
+describe("lease reclaim alerts", () => {
+  it("sends a single reclaim notification to the deployment-closed alert's channel and dedupes on replay", async () => {
+    const { module } = await setup();
+
+    try {
+      const controller = module.get(ChainEventsHandler);
+      const brokerService = module.get(BrokerService);
+      const db = module.get(DRIZZLE_PROVIDER_TOKEN);
+
+      const owner = mockAkashAddress();
+      const otherOwner = mockAkashAddress();
+      const dseq = String(faker.number.int({ min: 1, max: 999999 }));
+      const provider = mockAkashAddress();
+
+      vi.spyOn(brokerService, "publish").mockResolvedValue(undefined);
+
+      const [ownerChannel, otherOwnerChannel] = await db
+        .insert(NotificationChannel)
+        .values([generateNotificationChannel({}), generateNotificationChannel({})])
+        .returning();
+
+      const ownerClosedAlert = generateClosedAlert({ owner, dseq, notificationChannelId: ownerChannel.id });
+      // Same dseq, different owner, different channel: must NOT be borrowed.
+      const otherOwnerClosedAlert = generateClosedAlert({ owner: otherOwner, dseq, notificationChannelId: otherOwnerChannel.id });
+
+      await db.insert(schema.Alert).values([ownerClosedAlert, otherOwnerClosedAlert]);
+
+      const event = generateReclaimEvent({ owner, dseq, provider });
+
+      await controller.processLeaseReclaimStarted(event);
+      await controller.processLeaseReclaimStarted(event);
+
+      expect(brokerService.publish).toHaveBeenCalledTimes(1);
+      expect(brokerService.publish).toHaveBeenCalledWith(
+        eventKeyRegistry.createNotification,
+        expect.objectContaining({
+          notificationChannelId: ownerChannel.id,
+          payload: expect.objectContaining({
+            summary: expect.stringContaining(dseq),
+            description: expect.stringContaining(provider)
+          })
+        })
+      );
+    } finally {
+      await module.close();
+    }
+  });
+
+  it("does not send when the deployment-closed alert is disabled (opted out)", async () => {
+    const { module } = await setup();
+
+    try {
+      const controller = module.get(ChainEventsHandler);
+      const brokerService = module.get(BrokerService);
+      const db = module.get(DRIZZLE_PROVIDER_TOKEN);
+
+      const owner = mockAkashAddress();
+      const dseq = String(faker.number.int({ min: 1, max: 999999 }));
+
+      vi.spyOn(brokerService, "publish").mockResolvedValue(undefined);
+
+      const [channel] = await db
+        .insert(NotificationChannel)
+        .values([generateNotificationChannel({})])
+        .returning();
+      await db.insert(schema.Alert).values([generateClosedAlert({ owner, dseq, notificationChannelId: channel.id, enabled: false })]);
+
+      await controller.processLeaseReclaimStarted(generateReclaimEvent({ owner, dseq }));
+
+      expect(brokerService.publish).not.toHaveBeenCalled();
+    } finally {
+      await module.close();
+    }
+  });
+
+  it("does not send when there is no deployment-closed alert on file", async () => {
+    const { module } = await setup();
+
+    try {
+      const controller = module.get(ChainEventsHandler);
+      const brokerService = module.get(BrokerService);
+
+      vi.spyOn(brokerService, "publish").mockResolvedValue(undefined);
+
+      await controller.processLeaseReclaimStarted(generateReclaimEvent({ owner: mockAkashAddress(), dseq: String(faker.number.int({ min: 1, max: 999999 })) }));
+
+      expect(brokerService.publish).not.toHaveBeenCalled();
+    } finally {
+      await module.close();
+    }
+  });
+
+  function generateClosedAlert(input: { owner: string; dseq: string; notificationChannelId: string; enabled?: boolean }) {
+    return generateGeneralAlert({
+      type: "CHAIN_EVENT",
+      notificationChannelId: input.notificationChannelId,
+      enabled: input.enabled ?? true,
+      params: { dseq: input.dseq, type: "DEPLOYMENT_CLOSED" },
+      conditions: {
+        operator: "and",
+        value: [
+          { field: "action", value: "deployment-closed", operator: "eq" },
+          { field: "owner", value: input.owner, operator: "eq" },
+          { field: "dseq", value: input.dseq, operator: "eq" }
+        ]
+      },
+      summary: "Deployment closed",
+      description: "Deployment closed"
+    });
+  }
+
+  function generateReclaimEvent(input: { owner: string; dseq: string; provider?: string }): EventLeaseReclaimStartedDto {
+    return {
+      module: "market",
+      action: "lease-reclaim-started",
+      owner: input.owner,
+      dseq: input.dseq,
+      provider: input.provider ?? mockAkashAddress(),
+      reason: "lease_closed_reason_unstable",
+      deadline: "1749398400"
+    } as EventLeaseReclaimStartedDto;
+  }
+
+  async function setup() {
+    const module = await Test.createTestingModule({
+      imports: [AlertEventsModule]
+    }).compile();
+
+    return {
+      module
+    };
+  }
+});


### PR DESCRIPTION
## Why

When a provider starts reclaiming a lease, the chain emits `EventLeaseReclaimStarted` with a deadline after which the lease may be closed. The in-app reclamation card isn't enough — a tenant who doesn't open the dashboard misses the window. This adds an email push to the affected tenant.

Fixes CON-377

## What

Notifications-only. The reclaim email rides on the existing **deployment-closed alert** as the `(owner, dseq) → channel` record — no new configurable alert, no codegen, no migration.

- **Ingestion**: recognize `akash.market.v1.EventLeaseReclaimStarted` in `TxEventsService`; the poller fetches market events alongside deployment events and publishes `akash.v1.market.lease-reclaim-started`.
- **Matching**: a direct `(owner, dseq)` lookup (owner lives in the closed alert's `conditions.value[]`, dseq in `params`). Runs in a system context with **no CASL ability scope**, so it matches both to avoid borrowing another tenant's channel on a dseq collision.
- **Exactly-once / replay-safe**: a `params.reclaimNotifiedAt` claim-then-send. The pipeline is at-least-once (pg-boss redelivery + block reprocessing), so the atomic claim guards replay.
- **Opt-out honored**: if the deployment-closed alert is `enabled = false`, skip. No alert on file → skip, no crash.
- **Email content**: stated reason (complete `LeaseClosedReason` map + fallback), deadline as absolute UTC + relative, provider identity, and a deep link to `/deployments/{dseq}`.

`reason` and `deadline` tolerate the ambiguous on-chain string-or-number JSON encoding and are normalized in the service (the chain-sdk does not export a `fromJSON` helper in its runtime bundle).

Adds `apps/notifications/CONTEXT.md` documenting the alert / notification / reclaim domain language.

### Tests
Unit (parsing, poller wiring, reason/deadline helpers, reclaim service skip/dedupe branches, handler routing) and a functional spec against a real DB covering single-send, dedupe on replay, owner-scoping, opt-out, and no-alert. `npm test` → 241 passing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lease-reclaim alerting: notifications when a lease-reclaim-started event occurs, with human-readable reason text, formatted UTC deadline + relative timing, and a console link to the deployment.

* **Behavior**
  * Deduplication prevents duplicate notifications on event replays.
  * Alerts respect enabled/disabled state and atomically track/claim reclaim notifications to avoid re-sends.

* **Tests**
  * Added unit and functional tests covering event ingestion, message publishing, deadline formatting, reason mapping, and claim/dedup flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->