### PR TITLE
feat(stats): render MsgLeaseStartReclaim in transaction explorer

### DIFF
--- a/apps/stats-web/src/components/transactions/akash/MsgLeaseStartReclaim.tsx
+++ b/apps/stats-web/src/components/transactions/akash/MsgLeaseStartReclaim.tsx
@@ -1,0 +1,24 @@
+"use client";
+import Link from "next/link";
+
+import { LabelValue } from "../../LabelValue";
+import { createMsgView } from "../createMsgView";
+
+import { AddressLink } from "@/components/AddressLink";
+import { formatLeaseCloseReason } from "@/lib/leaseCloseReason";
+import { UrlService } from "@/lib/urlUtils";
+
+export const MsgLeaseStartReclaim = createMsgView(["v1beta5"], ({ message }) => {
+  const id = message?.data?.id;
+
+  return (
+    <>
+      <LabelValue label="Owner" value={<AddressLink address={id?.owner} />} />
+      <LabelValue label="dseq" value={<Link href={UrlService.deployment(id?.owner, id?.dseq)}>{id?.dseq}</Link>} />
+      <LabelValue label="gseq" value={id?.gseq} />
+      <LabelValue label="oseq" value={id?.oseq} />
+      <LabelValue label="Provider" value={<Link href={UrlService.address(id?.provider)}>{id?.provider}</Link>} />
+      <LabelValue label="Reason" value={formatLeaseCloseReason(message?.data?.reason)} />
+    </>
+  );
+});

--- a/apps/stats-web/src/components/transactions/akash/index.ts
+++ b/apps/stats-web/src/components/transactions/akash/index.ts
@@ -9,6 +9,7 @@ export * from "./MsgCreateLease";
 export * from "./MsgCreateProvider";
 export * from "./MsgDeleteProviderAttributes";
 export * from "./MsgDepositDeployment";
+export * from "./MsgLeaseStartReclaim";
 export * from "./MsgPauseGroup";
 export * from "./MsgRevokeCertificate";
 export * from "./MsgSignProviderAttributes";

--- a/apps/stats-web/src/lib/leaseCloseReason.spec.ts
+++ b/apps/stats-web/src/lib/leaseCloseReason.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { formatLeaseCloseReason } from "./leaseCloseReason";
+
+describe(formatLeaseCloseReason.name, () => {
+  it.each([
+    ["lease_closed_owner", "Closed by tenant"],
+    ["lease_closed_reason_unstable", "Workloads unstable (provider)"],
+    ["lease_closed_reason_decommission", "Provider decommissioned"],
+    ["lease_closed_reason_manifest_timeout", "Manifest timeout (provider)"],
+    ["lease_closed_reason_unspecified", "Unspecified (provider)"],
+    ["lease_closed_reason_insufficient_funds", "Insufficient funds"]
+  ])("maps the enum name %s to its friendly label", (reason, expected) => {
+    expect(formatLeaseCloseReason(reason)).toBe(expected);
+  });
+
+  it("resolves a numeric string that matches a known reason", () => {
+    // The provider "unstable" reason is enum value 10000.
+    expect(formatLeaseCloseReason("10000")).toBe("Workloads unstable (provider)");
+  });
+
+  it.each([
+    ["500", "Closed by tenant"],
+    ["15000", "Closed by provider"],
+    ["25000", "Closed by network"]
+  ])("falls back to a range-based label for unmapped value %s", (reason, expected) => {
+    expect(formatLeaseCloseReason(reason)).toBe(expected);
+  });
+
+  it("returns 'Unspecified' when the reason is omitted", () => {
+    expect(formatLeaseCloseReason()).toBe("Unspecified");
+  });
+
+  it.each(["0", "lease_closed_invalid", "UNRECOGNIZED"])("returns 'Unspecified' for the zero/invalid sentinel %s", reason => {
+    expect(formatLeaseCloseReason(reason)).toBe("Unspecified");
+  });
+
+  it("returns the raw value for an unrecognized reason name", () => {
+    expect(formatLeaseCloseReason("some_future_reason")).toBe("some_future_reason");
+  });
+
+  it("returns the raw value for an out-of-range numeric reason", () => {
+    expect(formatLeaseCloseReason("30000")).toBe("30000");
+  });
+});

