### PR TITLE
fix(deployment): keyset-paginate gpu-prices query to drop deployment seq scan

### DIFF
--- a/apps/api/src/deployment/repositories/deployment/deployment.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment/deployment.repository.integration.ts
@@ -1,0 +1,147 @@
+import { faker } from "@faker-js/faker";
+import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
+
+import { CHAIN_DB } from "@src/chain";
+import { DeploymentRepository } from "./deployment.repository";
+
+import { createAkashBlock, createAkashMessage, createDeployment, createDeploymentGroup, createDeploymentGroupResource, createTransaction } from "@test/seeders";
+
+const BID_TYPE = "/akash.market.v1beta5.MsgCreateBid";
+
+describe(DeploymentRepository.name, () => {
+  describe("findAllWithGpuResources", () => {
+    it("yields a single-GPU deployment with its bid message", async () => {
+      const { repository, base } = setup();
+      await createAkashBlock({ height: base });
+      const deployment = await seedGpuDeployment({ createdHeight: base, bidHeight: base });
+
+      const yielded = await collect(repository.findAllWithGpuResources({ minHeight: base }));
+
+      const mine = yielded.filter(d => d.id === deployment.id);
+      expect(mine).toHaveLength(1);
+      expect(mine[0].relatedMessages).toHaveLength(1);
+      expect(mine[0].relatedMessages[0].type).toBe(BID_TYPE);
+    });
+
+    it("excludes deployments without a gpuUnits=1 resource", async () => {
+      const { repository, base } = setup();
+      await createAkashBlock({ height: base });
+      const gpuDeployment = await seedGpuDeployment({ createdHeight: base, bidHeight: base });
+      const nonGpuDeployment = await seedGpuDeployment({ createdHeight: base, bidHeight: base, gpuUnits: 2 });
+
+      const yielded = await collect(repository.findAllWithGpuResources({ minHeight: base }));
+
+      const ids = yielded.map(d => d.id);
+      expect(ids).toContain(gpuDeployment.id);
+      expect(ids).not.toContain(nonGpuDeployment.id);
+    });
+
+    it("excludes deployments created before minHeight even when they have a qualifying bid", async () => {
+      const { repository, base } = setup();
+      await createAkashBlock({ height: base });
+      const tooOld = await seedGpuDeployment({ createdHeight: base - 1, bidHeight: base });
+
+      const yielded = await collect(repository.findAllWithGpuResources({ minHeight: base }));
+
+      expect(yielded.map(d => d.id)).not.toContain(tooOld.id);
+    });
+
+    it("counts a deployment with multiple gpuUnits=1 resources once (EXISTS, not a fanning JOIN)", async () => {
+      const { repository, base } = setup();
+      await createAkashBlock({ height: base });
+      // Two separate groups, each with a gpuUnits=1 resource: a JOIN deployment->group->resource
+      // would emit two rows for this deployment and double-count its single bid.
+      const deployment = await seedGpuDeployment({ createdHeight: base, bidHeight: base, groupCount: 2, bidCount: 1 });
+
+      const yielded = await collect(repository.findAllWithGpuResources({ minHeight: base }));
+
+      const mine = yielded.filter(d => d.id === deployment.id);
+      expect(mine).toHaveLength(1);
+      expect(mine[0].relatedMessages).toHaveLength(1);
+    });
+
+    it("yields every deployment exactly once across a chunk boundary", async () => {
+      const { repository, base, band } = setup();
+      await createAkashBlock({ height: base });
+      // Equal createdHeight forces the (createdHeight, id) tiebreaker to do the paging.
+      const d1 = await seedGpuDeployment({ id: orderedId(band, 1), createdHeight: base, bidHeight: base });
+      const d2 = await seedGpuDeployment({ id: orderedId(band, 2), createdHeight: base, bidHeight: base });
+      const d3 = await seedGpuDeployment({ id: orderedId(band, 3), createdHeight: base, bidHeight: base });
+
+      const yielded = await collect(repository.findAllWithGpuResources({ minHeight: base, chunkSize: 2 }));
+
+      const mine = yielded.filter(d => [d1.id, d2.id, d3.id].includes(d.id)).map(d => d.id);
+      expect(mine).toEqual([d1.id, d2.id, d3.id]);
+    });
+
+    it("does not skip later deployments when a chunk contains a GPU deployment with no qualifying bid", async () => {
+      const { repository, base, band } = setup();
+      await createAkashBlock({ height: base });
+      // D2 is a GPU deployment with no bid. With chunkSize=2 it shares the first window with D1.
+      // The bid load must not shorten the chunk and end paging early — every GPU deployment is
+      // still yielded once, in keyset order, with only the bid-bearing ones carrying a message.
+      const d1 = await seedGpuDeployment({ id: orderedId(band, 1), createdHeight: base, bidHeight: base });
+      const d2 = await seedGpuDeployment({ id: orderedId(band, 2), createdHeight: base, bidHeight: base, bidCount: 0 });
+      const d3 = await seedGpuDeployment({ id: orderedId(band, 3), createdHeight: base, bidHeight: base });
+      const d4 = await seedGpuDeployment({ id: orderedId(band, 4), createdHeight: base, bidHeight: base });
+
+      const yielded = await collect(repository.findAllWithGpuResources({ minHeight: base, chunkSize: 2 }));
+
+      const mine = yielded.filter(d => [d1.id, d2.id, d3.id, d4.id].includes(d.id));
+      expect(mine.map(d => d.id)).toEqual([d1.id, d2.id, d3.id, d4.id]);
+      expect(mine.map(d => d.relatedMessages.length)).toEqual([1, 0, 1, 1]);
+    });
+  });
+
+  let testBand = 0;
+
+  function setup() {
+    // Resolve CHAIN_DB so the chain Sequelize instance (and its models) is initialized — the
+    // repository uses the static models directly and does not inject the connection itself.
+    container.resolve(CHAIN_DB);
+    const repository = container.resolve(DeploymentRepository);
+    testBand += 1;
+    // Each test owns a disjoint, ascending height band so its query (minHeight = base) sees only
+    // its own deployments: lower bands are filtered out, higher bands are seeded by later tests.
+    const base = 1_000_000 + testBand * 10_000;
+    return { repository, base, band: testBand };
+  }
+
+  async function collect<T>(generator: AsyncGenerator<T>) {
+    const out: T[] = [];
+    for await (const item of generator) out.push(item);
+    return out;
+  }
+
+  // Deterministically ordered UUID: same band keeps the prefix fixed (so ids sort by seq within a
+  // test), distinct bands keep ids unique across tests in the shared per-file database.
+  function orderedId(band: number, seq: number) {
+    return `${band.toString(16).padStart(8, "0")}-0000-4000-8000-${seq.toString(16).padStart(12, "0")}`;
+  }
+
+  async function seedGpuDeployment(input: {
+    createdHeight: number;
+    bidHeight: number;
+    id?: string;
+    owner?: string;
+    groupCount?: number;
+    gpuUnits?: number;
+    bidCount?: number;
+  }) {
+    const owner = input.owner ?? faker.string.alphanumeric(44);
+    const deployment = await createDeployment({ id: input.id, owner, createdHeight: input.createdHeight, dseq: faker.string.numeric(12) });
+
+    for (let i = 0; i < (input.groupCount ?? 1); i++) {
+      const group = await createDeploymentGroup({ deploymentId: deployment.id, owner });
+      await createDeploymentGroupResource({ deploymentGroupId: group.id, gpuUnits: input.gpuUnits ?? 1 });
+    }
+
+    for (let i = 0; i < (input.bidCount ?? 1); i++) {
+      const transaction = await createTransaction({ height: input.bidHeight });
+      await createAkashMessage({ type: BID_TYPE, txId: transaction.id, height: input.bidHeight, relatedDeploymentId: deployment.id });
+    }
+
+    return deployment;
+  }
+});

