### PR TITLE
feat(auth): add FF-gated password escape hatch for e2e login

### DIFF
--- a/apps/deploy-web/src/components/auth/AuthPage/AuthPage.spec.tsx
+++ b/apps/deploy-web/src/components/auth/AuthPage/AuthPage.spec.tsx
@@ -18,15 +18,60 @@ describe(AuthPage.name, () => {
     expect(screen.queryByTestId("password")).not.toBeInTheDocument();
   });
 
-  function setup(input: { isPasswordless: boolean }) {
+  it("renders PasswordAuth when the escape hatch is on and ?auth=password is present", () => {
+    setup({ isPasswordless: true, canUsePassword: true, authParam: "password" });
+    expect(screen.getByTestId("password")).toBeInTheDocument();
+    expect(screen.queryByTestId("passwordless")).not.toBeInTheDocument();
+  });
+
+  it("ignores ?auth=password when the escape hatch is off", () => {
+    setup({ isPasswordless: true, canUsePassword: false, authParam: "password" });
+    expect(screen.getByTestId("passwordless")).toBeInTheDocument();
+    expect(screen.queryByTestId("password")).not.toBeInTheDocument();
+  });
+
+  it("renders PasswordlessAuth when the escape hatch is on but the param is absent", () => {
+    setup({ isPasswordless: true, canUsePassword: true });
+    expect(screen.getByTestId("passwordless")).toBeInTheDocument();
+    expect(screen.queryByTestId("password")).not.toBeInTheDocument();
+  });
+
+  it("strips the tab param without refresh when passwordless is shown", () => {
+    const { replace } = setup({ isPasswordless: true, tab: "signup" });
+    expect(replace).toHaveBeenCalledTimes(1);
+    expect(replace.mock.calls[0]).toEqual([expect.not.stringContaining("tab"), undefined, { shallow: true }]);
+  });
+
+  it("keeps the tab param when the password form is shown", () => {
+    const { replace } = setup({ isPasswordless: true, canUsePassword: true, authParam: "password", tab: "signup" });
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("does not touch the URL when passwordless is shown without a tab param", () => {
+    const { replace } = setup({ isPasswordless: true });
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  function setup(input: { isPasswordless?: boolean; canUsePassword?: boolean; authParam?: string; tab?: string }) {
+    const flags: Record<string, boolean> = {
+      console_auth_passwordless: input.isPasswordless ?? false,
+      console_auth_password_escape_hatch: input.canUsePassword ?? false
+    };
+    const params = new URLSearchParams();
+    if (input.authParam) params.set("auth", input.authParam);
+    if (input.tab) params.set("tab", input.tab);
+    const replace = vi.fn();
     const dependencies: typeof DEPENDENCIES = {
       AuthLayout: (({ children }: { children?: React.ReactNode }) => <div data-testid="layout">{children}</div>) as never,
       H100PriceStatus: (() => <div data-testid="h100" />) as never,
       NextSeo: (() => null) as never,
       PasswordAuth: vi.fn(() => <div data-testid="password" />) as never,
       PasswordlessAuth: vi.fn(() => <div data-testid="passwordless" />) as never,
-      useFlag: (() => input.isPasswordless) as never
+      useFlag: ((flag: string) => flags[flag] ?? false) as never,
+      useRouter: (() => ({ replace, pathname: "/login" })) as never,
+      useSearchParams: (() => params) as never
     };
     render(<AuthPage dependencies={dependencies} />);
+    return { ...input, replace };
   }
 });

--- a/apps/deploy-web/src/components/auth/AuthPage/AuthPage.tsx
+++ b/apps/deploy-web/src/components/auth/AuthPage/AuthPage.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
 
 import { AuthLayout } from "@src/components/auth/AuthLayout/AuthLayout";
@@ -14,7 +17,9 @@ export const DEPENDENCIES = {
   NextSeo,
   PasswordAuth,
   PasswordlessAuth: PasswordlessAuthClient,
-  useFlag
+  useFlag,
+  useRouter,
+  useSearchParams
 };
 
 interface Props {
@@ -22,12 +27,29 @@ interface Props {
 }
 
 export function AuthPage({ dependencies: d = DEPENDENCIES }: Props = {}) {
+  const router = d.useRouter();
+  const searchParams = d.useSearchParams();
   const isPasswordless = d.useFlag("console_auth_passwordless");
+  const canUsePassword = d.useFlag("console_auth_password_escape_hatch");
+  const forcePassword = canUsePassword && searchParams.get("auth") === "password";
+  const showPasswordless = isPasswordless && !forcePassword;
+
+  useEffect(
+    function stripTabParamWhenPasswordless() {
+      if (!showPasswordless || !searchParams.has("tab")) return;
+      const params = new URLSearchParams(searchParams);
+      params.delete("tab");
+      const query = params.toString();
+      router.replace(query ? `?${query}` : router.pathname, undefined, { shallow: true });
+    },
+    [showPasswordless, searchParams, router]
+  );
+
   return (
     <d.AuthLayout topRightContent={<d.H100PriceStatus />}>
       <d.NextSeo title="Sign in to Akash Console" />
       <div className="flex w-full max-w-[420px] flex-col items-center gap-6 px-3 py-4 sm:px-6 lg:px-0">
-        {isPasswordless ? <d.PasswordlessAuth /> : <d.PasswordAuth />}
+        {showPasswordless ? <d.PasswordlessAuth /> : <d.PasswordAuth />}
       </div>
     </d.AuthLayout>
   );

--- a/apps/deploy-web/src/components/layout/Sidebar.tsx
+++ b/apps/deploy-web/src/components/layout/Sidebar.tsx
@@ -63,42 +63,45 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
   const muiTheme = useMuiTheme();
   const smallScreen = useMediaQuery(muiTheme.breakpoints.down("md"));
   const { user } = useUser();
+  const isAuthenticated = !!user?.userId;
   const isAlertsEnabled = useFlag("alerts");
 
   const mainRoutes = useMemo(() => {
-    const routes: ISidebarRoute[] = [
-      {
-        title: "Home",
-        icon: props => <Home {...props} />,
-        url: UrlService.home(),
-        activeRoutes: [UrlService.home()]
-      },
-      {
-        title: "Deployments",
-        icon: props => <Cloud {...props} />,
-        url: UrlService.deploymentList(),
-        activeRoutes: [UrlService.deploymentList(), "/deployments", "/new-deployment"]
-      },
-      {
-        title: "Templates",
-        icon: props => <MultiplePages {...props} />,
-        url: UrlService.templates(),
-        activeRoutes: [UrlService.templates()]
-      },
-      {
-        title: "SDL Builder",
-        icon: props => <Tools {...props} />,
-        url: UrlService.sdlBuilder(),
-        activeRoutes: [UrlService.sdlBuilder()],
-        testId: "sidebar-sdl-builder-link"
-      },
-      {
-        title: "Providers",
-        icon: props => <Server {...props} />,
-        url: UrlService.providers(),
-        activeRoutes: [UrlService.providers()]
-      }
-    ];
+    const routes: ISidebarRoute[] = isAuthenticated
+      ? [
+          {
+            title: "Home",
+            icon: props => <Home {...props} />,
+            url: UrlService.home(),
+            activeRoutes: [UrlService.home()]
+          },
+          {
+            title: "Deployments",
+            icon: props => <Cloud {...props} />,
+            url: UrlService.deploymentList(),
+            activeRoutes: [UrlService.deploymentList(), "/deployments", "/new-deployment"]
+          },
+          {
+            title: "Templates",
+            icon: props => <MultiplePages {...props} />,
+            url: UrlService.templates(),
+            activeRoutes: [UrlService.templates()]
+          },
+          {
+            title: "SDL Builder",
+            icon: props => <Tools {...props} />,
+            url: UrlService.sdlBuilder(),
+            activeRoutes: [UrlService.sdlBuilder()],
+            testId: "sidebar-sdl-builder-link"
+          },
+          {
+            title: "Providers",
+            icon: props => <Server {...props} />,
+            url: UrlService.providers(),
+            activeRoutes: [UrlService.providers()]
+          }
+        ]
+      : [];
 
     if (isAlertsEnabled && user?.userId) {
       routes.push({
@@ -110,7 +113,7 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
     }
 
     return routes;
-  }, [isAlertsEnabled, user?.userId]);
+  }, [isAlertsEnabled, isAuthenticated, user?.userId]);
 
   const routeGroups: ISidebarGroupMenu[] = useMemo(
     () => [
@@ -285,18 +288,20 @@ export const Sidebar: React.FunctionComponent<Props> = ({ isMobileOpen, handleDr
     >
       <div className={cn("flex w-full flex-col items-center justify-between", { ["p-4"]: isNavOpen, ["pt-4"]: !isNavOpen })}>
         <div className={cn("flex w-full items-center justify-center pt-4")}>
-          <Link
-            className={cn(buttonVariants({ variant: "default", size: isNavOpen ? "lg" : "icon" }), "h-9 w-full leading-4", {
-              ["h-9 w-11 min-w-0 rounded-sm pb-2 pt-2"]: !isNavOpen
-            })}
-            href={UrlService.newDeployment()}
-            onClick={onDeployClick}
-            data-testid="sidebar-deploy-button"
-            aria-disabled={settings.isBlockchainDown}
-          >
-            <Rocket className={cn("rotate-45", { ["mr-2"]: isNavOpen })} fontSize="small" />
-            {isNavOpen && "Deploy "}
-          </Link>
+          {isAuthenticated && (
+            <Link
+              className={cn(buttonVariants({ variant: "default", size: isNavOpen ? "lg" : "icon" }), "h-9 w-full leading-4", {
+                ["h-9 w-11 min-w-0 rounded-sm pb-2 pt-2"]: !isNavOpen
+              })}
+              href={UrlService.newDeployment()}
+              onClick={onDeployClick}
+              data-testid="sidebar-deploy-button"
+              aria-disabled={settings.isBlockchainDown}
+            >
+              <Rocket className={cn("rotate-45", { ["mr-2"]: isNavOpen })} fontSize="small" />
+              {isNavOpen && "Deploy "}
+            </Link>
+          )}
         </div>
 
         {routeGroups.map((g, i) => (

--- a/apps/deploy-web/src/pages/404.tsx
+++ b/apps/deploy-web/src/pages/404.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";
 
 import { Title } from "@src/components/shared/Title";
+import { useUser } from "@src/hooks/useUser";
 import { isSelfCustodyRoute } from "@src/lib/nextjs/pageGuards/selfCustody";
 import { definePublicPage } from "@src/lib/pages/definePublicPage";
 import { UrlService } from "@src/utils/urlUtils";
@@ -17,6 +18,8 @@ export const CONSOLE_AIR_REPO_URL = "https://github.com/akash-network/console-ai
 const FourOhFour: React.FunctionComponent = () => {
   const router = useRouter();
   const showSelfCustodyHint = isSelfCustodyRoute(router.asPath);
+  const { user } = useUser();
+  const isAuthenticated = !!user?.userId;
 
   return (
     <Layout>
@@ -26,12 +29,14 @@ const FourOhFour: React.FunctionComponent = () => {
         <Title className="mb-2">404</Title>
         <h3 className="text-2xl">Page not found.</h3>
 
-        <div className="pt-6">
-          <Link href={UrlService.home()} className={cn(buttonVariants({ variant: "default" }), "inline-flex items-center")}>
-            <ArrowLeft className="mr-4" />
-            Go to homepage
-          </Link>
-        </div>
+        {isAuthenticated && (
+          <div className="pt-6">
+            <Link href={UrlService.home()} className={cn(buttonVariants({ variant: "default" }), "inline-flex items-center")}>
+              <ArrowLeft className="mr-4" />
+              Go to homepage
+            </Link>
+          </div>
+        )}
 
         {showSelfCustodyHint && (
           <Card className="mx-auto mt-10 max-w-xl text-left">

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -9,6 +9,7 @@ export type FeatureFlag =
   | "console_embedded_login"
   | "self_custody"
   | "console_auth_passwordless"
+  | "console_auth_password_escape_hatch"
   | "console_onboarding_redesign"
   | "bid_screening"
   | "ui_sdl_preview_panel";

--- a/apps/deploy-web/src/utils/walletUtils.spec.ts
+++ b/apps/deploy-web/src/utils/walletUtils.spec.ts
@@ -130,6 +130,27 @@ describe("walletUtils", () => {
       cleanup();
     });
 
+    it("returns undefined without throwing when an update has a null address and no prior entry", () => {
+      const { cleanup } = setup();
+
+      const result = updateStorageManagedWallet({ userId: USER_ID_1, address: null as never, creditAmount: 100, isTrialing: false });
+      expect(result).toBeUndefined();
+
+      cleanup();
+    });
+
+    it("falls back to the previous address when an update carries a null address", () => {
+      const { cleanup } = setup();
+
+      updateStorageManagedWallet(buildManagedLocalWallet({ address: WALLET_ADDRESS_1, userId: USER_ID_1, creditAmount: 100, isTrialing: false }));
+      const result = updateStorageManagedWallet({ userId: USER_ID_1, address: null as never, creditAmount: 150 });
+
+      expect(result?.address).toBe(WALLET_ADDRESS_1);
+      expect(result?.creditAmount).toBe(150);
+
+      cleanup();
+    });
+
     it("preserves other users' entries (multi-user isolation)", () => {
       const { cleanup } = setup();
 

--- a/apps/deploy-web/src/utils/walletUtils.ts
+++ b/apps/deploy-web/src/utils/walletUtils.ts
@@ -57,7 +57,11 @@ export function updateStorageManagedWallet(update: ManagedWalletUpdate): Managed
   const networkId = browserEnvConfig.NEXT_PUBLIC_MANAGED_WALLET_NETWORK_ID;
   const prev = getStorageManagedWallet(update.userId, networkId);
 
-  if (!prev && (update.address === undefined || update.creditAmount === undefined || update.isTrialing === undefined)) {
+  const address = update.address ?? prev?.address;
+  const creditAmount = update.creditAmount ?? prev?.creditAmount;
+  const isTrialing = update.isTrialing ?? prev?.isTrialing;
+
+  if (address === undefined || creditAmount === undefined || isTrialing === undefined) {
     errorHandler.reportError({
       error: new Error("Cannot create managed wallet entry without address, creditAmount and isTrialing"),
       severity: "warning",
@@ -68,10 +72,10 @@ export function updateStorageManagedWallet(update: ManagedWalletUpdate): Managed
   }
 
   const next: ManagedLocalWallet = {
-    address: update.address ?? prev!.address,
+    address,
     token: update.token ?? prev?.token,
-    creditAmount: update.creditAmount ?? prev!.creditAmount,
-    isTrialing: update.isTrialing ?? prev!.isTrialing,
+    creditAmount,
+    isTrialing,
     userId: update.userId,
     name: "Managed Wallet",
     isManaged: true,

--- a/apps/deploy-web/tests/ui/actions/auth.ts
+++ b/apps/deploy-web/tests/ui/actions/auth.ts
@@ -23,11 +23,17 @@ export function generateTestPassword(): string {
  * flow is active. Races a passwordless marker against an email/password marker
  * and returns the first to appear.
  *
+ * When `preferPassword` is set, navigates to /login?auth=password so the FF-gated
+ * password escape hatch (console_auth_password_escape_hatch) is selected when
+ * available; the param is inert when the flag is off, so callers transparently
+ * fall back to whichever UI the environment serves.
+ *
  * Throws if neither marker resolves within DETECT_TIMEOUT_MS.
  * Leaves the page on /login so callers can drive the matching flow directly.
  */
-export async function detectAuthType(page: Page): Promise<AuthType> {
-  await page.goto(`${testEnvConfig.BASE_URL}/login`);
+export async function detectAuthType(page: Page, options: { preferPassword?: boolean } = {}): Promise<AuthType> {
+  const path = options.preferPassword ? "/login?auth=password" : "/login";
+  await page.goto(`${testEnvConfig.BASE_URL}${path}`);
 
   const passwordless = page
     .getByRole("button", { name: /continue with email/i })
@@ -56,7 +62,7 @@ export async function loginExistingUser(page: Page): Promise<void> {
     throw new Error('TEST_USER_EMAIL env var is required for userType: "existing" tests');
   }
 
-  const authType = await detectAuthType(page);
+  const authType = await detectAuthType(page, { preferPassword: true });
 
   if (authType === "passwordless") {
     await signInPasswordless(page, email);
@@ -81,7 +87,7 @@ export async function registerNewUser(
   page: Page,
   deps: { auth0: Auth0ManagementService; emailVerification: EmailVerificationStrategy }
 ): Promise<{ email: string; userId: string }> {
-  const authType = await detectAuthType(page);
+  const authType = await detectAuthType(page, { preferPassword: true });
   const email = authType === "passwordless" ? await registerPasswordless(page) : await registerWithEmailPassword(page, deps);
 
   const auth0User = await deps.auth0.getUserByEmail(email);
@@ -101,7 +107,7 @@ async function registerWithEmailPassword(page: Page, deps: { auth0: Auth0Managem
   const email = deps.emailVerification.generateEmail();
   const auth = new AuthPage(page);
 
-  await page.goto(`${testEnvConfig.BASE_URL}/login?tab=signup`);
+  await page.goto(`${testEnvConfig.BASE_URL}/login?tab=signup&auth=password`);
 
   const sinceMs = Date.now();
   const signupResponse = page.waitForResponse(response => response.url().endsWith("/api/auth/password-signup") && response.ok(), {
@@ -128,7 +134,7 @@ async function signInWithPassword(page: Page, credentials: { email: string; pass
 }
 
 /** Drives the passwordless (email OTP via Mailsac) flow for the given email. Page is expected to be on /login. */
-async function signInPasswordless(page: Page, email: string): Promise<void> {
+export async function signInPasswordless(page: Page, email: string): Promise<void> {
   const otp = new MailsacCodeVerificationStrategy(testEnvConfig.MAILSAC_API_KEY);
   const auth = new AuthPagePasswordless(page);
 

--- a/apps/deploy-web/tests/ui/pages/HomePage.ts
+++ b/apps/deploy-web/tests/ui/pages/HomePage.ts
@@ -9,6 +9,20 @@ export class HomePage {
     await this.page.goto(testEnvConfig.BASE_URL);
   }
 
+  getConnectedWallet() {
+    return this.page.getByLabel("Connected wallet name and balance");
+  }
+
+  /**
+   * Waits for the authenticated shell to settle (connected wallet rendered) and
+   * resolves true when the app stayed on home rather than redirecting to
+   * onboarding or signup — i.e. the current user is an existing, onboarded one.
+   */
+  async isCurrentPage(): Promise<boolean> {
+    await this.getConnectedWallet().waitFor({ state: "visible", timeout: 30_000 });
+    return !/^\/(onboarding|signup)/.test(new URL(this.page.url()).pathname);
+  }
+
   async startTrial() {
     await this.page.getByRole("button", { name: /start trial/i }).click();
   }

--- a/apps/deploy-web/tests/ui/pages/OnboardingPage.ts
+++ b/apps/deploy-web/tests/ui/pages/OnboardingPage.ts
@@ -7,6 +7,15 @@ export class OnboardingPage {
     await this.page.waitForURL(/\/signup/);
   }
 
+  /**
+   * Resolves true once the app has settled on the onboarding flow (signup or the
+   * redesigned onboarding picker) — i.e. the current user is new and not yet onboarded.
+   */
+  async isCurrentPage(): Promise<boolean> {
+    await this.page.waitForURL(/\/(signup|onboarding)/, { timeout: 30_000 });
+    return /\/(signup|onboarding)/.test(new URL(this.page.url()).pathname);
+  }
+
   async startFreeTrial() {
     await this.page.getByRole("button", { name: /start free trial/i }).click();
   }

--- a/apps/deploy-web/tests/ui/passwordless-login.spec.ts
+++ b/apps/deploy-web/tests/ui/passwordless-login.spec.ts
@@ -1,47 +1,50 @@
 import { ManagementApiError } from "auth0";
 
-import { detectAuthType } from "./actions/auth";
-import { test } from "./fixture/base-test";
+import { signInPasswordless } from "./actions/auth";
+import { expect, test } from "./fixture/base-test";
 import { testEnvConfig } from "./fixture/test-env.config";
-import { AuthPagePasswordless } from "./pages/AuthPagePasswordless";
+import { HomePage } from "./pages/HomePage";
+import { OnboardingPage } from "./pages/OnboardingPage";
 import { MailsacCodeVerificationStrategy } from "./services/email-verification/mailsac-code.strategy";
 
-test.describe("Passwordless login", () => {
-  let testUserId: string | undefined;
+test.describe("Passwordless auth", () => {
+  let createdUserId: string | undefined;
   const otp = new MailsacCodeVerificationStrategy(testEnvConfig.MAILSAC_API_KEY);
 
   test.afterEach(async ({ auth0 }) => {
-    if (!testUserId) return;
+    if (!createdUserId) return;
     try {
-      await auth0.deleteUser(testUserId);
+      await auth0.deleteUser(createdUserId);
     } catch (error) {
       if (!(error instanceof ManagementApiError) || error.statusCode !== 404) {
         throw error;
       }
     } finally {
-      testUserId = undefined;
+      createdUserId = undefined;
     }
   });
 
-  test("receives OTP, verifies, lands authenticated", async ({ page, auth0 }) => {
+  test("new user registers via passwordless and lands on onboarding", async ({ page, auth0 }) => {
     test.setTimeout(3 * 60 * 1000);
 
-    const authType = await detectAuthType(page);
-    test.skip(authType !== "passwordless", "Skipped: /login renders email-password — passwordless flow not active in this environment");
-
     const email = otp.generateEmail();
-    const auth = new AuthPagePasswordless(page);
 
-    const sinceMs = Date.now();
-    await auth.startWithEmail(email);
-    await auth.waitForVerifyScreen();
-
-    await otp.verify({ context: page.context(), email, userId: "", sinceMs });
-
-    await auth.waitForRedirectAwayFromLogin();
+    await page.goto(`${testEnvConfig.BASE_URL}/login`);
+    await signInPasswordless(page, email);
 
     const auth0User = await auth0.getUserByEmail(email);
     if (!auth0User) throw new Error(`Auth0 user was not created for ${email}`);
-    testUserId = auth0User.user_id;
+    createdUserId = auth0User.user_id;
+
+    expect(await new OnboardingPage(page).isCurrentPage()).toBe(true);
+  });
+
+  test("existing user logs in via passwordless and lands on the home page", async ({ page }) => {
+    test.setTimeout(3 * 60 * 1000);
+
+    await page.goto(`${testEnvConfig.BASE_URL}/login`);
+    await signInPasswordless(page, testEnvConfig.TEST_USER_EMAIL!);
+
+    expect(await new HomePage(page).isCurrentPage()).toBe(true);
   });
 });

--- a/apps/deploy-web/tests/ui/services/email-verification/mailsac-code.strategy.ts
+++ b/apps/deploy-web/tests/ui/services/email-verification/mailsac-code.strategy.ts
@@ -9,11 +9,14 @@ import type { EmailVerificationStrategy } from "./email-verification.strategy";
  */
 const CODE_NEAR_KEYWORD = /\bcode\b[\s\S]{0,200}?\b(\d{6})\b/i;
 
-/** Delay between Mailsac inbox polls while waiting for a fresh code. */
-const POLL_INTERVAL_MS = 2_000;
+/** Total time to wait for a fresh code to arrive before giving up. */
+const POLL_DEADLINE_MS = 60_000;
 
-/** Maximum poll cycles before giving up on a fresh code arriving. ~60s at default interval. */
-const POLL_MAX_ATTEMPTS = 30;
+/** First delay between inbox polls; grows exponentially up to the cap to reduce API calls when delivery lags. */
+const POLL_INITIAL_INTERVAL_MS = 1_000;
+
+/** Upper bound on the backoff delay between polls. */
+const POLL_MAX_INTERVAL_MS = 5_000;
 
 /** How long after typing a code we wait for either successful navigation or a rejection alert. */
 const SUBMIT_TIMEOUT_MS = 10_000;
@@ -60,12 +63,13 @@ export class MailsacCodeVerificationStrategy implements EmailVerificationStrateg
   async verify(input: { context: BrowserContext; email: string; userId: string; sinceMs: number }): Promise<void> {
     const page = this.#requireActivePage(input.context);
     const triedMessageIds = new Set<string>();
+    const scannedWithoutCode = new Set<string>();
     const failures: CodeAttemptFailure[] = [];
 
     for (;;) {
       let candidate: CodeCandidate;
       try {
-        candidate = await this.#pollForNextCode(input.email, input.sinceMs, triedMessageIds);
+        candidate = await this.#pollForNextCode(input.email, input.sinceMs, triedMessageIds, scannedWithoutCode);
       } catch (pollError) {
         throw this.#buildExhaustedError(input.email, failures, pollError);
       }
@@ -86,28 +90,38 @@ export class MailsacCodeVerificationStrategy implements EmailVerificationStrateg
     return page;
   }
 
-  async #pollForNextCode(email: string, freshAfterMs: number, excludeMessageIds: Set<string>): Promise<CodeCandidate> {
+  async #pollForNextCode(email: string, freshAfterMs: number, excludeMessageIds: Set<string>, scannedWithoutCode: Set<string>): Promise<CodeCandidate> {
     const pollErrors: Error[] = [];
+    const deadline = Date.now() + POLL_DEADLINE_MS;
+    let interval = POLL_INITIAL_INTERVAL_MS;
 
-    for (let attempt = 0; attempt < POLL_MAX_ATTEMPTS; attempt++) {
+    for (;;) {
       try {
         const messages = await this.#fetchMessages(email);
-        for (const message of messages) {
-          if (excludeMessageIds.has(message._id)) continue;
+        for (const message of messagesNewestFirst(messages)) {
+          if (excludeMessageIds.has(message._id) || scannedWithoutCode.has(message._id)) continue;
           if (!isMessageFreshSince(message, freshAfterMs)) continue;
           const body = await this.#fetchMessageBody(email, message._id);
           const code = body.match(CODE_NEAR_KEYWORD)?.[1];
-          if (code) return { messageId: message._id, code };
+          if (code) {
+            return { messageId: message._id, code };
+          }
+          scannedWithoutCode.add(message._id);
         }
       } catch (error) {
         pollErrors.push(error instanceof Error ? error : new Error(String(error)));
       }
 
-      await sleep(POLL_INTERVAL_MS);
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await sleep(Math.min(interval, remaining));
+      interval = Math.min(interval * 2, POLL_MAX_INTERVAL_MS);
     }
 
-    const timeoutSec = (POLL_MAX_ATTEMPTS * POLL_INTERVAL_MS) / 1_000;
-    throw new AggregateError(pollErrors, `No fresh verification code found for ${email} within ${timeoutSec}s (excluded ${excludeMessageIds.size} tried)`);
+    throw new AggregateError(
+      pollErrors,
+      `No fresh verification code found for ${email} within ${POLL_DEADLINE_MS / 1_000}s (excluded ${excludeMessageIds.size} tried)`
+    );
   }
 
   async #submitCode(page: Page, code: string, mustWaitForInputClear: boolean): Promise<void> {
@@ -186,8 +200,21 @@ export class MailsacCodeVerificationStrategy implements EmailVerificationStrateg
 }
 
 function isMessageFreshSince(message: MailsacMessage, freshAfterMs: number): boolean {
-  const receivedMs = message.received ? Date.parse(message.received) : NaN;
-  return !Number.isNaN(receivedMs) && receivedMs >= freshAfterMs;
+  return receivedMs(message) >= freshAfterMs;
+}
+
+/**
+ * Sorts a copy newest-first so the most recent (and most likely OTP) message is scanned
+ * before older ones — the working code is then found in the fewest body fetches.
+ */
+function messagesNewestFirst(messages: MailsacMessage[]): MailsacMessage[] {
+  return [...messages].sort((a, b) => receivedMs(b) - receivedMs(a));
+}
+
+/** Parsed `received` timestamp in ms, or -Infinity when missing/unparseable so it sorts last. */
+function receivedMs(message: MailsacMessage): number {
+  const ms = message.received ? Date.parse(message.received) : NaN;
+  return Number.isNaN(ms) ? -Infinity : ms;
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## Why

Primary objective: cut Mailsac API usage in e2e. Two changes serve it:

1. **Password login needs no email.** Existing-user e2e login is the hot path; driving it through email/password instead of passwordless OTP removes Mailsac from that path entirely — zero inbox polls, zero body fetches.
2. **The remaining passwordless paths poll Mailsac more frugally.**

Production must stay passwordless-only, so the password flow is gated behind a feature flag and an explicit `?auth=password` opt-in. A managed-wallet storage crash surfaced while wiring the e2e flow is fixed here too.

## What

**Password escape hatch (FF-gated, prod stays passwordless)**
- New `console_auth_password_escape_hatch` feature flag.
- `AuthPage` renders `PasswordAuth` only when passwordless is on, the escape-hatch flag is on, and `?auth=password` is present; otherwise it stays passwordless. Inert in production where the flag is off.
- e2e auth helper navigates existing-user login to `/login?auth=password`, so that path authenticates via password and never touches Mailsac; falls back transparently to passwordless when the flag is off. The passwordless OTP path remains covered by a dedicated spec landing on home.

**Mailsac polling, leaner (for the paths that still need OTP)**
- Each message body is fetched at most once (skip-scanned set).
- Inbox is scanned newest-first so the OTP is found in the fewest body fetches.
- Polling uses exponential backoff against a 60s deadline instead of a fixed 2s interval — fewer calls while waiting for delivery.

**Managed-wallet crash fix**
- `updateStorageManagedWallet` no longer throws on a null address with no stored entry; merged values are derived via optional chaining and validated before building the entry, removing the unsafe `prev!` dereferences. Two new tests cover the null-address paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password sign-in can be forced via a URL parameter when allowed by a new feature flag.
  * Sidebar and 404 now adapt their UI based on authentication state.

* **Bug Fixes**
  * More reliable email-code verification with deadline-based polling and exponential backoff.

* **Improvements**
  * Safer managed-wallet updates: null-address updates preserve existing address and validate fields more strictly.

* **Tests**
  * Expanded auth tests for escape-hatch scenarios, updated UI test helpers and pages, and refactored end-to-end passwordless login.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->