### PR TITLE
feat(deployment): add IP endpoints management to deployment pane

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.spec.tsx
@@ -72,6 +72,13 @@ describe("DeploymentPane", () => {
     expect(onSelectService).toHaveBeenCalledWith("new-service-id");
   });
 
+  it("renders the IP endpoints section", () => {
+    const IpEndpointsSection = vi.fn(() => null);
+    setup({ dependencies: { IpEndpointsSection } });
+
+    expect(IpEndpointsSection).toHaveBeenCalled();
+  });
+
   function setup(input: {
     placements?: ReturnType<typeof defaultPlacement>[];
     onSelectService?: (serviceId: string) => void;

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
@@ -1,12 +1,13 @@
 import type { FC } from "react";
 import { useState } from "react";
-import { CustomTooltip } from "@akashnetwork/ui/components";
+import { Button, CustomTooltip } from "@akashnetwork/ui/components";
 import { InfoCircle, Plus, SidebarCollapse, SidebarExpand } from "iconoir-react";
 
+import { IpEndpointsSection } from "./IpEndpointsSection/IpEndpointsSection";
 import { PlacementCard } from "./PlacementCard/PlacementCard";
 import { usePlacementManager } from "./usePlacementManager/usePlacementManager";
 
-export const DEPENDENCIES = { PlacementCard, usePlacementManager };
+export const DEPENDENCIES = { PlacementCard, usePlacementManager, IpEndpointsSection };
 
 type Props = {
   selectedServiceId: string | null;
@@ -22,14 +23,9 @@ export const DeploymentPane: FC<Props> = ({ selectedServiceId, onSelectService, 
   if (minimized) {
     return (
       <aside aria-label="Deployment pane (minimized)" className="hidden h-full min-h-0 md:flex md:w-[48px] md:flex-col md:items-center md:pt-2">
-        <button
-          type="button"
-          onClick={toggle}
-          aria-label="Show deployment pane"
-          className="flex h-8 w-8 items-center justify-center rounded text-foreground hover:bg-accent"
-        >
+        <Button type="button" variant="ghost" onClick={toggle} aria-label="Show deployment pane" className="h-8 w-8 rounded p-0 text-foreground">
           <SidebarExpand className="h-5 w-5" />
-        </button>
+        </Button>
       </aside>
     );
   }
@@ -40,48 +36,49 @@ export const DeploymentPane: FC<Props> = ({ selectedServiceId, onSelectService, 
         <h2 id="configure-deployment-pane-heading" className="font-mono text-sm font-medium uppercase text-muted-foreground">
           1. Deployment
         </h2>
-        <button
-          type="button"
-          onClick={toggle}
-          aria-label="Hide deployment pane"
-          className="flex h-8 w-8 items-center justify-center rounded text-foreground hover:bg-accent"
-        >
+        <Button type="button" variant="ghost" onClick={toggle} aria-label="Hide deployment pane" className="h-8 w-8 rounded p-0 text-foreground">
           <SidebarCollapse className="h-5 w-5" />
-        </button>
+        </Button>
       </header>
-      <div className="flex-1 space-y-2 overflow-y-auto p-3">
-        <div className="flex items-center gap-1 px-1 font-mono text-xs uppercase text-muted-foreground">
-          Placement
-          <CustomTooltip
-            className="max-w-[260px] p-3 font-sans text-xs normal-case text-muted-foreground"
-            title="A placement sets a region and bundles services that should share a provider. Each placement is deployed together to one provider."
-          >
-            <InfoCircle className="h-3.5 w-3.5" />
-          </CustomTooltip>
+      <div className="flex-1 space-y-6 overflow-y-auto p-4">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2 px-1 font-mono text-xs uppercase text-muted-foreground">
+            Placement
+            <CustomTooltip
+              className="max-w-[260px] p-3 font-sans text-xs normal-case text-muted-foreground"
+              title="A placement sets a region and bundles services that should share a provider. Each placement is deployed together to one provider."
+            >
+              <InfoCircle className="h-3.5 w-3.5" />
+            </CustomTooltip>
+          </div>
+          <div className="space-y-4">
+            {manager.placements.map((placement, index) => (
+              <d.PlacementCard
+                key={placement.id}
+                placement={placement}
+                placementIndex={index}
+                services={manager.getPlacementServices(placement.id)}
+                selectedServiceId={selectedServiceId}
+                canRemove={manager.canRemovePlacement}
+                canRemoveService={manager.canRemoveService}
+                onSelectService={onSelectService}
+                onAddService={() => onSelectService(manager.addService(placement.id))}
+                onRemoveService={manager.removeService}
+                onRemove={() => manager.removePlacement(placement.id)}
+              />
+            ))}
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={manager.addPlacement}
+              className="w-full gap-1.5 rounded-lg border border-zinc-300 py-2 text-foreground dark:border-zinc-700"
+            >
+              <Plus className="h-4 w-4" />
+              Add Placement
+            </Button>
+          </div>
         </div>
-        {manager.placements.map((placement, index) => (
-          <d.PlacementCard
-            key={placement.id}
-            placement={placement}
-            placementIndex={index}
-            services={manager.getPlacementServices(placement.id)}
-            selectedServiceId={selectedServiceId}
-            canRemove={manager.canRemovePlacement}
-            canRemoveService={manager.canRemoveService}
-            onSelectService={onSelectService}
-            onAddService={() => onSelectService(manager.addService(placement.id))}
-            onRemoveService={manager.removeService}
-            onRemove={() => manager.removePlacement(placement.id)}
-          />
-        ))}
-        <button
-          type="button"
-          onClick={manager.addPlacement}
-          className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-zinc-300 py-2 text-sm font-medium text-foreground hover:bg-accent dark:border-zinc-700"
-        >
-          <Plus className="h-4 w-4" />
-          Add Placement
-        </button>
+        <d.IpEndpointsSection />
       </div>
     </section>
   );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/EndpointRow/EndpointRow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/EndpointRow/EndpointRow.spec.tsx
@@ -1,0 +1,46 @@
+import type { PropsWithChildren } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { EndpointRow } from "./EndpointRow";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe("EndpointRow", () => {
+  it("renders the endpoint name in an editable field", () => {
+    setup({});
+
+    expect(screen.getByRole("textbox", { name: "Endpoint name" })).toHaveValue("endpoint-1");
+  });
+
+  it("removes the endpoint", async () => {
+    const { onRemove } = setup({});
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove endpoint-1" }));
+
+    expect(onRemove).toHaveBeenCalled();
+  });
+
+  function setup(input: { name?: string }) {
+    const name = input.name ?? "endpoint-1";
+    const values: SdlBuilderFormValuesType = { ...defaultServiceWithPlacement(), endpoints: [{ id: "e-1", name }] };
+    const onRemove = vi.fn();
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values });
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    render(
+      <Wrapper>
+        <ul aria-label="IP endpoints">
+          <EndpointRow endpoint={values.endpoints![0]} endpointIndex={0} onRemove={onRemove} />
+        </ul>
+      </Wrapper>
+    );
+
+    return { onRemove };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/EndpointRow/EndpointRow.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/EndpointRow/EndpointRow.tsx
@@ -1,0 +1,34 @@
+import type { FC } from "react";
+import { Button, InlineEditInput } from "@akashnetwork/ui/components";
+import { Globe, Trash } from "iconoir-react";
+
+import type { EndpointType } from "@src/types";
+
+export const DEPENDENCIES = { InlineEditInput };
+
+type Props = {
+  endpoint: EndpointType;
+  endpointIndex: number;
+  onRemove: () => void;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+export const EndpointRow: FC<Props> = ({ endpoint, endpointIndex, onRemove, dependencies: d = DEPENDENCIES }) => {
+  return (
+    <li className="group flex items-start gap-2 rounded-md border border-zinc-300 px-2.5 py-2 dark:border-zinc-700">
+      <span className="flex h-5 shrink-0 items-center text-muted-foreground">
+        <Globe className="h-3.5 w-3.5" />
+      </span>
+      <d.InlineEditInput name={`endpoints.${endpointIndex}.name`} label="Endpoint name" />
+      <Button
+        type="button"
+        variant="text"
+        aria-label={`Remove ${endpoint.name}`}
+        onClick={onRemove}
+        className="invisible h-5 shrink-0 p-0 text-muted-foreground group-hover:visible hover:text-foreground focus-visible:visible"
+      >
+        <Trash className="h-3.5 w-3.5" />
+      </Button>
+    </li>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/IpEndpointsSection/IpEndpointsSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/IpEndpointsSection/IpEndpointsSection.spec.tsx
@@ -1,0 +1,108 @@
+import type { ComponentProps, PropsWithChildren } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { TooltipProvider } from "@akashnetwork/ui/components";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { SdlBuilderFormValuesSchema } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { DEPENDENCIES, IpEndpointsSection } from "./IpEndpointsSection";
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe("IpEndpointsSection", () => {
+  it("renders a row per endpoint", () => {
+    const EndpointRow = vi.fn<(props: ComponentProps<typeof DEPENDENCIES.EndpointRow>) => null>(() => null);
+    setup({
+      endpoints: [
+        { id: "e-1", name: "endpoint-1" },
+        { id: "e-2", name: "endpoint-2" }
+      ],
+      dependencies: { EndpointRow }
+    });
+
+    expect(EndpointRow).toHaveBeenCalledTimes(2);
+  });
+
+  it("adds an endpoint", async () => {
+    const { manager } = setup({ endpoints: [] });
+
+    await userEvent.click(screen.getByRole("button", { name: "Add endpoint" }));
+
+    expect(manager.addEndpoint).toHaveBeenCalled();
+  });
+
+  it("removes the endpoint by id", () => {
+    const EndpointRow = vi.fn<(props: ComponentProps<typeof DEPENDENCIES.EndpointRow>) => null>(() => null);
+    const { manager } = setup({ endpoints: [{ id: "e-1", name: "endpoint-1" }], dependencies: { EndpointRow } });
+
+    EndpointRow.mock.calls[0][0].onRemove();
+
+    expect(manager.removeEndpoint).toHaveBeenCalledWith("e-1");
+  });
+
+  function setup(input: { endpoints: { id: string; name: string }[]; dependencies?: Partial<typeof DEPENDENCIES> }) {
+    const manager = mock<ReturnType<typeof DEPENDENCIES.useEndpointManager>>({
+      endpoints: input.endpoints,
+      addEndpoint: vi.fn(),
+      removeEndpoint: vi.fn()
+    });
+    const useEndpointManager: typeof DEPENDENCIES.useEndpointManager = () => manager;
+
+    render(
+      <TooltipProvider>
+        <IpEndpointsSection dependencies={MockComponents(DEPENDENCIES, { useEndpointManager, ...input.dependencies })} />
+      </TooltipProvider>
+    );
+
+    return { manager };
+  }
+});
+
+describe("IpEndpointsSection uniqueness validation", () => {
+  it("removes the uniqueness error from the surviving row after a duplicate is deleted", async () => {
+    setup({
+      endpoints: [
+        { id: "e-1", name: "endpoint-1" },
+        { id: "e-2", name: "endpoint-2" }
+      ]
+    });
+
+    duplicateSecondRow("endpoint-1");
+    await waitFor(() => expect(screen.getAllByText("Endpoint name must be unique.")).toHaveLength(2));
+
+    const removeButtons = screen.getAllByRole("button", { name: /Remove endpoint-1/ });
+    fireEvent.click(removeButtons[removeButtons.length - 1]);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Endpoint name must be unique.")).not.toBeInTheDocument();
+    });
+  });
+
+  function duplicateSecondRow(value: string) {
+    const inputs = screen.getAllByLabelText("Endpoint name");
+    fireEvent.change(inputs[1], { target: { value } });
+    fireEvent.blur(inputs[1]);
+  }
+
+  function setup(input: { endpoints: SdlBuilderFormValuesType["endpoints"] }) {
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({
+        defaultValues: { ...defaultServiceWithPlacement(), endpoints: input.endpoints },
+        mode: "onChange",
+        resolver: zodResolver(SdlBuilderFormValuesSchema)
+      });
+      return (
+        <FormProvider {...form}>
+          <TooltipProvider>{children}</TooltipProvider>
+        </FormProvider>
+      );
+    };
+
+    return render(<IpEndpointsSection />, { wrapper: Wrapper });
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/IpEndpointsSection/IpEndpointsSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/IpEndpointsSection/IpEndpointsSection.tsx
@@ -1,0 +1,46 @@
+import type { FC } from "react";
+import { Button, CustomTooltip } from "@akashnetwork/ui/components";
+import { InfoCircle, Plus } from "iconoir-react";
+
+import { EndpointRow } from "../EndpointRow/EndpointRow";
+import { useEndpointManager } from "../useEndpointManager/useEndpointManager";
+
+export const DEPENDENCIES = { EndpointRow, useEndpointManager };
+
+type Props = {
+  dependencies?: typeof DEPENDENCIES;
+};
+
+export const IpEndpointsSection: FC<Props> = ({ dependencies: d = DEPENDENCIES }) => {
+  const manager = d.useEndpointManager();
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 px-1 font-mono text-xs uppercase text-muted-foreground">
+        IP Endpoints
+        <CustomTooltip
+          className="max-w-[260px] p-3 font-sans text-xs normal-case text-muted-foreground"
+          title="IP endpoints provide a dedicated IP for your deployment. Reference an endpoint from a service's port to bind that port to the leased IP."
+        >
+          <InfoCircle className="h-3.5 w-3.5" />
+        </CustomTooltip>
+      </div>
+      {manager.endpoints.length > 0 && (
+        <ul aria-label="IP endpoints" className="space-y-2">
+          {manager.endpoints.map((endpoint, index) => (
+            <d.EndpointRow key={endpoint.id} endpoint={endpoint} endpointIndex={index} onRemove={() => manager.removeEndpoint(endpoint.id)} />
+          ))}
+        </ul>
+      )}
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={manager.addEndpoint}
+        className="w-full gap-1.5 rounded-lg border border-zinc-300 py-2 text-foreground dark:border-zinc-700"
+      >
+        <Plus className="h-4 w-4" />
+        Add endpoint
+      </Button>
+    </div>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.spec.tsx
@@ -46,7 +46,7 @@ describe("PlacementCard", () => {
       service: defaultService(placement.id, { title }),
       index
     }));
-    const values: SdlBuilderFormValuesType = { placements: [placement], services: services.map(({ service }) => service) };
+    const values: SdlBuilderFormValuesType = { placements: [placement], services: services.map(({ service }) => service), endpoints: [] };
     const onAddService = vi.fn();
     const onRemove = vi.fn();
     const onSelectService = vi.fn();

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/useEndpointManager/useEndpointManager.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/useEndpointManager/useEndpointManager.spec.tsx
@@ -1,0 +1,61 @@
+import type { PropsWithChildren } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { useEndpointManager } from "./useEndpointManager";
+
+import { act, renderHook } from "@testing-library/react";
+
+describe("useEndpointManager", () => {
+  it("starts with no endpoints by default", () => {
+    const { result } = setup({ values: defaultServiceWithPlacement() });
+
+    expect(result.current.endpoints).toHaveLength(0);
+  });
+
+  it("appends an endpoint with a unique generated name", () => {
+    const { result } = setup({ values: defaultServiceWithPlacement() });
+
+    act(() => {
+      result.current.addEndpoint();
+    });
+
+    expect(result.current.endpoints).toHaveLength(1);
+    expect(result.current.endpoints[0].name).toBe("endpoint-1");
+
+    act(() => {
+      result.current.addEndpoint();
+    });
+
+    expect(result.current.endpoints).toHaveLength(2);
+    expect(result.current.endpoints[1].name).toBe("endpoint-2");
+  });
+
+  it("removes an endpoint by id", () => {
+    const values: SdlBuilderFormValuesType = {
+      ...defaultServiceWithPlacement(),
+      endpoints: [
+        { id: "e-1", name: "endpoint-1" },
+        { id: "e-2", name: "endpoint-2" }
+      ]
+    };
+    const { result } = setup({ values });
+
+    act(() => {
+      result.current.removeEndpoint("e-1");
+    });
+
+    expect(result.current.endpoints).toHaveLength(1);
+    expect(result.current.endpoints[0].id).toBe("e-2");
+  });
+
+  function setup(input: { values: SdlBuilderFormValuesType }) {
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: input.values });
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+    return renderHook(() => useEndpointManager(), { wrapper: Wrapper });
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/useEndpointManager/useEndpointManager.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/useEndpointManager/useEndpointManager.ts
@@ -1,0 +1,34 @@
+import { useCallback, useMemo } from "react";
+import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { defaultEndpoint } from "@src/utils/sdl/data";
+import { mergeFieldValues, nextEndpointName } from "@src/utils/sdl/formArrayHelpers";
+import { useRevalidateUniqueness } from "../useRevalidateUniqueness/useRevalidateUniqueness";
+
+export const useEndpointManager = () => {
+  const { control, getValues } = useFormContext<SdlBuilderFormValuesType>();
+  const watchedEndpoints = useWatch<SdlBuilderFormValuesType>({ control, name: "endpoints" });
+  const { fields, append, remove } = useFieldArray({ control, name: "endpoints", keyName: "fieldId" });
+
+  useRevalidateUniqueness("endpoints", endpoint => endpoint.name);
+
+  const endpoints = useMemo(() => mergeFieldValues(fields, watchedEndpoints as SdlBuilderFormValuesType["endpoints"]), [fields, watchedEndpoints]);
+
+  const addEndpoint = useCallback(() => {
+    append(defaultEndpoint({ name: nextEndpointName(getValues("endpoints") ?? []) }));
+  }, [append, getValues]);
+
+  const removeEndpoint = useCallback(
+    (endpointId: string) => {
+      const index = (getValues("endpoints") ?? []).findIndex(endpoint => endpoint.id === endpointId);
+      if (index === -1) {
+        return;
+      }
+      remove(index);
+    },
+    [getValues, remove]
+  );
+
+  return useMemo(() => ({ endpoints, addEndpoint, removeEndpoint }), [endpoints, addEndpoint, removeEndpoint]);
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/usePlacementManager/usePlacementManager.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/usePlacementManager/usePlacementManager.spec.tsx
@@ -42,7 +42,8 @@ describe("usePlacementManager", () => {
     const placementB = defaultPlacement({ name: "placement-2" });
     const values: SdlBuilderFormValuesType = {
       placements: [placementA, placementB],
-      services: [defaultService(placementA.id, { title: "web" }), defaultService(placementB.id, { title: "api" })]
+      services: [defaultService(placementA.id, { title: "web" }), defaultService(placementB.id, { title: "api" })],
+      endpoints: []
     };
     const { result } = setup({ values });
 
@@ -67,7 +68,8 @@ describe("usePlacementManager", () => {
     const placementB = defaultPlacement({ name: "placement-2" });
     const values: SdlBuilderFormValuesType = {
       placements: [placementA, placementB],
-      services: [defaultService(placementA.id, { title: "web" })]
+      services: [defaultService(placementA.id, { title: "web" })],
+      endpoints: []
     };
     const { result } = setup({ values });
 
@@ -86,7 +88,7 @@ describe("usePlacementManager", () => {
     const placement = defaultPlacement();
     const serviceA = defaultService(placement.id, { title: "web" });
     const serviceB = defaultService(placement.id, { title: "api" });
-    const { result } = setup({ values: { placements: [placement], services: [serviceA, serviceB] } });
+    const { result } = setup({ values: { placements: [placement], services: [serviceA, serviceB], endpoints: [] } });
 
     act(() => {
       result.current.removeService(serviceB.id as string);
@@ -108,7 +110,7 @@ describe("usePlacementManager", () => {
     const web = defaultService(placement.id, { title: "web" });
     const collector = defaultService(placement.id, { title: "web-log-collector", image: LOG_COLLECTOR_IMAGE });
     const api = defaultService(placement.id, { title: "api" });
-    const { result } = setup({ values: { placements: [placement], services: [web, collector, api] } });
+    const { result } = setup({ values: { placements: [placement], services: [web, collector, api], endpoints: [] } });
 
     act(() => {
       result.current.removeService(web.id as string);

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/usePlacementManager/usePlacementManager.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/usePlacementManager/usePlacementManager.ts
@@ -4,12 +4,17 @@ import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 import { isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
 import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { defaultPlacement, defaultService } from "@src/utils/sdl/data";
-import { nextPlacementName, nextServiceTitle, serviceRemovalIndexes } from "@src/utils/sdl/formArrayHelpers";
+import { mergeFieldValues, nextPlacementName, nextServiceTitle, serviceRemovalIndexes } from "@src/utils/sdl/formArrayHelpers";
+import { useRevalidateUniqueness } from "../useRevalidateUniqueness/useRevalidateUniqueness";
 
 export type IndexedService = { service: ServiceType; index: number };
 
 export const usePlacementManager = () => {
   const { control, getValues } = useFormContext<SdlBuilderFormValuesType>();
+
+  useRevalidateUniqueness("placements", placement => placement.name);
+  useRevalidateUniqueness("services", service => service.title);
+
   const watchedPlacements = useWatch<SdlBuilderFormValuesType>({ control, name: "placements" });
   const watchedServices = useWatch<SdlBuilderFormValuesType>({ control, name: "services" });
 
@@ -99,20 +104,3 @@ export const usePlacementManager = () => {
     [placements, getPlacementServices, addPlacement, canRemovePlacement, removePlacement, addService, canRemoveService, removeService]
   );
 };
-
-/**
- * Controlled field-array merge (per react-hook-form docs): `fields` is the
- * single source of truth for structure and ordering — which keeps the
- * library's internal re-index bookkeeping consistent with what is rendered —
- * while the watched values overlay live field edits (e.g. renames).
- *
- * Rendering from watched values alone drifts from RHF's field registry on
- * removal: index-based Controllers (`services.${i}.title`) shift their
- * registered path and the abandoned registration resurrects as a partial
- * `{ name }`/`{ title }`-only ghost row. Reading `fields[i]` alone instead
- * shows stale text until the next structural mutation. Merging avoids both.
- */
-function mergeFieldValues<T extends object>(fields: (T & { fieldId: string })[], values: T[] | undefined): T[] {
-  const liveValues = Array.isArray(values) ? values : [];
-  return fields.map((field, index) => ({ ...field, ...liveValues[index] }));
-}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness.spec.tsx
@@ -1,0 +1,145 @@
+import type { PropsWithChildren } from "react";
+import type { Path } from "react-hook-form";
+import { Controller, FormProvider, useForm, useFormContext, useWatch } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { describe, expect, it } from "vitest";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { SdlBuilderFormValuesSchema } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { useRevalidateUniqueness } from "./useRevalidateUniqueness";
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+type FieldArrayName = "placements" | "services" | "endpoints";
+
+describe(useRevalidateUniqueness.name, () => {
+  it("shows the uniqueness error on every conflicting endpoint row, not just the last", async () => {
+    setup({
+      name: "endpoints",
+      subField: "name",
+      values: {
+        ...defaultServiceWithPlacement(),
+        endpoints: [
+          { id: "e-1", name: "endpoint-1" },
+          { id: "e-2", name: "endpoint-2" }
+        ]
+      }
+    });
+
+    duplicateSecondRowOnto("endpoints", "endpoint-1");
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Endpoint name must be unique.")).toHaveLength(2);
+    });
+  });
+
+  it("clears the stale error on a sibling endpoint row once the conflict is resolved elsewhere", async () => {
+    setup({
+      name: "endpoints",
+      subField: "name",
+      values: {
+        ...defaultServiceWithPlacement(),
+        endpoints: [
+          { id: "e-1", name: "endpoint-1" },
+          { id: "e-2", name: "endpoint-2" }
+        ]
+      }
+    });
+    duplicateSecondRowOnto("endpoints", "endpoint-1");
+    await waitFor(() => expect(screen.getAllByText("Endpoint name must be unique.")).toHaveLength(2));
+
+    editRow("endpoints", 0, "endpoint-3");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Endpoint name must be unique.")).not.toBeInTheDocument();
+    });
+  });
+
+  it("clears the stale error on a sibling placement row once the conflict is resolved elsewhere", async () => {
+    setup({
+      name: "placements",
+      subField: "name",
+      values: {
+        ...defaultServiceWithPlacement(),
+        placements: [
+          { id: "p-1", name: "dcloud" },
+          { id: "p-2", name: "dcloud-2" }
+        ]
+      }
+    });
+    duplicateSecondRowOnto("placements", "dcloud");
+    await waitFor(() => expect(screen.getAllByText("Placement name must be unique.")).toHaveLength(2));
+
+    editRow("placements", 0, "dcloud-3");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Placement name must be unique.")).not.toBeInTheDocument();
+    });
+  });
+
+  function duplicateSecondRowOnto(name: FieldArrayName, value: string) {
+    editRow(name, 1, value);
+  }
+
+  function editRow(name: FieldArrayName, index: number, value: string) {
+    const input = screen.getByLabelText(`${name}-${index}`);
+    fireEvent.change(input, { target: { value } });
+    fireEvent.blur(input);
+  }
+
+  function setup<TName extends FieldArrayName>(input: {
+    name: TName;
+    subField: string;
+    values: SdlBuilderFormValuesType;
+    selectKey?: (item: SdlBuilderFormValuesType[TName][number]) => string;
+  }) {
+    const selectKey = input.selectKey ?? ((item: Record<string, unknown>) => String(item[input.subField]));
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({
+        defaultValues: input.values,
+        mode: "onChange",
+        resolver: zodResolver(SdlBuilderFormValuesSchema)
+      });
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+    render(
+      <Wrapper>
+        <Harness name={input.name} subField={input.subField} selectKey={selectKey as (item: SdlBuilderFormValuesType[TName][number]) => string} />
+      </Wrapper>
+    );
+  }
+});
+
+function Harness<TName extends FieldArrayName>({
+  name,
+  subField,
+  selectKey
+}: {
+  name: TName;
+  subField: string;
+  selectKey: (item: SdlBuilderFormValuesType[TName][number]) => string;
+}) {
+  useRevalidateUniqueness(name, selectKey);
+
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const items = (useWatch({ control, name }) ?? []) as unknown[];
+
+  return (
+    <>
+      {items.map((_, index) => (
+        <Controller
+          key={index}
+          control={control}
+          name={`${name}.${index}.${subField}` as Path<SdlBuilderFormValuesType>}
+          render={({ field, fieldState }) => (
+            <div>
+              <input aria-label={`${name}-${index}`} value={(field.value as string) ?? ""} onChange={event => field.onChange(event.target.value)} />
+              {fieldState.error && <span>{fieldState.error.message}</span>}
+            </div>
+          )}
+        />
+      ))}
+    </>
+  );
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+
+/** Field arrays whose rows are validated for a unique key (name/title). */
+type UniqueFieldArrayName = "placements" | "services" | "endpoints";
+
+/**
+ * Re-runs validation for the `name` field array whenever the `selectKey` value
+ * of any row changes. React Hook Form only refreshes the error slot of the field
+ * that changed, so a cross-row "must be unique" error stays stale on sibling rows
+ * even after the conflict is resolved or removed elsewhere. Re-validating the
+ * whole array recomputes every row's error and clears the stale ones.
+ *
+ * `trigger` is called with an array path rather than a bare string on purpose:
+ * each row's input subscribes to its exact field path (`endpoints.0.name`, …),
+ * and an array argument makes RHF broadcast the validation update to every field
+ * subscriber so sibling rows re-render. A bare string only notifies the array
+ * path itself, leaving the rows visually stale.
+ */
+export const useRevalidateUniqueness = <TName extends UniqueFieldArrayName>(
+  name: TName,
+  selectKey: (item: SdlBuilderFormValuesType[TName][number]) => string
+) => {
+  const { control, trigger } = useFormContext<SdlBuilderFormValuesType>();
+  const items = useWatch({ control, name }) as SdlBuilderFormValuesType[TName] | undefined;
+  const key = (items ?? []).map(selectKey).join("\u0000");
+
+  useEffect(
+    function revalidateOnKeyChange() {
+      void trigger([name]);
+    },
+    [key, name, trigger]
+  );
+};

--- a/apps/deploy-web/src/components/sdl/SimpleSdlBuilderForm.tsx
+++ b/apps/deploy-web/src/components/sdl/SimpleSdlBuilderForm.tsx
@@ -89,7 +89,7 @@ export const SimpleSDLBuilderForm: React.FunctionComponent = () => {
 
   useEffect(() => {
     if (_services) {
-      setSdlBuilderSdl({ placements: _placements as SdlBuilderFormValuesType["placements"], services: _services as ServiceType[] });
+      setSdlBuilderSdl({ placements: _placements as SdlBuilderFormValuesType["placements"], services: _services as ServiceType[], endpoints: [] });
     }
   }, [_services, _placements]);
 

--- a/apps/deploy-web/src/hooks/useSdlEnv/useSdlEnv.spec.tsx
+++ b/apps/deploy-web/src/hooks/useSdlEnv/useSdlEnv.spec.tsx
@@ -106,7 +106,8 @@ describe("useSdlEnv", () => {
       placements: [{ id: "p-1", name: "dcloud" }],
       services: [buildSDLService({ env: [] })],
       imageList: [],
-      hasSSHKey: false
+      hasSSHKey: false,
+      endpoints: []
     };
 
     const { result } = renderHook(

--- a/apps/deploy-web/src/hooks/useSdlServiceManager/useSdlServiceManager.spec.tsx
+++ b/apps/deploy-web/src/hooks/useSdlServiceManager/useSdlServiceManager.spec.tsx
@@ -222,7 +222,8 @@ describe(useSdlServiceManager.name, () => {
       placements: defaultPlacements,
       services: defaultServices,
       imageList: [],
-      hasSSHKey: false
+      hasSSHKey: false,
+      endpoints: []
     };
 
     const { result } = renderHook(

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { SdlBuilderFormValuesSchema, ServiceSchema } from "./sdlBuilder";
+import { EndpointSchema, SdlBuilderFormValuesSchema, ServiceSchema } from "./sdlBuilder";
 
 describe("ServiceSchema", () => {
   it("validates a minimal valid service", () => {
@@ -68,6 +68,7 @@ describe("SdlBuilderFormValuesSchema", () => {
 
     expect(result.success).toBe(false);
     if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["placements", 0, "name"], message: "Placement name must be unique." }));
     expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["placements", 1, "name"], message: "Placement name must be unique." }));
   });
 
@@ -88,6 +89,90 @@ describe("SdlBuilderFormValuesSchema", () => {
 
     expect(result.success).toBe(false);
     if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["services", 0, "title"], message: "Service name must be unique." }));
     expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["services", 1, "title"], message: "Service name must be unique." }));
+  });
+
+  it("accepts a valid endpoints array", () => {
+    const result = SdlBuilderFormValuesSchema.safeParse({
+      placements: [{ id: "p-1", name: "dcloud" }],
+      services: [
+        {
+          title: "web",
+          image: "nginx:latest",
+          profile: { cpu: 0.1, ram: 256, ramUnit: "Mi", storage: [{ size: 512, unit: "Mi" }] },
+          expose: [{ port: 80, as: 80, global: true }],
+          placementId: "p-1",
+          pricing: { amount: 1000, denom: "uakt" },
+          count: 1
+        }
+      ],
+      endpoints: [{ id: "e-1", name: "endpoint-1" }]
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects duplicate endpoint names", () => {
+    const result = SdlBuilderFormValuesSchema.safeParse({
+      placements: [{ id: "p-1", name: "dcloud" }],
+      services: [
+        {
+          title: "web",
+          image: "nginx:latest",
+          profile: { cpu: 0.1, ram: 256, ramUnit: "Mi", storage: [{ size: 512, unit: "Mi" }] },
+          expose: [{ port: 80, as: 80, global: true }],
+          placementId: "p-1",
+          pricing: { amount: 1000, denom: "uakt" },
+          count: 1
+        }
+      ],
+      endpoints: [
+        { id: "e-1", name: "endpoint-1" },
+        { id: "e-2", name: "endpoint-1" }
+      ]
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["endpoints", 0, "name"], message: "Endpoint name must be unique." }));
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["endpoints", 1, "name"], message: "Endpoint name must be unique." }));
+  });
+
+  it("flags duplicate endpoint names even when a service image is invalid", () => {
+    const result = SdlBuilderFormValuesSchema.safeParse({
+      placements: [{ id: "p-1", name: "dcloud" }],
+      services: [
+        {
+          title: "web",
+          image: "",
+          profile: { cpu: 0.1, ram: 256, ramUnit: "Mi", storage: [{ size: 512, unit: "Mi" }] },
+          expose: [{ port: 80, as: 80, global: true }],
+          placementId: "p-1",
+          pricing: { amount: 1000, denom: "uakt" },
+          count: 1
+        }
+      ],
+      endpoints: [
+        { id: "e-1", name: "endpoint-1" },
+        { id: "e-2", name: "endpoint-1" }
+      ]
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["endpoints", 1, "name"], message: "Endpoint name must be unique." }));
+  });
+});
+
+describe("EndpointSchema", () => {
+  it("rejects a name with invalid characters", () => {
+    const result = EndpointSchema.safeParse({ id: "e-1", name: "Endpoint_1!" });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts a valid lowercase-dashed name", () => {
+    const result = EndpointSchema.safeParse({ id: "e-1", name: "endpoint-1" });
+    expect(result.success).toBe(true);
   });
 });

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -215,6 +215,16 @@ export const PlacementSchema = z.object({
     .optional()
 });
 
+export const EndpointSchema = z.object({
+  id: z.string().min(1, { message: "Endpoint id is required." }),
+  name: z
+    .string()
+    .min(1, { message: "Endpoint name is required." })
+    .regex(ENDPOINT_NAME_VALIDATION_REGEX, { message: "Invalid endpoint name. It must only be lower case letters, numbers and dashes." })
+    .regex(/^[a-z]/, { message: "Invalid starting character. It can only start with a lowercase letter." })
+    .regex(/[^-]$/, { message: "Invalid ending character. It can only end with a lowercase letter or number" })
+});
+
 const validateCpuAmount = (value: number, serviceCount: number, context: z.RefinementCtx) => {
   if (serviceCount === 1 && value < 0.1) {
     context.addIssue({
@@ -384,16 +394,37 @@ const logProviderVars = z.discriminatedUnion("PROVIDER", [
   })
 ]);
 
+/**
+ * Returns the indexes of every item whose `selectKey` value is shared by more
+ * than one item, including the first occurrence — so each row in a duplicate
+ * group can be flagged, not just the later ones.
+ */
+function findDuplicateIndexes<T>(items: T[], selectKey: (item: T) => string): Set<number> {
+  const firstIndexByKey = new Map<string, number>();
+  const duplicateIndexes = new Set<number>();
+  items.forEach((item, index) => {
+    const key = selectKey(item);
+    const firstIndex = firstIndexByKey.get(key);
+    if (firstIndex === undefined) {
+      firstIndexByKey.set(key, index);
+    } else {
+      duplicateIndexes.add(firstIndex);
+      duplicateIndexes.add(index);
+    }
+  });
+  return duplicateIndexes;
+}
+
 export const SdlBuilderFormValuesSchema = z
   .object({
     placements: z.array(PlacementSchema).min(1, { message: "At least one placement is required." }),
-    services: z.array(ServiceSchema).min(1, { message: "At least one service is required." })
+    services: z.array(ServiceSchema).min(1, { message: "At least one service is required." }),
+    endpoints: z.array(EndpointSchema).optional().default([])
   })
   .merge(ImageList)
   .merge(SSHKey)
   .superRefine((data, ctx) => {
     const placementIds = new Set<string>();
-    const placementNames = new Set<string>();
     for (let i = 0; i < data.placements.length; i++) {
       const placementId = data.placements[i].id;
       if (placementIds.has(placementId)) {
@@ -406,18 +437,15 @@ export const SdlBuilderFormValuesSchema = z
         continue;
       }
       placementIds.add(placementId);
+    }
 
-      const placementName = data.placements[i].name;
-      if (placementNames.has(placementName)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "Placement name must be unique.",
-          path: ["placements", i, "name"],
-          fatal: true
-        });
-      } else {
-        placementNames.add(placementName);
-      }
+    for (const index of findDuplicateIndexes(data.placements, placement => placement.name)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Placement name must be unique.",
+        path: ["placements", index, "name"],
+        fatal: true
+      });
     }
 
     for (let i = 0; i < data.services.length; i++) {
@@ -431,19 +459,21 @@ export const SdlBuilderFormValuesSchema = z
       }
     }
 
-    const serviceTitles = new Set<string>();
-    for (let i = 0; i < data.services.length; i++) {
-      const title = data.services[i].title;
-      if (serviceTitles.has(title)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "Service name must be unique.",
-          path: ["services", i, "title"],
-          fatal: true
-        });
-      } else {
-        serviceTitles.add(title);
-      }
+    for (const index of findDuplicateIndexes(data.services, service => service.title)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Service name must be unique.",
+        path: ["services", index, "title"],
+        fatal: true
+      });
+    }
+
+    for (const index of findDuplicateIndexes(data.endpoints ?? [], endpoint => endpoint.name)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Endpoint name must be unique.",
+        path: ["endpoints", index, "name"]
+      });
     }
 
     if (data.imageList && data.imageList.length > 0) {
@@ -513,3 +543,4 @@ export type PlacementAttributeType = z.infer<typeof PlacementAttributeSchema>;
 export type SignedByType = z.infer<typeof SignedBySchema>;
 export type ExposeType = z.infer<typeof ExposeSchema>;
 export type PlacementType = z.infer<typeof PlacementSchema>;
+export type EndpointType = z.infer<typeof EndpointSchema>;

--- a/apps/deploy-web/src/utils/sdl/data.ts
+++ b/apps/deploy-web/src/utils/sdl/data.ts
@@ -1,7 +1,7 @@
 import { nanoid } from "nanoid";
 
 import { UACT_DENOM } from "@src/config/denom.config";
-import type { PlacementType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
+import type { EndpointType, PlacementType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
 
 export const protoTypes = [
   { id: 1, name: "http" },
@@ -29,6 +29,13 @@ export const defaultPlacement = (overrides?: Partial<PlacementType>): PlacementT
     allOf: []
   },
   attributes: [],
+  ...overrides
+});
+
+/** Builds a fresh IP endpoint with a generated id and the default name "endpoint-1"; callers pass a unique name via overrides. */
+export const defaultEndpoint = (overrides?: Partial<EndpointType>): EndpointType => ({
+  id: nanoid(),
+  name: "endpoint-1",
   ...overrides
 });
 
@@ -97,7 +104,8 @@ export const defaultServiceWithPlacement = (serviceOverrides?: Partial<ServiceTy
   const placement = defaultPlacement();
   return {
     placements: [placement],
-    services: [defaultService(placement.id, serviceOverrides)]
+    services: [defaultService(placement.id, serviceOverrides)],
+    endpoints: []
   };
 };
 

--- a/apps/deploy-web/src/utils/sdl/formArrayHelpers.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/formArrayHelpers.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { LOG_COLLECTOR_IMAGE } from "@src/config/log-collector.config";
-import { nextPlacementName, nextServiceTitle, serviceRemovalIndexes } from "./formArrayHelpers";
+import { nextEndpointName, nextPlacementName, nextServiceTitle, serviceRemovalIndexes } from "./formArrayHelpers";
 
 import { buildSDLService } from "@tests/seeders/sdlService";
 
@@ -54,5 +54,19 @@ describe("serviceRemovalIndexes", () => {
     const indexes = serviceRemovalIndexes(services, 0);
 
     expect(indexes).toEqual([1, 0]);
+  });
+});
+
+describe("nextEndpointName", () => {
+  it("starts numbering at endpoint-1 for an empty list", () => {
+    expect(nextEndpointName([])).toBe("endpoint-1");
+  });
+
+  it("skips names already taken", () => {
+    const endpoints = [
+      { id: "e-1", name: "endpoint-1" },
+      { id: "e-2", name: "endpoint-3" }
+    ];
+    expect(nextEndpointName(endpoints)).toBe("endpoint-2");
   });
 });

--- a/apps/deploy-web/src/utils/sdl/formArrayHelpers.ts
+++ b/apps/deploy-web/src/utils/sdl/formArrayHelpers.ts
@@ -1,5 +1,5 @@
 import { findOwnLogCollectorServiceIndex, isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
-import type { PlacementType, ServiceType } from "@src/types";
+import type { EndpointType, PlacementType, ServiceType } from "@src/types";
 
 /**
  * Next unique auto-generated service title ("service-N"), continuing from the
@@ -26,6 +26,15 @@ export const nextPlacementName = (placements: Pick<PlacementType, "id" | "name">
   );
 };
 
+/** Next unique auto-generated endpoint name ("endpoint-N"), always scanning up from 1. */
+export const nextEndpointName = (endpoints: Pick<EndpointType, "id" | "name">[]): string => {
+  return nextUniqueName(
+    "endpoint",
+    1,
+    endpoints.map(endpoint => endpoint.name)
+  );
+};
+
 /**
  * Indexes to remove when deleting the service at `index`, including its paired
  * log-collector service, sorted descending so removals don't shift positions.
@@ -41,4 +50,17 @@ function nextUniqueName(prefix: string, start: number, taken: string[]): string 
     next++;
   }
   return `${prefix}-${next}`;
+}
+
+/**
+ * Controlled field-array merge (per react-hook-form docs): `fields` is the
+ * single source of truth for structure and ordering — keeping the library's
+ * internal re-index bookkeeping consistent with what is rendered — while the
+ * watched values overlay live field edits (e.g. renames). Reading either source
+ * alone drifts: watched-only resurrects ghost rows on removal, fields-only shows
+ * stale text until the next structural mutation. Merging avoids both.
+ */
+export function mergeFieldValues<T extends object>(fields: (T & { fieldId: string })[], values: T[] | undefined): T[] {
+  const liveValues = Array.isArray(values) ? values : [];
+  return fields.map((field, index) => ({ ...field, ...liveValues[index] }));
 }

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
@@ -79,6 +79,15 @@ describe("sdlGenerator", () => {
       expect(Object.keys(parsed.profiles.placement["dcloud"].pricing)).toEqual(["web", "api"]);
     });
 
+    it("emits a declared endpoint with kind ip even when no port references it", () => {
+      const formValues = buildFormValues(buildLogCollectorService({ title: "web", image: "nginx:latest" }));
+      formValues.endpoints = [{ id: "e-1", name: "endpoint-1" }];
+      const result = generateSdl(formValues);
+      const parsed = yaml.load(result) as { endpoints?: Record<string, { kind: string }> };
+
+      expect(parsed.endpoints).toEqual({ "endpoint-1": { kind: "ip" } });
+    });
+
     function buildLogCollectorService(overrides?: Partial<ServiceType>): ServiceType {
       return {
         id: overrides?.title ? `${overrides.title}-id` : "web-log-collector",

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
@@ -231,6 +231,14 @@ export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
     };
   });
 
+  (formValues.endpoints ?? []).forEach(endpoint => {
+    if (!endpoint.name) {
+      return;
+    }
+    sdl["endpoints"] = sdl["endpoints"] || {};
+    sdl["endpoints"][endpoint.name] = { kind: "ip" };
+  });
+
   const result = yaml.dump(sdl, {
     indent: 2,
     quotingType: '"',

--- a/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
+import { defaultServiceWithPlacement } from "./data";
 import { buildCommand, generateSdl } from "./sdlGenerator";
 import { importSimpleSdl, parseSvcCommand } from "./sdlImport";
 
@@ -199,5 +200,16 @@ describe("sdlImport", () => {
       expect(parsed.services.web.command).toEqual(["sh", "-c", "echo hello"]);
       expect(parsed.services.web).not.toHaveProperty("args");
     });
+  });
+});
+
+describe("importSimpleSdl endpoints", () => {
+  it("round-trips a declared endpoint back into the form model", () => {
+    const formValues = { ...defaultServiceWithPlacement({ image: "nginx:latest" }), endpoints: [{ id: "e-1", name: "endpoint-1" }] };
+    const sdl = generateSdl(formValues);
+
+    const imported = importSimpleSdl(sdl);
+
+    expect(imported.endpoints?.map(endpoint => endpoint.name)).toEqual(["endpoint-1"]);
   });
 });

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -1,7 +1,7 @@
 import yaml from "js-yaml";
 import { nanoid } from "nanoid";
 
-import type { ExposeType, PlacementAttributeType, PlacementType, ProfileGpuModelType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
+import type { EndpointType, ExposeType, PlacementAttributeType, PlacementType, ProfileGpuModelType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { CustomValidationError } from "../deploymentData";
 import { capitalizeFirstLetter } from "../stringUtils";
 import { defaultHttpOptions } from "./data";
@@ -36,7 +36,12 @@ export const importSimpleSdl = (yamlStr: string, { placementPerService = false }
       throw new CustomValidationError("SDL root must be a YAML object.");
     }
 
-    if (!yamlJson.services) return { placements, services };
+    const endpoints: EndpointType[] =
+      yamlJson.endpoints && typeof yamlJson.endpoints === "object" && !Array.isArray(yamlJson.endpoints)
+        ? Object.keys(yamlJson.endpoints).map(name => ({ id: nanoid(), name }))
+        : [];
+
+    if (!yamlJson.services) return { placements, services, endpoints };
 
     Object.keys(yamlJson.services).forEach(svcName => {
       const svc = yamlJson.services[svcName];
@@ -161,7 +166,7 @@ export const importSimpleSdl = (yamlStr: string, { placementPerService = false }
       services.push(service as ServiceType);
     });
 
-    return { placements, services };
+    return { placements, services, endpoints };
   } catch (error) {
     console.error(error);
     throw error;


### PR DESCRIPTION
## Why

The Configure screen's Deployment pane has no way to declare IP endpoints. Users need to manage them directly — list, add, remove, and rename — and have them round-trip through the SDL.

Stacked on #3280 (placements and services pane); review/merge that first.

## What

- Add an **IP ENDPOINTS** section to the Deployment pane: list, add, remove, and inline-rename IP endpoints.
- Introduce an explicit top-level `endpoints` array in the SDL form model, with name-format and uniqueness validation surfaced inline.
- Map declared endpoints into the SDL `endpoints` block and round-trip them on import.
- Align Deployment pane spacing with the design.
- Port-to-endpoint binding remains for the Configuration pane's port section.
<img width="312" height="677" alt="image" src="https://github.com/user-attachments/assets/5821e0e0-354f-41ba-ac02-ee9006bc1e4d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IP Endpoints section added to deployment configuration: add, name, and remove endpoints with inline editing and automatic next-name generation.
  * Endpoints are persisted in form state and included when importing/exporting/generated SDL.

* **Quality**
  * Real-time uniqueness validation for endpoint names to prevent duplicates; stale cross-row errors are cleared automatically.

* **Tests**
  * Extensive tests added/updated to cover endpoints, naming, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->