### PR TITLE
fix(sdl): preserve service command/args on import instead of forcing sh -c

### DIFF
--- a/apps/deploy-web/src/components/sdl/CommandFormModal.tsx
+++ b/apps/deploy-web/src/components/sdl/CommandFormModal.tsx
@@ -38,7 +38,13 @@ export const CommandFormModal: React.FunctionComponent<Props> = ({ control, serv
           control={control}
           name={`services.${serviceIndex}.command.command`}
           render={({ field }) => (
-            <Textarea rows={4} label="Command" value={field.value} placeholder="Example: bash -c" onChange={event => field.onChange(event.target.value)} />
+            <Textarea
+              rows={4}
+              label="Command"
+              value={field.value}
+              placeholder={"One token per line. Example:\nsh\n-c"}
+              onChange={event => field.onChange(event.target.value)}
+            />
           )}
         />
 

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
@@ -98,33 +98,34 @@ describe("sdlGenerator", () => {
     }
   });
 
-  describe("buildCommand", () => {
-    it("returns empty string for an empty string", () => {
-      expect(buildCommand("")).toEqual("");
+  describe(buildCommand.name, () => {
+    it("returns an empty array for an empty string", () => {
+      expect(buildCommand("")).toEqual([]);
     });
 
-    it("returns string if command is a single line string", () => {
-      expect(buildCommand("echo 'foo'")).toEqual("echo 'foo'");
+    it("returns a single-element array for a single line", () => {
+      expect(buildCommand("echo 'foo'")).toEqual(["echo 'foo'"]);
     });
 
-    it("returns array starting with sh -c when it starts with sh -c", () => {
-      expect(buildCommand("sh -c foo")).toEqual(["sh", "-c", "foo\n"]);
+    it("splits newline-separated tokens into an array", () => {
+      expect(buildCommand("sh\n-c")).toEqual(["sh", "-c"]);
     });
 
-    it("returns array containing only sh -c when it is only with sh -c", () => {
-      expect(buildCommand("sh -c")).toEqual(["sh", "-c"]);
+    it("keeps a script token as its own array element", () => {
+      expect(buildCommand("sh\n-c\nfoo")).toEqual(["sh", "-c", "foo"]);
     });
 
-    it("returns array starting with sh -c for a multi-line string", () => {
-      expect(buildCommand("foo\nbar")).toEqual(["sh", "-c", "foo\nbar\n"]);
+    it("does not force a sh -c wrapper for multi-token commands", () => {
+      expect(buildCommand("bash\n-lc")).toEqual(["bash", "-lc"]);
     });
 
-    it("returns array starting with sh -c for a multi-line string with a newline at the end", () => {
-      expect(buildCommand("foo\nbar\n")).toEqual(["sh", "-c", "foo\nbar\n"]);
+    it("drops empty lines and trailing newlines", () => {
+      expect(buildCommand("foo\nbar\n")).toEqual(["foo", "bar"]);
+      expect(buildCommand("foo\nbar\n\n")).toEqual(["foo", "bar"]);
     });
 
-    it("returns array starting with sh -c for a multi-line string with multiple newlines at the end", () => {
-      expect(buildCommand("foo\nbar\n\n")).toEqual(["sh", "-c", "foo\nbar\n"]);
+    it("trims whitespace around each token", () => {
+      expect(buildCommand(" foo \n bar ")).toEqual(["foo", "bar"]);
     });
   });
 });

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
@@ -4,23 +4,16 @@ import { isLogCollectorService } from "@src/components/sdl/LogCollectorControl/L
 import type { ExposeType, PlacementType, ProfileGpuModelType, SdlBuilderFormValuesType } from "@src/types";
 import { defaultHttpOptions } from "./data";
 
-export const buildCommand = (command: string) => {
-  if (command.trim() === "sh -c") {
-    return ["sh", "-c"];
-  }
-
-  const lines = command.split("\n");
-
-  if (lines.length > 1 || command.startsWith("sh -c")) {
-    const commandWithoutEmptyLines =
-      lines
-        .map(line => line.trim())
-        .filter(Boolean)
-        .join("\n") + "\n";
-    return ["sh", "-c", commandWithoutEmptyLines.replace(/^sh -c\s*/, "")];
-  }
-
-  return command;
+/**
+ * Converts the Command form field (one command-array token per line) into the
+ * SDL `command` array. Tokens are trimmed and empty lines dropped. The user's
+ * command is preserved verbatim — no shell wrapper (e.g. `sh -c`) is forced.
+ */
+export const buildCommand = (command: string): string[] => {
+  return command
+    .split("\n")
+    .map(line => line.trim())
+    .filter(Boolean);
 };
 
 export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
@@ -81,7 +74,11 @@ export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
     const trimmedCommand = service.command?.command?.trim();
     if (trimmedCommand) {
       sdl.services[service.title].command = buildCommand(trimmedCommand);
-      sdl.services[service.title].args = [service.command?.arg?.trim()];
+
+      const arg = service.command?.arg;
+      if (arg) {
+        sdl.services[service.title].args = [arg];
+      }
     }
 
     if ((service.env?.length || 0) > 0) {

--- a/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { generateSdl } from "./sdlGenerator";
+import { buildCommand, generateSdl } from "./sdlGenerator";
 import { importSimpleSdl, parseSvcCommand } from "./sdlImport";
 
 describe("sdlImport", () => {
@@ -32,16 +32,16 @@ describe("sdlImport", () => {
       expect(parseSvcCommand(["echo", "", "foo"])).toEqual("echo\nfoo");
     });
 
-    it("returns command as string if command is array of strings with sh -c", () => {
-      expect(parseSvcCommand(["sh", "-c", "echo 'foo'"])).toEqual("echo 'foo'");
+    it("preserves a leading sh -c instead of stripping it", () => {
+      expect(parseSvcCommand(["sh", "-c", "echo 'foo'"])).toEqual("sh\n-c\necho 'foo'");
     });
 
-    it("returns rest of command as string if command is array of strings with sh -c", () => {
-      expect(parseSvcCommand(["sh", "-c", "echo 'foo'", "echo 'bar'"])).toEqual("echo 'foo'\necho 'bar'");
+    it("joins every command element with a newline", () => {
+      expect(parseSvcCommand(["sh", "-c", "echo 'foo'", "echo 'bar'"])).toEqual("sh\n-c\necho 'foo'\necho 'bar'");
     });
 
-    it("returns rest of command as string if command is array of strings with sh -c, drops empty lines", () => {
-      expect(parseSvcCommand(["sh", "-c", "echo 'foo'", "", "echo 'bar'"])).toEqual("echo 'foo'\necho 'bar'");
+    it("joins every command element with a newline, dropping empty lines", () => {
+      expect(parseSvcCommand(["sh", "-c", "echo 'foo'", "", "echo 'bar'"])).toEqual("sh\n-c\necho 'foo'\necho 'bar'");
     });
   });
 
@@ -126,6 +126,67 @@ describe("sdlImport", () => {
       const roundtripped = yaml.load(regenerated) as Record<string, unknown>;
 
       expect(roundtripped).toEqual(original);
+    });
+
+    it.each([
+      { command: ["bash", "-lc"], args: ["./run.sh"] },
+      { command: ["sh", "-c"], args: ["echo hi"] },
+      { command: ["sh", "-c", "echo foo"], args: undefined },
+      { command: ["bash", "-c"], args: ["run"] }
+    ])("preserves command $command and args $args without forcing a shell wrapper", ({ command, args }) => {
+      const formCommand = parseSvcCommand(command);
+      const formArg = args ? args[0] : "";
+
+      const rebuiltCommand = buildCommand(formCommand.trim());
+      const rebuiltArgs = formArg ? [formArg] : undefined;
+
+      expect(rebuiltCommand).toEqual(command);
+      expect(rebuiltArgs).toEqual(args);
+    });
+
+    it("does not emit an args key when a service has a command but no args", () => {
+      const yml = [
+        "version: '2.0'",
+        "services:",
+        "  web:",
+        "    image: nginx:1.0",
+        "    command:",
+        "      - sh",
+        "      - -c",
+        "      - echo hello",
+        "    expose:",
+        "      - port: 80",
+        "        as: 80",
+        "        to:",
+        "          - global: true",
+        "profiles:",
+        "  compute:",
+        "    web:",
+        "      resources:",
+        "        cpu:",
+        "          units: 0.5",
+        "        memory:",
+        "          size: 512Mi",
+        "        storage:",
+        "          - size: 512Mi",
+        "  placement:",
+        "    dcloud:",
+        "      pricing:",
+        "        web:",
+        "          denom: uact",
+        "          amount: 1000",
+        "deployment:",
+        "  web:",
+        "    dcloud:",
+        "      profile: web",
+        "      count: 1"
+      ].join("\n");
+
+      const regenerated = generateSdl(importSimpleSdl(yml));
+      const parsed = yaml.load(regenerated) as { services: Record<string, { command?: unknown }> };
+
+      expect(parsed.services.web.command).toEqual(["sh", "-c", "echo hello"]);
+      expect(parsed.services.web).not.toHaveProperty("args");
     });
   });
 });

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -15,10 +15,6 @@ export const parseSvcCommand = (command?: string | string[]): string => {
     return parseSvcCommand([command]);
   }
 
-  if (command[0] === "sh" && command[1] === "-c") {
-    return command.slice(2).filter(Boolean).join("\n");
-  }
-
   return command.filter(Boolean).join("\n");
 };
 


### PR DESCRIPTION
## Why

The simple SDL builder mangles a service's `command`/`args` on import → preview → deploy. When re-serializing the Command field it forces a hardcoded `sh -c` wrapper, so any command that isn't exactly `sh -c` is corrupted. Reported by a user: importing

```yaml
command: [bash, -lc]
args: ["./run.sh"]
```

and clicking Preview rewrites it to `command: [sh, -c, "bash\n-lc\n"]` — the original `bash -lc` is shoved into the script slot of an `sh -c` wrapper.

The round-trip was actually broken for **every** command shape, not just the reported one:

| Imported SDL | Old (buggy) export | Fixed |
|---|---|---|
| `command:[bash,-lc]` + `args:[script]` | `[sh,-c,"bash\n-lc\n"]` + `[script]` | preserved |
| `command:[sh,-c]` + `args:[script]` | **command + args dropped entirely** | preserved |
| `command:[sh,-c,script]` (no args) | bare string (invalid SDL) + bogus `args:[""]` | preserved |

Since the generated SDL is what gets deployed (form → `generateSdl` → manifest → chain), this is a correctness bug, not just cosmetic.

## What

Stop forcing a shell wrapper — the Command field is now treated as the literal SDL `command` array, one token per line, and preserved verbatim.

- `parseSvcCommand` (`sdlImport.ts`): no longer strips a leading `sh -c`; all command elements join by newline.
- `buildCommand` (`sdlGenerator.ts`): always returns `string[]` by splitting on newline (trim + drop empties); no `sh -c` forcing.
- Export call site: no longer trims the arg (a multi-line script's whitespace can be meaningful) and only emits `args:` when one is present (fixes the bogus `args: [""]`).
- `CommandFormModal.tsx`: Command field placeholder updated to teach the one-token-per-line convention.
- Tests: rewrote `buildCommand`/`parseSvcCommand` specs for the new behavior and added round-trip coverage proving all shapes survive (including the two that were silently broken).

### Example SDL to test

Import the following, click Preview, and confirm both services' `command`/`args` are unchanged:

```yaml
version: "2.0"
services:
  web:
    image: ubuntu:24.04
    command: [bash, "-lc"]
    args:
      - |
        echo "web started"; while true; do echo hi; sleep 10; done
    expose:
      - port: 8080
        as: 80
        to: [{ global: true }]
  worker:
    image: alpine:3.20
    command: [sh, "-c"]
    args: ["echo up; sleep infinity"]
profiles:
  compute:
    web: { resources: { cpu: { units: 0.5 }, memory: { size: 512Mi }, storage: [{ size: 512Mi }] } }
    worker: { resources: { cpu: { units: 0.5 }, memory: { size: 256Mi }, storage: [{ size: 256Mi }] } }
  placement:
    dcloud:
      pricing:
        web: { denom: uakt, amount: 10000 }
        worker: { denom: uakt, amount: 10000 }
deployment:
  web: { dcloud: { profile: web, count: 1 } }
  worker: { dcloud: { profile: worker, count: 1 } }
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Clarified command input placeholder to show "one token per line" with examples.

* **Bug Fixes**
  * Command parsing now treats each newline-separated token as a separate command element and trims/drops empty lines.
  * SDL import/export roundtrip preserved original command arrays and no longer injects automatic shell-wrapping or unnecessary args.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->