### PR TITLE
chore(ci): bump codecov-action to v7.0.0

### DIFF
--- a/.github/workflows/reusable-validate-app.yml
+++ b/.github/workflows/reusable-validate-app.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && steps.tests_details.outputs.has_tests == 'true' && github.event_name != 'merge_group' }}
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           report_type: test_results
           files: ./junit.xml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload Test Coverage
         if: steps.tests_details.outputs.has_tests == 'true' && github.event_name != 'merge_group'
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           fail_ci_if_error: true
           directory: ./apps/${{ inputs.app }}/coverage


### PR DESCRIPTION
## Why

CI is currently red across the whole repo (including `main`) — every `validate` job fails at the Codecov coverage-upload step with:

```
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
```

The root cause is server-side: Codecov lost control of their `keybase.io/codecovsecurity` account and bricked it, migrating to `codecovsecops`. Action versions ≤ v6.0.1 fetch the now-dead key URL, so the GPG key import returns no data and the CLI signature check fails with `No public key`. Confirmed by Codecov maintainers in codecov/codecov-action#1955 and codecov/codecov-action#1956. It reproduces on v5.5.4 (our current pin) **and** v6.0.1, so re-running or a v6 bump does not help.

## What

Bumps `codecov/codecov-action` from v5.5.4 → **v7.0.0** (pinned to SHA `fb8b358`) in `reusable-validate-app.yml` (both the test-results and coverage upload steps). v7.0.0 fetches the signing key from the new `codecovsecops` keybase account, resolving the verification failure.

Verified the inputs we use (`report_type`, `files`, `name`, `flags`, `token`, `fail_ci_if_error`, `directory`) are all still present in v7.0.0's `action.yml` — the v6→v7 changelog contains no user-facing input changes, so no breaking changes affect us.