### PR TITLE
feat(deployment): add screened provider marketplace to configure screen

### DIFF
--- a/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
+++ b/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
@@ -2,20 +2,20 @@ import { z } from "@hono/zod-openapi";
 
 const UIntStringSchema = z.string().regex(/^\d+$/, "Must be an unsigned integer string");
 
+/**
+ * Validates the resource value but does NOT transform it. This service only proxies the request to
+ * provider-inventory, which parses the value itself; transforming to BigInt here would break the
+ * `JSON.stringify` forward in the controller. Value is a non-negative integer string or its
+ * protobuf base64-encoded representation.
+ */
 const ResourceValueSchema = z.object({
   val: z
     .string()
     .max(80)
-    .transform(str => {
-      if (/^\d+$/.test(str)) return BigInt(str);
-      const parsed = Buffer.from(str, "base64").toString("utf-8");
-      if (/^\d+$/.test(parsed)) return BigInt(parsed);
-      return NaN;
-    })
-    .refine(
-      (val): val is bigint => !Number.isFinite(val) && typeof val === "bigint" && val >= 0n,
-      "Must be a non-negative integer or its protobuf base64-encoded representation"
-    )
+    .refine(str => {
+      const decoded = /^\d+$/.test(str) ? str : Buffer.from(str, "base64").toString("utf-8");
+      return /^\d+$/.test(decoded);
+    }, "Must be a non-negative integer or its protobuf base64-encoded representation")
 });
 
 // Mirrors AttributeNameRegexpStringWildcard in akash-network/chain-sdk

