### PR TITLE
refactor(billing): remove oracle V1 fallback from denom exchange

### DIFF
--- a/apps/api/src/chain/services/denom-exchange/denom-exchange.service.spec.ts
+++ b/apps/api/src/chain/services/denom-exchange/denom-exchange.service.spec.ts
@@ -65,63 +65,22 @@ describe(DenomExchangeService.name, () => {
     });
 
     it("keeps the V2 price when the 24h history query fails", async () => {
-      const { service, getAggregatedPriceV1, getLatestBlock, logger } = setup({ v2HistoryThrows: true });
+      const { service, logger } = setup({ v2HistoryThrows: true });
 
       const result = await service.getExchangeRateToUSD("akt");
 
       expect(result.price).toBe(0.56);
       expect(result.priceChange24h).toBe(0);
       expect(result.priceChangePercentage24).toBe(0);
-      expect(getAggregatedPriceV1).not.toHaveBeenCalled();
-      expect(getLatestBlock).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "ORACLE_V2_PRICE_HISTORY_UNAVAILABLE" }));
     });
 
-    it("falls back to V1 when the V2 query service is unavailable", async () => {
-      const { service, getAggregatedPriceV2, getAggregatedPriceV1, getPricesV1, logger } = setup({ v2Unavailable: true, currentHeight: 100000n });
-
-      const result = await service.getExchangeRateToUSD("akt");
-
-      expect(getAggregatedPriceV2).toHaveBeenCalled();
-      expect(getAggregatedPriceV1).toHaveBeenCalled();
-      expect(getPricesV1).toHaveBeenCalledWith(
-        expect.objectContaining({
-          filters: expect.objectContaining({ height: 100000n - (24n * 60n * 60n) / 6n })
-        })
-      );
-      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "ORACLE_V2_UNAVAILABLE_FALLBACK_V1" }));
-      expect(result.price).toBe(0.56);
-    });
-
-    it("does not fall back to V1 on a non-Unimplemented V2 error", async () => {
-      const { service, getAggregatedPriceV1, getLatestBlock, dayRepository, logger } = setup({ v2TransientError: true, latestAktPrice: 1.5 });
-
-      const result = await service.getExchangeRateToUSD("akt");
-
-      expect(getAggregatedPriceV1).not.toHaveBeenCalled();
-      expect(getLatestBlock).not.toHaveBeenCalled();
-      expect(dayRepository.getLatestAktPrice).toHaveBeenCalled();
-      expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "ORACLE_RPC_FAILED" }));
-      expect(result.price).toBe(1.5);
-    });
-
-    it("caches the V2-unavailable decision and skips V2 on subsequent calls", async () => {
-      const { service, getAggregatedPriceV2, getAggregatedPriceV1 } = setup({ v2Unavailable: true });
-
-      await service.getExchangeRateToUSD("akt");
-      await service.getExchangeRateToUSD("akash-network");
-
-      expect(getAggregatedPriceV2).toHaveBeenCalledTimes(1);
-      expect(getAggregatedPriceV1).toHaveBeenCalledTimes(2);
-    });
-
     it("falls back to DB price when oracle reports unhealthy", async () => {
-      const { service, dayRepository, logger, getAggregatedPriceV1 } = setup({ isHealthy: false, latestAktPrice: 1.23 });
+      const { service, dayRepository, logger } = setup({ isHealthy: false, latestAktPrice: 1.23 });
 
       const result = await service.getExchangeRateToUSD("akt");
 
       expect(dayRepository.getLatestAktPrice).toHaveBeenCalled();
-      expect(getAggregatedPriceV1).not.toHaveBeenCalled();
       expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "ORACLE_PRICE_UNHEALTHY" }));
       expect(result).toEqual({
         price: 1.23,
@@ -133,7 +92,7 @@ describe(DenomExchangeService.name, () => {
       });
     });
 
