### PR TITLE
chore(net): update mainnet version

### DIFF
--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -1,6 +1,6 @@
 export const netConfigData = {
   mainnet: {
-    version: "v2.0.1",
+    version: "v2.1.0",
     faucetUrl: null,
     apiUrls: [
       "https://rpc.akt.dev/rest",


### PR DESCRIPTION
## Summary
- regenerate packages/net config from current network metadata
- update mainnet version from v2.0.1 to v2.1.0

## Verification
- npm run generate -w packages/net
- npm run validate:types -w packages/net
- git diff --check