### PR TITLE
feat(deployment): populate configure screen from template query param

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.spec.tsx
@@ -1,182 +1,82 @@
-import { useFormContext, useWatch } from "react-hook-form";
+import type { TemplateOutput } from "@akashnetwork/http-sdk";
 import { createStore, Provider as JotaiStoreProvider } from "jotai";
+import type { ReadonlyURLSearchParams } from "next/navigation";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import sdlStore from "@src/store/sdlStore";
-import type { SdlBuilderFormValuesType, TemplateCreation } from "@src/types";
-import { defaultService } from "@src/utils/sdl/data";
+import type { TemplateCreation } from "@src/types";
+import { helloWorldTemplate } from "@src/utils/templates";
 import type { DEPENDENCIES } from "./ConfigureDeployment";
 import { ConfigureDeployment } from "./ConfigureDeployment";
 
-import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { render, screen } from "@testing-library/react";
 
-const VALID_SDL = [
-  "version: '2.0'",
-  "services:",
-  "  web:",
-  "    image: nginx:1.0",
-  "    expose:",
-  "      - port: 80",
-  "        as: 80",
-  "        to:",
-  "          - global: true",
-  "profiles:",
-  "  compute:",
-  "    web:",
-  "      resources:",
-  "        cpu:",
-  "          units: 0.5",
-  "        memory:",
-  "          size: 512Mi",
-  "        storage:",
-  "          - size: 512Mi",
-  "  placement:",
-  "    dcloud:",
-  "      pricing:",
-  "        web:",
-  "          denom: uact",
-  "          amount: 1000",
-  "deployment:",
-  "  web:",
-  "    dcloud:",
-  "      profile: web",
-  "      count: 1"
-].join("\n");
+describe(ConfigureDeployment.name, () => {
+  it("shows a loading state while the template is being fetched", () => {
+    const { ConfigureDeploymentForm } = setup({ templateId: "tpl-1", template: { isLoading: true } });
 
-const TWO_SERVICE_SDL = [
-  "version: '2.0'",
-  "services:",
-  "  web:",
-  "    image: nginx:1.0",
-  "    expose:",
-  "      - port: 80",
-  "        as: 80",
-  "        to:",
-  "          - global: true",
-  "  api:",
-  "    image: node:18",
-  "    expose:",
-  "      - port: 3000",
-  "        as: 3000",
-  "        to:",
-  "          - global: true",
-  "profiles:",
-  "  compute:",
-  "    web:",
-  "      resources:",
-  "        cpu:",
-  "          units: 0.5",
-  "        memory:",
-  "          size: 512Mi",
-  "        storage:",
-  "          - size: 512Mi",
-  "    api:",
-  "      resources:",
-  "        cpu:",
-  "          units: 0.5",
-  "        memory:",
-  "          size: 512Mi",
-  "        storage:",
-  "          - size: 512Mi",
-  "  placement:",
-  "    dcloud:",
-  "      pricing:",
-  "        web:",
-  "          denom: uact",
-  "          amount: 1000",
-  "        api:",
-  "          denom: uact",
-  "          amount: 1000",
-  "deployment:",
-  "  web:",
-  "    dcloud:",
-  "      profile: web",
-  "      count: 1",
-  "  api:",
-  "    dcloud:",
-  "      profile: api",
-  "      count: 1"
-].join("\n");
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(ConfigureDeploymentForm).not.toHaveBeenCalled();
+  });
 
-describe("ConfigureDeployment", () => {
-  it("seeds the panes with the carried-in template SDL", () => {
-    const { ConfigureDeploymentPanes } = setup({
-      deploySdl: mock<TemplateCreation>({ content: 'version: "2.0"' })
+  it("hydrates the form from the fetched template's SDL", () => {
+    const { ConfigureDeploymentForm } = setup({
+      templateId: "tpl-1",
+      template: { isLoading: false, data: mock<TemplateOutput>({ deploy: "version: '2.0'" }) }
     });
 
-    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ sdl: 'version: "2.0"' }), expect.anything());
+    expect(ConfigureDeploymentForm).toHaveBeenCalledWith(expect.objectContaining({ initialSdl: "version: '2.0'" }), expect.anything());
   });
 
-  it("generates the SDL of the default deployment when no template was carried in", () => {
-    const { ConfigureDeploymentPanes } = setup({ deploySdl: null });
-
-    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ sdl: expect.stringContaining('version: "2.0"') }), expect.anything());
-  });
-
-  it("selects the first service from the imported template", () => {
-    const { ConfigureDeploymentPanes } = setup({ deploySdl: mock<TemplateCreation>({ content: VALID_SDL }) });
-
-    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ selectedServiceId: expect.any(String) }), expect.anything());
-  });
-
-  it("hydrates the deployment pane with the imported template's services", () => {
-    setup({ deploySdl: mock<TemplateCreation>({ content: TWO_SERVICE_SDL }), Panes: ServiceListProbePanes });
-
-    expect(screen.getByTestId("service-titles").textContent).toBe("web,api");
-  });
-
-  it("surfaces an error and falls back to a default when the carried-in SDL cannot be imported", () => {
-    const { ConfigureDeploymentPanes, enqueueSnackbar } = setup({ deploySdl: mock<TemplateCreation>({ content: "services: [unclosed" }) });
+  it("surfaces an error and falls back to a default when the template can't be loaded", () => {
+    const { ConfigureDeploymentForm, enqueueSnackbar } = setup({ templateId: "tpl-1", template: { isLoading: false, isError: true } });
 
     expect(enqueueSnackbar).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "error" }));
-    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(
-      expect.objectContaining({ sdl: expect.stringContaining('version: "2.0"'), selectedServiceId: expect.any(String) }),
-      expect.anything()
-    );
+    expect(ConfigureDeploymentForm).toHaveBeenCalledWith(expect.objectContaining({ initialSdl: undefined }), expect.anything());
   });
 
