### PR TITLE
fix(billing): bump top-up amount in managed wallet credits e2e

### DIFF
--- a/apps/deploy-web/tests/ui/managed-wallet-credits.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-credits.spec.ts
@@ -2,6 +2,8 @@ import { expect, test } from "./fixture/base-test";
 import { BillingPage } from "./pages/BillingPage";
 import { HomePage } from "./pages/HomePage";
 
+const TOP_UP_AMOUNT = 100;
+
 test.describe("Managed wallet credits", () => {
   test.use({ userType: "existing" });
 
@@ -23,7 +25,7 @@ test.describe("Managed wallet credits", () => {
     });
 
     await test.step("submit payment", async () => {
-      await billingPage.submitPayment("20");
+      await billingPage.submitPayment(String(TOP_UP_AMOUNT));
     });
 
     await test.step("verify payment success", async () => {
@@ -34,7 +36,7 @@ test.describe("Managed wallet credits", () => {
       await expect(async () => {
         const text = await billingPage.getAvailableBalance().textContent();
         const balanceAfter = parseBalance(text);
-        expect(balanceAfter).toBeGreaterThanOrEqual(balanceBefore + 20);
+        expect(balanceAfter).toBeGreaterThanOrEqual(balanceBefore + TOP_UP_AMOUNT);
       }).toPass({ timeout: 30_000, intervals: [2_000] });
     });
   });


### PR DESCRIPTION
## Why

The minimum top-up amount increased, so the managed wallet credits e2e test was submitting a payment of `20` that no longer meets the threshold, causing it to fail.

## What

- Raise the top-up amount in `managed-wallet-credits.spec.ts` from `20` to `100`.
- Extract the value into a `TOP_UP_AMOUNT` constant so the submitted payment and the expected balance assertion stay in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated UI tests for managed wallet credits functionality to use configurable constants for improved test maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->