### PR TITLE
fix(deployment): hide Build and Deploy option behind feature flag

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/TemplateList.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/TemplateList.spec.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+import type { DEPENDENCIES } from "./TemplateList";
+import { TemplateList } from "./TemplateList";
+
+import { render, screen } from "@testing-library/react";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
+
+describe(TemplateList.name, () => {
+  it("hides the Build and Deploy card when the flag is disabled", () => {
+    setup({ isBuildAndDeployEnabled: false });
+
+    expect(screen.queryByText("Build and Deploy")).not.toBeInTheDocument();
+    expect(screen.getByText("Launch Container-VM")).toBeInTheDocument();
+    expect(screen.getByText("Run Custom Container")).toBeInTheDocument();
+  });
+
+  it("shows the Build and Deploy card when the flag is enabled", () => {
+    setup({ isBuildAndDeployEnabled: true });
+
+    expect(screen.getByText("Build and Deploy")).toBeInTheDocument();
+    expect(screen.getByText("Launch Container-VM")).toBeInTheDocument();
+    expect(screen.getByText("Run Custom Container")).toBeInTheDocument();
+  });
+
+  function setup(input: { isBuildAndDeployEnabled?: boolean }) {
+    const push = vi.fn();
+    const analyticsService = mock<AnalyticsService>();
+    // Stable references across renders — a fresh `templates` array each render would re-trigger
+    // TemplateList's `useEffect([templates])` indefinitely (react-query returns a stable ref in prod).
+    const templatesResult = mock<ReturnType<typeof DEPENDENCIES.useTemplates>>({ templates: [] });
+    const router = mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ push });
+
+    const dependencies: typeof DEPENDENCIES = {
+      useTemplates: () => templatesResult,
+      useRouter: () => router,
+      useFlag: flagName => (flagName === "ui_build_and_deploy" && input.isBuildAndDeployEnabled) ?? false
+    };
+
+    render(
+      <TestContainerProvider services={{ analyticsService: () => analyticsService }}>
+        <TemplateList onChangeGitProvider={vi.fn()} onTemplateSelected={vi.fn()} setEditedManifest={vi.fn()} dependencies={dependencies} />
+      </TestContainerProvider>
+    );
+
+    return { push, analyticsService };
+  }
+});

--- a/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
+++ b/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
@@ -9,6 +9,7 @@ import { useRouter } from "next/navigation";
 
 import { CI_CD_TEMPLATE_ID } from "@src/config/remote-deploy.config";
 import { useServices } from "@src/context/ServicesProvider";
+import { useFlag } from "@src/hooks/useFlag";
 import type { TemplateOutputSummaryWithCategory } from "@src/queries/useTemplateQuery";
 import { useTemplates } from "@src/queries/useTemplateQuery";
 import sdlStore from "@src/store/sdlStore";
@@ -39,18 +40,27 @@ const previewTemplateIds = [
   "akash-network-awesome-akash-FastChat"
 ];
 
+export const DEPENDENCIES = { useTemplates, useRouter, useFlag };
+
 type Props = {
   onChangeGitProvider: (gh: boolean) => void;
   onTemplateSelected: (template: TemplateCreation | null) => void;
   setEditedManifest: (manifest: string) => void;
+  dependencies?: typeof DEPENDENCIES;
 };
 
