### PR TITLE
fix(managed-wallet): stop trial-GPU warning snackbar from crashing the page

### DIFF
--- a/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.spec.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.spec.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+import { UrlService } from "@src/utils/urlUtils";
+import { AddCreditsSnackbarContent } from "./useSignAndBroadcast";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
+
+describe("AddCreditsSnackbarContent", () => {
+  // notistack renders snackbars in a portal mounted outside PopupProvider. Rendering this content
+  // without a PopupProvider reproduces that portal context: if it reached usePopup() (via AddFundsLink),
+  // it would throw "usePopup must be used within a PopupProvider" and crash the page instead of showing
+  // the trial-GPU warning. A plain next/link Link keeps the snackbar self-contained.
+  it("renders the Add Funds link without a PopupProvider in the tree", () => {
+    setup();
+
+    const link = screen.getByRole("link", { name: "Add Funds" });
+
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", UrlService.billing({ openPayment: true }));
+  });
+
+  it("renders the message when provided", () => {
+    setup({ message: "Add funds to unlock GPU access" });
+
+    expect(screen.getByText("Add funds to unlock GPU access")).toBeInTheDocument();
+  });
+
+  it("tracks analytics and calls onAction when the link is clicked", () => {
+    const onAction = vi.fn();
+    const { analyticsService } = setup({ onAction });
+
+    fireEvent.click(screen.getByRole("link", { name: "Add Funds" }));
+
+    expect(analyticsService.track).toHaveBeenCalledWith("add_funds_btn_clk");
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  function setup(input?: { message?: string; onAction?: () => void }) {
+    const analyticsService = mock<AnalyticsService>();
+    render(
+      <TestContainerProvider services={{ analyticsService: () => analyticsService }}>
+        <AddCreditsSnackbarContent message={input?.message} onAction={input?.onAction} />
+      </TestContainerProvider>
+    );
+    return { analyticsService, ...input };
+  }
+});

--- a/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/useSignAndBroadcast.tsx
@@ -3,10 +3,10 @@ import React, { useState } from "react";
 import { buttonVariants, Snackbar } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import type { EncodeObject } from "@cosmjs/proto-signing";
+import Link from "next/link";
 import { useSnackbar } from "notistack";
 
 import type { LoadingState } from "@src/components/layout/TransactionModal";
-import { AddFundsLink } from "@src/components/user/AddFundsLink";
 import { useNotificator } from "@src/hooks/useNotificator";
 import { useUser } from "@src/hooks/useUser";
 import { UrlService } from "@src/utils/urlUtils";
@@ -58,15 +58,24 @@ export function useSignAndBroadcast({ refetchBalances }: UseSignAndBroadcastInpu
   return { signAndBroadcastTx, loadingState };
 }
 
-const AddCreditsSnackbarContent: React.FC<{ message?: string; onAction?: () => void }> = ({ message, onAction }) => (
-  <>
-    {message && <div>{message}</div>}
-    <AddFundsLink
-      href={UrlService.billing({ openPayment: true })}
-      className={cn("mt-2 inline-flex h-7 items-center px-3 text-xs", buttonVariants({ variant: "default" }))}
-      onClick={onAction}
-    >
-      Add Funds
-    </AddFundsLink>
-  </>
-);
+// Rendered inside the notistack snackbar portal, which mounts outside PopupProvider. Use a plain
+// next/link Link (not AddFundsLink, which calls usePopup() via the email-verification hook and would
+// throw here); the billing page itself handles login/verification gating.
+export const AddCreditsSnackbarContent: React.FC<{ message?: string; onAction?: () => void }> = ({ message, onAction }) => {
+  const { analyticsService } = useServices();
+  return (
+    <>
+      {message && <div>{message}</div>}
+      <Link
+        href={UrlService.billing({ openPayment: true })}
+        className={cn("mt-2 inline-flex h-7 items-center px-3 text-xs", buttonVariants({ variant: "default" }))}
+        onClick={() => {
+          analyticsService.track("add_funds_btn_clk");
+          onAction?.();
+        }}
+      >
+        Add Funds
+      </Link>
+    </>
+  );
+};


### PR DESCRIPTION
## Why

Blocking high-end GPUs for managed-wallet trial accounts (#3198) introduced a regression: when a trial user tries to deploy with a blocked GPU, the API returns `402 Payment Required`, and the page **crashes into the error boundary** instead of showing the intended "Add Funds" warning snackbar.

The 402 handler renders `AddCreditsSnackbarContent` inside the notistack snackbar portal, which mounts **outside** `PopupProvider` (see `_app.tsx`). That content was rendering the shared `AddFundsLink`, which transitively calls `usePopup()` (via the email-verification hook). With no `PopupProvider` in the portal subtree, `usePopup()` throws `"usePopup must be used within a PopupProvider"`.

```
The above error occurred in the <AddFundsLink> component:
    at AddFundsLink (.../AddFundsLink.tsx)
    at AddCreditsSnackbarContent (.../useSignAndBroadcast.tsx)
    ...
    at SnackbarProvider (notistack)
    at CustomSnackbarProvider
```

PR #3198 originally fixed this exact crash with a plain `next/link` Link, but the wallet refactor in #3239/#3243 moved the code into `useSignAndBroadcast.tsx` and reintroduced `AddFundsLink`, bringing the crash back.

## What

- `useSignAndBroadcast.tsx`: restore the plain `next/link` Link with manual `add_funds_btn_clk` analytics tracking, so nothing in the snackbar tree reaches `usePopup()`. `useServices()` is safe there (resolves from `RootContainerProvider` at the top of the tree). Login/verification gating is handled by the billing page itself. Export `AddCreditsSnackbarContent` for testing.
- Add `useSignAndBroadcast.spec.tsx`: regression test rendering `AddCreditsSnackbarContent` **without** a `PopupProvider` (reproducing the portal context). Asserts it renders the Add Funds link to the billing URL and fires analytics + `onAction` on click. Throws on the old code, passes on the fix.

Verification: `npm run test:unit -- useSignAndBroadcast` (3 passed), `npm run lint -- --quiet` (clean), `npx tsc --noEmit` (no new errors).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the Add Credits component.

* **Refactor**
  * Updated the Add Credits component with improved link handling and integrated analytics tracking for user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->