### PR TITLE
fix: cleanup provider sdk on retry give up event

### DIFF
--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint .",
     "migration:exec": "node dist/db-migrate.js",
     "migration:gen": "drizzle-kit generate",
-    "prod": "node --permission --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --enable-source-maps --require ./dist/instrumentation.js ./dist/server.js",
+    "prod": "node --max-old-space-size=2300 --permission --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --heapsnapshot-near-heap-limit=2 --diagnostic-dir=/tmp --allow-fs-write=/tmp --enable-source-maps --require ./dist/instrumentation.js ./dist/server.js",
     "start": "tsup --watch",
     "test": "vitest run --project unit --project integration --project functional",
     "test:ci-setup": "dc up -d --wait --wait-timeout 60 db",

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -175,7 +175,11 @@ export class StreamLifecycleManagerService {
       onSettleAttempt();
       this.#lastInventoryPerProvider.delete(provider.owner);
       this.#onlineStatePerProvider.delete(provider.owner);
-      if (this.#activeStreams.get(provider.owner)?.controller.signal === signal) {
+      const activeStream = this.#activeStreams.get(provider.owner);
+      if (activeStream?.controller.signal === signal) {
+        this.#streamFactory.disposeProvider(activeStream.hostUri).catch(error => {
+          this.#logger.error({ event: "DISPOSE_STREAM_ERROR", owner: provider.owner, hostUri: activeStream.hostUri, error });
+        });
         this.#activeStreams.delete(provider.owner);
       }
     }


### PR DESCRIPTION
## Why

provider-inventory was restared once during the last 2 days because of OOM. this is an attempt to fix one a bit and add debugging details

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lifecycle handling for provider streams by ensuring the active stream is properly disposed during cleanup, with error logging if disposal fails.

* **Chores**
  * Updated production runtime configuration to improve performance and sandbox behavior, including increased memory limits, expanded file system read permissions, added temporary write access, and configured diagnostic output location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->