-    it("falls back to DB price when both oracle versions fail", async () => {
+    it("falls back to DB price when the oracle fails", async () => {
       const { service, dayRepository, logger } = setup({ oracleThrows: true, latestAktPrice: 0.99 });
 
       const result = await service.getExchangeRateToUSD("akt");
@@ -168,19 +127,13 @@ describe(DenomExchangeService.name, () => {
   });
 
   function setup(input: {
-    currentHeight?: bigint;
     historicalPrice?: string;
     emptyHistoricalPrices?: boolean;
     isHealthy?: boolean;
     oracleThrows?: boolean;
-    v2Unavailable?: boolean;
-    v2TransientError?: boolean;
     v2HistoryThrows?: boolean;
     latestAktPrice?: number | null;
   }) {
-    const getLatestBlock = vi.fn().mockResolvedValue({
-      block: { header: { height: { toBigInt: () => input.currentHeight ?? 1000000n } } }
-    });
     const aggregatedPriceResponse = {
       aggregatedPrice: { medianPrice: "0.56" },
       priceHealth: { isHealthy: input.isHealthy ?? true }
@@ -191,32 +144,17 @@ describe(DenomExchangeService.name, () => {
 
     const getAggregatedPriceV2 = vi.fn().mockResolvedValue(aggregatedPriceResponse);
     const getPricesV2 = vi.fn().mockResolvedValue(pricesResponse);
-    const getAggregatedPriceV1 = vi.fn().mockResolvedValue(aggregatedPriceResponse);
-    const getPricesV1 = vi.fn().mockResolvedValue(pricesResponse);
 
-    if (input.v2Unavailable) {
-      // gRPC Unimplemented (HTTP 501): the node hasn't registered the V2 query service yet.
-      getAggregatedPriceV2.mockRejectedValue(makeTransportError(12));
-    }
-    if (input.v2TransientError) {
-      // Any non-Unimplemented V2 error must NOT trigger the V1 fallback.
-      getAggregatedPriceV2.mockRejectedValue(makeTransportError(14));
-    }
     if (input.v2HistoryThrows) {
       getPricesV2.mockRejectedValue(new Error("price history pruned"));
     }
     if (input.oracleThrows) {
-      // V2 is unimplemented (-> tries V1) and V1 also fails, so the service falls through to CoinGecko.
-      getAggregatedPriceV2.mockRejectedValue(makeTransportError(12));
-      getLatestBlock.mockRejectedValue(new Error("RPC connection refused"));
+      getAggregatedPriceV2.mockRejectedValue(new Error("RPC connection refused"));
     }
 
     const chainSdk = mockDeep<ChainSDK>();
-    chainSdk.cosmos.base.tendermint.v1beta1.getLatestBlock.mockImplementation(getLatestBlock);
     chainSdk.akash.oracle.v2.getAggregatedPrice.mockImplementation(getAggregatedPriceV2);
     chainSdk.akash.oracle.v2.getPrices.mockImplementation(getPricesV2);
-    chainSdk.akash.oracle.v1.getAggregatedPrice.mockImplementation(getAggregatedPriceV1);
-    chainSdk.akash.oracle.v1.getPrices.mockImplementation(getPricesV1);
 
     const dayRepository = mock<DayRepository>();
     dayRepository.getLatestAktPrice.mockResolvedValue("latestAktPrice" in input ? input.latestAktPrice! : 1.23);
@@ -225,11 +163,6 @@ describe(DenomExchangeService.name, () => {
 
     const service = new DenomExchangeService(chainSdk, dayRepository, logger);
 
-    return { service, getLatestBlock, getAggregatedPriceV2, getPricesV2, getAggregatedPriceV1, getPricesV1, dayRepository, logger };
-  }
-
-  // Mirrors a chain-sdk TransportError (gRPC code 12 = Unimplemented for an unregistered method).
-  function makeTransportError(code: number) {
-    return Object.assign(new Error(`transport error ${code}`), { name: "TransportError", code });
+    return { service, getAggregatedPriceV2, getPricesV2, dayRepository, logger };
   }
 });

--- a/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
+++ b/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
@@ -52,7 +52,8 @@ export class DenomExchangeService {
     { cacheItemLimit: 10, ttl: minutesToMilliseconds(10) }
   );
 
-  // Queries Oracle V2 only. Any failure propagates to the caller's CoinGecko/DB fallback.
+  // Queries Oracle V2 only. A failed aggregated-price query propagates to the caller's
+  // CoinGecko/DB fallback; a failed 24h-history query is swallowed (see below).
   async #fetchOracleRate(mappedDenom: string) {
     const endTime = new Date();
     // 23h, not 24h: V2 prunes to ~24h, so the exact-24h price may already be gone.

--- a/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
+++ b/apps/api/src/chain/services/denom-exchange/denom-exchange.service.ts
@@ -5,22 +5,12 @@ import { memoizeAsync } from "@src/caching/helpers";
 import { CHAIN_SDK, type ChainSDK } from "@src/chain/providers/chain-sdk.provider";
 import { LoggerService } from "@src/core/providers/logging.provider";
 import { DayRepository } from "@src/gpu/repositories/day.repository";
-import { averageBlockTime } from "@src/utils/constants";
-
-// gRPC "Unimplemented" code, returned for an unregistered query method (chain-sdk's TransportErrorCode isn't exported).
-const TRANSPORT_CODE_UNIMPLEMENTED = 12;
-
-function isOracleQueryUnimplemented(error: unknown): boolean {
-  return error instanceof Error && error.name === "TransportError" && (error as { code?: unknown }).code === TRANSPORT_CODE_UNIMPLEMENTED;
-}
 
 @singleton()
 export class DenomExchangeService {
   readonly #chainSdk: ChainSDK;
   readonly #dayRepository: DayRepository;
   readonly #logger: LoggerService;
-  // Goes false once V2 returns Unimplemented; we then skip V2 until the V1 fallback breaks.
-  #isOracleV2Available = true;
 
   constructor(@inject(CHAIN_SDK) chainSdk: ChainSDK, dayRepository: DayRepository, logger: LoggerService) {
     this.#chainSdk = chainSdk;
@@ -62,28 +52,8 @@ export class DenomExchangeService {
     { cacheItemLimit: 10, ttl: minutesToMilliseconds(10) }
   );
 
-  // Prefer V2; fall back to V1 only when V2 is unimplemented (pre-v2.1.0), caching that until V1
-  // breaks. Other V2 errors propagate to the caller's CoinGecko fallback.
+  // Queries Oracle V2 only. Any failure propagates to the caller's CoinGecko/DB fallback.
   async #fetchOracleRate(mappedDenom: string) {
-    if (this.#isOracleV2Available) {
-      try {
-        return await this.#fetchOracleRateV2(mappedDenom);
-      } catch (error) {
-        if (!isOracleQueryUnimplemented(error)) throw error;
-        this.#isOracleV2Available = false;
-        this.#logger.warn({ event: "ORACLE_V2_UNAVAILABLE_FALLBACK_V1", denom: mappedDenom });
-      }
-    }
-
-    try {
-      return await this.#fetchOracleRateV1(mappedDenom);
-    } catch (error) {
-      this.#isOracleV2Available = true;
-      throw error;
-    }
-  }
-
-  async #fetchOracleRateV2(mappedDenom: string) {
     const endTime = new Date();
     // 23h, not 24h: V2 prunes to ~24h, so the exact-24h price may already be gone.
     const startTime = subHours(endTime, 23);
@@ -99,21 +69,6 @@ export class DenomExchangeService {
           this.#logger.warn({ event: "ORACLE_V2_PRICE_HISTORY_UNAVAILABLE", denom: mappedDenom, error });
           return { prices: [] };
         })
-    ]);
-    return { oracleRate, rate24hAgo };
-  }
-
-  async #fetchOracleRateV1(mappedDenom: string) {
-    const latestBlock = await this.#chainSdk.cosmos.base.tendermint.v1beta1.getLatestBlock();
-    const currentHeight = latestBlock.block?.header?.height?.toBigInt() ?? 0n;
-    const blocksPerDay = (24n * 60n * 60n) / BigInt(Math.ceil(averageBlockTime));
-    const blockHeight24hAgo = currentHeight > blocksPerDay ? currentHeight - blocksPerDay : 1n;
-    const [oracleRate, rate24hAgo] = await Promise.all([
-      this.#chainSdk.akash.oracle.v1.getAggregatedPrice({ denom: mappedDenom }),
-      this.#chainSdk.akash.oracle.v1.getPrices({
-        filters: { assetDenom: mappedDenom, baseDenom: "usd", height: blockHeight24hAgo },
-        pagination: { limit: 1 }
-      })
     ]);
     return { oracleRate, rate24hAgo };
   }

--- a/apps/api/test/functional/market-data.spec.ts
+++ b/apps/api/test/functional/market-data.spec.ts
@@ -8,12 +8,7 @@ describe("Market Data", () => {
   beforeAll(async () => {
     const restApiNodeUrl = container.resolve(CORE_CONFIG).REST_API_NODE_URL;
 
-    nock(restApiNodeUrl)
-      .persist()
-      .get("/cosmos/base/tendermint/v1beta1/blocks/latest")
-      .reply(200, { block: { header: { height: "1000000" } } });
-
-    // DenomExchangeService queries oracle V2 first and only falls back to V1 when V2 is unimplemented.
+    // DenomExchangeService queries Oracle V2.
     nock(restApiNodeUrl)
       .persist()
       .get("/akash/oracle/v2/aggregated_price/akt")


### PR DESCRIPTION
## Why

Oracle V2 is stable in production following the v2.1.0 network upgrade (June 11), so the V1 fallback added during the V2 migration (#3268) is now dead code. This removes it so `DenomExchangeService` queries Oracle V2 only.

Resolves CON-438

## What

- **`denom-exchange.service.ts`**: removed the `#isOracleV2Available` flag, the V1/V2 dispatcher, `#fetchOracleRateV1`, the `isOracleQueryUnimplemented` helper, and the now-unused `averageBlockTime` import. The V2 fetch is renamed to `#fetchOracleRate`; any V2 failure still propagates to the existing CoinGecko/DB price fallback (`#getFallbackExchangeRateToUSD`) via the outer `catch`.
- **`denom-exchange.service.spec.ts`**: dropped the three V1-fallback tests, renamed "both oracle versions fail" → "the oracle fails", and simplified `setup` (removed V1 mocks, `getLatestBlock`, and `makeTransportError`).
- **`market-data.spec.ts`** (functional): removed the now-dead latest-block nock (only V1 needed block height) and updated the comment.

No env var or feature flag governed the fallback — it was purely code-based — so no config changes were needed. Consumers (`StatsService`, `MasterWalletMintService`) only call the public `getExchangeRateToUSD()` and are unaffected.

## Verification

- `npm run test:unit -- denom-exchange` — 8/8 pass
- `npm run lint --quiet` on changed files — clean
- `tsc` — no errors in changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated the denom exchange rate logic to query Oracle V2 exclusively. If Oracle V2 data (including 24h history) is unavailable, the service falls back to alternative sources as before, and the 24h change is handled accordingly.

* **Tests**
  * Revised unit and functional tests to match the Oracle V2–only behavior and the updated failure/coverage scenarios, including the warning emitted when 24h price history cannot be retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->