### PR TITLE
feat(billing): allow removing payment methods during trial

### DIFF
--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -280,10 +280,33 @@ describe(StripeController.name, () => {
     });
   });
 
+  describe("removePaymentMethod", () => {
+    it("detaches the payment method without checking trial status", async () => {
+      const { controller, stripe, userWalletRepository, user } = setup();
+      const paymentMethodId = faker.string.uuid();
+      stripe.paymentMethods.retrieve.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: user.stripeCustomerId }));
+
+      await controller.removePaymentMethod(paymentMethodId);
+
+      expect(stripe.paymentMethods.detach).toHaveBeenCalledWith(paymentMethodId);
+      expect(userWalletRepository.findOneByUserId).not.toHaveBeenCalled();
+    });
+
+    it("rejects when the payment method does not belong to the user", async () => {
+      const { controller, stripe } = setup();
+      const paymentMethodId = faker.string.uuid();
+      stripe.paymentMethods.retrieve.mockResolvedValue(mock<Stripe.Response<Stripe.PaymentMethod>>({ customer: "cus_someoneelse" }));
+
+      await expect(controller.removePaymentMethod(paymentMethodId)).rejects.toMatchObject({ status: 403 });
+      expect(stripe.paymentMethods.detach).not.toHaveBeenCalled();
+    });
+  });
+
   function setup() {
     const user = createUser();
     const payingUser: PayingUser = { ...user, stripeCustomerId: user.stripeCustomerId! };
     const stripe = mock<StripeService>();
+    stripe.paymentMethods = mock<Stripe.PaymentMethodsResource>();
     const authService = mock<AuthService>({
       currentUser: user
     });

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.ts
@@ -176,10 +176,7 @@ export class StripeController {
   async removePaymentMethod(paymentMethodId: string): Promise<void> {
     const { currentUser } = this.authService;
 
-    const userWallet = await this.userWalletRepository.findOneByUserId(currentUser.id);
-
     assert(currentUser.stripeCustomerId, 500, "Payment account not properly configured. Please contact support.");
-    assert(!(userWallet && userWallet.isTrialing), 403, "Cannot remove payment method during trial. Please contact support.");
 
     try {
       // Verify payment method ownership

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.spec.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { PaymentMethod, SetupIntentResponse } from "@akashnetwork/http-sdk";
 import { describe, expect, it, type MockedFunction, vi } from "vitest";
 
-import type { useWallet } from "@src/context/WalletProvider";
 import type { usePaymentMethodsQuery, usePaymentMutations, useSetupIntentMutation, useWalletSettingsQuery } from "@src/queries";
 import type { PaymentMethodsViewProps } from "../PaymentMethodsView/PaymentMethodsView";
 import { PaymentMethodsContainer } from "./PaymentMethodsContainer";
@@ -152,16 +151,6 @@ describe(PaymentMethodsContainer.name, () => {
     expect(child.isInProgress).toBe(true);
   });
 
-  it("passes isTrialing as false when wallet is not trialing", async () => {
-    const { child } = await setup({ isTrialing: false });
-    expect(child.isTrialing).toBe(false);
-  });
-
-  it("passes isTrialing as true when wallet is trialing", async () => {
-    const { child } = await setup({ isTrialing: true });
-    expect(child.isTrialing).toBe(true);
-  });
-
   it("passes isAutoReloadEnabled as false when wallet settings have auto-reload disabled", async () => {
     const { child } = await setup({ autoReloadEnabled: false });
     expect(child.isAutoReloadEnabled).toBe(false);
@@ -190,7 +179,6 @@ describe(PaymentMethodsContainer.name, () => {
       isSetPaymentMethodAsDefaultPending: boolean;
       isRemovePaymentMethodPending: boolean;
       setupIntent: SetupIntentResponse;
-      isTrialing: boolean;
       autoReloadEnabled: boolean;
       isWalletSettingsLoading: boolean;
     }> = {}
@@ -233,10 +221,6 @@ describe(PaymentMethodsContainer.name, () => {
       reset: mockResetSetupIntent
     })) as unknown as MockedFunction<typeof useSetupIntentMutation>;
 
-    const mockedUseWallet = vi.fn(() => ({
-      isTrialing: overrides.isTrialing ?? false
-    })) as unknown as MockedFunction<typeof useWallet>;
-
     const walletSettingsData = Object.prototype.hasOwnProperty.call(overrides, "autoReloadEnabled")
       ? { autoReloadEnabled: overrides.autoReloadEnabled! }
       : undefined;
@@ -250,7 +234,6 @@ describe(PaymentMethodsContainer.name, () => {
       usePaymentMethodsQuery: mockedUsePaymentMethodsQuery,
       usePaymentMutations: mockedUsePaymentMutations,
       useSetupIntentMutation: mockedUseSetupIntentMutation,
-      useWallet: mockedUseWallet,
       useWalletSettingsQuery: mockedUseWalletSettingsQuery
     };
 

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsContainer/PaymentMethodsContainer.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState } from "react";
 
-import { useWallet } from "@src/context/WalletProvider";
 import { usePaymentMethodsQuery, usePaymentMutations, useSetupIntentMutation, useWalletSettingsQuery } from "@src/queries";
 import type { PaymentMethodsViewProps } from "../PaymentMethodsView/PaymentMethodsView";
 
@@ -8,7 +7,6 @@ const DEPENDENCIES = {
   usePaymentMethodsQuery,
   usePaymentMutations,
   useSetupIntentMutation,
-  useWallet,
   useWalletSettingsQuery
 };
 
@@ -24,7 +22,6 @@ export const PaymentMethodsContainer: React.FC<PaymentMethodsContainerProps> = (
     refetch: refetchPaymentMethods,
     isRefetching: isRefetchingPaymentMethods
   } = d.usePaymentMethodsQuery();
-  const { isTrialing } = d.useWallet();
   const { data: walletSettings, isLoading: isWalletSettingsLoading } = d.useWalletSettingsQuery();
   const isAutoReloadEnabled = walletSettings?.autoReloadEnabled ?? isWalletSettingsLoading;
   const paymentMutations = d.usePaymentMutations();
@@ -75,7 +72,6 @@ export const PaymentMethodsContainer: React.FC<PaymentMethodsContainerProps> = (
         setupIntent,
         onAddCardSuccess,
         isInProgress,
-        isTrialing,
         isAutoReloadEnabled
       })}
     </>

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.spec.tsx
@@ -153,44 +153,22 @@ describe(PaymentMethodsRow.name, () => {
       expect(button).toBeInTheDocument();
     });
 
-    it("renders dropdown menu button for the only payment method when not trialing", () => {
+    it("renders dropdown menu button for the only payment method", () => {
       setup({
-        hasOtherPaymentMethods: false,
-        isTrialing: false
+        hasOtherPaymentMethods: false
       });
 
       expect(screen.getByRole("button")).toBeInTheDocument();
     });
 
-    it("does not render dropdown menu button when hasOtherPaymentMethods is false and trialing", () => {
-      setup({
-        hasOtherPaymentMethods: false,
-        isTrialing: true
-      });
-
-      expect(screen.queryByRole("button")).not.toBeInTheDocument();
-    });
-
-    it("renders dropdown menu button for default payment method when not trialing", () => {
+    it("renders dropdown menu button for default payment method", () => {
       setup({
         paymentMethod: createMockPaymentMethod({
           isDefault: true
-        }),
-        isTrialing: false
+        })
       });
 
       expect(screen.getByRole("button")).toBeInTheDocument();
-    });
-
-    it("does not render dropdown menu button when payment method is default and trialing", () => {
-      setup({
-        paymentMethod: createMockPaymentMethod({
-          isDefault: true
-        }),
-        isTrialing: true
-      });
-
-      expect(screen.queryByRole("button")).not.toBeInTheDocument();
     });
   });
 
@@ -229,12 +207,11 @@ describe(PaymentMethodsRow.name, () => {
       });
     });
 
-    it("shows only 'Remove' for default payment method when not trialing", async () => {
+    it("shows only 'Remove' for default payment method", async () => {
       const user = userEvent.setup();
       setup({
         paymentMethod: createMockPaymentMethod({ isDefault: true }),
-        hasOtherPaymentMethods: true,
-        isTrialing: false
+        hasOtherPaymentMethods: true
       });
 
       const button = screen.getByRole("button");
@@ -246,12 +223,11 @@ describe(PaymentMethodsRow.name, () => {
       });
     });
 
-    it("shows only 'Remove' for the only payment method when not trialing", async () => {
+    it("shows only 'Remove' for the only payment method", async () => {
       const user = userEvent.setup();
       setup({
         paymentMethod: createMockPaymentMethod({ isDefault: true }),
-        hasOtherPaymentMethods: false,
-        isTrialing: false
+        hasOtherPaymentMethods: false
       });
 
       const button = screen.getByRole("button");
@@ -267,7 +243,6 @@ describe(PaymentMethodsRow.name, () => {
       setup({
         paymentMethod: createMockPaymentMethod({ isDefault: true }),
         hasOtherPaymentMethods: true,
-        isTrialing: false,
         isAutoReloadEnabled: true
       });
 
@@ -279,7 +254,6 @@ describe(PaymentMethodsRow.name, () => {
       setup({
         paymentMethod: createMockPaymentMethod({ isDefault: false }),
         hasOtherPaymentMethods: true,
-        isTrialing: false,
         isAutoReloadEnabled: true
       });
 
@@ -288,23 +262,6 @@ describe(PaymentMethodsRow.name, () => {
 
       await vi.waitFor(() => {
         expect(screen.getByText("Remove")).toBeInTheDocument();
-      });
-    });
-
-    it("shows only 'Set as default' for non-default payment method when trialing with other methods", async () => {
-      const user = userEvent.setup();
-      setup({
-        paymentMethod: createMockPaymentMethod({ isDefault: false }),
-        hasOtherPaymentMethods: true,
-        isTrialing: true
-      });
-
-      const button = screen.getByRole("button");
-      await user.click(button);
-
-      await vi.waitFor(() => {
-        expect(screen.getByText("Set as default")).toBeInTheDocument();
-        expect(screen.queryByText("Remove")).not.toBeInTheDocument();
       });
     });
   });
@@ -493,7 +450,6 @@ describe(PaymentMethodsRow.name, () => {
                 onSetPaymentMethodAsDefault={vi.fn()}
                 onRemovePaymentMethod={vi.fn()}
                 hasOtherPaymentMethods={true}
-                isTrialing={false}
                 isAutoReloadEnabled={false}
                 dependencies={mockDependencies}
               />
@@ -526,7 +482,6 @@ function setup(
     onSetPaymentMethodAsDefault?: Mock;
     onRemovePaymentMethod?: Mock;
     hasOtherPaymentMethods?: boolean;
-    isTrialing?: boolean;
     isAutoReloadEnabled?: boolean;
     dependencies?: typeof mockDependencies;
   } = {}
@@ -536,7 +491,6 @@ function setup(
     onSetPaymentMethodAsDefault: vi.fn(),
     onRemovePaymentMethod: vi.fn(),
     hasOtherPaymentMethods: true,
-    isTrialing: false,
     isAutoReloadEnabled: false,
     dependencies: mockDependencies
   };

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsRow.tsx
@@ -23,7 +23,6 @@ export type PaymentMethodsRowProps = {
   onSetPaymentMethodAsDefault: (id: string) => void;
   onRemovePaymentMethod: (id: string) => void;
   hasOtherPaymentMethods: boolean;
-  isTrialing: boolean;
   isAutoReloadEnabled: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
@@ -33,7 +32,6 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
   onSetPaymentMethodAsDefault,
   onRemovePaymentMethod,
   hasOtherPaymentMethods,
-  isTrialing,
   isAutoReloadEnabled,
   dependencies: d = DEPENDENCIES
 }) => {
@@ -102,7 +100,7 @@ export const PaymentMethodsRow: React.FC<PaymentMethodsRowProps> = ({
 
   const canSetAsDefault = !paymentMethod.isDefault && hasOtherPaymentMethods;
   const isDefaultBlockedByAutoReload = paymentMethod.isDefault && isAutoReloadEnabled;
-  const canRemove = !isDefaultBlockedByAutoReload && !isTrialing;
+  const canRemove = !isDefaultBlockedByAutoReload;
   const showActions = canSetAsDefault || canRemove;
 
   return (

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.spec.tsx
@@ -18,19 +18,12 @@ const mockUseTheme = vi.fn(() => ({
   systemTheme: "light" as "light" | "dark" | undefined
 }));
 
-const MockPaymentMethodsRow = ({
-  paymentMethod,
-  onSetPaymentMethodAsDefault,
-  onRemovePaymentMethod,
-  hasOtherPaymentMethods,
-  isTrialing,
-  isAutoReloadEnabled
-}: PaymentMethodsRowProps) => (
-  <tr data-testid={`payment-method-row-${paymentMethod.id}`} data-is-trialing={isTrialing} data-auto-reload={isAutoReloadEnabled}>
+const MockPaymentMethodsRow = ({ paymentMethod, onSetPaymentMethodAsDefault, onRemovePaymentMethod, isAutoReloadEnabled }: PaymentMethodsRowProps) => (
+  <tr data-testid={`payment-method-row-${paymentMethod.id}`} data-auto-reload={isAutoReloadEnabled}>
     <td>
       <span>{paymentMethod.card?.last4}</span>
       <button onClick={() => onSetPaymentMethodAsDefault(paymentMethod.id)}>Set as Default</button>
-      {(hasOtherPaymentMethods || !isTrialing) && <button onClick={() => onRemovePaymentMethod(paymentMethod.id)}>Remove</button>}
+      <button onClick={() => onRemovePaymentMethod(paymentMethod.id)}>Remove</button>
     </td>
   </tr>
 );
@@ -152,17 +145,9 @@ describe(PaymentMethodsView.name, () => {
       expect(row2.textContent).toContain("Remove");
     });
 
-    it("hides Remove for only payment method when trialing", () => {
+    it("shows Remove for only payment method", () => {
       const paymentMethods = [createMockPaymentMethods()[0]];
-      setup({ data: paymentMethods, isTrialing: true });
-
-      const row = screen.getByTestId("payment-method-row-pm_123");
-      expect(row.textContent).not.toContain("Remove");
-    });
-
-    it("shows Remove for only payment method when not trialing", () => {
-      const paymentMethods = [createMockPaymentMethods()[0]];
-      setup({ data: paymentMethods, isTrialing: false });
+      setup({ data: paymentMethods });
 
       const row = screen.getByTestId("payment-method-row-pm_123");
       expect(row.textContent).toContain("Remove");
@@ -420,7 +405,6 @@ function setup(
     setupIntent?: SetupIntentResponse;
     onAddCardSuccess?: Mock;
     isInProgress?: boolean;
-    isTrialing?: boolean;
     isAutoReloadEnabled?: boolean;
     dependencies?: typeof DEPENDENCIES;
   } = {}
@@ -436,7 +420,6 @@ function setup(
     setupIntent: undefined,
     onAddCardSuccess: vi.fn(),
     isInProgress: false,
-    isTrialing: false,
     isAutoReloadEnabled: false,
     dependencies: mockDependencies
   };

--- a/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentMethodsView/PaymentMethodsView.tsx
@@ -34,7 +34,6 @@ export type PaymentMethodsViewProps = {
   setupIntent: SetupIntentResponse | undefined;
   onAddCardSuccess: () => void;
   isInProgress: boolean;
-  isTrialing: boolean;
   isAutoReloadEnabled: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
@@ -50,7 +49,6 @@ export const PaymentMethodsView: React.FC<PaymentMethodsViewProps> = ({
   setupIntent,
   onAddCardSuccess,
   isInProgress,
-  isTrialing,
   isAutoReloadEnabled,
   dependencies: d = DEPENDENCIES
 }) => {
@@ -86,7 +84,6 @@ export const PaymentMethodsView: React.FC<PaymentMethodsViewProps> = ({
                       onSetPaymentMethodAsDefault={onSetPaymentMethodAsDefault}
                       onRemovePaymentMethod={onRemovePaymentMethod}
                       hasOtherPaymentMethods={data.length > 1}
-                      isTrialing={isTrialing}
                       isAutoReloadEnabled={isAutoReloadEnabled}
                     />
                   ))}

--- a/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.spec.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.spec.tsx
@@ -98,16 +98,10 @@ describe(PaymentMethodCard.name, () => {
       expect(onSelect).toHaveBeenCalledWith("pm_click");
     });
 
-    it("renders Remove button when not trialing", () => {
-      const { dependencies } = setup({ isSelectable: true, isTrialing: false });
+    it("renders Remove button in selectable mode", () => {
+      const { dependencies } = setup({ isSelectable: true });
 
       expect((dependencies.Button as Mock).mock.calls.length).toBeGreaterThan(0);
-    });
-
-    it("does not render Remove button when trialing", () => {
-      const { dependencies } = setup({ isSelectable: true, isTrialing: true });
-
-      expect((dependencies.Button as Mock).mock.calls.length).toBe(0);
     });
 
     it("does not show expiry for link methods", () => {
@@ -140,7 +134,6 @@ describe(PaymentMethodCard.name, () => {
       isSelected?: boolean;
       onSelect?: Mock;
       showValidationBadge?: boolean;
-      isTrialing?: boolean;
     } = {}
   ) {
     const dependencies = MockComponents(DEPENDENCIES);

--- a/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.spec.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.spec.tsx
@@ -99,9 +99,9 @@ describe(PaymentMethodCard.name, () => {
     });
 
     it("renders Remove button in selectable mode", () => {
-      const { dependencies } = setup({ isSelectable: true });
+      setup({ isSelectable: true });
 
-      expect((dependencies.Button as Mock).mock.calls.length).toBeGreaterThan(0);
+      expect(screen.getByText("Remove")).toBeInTheDocument();
     });
 
     it("does not show expiry for link methods", () => {

--- a/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodCard/PaymentMethodCard.tsx
@@ -48,7 +48,6 @@ interface PaymentMethodCardProps {
   isSelected?: boolean;
   onSelect?: (paymentMethodId: string) => void;
   showValidationBadge?: boolean;
-  isTrialing?: boolean;
   dependencies?: typeof DEPENDENCIES;
 }
 
@@ -60,7 +59,6 @@ export const PaymentMethodCard: React.FC<PaymentMethodCardProps> = ({
   isSelected = false,
   onSelect,
   showValidationBadge = true,
-  isTrialing = false,
   dependencies: d = DEPENDENCIES
 }) => {
   const handleCardClick = () => {
@@ -94,11 +92,9 @@ export const PaymentMethodCard: React.FC<PaymentMethodCardProps> = ({
             </div>
           </div>
         </div>
-        {!isTrialing && (
-          <d.Button variant="ghost" size="sm" onClick={handleRemoveClick} disabled={isRemoving}>
-            Remove
-          </d.Button>
-        )}
+        <d.Button variant="ghost" size="sm" onClick={handleRemoveClick} disabled={isRemoving}>
+          Remove
+        </d.Button>
       </div>
     );
   }

--- a/apps/deploy-web/src/components/shared/PaymentMethodsList/PaymentMethodsList.tsx
+++ b/apps/deploy-web/src/components/shared/PaymentMethodsList/PaymentMethodsList.tsx
@@ -14,7 +14,6 @@ interface PaymentMethodsListProps {
   onPaymentMethodSelect?: (id: string) => void;
   // Display mode props
   showValidationBadge?: boolean;
-  isTrialing?: boolean;
 }
 
 export const PaymentMethodsList: React.FC<PaymentMethodsListProps> = ({
@@ -24,8 +23,7 @@ export const PaymentMethodsList: React.FC<PaymentMethodsListProps> = ({
   isSelectable = false,
   selectedPaymentMethodId,
   onPaymentMethodSelect,
-  showValidationBadge = true,
-  isTrialing = false
+  showValidationBadge = true
 }) => {
   if (paymentMethods.length === 0) {
     return <p className="text-gray-500">No payment methods added yet.</p>;
@@ -47,7 +45,6 @@ export const PaymentMethodsList: React.FC<PaymentMethodsListProps> = ({
                   isSelectable={true}
                   isSelected={selectedPaymentMethodId === method.id}
                   onSelect={onPaymentMethodSelect}
-                  isTrialing={isTrialing}
                 />
               ))}
             </RadioGroup>


### PR DESCRIPTION
## Why

Users could not remove a saved payment method while their wallet was in trial (`isTrialing = true`). The backend returned `403 "Cannot remove payment method during trial. Please contact support."` and the UI hid the **Remove** action entirely. This forced trialing users to contact support for a routine self-service action. We want payment-method removal to be available at all times, with no restrictions.

## What

Removes the trial gate on payment-method removal across backend and frontend.

**Backend** — `apps/api`
- `StripeController.removePaymentMethod`: dropped the `403` trial assertion and the now-unused `userWallet` lookup. Ownership verification and Stripe detach are unchanged.
- Added a `removePaymentMethod` spec: detaches without checking trial status / without hitting the wallet repo, and still rejects payment methods that don't belong to the user.

**Frontend** — `apps/deploy-web`
- Billing page (`PaymentMethodsRow` / `PaymentMethodsView` / `PaymentMethodsContainer`): `canRemove` no longer depends on `isTrialing`; removed the `isTrialing` prop threading (and the now-unused `useWallet` dependency in the container).
- Shared `PaymentMethodCard` / `PaymentMethodsList`: removed the `{!isTrialing && <Remove>}` gate and the `isTrialing` prop so this surface is consistent (selectable mode is not yet wired into a production page, but the restriction is gone everywhere).
- Specs updated accordingly.

The default-payment-method-while-auto-reload-enabled guard (`isDefaultBlockedByAutoReload`) is a separate rule and is intentionally kept.

### Verification
- `apps/api`: `npm test -- stripe.controller` → 13 passed
- `apps/deploy-web`: `npm run test:unit -- PaymentMethod` → 117 passed
- Lint clean on all touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payment method removal is no longer blocked during trial periods — users can remove cards regardless of trial status.
* **UI Changes**
  * “Remove” is now consistently shown in selection mode and across payment method lists/rows where applicable.
* **Tests**
  * Updated and expanded tests to cover removal behavior and ownership/authorization checks for payment methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->