### PR TITLE
feat: adds support for client abort signal

### DIFF
--- a/apps/api/src/bid-screening/controllers/bid-screening/bid-screening.controller.ts
+++ b/apps/api/src/bid-screening/controllers/bid-screening/bid-screening.controller.ts
@@ -1,5 +1,6 @@
 import { HTTPException } from "hono/http-exception";
 import type { StatusCode } from "hono/utils/http-status";
+import type { Abortable } from "node:events";
 import { inject, singleton } from "tsyringe";
 
 import { BID_SCREENING_CONFIG, type BidScreeningConfig } from "@src/bid-screening/providers/config.provider";
@@ -17,7 +18,7 @@ export class BidScreeningController {
     this.#bidScreeningConfig = config;
   }
 
-  async screenProviders(request: BidScreeningRequest): Promise<BidScreeningResponse> {
+  async screenProviders(request: BidScreeningRequest, options?: Abortable): Promise<BidScreeningResponse> {
     if (!this.#featureFlagsService.isEnabled(FeatureFlags.BID_SCREENING)) {
       return { providers: [] };
     }
@@ -30,7 +31,8 @@ export class BidScreeningController {
       response = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(request)
+        body: JSON.stringify(request),
+        signal: options?.signal
       });
     } catch (error) {
       throw new HTTPException(503, {

--- a/apps/api/src/bid-screening/routes/bid-screening.router.ts
+++ b/apps/api/src/bid-screening/routes/bid-screening.router.ts
@@ -41,6 +41,6 @@ const postBidScreeningRoute = createRoute({
 
 bidScreeningRouter.openapi(postBidScreeningRoute, async function routePostBidScreening(c) {
   const request = c.req.valid("json");
-  const response = await container.resolve(BidScreeningController).screenProviders(request);
+  const response = await container.resolve(BidScreeningController).screenProviders(request, { signal: c.req.raw.signal });
   return c.json(response, 200);
 });

--- a/apps/provider-inventory/src/controllers/bid-screening/bid-screening.controller.ts
+++ b/apps/provider-inventory/src/controllers/bid-screening/bid-screening.controller.ts
@@ -1,3 +1,4 @@
+import type { Abortable } from "node:events";
 import { inject, singleton } from "tsyringe";
 
 import type { GroupSpecJSON } from "@src/mappers/groupspec-mapper/groupspec-mapper";
@@ -12,8 +13,8 @@ export class BidScreeningController {
     this.#bidScreeningService = bidScreeningService;
   }
 
-  async screenProviders(request: BidScreeningRequest): Promise<BidScreeningResponse> {
-    const results = await this.#bidScreeningService.findMatchingProviders(request as GroupSpecJSON);
+  async screenProviders(request: BidScreeningRequest, options?: Abortable): Promise<BidScreeningResponse> {
+    const results = await this.#bidScreeningService.findMatchingProviders(request as GroupSpecJSON, options);
     return { providers: results };
   }
 }

--- a/apps/provider-inventory/src/routes/bid-screening/bid-screening.router.ts
+++ b/apps/provider-inventory/src/routes/bid-screening/bid-screening.router.ts
@@ -40,6 +40,6 @@ const postBidScreeningRoute = createRoute({
 
 bidScreeningRouter.openapi(postBidScreeningRoute, async function routePostBidScreening(c) {
   const request = c.req.valid("json");
-  const response = await container.resolve(BidScreeningController).screenProviders(request);
+  const response = await container.resolve(BidScreeningController).screenProviders(request, { signal: c.req.raw.signal });
   return c.json(response, 200);
 });

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.spec.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.spec.ts
@@ -155,6 +155,63 @@ describe(BidScreeningService.name, () => {
       expect(results).toHaveLength(1);
       expect(results[0].incidents).toEqual([{ startedAt: "2026-06-01T00:00:00.000Z", endedAt: null }]);
     });
+
+    it("returns empty array without fetching candidates when the signal is already aborted", async () => {
+      const { service, repository, incidentRepository, matcher } = setup();
+      const controller = new AbortController();
+      controller.abort();
+
+      const results = await service.findMatchingProviders(makeRequest(), { signal: controller.signal });
+
+      expect(results).toEqual([]);
+      expect(repository.findCandidates).not.toHaveBeenCalled();
+      expect(matcher.match).not.toHaveBeenCalled();
+      expect(incidentRepository.findRecentByProviders).not.toHaveBeenCalled();
+    });
+
+    it("skips matching and incidents when the signal aborts during the candidates query", async () => {
+      const { service, repository, incidentRepository, matcher } = setup();
+      const controller = new AbortController();
+      repository.findCandidates.mockImplementation(async () => {
+        controller.abort();
+        return [makeCandidate("akash1abc")];
+      });
+
+      const results = await service.findMatchingProviders(makeRequest(), { signal: controller.signal });
+
+      expect(results).toEqual([]);
+      expect(matcher.match).not.toHaveBeenCalled();
+      expect(incidentRepository.findRecentByProviders).not.toHaveBeenCalled();
+    });
+
+    it("returns matched providers with empty incidents when the signal aborts during matching", async () => {
+      const { service, repository, incidentRepository, matcher } = setup();
+      const controller = new AbortController();
+      repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc")]);
+      matcher.match.mockImplementation(() => {
+        controller.abort();
+        return { matched: true };
+      });
+
+      const results = await service.findMatchingProviders(makeRequest(), { signal: controller.signal });
+
+      expect(results).toHaveLength(1);
+      expect(results[0].owner).toBe("akash1abc");
+      expect(results[0].incidents).toEqual([]);
+      expect(incidentRepository.findRecentByProviders).not.toHaveBeenCalled();
+    });
+
+    it("runs the full pipeline when a non-aborted signal is provided", async () => {
+      const { service, repository, incidentRepository, matcher } = setup();
+      repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc")]);
+      matcher.match.mockReturnValue({ matched: true });
+      incidentRepository.findRecentByProviders.mockResolvedValue([{ provider: "akash1abc", startedAt: "2026-06-01T00:00:00.000Z", endedAt: null }]);
+
+      const results = await service.findMatchingProviders(makeRequest(), { signal: new AbortController().signal });
+
+      expect(incidentRepository.findRecentByProviders).toHaveBeenCalledWith(["akash1abc"]);
+      expect(results[0].incidents).toEqual([{ startedAt: "2026-06-01T00:00:00.000Z", endedAt: null }]);
+    });
   });
 
   function setup() {

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
@@ -1,4 +1,5 @@
 import { withSpan } from "@akashnetwork/instrumentation";
+import type { Abortable } from "node:events";
 import { singleton } from "tsyringe";
 
 import { bidScreeningBinPackerMatched, bidScreeningPrefilterCandidates } from "@src/metrics/metrics";
@@ -23,10 +24,11 @@ export class BidScreeningService {
     this.#matcher = matcher;
   }
 
-  async findMatchingProviders(request: GroupSpecJSON): Promise<BidScreeningResult[]> {
+  async findMatchingProviders(request: GroupSpecJSON, options?: Abortable): Promise<BidScreeningResult[]> {
     const resourceUnits = await withSpan("mapRequestToResourceUnits", async () => mapGroupSpecToResourceUnits(request));
 
     const candidates = await withSpan("fetchCandidatesFromDB", async ({ activeSpan }) => {
+      if (options?.signal?.aborted) return [];
       const items = await this.#repository.findCandidates(resourceUnits, request.requirements);
       activeSpan.setAttribute("amountOfCandidatesFromDb", items.length);
       bidScreeningPrefilterCandidates.record(items.length);
@@ -34,6 +36,7 @@ export class BidScreeningService {
     });
 
     const matched = await withSpan("applyingBinPackingAlg", async ({ activeSpan }) => {
+      if (options?.signal?.aborted) return [];
       const items = this.#filterProviders(candidates, resourceUnits);
       activeSpan.setAttribute("amountOfCandidatesAfterBinPacking", items.length);
       bidScreeningBinPackerMatched.record(items.length);
@@ -41,7 +44,7 @@ export class BidScreeningService {
     });
 
     const incidentsByOwner = await withSpan("fetchIncidentsForMatched", async ({ activeSpan }) => {
-      if (!matched.length) return EMPTY_OBJECT;
+      if (!matched.length || options?.signal?.aborted) return EMPTY_OBJECT;
       const rows = await this.#incidentRepository.findRecentByProviders(matched.map(candidate => candidate.owner));
       activeSpan.setAttribute("amountOfIncidents", rows.length);
 


### PR DESCRIPTION
## Why

to avoid doing prescreening when client aborted request and free up event loop resources

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request cancellation support for bid-screening operations, enabling users to abort in-flight screening requests and preventing unnecessary downstream processing when cancellation occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->