### PR TITLE
feat(deployment): add partial config status for placements and inline field errors

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ConfigStatusIcon/ConfigStatusIcon.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ConfigStatusIcon/ConfigStatusIcon.spec.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { ConfigStatusIcon } from "./ConfigStatusIcon";
+
+import { render, screen } from "@testing-library/react";
+
+describe("ConfigStatusIcon", () => {
+  it("renders the complete marker when complete", () => {
+    render(<ConfigStatusIcon status="complete" />);
+
+    expect(screen.getByRole("img", { name: "Complete" })).toBeInTheDocument();
+  });
+
+  it("renders the partial marker when partial", () => {
+    render(<ConfigStatusIcon status="partial" />);
+
+    expect(screen.getByRole("img", { name: "Partial" })).toBeInTheDocument();
+  });
+
+  it("renders the incomplete marker when incomplete", () => {
+    render(<ConfigStatusIcon status="incomplete" />);
+
+    expect(screen.getByRole("img", { name: "Incomplete" })).toBeInTheDocument();
+  });
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ConfigStatusIcon/ConfigStatusIcon.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ConfigStatusIcon/ConfigStatusIcon.tsx
@@ -1,0 +1,35 @@
+import type { FC } from "react";
+import { CheckCircleSolid } from "iconoir-react";
+
+/** Configuration progress of a service or placement. `partial` only occurs for placements. */
+export type ConfigStatus = "incomplete" | "partial" | "complete";
+
+type Props = {
+  status: ConfigStatus;
+};
+
+/**
+ * Status marker: a green check when complete, a dashed ring with a centered dot
+ * while partially complete, and an empty dashed ring while incomplete.
+ */
+export const ConfigStatusIcon: FC<Props> = ({ status }) => {
+  if (status === "complete") {
+    return (
+      <span role="img" aria-label="Complete" className="shrink-0 text-green-600">
+        <CheckCircleSolid className="h-3.5 w-3.5" />
+      </span>
+    );
+  }
+  if (status === "partial") {
+    return (
+      <span
+        role="img"
+        aria-label="Partial"
+        className="flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded-full border border-dashed border-muted-foreground"
+      >
+        <span className="h-1 w-1 rounded-full bg-muted-foreground" />
+      </span>
+    );
+  }
+  return <span role="img" aria-label="Incomplete" className="block h-3.5 w-3.5 shrink-0 rounded-full border border-dashed border-muted-foreground" />;
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/EndpointRow/EndpointRow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/EndpointRow/EndpointRow.spec.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
-import { EndpointRow } from "./EndpointRow";
+import { DEPENDENCIES, EndpointRow } from "./EndpointRow";
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -24,7 +24,13 @@ describe("EndpointRow", () => {
     expect(onRemove).toHaveBeenCalled();
   });
 
-  function setup(input: { name?: string }) {
+  it("renders the validation error message below the row", () => {
+    setup({ error: "Names must start with a lower case letter." });
+
+    expect(screen.getByText("Names must start with a lower case letter.")).toBeInTheDocument();
+  });
+
+  function setup(input: { name?: string; error?: string }) {
     const name = input.name ?? "endpoint-1";
     const values: SdlBuilderFormValuesType = { ...defaultServiceWithPlacement(), endpoints: [{ id: "e-1", name }] };
     const onRemove = vi.fn();
@@ -36,7 +42,12 @@ describe("EndpointRow", () => {
     render(
       <Wrapper>
         <ul aria-label="IP endpoints">
-          <EndpointRow endpoint={values.endpoints![0]} endpointIndex={0} onRemove={onRemove} />
+          <EndpointRow
+            endpoint={values.endpoints![0]}
+            endpointIndex={0}
+            onRemove={onRemove}
+            dependencies={{ ...DEPENDENCIES, useFieldError: () => ({ error: input.error }) }}
+          />
         </ul>
       </Wrapper>
     );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/EndpointRow/EndpointRow.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/EndpointRow/EndpointRow.tsx
@@ -1,10 +1,12 @@
 import type { FC } from "react";
-import { Button, InlineEditInput } from "@akashnetwork/ui/components";
+import { useId } from "react";
+import { Button, FieldErrorMessage, InlineEditInput, useFieldError } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
 import { Globe, Trash } from "iconoir-react";
 
 import type { EndpointType } from "@src/types";
 
-export const DEPENDENCIES = { InlineEditInput };
+export const DEPENDENCIES = { InlineEditInput, useFieldError };
 
 type Props = {
   endpoint: EndpointType;
@@ -14,21 +16,32 @@ type Props = {
 };
 
 export const EndpointRow: FC<Props> = ({ endpoint, endpointIndex, onRemove, dependencies: d = DEPENDENCIES }) => {
+  const { error } = d.useFieldError(`endpoints.${endpointIndex}.name`);
+  const errorId = useId();
+
   return (
-    <li className="group flex items-start gap-2 rounded-md border border-zinc-300 px-2.5 py-2 dark:border-zinc-700">
-      <span className="flex h-5 shrink-0 items-center text-muted-foreground">
-        <Globe className="h-3.5 w-3.5" />
-      </span>
-      <d.InlineEditInput name={`endpoints.${endpointIndex}.name`} label="Endpoint name" />
-      <Button
-        type="button"
-        variant="text"
-        aria-label={`Remove ${endpoint.name}`}
-        onClick={onRemove}
-        className="invisible h-5 shrink-0 p-0 text-muted-foreground group-hover:visible hover:text-foreground focus-visible:visible"
+    <li className="group flex flex-col gap-1">
+      <div
+        className={cn("flex items-start gap-2 rounded-md border border-zinc-300 px-2.5 py-2", {
+          "border-destructive": !!error,
+          "border-zinc-300 dark:border-zinc-700": !error
+        })}
       >
-        <Trash className="h-3.5 w-3.5" />
-      </Button>
+        <span className="flex h-5 shrink-0 items-center text-muted-foreground">
+          <Globe className="h-3.5 w-3.5" />
+        </span>
+        <d.InlineEditInput name={`endpoints.${endpointIndex}.name`} label="Endpoint name" suppressErrorMessage errorMessageId={errorId} />
+        <Button
+          type="button"
+          variant="text"
+          aria-label={`Remove ${endpoint.name}`}
+          onClick={onRemove}
+          className="invisible h-5 shrink-0 p-0 text-muted-foreground group-hover:visible hover:text-foreground focus-visible:visible"
+        >
+          <Trash className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      {error && <FieldErrorMessage id={errorId}>{error}</FieldErrorMessage>}
     </li>
   );
 };

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.spec.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { defaultPlacement, defaultService } from "@src/utils/sdl/data";
+import type { ConfigStatus } from "../ConfigStatusIcon/ConfigStatusIcon";
 import { DEPENDENCIES, PlacementCard } from "./PlacementCard";
 
 import { render, screen } from "@testing-library/react";
@@ -40,7 +41,31 @@ describe("PlacementCard", () => {
     expect(screen.queryByRole("button", { name: "Remove placement" })).not.toBeInTheDocument();
   });
 
-  function setup(input: { serviceTitles: string[]; canRemove?: boolean; dependencies?: Partial<typeof DEPENDENCIES> }) {
+  it("shows the complete marker when the placement aggregates as complete", () => {
+    setup({ serviceTitles: ["web"], status: "complete" });
+
+    expect(screen.getByRole("img", { name: "Complete" })).toBeInTheDocument();
+  });
+
+  it("shows the partial marker when only some services are configured", () => {
+    setup({ serviceTitles: ["web"], status: "partial" });
+
+    expect(screen.getByRole("img", { name: "Partial" })).toBeInTheDocument();
+  });
+
+  it("shows the incomplete marker when no services are configured", () => {
+    setup({ serviceTitles: ["web"], status: "incomplete" });
+
+    expect(screen.getByRole("img", { name: "Incomplete" })).toBeInTheDocument();
+  });
+
+  it("renders the placement name error below the header", () => {
+    setup({ serviceTitles: ["web"], error: "Names must start with a lower case letter." });
+
+    expect(screen.getByText("Names must start with a lower case letter.")).toBeInTheDocument();
+  });
+
+  function setup(input: { serviceTitles: string[]; canRemove?: boolean; status?: ConfigStatus; error?: string; dependencies?: Partial<typeof DEPENDENCIES> }) {
     const placement = defaultPlacement({ name: "placement-1" });
     const services = input.serviceTitles.map((title, index) => ({
       service: defaultService(placement.id, { title }),
@@ -69,7 +94,11 @@ describe("PlacementCard", () => {
           onAddService={onAddService}
           onRemoveService={onRemoveService}
           onRemove={onRemove}
-          dependencies={MockComponents(DEPENDENCIES, input.dependencies)}
+          dependencies={MockComponents(DEPENDENCIES, {
+            usePlacementStatus: () => input.status ?? "incomplete",
+            useFieldError: () => ({ error: input.error }),
+            ...input.dependencies
+          })}
         />
       </Wrapper>
     );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.tsx
@@ -1,13 +1,16 @@
 import type { FC } from "react";
-import { InlineEditInput } from "@akashnetwork/ui/components";
+import { useId } from "react";
+import { FieldErrorMessage, InlineEditInput, useFieldError } from "@akashnetwork/ui/components";
 import { Plus, Trash } from "iconoir-react";
 
 import { RegionSelect } from "@src/components/sdl/RegionSelect/RegionSelect";
 import type { PlacementType } from "@src/types";
+import { ConfigStatusIcon } from "../ConfigStatusIcon/ConfigStatusIcon";
 import { ServiceRow } from "../ServiceRow/ServiceRow";
 import type { IndexedService } from "../usePlacementManager/usePlacementManager";
+import { usePlacementStatus } from "../usePlacementStatus/usePlacementStatus";
 
-export const DEPENDENCIES = { InlineEditInput, RegionSelect, ServiceRow };
+export const DEPENDENCIES = { InlineEditInput, RegionSelect, ServiceRow, usePlacementStatus, useFieldError };
 
 type Props = {
   placement: PlacementType;
@@ -36,15 +39,23 @@ export const PlacementCard: FC<Props> = ({
   onRemove,
   dependencies: d = DEPENDENCIES
 }) => {
+  const status = d.usePlacementStatus(placement.id as string);
+  const { error } = d.useFieldError(`placements.${placementIndex}.name`);
+  const errorId = useId();
+
   return (
     <div className="rounded-lg border border-zinc-300 p-2 dark:border-zinc-700">
-      <div className="flex items-center gap-2 px-1 pb-2">
-        <d.InlineEditInput name={`placements.${placementIndex}.name`} label="Placement name" />
-        {canRemove && (
-          <button type="button" aria-label="Remove placement" onClick={onRemove} className="shrink-0 text-muted-foreground hover:text-foreground">
-            <Trash className="h-3.5 w-3.5" />
-          </button>
-        )}
+      <div className="flex flex-col gap-1 px-1 pb-2">
+        <div className="flex items-center gap-2">
+          <ConfigStatusIcon status={status} />
+          <d.InlineEditInput name={`placements.${placementIndex}.name`} label="Placement name" suppressErrorMessage errorMessageId={errorId} />
+          {canRemove && (
+            <button type="button" aria-label="Remove placement" onClick={onRemove} className="shrink-0 text-muted-foreground hover:text-foreground">
+              <Trash className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+        {error && <FieldErrorMessage id={errorId}>{error}</FieldErrorMessage>}
       </div>
       <d.RegionSelect placementIndex={placementIndex} />
       <ul aria-label={`${placement.name} services`} className="mt-2 space-y-2">

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ServiceRow/ServiceRow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ServiceRow/ServiceRow.spec.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
-import { ServiceRow } from "./ServiceRow";
+import { DEPENDENCIES, ServiceRow } from "./ServiceRow";
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -47,10 +47,10 @@ describe("ServiceRow", () => {
     expect(screen.getByRole("img", { name: "Incomplete" })).toBeInTheDocument();
   });
 
-  it("shows the configured status for a valid service", () => {
+  it("shows the complete status for a valid service", () => {
     setup({ image: "nginx:latest" });
 
-    expect(screen.getByRole("img", { name: "Configured" })).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "Complete" })).toBeInTheDocument();
   });
 
   it("removes the service", async () => {
@@ -67,7 +67,19 @@ describe("ServiceRow", () => {
     expect(screen.queryByRole("button", { name: "Remove service-1" })).not.toBeInTheDocument();
   });
 
-  function setup(input: { isSelected?: boolean; canRemove?: boolean; image?: string }) {
+  it("renders the validation error message below the row", () => {
+    setup({ error: "Names must start with a lower case letter." });
+
+    expect(screen.getByText("Names must start with a lower case letter.")).toBeInTheDocument();
+  });
+
+  it("does not render an error message when the field is valid", () => {
+    setup({});
+
+    expect(screen.queryByText("Names must start with a lower case letter.")).not.toBeInTheDocument();
+  });
+
+  function setup(input: { isSelected?: boolean; canRemove?: boolean; image?: string; error?: string }) {
     const values = defaultServiceWithPlacement({ title: "service-1", image: input.image ?? "" });
     const onSelect = vi.fn();
     const onRemove = vi.fn();
@@ -86,6 +98,7 @@ describe("ServiceRow", () => {
             canRemove={input.canRemove ?? true}
             onSelect={onSelect}
             onRemove={onRemove}
+            dependencies={{ ...DEPENDENCIES, useFieldError: () => ({ error: input.error }) }}
           />
         </ul>
       </Wrapper>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ServiceRow/ServiceRow.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ServiceRow/ServiceRow.tsx
@@ -1,12 +1,14 @@
 import type { FC, MouseEvent } from "react";
-import { InlineEditInput } from "@akashnetwork/ui/components";
+import { useId } from "react";
+import { FieldErrorMessage, InlineEditInput, useFieldError } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
-import { CheckCircleSolid, Trash } from "iconoir-react";
+import { Trash } from "iconoir-react";
 
 import type { ServiceType } from "@src/types";
+import { ConfigStatusIcon } from "../ConfigStatusIcon/ConfigStatusIcon";
 import { useServiceStatus } from "../useServiceStatus/useServiceStatus";
 
-export const DEPENDENCIES = { InlineEditInput, useServiceStatus };
+export const DEPENDENCIES = { InlineEditInput, useFieldError, useServiceStatus };
 
 type Props = {
   service: ServiceType;
@@ -20,6 +22,8 @@ type Props = {
 
 export const ServiceRow: FC<Props> = ({ service, serviceIndex, isSelected, canRemove, onSelect, onRemove, dependencies: d = DEPENDENCIES }) => {
   const isConfigured = d.useServiceStatus(serviceIndex);
+  const { error } = d.useFieldError(`services.${serviceIndex}.title`);
+  const errorId = useId();
 
   function removeWithoutSelecting(event: MouseEvent<HTMLButtonElement>) {
     event.stopPropagation();
@@ -27,44 +31,35 @@ export const ServiceRow: FC<Props> = ({ service, serviceIndex, isSelected, canRe
   }
 
   return (
-    <li
-      onClick={onSelect}
-      className={cn("group flex cursor-pointer items-start gap-2 rounded-md border px-2.5 py-2", {
-        "border-foreground": isSelected,
-        "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-600": !isSelected
-      })}
-    >
-      <button
-        type="button"
-        aria-pressed={isSelected}
-        aria-label={`Select ${service.title}`}
-        className="flex h-5 shrink-0 items-center justify-center rounded-full outline-none focus-visible:ring-1 focus-visible:ring-ring"
+    <li onClick={onSelect} className="group flex cursor-pointer flex-col gap-1">
+      <div
+        className={cn("flex items-start gap-2 rounded-md border px-2.5 py-2", {
+          "border-destructive": !!error,
+          "border-foreground": isSelected && !error,
+          "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-600": !isSelected && !error
+        })}
       >
-        <ServiceStatusIcon isConfigured={isConfigured} />
-      </button>
-      <d.InlineEditInput name={`services.${serviceIndex}.title`} label="Service name" />
-      {canRemove && (
         <button
           type="button"
-          aria-label={`Remove ${service.title}`}
-          onClick={removeWithoutSelecting}
-          className="invisible flex h-5 shrink-0 items-center text-muted-foreground group-hover:visible hover:text-foreground focus-visible:visible"
+          aria-pressed={isSelected}
+          aria-label={`Select ${service.title}`}
+          className="flex h-5 shrink-0 items-center justify-center rounded-full outline-none focus-visible:ring-1 focus-visible:ring-ring"
         >
-          <Trash className="h-3.5 w-3.5" />
+          <ConfigStatusIcon status={isConfigured ? "complete" : "incomplete"} />
         </button>
-      )}
+        <d.InlineEditInput name={`services.${serviceIndex}.title`} label="Service name" suppressErrorMessage errorMessageId={errorId} />
+        {canRemove && (
+          <button
+            type="button"
+            aria-label={`Remove ${service.title}`}
+            onClick={removeWithoutSelecting}
+            className="invisible flex h-5 shrink-0 items-center text-muted-foreground group-hover:visible hover:text-foreground focus-visible:visible"
+          >
+            <Trash className="h-3.5 w-3.5" />
+          </button>
+        )}
+      </div>
+      {error && <FieldErrorMessage id={errorId}>{error}</FieldErrorMessage>}
     </li>
   );
 };
-
-/** Green check when every validation rule passes; dashed circle while incomplete. */
-function ServiceStatusIcon({ isConfigured }: { isConfigured: boolean }) {
-  if (isConfigured) {
-    return (
-      <span role="img" aria-label="Configured" className="shrink-0 text-green-600">
-        <CheckCircleSolid className="h-3.5 w-3.5" />
-      </span>
-    );
-  }
-  return <span role="img" aria-label="Incomplete" className="block h-3.5 w-3.5 shrink-0 rounded-full border border-dashed border-muted-foreground" />;
-}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/usePlacementStatus/usePlacementStatus.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/usePlacementStatus/usePlacementStatus.spec.tsx
@@ -1,0 +1,82 @@
+import type { PropsWithChildren } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { defaultPlacement, defaultService } from "@src/utils/sdl/data";
+import { getPlacementStatus, usePlacementStatus } from "./usePlacementStatus";
+
+import { renderHook } from "@testing-library/react";
+
+describe("getPlacementStatus", () => {
+  it("reports a placement with no services as incomplete", () => {
+    const placement = defaultPlacement();
+    const values: SdlBuilderFormValuesType = { placements: [placement], services: [], endpoints: [] };
+
+    expect(getPlacementStatus(values, placement.id)).toBe("incomplete");
+  });
+
+  it("reports a placement with no configured services as incomplete", () => {
+    const placement = defaultPlacement();
+    const values: SdlBuilderFormValuesType = {
+      placements: [placement],
+      services: [defaultService(placement.id, { title: "web", image: "" })],
+      endpoints: []
+    };
+
+    expect(getPlacementStatus(values, placement.id)).toBe("incomplete");
+  });
+
+  it("reports a placement as complete when all of its services are configured", () => {
+    const placement = defaultPlacement();
+    const values: SdlBuilderFormValuesType = {
+      placements: [placement],
+      services: [defaultService(placement.id, { title: "web", image: "nginx:latest" })],
+      endpoints: []
+    };
+
+    expect(getPlacementStatus(values, placement.id)).toBe("complete");
+  });
+
+  it("reports a placement as partial when some but not all of its services are configured", () => {
+    const placement = defaultPlacement();
+    const values: SdlBuilderFormValuesType = {
+      placements: [placement],
+      services: [defaultService(placement.id, { title: "web", image: "nginx:latest" }), defaultService(placement.id, { title: "api", image: "" })],
+      endpoints: []
+    };
+
+    expect(getPlacementStatus(values, placement.id)).toBe("partial");
+  });
+
+  it("ignores services that belong to other placements", () => {
+    const placement = defaultPlacement();
+    const other = defaultPlacement();
+    const values: SdlBuilderFormValuesType = {
+      placements: [placement, other],
+      services: [defaultService(placement.id, { title: "web", image: "nginx:latest" }), defaultService(other.id, { title: "api", image: "" })],
+      endpoints: []
+    };
+
+    expect(getPlacementStatus(values, placement.id)).toBe("complete");
+  });
+});
+
+describe("usePlacementStatus", () => {
+  it("derives the status from the form context", () => {
+    const placement = defaultPlacement();
+    const values: SdlBuilderFormValuesType = {
+      placements: [placement],
+      services: [defaultService(placement.id, { title: "web", image: "nginx:latest" })],
+      endpoints: []
+    };
+
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values });
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+    const { result } = renderHook(() => usePlacementStatus(placement.id), { wrapper: Wrapper });
+
+    expect(result.current).toBe("complete");
+  });
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/usePlacementStatus/usePlacementStatus.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/usePlacementStatus/usePlacementStatus.ts
@@ -1,0 +1,42 @@
+import { useMemo } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
+
+import { isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
+import type { SdlBuilderFormValuesType } from "@src/types";
+import type { ConfigStatus } from "../ConfigStatusIcon/ConfigStatusIcon";
+import { isServiceConfigured } from "../useServiceStatus/useServiceStatus";
+
+/** Aggregate configuration status of a placement, derived from the form context. */
+export const usePlacementStatus = (placementId: string): ConfigStatus => {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const values = useWatch({ control });
+
+  return useMemo(() => getPlacementStatus(values as SdlBuilderFormValuesType, placementId), [values, placementId]);
+};
+
+/**
+ * Aggregates the per-service configuration status for a placement: `complete`
+ * when it owns at least one non-log-collector service and all of them pass
+ * {@link isServiceConfigured}, `partial` when only some pass, and `incomplete`
+ * when none pass (or it has no services). The placement's own name/region are
+ * intentionally out of scope — the form resolver surfaces those inline.
+ */
+export function getPlacementStatus(values: SdlBuilderFormValuesType, placementId: string): ConfigStatus {
+  const services = values.services ?? [];
+  const indexes = services
+    .map((service, index) => ({ service, index }))
+    .filter(({ service }) => service.placementId === placementId && !isLogCollectorService(service))
+    .map(({ index }) => index);
+
+  if (indexes.length === 0) {
+    return "incomplete";
+  }
+
+  const completeCount = indexes.filter(index => isServiceConfigured(values, index)).length;
+
+  if (completeCount === 0) {
+    return "incomplete";
+  }
+
+  return completeCount === indexes.length ? "complete" : "partial";
+}

--- a/packages/ui/components/field-error-message.tsx
+++ b/packages/ui/components/field-error-message.tsx
@@ -1,0 +1,16 @@
+import type { FC, ReactNode } from "react";
+
+type Props = {
+  id?: string;
+  children: ReactNode;
+};
+
+/**
+ * Validation message shown full-width below an input or card, in muted,
+ * small text. Pair `id` with the input's `aria-describedby` for a11y.
+ */
+export const FieldErrorMessage: FC<Props> = ({ id, children }) => (
+  <p id={id} className="text-muted-foreground mt-1 text-sm">
+    {children}
+  </p>
+);

--- a/packages/ui/components/index.tsx
+++ b/packages/ui/components/index.tsx
@@ -16,6 +16,8 @@ export * from "./field";
 export * from "./form";
 export * from "./label";
 export * from "./inline-edit-input";
+export * from "./use-field-error";
+export * from "./field-error-message";
 export * from "./input";
 export * from "./navigation-menu";
 export * from "./pagination";

--- a/packages/ui/components/inline-edit-input.spec.tsx
+++ b/packages/ui/components/inline-edit-input.spec.tsx
@@ -57,17 +57,41 @@ describe("InlineEditInput", () => {
     expect(input).toHaveValue("service-1");
   });
 
-  it("renders the field error beneath the input", async () => {
-    const { setError } = setup({ initialValue: "service-1" });
+  it("renders its own error message beneath the input by default", () => {
+    const { setError, getInput } = setup({ initialValue: "service-1" });
 
     act(() => {
       setError("Invalid name.");
     });
 
-    expect(await screen.findByText("Invalid name.")).toBeInTheDocument();
+    const input = getInput();
+    expect(input).toHaveClass("text-destructive");
+    expect(screen.getByText("Invalid name.")).toBeInTheDocument();
+    const describedBy = input.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy as string)).toHaveTextContent("Invalid name.");
   });
 
-  function setup(input: { initialValue: string }) {
+  it("suppresses its own message and links the external id when suppressErrorMessage is set", () => {
+    const { setError, getInput } = setup({ initialValue: "service-1", suppressErrorMessage: true, errorMessageId: "err-1" });
+
+    act(() => {
+      setError("Invalid name.");
+    });
+
+    expect(getInput()).toHaveAttribute("aria-describedby", "err-1");
+    expect(getInput()).toHaveClass("text-destructive");
+    expect(screen.queryByText("Invalid name.")).not.toBeInTheDocument();
+  });
+
+  it("does not link or render an error while the field is valid", () => {
+    const { getInput } = setup({ initialValue: "service-1" });
+
+    expect(getInput()).not.toHaveAttribute("aria-describedby");
+    expect(screen.queryByText("Invalid name.")).not.toBeInTheDocument();
+  });
+
+  function setup(input: { initialValue: string; suppressErrorMessage?: boolean; errorMessageId?: string }) {
     let values: FormValues = { title: input.initialValue };
     const formRef: { current?: UseFormReturn<FormValues> } = {};
     const Wrapper = ({ children }: PropsWithChildren) => {
@@ -79,12 +103,13 @@ describe("InlineEditInput", () => {
 
     render(
       <Wrapper>
-        <InlineEditInput name="title" label="Title" />
+        <InlineEditInput name="title" label="Title" suppressErrorMessage={input.suppressErrorMessage} errorMessageId={input.errorMessageId} />
       </Wrapper>
     );
 
     return {
       getValue: () => values.title,
+      getInput: () => screen.getByRole("textbox", { name: "Title" }),
       setError: (message: string) => formRef.current?.setError("title", { message }),
       subscribeToValueChanges: () => {
         const onValueChange = vi.fn();

--- a/packages/ui/components/inline-edit-input.tsx
+++ b/packages/ui/components/inline-edit-input.tsx
@@ -4,20 +4,32 @@ import { useId, useRef, useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
 
 import { cn } from "../utils";
+import { FieldErrorMessage } from "./field-error-message";
 
 type Props = {
   name: string;
   label: string;
   className?: string;
+  /**
+   * When set, this component does not render the field's error message itself.
+   * The input still turns destructive on error and links to `errorMessageId`
+   * via aria-describedby, leaving the consumer to render the message where it
+   * wants (e.g. full-width below a card).
+   */
+  suppressErrorMessage?: boolean;
+  /** Id of the externally rendered error message; only used when `suppressErrorMessage` is set. */
+  errorMessageId?: string;
 };
 
 /**
  * Inline-editable text field bound to a react-hook-form field by `name`. Shows
- * the committed value as plain text-like input; edits commit on blur/Enter,
- * Escape reverts to the committed value, and the field's validation error (if
- * any) renders beneath it. Must be rendered within a FormProvider.
+ * the committed value as plain text-like input; edits commit on blur/Enter and
+ * Escape reverts to the committed value. On validation error the input text
+ * turns destructive and, by default, the message renders beneath the input. Set
+ * `suppressErrorMessage` to render the message elsewhere. Must be rendered
+ * within a FormProvider.
  */
-export const InlineEditInput: FC<Props> = ({ name, label, className }) => {
+export const InlineEditInput: FC<Props> = ({ name, label, className, suppressErrorMessage, errorMessageId }) => {
   const { control } = useFormContext();
 
   return (
@@ -25,7 +37,15 @@ export const InlineEditInput: FC<Props> = ({ name, label, className }) => {
       control={control}
       name={name}
       render={({ field, fieldState }) => (
-        <EditableText label={label} value={field.value} onCommit={field.onChange} error={fieldState.error?.message} className={className} />
+        <EditableText
+          label={label}
+          value={field.value}
+          onCommit={field.onChange}
+          error={fieldState.error?.message}
+          suppressErrorMessage={suppressErrorMessage}
+          errorMessageId={errorMessageId}
+          className={className}
+        />
       )}
     />
   );
@@ -36,13 +56,18 @@ interface EditableTextProps {
   value: string;
   onCommit: (value: string) => void;
   error?: string;
+  suppressErrorMessage?: boolean;
+  errorMessageId?: string;
   className?: string;
 }
 
-function EditableText({ label, value, onCommit, error, className }: EditableTextProps) {
+function EditableText({ label, value, onCommit, error, suppressErrorMessage, errorMessageId, className }: EditableTextProps) {
   const [draft, setDraft] = useState<string | null>(null);
   const isCancelling = useRef(false);
-  const errorId = useId();
+  const internalErrorId = useId();
+  const hasError = !!error;
+  const rendersOwnMessage = hasError && !suppressErrorMessage;
+  const describedById = hasError ? (suppressErrorMessage ? errorMessageId : internalErrorId) : undefined;
 
   function commitDraft() {
     if (draft !== null && draft !== value) {
@@ -77,18 +102,18 @@ function EditableText({ label, value, onCommit, error, className }: EditableText
       <input
         type="text"
         aria-label={label}
-        aria-describedby={error ? errorId : undefined}
+        aria-invalid={hasError || undefined}
+        aria-describedby={describedById}
         value={draft ?? value}
         onChange={event => setDraft(event.target.value)}
         onKeyDown={handleKeyDown}
         onBlur={handleBlur}
-        className="text-foreground focus:ring-ring block h-5 w-full truncate border-none bg-transparent p-0 font-mono text-sm leading-5 outline-none focus:rounded focus:ring-1"
+        className={cn(
+          "focus:ring-ring block h-5 w-full truncate border-none bg-transparent p-0 font-mono text-sm leading-5 outline-none focus:rounded focus:ring-1",
+          hasError ? "text-destructive" : "text-foreground"
+        )}
       />
-      {error && (
-        <p id={errorId} className="text-destructive mt-0.5 text-xs">
-          {error}
-        </p>
-      )}
+      {rendersOwnMessage && <FieldErrorMessage id={internalErrorId}>{error}</FieldErrorMessage>}
     </div>
   );
 }

--- a/packages/ui/components/use-field-error.spec.tsx
+++ b/packages/ui/components/use-field-error.spec.tsx
@@ -1,0 +1,38 @@
+import type { PropsWithChildren } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import { useFieldError } from "./use-field-error";
+
+import { act, renderHook } from "@testing-library/react";
+
+interface FormValues {
+  title: string;
+}
+
+describe("useFieldError", () => {
+  it("returns undefined when the field has no error", () => {
+    const { result } = setup();
+
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("returns the error message once the field is set in error", () => {
+    const { result, formRef } = setup();
+
+    act(() => formRef.current?.setError("title", { message: "Invalid name." }));
+
+    expect(result.current.error).toBe("Invalid name.");
+  });
+
+  function setup() {
+    const formRef: { current?: UseFormReturn<FormValues> } = {};
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<FormValues>({ defaultValues: { title: "service-1" } });
+      formRef.current = form;
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+    return { ...renderHook(() => useFieldError("title"), { wrapper: Wrapper }), formRef };
+  }
+});

--- a/packages/ui/components/use-field-error.ts
+++ b/packages/ui/components/use-field-error.ts
@@ -1,0 +1,14 @@
+"use client";
+import { useFormContext } from "react-hook-form";
+
+/**
+ * Returns the validation error message for the field named `name` from the
+ * surrounding react-hook-form context, or undefined when the field is valid.
+ * Lets a consumer drive its own error UI (border, message placement) without
+ * re-binding the field as a Controller. Must be used within a FormProvider.
+ */
+export function useFieldError(name: string): { error?: string } {
+  const { getFieldState, formState } = useFormContext();
+  const { error } = getFieldState(name, formState);
+  return { error: error?.message };
+}


### PR DESCRIPTION
## Why

The deployment pane shows no signal for how completely a placement (and its services) is configured, and validation errors on inline-edited fields had no consistent full-width treatment. Users need an at-a-glance status and clearer error placement.

Stacked on #3289 (IP endpoints pane); review/merge that first.

## What

- Introduce a three-state configuration status (incomplete / partial / complete) for placements and services in the deployment pane. Placements aggregate their services: complete when all are configured, partial when some are, incomplete when none are.
- Extract a shared `ConfigStatusIcon` for the markers and a `usePlacementStatus` hook to derive a placement's status from form context.
- Add `useFieldError` and `FieldErrorMessage` to the UI package.
- Let `InlineEditInput` suppress its own message so validation errors can render full-width below a card or row.

<img width="267" height="682" alt="Screenshot 2026-06-10 at 14 41 43" src="https://github.com/user-attachments/assets/66ef0136-b8a9-4c2f-8798-035ae08c2cc4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual status indicators (Complete, Partial, Incomplete) to deployment configuration items for improved clarity.
  * Implemented field-level validation error messages that display directly beneath configuration fields.
  * Enhanced error messaging across endpoint, placement, and service configuration rows.

* **Improvements**
  * Better accessibility support for status indicators and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->