### PR TITLE
feat: adds provider incidents to bid screening response

### DIFF
--- a/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
+++ b/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
@@ -103,7 +103,15 @@ const ProviderResultSchema = z.object({
   createdAt: z
     .string()
     .datetime()
-    .openapi({ description: "ISO 8601 timestamp marking when the provider was first enrolled in the inventory", example: "2026-01-01T00:00:00.000Z" })
+    .openapi({ description: "ISO 8601 timestamp marking when the provider was first enrolled in the inventory", example: "2026-01-01T00:00:00.000Z" }),
+  incidents: z
+    .array(
+      z.object({
+        startedAt: z.string().datetime(),
+        endedAt: z.string().datetime().nullable()
+      })
+    )
+    .openapi({ description: "Provider incident intervals within the last ~8 days; endedAt null = ongoing" })
 });
 
 export const BidScreeningResponseSchema = z.object({

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.integration.ts
@@ -120,12 +120,90 @@ describe(ProviderIncidentRepository.name, () => {
     });
   });
 
+  describe("findRecentByProviders", () => {
+    it("returns an empty array when called with no owners", async () => {
+      const { repository } = setup();
+
+      const rows = await repository.findRecentByProviders([]);
+
+      expect(rows).toEqual([]);
+    });
+
+    it("returns a closed incident inside the window", async () => {
+      const { repository, db } = setup();
+      await seedIncident(db, { provider: "akash1a", startedAt: daysAgo(2), endedAt: daysAgo(1) });
+
+      const rows = await repository.findRecentByProviders(["akash1a"]);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].provider).toBe("akash1a");
+      expect(rows[0].startedAt).toMatch(ISO_MS);
+      expect(rows[0].endedAt).toMatch(ISO_MS);
+    });
+
+    it("returns an ongoing incident with endedAt null", async () => {
+      const { repository, db } = setup();
+      await seedIncident(db, { provider: "akash1a", startedAt: daysAgo(3), endedAt: null });
+
+      const rows = await repository.findRecentByProviders(["akash1a"]);
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].endedAt).toBeNull();
+    });
+
+    it("includes an incident at the inner edge of the window and excludes one beyond it", async () => {
+      const { repository, db } = setup();
+      await seedIncident(db, { provider: "akash1in", startedAt: daysAgo(7.6), endedAt: daysAgo(7.5) });
+      await seedIncident(db, { provider: "akash1out", startedAt: daysAgo(9.1), endedAt: daysAgo(9) });
+
+      const rows = await repository.findRecentByProviders(["akash1in", "akash1out"]);
+
+      expect(rows.map(r => r.provider)).toEqual(["akash1in"]);
+    });
+
+    it("orders multiple incidents for one provider by startedAt ascending", async () => {
+      const { repository, db } = setup();
+      await seedIncident(db, { provider: "akash1a", startedAt: daysAgo(1), endedAt: daysAgo(0.5) });
+      await seedIncident(db, { provider: "akash1a", startedAt: daysAgo(5), endedAt: daysAgo(4) });
+      await seedIncident(db, { provider: "akash1a", startedAt: daysAgo(3), endedAt: daysAgo(2) });
+
+      const rows = await repository.findRecentByProviders(["akash1a"]);
+
+      expect(rows).toHaveLength(3);
+      const startedAts = rows.map(r => r.startedAt);
+      expect(startedAts).toEqual([...startedAts].sort());
+    });
+
+    it("returns only the real incident for a recently enrolled provider without fabricating pre-enrollment rows", async () => {
+      const { repository, db } = setup();
+      await seedIncident(db, { provider: "akash1a", startedAt: daysAgo(2), endedAt: daysAgo(1) });
+
+      const rows = await repository.findRecentByProviders(["akash1a"]);
+
+      expect(rows).toHaveLength(1);
+    });
+
+    it("groups and filters incidents by provider across a batched call", async () => {
+      const { repository, db } = setup();
+      await seedIncident(db, { provider: "akash1a", startedAt: daysAgo(2), endedAt: daysAgo(1) });
+      await seedIncident(db, { provider: "akash1b", startedAt: daysAgo(3), endedAt: null });
+      await seedIncident(db, { provider: "akash1c", startedAt: daysAgo(1), endedAt: daysAgo(0.5) });
+
+      const rows = await repository.findRecentByProviders(["akash1a", "akash1b"]);
+
+      const byProvider = rows.reduce<Record<string, number>>((acc, r) => ({ ...acc, [r.provider]: (acc[r.provider] ?? 0) + 1 }), {});
+      expect(byProvider).toEqual({ akash1a: 1, akash1b: 1 });
+    });
+  });
+
   function setup() {
     const repository = container.resolve(ProviderIncidentRepository);
     const db = container.resolve<PostgresJsDatabase>(DRIZZLE_DB);
     return { repository, db };
   }
 });
