### PR TITLE
feat(analytics): track passwordless auth events

### DIFF
--- a/apps/deploy-web/src/components/auth/EmailCodeStart/EmailCodeStart.spec.tsx
+++ b/apps/deploy-web/src/components/auth/EmailCodeStart/EmailCodeStart.spec.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import type { AuthService } from "@src/services/auth/auth/auth.service";
 import { DEPENDENCIES, EmailCodeStart } from "./EmailCodeStart";
 
@@ -33,17 +34,30 @@ describe(EmailCodeStart.name, () => {
     expect(authService.startEmailCode).not.toHaveBeenCalled();
   });
 
+  it("tracks email_login_init when a valid email starts the flow", async () => {
+    const { authService, analyticsService } = setup();
+    authService.startEmailCode.mockResolvedValue(undefined);
+
+    await userEvent.type(screen.getByLabelText("Email"), "alice@example.com");
+    await userEvent.click(screen.getByRole("button", { name: /continue with email/i }));
+
+    await vi.waitFor(() => {
+      expect(analyticsService.track).toHaveBeenCalledWith("email_login_init");
+    });
+  });
+
   function setup(input: { defaultEmail?: string; onStarted?: (email: string) => void; getCaptchaToken?: () => Promise<string> } = {}) {
     const authService = mock<AuthService>();
+    const analyticsService = mock<AnalyticsService>();
     const onStarted = input.onStarted ?? vi.fn();
     const getCaptchaToken = input.getCaptchaToken ?? vi.fn().mockResolvedValue("captcha-token");
 
     render(
-      <TestContainerProvider services={{ authService: () => authService }}>
+      <TestContainerProvider services={{ authService: () => authService, analyticsService: () => analyticsService }}>
         <EmailCodeStart defaultEmail={input.defaultEmail} onStarted={onStarted} getCaptchaToken={getCaptchaToken} dependencies={DEPENDENCIES} />
       </TestContainerProvider>
     );
 
-    return { authService, onStarted, getCaptchaToken };
+    return { authService, analyticsService, onStarted, getCaptchaToken };
   }
 });

