### PR TITLE
fix(deployment): polish reclamation card spacing, copy, and secondary button

### DIFF
--- a/apps/deploy-web/src/components/deployments/LeaseRow.tsx
+++ b/apps/deploy-web/src/components/deployments/LeaseRow.tsx
@@ -194,9 +194,9 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(
           </div>
         </CardHeader>
         <CardContent className="pt-6">
-          {isReclaimed && <ReclamationCard lease={lease} dseq={dseq} onClosed={loadDeploymentDetail} />}
-
           <div className="space-y-4">
+            {isReclaimed && <ReclamationCard lease={lease} dseq={dseq} onClosed={loadDeploymentDetail} />}
+
             <div>
               <SpecDetail
                 cpuAmount={lease.cpuAmount}

--- a/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.spec.tsx
@@ -19,7 +19,7 @@ describe("ReclamationCard", () => {
   it("offers Close + Redeploy and no restart control", () => {
     setup({ hasLocalManifest: true });
 
-    expect(screen.getByRole("button", { name: "Close (recover escrow)" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close & refund" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Redeploy" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /restart/i })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /resume/i })).not.toBeInTheDocument();
@@ -28,7 +28,7 @@ describe("ReclamationCard", () => {
   it("falls back to a 'new SDL' link when there is no local manifest", () => {
     setup({ hasLocalManifest: false });
 
-    expect(screen.getByRole("link", { name: "Start from a new SDL" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Start a new deployment" })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Redeploy" })).not.toBeInTheDocument();
   });
 
@@ -36,7 +36,7 @@ describe("ReclamationCard", () => {
     const onClosed = vi.fn();
     const { wallet, confirm } = setup({ isConfirmed: true, onClosed });
 
-    await userEvent.click(screen.getByRole("button", { name: "Close (recover escrow)" }));
+    await userEvent.click(screen.getByRole("button", { name: "Close & refund" }));
 
     await waitFor(() => expect(wallet.signAndBroadcastTx).toHaveBeenCalled());
     expect(confirm.closeDeploymentConfirm).toHaveBeenCalledWith(["123"]);
@@ -46,7 +46,7 @@ describe("ReclamationCard", () => {
   it("does not close when the confirmation is declined", async () => {
     const { wallet, confirm } = setup({ isConfirmed: false });
 
-    await userEvent.click(screen.getByRole("button", { name: "Close (recover escrow)" }));
+    await userEvent.click(screen.getByRole("button", { name: "Close & refund" }));
 
     await waitFor(() => expect(confirm.closeDeploymentConfirm).toHaveBeenCalled());
     expect(wallet.signAndBroadcastTx).not.toHaveBeenCalled();

--- a/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ReclamationCard/ReclamationCard.tsx
@@ -56,25 +56,24 @@ export const ReclamationCard: React.FunctionComponent<Props> = ({ lease, dseq, o
   const redeploy = () => router.push(UrlService.newDeployment({ redeploy: dseq }));
 
   return (
-    <Alert variant="warning" className="mt-4">
+    <Alert variant="warning" className="p-4">
       <WarningTriangle className="h-4 w-4" />
       <AlertTitle>{reasonLabel}</AlertTitle>
       <AlertDescription>
         <p>
-          This lease was reclaimed by the provider and is no longer running. Closing the deployment recovers any remaining escrow; redeploying starts it again
-          on a new lease.
+          This deployment was stopped by the provider, so it&apos;s no longer running. Redeploy to get back online, or close it to recover any unused funds.
         </p>
         <div className="mt-3 flex flex-wrap items-center gap-2">
           <Button variant="default" size="sm" onClick={confirmAndClose} disabled={isClosing}>
-            {isClosing ? <Spinner size="small" /> : "Close (recover escrow)"}
+            {isClosing ? <Spinner size="small" /> : "Close & refund"}
           </Button>
           {hasLocalManifest ? (
-            <Button variant="outline" size="sm" onClick={redeploy}>
+            <Button variant="outline" size="sm" className="text-foreground" onClick={redeploy}>
               Redeploy
             </Button>
           ) : (
-            <Link href={UrlService.newDeployment()} className={cn(buttonVariants({ variant: "outline", size: "sm" }))}>
-              Start from a new SDL
+            <Link href={UrlService.newDeployment()} className={cn(buttonVariants({ variant: "outline", size: "sm" }), "text-foreground")}>
+              Start a new deployment
             </Link>
           )}
         </div>


### PR DESCRIPTION
## Why

Follow-up polish on the per-lease "closed by provider" reclamation card (added in #3285 / CON-379). The card had a doubled top gap, jargon-heavy copy ("lease", "reclaimed", "escrow", "SDL"), and a secondary action button rendering as a stray orange link. Ref CON-379.

## What

Frontend-only changes to `ReclamationCard` and its placement in `LeaseRow`:

- **Spacing**: moved the card inside the existing `space-y-4` container in `LeaseRow` and dropped the card's `mt-4`, removing the ~40px doubled gap above and giving consistent rhythm to the rows below. Tightened the alert padding (`p-6` → `p-4`) so the warning icon lines up with the title.
- **De-jargoned copy**:
  - Body: "This deployment was stopped by the provider, so it's no longer running. Redeploy to get back online, or close it to recover any unused funds."
  - `Close (recover escrow)` → `Close & refund`
  - `Start from a new SDL` → `Start a new deployment`
- **Fixed secondary button color**: the `outline` button/link inherited the alert's `text-warning`, reading as orange. Added `text-foreground` so it renders as a neutral secondary action.

Titles (the close-reason label) and button hierarchy are unchanged.

Tests: updated the 4 copy assertions in `ReclamationCard.spec.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced lease reclamation interface with improved alert styling and layout
  * Updated button labels: "Close & refund" and "Start a new deployment" for clearer user intent
  * Refined descriptive text in the lease closure flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->