-export const TemplateList: React.FunctionComponent<Props> = ({ onChangeGitProvider, onTemplateSelected, setEditedManifest }) => {
+export const TemplateList: React.FunctionComponent<Props> = ({
+  onChangeGitProvider,
+  onTemplateSelected,
+  setEditedManifest,
+  dependencies: d = DEPENDENCIES
+}) => {
   const { analyticsService } = useServices();
-  const { templates } = useTemplates();
-  const router = useRouter();
+  const { templates } = d.useTemplates();
+  const router = d.useRouter();
   const [previewTemplates, setPreviewTemplates] = useState<TemplateOutputSummaryWithCategory[]>([]);
   const [, setSdlEditMode] = useAtom(sdlStore.selectedSdlEditMode);
+  const isBuildAndDeployEnabled = d.useFlag("ui_build_and_deploy");
 
   const handleGithubTemplate = async () => {
     analyticsService.track("build_n_deploy_btn_clk", "Amplitude");
@@ -113,19 +123,21 @@ export const TemplateList: React.FunctionComponent<Props> = ({ onChangeGitProvid
             <span>Upload SDL</span>
           </FileButton>
         </CardHeader>
-        <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          <DeployOptionBox
-            title="Build and Deploy"
-            description="Build & Deploy directly from a code repository (VCS)"
-            topIcons={[{ light: "/images/github.png", dark: "/images/github-dark.svg" }, "/images/gitlab.png", "/images/bitbucket.png"]}
-            bottomIcons={[
-              { light: "/images/nextjs.png", dark: "/images/nextjs-dark.svg" },
-              "/images/vuejs.png",
-              { light: "/images/astrojs.png", dark: "/images/astrojs-dark.svg" },
-              "/images/python.png"
-            ]}
-            onClick={handleGithubTemplate}
-          />
+        <CardContent className={cn("grid grid-cols-1 gap-4", isBuildAndDeployEnabled ? "md:grid-cols-3" : "md:grid-cols-2")}>
+          {isBuildAndDeployEnabled && (
+            <DeployOptionBox
+              title="Build and Deploy"
+              description="Build & Deploy directly from a code repository (VCS)"
+              topIcons={[{ light: "/images/github.png", dark: "/images/github-dark.svg" }, "/images/gitlab.png", "/images/bitbucket.png"]}
+              bottomIcons={[
+                { light: "/images/nextjs.png", dark: "/images/nextjs-dark.svg" },
+                "/images/vuejs.png",
+                { light: "/images/astrojs.png", dark: "/images/astrojs-dark.svg" },
+                "/images/python.png"
+              ]}
+              onClick={handleGithubTemplate}
+            />
+          )}
 
           <DeployOptionBox
             title="Launch Container-VM"

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -12,4 +12,5 @@ export type FeatureFlag =
   | "console_auth_password_escape_hatch"
   | "console_onboarding_redesign"
   | "bid_screening"
-  | "ui_sdl_preview_panel";
+  | "ui_sdl_preview_panel"
+  | "ui_build_and_deploy";


### PR DESCRIPTION
## Why

The VCS **"Build and Deploy"** card on the new-deployment screen launches a remote-deploy flow (GitHub/GitLab/Bitbucket) that is badly implemented and needs to be refactored. This temporarily hides its entry point in production while the implementation is reworked behind the scenes.

## What

- Added a new `ui_build_and_deploy` Unleash feature flag and gated the **Build and Deploy** card in `TemplateList` behind it. The flag is **off by default**, so the card is hidden in prod as soon as this ships; it still renders locally with `NEXT_PUBLIC_UNLEASH_ENABLE_ALL=true`.
- The "Build Your Own" grid drops from 3 → 2 columns when the card is hidden so the remaining **Launch Container-VM** and **Run Custom Container** cards stay balanced.
- **No code removed** — the route, click handler, and the entire VCS/remote-deploy implementation stay in place for the upcoming refactor. Direct URLs (`?gitProvider=github`) and external "Deploy to Akash" buttons still work, and existing remote deployments remain fully viewable/updatable (they key off `sdlAnalyzer.hasCiCdImage(...)`, not the card).
- Added `TemplateList.spec.tsx` covering the flag on/off rendering. This also introduces a `DEPENDENCIES` DI export on `TemplateList` so the component is testable (consistent with the pattern in `AccountMenu`, `NewDeploymentContainer`, etc.).

> [!IMPORTANT]
> The flag is **off by default**. To re-show the card (e.g. once the refactor lands), `ui_build_and_deploy` must be **created and enabled in the Unleash dashboard** for the target environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Build and Deploy" deployment template option with feature flag support for conditional visibility in the template selection interface.

* **Tests**
  * Added comprehensive unit tests to verify proper rendering of deployment templates and conditional display of the new "Build and Deploy" option based on feature flag status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->