--- a/apps/stats-web/src/lib/leaseCloseReason.ts
+++ b/apps/stats-web/src/lib/leaseCloseReason.ts
@@ -1,0 +1,64 @@
+import { LeaseClosedReason } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+
+/**
+ * Viewer-neutral labels for a lease's close/reclaim reason, for the public transaction explorer.
+ *
+ * Unlike deploy-web's tenant-centric labels (e.g. "Closed by you"), these read correctly for any
+ * third-party viewer of stats.akash.network.
+ *
+ * Source of truth for the values/names is `LeaseClosedReason` in @akashnetwork/chain-sdk
+ * (akash.market.v1). The chain encodes who initiated the close in numeric ranges:
+ *   1..9999      tenant-initiated
+ *   10000..19999 provider-initiated
+ *   20000..29999 network-initiated
+ */
+const REASON_LABELS: Partial<Record<LeaseClosedReason, string>> = {
+  [LeaseClosedReason.lease_closed_owner]: "Closed by tenant",
+  [LeaseClosedReason.lease_closed_reason_unstable]: "Workloads unstable (provider)",
+  [LeaseClosedReason.lease_closed_reason_decommission]: "Provider decommissioned",
+  [LeaseClosedReason.lease_closed_reason_manifest_timeout]: "Manifest timeout (provider)",
+  [LeaseClosedReason.lease_closed_reason_unspecified]: "Unspecified (provider)",
+  [LeaseClosedReason.lease_closed_reason_insufficient_funds]: "Insufficient funds"
+};
+
+function toNumericReason(reason: string): number | undefined {
+  if (/^\d+$/.test(reason)) {
+    return Number(reason);
+  }
+
+  // Numeric enums expose a name->value mapping, so a known enum name resolves to its number.
+  const value = LeaseClosedReason[reason as keyof typeof LeaseClosedReason];
+  return typeof value === "number" ? value : undefined;
+}
+
+function classifyByRange(value: number): string | undefined {
+  if (value >= 1 && value <= 9999) return "Closed by tenant";
+  if (value >= 10000 && value <= 19999) return "Closed by provider";
+  if (value >= 20000 && value <= 29999) return "Closed by network";
+  return undefined;
+}
+
+/**
+ * Formats a lease close reason into a friendly, viewer-neutral label.
+ *
+ * The API serializes the reason as the enum *name* string (e.g. "lease_closed_reason_unstable"),
+ * and omits it entirely for the zero value, so this accepts an optional string. A numeric string is
+ * also accepted defensively. Unknown values fall back to a range-based label, then to the raw value.
+ */
+export function formatLeaseCloseReason(reason?: string): string {
+  if (!reason) {
+    return "Unspecified";
+  }
+
+  const value = toNumericReason(reason);
+  if (value === undefined) {
+    // Unknown enum name — surface the raw value rather than hide information.
+    return reason;
+  }
+  if (value <= 0) {
+    // lease_closed_invalid (0) or UNRECOGNIZED (-1)
+    return "Unspecified";
+  }
+
+  return REASON_LABELS[value as LeaseClosedReason] ?? classifyByRange(value) ?? reason;
+}


### PR DESCRIPTION
## Why

`stats.akash.network` is the public record of on-chain Console activity. After the v2.1.0 network upgrade (AEP-82 resource reclamation), providers submit `MsgLeaseStartReclaim` to begin reclaiming a lease. Without a dedicated component the stats-web transaction explorer renders it through the raw-JSON fallback. This adds a proper component so it renders like every other recognized Akash message type.

Closes CON-379

> [!NOTE]
> The reclamation **deadline** is intentionally out of scope: it lives only on the `EventLeaseReclaimStarted` block event (not on the message), the tx explorer renders message data only, and the indexer work to surface it (CON-287) was cancelled. This PR ships the **lease + provider reason**. CON-379's acceptance criteria should be updated to drop the deadline bullet.

## What

- **New** `apps/stats-web/src/lib/leaseCloseReason.ts` — `formatLeaseCloseReason()`, a pure helper mapping the chain's `LeaseClosedReason` to **viewer-neutral** labels (e.g. "Workloads unstable (provider)", "Provider decommissioned"), with numeric-range and raw-value fallbacks. Deliberately neutral, unlike deploy-web's tenant-centric "Closed by you".
- **New** `apps/stats-web/src/components/transactions/akash/MsgLeaseStartReclaim.tsx` — renders owner/dseq/gseq/oseq/provider + a friendly Reason row. Auto-wired into the dispatcher purely via the `akash/` barrel export (no dispatcher edit needed).
- **New** `leaseCloseReason.spec.ts` — 16 cases: each enum name, numeric/range fallbacks, omitted/zero/invalid sentinels, raw fallback.

No backend changes — the API already decodes the message generically (`msgToJSON`) and the indexer stores it generically.

**Verification (from `apps/stats-web`):** `npx tsc --noEmit` ✅ · `npm run lint -- --quiet` ✅ · `npm run test:unit` ✅ (37 passed)

stats-web has no component-test (RTL/jsdom) infrastructure — vitest runs `environment: "node"` and globs only `*.spec.ts` — so the component is verified by type-checking; its only logic is the unit-tested helper. Manual smoke once a real reclaim tx exists post-upgrade: open `/transactions/{hash}` and confirm the lease + Reason rows render instead of the JSON fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added UI component for displaying lease start reclaim transactions, including owner, provider, deployment details, and reclaim reason information
  * Implemented human-readable formatting for lease close and reclaim reasons to improve stats explorer usability

* **Tests**
  * Added comprehensive test coverage for lease close reason formatting with various input scenarios and edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->