### PR TITLE
fix: marks provider inventory as online if its is_online_since is null

### DIFF
--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.integration.ts
@@ -278,6 +278,18 @@ describe(ProviderInventoryRepository.name, () => {
       expect(row.isOnlineSince?.toISOString()).toBe(onlineSince.toISOString());
       expect(row.updatedAt.toISOString()).toBe(updatedAt.toISOString());
     });
+
+    it("re-stamps isOnlineSince for a provider left online by the boot-time resetOnlineSince ritual", async () => {
+      const { repository, db } = setup();
+      await seed(db, { owner: "akash1a", isOnline: true, isOnlineSince: new Date("2026-01-01T00:00:00Z") });
+
+      await repository.resetOnlineSince();
+      await repository.markAsOnline("akash1a");
+
+      const [row] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1a"));
+      expect(row.isOnline).toBe(true);
+      expect(row.isOnlineSince).toBeInstanceOf(Date);
+    });
   });
 
   describe("bulkMarkOffline", () => {

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
@@ -1,5 +1,5 @@
 import type { InferSelectModel } from "drizzle-orm";
-import { and, eq, gt, inArray, lt, sql as rawSql } from "drizzle-orm";
+import { and, eq, gt, inArray, isNull, lt, or, sql as rawSql } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { paginate } from "@src/lib/generators/paginate/paginate";
@@ -70,7 +70,17 @@ export class ProviderInventoryRepository {
       .getDb()
       .update(providerInventory)
       .set({ isOnline: true, isOnlineSince: new Date(), updatedAt: rawSql`now()` })
-      .where(and(eq(providerInventory.owner, owner), eq(providerInventory.isOnline, false)));
+      .where(
+        and(
+          // keep new line
+          eq(providerInventory.owner, owner),
+          or(
+            // keep new line
+            eq(providerInventory.isOnline, false),
+            isNull(providerInventory.isOnlineSince)
+          )
+        )
+      );
   }
 
   async updateInventory(provider: ChainProvider, cluster: ClusterState): Promise<void> {


### PR DESCRIPTION
## Why

`markAsOnline` marked online providers which `isOnline` was set to `false` and ignored those which `isOnline` = true but `isOnlineSince` was null

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed provider online status tracking to correctly update providers with missing timestamp information, ensuring accurate status records for all providers when marked as online.

## Tests
* Added integration test coverage for provider online status timestamp updates under edge case conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->