+
+const ISO_MS = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 
 interface SeedClosedInput {
   provider: string;
@@ -139,4 +217,12 @@ async function seedClosed(db: PostgresJsDatabase, input: SeedClosedInput): Promi
     startedAt: input.startedAt ?? new Date(input.endedAt.getTime() - 60_000),
     endedAt: input.endedAt
   });
+}
+
+function daysAgo(days: number): Date {
+  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+}
+
+async function seedIncident(db: PostgresJsDatabase, input: { provider: string; startedAt: Date; endedAt: Date | null }): Promise<void> {
+  await db.insert(providerIncidents).values({ provider: input.provider, startedAt: input.startedAt, endedAt: input.endedAt });
 }

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
@@ -1,15 +1,47 @@
-import { and, eq, inArray, isNull, sql } from "drizzle-orm";
-import { singleton } from "tsyringe";
+import { and, eq, getTableName, inArray, isNull, sql } from "drizzle-orm";
+import { inject, singleton } from "tsyringe";
 
 import { providerIncidents } from "@src/model-schemas/provider-incident/provider-incident.schema";
+import { type Database, PG_CLIENT } from "@src/providers/postgres.provider";
 import { DbDriver } from "../db-driver/db-driver";
+
+const INCIDENTS_TABLE = getTableName(providerIncidents);
+
+export interface RecentIncidentRow {
+  provider: string;
+  startedAt: string;
+  endedAt: string | null;
+}
 
 @singleton()
 export class ProviderIncidentRepository {
   readonly driver: DbDriver;
+  readonly #sql: Database;
 
-  constructor(driver: DbDriver) {
+  constructor(driver: DbDriver, @inject(PG_CLIENT) sql: Database) {
     this.driver = driver;
+    this.#sql = sql;
+  }
+
+  /**
+   * Returns raw incident intervals for the given providers within the rolling window (default 8 days).
+   * Ongoing incidents (`ended_at IS NULL`) are always included with `endedAt: null`.
+   * Rows are flat and ordered by `(provider, started_at ASC)` so callers can group in returned order.
+   */
+  async findRecentByProviders(owners: string[], days = 8): Promise<RecentIncidentRow[]> {
+    if (owners.length === 0) return [];
+
+    const sql = this.#sql;
+    return sql<RecentIncidentRow[]>`
+      SELECT
+        ${sql(providerIncidents.provider.name)} AS provider,
+        to_char(${sql(providerIncidents.startedAt.name)} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS "startedAt",
+        to_char(${sql(providerIncidents.endedAt.name)} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS "endedAt"
+      FROM ${sql(INCIDENTS_TABLE)}
+      WHERE ${sql(providerIncidents.provider.name)} IN ${sql(owners)}
+        AND (${sql(providerIncidents.endedAt.name)} IS NULL OR ${sql(providerIncidents.endedAt.name)} >= now() - make_interval(days => ${days}))
+      ORDER BY ${sql(providerIncidents.provider.name)}, ${sql(providerIncidents.startedAt.name)} ASC
+    `;
   }
 
   async openIncident(provider: string): Promise<void> {

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.spec.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.spec.ts
@@ -3,6 +3,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { GroupSpecJSON } from "@src/mappers/groupspec-mapper/groupspec-mapper";
 import type { BidScreeningCandidate, BidScreeningRepository } from "@src/repositories/bid-screening/bid-screening.repository";
+import type { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import type { ClusterInventoryMatcherService } from "../cluster-inventory-matcher/cluster-inventory-matcher.service";
 import { BidScreeningService } from "./bid-screening.service";
 
@@ -20,7 +21,8 @@ describe(BidScreeningService.name, () => {
           owner: "akash1abc",
           hostUri: "https://provider.example.com:8443",
           isAudited: false,
-          createdAt: "2026-01-01T00:00:00.000Z"
+          createdAt: "2026-01-01T00:00:00.000Z",
+          incidents: []
         }
       ]);
     });
@@ -88,13 +90,69 @@ describe(BidScreeningService.name, () => {
       expect(results.find(r => r.owner === "akash1abc")?.isAudited).toBe(true);
       expect(results.find(r => r.owner === "akash1def")?.isAudited).toBe(false);
     });
+
+    it("groups flat incident rows into per-owner arrays on the results", async () => {
+      const { service, repository, incidentRepository, matcher } = setup();
+      repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc"), makeCandidate("akash1def")]);
+      matcher.match.mockReturnValue({ matched: true });
+      incidentRepository.findRecentByProviders.mockResolvedValue([
+        { provider: "akash1abc", startedAt: "2026-06-01T00:00:00.000Z", endedAt: "2026-06-01T01:00:00.000Z" },
+        { provider: "akash1abc", startedAt: "2026-06-03T00:00:00.000Z", endedAt: null },
+        { provider: "akash1def", startedAt: "2026-06-02T00:00:00.000Z", endedAt: "2026-06-02T02:00:00.000Z" }
+      ]);
+
+      const results = await service.findMatchingProviders(makeRequest());
+
+      expect(results.find(r => r.owner === "akash1abc")?.incidents).toEqual([
+        { startedAt: "2026-06-01T00:00:00.000Z", endedAt: "2026-06-01T01:00:00.000Z" },
+        { startedAt: "2026-06-03T00:00:00.000Z", endedAt: null }
+      ]);
+      expect(results.find(r => r.owner === "akash1def")?.incidents).toEqual([{ startedAt: "2026-06-02T00:00:00.000Z", endedAt: "2026-06-02T02:00:00.000Z" }]);
+    });
+
+    it("defaults incidents to an empty array for a matched provider with no incident rows", async () => {
+      const { service, repository, incidentRepository, matcher } = setup();
+      repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc")]);
+      matcher.match.mockReturnValue({ matched: true });
+      incidentRepository.findRecentByProviders.mockResolvedValue([]);
+
+      const results = await service.findMatchingProviders(makeRequest());
+
+      expect(results[0].incidents).toEqual([]);
+    });
+
+    it("does not query incidents when the matched set is empty", async () => {
+      const { service, repository, incidentRepository, matcher } = setup();
+      repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc")]);
+      matcher.match.mockReturnValue({ matched: false, error: "INSUFFICIENT_CAPACITY" });
+
+      const results = await service.findMatchingProviders(makeRequest());
+
+      expect(results).toEqual([]);
+      expect(incidentRepository.findRecentByProviders).not.toHaveBeenCalled();
+    });
+
+    it("fetches incidents only for matched providers, not dropped candidates", async () => {
+      const { service, repository, incidentRepository, matcher } = setup();
+      repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc"), makeCandidate("akash1def")]);
+      matcher.match.mockReturnValueOnce({ matched: true }).mockReturnValueOnce({ matched: false, error: "INSUFFICIENT_CAPACITY" });
+      incidentRepository.findRecentByProviders.mockResolvedValue([{ provider: "akash1abc", startedAt: "2026-06-01T00:00:00.000Z", endedAt: null }]);
+
+      const results = await service.findMatchingProviders(makeRequest());
+
+      expect(incidentRepository.findRecentByProviders).toHaveBeenCalledWith(["akash1abc"]);
+      expect(results).toHaveLength(1);
+      expect(results[0].incidents).toEqual([{ startedAt: "2026-06-01T00:00:00.000Z", endedAt: null }]);
+    });
   });
 
   function setup() {
     const repository = mock<BidScreeningRepository>();
+    const incidentRepository = mock<ProviderIncidentRepository>();
+    incidentRepository.findRecentByProviders.mockResolvedValue([]);
     const matcher = mock<ClusterInventoryMatcherService>();
-    const service = new BidScreeningService(repository, matcher);
-    return { service, repository, matcher };
+    const service = new BidScreeningService(repository, incidentRepository, matcher);
+    return { service, repository, incidentRepository, matcher };
   }
 });
 

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
@@ -2,18 +2,23 @@ import { withSpan } from "@akashnetwork/instrumentation";
 import { singleton } from "tsyringe";
 
 import { type BidScreeningCandidate, BidScreeningRepository } from "@src/repositories/bid-screening/bid-screening.repository";
