### PR TITLE
refactor: allows to pass empty resource units in bid screening

### DIFF
--- a/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
+++ b/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
@@ -1,4 +1,3 @@
-/* v8 ignore start */
 import { z } from "@hono/zod-openapi";
 
 const UIntStringSchema = z.string().regex(/^\d+$/, "Must be an unsigned integer string");
@@ -14,7 +13,7 @@ const ResourceValueSchema = z.object({
       return NaN;
     })
     .refine(
-      val => !Number.isFinite(val) && typeof val === "bigint" && val >= 0n,
+      (val): val is bigint => !Number.isFinite(val) && typeof val === "bigint" && val >= 0n,
       "Must be a non-negative integer or its protobuf base64-encoded representation"
     )
 });
@@ -93,7 +92,7 @@ const RequirementsSchema = z.object({
 export const BidScreeningRequestSchema = z.object({
   name: z.string().openapi({ description: "Group name", example: "westcoast" }),
   requirements: RequirementsSchema.default({}),
-  resources: z.array(ResourceUnitSchema).min(1).openapi({ description: "Resource units with replica counts" })
+  resources: z.array(ResourceUnitSchema).openapi({ description: "Resource units with replica counts" })
 });
 export type BidScreeningRequest = z.infer<typeof BidScreeningRequestSchema>;
 
@@ -108,7 +107,15 @@ const ProviderResultSchema = z.object({
   location: z.string().nullable().openapi({
     description: "Provider region from the location-region attribute (signed preferred, else self-declared); null if unset",
     example: "us-west"
-  })
+  }),
+  incidents: z
+    .array(
+      z.object({
+        startedAt: z.string().datetime(),
+        endedAt: z.string().datetime().nullable()
+      })
+    )
+    .openapi({ description: "Provider incident intervals within the last ~8 days; endedAt null = ongoing" })
 });
 
 export const BidScreeningResponseSchema = z.object({

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -3047,7 +3047,6 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                       ],
                       "type": "object",
                     },
-                    "minItems": 1,
                     "type": "array",
                   },
                 },
@@ -3080,6 +3079,28 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "example": "https://provider.europlots.com:8443",
                             "type": "string",
                           },
+                          "incidents": {
+                            "description": "Provider incident intervals within the last ~8 days; endedAt null = ongoing",
+                            "items": {
+                              "properties": {
+                                "endedAt": {
+                                  "format": "date-time",
+                                  "nullable": true,
+                                  "type": "string",
+                                },
+                                "startedAt": {
+                                  "format": "date-time",
+                                  "type": "string",
+                                },
+                              },
+                              "required": [
+                                "startedAt",
+                                "endedAt",
+                              ],
+                              "type": "object",
+                            },
+                            "type": "array",
+                          },
                           "isAudited": {
                             "description": "True if signed by a known auditor",
                             "type": "boolean",
@@ -3102,6 +3123,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "isAudited",
                           "createdAt",
                           "location",
+                          "incidents",
                         ],
                         "type": "object",
                       },

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "NODE_ENV=production tsup && tsc --noEmit",
     "build:container": "dc build provider-inventory",
-    "dev": "npm run migration:exec && npm run start",
+    "dev": "npm run start",
     "format": "prettier --write ./*.{ts,js,json} **/*.{ts,js,json}",
     "lint": "eslint .",
     "migration:exec": "node dist/db-migrate.js",

