### PR TITLE
fix(sdl): keep legacy builder placements independent per service

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/SdlBuilder.tsx
+++ b/apps/deploy-web/src/components/new-deployment/SdlBuilder.tsx
@@ -140,7 +140,7 @@ export const SdlBuilder = React.forwardRef<SdlBuilderRefType, Props>(
       try {
         if (!yamlStr) return null;
 
-        const formValues = importSimpleSdl(yamlStr);
+        const formValues = importSimpleSdl(yamlStr, { placementPerService: true });
 
         setError(null);
 

--- a/apps/deploy-web/src/components/remote-deploy/update/RemoteDeployUpdate.tsx
+++ b/apps/deploy-web/src/components/remote-deploy/update/RemoteDeployUpdate.tsx
@@ -56,7 +56,7 @@ const RemoteDeployUpdate = ({ sdlString, onManifestChange }: { sdlString: string
 
   const createAndValidateSdl = (yamlStr: string) => {
     try {
-      return yamlStr ? importSimpleSdl(yamlStr) : null;
+      return yamlStr ? importSimpleSdl(yamlStr, { placementPerService: true }) : null;
     } catch (err: any) {
       if (err.name === "YAMLException" || err.name === "CustomValidationError") {
         enqueueSnackbar(<Snackbar title={err.message} />, { variant: "error" });

--- a/apps/deploy-web/src/components/sdl/ImportSdlModal.tsx
+++ b/apps/deploy-web/src/components/sdl/ImportSdlModal.tsx
@@ -33,7 +33,7 @@ export const ImportSdlModal: React.FunctionComponent<Props> = ({ onClose, setVal
     try {
       if (!yamlStr) return null;
 
-      const formValues = importSimpleSdl(yamlStr);
+      const formValues = importSimpleSdl(yamlStr, { placementPerService: true });
 
       setParsingError(null);
 

--- a/apps/deploy-web/src/components/sdl/SimpleSdlBuilderForm.tsx
+++ b/apps/deploy-web/src/components/sdl/SimpleSdlBuilderForm.tsx
@@ -99,7 +99,7 @@ export const SimpleSDLBuilderForm: React.FunctionComponent = () => {
       const response = await consoleApiHttpClient.get(`/v1/user/template/${id}`);
       const template: ITemplate = response.data;
 
-      const imported = importSimpleSdl(template.sdl);
+      const imported = importSimpleSdl(template.sdl, { placementPerService: true });
 
       setIsLoadingTemplate(false);
 

--- a/apps/deploy-web/src/hooks/useSdlServiceManager/useSdlServiceManager.spec.tsx
+++ b/apps/deploy-web/src/hooks/useSdlServiceManager/useSdlServiceManager.spec.tsx
@@ -157,7 +157,57 @@ describe(useSdlServiceManager.name, () => {
     expect(currentServices[0].title).toBe("service-1");
   });
 
-  async function setup({ defaultServices = [] }: { defaultServices?: SdlBuilderFormValuesType["services"] } = {}) {
+  it("gives each added service its own placement", async () => {
+    const { result, form } = await setup({ defaultServices: [], defaultPlacements: [] });
+
+    await act(async () => {
+      result.current.add();
+    });
+    await act(async () => {
+      result.current.add();
+    });
+
+    const services = form.getValues("services");
+    const placements = form.getValues("placements");
+    const placementIds = services.map(service => service.placementId);
+
+    expect(new Set(placementIds).size).toBe(services.length);
+    placementIds.forEach(id => expect(placements.some(placement => placement.id === id)).toBe(true));
+  });
+
+  it("removes the placement of a removed service when no other service references it", async () => {
+    const { result, form } = await setup({
+      defaultServices: [buildSDLService({ title: "service-1", placementId: "p-a" }), buildSDLService({ title: "service-2", placementId: "p-b" })],
+      defaultPlacements: [
+        { id: "p-a", name: "dcloud" },
+        { id: "p-b", name: "dcloud" }
+      ]
+    });
+
+    await act(async () => {
+      result.current.remove(0);
+    });
+
+    expect(form.getValues("placements").map(placement => placement.id)).toEqual(["p-b"]);
+  });
+
+  it("keeps a placement that another service still references", async () => {
+    const { result, form } = await setup({
+      defaultServices: [buildSDLService({ title: "service-1", placementId: "p-shared" }), buildSDLService({ title: "service-2", placementId: "p-shared" })],
+      defaultPlacements: [{ id: "p-shared", name: "dcloud" }]
+    });
+
+    await act(async () => {
+      result.current.remove(0);
+    });
+
+    expect(form.getValues("placements").map(placement => placement.id)).toEqual(["p-shared"]);
+  });
+
+  async function setup({
+    defaultServices = [],
+    defaultPlacements = [{ id: "p-1", name: "dcloud" }]
+  }: { defaultServices?: SdlBuilderFormValuesType["services"]; defaultPlacements?: SdlBuilderFormValuesType["placements"] } = {}) {
     let methods: UseFormReturn<SdlBuilderFormValuesType>;
 
     const TestWrapper = ({ children, defaultValues }: { children: React.ReactNode; defaultValues: SdlBuilderFormValuesType }) => {
@@ -169,7 +219,7 @@ describe(useSdlServiceManager.name, () => {
     };
 
     const defaultFormValues: SdlBuilderFormValuesType = {
-      placements: [{ id: "p-1", name: "dcloud" }],
+      placements: defaultPlacements,
       services: defaultServices,
       imageList: [],
       hasSSHKey: false

--- a/apps/deploy-web/src/hooks/useSdlServiceManager/useSdlServiceManager.ts
+++ b/apps/deploy-web/src/hooks/useSdlServiceManager/useSdlServiceManager.ts
@@ -26,7 +26,7 @@ export const useSdlServiceManager = ({ control }: Props) => {
     keyName: "id"
   });
 
-  const { append: appendPlacement } = useFieldArray({
+  const { append: appendPlacement, remove: removePlacement } = useFieldArray({
     control,
     name: "placements",
     keyName: "id"
@@ -52,22 +52,30 @@ export const useSdlServiceManager = ({ control }: Props) => {
   }, [services]);
 
   const add = useCallback(() => {
-    let placementId = placements[0]?.id;
-    if (!placementId) {
-      const placement = defaultPlacement();
-      placementId = placement.id;
-      appendPlacement(placement);
-    }
-    appendService({ ...defaultService(placementId), id: nanoid(), title: calcNextServiceTitle() });
-  }, [appendService, appendPlacement, calcNextServiceTitle, placements]);
+    const placement = defaultPlacement();
+    appendPlacement(placement);
+    appendService({ ...defaultService(placement.id), id: nanoid(), title: calcNextServiceTitle() });
+  }, [appendService, appendPlacement, calcNextServiceTitle]);
 
   const remove = useCallback(
     (index: number) => {
       const ownLogCollectorServiceIndex = findOwnLogCollectorServiceIndex(services[index], services);
       const indexes = (ownLogCollectorServiceIndex === -1 ? [index] : [index, ownLogCollectorServiceIndex]).sort((a, b) => b - a);
+
+      const removedPlacementIds = new Set(indexes.map(serviceIndex => services[serviceIndex]?.placementId));
+      const remainingPlacementIds = new Set(services.filter((_, serviceIndex) => !indexes.includes(serviceIndex)).map(service => service.placementId));
+      const orphanPlacementIndexes = placements
+        .map((placement, placementIndex) => ({ placement, placementIndex }))
+        .filter(({ placement }) => removedPlacementIds.has(placement.id) && !remainingPlacementIds.has(placement.id))
+        .map(({ placementIndex }) => placementIndex)
+        .sort((a, b) => b - a);
+
       removeService(indexes);
+      if (orphanPlacementIndexes.length > 0) {
+        removePlacement(orphanPlacementIndexes);
+      }
     },
-    [services, removeService]
+    [services, placements, removeService, removePlacement]
   );
 
   return useMemo(

--- a/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
@@ -64,6 +64,17 @@ describe("sdlImport", () => {
       expect(services.every(service => service.placementId === placements[0].id)).toBe(true);
     });
 
+    it("gives each service its own placement when placementPerService is set", () => {
+      const yml = fs.readFileSync(path.resolve(__dirname, "../../../tests/mocks/two-services-sdl.yml"), "utf8");
+
+      const { placements, services } = importSimpleSdl(yml, { placementPerService: true });
+
+      expect(placements).toHaveLength(2);
+      expect(placements.every(placement => placement.name === "dcloud")).toBe(true);
+      expect(services.map(service => service.placementId)).toEqual([placements[0].id, placements[1].id]);
+      expect(new Set(services.map(service => service.placementId)).size).toBe(2);
+    });
+
     it("lifts location-region attribute onto placement.region", () => {
       const yml = [
         "version: '2.0'",

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -18,7 +18,14 @@ export const parseSvcCommand = (command?: string | string[]): string => {
   return command.filter(Boolean).join("\n");
 };
 
-export const importSimpleSdl = (yamlStr: string): SdlBuilderFormValuesType => {
+/**
+ * Imports an SDL YAML into builder form values. By default placements are
+ * deduplicated by name (a placement's identity is its name), so services that
+ * share a placement name reference one record. Pass `placementPerService` for
+ * the legacy builder, which edits a placement per service and needs each to
+ * stay independent across edits/round-trips.
+ */
+export const importSimpleSdl = (yamlStr: string, { placementPerService = false }: { placementPerService?: boolean } = {}): SdlBuilderFormValuesType => {
   try {
     const yamlJson = yaml.load(yamlStr) as any;
     const placements: PlacementType[] = [];
@@ -122,11 +129,19 @@ export const importSimpleSdl = (yamlStr: string): SdlBuilderFormValuesType => {
         throw new CustomValidationError(`Unable to find placement: ${placementName}`);
       }
 
-      let placementId = placementIdByName.get(placementName);
-      if (!placementId) {
+      let placementId: string;
+      if (placementPerService) {
         placementId = nanoid();
-        placementIdByName.set(placementName, placementId);
         placements.push(hydratePlacement(placementId, placementName, placementProfile));
+      } else {
+        const existingPlacementId = placementIdByName.get(placementName);
+        if (existingPlacementId) {
+          placementId = existingPlacementId;
+        } else {
+          placementId = nanoid();
+          placementIdByName.set(placementName, placementId);
+          placements.push(hydratePlacement(placementId, placementName, placementProfile));
+        }
       }
 
       const placementPricing = placementProfile.pricing?.[svcName];


### PR DESCRIPTION
## Why

The legacy SDL builder edits a placement per service, but adding a service reused the first placement and importing deduped placements by name. As a result all services ended up sharing one placement record — renaming one renamed them all.

## What

- Give each added service its own placement, and drop a service's placement on removal when nothing else references it.
- Add a `placementPerService` option to `importSimpleSdl` (off by default, preserving the shared placement-first import) that the legacy builder entry points opt into, so a service keeps its own placement across YAML round-trips.
- SDL output is unchanged — generation still groups placements by name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated deployment import and service management to assign placements more consistently across services during SDL import, template loading, and service addition/removal operations.

* **Tests**
  * Added test coverage for placement behavior when adding and removing services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->