### PR TITLE
feat: adds createdAt to provider inventory

### DIFF
--- a/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
+++ b/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
@@ -100,9 +100,11 @@ export type BidScreeningRequest = z.infer<typeof BidScreeningRequestSchema>;
 const ProviderResultSchema = z.object({
   owner: z.string().openapi({ description: "Provider address", example: "akash1q7spv2cw06yszgfp4f9ed59lkka6ytn8g4tkjf" }),
   hostUri: z.string().openapi({ description: "Provider HTTPS endpoint", example: "https://provider.europlots.com:8443" }),
-  region: z.string().nullable().openapi({ description: "Geo-resolved region from IP" }),
-  uptime7d: z.number().nullable().openapi({ description: "7-day uptime as decimal (0.0-1.0)", example: 0.998 }),
-  isAudited: z.boolean().openapi({ description: "True if signed by a known auditor" })
+  isAudited: z.boolean().openapi({ description: "True if signed by a known auditor" }),
+  createdAt: z
+    .string()
+    .datetime()
+    .openapi({ description: "ISO 8601 timestamp marking when the provider was first enrolled in the inventory", example: "2026-01-01T00:00:00.000Z" })
 });
 
 export const BidScreeningResponseSchema = z.object({

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -16727,28 +16727,22 @@
                             "description": "Provider HTTPS endpoint",
                             "example": "https://provider.europlots.com:8443"
                           },
-                          "region": {
-                            "type": "string",
-                            "nullable": true,
-                            "description": "Geo-resolved region from IP"
-                          },
-                          "uptime7d": {
-                            "type": "number",
-                            "nullable": true,
-                            "description": "7-day uptime as decimal (0.0-1.0)",
-                            "example": 0.998
-                          },
                           "isAudited": {
                             "type": "boolean",
                             "description": "True if signed by a known auditor"
+                          },
+                          "createdAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "description": "ISO 8601 timestamp marking when the provider was first enrolled in the inventory",
+                            "example": "2026-01-01T00:00:00.000Z"
                           }
                         },
                         "required": [
                           "owner",
                           "hostUri",
-                          "region",
-                          "uptime7d",
-                          "isAudited"
+                          "isAudited",
+                          "createdAt"
                         ]
                       }
                     }

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -3069,6 +3069,12 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     "providers": {
                       "items": {
                         "properties": {
+                          "createdAt": {
+                            "description": "ISO 8601 timestamp marking when the provider was first enrolled in the inventory",
+                            "example": "2026-01-01T00:00:00.000Z",
+                            "format": "date-time",
+                            "type": "string",
+                          },
                           "hostUri": {
                             "description": "Provider HTTPS endpoint",
                             "example": "https://provider.europlots.com:8443",
@@ -3083,24 +3089,12 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "example": "akash1q7spv2cw06yszgfp4f9ed59lkka6ytn8g4tkjf",
                             "type": "string",
                           },
-                          "region": {
-                            "description": "Geo-resolved region from IP",
-                            "nullable": true,
-                            "type": "string",
-                          },
-                          "uptime7d": {
-                            "description": "7-day uptime as decimal (0.0-1.0)",
-                            "example": 0.998,
-                            "nullable": true,
-                            "type": "number",
-                          },
                         },
                         "required": [
                           "owner",
                           "hostUri",
-                          "region",
-                          "uptime7d",
                           "isAudited",
+                          "createdAt",
                         ],
                         "type": "object",
                       },

--- a/apps/provider-inventory/drizzle/0002_add_created_at_column.sql
+++ b/apps/provider-inventory/drizzle/0002_add_created_at_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "provider_inventory" ADD COLUMN "created_at" timestamp with time zone DEFAULT now() NOT NULL;

--- a/apps/provider-inventory/drizzle/meta/0002_snapshot.json
+++ b/apps/provider-inventory/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,193 @@
+{
+  "id": "748b1d55-6cb9-407b-93a7-1e8997767b55",
+  "prevId": "b5bc1ea9-e4f7-46f1-8cb8-43cb58b9ba51",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.provider_inventory": {
+      "name": "provider_inventory",
+      "schema": "",
+      "columns": {
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_uri": {
+          "name": "host_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_online": {
+          "name": "is_online",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_online_since": {
+          "name": "is_online_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventory": {
+          "name": "inventory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "total_available_cpu": {
+          "name": "total_available_cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_memory": {
+          "name": "total_available_memory",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_gpu": {
+          "name": "total_available_gpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_eph": {
+          "name": "total_available_eph",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_persistent": {
+          "name": "total_available_persistent",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_leased_ip": {
+          "name": "total_available_leased_ip",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "max_node_free_cpu": {
+          "name": "max_node_free_cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "max_node_free_memory": {
+          "name": "max_node_free_memory",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "max_node_free_gpu": {
+          "name": "max_node_free_gpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "gpu_models": {
+          "name": "gpu_models",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "storage_classes": {
+          "name": "storage_classes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "self_attributes": {
+          "name": "self_attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "signed_attributes": {
+          "name": "signed_attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "audited_by": {
+          "name": "audited_by",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_inventory_online": {
+          "name": "idx_provider_inventory_online",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "is_online AND is_online_since IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/provider-inventory/drizzle/meta/_journal.json
+++ b/apps/provider-inventory/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1780549868503,
       "tag": "0001_add_leased_ip_column",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1780921639304,
+      "tag": "0002_add_created_at_column",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
+++ b/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
@@ -99,7 +99,11 @@ export type BidScreeningRequest = z.infer<typeof BidScreeningRequestSchema>;
 const ProviderResultSchema = z.object({
   owner: z.string().openapi({ description: "Provider address", example: "akash1q7spv2cw06yszgfp4f9ed59lkka6ytn8g4tkjf" }),
   hostUri: z.string().openapi({ description: "Provider HTTPS endpoint", example: "https://provider.europlots.com:8443" }),
-  isAudited: z.boolean().openapi({ description: "True if signed by a known auditor" })
+  isAudited: z.boolean().openapi({ description: "True if signed by a known auditor" }),
+  createdAt: z
+    .string()
+    .datetime()
+    .openapi({ description: "ISO 8601 timestamp marking when the provider was first enrolled in the inventory", example: "2026-01-01T00:00:00.000Z" })
 });
 
 export const BidScreeningResponseSchema = z.object({

--- a/apps/provider-inventory/src/model-schemas/provider-inventory/provider-inventory.schema.ts
+++ b/apps/provider-inventory/src/model-schemas/provider-inventory/provider-inventory.schema.ts
@@ -48,6 +48,7 @@ export const providerInventory = pgTable(
     signedAttributes: jsonbBigint("signed_attributes").notNull().default([]),
     auditedBy: text("audited_by").array().notNull().default([]),
 
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow()
   },
   table => ({

--- a/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.integration.ts
@@ -179,6 +179,17 @@ describe(BidScreeningRepository.name, () => {
     });
   });
 
+  describe("createdAt projection", () => {
+    it("returns the persisted created_at as the candidate enrollment date", async () => {
+      const enrolledAt = new Date("2025-07-15T12:34:56.789Z");
+      await seed({ owner: "akash1enrolled", createdAt: enrolledAt });
+
+      const [row] = await repository.findCandidates([unit({})], requirements());
+
+      expect(row.createdAt).toBe(enrolledAt.toISOString());
+    });
+  });
+
   describe("gpu_models filter", () => {
     it("vendor-only request matches mixed-model providers via the vendor token", async () => {
       await seed({ owner: "akash1nvidiaA100", gpuModels: ["nvidia", "nvidia/a100"], totalAvailableGpu: 8n, maxNodeFreeGpu: 8n });
@@ -499,6 +510,7 @@ describe(BidScreeningRepository.name, () => {
     gpuModels?: string[];
     storageClasses?: string[];
     inventory?: unknown;
+    createdAt?: Date;
   }
 
   async function seed(input: SeedInput): Promise<void> {
@@ -520,7 +532,8 @@ describe(BidScreeningRepository.name, () => {
       auditedBy: input.auditedBy ?? [],
       gpuModels: input.gpuModels ?? [],
       storageClasses: input.storageClasses ?? [],
-      inventory: input.inventory ?? { nodes: [], storage: {} }
+      inventory: input.inventory ?? { nodes: [], storage: {} },
+      createdAt: input.createdAt
     });
   }
 });

--- a/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.ts
+++ b/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.ts
@@ -15,6 +15,7 @@ export interface BidScreeningCandidate {
   hostUri: string;
   cluster?: ClusterState;
   isAudited: boolean;
+  createdAt: string;
   updatedAt: string;
 }
 
@@ -40,7 +41,7 @@ export class BidScreeningRepository {
     const rows = await sql<Array<{ owner: string; updatedAt: string }>>`
       SELECT
         ${sql(providerInventory.owner.name)} AS owner,
-        ${sql(providerInventory.updatedAt.name)} AS "updatedAt"
+        to_char(${sql(providerInventory.updatedAt.name)} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS "updatedAt"
       FROM ${sql(TABLE)}
       WHERE ${where}
     `;
@@ -63,7 +64,8 @@ export class BidScreeningRepository {
       const candidates = await sql<BidScreeningCandidate[]>`
         SELECT
           ${sql(providerInventory.owner.name)} AS owner,
-          ${sql(providerInventory.updatedAt.name)} AS "updatedAt",
+          to_char(${sql(providerInventory.updatedAt.name)} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS "updatedAt",
+          to_char(${sql(providerInventory.createdAt.name)} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS "createdAt",
           ${sql(providerInventory.hostUri.name)} AS "hostUri",
           ${sql(providerInventory.inventory.name)} AS cluster,
           ${sql(providerInventory.auditedBy.name)} @> ARRAY[${AUDITOR}]::text[] AS "isAudited"

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.spec.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.spec.ts
@@ -19,7 +19,8 @@ describe(BidScreeningService.name, () => {
         {
           owner: "akash1abc",
           hostUri: "https://provider.example.com:8443",
-          isAudited: false
+          isAudited: false,
+          createdAt: "2026-01-01T00:00:00.000Z"
         }
       ]);
     });
@@ -97,11 +98,12 @@ describe(BidScreeningService.name, () => {
   }
 });
 
-function makeCandidate(owner: string, overrides?: { isAudited?: boolean }): BidScreeningCandidate {
+function makeCandidate(owner: string, overrides?: { isAudited?: boolean; createdAt?: string }): BidScreeningCandidate {
   return {
     owner,
     hostUri: "https://provider.example.com:8443",
     isAudited: overrides?.isAudited ?? false,
+    createdAt: overrides?.createdAt ?? "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
     cluster: {
       nodes: [

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
@@ -54,7 +54,8 @@ export class BidScreeningService {
     return {
       owner: candidate.owner,
       hostUri: candidate.hostUri,
-      isAudited: candidate.isAudited
+      isAudited: candidate.isAudited,
+      createdAt: candidate.createdAt
     };
   }
 }

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
@@ -36,6 +36,7 @@ export class BidScreeningService {
   }
 
   #filterProviders(candidates: BidScreeningCandidate[], resourceUnits: RequestedResourceUnit[]): BidScreeningResult[] {
+    if (!candidates.length) return candidates;
     const results: BidScreeningResult[] = [];
 
     for (const candidate of candidates) {

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -184,7 +184,7 @@ export class StreamLifecycleManagerService {
         this.#logger.debug({ event: "STREAM_MESSAGE_RECEIVED", owner: provider.owner });
         if (outerSignal.aborted) return;
         releasePermit();
-        await this.#applyMessage(provider, message);
+        await this.#updateProviderInventory(provider, message);
       }
 
       if (outerSignal.aborted) return;
@@ -202,7 +202,7 @@ export class StreamLifecycleManagerService {
     }
   }
 
-  async #applyMessage(provider: ChainProvider, cluster: ClusterState): Promise<void> {
+  async #updateProviderInventory(provider: ChainProvider, cluster: ClusterState): Promise<void> {
     const cached = this.#lastInventoryPerProvider.get(provider.owner);
 
     if (!this.#onlineStatePerProvider.get(provider.owner)) {

--- a/apps/provider-inventory/src/types/inventory.ts
+++ b/apps/provider-inventory/src/types/inventory.ts
@@ -69,6 +69,7 @@ export interface BidScreeningResult {
   owner: string;
   hostUri: string;
   isAudited: boolean;
+  createdAt: string;
 }
 
 export type ToJSON<T> = T extends Uint8Array ? bigint : T extends object ? { -readonly [K in keyof T]: ToJSON<Exclude<T[K], undefined>> } : T;

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -6958,15 +6958,14 @@ export interface paths {
                  * @example https://provider.europlots.com:8443
                  */
                 hostUri: string;
-                /** @description Geo-resolved region from IP */
-                region: string | null;
-                /**
-                 * @description 7-day uptime as decimal (0.0-1.0)
-                 * @example 0.998
-                 */
-                uptime7d: number | null;
                 /** @description True if signed by a known auditor */
                 isAudited: boolean;
+                /**
+                 * Format: date-time
+                 * @description ISO 8601 timestamp marking when the provider was first enrolled in the inventory
+                 * @example 2026-01-01T00:00:00.000Z
+                 */
+                createdAt: string;
               }[];
             };
           };


### PR DESCRIPTION
## Why

closes CON-444

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider creation timestamp (createdAt, ISO-8601 datetime) is now included in bid‑screening API results.

* **Bug Fixes / API Changes**
  * Removed provider fields "region" and "uptime7d" from bid‑screening responses.
  * isAudited remains included in returned provider metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->