### PR TITLE
feat: adds proper handling of dead and stale providers

### DIFF
--- a/apps/provider-inventory/src/config/env.config.ts
+++ b/apps/provider-inventory/src/config/env.config.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+const ONE_MINUTE = 60 * 1000;
+
 export const envSchema = z.object({
   PROVIDER_INVENTORY_POSTGRES_URL: z.string(),
   POSTGRES_MAX_CONNECTIONS: z.number({ coerce: true }).int().min(1).default(20),
@@ -11,13 +13,14 @@ export const envSchema = z.object({
   STD_OUT_LOG_FORMAT: z.enum(["json", "pretty"]).default("json"),
   SQL_LOG_FORMAT: z.enum(["raw", "pretty"]).default("raw"),
   PORT: z.number({ coerce: true }).default(3092),
-  DISCOVERY_INTERVAL_MS: z.number({ coerce: true }).default(10 * 60 * 1000),
+  DISCOVERY_INTERVAL_MS: z.number({ coerce: true }).default(10 * ONE_MINUTE),
   MAX_CONCURRENT_STREAM_CONNECTIONS: z.number({ coerce: true }).positive().default(100),
   STREAM_RECONNECT_INITIAL_DELAY_MS: z.number({ coerce: true }).default(60_000),
-  STREAM_RECONNECT_MAX_DELAY_MS: z.number({ coerce: true }).default(5 * 60 * 1000),
+  STREAM_RECONNECT_MAX_DELAY_MS: z.number({ coerce: true }).default(5 * ONE_MINUTE),
   STREAM_FIRST_MESSAGE_TIMEOUT_MS: z.number({ coerce: true }).default(10_000),
   STREAM_UPDATE_THROTTLE_MS: z.number({ coerce: true }).nonnegative().default(1000),
-  REST_API_NODE_URL: z.string().url()
+  REST_API_NODE_URL: z.string().url(),
+  DEAD_PROVIDER_UPDATED_THRESHOLD_MS: z.number({ coerce: true }).default(10 * 24 * 60 * ONE_MINUTE)
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.integration.ts
@@ -265,6 +265,116 @@ describe(ProviderInventoryRepository.name, () => {
       expect(other.isOnline).toBe(false);
       expect(other.isOnlineSince).toBeNull();
     });
+
+    it("leaves an already-online provider's updatedAt and isOnlineSince untouched", async () => {
+      const { repository, db } = setup();
+      const onlineSince = new Date("2026-01-01T00:00:00Z");
+      const updatedAt = new Date("2026-01-02T00:00:00Z");
+      await seed(db, { owner: "akash1a", isOnline: true, isOnlineSince: onlineSince, updatedAt });
+
+      await repository.markAsOnline("akash1a");
+
+      const [row] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1a"));
+      expect(row.isOnlineSince?.toISOString()).toBe(onlineSince.toISOString());
+      expect(row.updatedAt.toISOString()).toBe(updatedAt.toISOString());
+    });
+  });
+
+  describe("bulkMarkOffline", () => {
+    it("flips an online provider to offline and clears isOnlineSince", async () => {
+      const { repository, db } = setup();
+      await seed(db, { owner: "akash1a", isOnline: true, isOnlineSince: new Date() });
+
+      await repository.bulkMarkOffline(["akash1a"]);
+
+      const [row] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1a"));
+      expect(row.isOnline).toBe(false);
+      expect(row.isOnlineSince).toBeNull();
+    });
+
+    it("bumps updatedAt when transitioning from online to offline", async () => {
+      const { repository, db } = setup();
+      const updatedAt = new Date("2026-01-01T00:00:00Z");
+      await seed(db, { owner: "akash1a", isOnline: true, isOnlineSince: new Date(), updatedAt });
+
+      await repository.bulkMarkOffline(["akash1a"]);
+
+      const [row] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1a"));
+      expect(row.updatedAt.getTime()).toBeGreaterThan(updatedAt.getTime());
+    });
+
+    it("leaves an already-offline provider's updatedAt frozen so it can age into the dead-provider threshold", async () => {
+      const { repository, db } = setup();
+      const updatedAt = new Date("2026-01-01T00:00:00Z");
+      await seed(db, { owner: "akash1a", isOnline: false, isOnlineSince: null, updatedAt });
+
+      await repository.bulkMarkOffline(["akash1a"]);
+
+      const [row] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1a"));
+      expect(row.updatedAt.toISOString()).toBe(updatedAt.toISOString());
+    });
+
+    it("only marks the listed owners offline", async () => {
+      const { repository, db } = setup();
+      await seed(db, { owner: "akash1a", isOnline: true, isOnlineSince: new Date() });
+      await seed(db, { owner: "akash1b", isOnline: true, isOnlineSince: new Date() });
+
+      await repository.bulkMarkOffline(["akash1a"]);
+
+      const [other] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1b"));
+      expect(other.isOnline).toBe(true);
+    });
+
+    it("is a no-op when called with an empty list", async () => {
+      const { repository, db } = setup();
+      await seed(db, { owner: "akash1a", isOnline: true, isOnlineSince: new Date() });
+
+      await repository.bulkMarkOffline([]);
+
+      const [row] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1a"));
+      expect(row.isOnline).toBe(true);
+    });
+  });
+
+  describe("getInventoryLastUpdatedPerOfflineProvider", () => {
+    it("returns the updatedAt timestamp for each offline provider in the list", async () => {
+      const { repository, db } = setup();
+      const updatedAt = new Date("2026-01-01T00:00:00Z");
+      await seed(db, { owner: "akash1a", isOnline: false, isOnlineSince: null, updatedAt });
+
+      const result = await repository.getInventoryLastUpdatedPerOfflineProvider(["akash1a"]);
+
+      expect(result.get("akash1a")?.toISOString()).toBe(updatedAt.toISOString());
+    });
+
+    it("excludes providers that are currently online", async () => {
+      const { repository, db } = setup();
+      await seed(db, { owner: "akash1online", isOnline: true, isOnlineSince: new Date() });
+      await seed(db, { owner: "akash1offline", isOnline: false, isOnlineSince: null });
+
+      const result = await repository.getInventoryLastUpdatedPerOfflineProvider(["akash1online", "akash1offline"]);
+
+      expect(result.has("akash1online")).toBe(false);
+      expect(result.has("akash1offline")).toBe(true);
+    });
+
+    it("excludes owners that are not in the requested list", async () => {
+      const { repository, db } = setup();
+      await seed(db, { owner: "akash1a", isOnline: false, isOnlineSince: null });
+      await seed(db, { owner: "akash1b", isOnline: false, isOnlineSince: null });
+
+      const result = await repository.getInventoryLastUpdatedPerOfflineProvider(["akash1a"]);
+
+      expect([...result.keys()]).toEqual(["akash1a"]);
+    });
+
+    it("returns an empty map for an empty list", async () => {
+      const { repository } = setup();
+
+      const result = await repository.getInventoryLastUpdatedPerOfflineProvider([]);
+
+      expect(result.size).toBe(0);
+    });
   });
 
   function setup() {

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
@@ -61,7 +61,7 @@ export class ProviderInventoryRepository {
       .getDb()
       .update(providerInventory)
       .set({ isOnline: false, isOnlineSince: null, updatedAt: rawSql`now()` })
-      .where(inArray(providerInventory.owner, owners));
+      .where(and(inArray(providerInventory.owner, owners), eq(providerInventory.isOnline, true)));
   }
 
   async markAsOnline(owner: string): Promise<void> {
@@ -69,7 +69,7 @@ export class ProviderInventoryRepository {
       .getDb()
       .update(providerInventory)
       .set({ isOnline: true, isOnlineSince: new Date(), updatedAt: rawSql`now()` })
-      .where(eq(providerInventory.owner, owner));
+      .where(and(eq(providerInventory.owner, owner), eq(providerInventory.isOnline, false)));
   }
 
   async updateInventory(provider: ChainProvider, cluster: ClusterState): Promise<void> {
@@ -131,5 +131,22 @@ export class ProviderInventoryRepository {
         },
         setWhere: hasChanges
       });
+  }
+
+  async getInventoryLastUpdatedPerOfflineProvider(providers: string[]): Promise<Map<string, Date | null>> {
+    if (providers.length === 0) return new Map();
+    const db = this.#driver.getDb();
+    const rows = await db
+      .select({
+        owner: providerInventory.owner,
+        updatedAt: providerInventory.updatedAt
+      })
+      .from(providerInventory)
+      .where(and(inArray(providerInventory.owner, providers), eq(providerInventory.isOnline, false)));
+    const result = new Map<string, Date | null>();
+    for (const row of rows) {
+      result.set(row.owner, new Date(row.updatedAt));
+    }
+    return result;
   }
 }

--- a/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.spec.ts
+++ b/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.spec.ts
@@ -9,6 +9,8 @@ import type { StreamLifecycleManagerService } from "@src/services/stream-lifecyc
 import type { ChainProvider } from "@src/types/chain-provider";
 import { DiscoverySchedulerService } from "./discovery-scheduler.service";
 
+const DEAD_PROVIDER_UPDATED_THRESHOLD_MS = 10 * 24 * 60 * 60 * 1000;
+
 describe(DiscoverySchedulerService.name, () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -74,7 +76,42 @@ describe(DiscoverySchedulerService.name, () => {
 
     expect(lifecycle.getRegistry).toHaveBeenCalled();
     expect(writer.bulkUpsertProviders).toHaveBeenCalledWith([fresh]);
-    expect(lifecycle.start).toHaveBeenCalledWith(fresh, expect.any(AbortSignal));
+    expect(lifecycle.start).toHaveBeenCalledWith({ ...fresh, lastUpdated: null }, expect.any(AbortSignal));
+  });
+
+  it("forwards the offline provider's last-updated timestamp to lifecycle.start", async () => {
+    const offline = createProvider({ owner: "offline", hostUri: "https://offline:8443" });
+    const lastUpdated = new Date(Date.now() - 60_000);
+    const { lifecycle } = setup({ providers: [offline], lastUpdated: new Map([[offline.owner, lastUpdated]]) });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(lifecycle.start).toHaveBeenCalledWith({ ...offline, lastUpdated }, expect.any(AbortSignal));
+  });
+
+  it("skips a provider whose inventory has not been updated past the dead-provider threshold", async () => {
+    const dead = createProvider({ owner: "dead", hostUri: "https://dead:8443" });
+    const lastUpdated = new Date(Date.now() - DEAD_PROVIDER_UPDATED_THRESHOLD_MS - 1_000);
+    const { lifecycle, logger } = setup({ providers: [dead], lastUpdated: new Map([[dead.owner, lastUpdated]]) });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(lifecycle.start).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "DISCOVERY_SKIP_PROVIDER", owner: "dead" }));
+  });
+
+  it("forwards the last-updated timestamp to lifecycle.restart when an observed provider changes hostUri", async () => {
+    const updated = createProvider({ owner: "moving", hostUri: "https://new:8443" });
+    const lastUpdated = new Date(Date.now() - 60_000);
+    const { lifecycle } = setup({
+      providers: [updated],
+      watched: new Map([["moving", { hostUri: "https://old:8443" }]]),
+      lastUpdated: new Map([[updated.owner, lastUpdated]])
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(lifecycle.restart).toHaveBeenCalledWith({ ...updated, lastUpdated }, expect.any(AbortSignal));
   });
 
   it("continues after a poll error and re-arms the next tick", async () => {
@@ -193,14 +230,17 @@ describe(DiscoverySchedulerService.name, () => {
     pollDelay?: (config: EnvConfig) => number;
     onlineOwners?: Pick<ProviderInventory, "owner" | "hostUri">[];
     autoStart?: boolean;
+    watched?: Map<string, { hostUri: string }>;
+    lastUpdated?: Map<string, Date>;
   }) {
     const poller = mock<ChainProviderPollerService>();
     const writer = mock<ProviderInventoryRepository>();
     const lifecycle = mock<StreamLifecycleManagerService>();
-    lifecycle.getRegistry.mockReturnValue(new Map());
+    lifecycle.getRegistry.mockReturnValue(input?.watched ?? new Map());
     lifecycle.stopAndDelete.mockResolvedValue();
     lifecycle.waitForPendingConnections.mockResolvedValue();
     writer.bulkUpsertProviders.mockResolvedValue();
+    writer.getInventoryLastUpdatedPerOfflineProvider.mockResolvedValue(input?.lastUpdated ?? new Map());
 
     const onlineOwners = input?.onlineOwners ?? [];
     writer.streamOnlineProviders.mockReturnValue(
@@ -221,6 +261,7 @@ describe(DiscoverySchedulerService.name, () => {
       STREAM_RECONNECT_INITIAL_DELAY_MS: 1_000,
       STREAM_RECONNECT_MAX_DELAY_MS: 300_000,
       STREAM_FIRST_MESSAGE_TIMEOUT_MS: 10_000,
+      DEAD_PROVIDER_UPDATED_THRESHOLD_MS,
       REST_API_NODE_URL: "http://localhost:1317"
     } as EnvConfig;
 

--- a/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
+++ b/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
@@ -45,7 +45,8 @@ export class DiscoverySchedulerService {
           ...provider,
           selfAttributes: EMPTY_ARRAY,
           signedAttributes: EMPTY_ARRAY,
-          auditedBy: EMPTY_ARRAY
+          auditedBy: EMPTY_ARRAY,
+          lastUpdated: null
         },
         signal
       );
@@ -97,16 +98,26 @@ export class DiscoverySchedulerService {
 
         // important to upsert before starting new stream,
         // otherwise stream will have nothing to update in the db
-        const isUpsertedBatch = await this.#upsertProviders(providers);
+        const [isUpsertedBatch, lastUpdatedPerProvider] = await Promise.all([
+          this.#upsertProviders(providers),
+          this.#repository.getInventoryLastUpdatedPerOfflineProvider(providers.map(p => p.owner))
+        ]);
         for (const provider of providers) {
           const observedProvider = watchedProviders.get(provider.owner);
+          const lastUpdated = lastUpdatedPerProvider.get(provider.owner);
+
+          if (lastUpdated && Date.now() - lastUpdated.getTime() >= this.#config.DEAD_PROVIDER_UPDATED_THRESHOLD_MS) {
+            this.#logger.debug({ event: "DISCOVERY_SKIP_PROVIDER", owner: provider.owner, reason: "provider inventory has not been updated for a long time" });
+            continue;
+          }
+
           if (!observedProvider) {
             if (isUpsertedBatch) {
-              this.#lifecycle.start(provider, signal);
+              this.#lifecycle.start({ ...provider, lastUpdated: lastUpdated ?? null }, signal);
               startedProvidersCount++;
             }
           } else if (observedProvider.hostUri !== provider.hostUri) {
-            this.#lifecycle.restart(provider, signal);
+            this.#lifecycle.restart({ ...provider, lastUpdated: lastUpdated ?? null }, signal);
             restartedProvidersCount++;
           }
 

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
@@ -8,7 +8,7 @@ import type { LoggerFactory } from "@src/providers/logger-factory.provider";
 import type { DbDriver } from "@src/repositories/db-driver/db-driver";
 import type { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import type { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
-import type { ChainProvider } from "@src/types/chain-provider";
+import type { ChainProvider, ChainProviderWithLastUpdated } from "@src/types/chain-provider";
 import type { ClusterState, NodeState } from "@src/types/inventory";
 import type { ProviderStreamFactory } from "../provider-stream-factory/provider-stream-factory.sevice";
 import { StreamLifecycleManagerService } from "./stream-lifecycle-manager.service";
@@ -380,6 +380,65 @@ describe(StreamLifecycleManagerService.name, () => {
     });
   });
 
+  describe("dead provider retry policy", () => {
+    it("attempts a long-dead provider at most twice before giving up", async () => {
+      const streamFactory = mock<ProviderStreamFactory>();
+      streamFactory.disposeProvider.mockResolvedValue();
+      streamFactory.openStatusStream.mockImplementation(() => throwingStream(new Error("connection lost")));
+      const { manager, incidents, logger } = setup({ streamFactory });
+      const longDead = createProvider({ lastUpdated: new Date(Date.now() - 10_000) });
+
+      manager.start(longDead);
+
+      await vi.waitFor(() => expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_GAVE_UP", owner: "akash1owner" })), {
+        timeout: 5000
+      });
+      expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(2);
+      expect(incidents.openIncident).toHaveBeenCalledWith("akash1owner");
+    });
+
+    it("logs STREAM_RECONNECTING only once for a long-dead provider", async () => {
+      const streamFactory = mock<ProviderStreamFactory>();
+      streamFactory.disposeProvider.mockResolvedValue();
+      streamFactory.openStatusStream.mockImplementation(() => throwingStream(new Error("connection lost")));
+      const { manager, logger } = setup({ streamFactory });
+      const countReconnects = () => logger.warn.mock.calls.filter(([arg]) => (arg as { event?: string })?.event === "STREAM_RECONNECTING").length;
+
+      manager.start(createProvider({ lastUpdated: new Date(Date.now() - 10_000) }));
+
+      await vi.waitFor(() => expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_GAVE_UP" })), { timeout: 5000 });
+      expect(countReconnects()).toBe(1);
+    });
+
+    it("uses the full retry budget for a recently-updated offline provider", async () => {
+      const streamFactory = mock<ProviderStreamFactory>();
+      streamFactory.disposeProvider.mockResolvedValue();
+      streamFactory.openStatusStream.mockImplementation(() => throwingStream(new Error("connection lost")));
+      const { manager, logger } = setup({ streamFactory });
+
+      manager.start(createProvider({ lastUpdated: new Date(Date.now() - 100) }));
+
+      await vi.waitFor(() => expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_GAVE_UP" })), { timeout: 5000 });
+      expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(6);
+    });
+
+    it("recovers a long-dead provider when its single retry succeeds", async () => {
+      let attempt = 0;
+      const streamFactory = mock<ProviderStreamFactory>();
+      streamFactory.disposeProvider.mockResolvedValue();
+      streamFactory.openStatusStream.mockImplementation(() => {
+        attempt++;
+        if (attempt === 1) return throwingStream(new Error("initial failure"));
+        return msgsThenHang([createCluster()]);
+      });
+      const { manager, writer } = setup({ streamFactory });
+
+      manager.start(createProvider({ lastUpdated: new Date(Date.now() - 10_000) }));
+
+      await vi.waitFor(() => expect(writer.updateInventory).toHaveBeenCalledTimes(1), { timeout: 5000 });
+    });
+  });
+
   describe("stale finalizer", () => {
     it("does not evict a replacement stream's registry entry when the old stream finishes", async () => {
       let resolveOldStream!: () => void;
@@ -479,6 +538,7 @@ describe(StreamLifecycleManagerService.name, () => {
     streams?: Record<string, AsyncIterable<ClusterState> | "hang">;
     streamFactory?: MockProxy<ProviderStreamFactory>;
     throttleMs?: number;
+    deadProviderThresholdMs?: number;
   }) {
     const streamFactory = input?.streamFactory ?? mock<ProviderStreamFactory>();
     streamFactory.disposeProvider.mockResolvedValue();
@@ -498,7 +558,8 @@ describe(StreamLifecycleManagerService.name, () => {
       STREAM_RECONNECT_INITIAL_DELAY_MS: 10,
       STREAM_RECONNECT_MAX_DELAY_MS: 50,
       STREAM_FIRST_MESSAGE_TIMEOUT_MS: 80,
-      STREAM_UPDATE_THROTTLE_MS: input?.throttleMs ?? 0
+      STREAM_UPDATE_THROTTLE_MS: input?.throttleMs ?? 0,
+      DEAD_PROVIDER_UPDATED_THRESHOLD_MS: input?.deadProviderThresholdMs ?? 1000
     });
 
     if (!input?.streamFactory) {
@@ -517,13 +578,14 @@ describe(StreamLifecycleManagerService.name, () => {
   }
 });
 
-function createProvider(overrides?: Partial<ChainProvider>): ChainProvider {
+function createProvider(overrides?: Partial<ChainProviderWithLastUpdated>): ChainProviderWithLastUpdated {
   return {
     owner: "akash1owner",
     hostUri: "https://p1:8443",
     selfAttributes: [],
     signedAttributes: [],
     auditedBy: [],
+    lastUpdated: null,
     ...overrides
   };
 }

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -15,7 +15,7 @@ import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
 import { DbDriver } from "@src/repositories/db-driver/db-driver";
 import { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
-import type { ChainProvider } from "@src/types/chain-provider";
+import type { ChainProviderWithLastUpdated } from "@src/types/chain-provider";
 import type { ClusterState } from "@src/types/inventory";
 import { ProviderStreamFactory } from "../provider-stream-factory/provider-stream-factory.sevice";
 
@@ -35,7 +35,8 @@ export class StreamLifecycleManagerService {
   >();
   readonly #lastInventoryPerProvider = new Map<string, ClusterState>();
   readonly #onlineStatePerProvider = new Map<string, boolean>();
-  readonly #retryStreamPolicy: RetryPolicy;
+  readonly #healthyProviderRetryStreamPolicy: RetryPolicy;
+  readonly #potentiallyDeadProviderRetryStreamPolicy: RetryPolicy;
   readonly #offlineDataloader: Dataloader<string, null>;
   readonly #startStreamSemaphore: Sema;
   readonly #pendingFirstAttempts = new Set<Promise<void>>();
@@ -55,8 +56,15 @@ export class StreamLifecycleManagerService {
     this.#dbDriver = dbDriver;
     this.#config = config;
     this.#logger = loggerFactory({ context: "StreamLifecycleManager" });
-    this.#retryStreamPolicy = retry(handleAll, {
+    this.#healthyProviderRetryStreamPolicy = retry(handleAll, {
       maxAttempts: 5,
+      backoff: new ExponentialBackoff({
+        initialDelay: this.#config.STREAM_RECONNECT_INITIAL_DELAY_MS,
+        maxDelay: this.#config.STREAM_RECONNECT_MAX_DELAY_MS
+      })
+    });
+    this.#potentiallyDeadProviderRetryStreamPolicy = retry(handleAll, {
+      maxAttempts: 1,
       backoff: new ExponentialBackoff({
         initialDelay: this.#config.STREAM_RECONNECT_INITIAL_DELAY_MS,
         maxDelay: this.#config.STREAM_RECONNECT_MAX_DELAY_MS
@@ -81,7 +89,7 @@ export class StreamLifecycleManagerService {
     return this.#activeStreams;
   }
 
-  start(provider: ChainProvider, signal?: AbortSignal): void {
+  start(provider: ChainProviderWithLastUpdated, signal?: AbortSignal): void {
     if (signal?.aborted) {
       this.#logger.warn({ event: "STREAM_START_ABORTED", owner: provider.owner, reason: "Received already aborted signal" });
       return;
@@ -101,7 +109,7 @@ export class StreamLifecycleManagerService {
     void this.#runStream(provider, controller.signal, firstAttempt.resolve).finally(() => signal?.removeEventListener("abort", abortProviderStream));
   }
 
-  restart(provider: ChainProvider, signal?: AbortSignal): void {
+  restart(provider: ChainProviderWithLastUpdated, signal?: AbortSignal): void {
     const previousHostUri = this.#activeStreams.get(provider.owner)?.hostUri;
     this.#abortIfActive(provider.owner, "STREAM_STOPPED_HOSTURI_CHANGE");
     if (previousHostUri && previousHostUri !== provider.hostUri) {
@@ -135,10 +143,13 @@ export class StreamLifecycleManagerService {
     this.#logger.info({ event, owner });
   }
 
-  async #runStream(provider: ChainProvider, signal: AbortSignal, onFirstAttemptSettled: () => void): Promise<void> {
+  async #runStream(provider: ChainProviderWithLastUpdated, signal: AbortSignal, onFirstAttemptSettled: () => void): Promise<void> {
     const onSettleAttempt = once(onFirstAttemptSettled);
     try {
-      await this.#retryStreamPolicy.execute(ctx => {
+      const isPotentiallyDeadProvider =
+        provider.lastUpdated && Date.now() - provider.lastUpdated.getTime() > this.#config.DEAD_PROVIDER_UPDATED_THRESHOLD_MS / 2;
+      const retryPolicy = isPotentiallyDeadProvider ? this.#potentiallyDeadProviderRetryStreamPolicy : this.#healthyProviderRetryStreamPolicy;
+      await retryPolicy.execute(ctx => {
         if (signal.aborted) return;
         if (ctx.attempt > 0) {
           this.#logger.warn({
@@ -168,7 +179,7 @@ export class StreamLifecycleManagerService {
     }
   }
 
-  async #runAttempt(provider: ChainProvider, outerSignal: AbortSignal, onAttemptSettled: () => void): Promise<void> {
+  async #runAttempt(provider: ChainProviderWithLastUpdated, outerSignal: AbortSignal, onAttemptSettled: () => void): Promise<void> {
     if (outerSignal.aborted) return;
 
     this.#lastInventoryPerProvider.delete(provider.owner);
@@ -216,7 +227,7 @@ export class StreamLifecycleManagerService {
     }
   }
 
-  async #updateProviderInventory(provider: ChainProvider, cluster: ClusterState): Promise<void> {
+  async #updateProviderInventory(provider: ChainProviderWithLastUpdated, cluster: ClusterState): Promise<void> {
     const cached = this.#lastInventoryPerProvider.get(provider.owner);
 
     if (!this.#onlineStatePerProvider.get(provider.owner)) {

--- a/apps/provider-inventory/src/types/chain-provider.ts
+++ b/apps/provider-inventory/src/types/chain-provider.ts
@@ -16,3 +16,7 @@ export interface ChainProvider {
   signedAttributes: SignedAttribute[];
   auditedBy: string[];
 }
+
+export interface ChainProviderWithLastUpdated extends ChainProvider {
+  lastUpdated: Date | null;
+}


### PR DESCRIPTION
## Why

Closes CON-461

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dead-provider detection to skip discovery for providers with stale inventory beyond a configurable threshold.
  * Adaptive retry strategies that reduce retry budgets for potentially stale providers.
  * Discovery now forwards per-provider last-updated info when starting/restarting streams.

* **Bug Fixes**
  * Prevent redundant online/offline transitions and avoid unnecessary timestamp changes.

* **Tests**
  * Expanded integration and unit tests covering dead-provider behavior, retry policies, and inventory timestamp handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->