+import { ProviderIncidentRepository, RecentIncidentRow } from "@src/repositories/provider-incident/provider-incident.repository";
 import type { GroupSpecJSON } from "../../mappers/groupspec-mapper/groupspec-mapper";
 import { mapGroupSpecToResourceUnits } from "../../mappers/groupspec-mapper/groupspec-mapper";
-import type { BidScreeningResult, RequestedResourceUnit } from "../../types/inventory";
+import type { BidScreeningResult, Incident, RequestedResourceUnit } from "../../types/inventory";
 import { ClusterInventoryMatcherService } from "../cluster-inventory-matcher/cluster-inventory-matcher.service";
+
+const EMPTY_OBJECT = Object.freeze(Object.create(null));
 
 @singleton()
 export class BidScreeningService {
   readonly #repository: BidScreeningRepository;
+  readonly #incidentRepository: ProviderIncidentRepository;
   readonly #matcher: ClusterInventoryMatcherService;
 
-  constructor(repository: BidScreeningRepository, matcher: ClusterInventoryMatcherService) {
+  constructor(repository: BidScreeningRepository, incidentRepository: ProviderIncidentRepository, matcher: ClusterInventoryMatcherService) {
     this.#repository = repository;
+    this.#incidentRepository = incidentRepository;
     this.#matcher = matcher;
   }
 
@@ -26,36 +31,50 @@ export class BidScreeningService {
       return items;
     });
 
-    const results = await withSpan("applyingBinPackingAlg", async ({ activeSpan }) => {
+    const matched = await withSpan("applyingBinPackingAlg", async ({ activeSpan }) => {
       const items = this.#filterProviders(candidates, resourceUnits);
       activeSpan.setAttribute("amountOfCandidatesAfterBinPacking", items.length);
       return items;
     });
 
-    return results;
+    const incidentsByOwner = await withSpan("fetchIncidentsForMatched", async ({ activeSpan }) => {
+      if (!matched.length) return EMPTY_OBJECT;
+      const rows = await this.#incidentRepository.findRecentByProviders(matched.map(candidate => candidate.owner));
+      activeSpan.setAttribute("amountOfIncidents", rows.length);
+
+      const grouped = Object.create(null) as Partial<Record<string, Pick<RecentIncidentRow, "startedAt" | "endedAt">[]>>;
+      for (const row of rows) {
+        grouped[row.provider] ??= [];
+        grouped[row.provider]!.push({ startedAt: row.startedAt, endedAt: row.endedAt });
+      }
+      return grouped;
+    });
+
+    return matched.map(candidate => this.#toResult(candidate, incidentsByOwner));
   }
 
-  #filterProviders(candidates: BidScreeningCandidate[], resourceUnits: RequestedResourceUnit[]): BidScreeningResult[] {
-    if (!candidates.length) return candidates;
-    const results: BidScreeningResult[] = [];
+  #filterProviders(candidates: BidScreeningCandidate[], resourceUnits: RequestedResourceUnit[]): BidScreeningCandidate[] {
+    if (!candidates.length) return [];
+    const matched: BidScreeningCandidate[] = [];
 
     for (const candidate of candidates) {
       const matchResult = this.#matcher.match(candidate.cluster, resourceUnits);
 
       if (matchResult.matched) {
-        results.push(this.#toResult(candidate));
+        matched.push(candidate);
       }
     }
 
-    return results;
+    return matched;
   }
 
-  #toResult(candidate: BidScreeningCandidate): BidScreeningResult {
+  #toResult(candidate: BidScreeningCandidate, incidentsByOwner: Record<string, Incident[]>): BidScreeningResult {
     return {
       owner: candidate.owner,
       hostUri: candidate.hostUri,
       isAudited: candidate.isAudited,
-      createdAt: candidate.createdAt
+      createdAt: candidate.createdAt,
+      incidents: incidentsByOwner[candidate.owner] ?? []
     };
   }
 }

--- a/apps/provider-inventory/src/types/inventory.ts
+++ b/apps/provider-inventory/src/types/inventory.ts
@@ -65,11 +65,17 @@ export interface MatchResult {
   error?: "INSUFFICIENT_CAPACITY" | "GROUP_RESOURCE_MISMATCH";
 }
 
+export interface Incident {
+  startedAt: string;
+  endedAt: string | null;
+}
+
 export interface BidScreeningResult {
   owner: string;
   hostUri: string;
   isAudited: boolean;
   createdAt: string;
+  incidents: Incident[];
 }
 
 export type ToJSON<T> = T extends Uint8Array ? bigint : T extends object ? { -readonly [K in keyof T]: ToJSON<Exclude<T[K], undefined>> } : T;


### PR DESCRIPTION
## Why

Closes CON-445

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bid screening results now include per-provider incident histories (startedAt and nullable endedAt). Ongoing incidents are shown with a null end time and recent incidents (~last 8 days) are included alongside matched candidates.

* **Tests**
  * Added integration and unit tests covering recent-incident retrieval, grouping by provider, ordering, time-window boundaries, and cases with no matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->