-  it("starts with a default service selected when no template was carried in", () => {
-    const { ConfigureDeploymentPanes } = setup({ deploySdl: null });
+  it("falls back to the carried-in deploySdl when no template id is present", () => {
+    const { ConfigureDeploymentForm } = setup({ templateId: null, deploySdl: mock<TemplateCreation>({ content: "carried: sdl" }) });
 
-    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ selectedServiceId: expect.any(String) }), expect.anything());
+    expect(ConfigureDeploymentForm).toHaveBeenCalledWith(expect.objectContaining({ initialSdl: "carried: sdl" }), expect.anything());
   });
 
-  it("regenerates the SDL preview when the form changes", async () => {
-    setup({ deploySdl: null, Panes: SdlProbePanes });
+  it("does not query a template when no template id is present", () => {
+    const { usePublicTemplate } = setup({ templateId: null });
 
-    await userEvent.click(screen.getByRole("button", { name: "change image" }));
-
-    await waitFor(() => expect(screen.getByTestId("sdl").textContent).toContain("nginx:latest"));
+    expect(usePublicTemplate).toHaveBeenCalledWith(undefined);
   });
 
-  it("reselects the first remaining service when the selected one is removed", async () => {
-    setup({ deploySdl: null, Panes: SelectionProbePanes });
-    const initialSelectedId = screen.getByTestId("selected").textContent;
+  it("resolves a hardcoded template by code without fetching", () => {
+    const { ConfigureDeploymentForm, usePublicTemplate } = setup({ templateId: helloWorldTemplate.code });
 
-    await userEvent.click(screen.getByRole("button", { name: "replace services" }));
-
-    await waitFor(() => {
-      expect(screen.getByTestId("selected").textContent).not.toBe(initialSelectedId);
-      expect(screen.getByTestId("selected").textContent).toBe(screen.getByTestId("first-service-id").textContent);
-    });
+    expect(usePublicTemplate).toHaveBeenCalledWith(undefined);
+    expect(ConfigureDeploymentForm).toHaveBeenCalledWith(expect.objectContaining({ initialSdl: helloWorldTemplate.content }), expect.anything());
   });
 
-  function setup(input: { deploySdl: TemplateCreation | null; Panes?: typeof SdlProbePanes }) {
-    const ConfigureDeploymentPanes = vi.fn(input.Panes ?? (() => <div data-testid="panes-mock" />));
+  function setup(input: {
+    templateId: string | null;
+    template?: { isLoading?: boolean; isError?: boolean; data?: TemplateOutput };
+    deploySdl?: TemplateCreation | null;
+  }) {
+    const ConfigureDeploymentForm = vi.fn(() => <div data-testid="form-mock" />);
     const enqueueSnackbar = vi.fn();
-    const Snackbar = vi.fn(() => null);
+    const usePublicTemplate = vi.fn(() => mock<ReturnType<typeof DEPENDENCIES.usePublicTemplate>>(input.template as never));
+    const params = new URLSearchParams(input.templateId ? { templateId: input.templateId } : {});
+
     const dependencies: typeof DEPENDENCIES = {
       Layout: vi.fn(({ children }) => <div data-testid="layout-mock">{children}</div>) as never,
       NextSeo: vi.fn(() => null) as never,
-      ConfigureDeploymentHeader: vi.fn(() => <div data-testid="header-mock" />),
-      ConfigureDeploymentPanes: ConfigureDeploymentPanes as never,
+      ConfigureDeploymentForm: ConfigureDeploymentForm as never,
+      usePublicTemplate: usePublicTemplate as never,
+      useSearchParams: () => params as unknown as ReadonlyURLSearchParams,
       useSnackbar: () => mock<ReturnType<typeof DEPENDENCIES.useSnackbar>>({ enqueueSnackbar }),
-      Snackbar: Snackbar as never
+      Snackbar: vi.fn(() => null) as never
     };
+
     const store = createStore();
-    store.set(sdlStore.deploySdl, input.deploySdl);
+    store.set(sdlStore.deploySdl, input.deploySdl ?? null);
 
     render(
       <JotaiStoreProvider store={store}>
@@ -184,47 +84,6 @@ describe("ConfigureDeployment", () => {
       </JotaiStoreProvider>
     );
 
-    return { ConfigureDeploymentPanes, enqueueSnackbar };
+    return { ConfigureDeploymentForm, usePublicTemplate, enqueueSnackbar };
   }
 });
-
-interface ProbePanesProps {
-  sdl: string;
-  selectedServiceId: string | null;
-}
-
-/** Panes stand-in that mutates the shared form to drive the SDL preview subscription. */
-function SdlProbePanes({ sdl }: ProbePanesProps) {
-  const { setValue } = useFormContext<SdlBuilderFormValuesType>();
-  return (
-    <div>
-      <div data-testid="sdl">{sdl}</div>
-      <button type="button" onClick={() => setValue("services.0.image", "nginx:latest")}>
-        change image
-      </button>
-    </div>
-  );
-}
-
-/** Panes stand-in that reports the imported services so hydration can be asserted. */
-function ServiceListProbePanes() {
-  const services = useWatch<SdlBuilderFormValuesType>({ name: "services" });
-  const titles = Array.isArray(services) ? (services as SdlBuilderFormValuesType["services"]).map(service => service.title) : [];
-  return <div data-testid="service-titles">{titles.join(",")}</div>;
-}
-
-/** Panes stand-in that swaps out the services to drive the reselection subscription. */
-function SelectionProbePanes({ selectedServiceId }: ProbePanesProps) {
-  const { setValue, getValues } = useFormContext<SdlBuilderFormValuesType>();
-  const services = useWatch<SdlBuilderFormValuesType>({ name: "services" });
-  const firstServiceId = Array.isArray(services) ? (services as SdlBuilderFormValuesType["services"])[0]?.id : undefined;
-  return (
-    <div>
-      <div data-testid="selected">{selectedServiceId ?? ""}</div>
-      <div data-testid="first-service-id">{firstServiceId ?? ""}</div>
-      <button type="button" onClick={() => setValue("services", [defaultService(getValues("placements")[0].id, { title: "service-2" })])}>
-        replace services
-      </button>
-    </div>
-  );
-}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.tsx
@@ -1,156 +1,66 @@
 "use client";
 import type { FC } from "react";
-import { useEffect, useState } from "react";
-import { FormProvider, useForm } from "react-hook-form";
-import { Snackbar } from "@akashnetwork/ui/components";
-import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { Snackbar, Spinner } from "@akashnetwork/ui/components";
 import { useAtomValue } from "jotai";
-import debounce from "lodash/debounce";
+import { useSearchParams } from "next/navigation";
 import { NextSeo } from "next-seo";
 import { useSnackbar } from "notistack";
 
 import Layout from "@src/components/layout/Layout";
-import { isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
+import { usePublicTemplate } from "@src/queries/useTemplateQuery";
 import sdlStore from "@src/store/sdlStore";
-import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
-import { SdlBuilderFormValuesSchema } from "@src/types";
-import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
-import { generateSdl } from "@src/utils/sdl/sdlGenerator";
-import { importSimpleSdl } from "@src/utils/sdl/sdlImport";
-import { ConfigureDeploymentHeader } from "../ConfigureDeploymentHeader/ConfigureDeploymentHeader";
-import { ConfigureDeploymentPanes } from "../ConfigureDeploymentPanes/ConfigureDeploymentPanes";
+import { hardcodedTemplates } from "@src/utils/templates";
+import { ConfigureDeploymentForm } from "../ConfigureDeploymentForm/ConfigureDeploymentForm";
 
-export const DEPENDENCIES = { Layout, NextSeo, ConfigureDeploymentHeader, ConfigureDeploymentPanes, useSnackbar, Snackbar };
-
-/** Delay between a form edit and regenerating the SDL preview. */
-const SDL_SYNC_DEBOUNCE_MS = 300;
+export const DEPENDENCIES = { Layout, NextSeo, ConfigureDeploymentForm, usePublicTemplate, useSearchParams, useSnackbar, Snackbar };
 
 type Props = {
   dependencies?: typeof DEPENDENCIES;
 };
 
+/**
+ * Resolves the SDL the Configure screen starts from, then hands it to the form.
+ * A `templateId` query param takes precedence and is resolved the same way the
+ * legacy flow does: hardcoded templates (e.g. hello-world) carry their SDL inline
+ * and are matched by code, while everything else is fetched as a public gallery
+ * template. Without a param the carried-in `deploySdl` atom is used. Keeping
+ * resolution here lets the form initialize synchronously from a single source.
+ */
 export const ConfigureDeployment: FC<Props> = ({ dependencies: d = DEPENDENCIES }) => {
+  const searchParams = d.useSearchParams();
+  const templateId = searchParams?.get("templateId") ?? undefined;
   const deploySdl = useAtomValue(sdlStore.deploySdl);
-  const [initialState] = useState(() => getInitialState(deploySdl?.content));
-  const [sdl, setSdl] = useState(initialState.sdl);
-  const [selectedServiceId, setSelectedServiceId] = useState<string | null>(initialState.selectedServiceId);
+  const hardcodedTemplate = templateId ? hardcodedTemplates.find(template => template.code === templateId) : undefined;
+  const fetchedTemplateId = hardcodedTemplate ? undefined : templateId;
+  const templateQuery = d.usePublicTemplate(fetchedTemplateId);
   const { enqueueSnackbar } = d.useSnackbar();
-  const form = useForm<SdlBuilderFormValuesType>({
-    defaultValues: initialState.values,
-    mode: "onChange",
-    resolver: zodResolver(SdlBuilderFormValuesSchema)
-  });
 
   useEffect(
-    function notifyOnImportError() {
-      if (!initialState.importError) {
+    function notifyOnTemplateError() {
+      if (!fetchedTemplateId || !templateQuery.isError) {
         return;
       }
-      enqueueSnackbar(<d.Snackbar title="Couldn't load the deployment" subTitle={initialState.importError} iconVariant="error" />, { variant: "error" });
+      enqueueSnackbar(
+        <d.Snackbar title="Couldn't load the template" subTitle="Starting from a default deployment instead." iconVariant="error" />,
+        { variant: "error" }
+      );
     },
-    [initialState, enqueueSnackbar, d]
+    [fetchedTemplateId, templateQuery.isError, enqueueSnackbar, d]
   );
 
-  useEffect(
-    function syncSdlPreview() {
-      const writeSdl = debounce((values: unknown) => {
-        setSdl(previous => regenerateSdl(values as SdlBuilderFormValuesType, previous));
-      }, SDL_SYNC_DEBOUNCE_MS);
-      const subscription = form.watch(values => writeSdl(values));
-      return function teardownSdlSync() {
-        writeSdl.cancel();
-        subscription.unsubscribe();
-      };
-    },
-    [form]
-  );
-
-  useEffect(
-    function reselectRemovedService() {
-      const subscription = form.watch(values => {
-        setSelectedServiceId(previous => nextSelectedServiceId(values as SdlBuilderFormValuesType, previous));
-      });
-      return function teardownReselect() {
-        subscription.unsubscribe();
-      };
-    },
-    [form]
-  );
-
-  return (
-    <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col">
-      <d.NextSeo title="Configure your deployment" />
-      <FormProvider {...form}>
-        <div className="px-6 pt-6">
-          <d.ConfigureDeploymentHeader />
+  if (fetchedTemplateId && templateQuery.isLoading) {
+    return (
+      <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col">
+        <d.NextSeo title="Configure your deployment" />
+        <div className="flex flex-1 items-center justify-center">
+          <Spinner size="large" />
         </div>
-        <div className="mt-6 flex min-h-0 flex-1">
-          <d.ConfigureDeploymentPanes sdl={sdl} selectedServiceId={selectedServiceId} onSelectService={setSelectedServiceId} />
-        </div>
-      </FormProvider>
-    </d.Layout>
-  );
+      </d.Layout>
+    );
+  }
+
+  const initialSdl = hardcodedTemplate?.content ?? (fetchedTemplateId ? templateQuery.data?.deploy : deploySdl?.content);
+
+  return <d.ConfigureDeploymentForm initialSdl={initialSdl} />;
 };
-
-interface InitialState {
-  values: SdlBuilderFormValuesType;
-  sdl: string;
-  selectedServiceId: string | null;
-  importError?: string;
-}
-
-/**
- * Derives the form values, preview SDL, and initial selection from one source
- * so they can never diverge. A parseable carried-in template keeps its exact
- * SDL text for the preview; if it can't be imported the screen falls back to a
- * default deployment and reports `importError` so the failure is surfaced
- * rather than silently swallowed.
- */
-function getInitialState(carriedInSdl: string | undefined): InitialState {
-  if (carriedInSdl) {
-    try {
-      const values = importSimpleSdl(carriedInSdl);
-      return { values, sdl: carriedInSdl, selectedServiceId: seedSelectedServiceId(values) };
-    } catch (error) {
-      const values = defaultServiceWithPlacement();
-      return { values, sdl: regenerateSdl(values, ""), selectedServiceId: seedSelectedServiceId(values), importError: getImportErrorMessage(error) };
-    }
-  }
-  const values = defaultServiceWithPlacement();
-  return { values, sdl: regenerateSdl(values, ""), selectedServiceId: seedSelectedServiceId(values) };
-}
-
-/**
- * Maps an SDL import failure to a fixed, user-facing message. The raw exception
- * text is intentionally not surfaced: it's parser-internal and untrusted, so
- * keeping it out of the rendered DOM avoids any injection surface.
- */
-function getImportErrorMessage(error: unknown): string {
-  if (error instanceof Error && (error.name === "YAMLException" || error.name === "CustomValidationError" || error.name === "TemplateValidation")) {
-    return "The deployment couldn't be loaded because its SDL is invalid.";
-  }
-  return "The deployment couldn't be loaded.";
-}
-
-/** Picks the first user-visible service to focus when the screen first mounts. */
-function seedSelectedServiceId(values: SdlBuilderFormValuesType): string | null {
-  return values.services.find(service => !isLogCollectorService(service))?.id ?? null;
-}
-
-/** Regenerates the preview SDL, keeping the last good output while the form is mid-edit. */
-function regenerateSdl(values: SdlBuilderFormValuesType, previous: string): string {
-  try {
-    return generateSdl(values);
-  } catch {
-    return previous;
-  }
-}
-
-/** Keeps the selection on an existing service, falling back to the first visible one after a removal. */
-function nextSelectedServiceId(values: SdlBuilderFormValuesType, previous: string | null): string | null {
-  const services = values.services ?? [];
-  if (previous && services.some(service => service?.id === previous)) {
-    return previous;
-  }
-  return services.find(service => service && !isLogCollectorService(service as ServiceType))?.id ?? null;
-}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -1,0 +1,220 @@
+import { useFormContext, useWatch } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { defaultService } from "@src/utils/sdl/data";
+import type { DEPENDENCIES } from "./ConfigureDeploymentForm";
+import { ConfigureDeploymentForm } from "./ConfigureDeploymentForm";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const VALID_SDL = [
+  "version: '2.0'",
+  "services:",
+  "  web:",
+  "    image: nginx:1.0",
+  "    expose:",
+  "      - port: 80",
+  "        as: 80",
+  "        to:",
+  "          - global: true",
+  "profiles:",
+  "  compute:",
+  "    web:",
+  "      resources:",
+  "        cpu:",
+  "          units: 0.5",
+  "        memory:",
+  "          size: 512Mi",
+  "        storage:",
+  "          - size: 512Mi",
+  "  placement:",
+  "    dcloud:",
+  "      pricing:",
+  "        web:",
+  "          denom: uact",
+  "          amount: 1000",
+  "deployment:",
+  "  web:",
+  "    dcloud:",
+  "      profile: web",
+  "      count: 1"
+].join("\n");
+
+const TWO_SERVICE_SDL = [
+  "version: '2.0'",
+  "services:",
+  "  web:",
+  "    image: nginx:1.0",
+  "    expose:",
+  "      - port: 80",
+  "        as: 80",
+  "        to:",
+  "          - global: true",
+  "  api:",
+  "    image: node:18",
+  "    expose:",
+  "      - port: 3000",
+  "        as: 3000",
+  "        to:",
+  "          - global: true",
+  "profiles:",
+  "  compute:",
+  "    web:",
+  "      resources:",
+  "        cpu:",
+  "          units: 0.5",
+  "        memory:",
+  "          size: 512Mi",
+  "        storage:",
+  "          - size: 512Mi",
+  "    api:",
+  "      resources:",
+  "        cpu:",
+  "          units: 0.5",
+  "        memory:",
+  "          size: 512Mi",
+  "        storage:",
+  "          - size: 512Mi",
+  "  placement:",
+  "    dcloud:",
+  "      pricing:",
+  "        web:",
+  "          denom: uact",
+  "          amount: 1000",
+  "        api:",
+  "          denom: uact",
+  "          amount: 1000",
+  "deployment:",
+  "  web:",
+  "    dcloud:",
+  "      profile: web",
+  "      count: 1",
+  "  api:",
+  "    dcloud:",
+  "      profile: api",
+  "      count: 1"
+].join("\n");
+
+describe(ConfigureDeploymentForm.name, () => {
+  it("seeds the panes with the carried-in template SDL", () => {
+    const { ConfigureDeploymentPanes } = setup({ initialSdl: 'version: "2.0"' });
+
+    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ sdl: 'version: "2.0"' }), expect.anything());
+  });
+
+  it("generates the SDL of the default deployment when no SDL was provided", () => {
+    const { ConfigureDeploymentPanes } = setup({ initialSdl: undefined });
+
+    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ sdl: expect.stringContaining('version: "2.0"') }), expect.anything());
+  });
+
+  it("selects the first service from the imported template", () => {
+    const { ConfigureDeploymentPanes } = setup({ initialSdl: VALID_SDL });
+
+    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ selectedServiceId: expect.any(String) }), expect.anything());
+  });
+
+  it("hydrates the deployment pane with the imported template's services", () => {
+    setup({ initialSdl: TWO_SERVICE_SDL, Panes: ServiceListProbePanes });
+
+    expect(screen.getByTestId("service-titles").textContent).toBe("web,api");
+  });
+
+  it("surfaces an error and falls back to a default when the SDL cannot be imported", () => {
+    const { ConfigureDeploymentPanes, enqueueSnackbar } = setup({ initialSdl: "services: [unclosed" });
+
+    expect(enqueueSnackbar).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "error" }));
+    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(
+      expect.objectContaining({ sdl: expect.stringContaining('version: "2.0"'), selectedServiceId: expect.any(String) }),
+      expect.anything()
+    );
+  });
+
+  it("starts with a default service selected when no SDL was provided", () => {
+    const { ConfigureDeploymentPanes } = setup({ initialSdl: undefined });
+
+    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ selectedServiceId: expect.any(String) }), expect.anything());
+  });
+
+  it("regenerates the SDL preview when the form changes", async () => {
+    setup({ initialSdl: undefined, Panes: SdlProbePanes });
+
+    await userEvent.click(screen.getByRole("button", { name: "change image" }));
+
+    await waitFor(() => expect(screen.getByTestId("sdl").textContent).toContain("nginx:latest"));
+  });
+
+  it("reselects the first remaining service when the selected one is removed", async () => {
+    setup({ initialSdl: undefined, Panes: SelectionProbePanes });
+    const initialSelectedId = screen.getByTestId("selected").textContent;
+
+    await userEvent.click(screen.getByRole("button", { name: "replace services" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("selected").textContent).not.toBe(initialSelectedId);
+      expect(screen.getByTestId("selected").textContent).toBe(screen.getByTestId("first-service-id").textContent);
+    });
+  });
+
+  function setup(input: { initialSdl: string | undefined; Panes?: typeof SdlProbePanes }) {
+    const ConfigureDeploymentPanes = vi.fn(input.Panes ?? (() => <div data-testid="panes-mock" />));
+    const enqueueSnackbar = vi.fn();
+    const Snackbar = vi.fn(() => null);
+    const dependencies: typeof DEPENDENCIES = {
+      Layout: vi.fn(({ children }) => <div data-testid="layout-mock">{children}</div>) as never,
+      NextSeo: vi.fn(() => null) as never,
+      ConfigureDeploymentHeader: vi.fn(() => <div data-testid="header-mock" />),
+      ConfigureDeploymentPanes: ConfigureDeploymentPanes as never,
+      useSnackbar: () => mock<ReturnType<typeof DEPENDENCIES.useSnackbar>>({ enqueueSnackbar }),
+      Snackbar: Snackbar as never
+    };
+
+    render(<ConfigureDeploymentForm initialSdl={input.initialSdl} dependencies={dependencies} />);
+
+    return { ConfigureDeploymentPanes, enqueueSnackbar };
+  }
+});
+
+interface ProbePanesProps {
+  sdl: string;
+  selectedServiceId: string | null;
+}
+
+/** Panes stand-in that mutates the shared form to drive the SDL preview subscription. */
+function SdlProbePanes({ sdl }: ProbePanesProps) {
+  const { setValue } = useFormContext<SdlBuilderFormValuesType>();
+  return (
+    <div>
+      <div data-testid="sdl">{sdl}</div>
+      <button type="button" onClick={() => setValue("services.0.image", "nginx:latest")}>
+        change image
+      </button>
+    </div>
+  );
+}
+
+/** Panes stand-in that reports the imported services so hydration can be asserted. */
+function ServiceListProbePanes() {
+  const services = useWatch<SdlBuilderFormValuesType>({ name: "services" });
+  const titles = Array.isArray(services) ? (services as SdlBuilderFormValuesType["services"]).map(service => service.title) : [];
+  return <div data-testid="service-titles">{titles.join(",")}</div>;
+}
+
+/** Panes stand-in that swaps out the services to drive the reselection subscription. */
+function SelectionProbePanes({ selectedServiceId }: ProbePanesProps) {
+  const { setValue, getValues } = useFormContext<SdlBuilderFormValuesType>();
+  const services = useWatch<SdlBuilderFormValuesType>({ name: "services" });
+  const firstServiceId = Array.isArray(services) ? (services as SdlBuilderFormValuesType["services"])[0]?.id : undefined;
+  return (
+    <div>
+      <div data-testid="selected">{selectedServiceId ?? ""}</div>
+      <div data-testid="first-service-id">{firstServiceId ?? ""}</div>
+      <button type="button" onClick={() => setValue("services", [defaultService(getValues("placements")[0].id, { title: "service-2" })])}>
+        replace services
+      </button>
+    </div>
+  );
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -1,0 +1,154 @@
+"use client";
+import type { FC } from "react";
+import { useEffect, useState } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { Snackbar } from "@akashnetwork/ui/components";
+import { zodResolver } from "@hookform/resolvers/zod";
+import debounce from "lodash/debounce";
+import { NextSeo } from "next-seo";
+import { useSnackbar } from "notistack";
+
+import Layout from "@src/components/layout/Layout";
+import { isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
+import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
+import { SdlBuilderFormValuesSchema } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { generateSdl } from "@src/utils/sdl/sdlGenerator";
+import { importSimpleSdl } from "@src/utils/sdl/sdlImport";
+import { ConfigureDeploymentHeader } from "../ConfigureDeploymentHeader/ConfigureDeploymentHeader";
+import { ConfigureDeploymentPanes } from "../ConfigureDeploymentPanes/ConfigureDeploymentPanes";
+
+export const DEPENDENCIES = { Layout, NextSeo, ConfigureDeploymentHeader, ConfigureDeploymentPanes, useSnackbar, Snackbar };
+
+/** Delay between a form edit and regenerating the SDL preview. */
+const SDL_SYNC_DEBOUNCE_MS = 300;
+
+type Props = {
+  initialSdl?: string;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, dependencies: d = DEPENDENCIES }) => {
+  const [initialState] = useState(() => getInitialState(initialSdl));
+  const [sdl, setSdl] = useState(initialState.sdl);
+  const [selectedServiceId, setSelectedServiceId] = useState<string | null>(initialState.selectedServiceId);
+  const { enqueueSnackbar } = d.useSnackbar();
+  const form = useForm<SdlBuilderFormValuesType>({
+    defaultValues: initialState.values,
+    mode: "onChange",
+    resolver: zodResolver(SdlBuilderFormValuesSchema)
+  });
+
+  useEffect(
+    function notifyOnImportError() {
+      if (!initialState.importError) {
+        return;
+      }
+      enqueueSnackbar(<d.Snackbar title="Couldn't load the deployment" subTitle={initialState.importError} iconVariant="error" />, { variant: "error" });
+    },
+    [initialState, enqueueSnackbar, d]
+  );
+
+  useEffect(
+    function syncSdlPreview() {
+      const writeSdl = debounce((values: unknown) => {
+        setSdl(previous => regenerateSdl(values as SdlBuilderFormValuesType, previous));
+      }, SDL_SYNC_DEBOUNCE_MS);
+      const subscription = form.watch(values => writeSdl(values));
+      return function teardownSdlSync() {
+        writeSdl.cancel();
+        subscription.unsubscribe();
+      };
+    },
+    [form]
+  );
+
+  useEffect(
+    function reselectRemovedService() {
+      const subscription = form.watch(values => {
+        setSelectedServiceId(previous => nextSelectedServiceId(values as SdlBuilderFormValuesType, previous));
+      });
+      return function teardownReselect() {
+        subscription.unsubscribe();
+      };
+    },
+    [form]
+  );
+
+  return (
+    <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col">
+      <d.NextSeo title="Configure your deployment" />
+      <FormProvider {...form}>
+        <div className="px-6 pt-6">
+          <d.ConfigureDeploymentHeader />
+        </div>
+        <div className="mt-6 flex min-h-0 flex-1">
+          <d.ConfigureDeploymentPanes sdl={sdl} selectedServiceId={selectedServiceId} onSelectService={setSelectedServiceId} />
+        </div>
+      </FormProvider>
+    </d.Layout>
+  );
+};
+
+interface InitialState {
+  values: SdlBuilderFormValuesType;
+  sdl: string;
+  selectedServiceId: string | null;
+  importError?: string;
+}
+
+/**
+ * Derives the form values, preview SDL, and initial selection from one source
+ * so they can never diverge. A parseable carried-in template keeps its exact
+ * SDL text for the preview; if it can't be imported the screen falls back to a
+ * default deployment and reports `importError` so the failure is surfaced
+ * rather than silently swallowed.
+ */
+function getInitialState(carriedInSdl: string | undefined): InitialState {
+  if (carriedInSdl) {
+    try {
+      const values = importSimpleSdl(carriedInSdl);
+      return { values, sdl: carriedInSdl, selectedServiceId: seedSelectedServiceId(values) };
+    } catch (error) {
+      const values = defaultServiceWithPlacement();
+      return { values, sdl: regenerateSdl(values, ""), selectedServiceId: seedSelectedServiceId(values), importError: getImportErrorMessage(error) };
+    }
+  }
+  const values = defaultServiceWithPlacement();
+  return { values, sdl: regenerateSdl(values, ""), selectedServiceId: seedSelectedServiceId(values) };
+}
+
+/**
+ * Maps an SDL import failure to a fixed, user-facing message. The raw exception
+ * text is intentionally not surfaced: it's parser-internal and untrusted, so
+ * keeping it out of the rendered DOM avoids any injection surface.
+ */
+function getImportErrorMessage(error: unknown): string {
+  if (error instanceof Error && (error.name === "YAMLException" || error.name === "CustomValidationError" || error.name === "TemplateValidation")) {
+    return "The deployment couldn't be loaded because its SDL is invalid.";
+  }
+  return "The deployment couldn't be loaded.";
+}
+
+/** Picks the first user-visible service to focus when the screen first mounts. */
+function seedSelectedServiceId(values: SdlBuilderFormValuesType): string | null {
+  return values.services.find(service => !isLogCollectorService(service))?.id ?? null;
+}
+
+/** Regenerates the preview SDL, keeping the last good output while the form is mid-edit. */
+function regenerateSdl(values: SdlBuilderFormValuesType, previous: string): string {
+  try {
+    return generateSdl(values);
+  } catch {
+    return previous;
+  }
+}
+
+/** Keeps the selection on an existing service, falling back to the first visible one after a removal. */
+function nextSelectedServiceId(values: SdlBuilderFormValuesType, previous: string | null): string | null {
+  const services = values.services ?? [];
+  if (previous && services.some(service => service?.id === previous)) {
+    return previous;
+  }
+  return services.find(service => service && !isLogCollectorService(service as ServiceType))?.id ?? null;
+}

--- a/apps/deploy-web/src/queries/queryKeys.ts
+++ b/apps/deploy-web/src/queries/queryKeys.ts
@@ -17,6 +17,7 @@ export class QueryKeys {
   static getValidatorsKey = () => ["VALIDATORS"];
   static getProposalsKey = () => ["PROPOSALS"];
   static getTemplateKey = (id: string) => ["SDL_TEMPLATES", id];
+  static getPublicTemplateKey = (id: string) => ["PUBLIC_TEMPLATE", id];
   static getUserTemplatesKey = (username: string) => ["USER_TEMPLATES", username];
   static getUserFavoriteTemplatesKey = (userId: string) => ["USER_FAVORITES_TEMPLATES", userId];
   // Deploy

--- a/apps/deploy-web/src/queries/useTemplateQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useTemplateQuery.spec.tsx
@@ -1,4 +1,4 @@
-import type { TemplateHttpService } from "@akashnetwork/http-sdk";
+import type { TemplateHttpService, TemplateOutput } from "@akashnetwork/http-sdk";
 import type { UserProfile } from "@auth0/nextjs-auth0/client";
 import { UserProvider } from "@auth0/nextjs-auth0/client";
 import type { AxiosInstance } from "axios";
@@ -12,6 +12,7 @@ import { setupQuery } from "../../tests/unit/query-client";
 import {
   useAddFavoriteTemplate,
   useDeleteTemplate,
+  usePublicTemplate,
   useRemoveFavoriteTemplate,
   useSaveUserTemplate,
   useTemplate,
@@ -352,6 +353,44 @@ describe("useTemplateQuery", () => {
       return setupQuery(() => useRemoveFavoriteTemplate(input?.templateId || "template-1"), {
         services: input?.services,
         wrapper: ({ children }) => <CustomSnackbarProvider>{children}</CustomSnackbarProvider>
+      });
+    }
+  });
+
+  describe(usePublicTemplate.name, () => {
+    it("fetches a public template by id", async () => {
+      const template = mock<TemplateOutput>({ id: "tpl-1", deploy: "version: '2.0'" });
+      const templateService = mock<TemplateHttpService>({ findById: vi.fn().mockResolvedValue(template) });
+
+      const { result } = setup({ id: "tpl-1", services: { template: () => templateService } });
+
+      await vi.waitFor(() => {
+        expect(templateService.findById).toHaveBeenCalledWith("tpl-1");
+        expect(result.current.isSuccess).toBe(true);
+        expect(result.current.data).toEqual(template);
+      });
+    });
+
+    it("does not fetch when id is undefined", () => {
+      const templateService = mock<TemplateHttpService>({ findById: vi.fn() });
+
+      const { result } = setup({ id: undefined, services: { template: () => templateService } });
+
+      expect(templateService.findById).not.toHaveBeenCalled();
+      expect(result.current.fetchStatus).toBe("idle");
+    });
+
+    it("handles error when fetching a public template", async () => {
+      const templateService = mock<TemplateHttpService>({ findById: vi.fn().mockRejectedValue(new Error("Template not found")) });
+
+      const { result } = setup({ id: "tpl-1", services: { template: () => templateService } });
+
+      await vi.waitFor(() => expect(result.current.isError).toBe(true));
+    });
+
+    function setup(input: { id: string | undefined; services?: ServicesProviderProps["services"] }) {
+      return setupQuery(() => usePublicTemplate(input.id), {
+        services: input.services
       });
     }
   });

--- a/apps/deploy-web/src/queries/useTemplateQuery.tsx
+++ b/apps/deploy-web/src/queries/useTemplateQuery.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import type { TemplateCategory, TemplateHttpService, TemplateOutputSummary } from "@akashnetwork/http-sdk";
+import type { TemplateCategory, TemplateHttpService, TemplateOutput, TemplateOutputSummary } from "@akashnetwork/http-sdk";
 import { Snackbar } from "@akashnetwork/ui/components";
 import type { QueryKey, UseQueryOptions } from "@tanstack/react-query";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -36,6 +36,21 @@ export function useTemplate(id: string, options?: Omit<UseQueryOptions<ITemplate
   return useQuery<ITemplate, Error>({
     queryKey: QueryKeys.getTemplateKey(id),
     queryFn: () => consoleApiHttpClient.get<ITemplate>(`/v1/user/template/${id}`).then(response => response.data),
+    ...options
+  });
+}
+
+/**
+ * Fetches a public gallery template by id (same source the legacy new-deployment
+ * flow resolves `templateId` against). The query stays idle until an id is given.
+ */
+export function usePublicTemplate(id: string | undefined, options?: Omit<UseQueryOptions<TemplateOutput, Error, any, QueryKey>, "queryKey" | "queryFn">) {
+  const { template: templateService } = useServices();
+
+  return useQuery<TemplateOutput, Error>({
+    queryKey: QueryKeys.getPublicTemplateKey(id ?? ""),
+    queryFn: () => templateService.findById(id as string),
+    enabled: !!id,
     ...options
   });
 }


### PR DESCRIPTION
## Why

The Configure screen needs to start from a template selected upstream, the way the legacy flow did — both the hardcoded starter templates and public gallery templates referenced by id. Without it, a `templateId` in the URL is ignored and the form always starts empty.

Stacked on #3294 (partial config status); review/merge that first.

## What

- Resolve a `templateId` query param into the Configure screen's starting SDL, matching the legacy flow: hardcoded templates (e.g. hello-world) are matched by code and carry their SDL inline, while other ids are fetched as public gallery templates via a new `usePublicTemplate` hook.
- Split `ConfigureDeployment` into a thin resolver (param/atom resolution, loading, fetch errors) and `ConfigureDeploymentForm` (the existing synchronous form, now seeded by an `initialSdl` prop), so the form keeps initializing from a single source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment configuration now supports template-driven initialization via URL parameters, with loading indicators and error notifications when templates fail to load.

* **Tests**
  * Added comprehensive test suites for template configuration and form components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->