--- a/apps/deploy-web/src/components/auth/EmailCodeStart/EmailCodeStart.tsx
+++ b/apps/deploy-web/src/components/auth/EmailCodeStart/EmailCodeStart.tsx
@@ -35,10 +35,11 @@ interface Props {
 }
 
 export function EmailCodeStart({ dependencies: d = DEPENDENCIES, ...props }: Props) {
-  const { authService } = useServices();
+  const { authService, analyticsService } = useServices();
 
   const startMutation = d.useMutation({
     async mutationFn(input: { email: string }) {
+      analyticsService.track("email_login_init");
       const captchaToken = await props.getCaptchaToken();
       await authService.startEmailCode({ email: input.email, captchaToken });
     },

--- a/apps/deploy-web/src/components/auth/EmailCodeVerify/EmailCodeVerify.spec.tsx
+++ b/apps/deploy-web/src/components/auth/EmailCodeVerify/EmailCodeVerify.spec.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { VerificationCodeInputRef } from "@src/components/onboarding/steps/EmailVerificationStep/VerificationCodeInput";
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import type { AuthService } from "@src/services/auth/auth/auth.service";
 import { DEPENDENCIES, EmailCodeVerify, RESEND_COOLDOWN_SEC } from "./EmailCodeVerify";
 
@@ -48,13 +49,14 @@ describe(EmailCodeVerify.name, () => {
     });
   });
 
-  it("calls onEditEmail when 'Wrong email? Edit' is clicked", async () => {
+  it("calls onEditEmail and tracks wrong_email_clk when 'Wrong email? Edit' is clicked", async () => {
     const onEditEmail = vi.fn();
-    setup({ onEditEmail });
+    const { analyticsService } = setup({ onEditEmail });
 
     await userEvent.click(screen.getByRole("button", { name: /edit/i }));
 
     expect(onEditEmail).toHaveBeenCalledTimes(1);
+    expect(analyticsService.track).toHaveBeenCalledWith("wrong_email_clk");
   });
 
   it("disables resend during the initial cooldown and enables it when the timer hits zero", async () => {
@@ -74,7 +76,7 @@ describe(EmailCodeVerify.name, () => {
 
   it("resends the code and restarts the cooldown on successful resend", async () => {
     const getCaptchaToken = vi.fn().mockResolvedValue("captcha-2");
-    const { authService } = setup({ getCaptchaToken });
+    const { authService, analyticsService } = setup({ getCaptchaToken });
     authService.startEmailCode.mockResolvedValue(undefined);
 
     await act(async () => {
@@ -88,6 +90,7 @@ describe(EmailCodeVerify.name, () => {
     await vi.waitFor(() => {
       expect(authService.startEmailCode).toHaveBeenCalledWith({ email: "alice@example.com", captchaToken: "captcha-2" });
     });
+    expect(analyticsService.track).toHaveBeenCalledWith("resend_code_clk");
     expect(screen.getByRole("button", { name: /resend/i })).toHaveTextContent(`Resend in ${RESEND_COOLDOWN_SEC}s`);
   });
 
@@ -100,6 +103,7 @@ describe(EmailCodeVerify.name, () => {
     } = {}
   ) {
     const authService = mock<AuthService>();
+    const analyticsService = mock<AnalyticsService>();
     const onVerified = input.onVerified ?? vi.fn();
     const onEditEmail = input.onEditEmail ?? vi.fn();
     const getCaptchaToken = input.getCaptchaToken ?? vi.fn().mockResolvedValue("captcha-token");
@@ -114,7 +118,7 @@ describe(EmailCodeVerify.name, () => {
     );
 
     render(
-      <TestContainerProvider services={{ authService: () => authService }}>
+      <TestContainerProvider services={{ authService: () => authService, analyticsService: () => analyticsService }}>
         <EmailCodeVerify
           email="alice@example.com"
           getCaptchaToken={getCaptchaToken}
@@ -125,6 +129,6 @@ describe(EmailCodeVerify.name, () => {
       </TestContainerProvider>
     );
 
-    return { authService, onVerified, onEditEmail, captureOnComplete: () => capturedOnComplete };
+    return { authService, analyticsService, onVerified, onEditEmail, captureOnComplete: () => capturedOnComplete };
   }
 });

--- a/apps/deploy-web/src/components/auth/EmailCodeVerify/EmailCodeVerify.tsx
+++ b/apps/deploy-web/src/components/auth/EmailCodeVerify/EmailCodeVerify.tsx
@@ -28,7 +28,7 @@ interface Props {
 }
 
 export function EmailCodeVerify({ dependencies: d = DEPENDENCIES, ...props }: Props) {
-  const { authService } = useServices();
+  const { authService, analyticsService } = useServices();
   const verifyInputRef = useRef<VerificationCodeInputRef>(null);
   const [resendCooldownSec, setResendCooldownSec] = useState(RESEND_COOLDOWN_SEC);
 
@@ -79,13 +79,23 @@ export function EmailCodeVerify({ dependencies: d = DEPENDENCIES, ...props }: Pr
   const resendLabel = resendCooldownSec > 0 ? `Resend in ${resendCooldownSec}s` : "Resend code";
   const activeError = isAnyMutationPending ? null : verifyMutation.error ?? resendMutation.error;
 
+  function editEmail() {
+    analyticsService.track("wrong_email_clk");
+    props.onEditEmail();
+  }
+
+  function resendCode() {
+    analyticsService.track("resend_code_clk");
+    resendMutation.mutate();
+  }
+
   return (
     <>
       <d.RemoteApiError className="w-full" error={activeError} />
       <div className="flex flex-col items-center gap-5 self-stretch">
         <p className="text-sm text-neutral-500">
           Enter the 6-digit code sent to <span className="font-medium text-neutral-900 dark:text-neutral-100">{props.email}</span>.{" "}
-          <d.Button variant="link" className="h-auto p-0 align-baseline text-sm" onClick={props.onEditEmail} type="button">
+          <d.Button variant="link" className="h-auto p-0 align-baseline text-sm" onClick={editEmail} type="button">
             Wrong email? Edit
           </d.Button>
         </p>
@@ -95,7 +105,7 @@ export function EmailCodeVerify({ dependencies: d = DEPENDENCIES, ...props }: Pr
           disabled={verifyMutation.isPending || resendMutation.isPending}
         />
         <p className="text-xs text-neutral-500">Code expires in 10 minutes.</p>
-        <d.Button variant="link" className="h-auto p-0 text-sm" disabled={isResendDisabled} onClick={() => resendMutation.mutate()} type="button">
+        <d.Button variant="link" className="h-auto p-0 text-sm" disabled={isResendDisabled} onClick={resendCode} type="button">
           {resendLabel}
         </d.Button>
       </div>

--- a/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.spec.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.spec.tsx
@@ -1,11 +1,13 @@
-import type { RefObject } from "react";
+import type { ReactNode, RefObject } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { TurnstileRef } from "@src/components/turnstile/Turnstile";
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
 import { DEPENDENCIES, PasswordlessAuth } from "./PasswordlessAuth";
 
 import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ComponentMock, MockComponents } from "@tests/unit/mocks";
 import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
 
@@ -94,6 +96,22 @@ describe(PasswordlessAuth.name, () => {
     expect(screen.queryByText(/\$5 credit to deploy your first container/i)).not.toBeInTheDocument();
   });
 
+  it("tracks terms_link_clk when the Terms link is clicked", async () => {
+    const { analyticsService } = setup({ dependencies: { Link: AnchorLink as never } });
+
+    await userEvent.click(screen.getByRole("link", { name: "Terms" }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("terms_link_clk");
+  });
+
+  it("tracks privacy_policy_link_clk when the Privacy Policy link is clicked", async () => {
+    const { analyticsService } = setup({ dependencies: { Link: AnchorLink as never } });
+
+    await userEvent.click(screen.getByRole("link", { name: "Privacy Policy" }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("privacy_policy_link_clk");
+  });
+
   function setup(
     input: {
       initialEmail?: string;
@@ -102,6 +120,7 @@ describe(PasswordlessAuth.name, () => {
       dependencies?: Partial<typeof DEPENDENCIES>;
     } = {}
   ) {
+    const analyticsService = mock<AnalyticsService>();
     const onFlowChange = vi.fn();
     const onFlowReset = vi.fn();
     const checkSession = vi.fn(async () => undefined);
@@ -132,7 +151,7 @@ describe(PasswordlessAuth.name, () => {
     });
 
     render(
-      <TestContainerProvider services={{}}>
+      <TestContainerProvider services={{ analyticsService: () => analyticsService }}>
         <PasswordlessAuth
           initialEmail={input.initialEmail ?? ""}
           initialScreen={input.initialScreen ?? "entry"}
@@ -150,6 +169,15 @@ describe(PasswordlessAuth.name, () => {
       </TestContainerProvider>
     );
 
-    return { onFlowChange, onFlowReset, checkSession, navigateBack };
+    return { analyticsService, onFlowChange, onFlowReset, checkSession, navigateBack };
   }
 });
+
+/** Renders Link dependency as a real anchor so click handlers are exercised in tests. */
+function AnchorLink({ children, onClick }: { children: ReactNode; onClick?: () => void }) {
+  return (
+    <a href="#" onClick={onClick}>
+      {children}
+    </a>
+  );
+}

--- a/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.tsx
@@ -32,7 +32,7 @@ interface Props extends PassedFlowProps {
 }
 
 export function PasswordlessAuth({ dependencies: d = DEPENDENCIES, ...props }: Props) {
-  const { publicConfig } = useServices();
+  const { publicConfig, analyticsService } = useServices();
   const { navigateBack } = d.useReturnTo({ defaultReturnTo: "/" });
   const { checkSession } = d.useUser();
   const isOnboardingRedesignEnabled = d.useFlag("console_onboarding_redesign");
@@ -109,6 +109,7 @@ export function PasswordlessAuth({ dependencies: d = DEPENDENCIES, ...props }: P
               prefetch={false}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() => analyticsService.track("terms_link_clk")}
               className="font-medium text-neutral-950 underline dark:text-neutral-50"
             >
               Terms
@@ -119,6 +120,7 @@ export function PasswordlessAuth({ dependencies: d = DEPENDENCIES, ...props }: P
               prefetch={false}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={() => analyticsService.track("privacy_policy_link_clk")}
               className="font-medium text-neutral-950 underline dark:text-neutral-50"
             >
               Privacy Policy

--- a/apps/deploy-web/src/services/analytics/analytics.service.ts
+++ b/apps/deploy-web/src/services/analytics/analytics.service.ts
@@ -33,6 +33,11 @@ type AnalyticsTarget = "Amplitude" | "GA";
 
 export type AnalyticsEvent =
   | "social_login_init"
+  | "email_login_init"
+  | "terms_link_clk"
+  | "privacy_policy_link_clk"
+  | "wrong_email_clk"
+  | "resend_code_clk"
   | "password_auth_submit"
   | "connect_wallet"
   | "connect_managed_wallet"

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -1,6 +1,6 @@
 export const netConfigData = {
   mainnet: {
-    version: "v2.0.1",
+    version: "v2.1.0",
     faucetUrl: null,
     apiUrls: [
       "https://rpc.akt.dev/rest",


### PR DESCRIPTION
## Why

Several login-page actions in the passwordless flow weren't tracked in Amplitude, leaving gaps in the auth funnel.

## What

Add Amplitude tracking for previously-untracked login-page actions:
- `email_login_init` on email submit
- `terms_link_clk` and `privacy_policy_link_clk` on the entry screen
- `wrong_email_clk` and `resend_code_clk` on the verify screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics tracking across authentication flows, including email login initiation, email verification actions (edit email, resend code), and Terms/Privacy Policy link interactions. Tracking events now capture user behavior patterns during the authentication process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->