--- a/apps/api/src/deployment/repositories/deployment/deployment.repository.integration.ts
+++ b/apps/api/src/deployment/repositories/deployment/deployment.repository.integration.ts
@@ -75,6 +75,12 @@ describe(DeploymentRepository.name, () => {
       expect(mine).toEqual([d1.id, d2.id, d3.id]);
     });
 
+    it("rejects a non-positive chunkSize", async () => {
+      const { repository, base } = setup();
+
+      await expect(collect(repository.findAllWithGpuResources({ minHeight: base, chunkSize: 0 }))).rejects.toThrow("positive integer");
+    });
+
     it("does not skip later deployments when a chunk contains a GPU deployment with no qualifying bid", async () => {
       const { repository, base, band } = setup();
       await createAkashBlock({ height: base });

--- a/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
@@ -107,6 +107,12 @@ export class DeploymentRepository {
   async *findAllWithGpuResources(options: { minHeight: number; chunkSize?: number }) {
     const BID_TYPES = ["/akash.market.v1beta4.MsgCreateBid", "/akash.market.v1beta5.MsgCreateBid"];
     const chunkSize = options.chunkSize ?? 1000;
+    // A non-positive chunkSize would make `batch.length < chunkSize` never break on an empty
+    // result and then dereference batch[-1] for the cursor. chunkSize is internal/test-only, so
+    // treat a bad value as a programmer error.
+    if (!Number.isInteger(chunkSize) || chunkSize <= 0) {
+      throw new Error("findAllWithGpuResources: chunkSize must be a positive integer");
+    }
     // Keyset cursor over (createdHeight, id) — the leading columns of the existing
     // `deployment_created_height_closed_height` index, so each chunk is an index scan
     // (no full `deployment` seq scan) and we never prefetch the whole ID list.

--- a/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment/deployment.repository.ts
@@ -104,48 +104,52 @@ export class DeploymentRepository {
     return deployments ? (deployments as unknown as StaleDeploymentsOutput[]) : [];
   }
 
-  async *findAllWithGpuResources(options: { minHeight: number }) {
-    // First, get all deployment IDs matching the criteria (lightweight query)
-    const recordsWithIds = await Deployment.findAll({
-      attributes: ["id"],
-      where: { createdHeight: { [Op.gte]: options.minHeight } },
-      include: [
-        {
-          attributes: [],
-          model: DeploymentGroup,
-          required: true,
-          include: [
-            {
-              attributes: [],
-              model: DeploymentGroupResource,
-              required: true,
-              where: { gpuUnits: 1 }
-            }
-          ]
-        }
-      ],
-      raw: true
-    });
+  async *findAllWithGpuResources(options: { minHeight: number; chunkSize?: number }) {
+    const BID_TYPES = ["/akash.market.v1beta4.MsgCreateBid", "/akash.market.v1beta5.MsgCreateBid"];
+    const chunkSize = options.chunkSize ?? 1000;
+    // Keyset cursor over (createdHeight, id) — the leading columns of the existing
+    // `deployment_created_height_closed_height` index, so each chunk is an index scan
+    // (no full `deployment` seq scan) and we never prefetch the whole ID list.
+    let cursor: { createdHeight: number; id: string } | undefined;
 
-    const ids = recordsWithIds.map(r => r.id);
-    const BATCH_SIZE = 200;
-
-    // Iterate over IDs in batches and yield each deployment
-    for (let i = 0; i < ids.length; i += BATCH_SIZE) {
-      const batchIds = ids.slice(i, i + BATCH_SIZE);
-
+    while (true) {
       const batch = await Deployment.findAll({
-        attributes: ["id", "owner"],
-        where: { id: { [Op.in]: batchIds } },
+        attributes: ["id", "owner", "createdHeight"],
+        where: {
+          [Op.and]: [
+            { createdHeight: { [Op.gte]: options.minHeight } },
+            ...(cursor
+              ? [
+                  {
+                    [Op.or]: [{ createdHeight: { [Op.gt]: cursor.createdHeight } }, { createdHeight: cursor.createdHeight, id: { [Op.gt]: cursor.id } }]
+                  }
+                ]
+              : []),
+            // Express the single-GPU membership as a non-fanning EXISTS instead of an
+            // INNER JOIN: a deployment with >1 matching resource must still be yielded once.
+            // Correlates on the main query's "deployment" alias (lowercase, matching the SQL
+            // Sequelize emits for this model).
+            literal(`EXISTS (
+              SELECT 1
+              FROM "deploymentGroup" dg
+              JOIN "deploymentGroupResource" dgr ON dgr."deploymentGroupId" = dg."id"
+              WHERE dg."deploymentId" = "deployment"."id" AND dgr."gpuUnits" = 1
+            )`)
+          ]
+        },
         include: [
           {
-            attributes: ["height", "data", "type"],
             model: AkashMessage,
             as: "relatedMessages",
+            // Load bids in a dedicated query keyed on the indexed relatedDeploymentId instead of
+            // joining inline. This keeps the main query a pure indexed deployment scan, so LIMIT
+            // counts deployments and the keyset cursor stays exact. Joining inline would make
+            // LIMIT count joined message rows and a non-bid deployment in the window could shorten
+            // a chunk and end paging early.
+            separate: true,
+            attributes: ["height", "data", "type"],
             where: {
-              type: {
-                [Op.or]: ["/akash.market.v1beta4.MsgCreateBid", "/akash.market.v1beta5.MsgCreateBid"]
-              },
+              type: { [Op.in]: BID_TYPES },
               height: { [Op.gte]: options.minHeight }
             },
             include: [
@@ -153,12 +157,21 @@ export class DeploymentRepository {
               { model: Transaction, attributes: ["hash"], required: true }
             ]
           }
-        ]
+        ],
+        order: [
+          ["createdHeight", "ASC"],
+          ["id", "ASC"]
+        ] as [string, "ASC" | "DESC"][],
+        limit: chunkSize
       });
 
       for (const deployment of batch) {
         yield deployment;
       }
+
+      if (batch.length < chunkSize) break;
+      const last = batch[batch.length - 1];
+      cursor = { createdHeight: last.createdHeight, id: last.id };
     }
   }
 

--- a/apps/indexer/drizzle/0008_add_deployment_group_deployment_id_index.sql
+++ b/apps/indexer/drizzle/0008_add_deployment_group_deployment_id_index.sql
@@ -1,0 +1,6 @@
+-- Index deploymentGroup.deploymentId (FK with no index — Postgres does not auto-index FKs).
+-- Needed by the correlated EXISTS in DeploymentRepository.findAllWithGpuResources so the
+-- gpuUnits=1 membership probe is index-driven instead of seq-scanning deploymentGroup.
+-- https://github.com/drizzle-team/drizzle-orm/issues/860#issuecomment-2544465387
+COMMIT;--> statement-breakpoint
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "deployment_group_deployment_id" ON "deploymentGroup" USING btree ("deploymentId");

--- a/apps/indexer/drizzle/meta/_journal.json
+++ b/apps/indexer/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1762800000000,
       "tag": "0007_add_bme_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1762900000000,
+      "tag": "0008_add_deployment_group_deployment_id_index",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/indexer/drizzle/schema.ts
+++ b/apps/indexer/drizzle/schema.ts
@@ -35,6 +35,7 @@ export const deploymentGroup = pgTable(
       table.dseq.asc().nullsLast().op("text_ops"),
       table.gseq.asc().nullsLast().op("int4_ops")
     ),
+    index("deployment_group_deployment_id").using("btree", table.deploymentId.asc().nullsLast().op("uuid_ops")),
     foreignKey({
       columns: [table.deploymentId],
       foreignColumns: [deployment.id],

--- a/packages/database/dbSchemas/akash/deploymentGroup.ts
+++ b/packages/database/dbSchemas/akash/deploymentGroup.ts
@@ -18,6 +18,9 @@ import { Lease } from "./lease"; // eslint-disable-line import-x/no-cycle
     {
       unique: true,
       fields: ["owner", "dseq", "gseq"]
+    },
+    {
+      fields: ["deploymentId"]
     }
   ]
 })


### PR DESCRIPTION
## Why

`GET /v1/gpu-prices` is the #1 Postgres query by total DB load (~267K calls/24h), driving CPU spikes. Its repository query, `DeploymentRepository.findAllWithGpuResources`, prefetched every single-GPU deployment id, then re-fetched them in 200-id batches via `WHERE deployment.id IN (...)`. Per the GCP query plan, that predicate **seq-scanned the entire `deployment` table on every batch** (~309 ms × ~1,291 batches/refresh) — the dominant cost. Everything else (message/block/transaction lookups) was already sub-millisecond.

## What

- **Rewrote `findAllWithGpuResources`** to a keyset-paginated, indexed scan:
  - Pages over `deployment(createdHeight, id)` (leading columns of the existing `deployment_created_height_closed_height` index) — `ORDER BY … LIMIT` forces an index scan, eliminating the seq scan and folding away the ID-prefetch query.
  - Expresses the `gpuUnits=1` membership as a non-fanning `EXISTS` (an INNER JOIN to `deploymentGroupResource` would double-count bids for deployments with >1 GPU resource).
  - Loads bid messages via `separate: true` (a dedicated query keyed on the indexed `message.relatedDeploymentId`), so `LIMIT` counts deployments and the cursor stays exact.
  - **Output is byte-identical** — the consumer only accumulates bids and aggregates set-wise.
- **Added index** `deployment_group_deployment_id` on `deploymentGroup(deploymentId)` (an FK with no index) via **indexer migration `0008`**, so the `EXISTS` probe is index-driven. Uses `CREATE INDEX CONCURRENTLY` (non-blocking on prod) following the existing `COMMIT;--> statement-breakpoint` pattern.

### Migration safety
`0008` is `CREATE INDEX CONCURRENTLY IF NOT EXISTS` — non-blocking and idempotent. Verified it applies cleanly and creates the index in a fresh DB.

### Tests
- New `deployment.repository.integration.ts`: EXISTS double-count guard, keyset chunk-boundary (equal-`createdHeight` ties), and a no-bid-mid-chunk case proving paging doesn't terminate early.
- Existing functional exact-JSON test for `GET /v1/gpu-prices` stays green (output equivalence).

### Validated on prod (`prod-mainnet`, read-only EXPLAIN; index created `CONCURRENTLY` then dropped)

`EXPLAIN (ANALYZE, BUFFERS)` per keyset chunk on real `akash-mainnet` data (`createdHeight ≥ ~31d`, chunk 1000):

| Query | Plan | Exec |
|---|---|---|
| OLD `id IN (200)` batch | Seq Scan on `deployment` | **555 ms** × ~1,291 batches/refresh |
| NEW keyset chunk — **no index** | `EXISTS` → hash semi join over full `deploymentGroup` (1.44M) + `deploymentGroupResource` (1.26M) scans + top-N sort | **7,638 ms** |
| NEW keyset chunk — **with `deployment_group_deployment_id`** | `EXISTS` → Nested Loop Semi Join via the index; index scan on `createdHeight`; `LIMIT` short-circuits (~7K rows, not 306K) | **346 ms** |

⇒ The `0008` index is **load-bearing, not optional**: without it the rewrite is slower than today; with it, ~22× faster per chunk and the `LIMIT` short-circuits. **Deploy ordering:** the index is created by the indexer's 0008 migration, so the indexer should deploy before/with the api or there's a transient window of slow background refreshes (tolerable — `/v1/gpu-prices` is a memoized 15-min background refresh, p75 31 ms cache hits in Sentry).

**Output equivalence on prod data:** the new `EXISTS` selects the **identical 262,362 GPU deployments** as the old join (`DISTINCT`), with the same bids. 159 deployments (0.06%) have >1 `gpuUnits=1` resource; the old path could double-count their bids across 200-batches, the new yields each once — but that only affected the debug-only `bidCount`, never the public `price`/`priceUakt`/`availability` (best-bid-per-provider aggregation is duplicate-insensitive). **Public output unchanged.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable keyset pagination for GPU deployment queries with chunk-size validation.

* **Performance Improvements**
  * Keyset-based scan and a new DB index to speed GPU-resource membership checks and scalable enumeration.

* **Bug Fixes**
  * Ensure deployments with only non-qualifying GPU units or with creation before minHeight are excluded; avoid duplicate results.

* **Tests**
  * Integration tests covering filtering rules, bid-association, deterministic pagination, and boundary/edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
