### PR TITLE
fix(bid): derive bid countdown from dseq timestamp

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/BidCountdownTimer.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/BidCountdownTimer.spec.tsx
@@ -1,0 +1,54 @@
+import { TooltipProvider } from "@akashnetwork/ui/components";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BidCountdownTimer } from "./BidCountdownTimer";
+
+import { render, screen } from "@testing-library/react";
+
+describe(BidCountdownTimer.name, () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the remaining time derived from the dseq timestamp", () => {
+    const now = new Date("2026-06-05T00:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const dseq = createdAgo(now, 60); // created 1 minute ago
+
+    setup({ dseq });
+
+    // 5min window - 60s elapsed + 20s buffer = 260s => 04:20
+    expect(screen.getByText("Time Remaining: 04:20")).toBeInTheDocument();
+  });
+
+  it("renders 'Time's up!' once the 5 minute bid window has elapsed", () => {
+    const now = new Date("2026-06-05T00:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    const dseq = createdAgo(now, 6 * 60); // created 6 minutes ago
+
+    setup({ dseq });
+
+    expect(screen.getByText("Time's up!")).toBeInTheDocument();
+  });
+
+  it("renders nothing when dseq is null", () => {
+    setup({ dseq: null });
+
+    expect(screen.queryByText(/Time Remaining/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Time's up!")).not.toBeInTheDocument();
+  });
+
+  function createdAgo(now: Date, seconds: number) {
+    return (now.getTime() - seconds * 1000).toString();
+  }
+
+  function setup(input: { dseq: string | null }) {
+    return render(
+      <TooltipProvider>
+        <BidCountdownTimer dseq={input.dseq} />
+      </TooltipProvider>
+    );
+  }
+});

--- a/apps/deploy-web/src/components/new-deployment/BidCountdownTimer.tsx
+++ b/apps/deploy-web/src/components/new-deployment/BidCountdownTimer.tsx
@@ -5,31 +5,26 @@ import { cn } from "@akashnetwork/ui/utils";
 import { differenceInSeconds } from "date-fns";
 import { InfoCircle } from "iconoir-react";
 
-import { useBlock } from "@src/queries/useBlocksQuery";
-
 type Props = {
-  height: string | null;
+  // The deployment dseq, which is a millisecond timestamp of the deployment creation time.
+  dseq: string | null;
 };
 
 // 5 minutes
 const time = 5 * 60;
 
-export const BidCountdownTimer: React.FunctionComponent<Props> = ({ height }) => {
+export const BidCountdownTimer: React.FunctionComponent<Props> = ({ dseq }) => {
   const [timeLeft, setTimeLeft] = useState(time); // Set the initial time in seconds
   const [isTimerInit, setIsTimerInit] = useState(false);
-  const { data: block, refetch: getBlock } = useBlock(height || "");
 
   useEffect(() => {
-    getBlock();
-  }, []);
-  useEffect(() => {
-    const date = block ? new Date(block.block.header.time) : new Date(0);
+    const date = dseq ? new Date(Number(dseq)) : new Date(0);
     const now = new Date();
     // add 20 seconds for the delay between deployment creation and bid creation
     const diff = Math.max(0, time - differenceInSeconds(now, date) + 20);
     setTimeLeft(diff);
-    setIsTimerInit(!!block);
-  }, [block]);
+    setIsTimerInit(!!dseq);
+  }, [dseq]);
 
   useEffect(() => {
     // Exit early when we reach 0
@@ -42,7 +37,7 @@ export const BidCountdownTimer: React.FunctionComponent<Props> = ({ height }) =>
 
     // Clear interval on unmount
     return () => clearInterval(intervalId);
-  }, [timeLeft, block]);
+  }, [timeLeft]);
 
   // Calculate the minutes and seconds
   const minutes = Math.floor(timeLeft / 60);

--- a/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
+++ b/apps/deploy-web/src/components/new-deployment/CreateLease/CreateLease.tsx
@@ -510,7 +510,7 @@ export const CreateLease: React.FunctionComponent<Props> = ({ dseq, dependencies
 
             {!isSendingManifest && (
               <div className="mt-2 flex items-center self-start sm:self-center md:ml-4 md:mt-0">
-                <d.BidCountdownTimer height={bids && bids?.length > 0 ? bids[0].dseq : null} />
+                <d.BidCountdownTimer dseq={bids && bids?.length > 0 ? bids[0].dseq : null} />
               </div>
             )}
 


### PR DESCRIPTION
## Why

Since the Console migration, the deployment **DSEQ** is no longer the current chain block height — it's a `Date.now()` millisecond timestamp (chosen to avoid collisions). But the bid countdown timer in the new-deployment flow still treated the DSEQ as a block height: it passed `bids[0].dseq` to `useBlock`, which fetched the chain block at that height. The timestamp is far larger than the chain length, so the node rejected it with:

> requested block height is bigger then the chain length

This surfaced as an error in the browser during the bid screen.

## What

The timer only fetched the block to read its `header.time` (the deployment creation time). The DSEQ **is** that creation timestamp now, so we derive the date directly from it and drop the block fetch entirely.

- `BidCountdownTimer`: removed `useBlock`/`getBlock`; prop renamed `height` → `dseq`; creation date now comes from `new Date(Number(dseq))`. The 5-minute window and `+20s` buffer are unchanged.
- `CreateLease`: updated the prop name to `dseq`.
- Added `BidCountdownTimer.spec.tsx` covering remaining-time rendering, the "Time's up!" state past 5 minutes, and the `null` (renders nothing) case.

`useBlock` stays in the codebase — it's still used legitimately with `"latest"` in `useRealTimeLeft` and `useTrialDeploymentTimeRemaining`, which read on-chain escrow block heights rather than the DSEQ.

### Verification
- `npm run test:unit -- BidCountdownTimer CreateLease` → 13 passed
- `npx tsc --noEmit` → no errors in changed files
- `npm run lint -- --quiet` on changed files → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for the bid countdown timer to validate time remaining calculations and edge cases.

* **Refactor**
  * Updated bid countdown timer to use deployment sequence timestamp for time calculations, improving accuracy and simplifying the calculation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->