### PR TITLE
feat: adds provider incidents tracking

### DIFF
--- a/apps/provider-inventory/drizzle/0003_add_provider_incidents.sql
+++ b/apps/provider-inventory/drizzle/0003_add_provider_incidents.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "provider_incidents" (
+	"provider" text NOT NULL,
+	"started_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"ended_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uniq_provider_incidents_open_per_provider" ON "provider_incidents" USING btree ("provider") WHERE ended_at IS NULL;--> statement-breakpoint
+CREATE INDEX "idx_incidents_provider" ON "provider_incidents" USING btree ("provider","started_at");

--- a/apps/provider-inventory/drizzle/meta/0003_snapshot.json
+++ b/apps/provider-inventory/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,263 @@
+{
+  "id": "a09c9f56-518d-468c-bbad-11b84796d631",
+  "prevId": "748b1d55-6cb9-407b-93a7-1e8997767b55",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.provider_incidents": {
+      "name": "provider_incidents",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uniq_provider_incidents_open_per_provider": {
+          "name": "uniq_provider_incidents_open_per_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "ended_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_incidents_provider": {
+          "name": "idx_incidents_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_inventory": {
+      "name": "provider_inventory",
+      "schema": "",
+      "columns": {
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host_uri": {
+          "name": "host_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_online": {
+          "name": "is_online",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_online_since": {
+          "name": "is_online_since",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inventory": {
+          "name": "inventory",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "total_available_cpu": {
+          "name": "total_available_cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_memory": {
+          "name": "total_available_memory",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_gpu": {
+          "name": "total_available_gpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_eph": {
+          "name": "total_available_eph",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_persistent": {
+          "name": "total_available_persistent",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "total_available_leased_ip": {
+          "name": "total_available_leased_ip",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "max_node_free_cpu": {
+          "name": "max_node_free_cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "max_node_free_memory": {
+          "name": "max_node_free_memory",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "max_node_free_gpu": {
+          "name": "max_node_free_gpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "gpu_models": {
+          "name": "gpu_models",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "storage_classes": {
+          "name": "storage_classes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "self_attributes": {
+          "name": "self_attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "signed_attributes": {
+          "name": "signed_attributes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "audited_by": {
+          "name": "audited_by",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_inventory_online": {
+          "name": "idx_provider_inventory_online",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "is_online AND is_online_since IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/provider-inventory/drizzle/meta/_journal.json
+++ b/apps/provider-inventory/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1780921639304,
       "tag": "0002_add_created_at_column",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1780929614273,
+      "tag": "0003_add_provider_incidents",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/provider-inventory/src/model-schemas/index.ts
+++ b/apps/provider-inventory/src/model-schemas/index.ts
@@ -1,1 +1,2 @@
+export * from "./provider-incident/provider-incident.schema";
 export * from "./provider-inventory/provider-inventory.schema";

--- a/apps/provider-inventory/src/model-schemas/provider-incident/provider-incident.schema.ts
+++ b/apps/provider-inventory/src/model-schemas/provider-incident/provider-incident.schema.ts
@@ -1,0 +1,17 @@
+import { sql } from "drizzle-orm";
+import { index, pgTable, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
+
+export const providerIncidents = pgTable(
+  "provider_incidents",
+  {
+    provider: text("provider").notNull(),
+    startedAt: timestamp("started_at", { withTimezone: true }).notNull().defaultNow(),
+    endedAt: timestamp("ended_at", { withTimezone: true })
+  },
+  table => ({
+    openIncidentUnique: uniqueIndex("uniq_provider_incidents_open_per_provider")
+      .on(table.provider)
+      .where(sql`ended_at IS NULL`),
+    providerStartedAtIdx: index("idx_incidents_provider").on(table.provider, table.startedAt)
+  })
+);

--- a/apps/provider-inventory/src/providers-sync-app.ts
+++ b/apps/provider-inventory/src/providers-sync-app.ts
@@ -5,6 +5,7 @@ import { Hono } from "hono";
 import { container } from "tsyringe";
 
 import { APP_CONFIG } from "@src/providers/app-config.provider";
+import { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import { healthzRouter } from "@src/routes";
 import { DiscoverySchedulerService } from "@src/services/discovery-scheduler/discovery-scheduler.service";
@@ -22,7 +23,7 @@ export async function bootstrap(): Promise<void> {
   const server = await startServer(app, createOtelLogger({ context: "PROVIDERS_SYNC" }), process, {
     port: container.resolve(APP_CONFIG).PORT,
     beforeStart: async () => {
-      await container.resolve(ProviderInventoryRepository).resetOnlineSince();
+      await Promise.all([container.resolve(ProviderInventoryRepository).resetOnlineSince(), container.resolve(ProviderIncidentRepository).closeAllOpen()]);
     }
   });
 

--- a/apps/provider-inventory/src/providers-sync-app.ts
+++ b/apps/provider-inventory/src/providers-sync-app.ts
@@ -20,10 +20,21 @@ export async function bootstrap(): Promise<void> {
   app.route("/", healthzRouter);
   app.onError(container.resolve(HonoErrorHandlerService).handle);
 
-  const server = await startServer(app, createOtelLogger({ context: "PROVIDERS_SYNC" }), process, {
+  const appLogger = createOtelLogger({ context: "PROVIDERS_SYNC" });
+  const server = await startServer(app, appLogger, process, {
     port: container.resolve(APP_CONFIG).PORT,
     beforeStart: async () => {
-      await Promise.all([container.resolve(ProviderInventoryRepository).resetOnlineSince(), container.resolve(ProviderIncidentRepository).closeAllOpen()]);
+      await Promise.all([
+        // keep new line
+        container
+          .resolve(ProviderInventoryRepository)
+          .resetOnlineSince()
+          .then(() => appLogger.info({ event: "ONLINE_SINCE_RESET" })),
+        container
+          .resolve(ProviderIncidentRepository)
+          .closeAllOpen()
+          .then(() => appLogger.info({ event: "OPEN_INCIDENTS_CLOSED" }))
+      ]);
     }
   });
 

--- a/apps/provider-inventory/src/repositories/db-driver/db-driver.ts
+++ b/apps/provider-inventory/src/repositories/db-driver/db-driver.ts
@@ -1,0 +1,39 @@
+import type { ExtractTablesWithRelations } from "drizzle-orm";
+import type { PgTransaction } from "drizzle-orm/pg-core";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js/session";
+import { AsyncLocalStorage } from "node:async_hooks";
+import { inject, singleton } from "tsyringe";
+
+import { DRIZZLE_DB } from "@src/providers/drizzle.provider";
+
+@singleton()
+export class DbDriver {
+  readonly #storage = new AsyncLocalStorage<
+    Map<"PG_TX", PgTransaction<PostgresJsQueryResultHKT, Record<string, never>, ExtractTablesWithRelations<Record<string, never>>>>
+  >();
+  readonly #db: PostgresJsDatabase;
+
+  constructor(@inject(DRIZZLE_DB) db: PostgresJsDatabase) {
+    this.#db = db;
+  }
+
+  async transaction<T>(cb: () => Promise<T>) {
+    const existingTx = this.#storage.getStore()?.get("PG_TX");
+
+    if (existingTx) {
+      return await cb();
+    }
+
+    return await this.#db.transaction(async tx => {
+      return this.#storage.run(new Map(), async () => {
+        this.#storage.getStore()?.set("PG_TX", tx);
+        return await cb();
+      });
+    });
+  }
+
+  getDb() {
+    return this.#storage.getStore()?.get("PG_TX") ?? this.#db;
+  }
+}

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.integration.ts
@@ -1,0 +1,144 @@
+import "@src/providers";
+
+import { eq } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
+
+import { providerIncidents } from "@src/model-schemas/provider-incident/provider-incident.schema";
+import { DRIZZLE_DB } from "@src/providers/drizzle.provider";
+import { ProviderIncidentRepository } from "./provider-incident.repository";
+
+describe(ProviderIncidentRepository.name, () => {
+  describe("openIncident", () => {
+    it("inserts an open row when no prior incident exists for the provider", async () => {
+      const { repository, db } = setup();
+
+      await repository.openIncident("akash1a");
+
+      const rows = await db.select().from(providerIncidents);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({ provider: "akash1a", endedAt: null });
+      expect(rows[0].startedAt).toBeInstanceOf(Date);
+    });
+
+    it("is idempotent while an incident is already open", async () => {
+      const { repository, db } = setup();
+
+      await repository.openIncident("akash1a");
+      const [firstRow] = await db.select().from(providerIncidents);
+
+      await repository.openIncident("akash1a");
+
+      const rows = await db.select().from(providerIncidents);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].endedAt).toBeNull();
+      expect(rows[0].startedAt.toISOString()).toBe(firstRow.startedAt.toISOString());
+    });
+
+    it("opens a new incident for a fresh outage and leaves the prior closed incident intact", async () => {
+      const { repository, db } = setup();
+      await seedClosed(db, { provider: "akash1a", startedAt: new Date("2026-01-01T00:00:00Z"), endedAt: new Date("2026-01-01T00:05:00Z") });
+
+      await repository.openIncident("akash1a");
+
+      const rows = await db.select().from(providerIncidents).where(eq(providerIncidents.provider, "akash1a"));
+      expect(rows).toHaveLength(2);
+
+      const open = rows.filter(r => r.endedAt === null);
+      const closed = rows.filter(r => r.endedAt !== null);
+      expect(open).toHaveLength(1);
+      expect(closed).toHaveLength(1);
+      expect(closed[0].startedAt.toISOString()).toBe("2026-01-01T00:00:00.000Z");
+      expect(closed[0].endedAt?.toISOString()).toBe("2026-01-01T00:05:00.000Z");
+      expect(open[0].startedAt.getTime()).toBeGreaterThan(closed[0].startedAt.getTime());
+    });
+  });
+
+  describe("closeIncident", () => {
+    it("closes the open row for the given provider", async () => {
+      const { repository, db } = setup();
+      await repository.openIncident("akash1a");
+      await repository.openIncident("akash1b");
+
+      await repository.closeIncident("akash1a");
+
+      const rows = await db.select().from(providerIncidents);
+      const byProvider = Object.fromEntries(rows.map(r => [r.provider, r.endedAt]));
+      expect(byProvider["akash1a"]).toBeInstanceOf(Date);
+      expect(byProvider["akash1b"]).toBeNull();
+    });
+
+    it("is a no-op when no incident is open for the provider", async () => {
+      const { repository, db } = setup();
+      await seedClosed(db, { provider: "akash1a", endedAt: new Date("2026-01-01T00:05:00Z") });
+
+      await repository.closeIncident("akash1a");
+
+      const [row] = await db.select().from(providerIncidents).where(eq(providerIncidents.provider, "akash1a"));
+      expect(row.endedAt?.toISOString()).toBe("2026-01-01T00:05:00.000Z");
+    });
+
+    it("closes every open row matching the given owners in a single statement when called with an array", async () => {
+      const { repository, db } = setup();
+      await repository.openIncident("akash1a");
+      await repository.openIncident("akash1b");
+      await repository.openIncident("akash1c");
+
+      await repository.closeIncident(["akash1a", "akash1c"]);
+
+      const rows = await db.select().from(providerIncidents);
+      const byProvider = Object.fromEntries(rows.map(r => [r.provider, r.endedAt]));
+      expect(byProvider["akash1a"]).toBeInstanceOf(Date);
+      expect(byProvider["akash1b"]).toBeNull();
+      expect(byProvider["akash1c"]).toBeInstanceOf(Date);
+    });
+
+    it("does nothing when called with an empty array", async () => {
+      const { repository, db } = setup();
+      await repository.openIncident("akash1a");
+
+      await repository.closeIncident([]);
+
+      const [row] = await db.select().from(providerIncidents).where(eq(providerIncidents.provider, "akash1a"));
+      expect(row.endedAt).toBeNull();
+    });
+  });
+
+  describe("closeAllOpen", () => {
+    it("closes every open row and leaves already-closed rows untouched", async () => {
+      const { repository, db } = setup();
+      await repository.openIncident("akash1a");
+      await repository.openIncident("akash1b");
+      await seedClosed(db, { provider: "akash1c", endedAt: new Date("2026-01-01T00:05:00Z") });
+
+      await repository.closeAllOpen();
+
+      const rows = await db.select().from(providerIncidents);
+      const byProvider = Object.fromEntries(rows.map(r => [r.provider, r.endedAt]));
+      expect(byProvider["akash1a"]).toBeInstanceOf(Date);
+      expect(byProvider["akash1b"]).toBeInstanceOf(Date);
+      expect(byProvider["akash1c"]?.toISOString()).toBe("2026-01-01T00:05:00.000Z");
+    });
+  });
+
+  function setup() {
+    const repository = container.resolve(ProviderIncidentRepository);
+    const db = container.resolve<PostgresJsDatabase>(DRIZZLE_DB);
+    return { repository, db };
+  }
+});
+
+interface SeedClosedInput {
+  provider: string;
+  startedAt?: Date;
+  endedAt: Date;
+}
+
+async function seedClosed(db: PostgresJsDatabase, input: SeedClosedInput): Promise<void> {
+  await db.insert(providerIncidents).values({
+    provider: input.provider,
+    startedAt: input.startedAt ?? new Date(input.endedAt.getTime() - 60_000),
+    endedAt: input.endedAt
+  });
+}

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.integration.ts
@@ -1,5 +1,3 @@
-import "@src/providers";
-
 import { eq } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { container } from "tsyringe";

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
@@ -1,29 +1,19 @@
-import type { LoggerService } from "@akashnetwork/logging";
 import { and, eq, inArray, isNull, sql } from "drizzle-orm";
-import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
-import { inject, singleton } from "tsyringe";
+import { singleton } from "tsyringe";
 
 import { providerIncidents } from "@src/model-schemas/provider-incident/provider-incident.schema";
-import { DRIZZLE_DB } from "@src/providers/drizzle.provider";
-import type { LoggerFactory } from "@src/providers/logger-factory.provider";
-import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
+import { DbDriver } from "../db-driver/db-driver";
 
 @singleton()
 export class ProviderIncidentRepository {
-  readonly #logger: LoggerService;
-  readonly #db: PostgresJsDatabase;
+  readonly driver: DbDriver;
 
-  constructor(@inject(DRIZZLE_DB) db: PostgresJsDatabase, @inject(LOGGER_FACTORY) loggerFactory: LoggerFactory) {
-    this.#db = db;
-    this.#logger = loggerFactory({ context: "ProviderIncidentRepository" });
+  constructor(driver: DbDriver) {
+    this.driver = driver;
   }
 
   async openIncident(provider: string): Promise<void> {
-    const [opened] = await this.#db.insert(providerIncidents).values({ provider }).onConflictDoNothing().returning({ provider: providerIncidents.provider });
-
-    if (opened) {
-      this.#logger.info({ event: "PROVIDER_INCIDENT_OPENED", provider });
-    }
+    await this.driver.getDb().insert(providerIncidents).values({ provider }).onConflictDoNothing().returning({ provider: providerIncidents.provider });
   }
 
   async closeIncident(provider: string | string[]): Promise<void> {
@@ -31,17 +21,18 @@ export class ProviderIncidentRepository {
 
     const where = Array.isArray(provider) ? inArray(providerIncidents.provider, provider) : eq(providerIncidents.provider, provider);
 
-    await this.#db
+    await this.driver
+      .getDb()
       .update(providerIncidents)
       .set({ endedAt: sql`now()` })
       .where(and(where, isNull(providerIncidents.endedAt)));
   }
 
   async closeAllOpen(): Promise<void> {
-    await this.#db
+    await this.driver
+      .getDb()
       .update(providerIncidents)
       .set({ endedAt: sql`now()` })
       .where(isNull(providerIncidents.endedAt));
-    this.#logger.info({ event: "PROVIDER_INCIDENTS_CLOSED_ALL_OPEN" });
   }
 }

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
@@ -1,0 +1,47 @@
+import type { LoggerService } from "@akashnetwork/logging";
+import { and, eq, inArray, isNull, sql } from "drizzle-orm";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import { inject, singleton } from "tsyringe";
+
+import { providerIncidents } from "@src/model-schemas/provider-incident/provider-incident.schema";
+import { DRIZZLE_DB } from "@src/providers/drizzle.provider";
+import type { LoggerFactory } from "@src/providers/logger-factory.provider";
+import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
+
+@singleton()
+export class ProviderIncidentRepository {
+  readonly #logger: LoggerService;
+  readonly #db: PostgresJsDatabase;
+
+  constructor(@inject(DRIZZLE_DB) db: PostgresJsDatabase, @inject(LOGGER_FACTORY) loggerFactory: LoggerFactory) {
+    this.#db = db;
+    this.#logger = loggerFactory({ context: "ProviderIncidentRepository" });
+  }
+
+  async openIncident(provider: string): Promise<void> {
+    const [opened] = await this.#db.insert(providerIncidents).values({ provider }).onConflictDoNothing().returning({ provider: providerIncidents.provider });
+
+    if (opened) {
+      this.#logger.info({ event: "PROVIDER_INCIDENT_OPENED", provider });
+    }
+  }
+
+  async closeIncident(provider: string | string[]): Promise<void> {
+    if (Array.isArray(provider) && provider.length === 0) return;
+
+    const where = Array.isArray(provider) ? inArray(providerIncidents.provider, provider) : eq(providerIncidents.provider, provider);
+
+    await this.#db
+      .update(providerIncidents)
+      .set({ endedAt: sql`now()` })
+      .where(and(where, isNull(providerIncidents.endedAt)));
+  }
+
+  async closeAllOpen(): Promise<void> {
+    await this.#db
+      .update(providerIncidents)
+      .set({ endedAt: sql`now()` })
+      .where(isNull(providerIncidents.endedAt));
+    this.#logger.info({ event: "PROVIDER_INCIDENTS_CLOSED_ALL_OPEN" });
+  }
+}

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.integration.ts
@@ -82,6 +82,45 @@ describe(ProviderInventoryRepository.name, () => {
       });
     });
 
+    it("leaves updatedAt untouched when the upserted values are identical", async () => {
+      const { repository, db } = setup();
+      const upsertedAt = new Date("2026-01-01T00:00:00Z");
+      await seed(db, {
+        owner: "akash1a",
+        hostUri: "https://h:8443",
+        selfAttributes: [{ key: "region", value: "us-east" }],
+        signedAttributes: [{ key: "tier", value: "gold", auditor: "aud-1" }],
+        auditedBy: ["aud-1"],
+        updatedAt: upsertedAt
+      });
+
+      await repository.bulkUpsertProviders([
+        createProvider({
+          owner: "akash1a",
+          hostUri: "https://h:8443",
+          selfAttributes: [{ key: "region", value: "us-east" }],
+          signedAttributes: [{ key: "tier", value: "gold", auditor: "aud-1" }],
+          auditedBy: ["aud-1"]
+        })
+      ]);
+
+      const [row] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1a"));
+      expect(row.updatedAt.toISOString()).toBe(upsertedAt.toISOString());
+    });
+
+    it("bumps updatedAt when an attribute changes", async () => {
+      const { repository, db } = setup();
+      const upsertedAt = new Date("2026-01-01T00:00:00Z");
+      await seed(db, { owner: "akash1a", hostUri: "https://h:8443", selfAttributes: [{ key: "region", value: "us-east" }], updatedAt: upsertedAt });
+
+      await repository.bulkUpsertProviders([
+        createProvider({ owner: "akash1a", hostUri: "https://h:8443", selfAttributes: [{ key: "region", value: "us-west" }] })
+      ]);
+
+      const [row] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1a"));
+      expect(row.updatedAt.getTime()).toBeGreaterThan(upsertedAt.getTime());
+    });
+
     it("sorts the provider's auditedBy list before writing", async () => {
       const { repository, db } = setup();
 
@@ -214,6 +253,7 @@ interface SeedInput {
   selfAttributes?: { key: string; value: string }[];
   signedAttributes?: { key: string; value: string; auditor: string }[];
   auditedBy?: string[];
+  updatedAt?: Date;
 }
 
 async function seed(db: PostgresJsDatabase, input: SeedInput): Promise<void> {
@@ -224,7 +264,8 @@ async function seed(db: PostgresJsDatabase, input: SeedInput): Promise<void> {
     isOnlineSince: input.isOnlineSince === undefined ? new Date() : input.isOnlineSince,
     selfAttributes: input.selfAttributes ?? [],
     signedAttributes: input.signedAttributes ?? [],
-    auditedBy: input.auditedBy ?? []
+    auditedBy: input.auditedBy ?? [],
+    ...(input.updatedAt && { updatedAt: input.updatedAt })
   });
 }
 

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.integration.ts
@@ -198,8 +198,18 @@ describe(ProviderInventoryRepository.name, () => {
 
       const rows = await db.select().from(providerInventory);
       expect(rows).toHaveLength(1);
-      expect(rows[0]).toMatchObject({ owner: "akash1a", totalAvailableCpu: 1000n, isOnline: true });
-      expect(rows[0].isOnlineSince).toBeInstanceOf(Date);
+      expect(rows[0]).toMatchObject({ owner: "akash1a", totalAvailableCpu: 1000n });
+    });
+
+    it("leaves online state untouched", async () => {
+      const { repository, db } = setup();
+      await seed(db, { owner: "akash1a", isOnline: false, isOnlineSince: null });
+
+      await repository.updateInventory(createProvider({ owner: "akash1a" }), createCluster({ cpu: 1000n }));
+
+      const [row] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1a"));
+      expect(row.isOnline).toBe(false);
+      expect(row.isOnlineSince).toBeNull();
     });
 
     it("writes the ClusterState as inventory JSONB", async () => {
@@ -220,7 +230,7 @@ describe(ProviderInventoryRepository.name, () => {
       });
     });
 
-    it("preserves isOnlineSince on subsequent updates via coalesce", async () => {
+    it("preserves an existing isOnlineSince across updates", async () => {
       const { repository, db } = setup();
       const firstSeenAt = new Date("2026-01-01T00:00:00Z");
       await seed(db, { owner: "akash1a", isOnlineSince: firstSeenAt });
@@ -229,6 +239,31 @@ describe(ProviderInventoryRepository.name, () => {
 
       const [row] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1a"));
       expect(row.isOnlineSince?.toISOString()).toBe(firstSeenAt.toISOString());
+    });
+  });
+
+  describe("markAsOnline", () => {
+    it("flips an offline provider to online and stamps isOnlineSince", async () => {
+      const { repository, db } = setup();
+      await seed(db, { owner: "akash1a", isOnline: false, isOnlineSince: null });
+
+      await repository.markAsOnline("akash1a");
+
+      const [row] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1a"));
+      expect(row.isOnline).toBe(true);
+      expect(row.isOnlineSince).toBeInstanceOf(Date);
+    });
+
+    it("does not affect other providers", async () => {
+      const { repository, db } = setup();
+      await seed(db, { owner: "akash1a", isOnline: false, isOnlineSince: null });
+      await seed(db, { owner: "akash1b", isOnline: false, isOnlineSince: null });
+
+      await repository.markAsOnline("akash1a");
+
+      const [other] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1b"));
+      expect(other.isOnline).toBe(false);
+      expect(other.isOnlineSince).toBeNull();
     });
   });
 

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
@@ -110,6 +110,12 @@ export class ProviderInventoryRepository {
       };
     });
 
+    const conflictColumns = [providerInventory.hostUri, providerInventory.selfAttributes, providerInventory.signedAttributes, providerInventory.auditedBy];
+    const hasChanges = rawSql.join(
+      conflictColumns.map(column => rawSql`${column} IS DISTINCT FROM excluded.${rawSql.raw(column.name)}`),
+      rawSql` OR `
+    );
+
     await this.#db
       .insert(providerInventory)
       .values(rows)
@@ -121,7 +127,8 @@ export class ProviderInventoryRepository {
           signedAttributes: rawSql.raw(`excluded.${providerInventory.signedAttributes.name}`),
           auditedBy: rawSql.raw(`excluded.${providerInventory.auditedBy.name}`),
           updatedAt: NOW_SQL
-        }
+        },
+        setWhere: hasChanges
       });
   }
 }

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
@@ -1,16 +1,12 @@
-import type { LoggerService } from "@akashnetwork/logging";
 import type { InferSelectModel } from "drizzle-orm";
 import { and, eq, gt, inArray, sql as rawSql } from "drizzle-orm";
-import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
-import { inject, singleton } from "tsyringe";
+import { singleton } from "tsyringe";
 
 import { paginate } from "@src/lib/generators/paginate/paginate";
 import { providerInventory } from "@src/model-schemas/provider-inventory/provider-inventory.schema";
-import { DRIZZLE_DB } from "@src/providers/drizzle.provider";
-import type { LoggerFactory } from "@src/providers/logger-factory.provider";
-import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
 import type { ChainProvider } from "@src/types/chain-provider";
 import { ClusterState } from "@src/types/inventory";
+import { DbDriver } from "../db-driver/db-driver";
 import { mapToStoredClusterState } from "./stored-cluster-state-mapper/stored-cluster-state-mapper";
 
 export type ProviderInventory = InferSelectModel<typeof providerInventory>;
@@ -19,22 +15,20 @@ const DEFAULT_ONLINE_STREAM_BATCH_SIZE = 500;
 
 @singleton()
 export class ProviderInventoryRepository {
-  readonly #logger: LoggerService;
-  readonly #db: PostgresJsDatabase;
+  readonly #driver: DbDriver;
 
-  constructor(@inject(DRIZZLE_DB) db: PostgresJsDatabase, @inject(LOGGER_FACTORY) loggerFactory: LoggerFactory) {
-    this.#db = db;
-    this.#logger = loggerFactory({ context: "ProviderInventoryRepository" });
+  constructor(dbDriver: DbDriver) {
+    this.#driver = dbDriver;
   }
 
   async resetOnlineSince(): Promise<void> {
-    await this.#db.update(providerInventory).set({ isOnlineSince: null });
-    this.#logger.info({ event: "ONLINE_SINCE_RESET" });
+    await this.#driver.getDb().update(providerInventory).set({ isOnlineSince: null });
   }
 
   async *streamOnlineProviders(options?: { batchSize?: number }): AsyncGenerator<Pick<ProviderInventory, "owner" | "hostUri">> {
     const batchSize = options?.batchSize ?? DEFAULT_ONLINE_STREAM_BATCH_SIZE;
-    const baseQuery = this.#db
+    const baseQuery = this.#driver
+      .getDb()
       .select({ owner: providerInventory.owner, hostUri: providerInventory.hostUri })
       .from(providerInventory)
       .orderBy(providerInventory.owner)
@@ -53,25 +47,35 @@ export class ProviderInventoryRepository {
   }
 
   async deleteByOwner(owner: string | string[]): Promise<void> {
+    const db = this.#driver.getDb();
     if (Array.isArray(owner)) {
-      await this.#db.delete(providerInventory).where(inArray(providerInventory.owner, owner));
+      await db.delete(providerInventory).where(inArray(providerInventory.owner, owner));
     } else {
-      await this.#db.delete(providerInventory).where(eq(providerInventory.owner, owner));
+      await db.delete(providerInventory).where(eq(providerInventory.owner, owner));
     }
   }
 
   async bulkMarkOffline(owners: string[]): Promise<void> {
     if (owners.length === 0) return;
-    await this.#db
+    await this.#driver
+      .getDb()
       .update(providerInventory)
       .set({ isOnline: false, isOnlineSince: null, updatedAt: rawSql`now()` })
       .where(inArray(providerInventory.owner, owners));
-    this.#logger.info({ event: "PROVIDERS_MARKED_OFFLINE", owners });
+  }
+
+  async markAsOnline(owner: string): Promise<void> {
+    await this.#driver
+      .getDb()
+      .update(providerInventory)
+      .set({ isOnline: true, isOnlineSince: new Date(), updatedAt: rawSql`now()` })
+      .where(eq(providerInventory.owner, owner));
   }
 
   async updateInventory(provider: ChainProvider, cluster: ClusterState): Promise<void> {
     const row = mapToStoredClusterState(cluster);
-    await this.#db
+    await this.#driver
+      .getDb()
       .update(providerInventory)
       .set({
         inventory: row.cluster,
@@ -86,13 +90,9 @@ export class ProviderInventoryRepository {
         maxNodeFreeGpu: row.maxNodeFreeGpu,
         gpuModels: row.gpuModels,
         storageClasses: row.storageClasses,
-        isOnline: true,
-        isOnlineSince: rawSql`coalesce(${providerInventory.isOnlineSince}, now())`,
         updatedAt: rawSql`now()`
       })
       .where(eq(providerInventory.owner, provider.owner));
-
-    this.#logger.debug({ event: "PROVIDER_INVENTORY_UPDATED", owner: provider.owner });
   }
 
   async bulkUpsertProviders(providers: ChainProvider[]): Promise<void> {
@@ -116,7 +116,8 @@ export class ProviderInventoryRepository {
       rawSql` OR `
     );
 
-    await this.#db
+    await this.#driver
+      .getDb()
       .insert(providerInventory)
       .values(rows)
       .onConflictDoUpdate({

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
@@ -5,6 +5,7 @@ import { mock, type MockProxy } from "vitest-mock-extended";
 
 import type { EnvConfig } from "@src/providers/app-config.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
+import type { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import type { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import type { ChainProvider } from "@src/types/chain-provider";
 import type { ClusterState, NodeState } from "@src/types/inventory";
@@ -318,6 +319,66 @@ describe(StreamLifecycleManagerService.name, () => {
     });
   });
 
+  describe("incident tracking", () => {
+    it("opens an incident after all retries are exhausted", async () => {
+      const streamFactory = mock<ProviderStreamFactory>();
+      streamFactory.disposeProvider.mockResolvedValue();
+      streamFactory.openStatusStream.mockImplementation(() => throwingStream(new Error("connection lost")));
+      const { manager, incidents, logger } = setup({ streamFactory });
+
+      manager.start(createProvider());
+
+      await vi.waitFor(() => expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_GAVE_UP", owner: "akash1owner" })), {
+        timeout: 5000
+      });
+      expect(incidents.openIncident).toHaveBeenCalledWith("akash1owner");
+      expect(incidents.openIncident).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not open an incident when the stream is aborted intentionally", async () => {
+      const streamFactory = mock<ProviderStreamFactory>();
+      streamFactory.disposeProvider.mockResolvedValue();
+      streamFactory.openStatusStream.mockImplementation(() => throwingStream(new Error("connection lost")));
+      const { manager, incidents } = setup({ streamFactory });
+
+      manager.start(createProvider());
+      manager.shutdown();
+
+      await delay(100);
+      expect(incidents.openIncident).not.toHaveBeenCalled();
+    });
+
+    it("closes the incident on offline → online transition", async () => {
+      let attempt = 0;
+      const streamFactory = mock<ProviderStreamFactory>();
+      streamFactory.disposeProvider.mockResolvedValue();
+      streamFactory.openStatusStream.mockImplementation(() => {
+        attempt++;
+        if (attempt === 1) return throwingStream(new Error("initial failure"));
+        return msgsThenHang([createCluster()]);
+      });
+      const { manager, incidents } = setup({ streamFactory });
+
+      manager.start(createProvider());
+
+      await vi.waitFor(() => expect(incidents.closeIncident).toHaveBeenCalledWith("akash1owner"), { timeout: 5000 });
+    });
+
+    it("closes incidents in a single batched call on stopAndDelete", async () => {
+      const a = createProvider({ owner: "a", hostUri: "https://a:8443" });
+      const b = createProvider({ owner: "b", hostUri: "https://b:8443" });
+      const { manager, streamFactory, incidents } = setup({ streams: { "https://a:8443": "hang", "https://b:8443": "hang" } });
+      manager.start(a);
+      manager.start(b);
+      await vi.waitFor(() => expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(2));
+
+      await manager.stopAndDelete(["a", "b"]);
+
+      expect(incidents.closeIncident).toHaveBeenCalledWith(["a", "b"]);
+      expect(incidents.closeIncident).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe("stale finalizer", () => {
     it("does not evict a replacement stream's registry entry when the old stream finishes", async () => {
       let resolveOldStream!: () => void;
@@ -424,6 +485,9 @@ describe(StreamLifecycleManagerService.name, () => {
     writer.deleteByOwner.mockResolvedValue();
     writer.bulkMarkOffline.mockResolvedValue();
     writer.updateInventory.mockResolvedValue();
+    const incidents = mock<ProviderIncidentRepository>();
+    incidents.openIncident.mockResolvedValue();
+    incidents.closeIncident.mockResolvedValue();
     const logger = mock<LoggerService>();
     const loggerFactory: LoggerFactory = () => logger;
     const config = mock<EnvConfig>({
@@ -444,9 +508,9 @@ describe(StreamLifecycleManagerService.name, () => {
       });
     }
 
-    const manager = new StreamLifecycleManagerService(streamFactory, writer, loggerFactory, config);
+    const manager = new StreamLifecycleManagerService(streamFactory, writer, incidents, loggerFactory, config);
 
-    return { manager, streamFactory, writer, logger };
+    return { manager, streamFactory, writer, incidents, logger };
   }
 });
 

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
@@ -5,6 +5,7 @@ import { mock, type MockProxy } from "vitest-mock-extended";
 
 import type { EnvConfig } from "@src/providers/app-config.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
+import type { DbDriver } from "@src/repositories/db-driver/db-driver";
 import type { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import type { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import type { ChainProvider } from "@src/types/chain-provider";
@@ -488,6 +489,8 @@ describe(StreamLifecycleManagerService.name, () => {
     const incidents = mock<ProviderIncidentRepository>();
     incidents.openIncident.mockResolvedValue();
     incidents.closeIncident.mockResolvedValue();
+    const dbDriver = mock<DbDriver>();
+    dbDriver.transaction.mockImplementation(cb => cb());
     const logger = mock<LoggerService>();
     const loggerFactory: LoggerFactory = () => logger;
     const config = mock<EnvConfig>({
@@ -508,9 +511,9 @@ describe(StreamLifecycleManagerService.name, () => {
       });
     }
 
-    const manager = new StreamLifecycleManagerService(streamFactory, writer, incidents, loggerFactory, config);
+    const manager = new StreamLifecycleManagerService(streamFactory, writer, incidents, dbDriver, loggerFactory, config);
 
-    return { manager, streamFactory, writer, incidents, logger };
+    return { manager, streamFactory, writer, incidents, dbDriver, logger };
   }
 });
 

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -12,6 +12,7 @@ import type { EnvConfig } from "@src/providers/app-config.provider";
 import { APP_CONFIG } from "@src/providers/app-config.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
 import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
+import { DbDriver } from "@src/repositories/db-driver/db-driver";
 import { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import type { ChainProvider } from "@src/types/chain-provider";
@@ -38,17 +39,20 @@ export class StreamLifecycleManagerService {
   readonly #offlineDataloader: Dataloader<string, null>;
   readonly #startStreamSemaphore: Sema;
   readonly #pendingFirstAttempts = new Set<Promise<void>>();
+  readonly #dbDriver: DbDriver;
 
   constructor(
     streamFactory: ProviderStreamFactory,
     inventoryRepo: ProviderInventoryRepository,
     incidentsRepo: ProviderIncidentRepository,
+    dbDriver: DbDriver,
     @inject(LOGGER_FACTORY) loggerFactory: LoggerFactory,
     @inject(APP_CONFIG) config: EnvConfig
   ) {
     this.#streamFactory = streamFactory;
     this.#inventoryRepo = inventoryRepo;
     this.#incidentsRepo = incidentsRepo;
+    this.#dbDriver = dbDriver;
     this.#config = config;
     this.#logger = loggerFactory({ context: "StreamLifecycleManager" });
     this.#retryStreamPolicy = retry(handleAll, {
@@ -61,6 +65,7 @@ export class StreamLifecycleManagerService {
     this.#offlineDataloader = new Dataloader(
       async owners => {
         await this.#inventoryRepo.bulkMarkOffline(owners as string[]);
+        this.#logger.info({ event: "PROVIDERS_MARKED_OFFLINE", owners });
         return Array.from(owners, () => null);
       },
       {
@@ -215,10 +220,14 @@ export class StreamLifecycleManagerService {
     const cached = this.#lastInventoryPerProvider.get(provider.owner);
 
     if (!this.#onlineStatePerProvider.get(provider.owner)) {
-      this.#onlineStatePerProvider.set(provider.owner, true);
       try {
-        await this.#incidentsRepo.closeIncident(provider.owner);
+        this.#onlineStatePerProvider.set(provider.owner, true);
+        await this.#dbDriver.transaction(async () => {
+          await Promise.all([this.#inventoryRepo.markAsOnline(provider.owner), this.#incidentsRepo.closeIncident(provider.owner)]);
+        });
+        this.#logger.info({ event: "PROVIDER_MARKED_ONLINE", owner: provider.owner });
       } catch (error) {
+        this.#onlineStatePerProvider.set(provider.owner, false);
         this.#logger.error({ event: "CLOSE_INCIDENT_ERROR", owner: provider.owner, error });
       }
     }
@@ -230,6 +239,7 @@ export class StreamLifecycleManagerService {
 
     try {
       await this.#inventoryRepo.updateInventory(provider, cluster);
+      this.#logger.debug({ event: "PROVIDER_INVENTORY_UPDATED", owner: provider.owner });
       this.#lastInventoryPerProvider.set(provider.owner, cluster);
     } catch (error) {
       this.#logger.error({ event: "STREAM_PROVIDER_WRITE_ERROR", owner: provider.owner, error });

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -12,6 +12,7 @@ import type { EnvConfig } from "@src/providers/app-config.provider";
 import { APP_CONFIG } from "@src/providers/app-config.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
 import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
+import { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import type { ChainProvider } from "@src/types/chain-provider";
 import type { ClusterState } from "@src/types/inventory";
@@ -21,7 +22,8 @@ import { ProviderStreamFactory } from "../provider-stream-factory/provider-strea
 export class StreamLifecycleManagerService {
   readonly #logger: LoggerService;
   readonly #streamFactory: ProviderStreamFactory;
-  readonly #writer: ProviderInventoryRepository;
+  readonly #inventoryRepo: ProviderInventoryRepository;
+  readonly #incidentsRepo: ProviderIncidentRepository;
   readonly #config: EnvConfig;
   readonly #activeStreams = new Map<
     string,
@@ -39,12 +41,14 @@ export class StreamLifecycleManagerService {
 
   constructor(
     streamFactory: ProviderStreamFactory,
-    writer: ProviderInventoryRepository,
+    inventoryRepo: ProviderInventoryRepository,
+    incidentsRepo: ProviderIncidentRepository,
     @inject(LOGGER_FACTORY) loggerFactory: LoggerFactory,
     @inject(APP_CONFIG) config: EnvConfig
   ) {
     this.#streamFactory = streamFactory;
-    this.#writer = writer;
+    this.#inventoryRepo = inventoryRepo;
+    this.#incidentsRepo = incidentsRepo;
     this.#config = config;
     this.#logger = loggerFactory({ context: "StreamLifecycleManager" });
     this.#retryStreamPolicy = retry(handleAll, {
@@ -56,7 +60,7 @@ export class StreamLifecycleManagerService {
     });
     this.#offlineDataloader = new Dataloader(
       async owners => {
-        await this.#writer.bulkMarkOffline(owners as string[]);
+        await this.#inventoryRepo.bulkMarkOffline(owners as string[]);
         return Array.from(owners, () => null);
       },
       {
@@ -114,7 +118,7 @@ export class StreamLifecycleManagerService {
       this.#abortIfActive(owner, "STREAM_STOPPED_PROVIDER_GONE");
     }
 
-    await Promise.all([Promise.all(promises), this.#writer.deleteByOwner(owners)]);
+    await Promise.all([Promise.all(promises), this.#inventoryRepo.deleteByOwner(owners), this.#incidentsRepo.closeIncident(owners)]);
     this.#logger.info({ event: "PROVIDER_INVENTORY_DELETED", owners });
   }
 
@@ -143,6 +147,11 @@ export class StreamLifecycleManagerService {
     } catch (error) {
       if (!signal.aborted) {
         this.#logger.error({ event: "STREAM_GAVE_UP", owner: provider.owner, error });
+        try {
+          await this.#incidentsRepo.openIncident(provider.owner);
+        } catch (incidentError) {
+          this.#logger.error({ event: "OPEN_INCIDENT_ERROR", owner: provider.owner, error: incidentError });
+        }
       }
     } finally {
       onSettleAttempt();
@@ -207,6 +216,11 @@ export class StreamLifecycleManagerService {
 
     if (!this.#onlineStatePerProvider.get(provider.owner)) {
       this.#onlineStatePerProvider.set(provider.owner, true);
+      try {
+        await this.#incidentsRepo.closeIncident(provider.owner);
+      } catch (error) {
+        this.#logger.error({ event: "CLOSE_INCIDENT_ERROR", owner: provider.owner, error });
+      }
     }
 
     if (cached && isEqualClusterState(cached, cluster)) {
@@ -215,7 +229,7 @@ export class StreamLifecycleManagerService {
     }
 
     try {
-      await this.#writer.updateInventory(provider, cluster);
+      await this.#inventoryRepo.updateInventory(provider, cluster);
       this.#lastInventoryPerProvider.set(provider.owner, cluster);
     } catch (error) {
       this.#logger.error({ event: "STREAM_PROVIDER_WRITE_ERROR", owner: provider.owner, error });

--- a/apps/provider-inventory/test/services/test-database.service.ts
+++ b/apps/provider-inventory/test/services/test-database.service.ts
@@ -41,7 +41,7 @@ export class TestDatabaseService {
   async truncate(): Promise<void> {
     const sql = postgres(`${this.#postgresUri}/${this.#dbName}`, { max: 1 });
     try {
-      await sql`TRUNCATE TABLE provider_inventory RESTART IDENTITY CASCADE`;
+      await sql`TRUNCATE TABLE provider_inventory, provider_incidents RESTART IDENTITY CASCADE`;
     } finally {
       await sql.end();
     }


### PR DESCRIPTION
## Why

Closes CON-443

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider incident tracking: record open/closed incidents per provider, prevent multiple simultaneous open incidents, bulk-close support, and integration with stream lifecycle (opens on persistent failures, closes on recovery).

* **Bug Fixes**
  * Inventory upserts preserve timestamps when data is unchanged.
  * Startup now resets online timestamps and closes lingering open incidents.
  * Marking online stamps online-since only when transitioning from offline.

* **Tests**
  * Added integration and unit tests covering incident lifecycle, upsert behaviors, online/mark-as-online flows, and lifecycle interactions.

* **Chores**
  * Database migration and schema snapshot added for incidents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->