--- a/apps/api/src/bid-screening/routes/bid-screening.router.ts
+++ b/apps/api/src/bid-screening/routes/bid-screening.router.ts
@@ -16,6 +16,7 @@ export const bidScreeningRouter = new OpenApiHonoHandler();
 
 const postBidScreeningRoute = createRoute({
   method: "post",
+  operationId: "screenProviders",
   path: "/v1/bid-screening",
   summary: "Screen providers by deployment resource requirements",
   tags: ["Bid Screening"],

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -16378,6 +16378,7 @@
     },
     "/v1/bid-screening": {
       "post": {
+        "operationId": "screenProviders",
         "summary": "Screen providers by deployment resource requirements",
         "tags": [
           "Bid Screening"
@@ -16736,13 +16737,20 @@
                             "format": "date-time",
                             "description": "ISO 8601 timestamp marking when the provider was first enrolled in the inventory",
                             "example": "2026-01-01T00:00:00.000Z"
+                          },
+                          "location": {
+                            "type": "string",
+                            "description": "Provider region from the location-region attribute (signed preferred, else self-declared); null if unset",
+                            "example": "us-west",
+                            "nullable": true
                           }
                         },
                         "required": [
                           "owner",
                           "hostUri",
                           "isAudited",
-                          "createdAt"
+                          "createdAt",
+                          "location"
                         ]
                       }
                     }

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -2739,6 +2739,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
     },
     "/v1/bid-screening": {
       "post": {
+        "operationId": "screenProviders",
         "requestBody": {
           "content": {
             "application/json": {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.spec.tsx
@@ -11,19 +11,19 @@ import { render, screen } from "@testing-library/react";
 describe("ConfigurationPane", () => {
   it("shows the selected service title", () => {
     const values = defaultServiceWithPlacement({ title: "api" });
-    setup({ values, selectedServiceId: values.services[0].id as string });
+    setup({ values, selectedServiceId: values.services[0].id });
 
     expect(screen.getByText("api")).toBeInTheDocument();
   });
 
-  it("shows no target when nothing is selected", () => {
+  it("shows no target when the selection matches no service", () => {
     const values = defaultServiceWithPlacement({ title: "api" });
-    setup({ values, selectedServiceId: null });
+    setup({ values, selectedServiceId: "missing" });
 
     expect(screen.queryByText("api")).not.toBeInTheDocument();
   });
 
-  function setup(input: { values: SdlBuilderFormValuesType; selectedServiceId: string | null }) {
+  function setup(input: { values: SdlBuilderFormValuesType; selectedServiceId: string }) {
     const Wrapper = ({ children }: PropsWithChildren) => {
       const form = useForm<SdlBuilderFormValuesType>({ defaultValues: input.values });
       return <FormProvider {...form}>{children}</FormProvider>;

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.tsx
@@ -4,7 +4,7 @@ import { useFormContext, useWatch } from "react-hook-form";
 import type { SdlBuilderFormValuesType } from "@src/types";
 
 type Props = {
-  selectedServiceId: string | null;
+  selectedServiceId: string;
 };
 
 export const ConfigurationPane: FC<Props> = ({ selectedServiceId }) => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -100,9 +100,19 @@ const TWO_SERVICE_SDL = [
 
 describe(ConfigureDeploymentForm.name, () => {
   it("seeds the panes with the carried-in template SDL", () => {
-    const { ConfigureDeploymentPanes } = setup({ initialSdl: 'version: "2.0"' });
+    const { ConfigureDeploymentPanes } = setup({ initialSdl: VALID_SDL });
 
-    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ sdl: 'version: "2.0"' }), expect.anything());
+    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ sdl: VALID_SDL }), expect.anything());
+  });
+
+  it("falls back to a default deployment when the carried-in SDL has no services", () => {
+    const { ConfigureDeploymentPanes, enqueueSnackbar } = setup({ initialSdl: 'version: "2.0"' });
+
+    expect(enqueueSnackbar).not.toHaveBeenCalled();
+    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(
+      expect.objectContaining({ sdl: expect.stringContaining('version: "2.0"'), selectedServiceId: expect.any(String) }),
+      expect.anything()
+    );
   });
 
   it("generates the SDL of the default deployment when no SDL was provided", () => {
@@ -180,7 +190,7 @@ describe(ConfigureDeploymentForm.name, () => {
 
 interface ProbePanesProps {
   sdl: string;
-  selectedServiceId: string | null;
+  selectedServiceId: string;
 }
 
 /** Panes stand-in that mutates the shared form to drive the SDL preview subscription. */
@@ -210,7 +220,7 @@ function SelectionProbePanes({ selectedServiceId }: ProbePanesProps) {
   const firstServiceId = Array.isArray(services) ? (services as SdlBuilderFormValuesType["services"])[0]?.id : undefined;
   return (
     <div>
-      <div data-testid="selected">{selectedServiceId ?? ""}</div>
+      <div data-testid="selected">{selectedServiceId}</div>
       <div data-testid="first-service-id">{firstServiceId ?? ""}</div>
       <button type="button" onClick={() => setValue("services", [defaultService(getValues("placements")[0].id, { title: "service-2" })])}>
         replace services

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 import type { FC } from "react";
 import { useEffect, useState } from "react";
-import { FormProvider, useForm } from "react-hook-form";
+import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { Snackbar } from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
 import debounce from "lodash/debounce";
@@ -31,13 +31,16 @@ type Props = {
 export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, dependencies: d = DEPENDENCIES }) => {
   const [initialState] = useState(() => getInitialState(initialSdl));
   const [sdl, setSdl] = useState(initialState.sdl);
-  const [selectedServiceId, setSelectedServiceId] = useState<string | null>(initialState.selectedServiceId);
+  const [selectedServiceId, setSelectedServiceId] = useState<string>(initialState.selectedServiceId);
   const { enqueueSnackbar } = d.useSnackbar();
   const form = useForm<SdlBuilderFormValuesType>({
     defaultValues: initialState.values,
     mode: "onChange",
     resolver: zodResolver(SdlBuilderFormValuesSchema)
   });
+  const services = useWatch({ control: form.control, name: "services" });
+  const placements = useWatch({ control: form.control, name: "placements" });
+  const selectedPlacementName = resolveSelectedPlacementName(services, placements, selectedServiceId);
 
   useEffect(
     function notifyOnImportError() {
@@ -83,7 +86,12 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, dependencies: d
           <d.ConfigureDeploymentHeader />
         </div>
         <div className="mt-6 flex min-h-0 flex-1">
-          <d.ConfigureDeploymentPanes sdl={sdl} selectedServiceId={selectedServiceId} onSelectService={setSelectedServiceId} />
+          <d.ConfigureDeploymentPanes
+            sdl={sdl}
+            selectedServiceId={selectedServiceId}
+            selectedPlacementName={selectedPlacementName}
+            onSelectService={setSelectedServiceId}
+          />
         </div>
       </FormProvider>
     </d.Layout>
@@ -93,29 +101,39 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, dependencies: d
 interface InitialState {
   values: SdlBuilderFormValuesType;
   sdl: string;
-  selectedServiceId: string | null;
+  selectedServiceId: string;
   importError?: string;
 }
 
 /**
- * Derives the form values, preview SDL, and initial selection from one source
- * so they can never diverge. A parseable carried-in template keeps its exact
- * SDL text for the preview; if it can't be imported the screen falls back to a
- * default deployment and reports `importError` so the failure is surfaced
- * rather than silently swallowed.
+ * Derives the form values, preview SDL, and initial selection from one source so they can never diverge.
+ * A carried-in SDL is used only when it imports to a usable deployment (at least one visible service);
+ * otherwise — invalid YAML, or a service-less SDL the configure screen can't work with — the screen falls
+ * back to a default deployment. This guarantees there is always a service (and placement) to select.
  */
 function getInitialState(carriedInSdl: string | undefined): InitialState {
   if (carriedInSdl) {
     try {
       const values = importSimpleSdl(carriedInSdl);
-      return { values, sdl: carriedInSdl, selectedServiceId: seedSelectedServiceId(values) };
+      if (hasVisibleService(values)) {
+        return { values, sdl: carriedInSdl, selectedServiceId: seedSelectedServiceId(values) };
+      }
     } catch (error) {
-      const values = defaultServiceWithPlacement();
-      return { values, sdl: regenerateSdl(values, ""), selectedServiceId: seedSelectedServiceId(values), importError: getImportErrorMessage(error) };
+      return defaultInitialState(getImportErrorMessage(error));
     }
   }
+  return defaultInitialState();
+}
+
+/** A fresh default deployment, optionally annotated with the error that made an import unusable. */
+function defaultInitialState(importError?: string): InitialState {
   const values = defaultServiceWithPlacement();
-  return { values, sdl: regenerateSdl(values, ""), selectedServiceId: seedSelectedServiceId(values) };
+  return { values, sdl: regenerateSdl(values, ""), selectedServiceId: seedSelectedServiceId(values), importError };
+}
+
+/** A usable deployment has at least one service the user can configure (log collectors don't count). */
+function hasVisibleService(values: SdlBuilderFormValuesType): boolean {
+  return values.services.some(service => !isLogCollectorService(service));
 }
 
 /**
@@ -130,9 +148,10 @@ function getImportErrorMessage(error: unknown): string {
   return "The deployment couldn't be loaded.";
 }
 
-/** Picks the first user-visible service to focus when the screen first mounts. */
-function seedSelectedServiceId(values: SdlBuilderFormValuesType): string | null {
-  return values.services.find(service => !isLogCollectorService(service))?.id ?? null;
+/** Picks the first user-visible service to focus when the screen first mounts. `getInitialState` guarantees one exists. */
+function seedSelectedServiceId(values: SdlBuilderFormValuesType): string {
+  const visible = values.services.find(candidate => !isLogCollectorService(candidate)) ?? values.services[0];
+  return visible.id;
 }
 
 /** Regenerates the preview SDL, keeping the last good output while the form is mid-edit. */
@@ -144,11 +163,29 @@ function regenerateSdl(values: SdlBuilderFormValuesType, previous: string): stri
   }
 }
 
+/**
+ * Resolves the placement the marketplace is scoped to. There is always a placement and a service, so this
+ * returns a name rather than null: it uses the selected service when present, otherwise the first visible
+ * service (which also covers the brief window after a removal, before the reselect effect runs), and falls
+ * back to the first placement.
+ */
+function resolveSelectedPlacementName(
+  services: SdlBuilderFormValuesType["services"],
+  placements: SdlBuilderFormValuesType["placements"],
+  selectedServiceId: string
+): string {
+  const selected = services.find(candidate => candidate.id === selectedServiceId);
+  const service = selected ?? services.find(candidate => !isLogCollectorService(candidate));
+  const placement = (service && placements.find(candidate => candidate.id === service.placementId)) || placements[0];
+  return placement.name;
+}
+
 /** Keeps the selection on an existing service, falling back to the first visible one after a removal. */
-function nextSelectedServiceId(values: SdlBuilderFormValuesType, previous: string | null): string | null {
+function nextSelectedServiceId(values: SdlBuilderFormValuesType, previous: string): string {
   const services = values.services ?? [];
-  if (previous && services.some(service => service?.id === previous)) {
+  if (services.some(candidate => candidate?.id === previous)) {
     return previous;
   }
-  return services.find(service => service && !isLogCollectorService(service as ServiceType))?.id ?? null;
+  const visible = services.find(candidate => candidate && !isLogCollectorService(candidate as ServiceType)) ?? services[0];
+  return visible.id;
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
@@ -97,12 +97,19 @@ describe("ConfigureDeploymentPanes", () => {
     expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ selectedServiceId: "svc-1" }), expect.anything());
   });
 
+  it("threads the sdl and selected placement into the marketplace pane", () => {
+    const { MarketplacePane } = setup({ sdl: 'version: "2.0"', selectedPlacementName: "dcloud" });
+
+    expect(MarketplacePane).toHaveBeenCalledWith(expect.objectContaining({ sdl: 'version: "2.0"', placementName: "dcloud" }), expect.anything());
+  });
+
   function setup(
     input: {
       isSdlPreviewEnabled?: boolean;
       sdl?: string;
       preserveStorage?: boolean;
-      selectedServiceId?: string | null;
+      selectedServiceId?: string;
+      selectedPlacementName?: string;
       onSelectService?: (serviceId: string) => void;
     } = {}
   ) {
@@ -114,10 +121,11 @@ describe("ConfigureDeploymentPanes", () => {
     ));
     const DeploymentPane = vi.fn(() => <div data-testid="deployment-pane-mock" />);
     const ConfigurationPane = vi.fn(() => <div data-testid="configuration-pane-mock" />);
+    const MarketplacePane = vi.fn(() => <div data-testid="marketplace-pane-mock" />);
     const dependencies: typeof DEPENDENCIES = {
       DeploymentPane: DeploymentPane as never,
       ConfigurationPane: ConfigurationPane as never,
-      MarketplacePane: vi.fn(() => <div data-testid="marketplace-pane-mock" />),
+      MarketplacePane: MarketplacePane as never,
       SdlPreviewPane: SdlPreviewPane as never,
       useFlag: (() => input.isSdlPreviewEnabled ?? false) as never
     };
@@ -130,13 +138,14 @@ describe("ConfigureDeploymentPanes", () => {
       <JotaiStoreProvider store={createStore()}>
         <ConfigureDeploymentPanes
           sdl={input.sdl ?? ""}
-          selectedServiceId={input.selectedServiceId ?? null}
+          selectedServiceId={input.selectedServiceId ?? ""}
+          selectedPlacementName={input.selectedPlacementName ?? "dcloud"}
           onSelectService={input.onSelectService ?? vi.fn()}
           dependencies={dependencies}
         />
       </JotaiStoreProvider>
     );
 
-    return { SdlPreviewPane, DeploymentPane, ConfigurationPane, unmount };
+    return { SdlPreviewPane, DeploymentPane, ConfigurationPane, MarketplacePane, unmount };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
@@ -16,12 +16,13 @@ export const DEPENDENCIES = { DeploymentPane, ConfigurationPane, MarketplacePane
 
 type Props = {
   sdl: string;
-  selectedServiceId: string | null;
+  selectedServiceId: string;
+  selectedPlacementName: string;
   onSelectService: (serviceId: string) => void;
   dependencies?: typeof DEPENDENCIES;
 };
 
-export const ConfigureDeploymentPanes: FC<Props> = ({ sdl, selectedServiceId, onSelectService, dependencies: d = DEPENDENCIES }) => {
+export const ConfigureDeploymentPanes: FC<Props> = ({ sdl, selectedServiceId, selectedPlacementName, onSelectService, dependencies: d = DEPENDENCIES }) => {
   const [activePane, setActivePane] = useState<ActivePane>("deployment");
   const [isSdlPreviewOpen, setIsSdlPreviewOpen] = useAtom(sdlStore.sdlPreviewOpen);
   const isSdlPreviewEnabled = d.useFlag("ui_sdl_preview_panel");
@@ -36,7 +37,7 @@ export const ConfigureDeploymentPanes: FC<Props> = ({ sdl, selectedServiceId, on
           <d.ConfigurationPane selectedServiceId={selectedServiceId} />
         </div>
         <div className={cn("min-h-0 md:block", { hidden: activePane !== "marketplace" })}>
-          <d.MarketplacePane />
+          <d.MarketplacePane sdl={sdl} placementName={selectedPlacementName} />
         </div>
         {isSdlPreviewEnabled && (
           <d.SdlPreviewPane sdl={sdl} isOpen={isSdlPreviewOpen} onOpen={() => setIsSdlPreviewOpen(true)} onClose={() => setIsSdlPreviewOpen(false)} />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.spec.tsx
@@ -96,7 +96,7 @@ describe("DeploymentPane", () => {
     render(
       <TooltipProvider>
         <DeploymentPane
-          selectedServiceId={null}
+          selectedServiceId=""
           onSelectService={input.onSelectService ?? vi.fn()}
           dependencies={MockComponents(DEPENDENCIES, { usePlacementManager, ...input.dependencies })}
         />
@@ -119,8 +119,8 @@ describe("DeploymentPane placement management", () => {
     const values = getForm().getValues();
     expect(values.placements).toHaveLength(1);
     expect(values.placements[0].name).toBe("placement-1");
-    expect(values.services).toHaveLength(2);
-    expect(values.services.map(service => service.title)).toEqual(["service-2", "service-3"]);
+    expect(values.services).toHaveLength(3);
+    expect(values.services.map(service => service.title)).toEqual(["service-2", "service-3", "service-4"]);
     expect(values.services.every(service => service.placementId === values.placements[0].id)).toBe(true);
   });
 
@@ -142,7 +142,7 @@ describe("DeploymentPane placement management", () => {
 
     render(
       <Wrapper>
-        <DeploymentPane selectedServiceId={null} onSelectService={vi.fn()} dependencies={{ ...DEPENDENCIES, PlacementCard: PlacementCardWithStubbedRegion }} />
+        <DeploymentPane selectedServiceId="" onSelectService={vi.fn()} dependencies={{ ...DEPENDENCIES, PlacementCard: PlacementCardWithStubbedRegion }} />
       </Wrapper>
     );
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
@@ -10,7 +10,7 @@ import { usePlacementManager } from "./usePlacementManager/usePlacementManager";
 export const DEPENDENCIES = { PlacementCard, usePlacementManager, IpEndpointsSection };
 
 type Props = {
-  selectedServiceId: string | null;
+  selectedServiceId: string;
   onSelectService: (serviceId: string) => void;
   dependencies?: typeof DEPENDENCIES;
 };
@@ -70,7 +70,7 @@ export const DeploymentPane: FC<Props> = ({ selectedServiceId, onSelectService, 
             <Button
               type="button"
               variant="ghost"
-              onClick={manager.addPlacement}
+              onClick={() => onSelectService(manager.addPlacement())}
               className="w-full gap-1.5 rounded-lg border border-zinc-300 py-2 text-foreground dark:border-zinc-700"
             >
               <Plus className="h-4 w-4" />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.spec.tsx
@@ -65,6 +65,23 @@ describe("PlacementCard", () => {
     expect(screen.getByText("Names must start with a lower case letter.")).toBeInTheDocument();
   });
 
+  it("selects the placement's first service when the placement card is clicked", async () => {
+    const { onSelectService, services, container } = setup({ serviceTitles: ["web", "api"] });
+
+    await userEvent.click(container.firstChild as Element);
+
+    expect(onSelectService).toHaveBeenCalledWith(services[0].service.id);
+  });
+
+  it("selects the clicked service rather than the placement's first", async () => {
+    const { onSelectService, services } = setup({ serviceTitles: ["web", "api"], dependencies: { ServiceRow: DEPENDENCIES.ServiceRow } });
+
+    await userEvent.click(screen.getByRole("button", { name: "Select api" }));
+
+    expect(onSelectService).toHaveBeenCalledWith(services[1].service.id);
+    expect(onSelectService).not.toHaveBeenCalledWith(services[0].service.id);
+  });
+
   function setup(input: { serviceTitles: string[]; canRemove?: boolean; status?: ConfigStatus; error?: string; dependencies?: Partial<typeof DEPENDENCIES> }) {
     const placement = defaultPlacement({ name: "placement-1" });
     const services = input.serviceTitles.map((title, index) => ({
@@ -81,13 +98,13 @@ describe("PlacementCard", () => {
       return <FormProvider {...form}>{children}</FormProvider>;
     };
 
-    render(
+    const { container } = render(
       <Wrapper>
         <PlacementCard
           placement={placement}
           placementIndex={0}
           services={services}
-          selectedServiceId={null}
+          selectedServiceId=""
           canRemove={input.canRemove ?? true}
           canRemoveService={true}
           onSelectService={onSelectService}
@@ -103,6 +120,6 @@ describe("PlacementCard", () => {
       </Wrapper>
     );
 
-    return { onAddService, onRemove, onSelectService, onRemoveService };
+    return { onAddService, onRemove, onSelectService, onRemoveService, services, container };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.tsx
@@ -1,6 +1,7 @@
-import type { FC } from "react";
+import type { FC, MouseEvent } from "react";
 import { useId } from "react";
 import { FieldErrorMessage, InlineEditInput, useFieldError } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
 import { Plus, Trash } from "iconoir-react";
 
 import { RegionSelect } from "@src/components/sdl/RegionSelect/RegionSelect";
@@ -16,7 +17,7 @@ type Props = {
   placement: PlacementType;
   placementIndex: number;
   services: IndexedService[];
-  selectedServiceId: string | null;
+  selectedServiceId: string;
   canRemove: boolean;
   canRemoveService: boolean;
   onSelectService: (serviceId: string) => void;
@@ -42,15 +43,38 @@ export const PlacementCard: FC<Props> = ({
   const status = d.usePlacementStatus(placement.id as string);
   const { error } = d.useFieldError(`placements.${placementIndex}.name`);
   const errorId = useId();
+  const isSelected = services.some(({ service }) => service.id === selectedServiceId);
+  const firstServiceId = services[0]?.service.id as string | undefined;
+
+  /** Selecting a placement focuses its first service (the marketplace is placement-scoped). */
+  function selectPlacement() {
+    if (firstServiceId) onSelectService(firstServiceId);
+  }
+
+  function removePlacement(event: MouseEvent<HTMLButtonElement>) {
+    event.stopPropagation();
+    onRemove();
+  }
+
+  function addService(event: MouseEvent<HTMLButtonElement>) {
+    event.stopPropagation();
+    onAddService();
+  }
 
   return (
-    <div className="rounded-lg border border-zinc-300 p-2 dark:border-zinc-700">
+    <div
+      onClick={selectPlacement}
+      className={cn("cursor-pointer rounded-lg border p-2", {
+        "border-foreground ring-[3px] ring-blue-500/25": isSelected,
+        "border-zinc-300 dark:border-zinc-700": !isSelected
+      })}
+    >
       <div className="flex flex-col gap-1 px-1 pb-2">
         <div className="flex items-center gap-2">
           <ConfigStatusIcon status={status} />
           <d.InlineEditInput name={`placements.${placementIndex}.name`} label="Placement name" suppressErrorMessage errorMessageId={errorId} />
           {canRemove && (
-            <button type="button" aria-label="Remove placement" onClick={onRemove} className="shrink-0 text-muted-foreground hover:text-foreground">
+            <button type="button" aria-label="Remove placement" onClick={removePlacement} className="shrink-0 text-muted-foreground hover:text-foreground">
               <Trash className="h-3.5 w-3.5" />
             </button>
           )}
@@ -74,7 +98,7 @@ export const PlacementCard: FC<Props> = ({
       <button
         type="button"
         aria-label="Add service"
-        onClick={onAddService}
+        onClick={addService}
         className="mt-2 flex w-full items-center justify-center rounded-md py-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
       >
         <Plus className="h-4 w-4" />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ServiceRow/ServiceRow.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ServiceRow/ServiceRow.tsx
@@ -30,12 +30,17 @@ export const ServiceRow: FC<Props> = ({ service, serviceIndex, isSelected, canRe
     onRemove();
   }
 
+  function selectWithoutSelectingPlacement(event: MouseEvent<HTMLLIElement>) {
+    event.stopPropagation();
+    onSelect();
+  }
+
   return (
-    <li onClick={onSelect} className="group flex cursor-pointer flex-col gap-1">
+    <li onClick={selectWithoutSelectingPlacement} className="group flex cursor-pointer flex-col gap-1">
       <div
         className={cn("flex items-start gap-2 rounded-md border px-2.5 py-2", {
           "border-destructive": !!error,
-          "border-foreground": isSelected && !error,
+          "border-foreground bg-accent": isSelected && !error,
           "border-zinc-300 hover:border-zinc-400 dark:border-zinc-700 dark:hover:border-zinc-600": !isSelected && !error
         })}
       >

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/usePlacementManager/usePlacementManager.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/usePlacementManager/usePlacementManager.spec.tsx
@@ -10,15 +10,20 @@ import { usePlacementManager } from "./usePlacementManager";
 import { act, renderHook } from "@testing-library/react";
 
 describe("usePlacementManager", () => {
-  it("appends a placement with a unique generated name", () => {
+  it("appends a placement with a unique generated name and a default service, returning the service id", () => {
     const { result } = setup({ values: defaultServiceWithPlacement() });
 
+    let addedServiceId = "";
     act(() => {
-      result.current.addPlacement();
+      addedServiceId = result.current.addPlacement();
     });
 
     expect(result.current.placements).toHaveLength(2);
     expect(result.current.placements[1].name).toBe("placement-1");
+
+    const newPlacementServices = result.current.getPlacementServices(result.current.placements[1].id);
+    expect(newPlacementServices).toHaveLength(1);
+    expect(newPlacementServices[0].service.id).toBe(addedServiceId);
   });
 
   it("adds a service bound to the given placement with the next generated title and returns its id", () => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/usePlacementManager/usePlacementManager.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/usePlacementManager/usePlacementManager.ts
@@ -46,8 +46,12 @@ export const usePlacementManager = () => {
   );
 
   const addPlacement = useCallback(() => {
-    appendPlacement(defaultPlacement({ name: nextPlacementName(getValues("placements")) }));
-  }, [appendPlacement, getValues]);
+    const placement = defaultPlacement({ name: nextPlacementName(getValues("placements")) });
+    const service = defaultService(placement.id as string, { title: nextServiceTitle(getValues("services")) });
+    appendPlacement(placement);
+    appendService(service);
+    return service.id as string;
+  }, [appendPlacement, appendService, getValues]);
 
   const canRemovePlacement = placements.length > 1;
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
+import type { DEPENDENCIES } from "./MarketplacePane";
+import { MarketplacePane } from "./MarketplacePane";
+
+import { render, screen } from "@testing-library/react";
+
+describe("MarketplacePane", () => {
+  it("screens the given placement using the current sdl", () => {
+    const { useScreenedProviders } = setup({ sdl: "version: 2.0", placementName: "dcloud" });
+
+    expect(useScreenedProviders).toHaveBeenCalledWith({ sdl: "version: 2.0", placementName: "dcloud" });
+  });
+
+  it("shows the placement name in the header", () => {
+    setup({ placementName: "dcloud" });
+
+    expect(screen.getByText("• dcloud")).toBeInTheDocument();
+  });
+
+  it("passes screened providers and loading state to the table", () => {
+    const providers = [makeProvider()];
+    const { MarketplaceProvidersTable } = setup({ providers, isLoading: false });
+
+    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ providers, isLoading: false }), expect.anything());
+  });
+
+  it("renders an error message and no table when the query fails with no data", () => {
+    const { MarketplaceProvidersTable } = setup({ isError: true });
+
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(MarketplaceProvidersTable).not.toHaveBeenCalled();
+  });
+
+  it("keeps the table when a refetch fails but providers are still cached", () => {
+    const providers = [makeProvider()];
+    const { MarketplaceProvidersTable } = setup({ isError: true, providers });
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ providers }), expect.anything());
+  });
+
+  function makeProvider(): ScreenedProvider {
+    return { owner: "akash1a", hostUri: "https://a.example:8443", isAudited: true, location: "us-west", createdAt: "2026-01-01T00:00:00.000Z" };
+  }
+
+  function setup(input: { sdl?: string; placementName?: string; providers?: ScreenedProvider[]; isLoading?: boolean; isError?: boolean } = {}) {
+    const useScreenedProviders = vi.fn(() => ({
+      providers: input.providers ?? [],
+      isLoading: input.isLoading ?? false,
+      isError: input.isError ?? false
+    }));
+    const MarketplaceProvidersTable = vi.fn(() => <div data-testid="marketplace-table-mock" />);
+    const dependencies: typeof DEPENDENCIES = {
+      useScreenedProviders: useScreenedProviders as never,
+      MarketplaceProvidersTable: MarketplaceProvidersTable as never
+    };
+
+    render(<MarketplacePane sdl={input.sdl ?? ""} placementName={input.placementName ?? "dcloud"} dependencies={dependencies} />);
+    return { useScreenedProviders, MarketplaceProvidersTable };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
@@ -1,14 +1,37 @@
 import type { FC } from "react";
 
-export const MarketplacePane: FC = () => {
+import { useScreenedProviders } from "@src/queries/useScreenedProviders";
+import { MarketplaceProvidersTable } from "./MarketplaceProvidersTable/MarketplaceProvidersTable";
+
+export const DEPENDENCIES = { useScreenedProviders, MarketplaceProvidersTable };
+
+interface Props {
+  sdl: string;
+  placementName: string;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+export const MarketplacePane: FC<Props> = ({ sdl, placementName, dependencies: d = DEPENDENCIES }) => {
+  const { providers, isLoading, isError } = d.useScreenedProviders({ sdl, placementName });
+  const hasFailedWithoutData = isError && providers.length === 0;
+
   return (
     <section aria-labelledby="configure-marketplace-pane-heading" className="flex h-full min-h-0 flex-col">
       <header className="hidden h-[52px] shrink-0 items-center border-b border-zinc-300 px-4 md:flex dark:border-zinc-700">
         <h2 id="configure-marketplace-pane-heading" className="font-mono text-sm font-medium uppercase text-muted-foreground">
           3. Compute Marketplace
         </h2>
+        <span className="ml-2 font-mono text-sm font-semibold text-blue-500">• {placementName}</span>
       </header>
-      <div className="flex-1 overflow-y-auto" />
+      <div className="flex-1 overflow-y-auto p-4">
+        {hasFailedWithoutData ? (
+          <p role="alert" className="text-sm text-muted-foreground">
+            Failed to load providers. Please try again.
+          </p>
+        ) : (
+          <d.MarketplaceProvidersTable providers={providers} isLoading={isLoading} />
+        )}
+      </div>
     </section>
   );
 };

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
@@ -1,0 +1,73 @@
+import { TooltipProvider } from "@akashnetwork/ui/components";
+import { describe, expect, it } from "vitest";
+
+import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
+import { MarketplaceProvidersTable } from "./MarketplaceProvidersTable";
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe("MarketplaceProvidersTable", () => {
+  it("renders a row per provider showing host and region", () => {
+    setup({
+      providers: [
+        makeProvider({ hostUri: "https://a.example:8443", location: "us-west" }),
+        makeProvider({ hostUri: "https://b.example:8443", location: "eu-central" })
+      ]
+    });
+
+    expect(screen.getByText("a.example")).toBeInTheDocument();
+    expect(screen.getByText("us-west")).toBeInTheDocument();
+    expect(screen.getByText("b.example")).toBeInTheDocument();
+    expect(screen.getByText("eu-central")).toBeInTheDocument();
+  });
+
+  it("renders an em dash when region is null", () => {
+    setup({ providers: [makeProvider({ hostUri: "https://a.example:8443", location: null })] });
+
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("sorts rows by provider host when the Provider header is toggled ascending", async () => {
+    setup({
+      providers: [makeProvider({ hostUri: "https://zeta.example:8443" }), makeProvider({ hostUri: "https://alpha.example:8443" })]
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Provider/ }));
+
+    const rows = screen.getAllByRole("row");
+    expect(within(rows[1]).getByText("alpha.example")).toBeInTheDocument();
+    expect(within(rows[2]).getByText("zeta.example")).toBeInTheDocument();
+  });
+
+  it("sorts by the displayed hostname regardless of scheme or port", async () => {
+    setup({
+      providers: [makeProvider({ hostUri: "http://zeta.example:80" }), makeProvider({ hostUri: "https://alpha.example:8443" })]
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Provider/ }));
+
+    const rows = screen.getAllByRole("row");
+    expect(within(rows[1]).getByText("alpha.example")).toBeInTheDocument();
+    expect(within(rows[2]).getByText("zeta.example")).toBeInTheDocument();
+  });
+
+  function makeProvider(overrides: Partial<ScreenedProvider>): ScreenedProvider {
+    return {
+      owner: "akash1a",
+      hostUri: "https://a.example:8443",
+      isAudited: true,
+      location: "us-west",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      ...overrides
+    };
+  }
+
+  function setup(input: { providers: ScreenedProvider[] }) {
+    return render(
+      <TooltipProvider>
+        <MarketplaceProvidersTable providers={input.providers} />
+      </TooltipProvider>
+    );
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
@@ -1,0 +1,106 @@
+import type { FC } from "react";
+import { useState } from "react";
+import { Spinner, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@akashnetwork/ui/components";
+import type { Column, SortingState } from "@tanstack/react-table";
+import { createColumnHelper, flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
+import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react";
+
+import { ShortenedValue } from "@src/components/shared/ShortenedValue";
+import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
+import { getProviderNameFromUri } from "@src/utils/providerUtils";
+
+const columnHelper = createColumnHelper<ScreenedProvider>();
+
+/** Shown when a provider has no region attribute. */
+const NO_REGION = "—";
+
+const columns = [
+  columnHelper.accessor(provider => getProviderNameFromUri(provider.hostUri), {
+    id: "hostUri",
+    header: ({ column }) => <SortableHeader column={column} title="Provider" />,
+    cell: info => <ShortenedValue value={info.getValue()} maxLength={40} headLength={14} />
+  }),
+  columnHelper.accessor("location", {
+    header: ({ column }) => <SortableHeader column={column} title="Region" />,
+    cell: info => info.getValue() ?? NO_REGION
+  })
+];
+
+interface Props {
+  providers: ScreenedProvider[];
+  isLoading?: boolean;
+}
+
+export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading }) => {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const table = useReactTable({
+    data: providers,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel()
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-4">
+        <Spinner size="large" />
+      </div>
+    );
+  }
+
+  if (providers.length === 0) {
+    return <p className="p-4 text-sm text-muted-foreground">No providers found.</p>;
+  }
+
+  return (
+    <div className="overflow-hidden rounded-[14px] border shadow-sm">
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map(headerGroup => (
+            <TableRow key={headerGroup.id} className="hover:bg-transparent">
+              {headerGroup.headers.map(header => (
+                <TableHead key={header.id} className="h-10 pl-4 pr-2">
+                  {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                </TableHead>
+              ))}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows.map(row => (
+            <TableRow key={row.id} className="h-[52px]">
+              {row.getVisibleCells().map(cell => (
+                <TableCell key={cell.id} className="py-2 pl-4 pr-2 text-sm font-medium text-foreground">
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};
+
+/** Design-system column header: an uppercase mono label that toggles sort on click. */
+function SortableHeader({ column, title }: { column: Column<ScreenedProvider, unknown>; title: string }) {
+  const sorted = column.getIsSorted();
+  return (
+    <button
+      type="button"
+      onClick={() => column.toggleSorting(sorted === "asc")}
+      className="group flex items-center gap-1 font-mono text-sm font-normal uppercase text-muted-foreground"
+    >
+      {title}
+      {sorted === "asc" ? (
+        <ArrowUp className="h-3.5 w-3.5" />
+      ) : sorted === "desc" ? (
+        <ArrowDown className="h-3.5 w-3.5" />
+      ) : (
+        <ChevronsUpDown className="h-3.5 w-3.5 opacity-0 transition-opacity group-hover:opacity-50" />
+      )}
+    </button>
+  );
+}

--- a/apps/deploy-web/src/queries/useScreenedProviders.spec.tsx
+++ b/apps/deploy-web/src/queries/useScreenedProviders.spec.tsx
@@ -1,0 +1,111 @@
+import type { UseQueryResult } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { AUDITOR } from "@src/utils/deploymentData/v1beta3";
+import { setupQuery } from "../../tests/unit/query-client";
+import type { ScreenedProvider, ScreenedProvidersResponse } from "./useScreenedProviders";
+import { buildPlacementScreeningRequest, useScreenedProviders } from "./useScreenedProviders";
+
+const HELLO_WORLD_SDL = `---
+version: "2.0"
+services:
+  web:
+    image: nginx
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.1
+        memory:
+          size: 512Mi
+        storage:
+          size: 1Gi
+  placement:
+    dcloud:
+      pricing:
+        web:
+          denom: uact
+          amount: 1000
+deployment:
+  web:
+    dcloud:
+      profile: web
+      count: 1
+`;
+
+describe("useScreenedProviders", () => {
+  it("screens the given placement's group spec, audited-only", () => {
+    const { useQuery } = setup({ placementName: "dcloud" });
+
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "dcloud",
+        requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [] },
+        resources: expect.arrayContaining([expect.objectContaining({ count: 1 })])
+      })
+    );
+  });
+
+  it("falls back to the full audited catalog (empty resources) when the SDL is invalid", () => {
+    const { useQuery } = setup({ sdl: "foo: [unclosed", placementName: "dcloud" });
+
+    expect(useQuery).toHaveBeenCalledWith({
+      name: "screening",
+      requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [] },
+      resources: []
+    });
+  });
+
+  it("returns the screened providers from the query result", () => {
+    const providers = [makeProvider()];
+    const { result } = setup({ placementName: "dcloud", providers });
+
+    expect(result.current.providers).toEqual(providers);
+  });
+
+  function makeProvider(): ScreenedProvider {
+    return { owner: "akash1a", hostUri: "https://a.example:8443", isAudited: true, location: "us-west", createdAt: "2026-01-01T00:00:00.000Z" };
+  }
+
+  function setup(input: { placementName: string; sdl?: string; providers?: ScreenedProvider[] }) {
+    const useQuery = vi.fn().mockReturnValue(
+      mock<UseQueryResult<ScreenedProvidersResponse>>({
+        data: { providers: input.providers ?? [] },
+        isLoading: false,
+        isError: false
+      })
+    );
+    const api = { v1: { screenProviders: { useQuery } } } as unknown as ReturnType<
+      NonNullable<NonNullable<NonNullable<Parameters<typeof setupQuery>[1]>["services"]>["api"]>
+    >;
+
+    const { result } = setupQuery(() => useScreenedProviders({ sdl: input.sdl ?? HELLO_WORLD_SDL, placementName: input.placementName }), {
+      services: { api: () => api }
+    });
+    return { result, useQuery };
+  }
+});
+
+describe("buildPlacementScreeningRequest", () => {
+  it("builds an audited request from the matching placement group spec", () => {
+    const request = buildPlacementScreeningRequest(HELLO_WORLD_SDL, "dcloud");
+
+    expect(request).toMatchObject({ name: "dcloud", requirements: { signedBy: { allOf: [AUDITOR] } } });
+    expect(request?.resources[0].resource.cpu.units.val).toBeTruthy();
+  });
+
+  it("returns null when the placement is not in the SDL", () => {
+    expect(buildPlacementScreeningRequest(HELLO_WORLD_SDL, "missing")).toBeNull();
+  });
+
+  it("returns null when the SDL is invalid", () => {
+    expect(buildPlacementScreeningRequest("foo: [unclosed", "dcloud")).toBeNull();
+  });
+});

--- a/apps/deploy-web/src/queries/useScreenedProviders.ts
+++ b/apps/deploy-web/src/queries/useScreenedProviders.ts
@@ -1,0 +1,89 @@
+import { useMemo } from "react";
+import { GroupSpec } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import type { paths } from "@akashnetwork/console-api-types";
+
+import { useServices } from "@src/context/ServicesProvider";
+import { DeploymentGroups } from "@src/utils/deploymentData/helpers";
+import { AUDITOR } from "@src/utils/deploymentData/v1beta3";
+
+type ScreeningRequest = NonNullable<paths["/v1/bid-screening"]["post"]["requestBody"]>["content"]["application/json"];
+
+export type ScreenedProvidersResponse = paths["/v1/bid-screening"]["post"]["responses"][200]["content"]["application/json"];
+
+export type ScreenedProvider = ScreenedProvidersResponse["providers"][number];
+
+interface UseScreenedProvidersInput {
+  sdl: string;
+  placementName: string;
+}
+
+interface UseScreenedProvidersResult {
+  providers: ScreenedProvider[];
+  isLoading: boolean;
+  isError: boolean;
+}
+
+/** Group name required by the request but irrelevant to catalog matching when no placement resolves. */
+const SCREENING_GROUP_NAME = "screening";
+
+/**
+ * Full audited catalog query, used before a deployment is configured (no SDL yet, mid-edit/invalid SDL,
+ * or no placement selected). The screening endpoint returns every audited provider for an empty resource spec.
+ */
+const EMPTY_CATALOG_REQUEST: ScreeningRequest = {
+  name: SCREENING_GROUP_NAME,
+  requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [] },
+  resources: []
+};
+
+/**
+ * Screens providers for the given placement's group spec. The marketplace is placement-scoped: it converts
+ * the current SDL to group specs and queries the one matching `placementName`. While the SDL is mid-edit or
+ * invalid it falls back to the full audited catalog (empty resource spec). Audited-only via signedBy.
+ */
+export function useScreenedProviders({ sdl, placementName }: UseScreenedProvidersInput): UseScreenedProvidersResult {
+  const { api } = useServices();
+  const request = useMemo(() => buildPlacementScreeningRequest(sdl, placementName) ?? EMPTY_CATALOG_REQUEST, [sdl, placementName]);
+  const query = api.v1.screenProviders.useQuery(request);
+
+  return {
+    providers: query.data?.providers ?? [],
+    isLoading: query.isLoading,
+    isError: query.isError
+  };
+}
+
+/**
+ * Converts the current SDL into a screening request for a single placement's group spec. Returns null
+ * when the SDL is incomplete/invalid (e.g. mid-edit) or the placement isn't in it yet, so the caller can
+ * fall back to the full catalog. `signedBy` forces audited-only screening; `attributes` are passed through
+ * from the placement and carry the `location-region` filter (and any other declared attribute). The proto
+ * JSON encodes resource values as base64 integer strings, which the screening endpoint accepts.
+ */
+export function buildPlacementScreeningRequest(sdl: string, placementName: string): ScreeningRequest | null {
+  if (!sdl) return null;
+
+  let groups: ReturnType<typeof DeploymentGroups>;
+  try {
+    groups = DeploymentGroups(sdl);
+  } catch {
+    return null;
+  }
+
+  const group = groups.find(candidate => candidate.name === placementName);
+  if (!group) return null;
+
+  const groupJson = GroupSpec.toJSON(group) as {
+    resources: ScreeningRequest["resources"];
+    requirements?: { attributes?: Array<{ key: string; value: string }> };
+  };
+
+  return {
+    name: placementName,
+    requirements: {
+      signedBy: { allOf: [AUDITOR] },
+      attributes: groupJson.requirements?.attributes ?? []
+    },
+    resources: groupJson.resources
+  };
+}

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
@@ -5,6 +5,7 @@ import { EndpointSchema, SdlBuilderFormValuesSchema, ServiceSchema } from "./sdl
 describe("ServiceSchema", () => {
   it("validates a minimal valid service", () => {
     const result = ServiceSchema.safeParse({
+      id: "svc-1",
       title: "web",
       image: "nginx:latest",
       profile: {
@@ -29,6 +30,7 @@ describe("SdlBuilderFormValuesSchema", () => {
       placements: [{ id: "p-1", name: "dcloud" }],
       services: [
         {
+          id: "svc-1",
           title: "web",
           image: "nginx:latest",
           profile: { cpu: 0.1, ram: 256, ramUnit: "Mi", storage: [{ size: 512, unit: "Mi" }] },
@@ -55,6 +57,7 @@ describe("SdlBuilderFormValuesSchema", () => {
       ],
       services: [
         {
+          id: "svc-1",
           title: "web",
           image: "nginx:latest",
           profile: { cpu: 0.1, ram: 256, ramUnit: "Mi", storage: [{ size: 512, unit: "Mi" }] },
@@ -74,6 +77,7 @@ describe("SdlBuilderFormValuesSchema", () => {
 
   it("rejects duplicate service titles", () => {
     const service = {
+      id: "svc-1",
       title: "web",
       image: "nginx:latest",
       profile: { cpu: 0.1, ram: 256, ramUnit: "Mi", storage: [{ size: 512, unit: "Mi" }] },
@@ -84,7 +88,7 @@ describe("SdlBuilderFormValuesSchema", () => {
     };
     const result = SdlBuilderFormValuesSchema.safeParse({
       placements: [{ id: "p-1", name: "dcloud" }],
-      services: [service, { ...service }]
+      services: [service, { ...service, id: "svc-2" }]
     });
 
     expect(result.success).toBe(false);
@@ -98,6 +102,7 @@ describe("SdlBuilderFormValuesSchema", () => {
       placements: [{ id: "p-1", name: "dcloud" }],
       services: [
         {
+          id: "svc-1",
           title: "web",
           image: "nginx:latest",
           profile: { cpu: 0.1, ram: 256, ramUnit: "Mi", storage: [{ size: 512, unit: "Mi" }] },
@@ -118,6 +123,7 @@ describe("SdlBuilderFormValuesSchema", () => {
       placements: [{ id: "p-1", name: "dcloud" }],
       services: [
         {
+          id: "svc-1",
           title: "web",
           image: "nginx:latest",
           profile: { cpu: 0.1, ram: 256, ramUnit: "Mi", storage: [{ size: 512, unit: "Mi" }] },
@@ -144,6 +150,7 @@ describe("SdlBuilderFormValuesSchema", () => {
       placements: [{ id: "p-1", name: "dcloud" }],
       services: [
         {
+          id: "svc-1",
           title: "web",
           image: "",
           profile: { cpu: 0.1, ram: 256, ramUnit: "Mi", storage: [{ size: 512, unit: "Mi" }] },

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -342,7 +342,7 @@ const validateStorageAmount = (value: number, storageUnit: string, serviceCount:
 
 export const ServiceSchema = z
   .object({
-    id: z.string().optional(),
+    id: z.string().min(1, { message: "Service id is required." }),
     title: z
       .string()
       .min(1, { message: "Service name is required." })

--- a/packages/console-api-types/src/operations.gen.ts
+++ b/packages/console-api-types/src/operations.gen.ts
@@ -19,6 +19,7 @@ export const operations = {
     createLease: { path: "/v1/leases", method: "post", operationId: "createLease", pathParams: [], queryParams: [], hasBody: true },
     listApiKeys: { path: "/v1/api-keys", method: "get", operationId: "listApiKeys", pathParams: [], queryParams: [], hasBody: false },
     listBids: { path: "/v1/bids", method: "get", operationId: "listBids", pathParams: [], queryParams: ["dseq"], hasBody: false },
+    screenProviders: { path: "/v1/bid-screening", method: "post", operationId: "screenProviders", pathParams: [], queryParams: [], hasBody: true },
     listGpuPrices: { path: "/v1/gpu-prices", method: "get", operationId: "listGpuPrices", pathParams: [], queryParams: [], hasBody: false },
     createAlert: { path: "/v1/alerts", method: "post", operationId: "createAlert", pathParams: [], queryParams: [], hasBody: true },
     listAlerts: {

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -6966,6 +6966,11 @@ export interface paths {
                  * @example 2026-01-01T00:00:00.000Z
                  */
                 createdAt: string;
+                /**
+                 * @description Provider region from the location-region attribute (signed preferred, else self-declared); null if unset
+                 * @example us-west
+                 */
+                location: string | null;
               }[];
             };
           };

--- a/packages/dev-config/.eslintrc.base.js
+++ b/packages/dev-config/.eslintrc.base.js
@@ -39,7 +39,7 @@ module.exports = {
       "error",
       {
         additionalVerbs: {
-          post: { collection: ["deposit"] },
+          post: { collection: ["deposit", "screen"] },
           delete: { single: ["close"] }
         }
       }


### PR DESCRIPTION
## Why

The Compute Marketplace pane on the Configure screen showed no providers. Users need to see audited providers screened against the selected placement's group spec so they can pick where to deploy.

Closes CON-421

## What

- Populate the Compute Marketplace pane with audited providers screened for the selected placement's group spec, and add service/placement selection in the deployment pane that drives it.
- Expose the `screenProviders` operationId on `POST /v1/bid-screening` and regenerate the typed `console-api-types` SDK (incl. the `location` response field).
- Validate (not transform) resource values in the api request schema so the proxy can forward them without a BigInt serialization error.
- Register the `screen` domain verb for the operation-id-format lint rule.
- Add `useScreenedProviders`: screens the selected placement's group spec (audited via `signedBy`, region via attributes), falling back to the full audited catalog (empty resources) when no placement/SDL is available.
- Add `MarketplaceProvidersTable` (Provider, Region, sortable; empty Cost column with an estimate tooltip) styled to the design system; host shown like the bid list via `getProviderNameFromUri`.
- Resolve the selected placement in the form and pass it to the marketplace.
- Select a placement by clicking it (focuses its first service); add a default service when adding a placement; track selected service/placement state.

<img width="1239" height="634" alt="image" src="https://github.com/user-attachments/assets/06cfcf0a-4c52-4f17-a07f-09dd8e6beeb2" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added marketplace provider screening interface with sortable provider table
  * Provider location information now displayed in screening results
  * Enhanced service and placement selection workflow in deployment configuration

* **Bug Fixes**
  * Improved service selection validation and flow consistency
<!-- end of auto-generated comment: release notes by coderabbit.ai -->