### PR TITLE
feat(bid): forward reclamation window through bid read path

### DIFF
--- a/apps/api/src/bid/http-schemas/bid.schema.spec.ts
+++ b/apps/api/src/bid/http-schemas/bid.schema.spec.ts
@@ -1,0 +1,22 @@
+import { BidResponseSchema } from "./bid.schema";
+
+import { createBid } from "@test/seeders/bid.seeder";
+
+describe("BidResponseSchema", () => {
+  it("keeps the reclamation_window when the provider offers one", () => {
+    const bid = createBid();
+    bid.bid.reclamation_window = "86400s";
+
+    const result = BidResponseSchema.parse(bid);
+
+    expect(result.bid.reclamation_window).toBe("86400s");
+  });
+
+  it("parses a bid without a reclamation_window", () => {
+    const bid = createBid();
+
+    const result = BidResponseSchema.parse(bid);
+
+    expect(result.bid.reclamation_window).toBeUndefined();
+  });
+});

--- a/apps/api/src/bid/http-schemas/bid.schema.ts
+++ b/apps/api/src/bid/http-schemas/bid.schema.ts
@@ -79,7 +79,10 @@ export const BidResponseSchema = z.object({
         resources: DeploymentResource_V3,
         count: z.number()
       })
-    )
+    ),
+    // Present only on v2.1+ bids where the provider offers a reclamation window (AEP-82).
+    // Zod strips unknown keys, so without this the field would be dropped from the managed API response.
+    reclamation_window: z.string().optional()
   }),
   escrow_account: z.object({
     id: z.object({

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -3196,6 +3196,9 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                 ],
                                 "type": "object",
                               },
+                              "reclamation_window": {
+                                "type": "string",
+                              },
                               "resources_offer": {
                                 "items": {
                                   "properties": {
@@ -3640,6 +3643,9 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                                   "amount",
                                 ],
                                 "type": "object",
+                              },
+                              "reclamation_window": {
+                                "type": "string",
                               },
                               "resources_offer": {
                                 "items": {

--- a/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentListRow.tsx
@@ -76,7 +76,7 @@ export const DeploymentListRow: React.FunctionComponent<Props> = ({ deployment, 
   const reclaimingLease = filteredLeases?.find(isReclaiming);
   const closedLease = filteredLeases?.find(l => !isLeaseLive(l));
   const isAllLeasesClosed = !!filteredLeases?.length && !hasActiveLeases;
-  const deploymentCost = hasActiveLeases ? liveLeases?.reduce((prev, current) => prev + parseFloat(current.price.amount), 0) : 0;
+  const deploymentCost = liveLeases?.reduce((prev, current) => prev + parseFloat(current.price.amount), 0) ?? 0;
   const reclaimDeadline = reclaimingLease ? getReclamationDeadline(reclaimingLease) : null;
   const closedReasonLabel = closedLease ? getClosedLeaseLabel(closedLease) : null;
   const hasGpu = Boolean(deployment.gpuAmount && deployment.gpuAmount > 0);

--- a/apps/deploy-web/src/components/new-deployment/BidRow/BidRow.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/BidRow/BidRow.spec.tsx
@@ -93,6 +93,20 @@ describe(BidRow.name, () => {
     expect(components.RadioGroupItem).not.toHaveBeenCalled();
   });
 
+  it("displays the offered reclamation window when the bid has one", () => {
+    const bid = buildDeploymentBid({ reclamationWindow: "86400s" });
+    const { getByText } = setup({ bid });
+
+    expect(getByText(/Reclamation: 1 day/)).toBeInTheDocument();
+  });
+
+  it("does not display a reclamation window when the bid has none", () => {
+    const bid = buildDeploymentBid({ reclamationWindow: undefined });
+    const { queryByText } = setup({ bid });
+
+    expect(queryByText(/Reclamation:/)).not.toBeInTheDocument();
+  });
+
   function setup(
     props: Partial<{
       bid: BidDto;

--- a/apps/deploy-web/src/components/new-deployment/BidRow/BidRow.tsx
+++ b/apps/deploy-web/src/components/new-deployment/BidRow/BidRow.tsx
@@ -2,7 +2,9 @@
 import { useEffect } from "react";
 import { Badge, CustomTooltip, RadioGroup, RadioGroupItem, Spinner, TableCell, TableRow } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
-import { CloudXmark, WarningTriangle } from "iconoir-react";
+import formatDuration from "date-fns/formatDuration";
+import intervalToDuration from "date-fns/intervalToDuration";
+import { CloudXmark, ShieldCheck, WarningTriangle } from "iconoir-react";
 
 import { useLocalNotes } from "@src/components/LocalNoteManager";
 import { useServices } from "@src/context/ServicesProvider";
@@ -12,6 +14,7 @@ import type { ApiProviderList } from "@src/types/provider";
 import { getGpusFromAttributes } from "@src/utils/deploymentUtils";
 import { hasSomeParentTheClass } from "@src/utils/domUtils";
 import { udenomToDenom } from "@src/utils/mathHelpers";
+import { parseReclamationWindowSeconds } from "@src/utils/reclamationUtils";
 import { AuditorButton } from "../../providers/AuditorButton";
 import { Uptime } from "../../providers/Uptime";
 import { CopyTextToClipboardButton } from "../../shared/CopyTextToClipboardButton";
@@ -44,6 +47,7 @@ export const COMPONENTS = {
   ProviderName,
   CopyTextToClipboardButton,
   CloudXmark,
+  ShieldCheck,
   Uptime,
   AuditorButton
 };
@@ -70,6 +74,9 @@ export const BidRow: React.FunctionComponent<Props> = ({
     retry: false
   });
   const gpuModels = bid.resourcesOffer.flatMap(x => getGpusFromAttributes(x.resources.gpu.attributes));
+  const reclamationWindowSeconds = parseReclamationWindowSeconds(bid.reclamationWindow);
+  const reclamationWindowLabel =
+    reclamationWindowSeconds !== null ? formatDuration(intervalToDuration({ start: 0, end: reclamationWindowSeconds * 1000 })) : null;
 
   useEffect(() => {
     if (provider) {
@@ -146,6 +153,14 @@ export const BidRow: React.FunctionComponent<Props> = ({
             <c.CopyTextToClipboardButton value={provider?.name ?? provider?.hostUri ?? "-"} />
           </div>
         </div>
+        {reclamationWindowLabel && (
+          <c.CustomTooltip title={<>This provider offers a reclamation window of {reclamationWindowLabel} before reclaiming the lease.</>}>
+            <c.Badge variant="secondary" className="mt-1 inline-flex items-center gap-1 px-1.5 py-0 text-xs font-normal">
+              <c.ShieldCheck className="text-xs" />
+              <span>Reclamation: {reclamationWindowLabel}</span>
+            </c.Badge>
+          </c.CustomTooltip>
+        )}
       </c.TableCell>
 
       {gpuModels.length > 0 && (

--- a/apps/deploy-web/src/queries/useBidQuery.spec.ts
+++ b/apps/deploy-web/src/queries/useBidQuery.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import type { RpcBid } from "@src/types/deployment";
+import { mapToBidDto } from "./useBidQuery";
+
+describe(mapToBidDto.name, () => {
+  it("maps the reclamation_window field to reclamationWindow", () => {
+    const result = mapToBidDto(buildRpcBid({ reclamation_window: "86400s" }));
+
+    expect(result.reclamationWindow).toBe("86400s");
+  });
+
+  it("leaves reclamationWindow undefined when the bid offers no reclamation window", () => {
+    const result = mapToBidDto(buildRpcBid());
+
+    expect(result.reclamationWindow).toBeUndefined();
+  });
+
+  it("maps the core bid identity and price", () => {
+    const result = mapToBidDto(buildRpcBid());
+
+    expect(result).toMatchObject({
+      owner: "akash1owner",
+      provider: "akash1provider",
+      dseq: "123",
+      gseq: 1,
+      oseq: 1,
+      state: "open",
+      price: { denom: "uakt", amount: "100" }
+    });
+  });
+
+  function buildRpcBid(bidOverrides?: Partial<RpcBid["bid"]>): RpcBid {
+    return {
+      bid: {
+        id: { owner: "akash1owner", dseq: "123", gseq: 1, oseq: 1, provider: "akash1provider", bseq: 1 },
+        state: "open",
+        price: { denom: "uakt", amount: "100" },
+        resources_offer: [],
+        created_at: "1700000000",
+        ...bidOverrides
+      },
+      escrow_account: {
+        id: { scope: "bid", xid: "xid" },
+        state: { owner: "akash1owner", state: "open", transferred: [], settled_at: "0", funds: [], deposits: [] }
+      }
+    };
+  }
+});

--- a/apps/deploy-web/src/queries/useBidQuery.ts
+++ b/apps/deploy-web/src/queries/useBidQuery.ts
@@ -26,7 +26,8 @@ export function mapToBidDto(b: RpcBid): BidDto {
     oseq: b.bid.id.oseq,
     price: b.bid.price,
     state: b.bid.state,
-    resourcesOffer: b.bid.resources_offer
+    resourcesOffer: b.bid.resources_offer,
+    reclamationWindow: b.bid.reclamation_window
   };
 }
 

--- a/apps/deploy-web/src/types/deployment.ts
+++ b/apps/deploy-web/src/types/deployment.ts
@@ -313,6 +313,9 @@ export interface BidDto {
     resources: DeploymentResource_V3;
     count: number;
   }>;
+  // Reclamation window the provider offers for this bid (AEP-82), as a REST Duration string e.g. "86400s".
+  // Undefined on pre-v2.1 bids or when the provider offers no reclamation.
+  reclamationWindow?: string;
 }
 
 export interface RpcDepositParams {

--- a/apps/deploy-web/src/utils/reclamationUtils.spec.ts
+++ b/apps/deploy-web/src/utils/reclamationUtils.spec.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from "vitest";
 
 import type { DeploymentGroup, LeaseDto } from "@src/types/deployment";
-import { classifyLeaseCloseReason, getLeaseCloseReasonLabel, getReclamationDeadline, isLeaseLive, isProviderReclaimed, isReclaiming } from "./reclamationUtils";
+import {
+  classifyLeaseCloseReason,
+  getLeaseCloseReasonLabel,
+  getReclamationDeadline,
+  isLeaseLive,
+  isProviderReclaimed,
+  isReclaiming,
+  parseReclamationWindowSeconds
+} from "./reclamationUtils";
 
 describe("reclamationUtils", () => {
   describe("classifyLeaseCloseReason", () => {
@@ -53,6 +61,27 @@ describe("reclamationUtils", () => {
 
     it("never returns a raw enum name", () => {
       expect(getLeaseCloseReasonLabel("lease_closed_reason_unstable")).not.toMatch(/lease_closed/);
+    });
+  });
+
+  describe("parseReclamationWindowSeconds", () => {
+    it("parses a REST Duration string to seconds", () => {
+      expect(parseReclamationWindowSeconds("86400s")).toBe(86400);
+    });
+
+    it("tolerates a bare seconds count without the trailing 's'", () => {
+      expect(parseReclamationWindowSeconds("3600")).toBe(3600);
+    });
+
+    it("returns null when the window is absent or empty", () => {
+      expect(parseReclamationWindowSeconds(undefined)).toBeNull();
+      expect(parseReclamationWindowSeconds("")).toBeNull();
+    });
+
+    it("returns null for a non-positive or unparseable window", () => {
+      expect(parseReclamationWindowSeconds("0s")).toBeNull();
+      expect(parseReclamationWindowSeconds("-100s")).toBeNull();
+      expect(parseReclamationWindowSeconds("abc")).toBeNull();
     });
   });
 

--- a/apps/deploy-web/src/utils/reclamationUtils.ts
+++ b/apps/deploy-web/src/utils/reclamationUtils.ts
@@ -57,9 +57,9 @@ export function getLeaseCloseReasonLabel(reason?: string): string {
  * absent/empty/non-positive/unparseable. The trailing "s" is optional for resilience against a bare
  * seconds count. Used to format the offered window in the bid-selection UI (AEP-82).
  */
-export function parseReclamationWindowSeconds(window?: string): number | null {
-  if (!window) return null;
-  const seconds = Number(window.trim().replace(/s$/, ""));
+export function parseReclamationWindowSeconds(reclamationWindow?: string): number | null {
+  if (!reclamationWindow) return null;
+  const seconds = Number(reclamationWindow.trim().replace(/s$/, ""));
   if (!Number.isFinite(seconds) || seconds <= 0) return null;
   return seconds;
 }

--- a/apps/deploy-web/src/utils/reclamationUtils.ts
+++ b/apps/deploy-web/src/utils/reclamationUtils.ts
@@ -52,6 +52,18 @@ export function getLeaseCloseReasonLabel(reason?: string): string {
   }
 }
 
+/**
+ * Parse a bid's offered reclamation window (REST Duration, e.g. "86400s") to seconds, or null when
+ * absent/empty/non-positive/unparseable. The trailing "s" is optional for resilience against a bare
+ * seconds count. Used to format the offered window in the bid-selection UI (AEP-82).
+ */
+export function parseReclamationWindowSeconds(window?: string): number | null {
+  if (!window) return null;
+  const seconds = Number(window.trim().replace(/s$/, ""));
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  return seconds;
+}
+
 /** Reclamation deadline as a Date, or null when absent/0/NaN. `deadline` is unix seconds. */
 export function getReclamationDeadline(lease: Pick<LeaseDto, "reclamation">): Date | null {
   const deadline = lease.reclamation?.deadline;

--- a/packages/http-sdk/src/bid/bid-http.service.ts
+++ b/packages/http-sdk/src/bid/bid-http.service.ts
@@ -60,6 +60,9 @@ export type Bid = {
       count: number;
     }[];
     created_at: string;
+    // Present only on v2.1+ bids where the provider offers a reclamation window (AEP-82).
+    // Nil when the provider offers no reclamation. REST serializes the Duration, e.g. "86400s".
+    reclamation_window?: string;
   };
   escrow_account: {
     id: {


### PR DESCRIPTION
## Why

Part of the AEP-82 lease-reclamation feature family (sibling to CON-289 lease-reclamation display). When a provider offers a reclamation window on a bid, a tenant who requested reclamation (SDL 2.1 `min_window`) currently has no way to see which providers honor it when choosing a bid. This forwards the bid's `reclamation_window` through Console's bid read path and surfaces it in the bid-selection UI.

The literal CON-290 framing ("bid creation paths") doesn't map to this repo — Console never *builds* `MsgCreateBid` (providers do). The coherent Console scope is the **bid read/forward path**, which this PR implements. The indexer reclamation gap (`MsgLeaseStartReclaim` unhandled, no DB columns) is deliberately out of scope and tracked separately.

Ref CON-290

## What

Forwards `reclamation_window` end to end:

- **http-sdk** ([bid-http.service.ts](packages/http-sdk/src/bid/bid-http.service.ts)) — optional `reclamation_window?: string` on `Bid.bid`.
- **API** ([bid.schema.ts](apps/api/src/bid/http-schemas/bid.schema.ts)) — `reclamation_window: z.string().optional()` so Zod doesn't strip it from the managed endpoint. `BidService` forwards as-is, so no service change.
- **deploy-web** — `reclamationWindow?` on `BidDto`, mapped in `mapToBidDto`.
- **UI** ([BidRow.tsx](apps/deploy-web/src/components/new-deployment/BidRow/BidRow.tsx)) — a `ShieldCheck` badge + tooltip in the Provider cell, rendered only when a window is offered, formatted via `date-fns` `formatDuration`. New `parseReclamationWindowSeconds` helper colocated in `reclamationUtils.ts`.

**Forward-compatible:** until providers emit the field (provider v0.13 / node 2.1) every bid's window is nil and the UI shows nothing — this lights up automatically once providers ship it.

Tests cover the mapping, the schema (present + absent), the helper parsing, and the BidRow rendering (present + absent).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bid details now display provider-supplied reclamation window information when available, presented as a formatted duration with a protection indicator.

* **Tests**
  * Added comprehensive test coverage for reclamation window data parsing, display rendering, and API response schema validation across multiple components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->