--- a/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
+++ b/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
@@ -92,7 +92,7 @@ const RequirementsSchema = z.object({
 export const BidScreeningRequestSchema = z.object({
   name: z.string().openapi({ description: "Group name", example: "westcoast" }),
   requirements: RequirementsSchema.default({}),
-  resources: z.array(ResourceUnitSchema).min(1).openapi({ description: "Resource units with replica counts" })
+  resources: z.array(ResourceUnitSchema).openapi({ description: "Resource units with replica counts" })
 });
 export type BidScreeningRequest = z.infer<typeof BidScreeningRequestSchema>;
 

--- a/apps/provider-inventory/src/providers/drizzle.provider.ts
+++ b/apps/provider-inventory/src/providers/drizzle.provider.ts
@@ -1,23 +1,19 @@
-import { PostgresLoggerService } from "@akashnetwork/logging/sql";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { drizzle } from "drizzle-orm/postgres-js";
 import type { InjectionToken } from "tsyringe";
 import { container, instancePerContainerCachingFactory } from "tsyringe";
 
 import { parseJsonb, serializeJsonb } from "@src/lib/jsonb-bigint/jsonb-bigint";
-import { APP_CONFIG } from "@src/providers/app-config.provider";
-import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
-import { JSON_OIDS, PG_CLIENT } from "@src/providers/postgres.provider";
+import { DB_LOGGER, JSON_OIDS, PG_CLIENT } from "@src/providers/postgres.provider";
 import * as modelsSchema from "../model-schemas";
 
 export const DRIZZLE_DB: InjectionToken<PostgresJsDatabase> = Symbol("DRIZZLE_DB");
 
 container.register(DRIZZLE_DB, {
   useFactory: instancePerContainerCachingFactory(c => {
-    const config = c.resolve(APP_CONFIG);
     const client = c.resolve(PG_CLIENT);
     const db = drizzle(client, {
-      logger: new PostgresLoggerService(c.resolve(LOGGER_FACTORY), { useFormat: config.SQL_LOG_FORMAT === "pretty" }),
+      logger: c.resolve(DB_LOGGER),
       schema: modelsSchema
     });
 

--- a/apps/provider-inventory/src/providers/postgres.provider.ts
+++ b/apps/provider-inventory/src/providers/postgres.provider.ts
@@ -1,3 +1,4 @@
+import { PostgresLoggerService } from "@akashnetwork/logging/sql";
 import postgres from "postgres";
 import type { InjectionToken } from "tsyringe";
 import { container, instancePerContainerCachingFactory } from "tsyringe";
@@ -6,12 +7,19 @@ import { parseJsonb, serializeJsonb } from "@src/lib/jsonb-bigint/jsonb-bigint";
 import { APP_CONFIG } from "@src/providers/app-config.provider";
 import { LOGGER_FACTORY } from "./logger-factory.provider";
 
-const logger = container.resolve(LOGGER_FACTORY)({ context: "POSTGRES" });
-
 // The runtime client registers `postgres.BigInt` (see postgres.provider), so bigint params
 // are serialized correctly; reflect that in the type so bigint criteria can be bound directly.
 export type Database = postgres.Sql<{ bigint: bigint }>;
 export const PG_CLIENT = Symbol("APP_PG_CLIENT") as InjectionToken<Database>;
+
+export const DB_LOGGER = Symbol("DB_LOGGER") as InjectionToken<PostgresLoggerService>;
+
+container.register(DB_LOGGER, {
+  useFactory: instancePerContainerCachingFactory(c => {
+    const config = c.resolve(APP_CONFIG);
+    return new PostgresLoggerService(c.resolve(LOGGER_FACTORY), { useFormat: config.SQL_LOG_FORMAT === "pretty" });
+  })
+});
 
 // json (OID 114) and jsonb (OID 3802). drizzle's construct() overrides the serializers for both
 // with a passthrough on the shared client, expecting column types to own serialization.
@@ -20,12 +28,14 @@ export const JSON_OIDS = [114, 3802];
 container.register(PG_CLIENT, {
   useFactory: instancePerContainerCachingFactory(c => {
     const config = c.resolve(APP_CONFIG);
+    const logger = c.resolve(DB_LOGGER);
     return postgres(config.PROVIDER_INVENTORY_POSTGRES_URL, {
       max: config.POSTGRES_MAX_CONNECTIONS,
       connect_timeout: config.POSTGRES_CONNECT_TIMEOUT,
       idle_timeout: config.POSTGRES_IDLE_TIMEOUT,
       max_lifetime: config.POSTGRES_MAX_LIFETIME,
-      onnotice: logger.info.bind(logger),
+      onnotice: msg => logger.logNotice(msg),
+      debug: (_, query, params) => logger.logQuery(query, params),
       types: {
         bigint: postgres.BigInt,
         json: {

--- a/apps/provider-inventory/tsup.config.ts
+++ b/apps/provider-inventory/tsup.config.ts
@@ -24,7 +24,7 @@ export default defineConfig(async overrideOptions =>
     external: ["pino-pretty"],
     dts: false,
     plugins: [...(isProduction ? [copyDrizzlePlugin] : [])],
-    onSuccess: overrideOptions.watch && !isProduction ? "NODE_OPTIONS='--allow-worker' npm run prod" : undefined,
+    onSuccess: overrideOptions.watch && !isProduction ? "npm run migration:exec && NODE_OPTIONS='--allow-worker' npm run prod" : undefined,
     ...overrideOptions
   })
 );

--- a/packages/instrumentation/src/index.ts
+++ b/packages/instrumentation/src/index.ts
@@ -1,3 +1,36 @@
 export { sdk } from "./instrumentation";
-export * from "@opentelemetry/api";
+export type * from "@opentelemetry/api";
+// `export *` of runtime values is NOT statically analyzable here because "@opentelemetry/api" is
+// external in app bundles. tsup's experimental CJS code-splitting converts the resulting namespace
+// re-export with a positional `require` that runs after `__reExport`, so every re-exported binding
+// ends up undefined at runtime. Keep these value re-exports explicit.
+export {
+  baggageEntryMetadataFromString,
+  context,
+  createContextKey,
+  createNoopMeter,
+  createTraceState,
+  defaultTextMapGetter,
+  defaultTextMapSetter,
+  diag,
+  DiagConsoleLogger,
+  DiagLogLevel,
+  INVALID_SPAN_CONTEXT,
+  INVALID_SPANID,
+  INVALID_TRACEID,
+  isSpanContextValid,
+  isValidSpanId,
+  isValidTraceId,
+  metrics,
+  propagation,
+  ProxyTracer,
+  ProxyTracerProvider,
+  ROOT_CONTEXT,
+  SamplingDecision,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+  TraceFlags,
+  ValueType
+} from "@opentelemetry/api";
 export * from "./util/tracing/tracing.util";

--- a/packages/logging/src/services/postgres-logger/postgres-logger.service.ts
+++ b/packages/logging/src/services/postgres-logger/postgres-logger.service.ts
@@ -48,6 +48,10 @@ export class PostgresLoggerService implements Logger {
 
     this.#logger.debug(formatted);
   }
+
+  logNotice(message: unknown): void {
+    this.#logger.warn(message);
+  }
 }
 
 function stringifyParam(param: unknown): string {


### PR DESCRIPTION
## Why

Closes CON-475

## What

to get all providers, client can send this request:

```
POST /v1/bid-screening
{
  "name": "westcoast",
  "resources": []
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Provider bid-screening responses now include incident intervals with start and end times (ongoing if end is null).

* **Changes**
  - Bid-screening requests now accept empty resource lists.
  - Database logging enhanced: notices are surfaced and logger wiring improved for clearer DB diagnostics.
  - Build/dev tooling adjusted to run migrations in relevant watch/start workflows.
  - Library exports cleaned up to explicit runtime/value re-exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->