### PR TITLE
feat(auth): add CLI command to link Auth0 accounts

### DIFF
--- a/apps/api/src/app/console.ts
+++ b/apps/api/src/app/console.ts
@@ -7,6 +7,7 @@ import { Err } from "ts-results";
 import { container } from "tsyringe";
 import { z } from "zod";
 
+import { Auth0AccountLinkerService } from "@src/auth/services/auth0-account-linker/auth0-account-linker.service";
 import { MasterWalletMintController } from "@src/billing/controllers/master-wallet-mint/master-wallet-mint.controller";
 import { WalletController } from "@src/billing/controllers/wallet/wallet.controller";
 import { ExecutionContextService } from "@src/core/services/execution-context/execution-context.service";
@@ -77,6 +78,15 @@ program
   .action(async (options, command) => {
     await executeCliHandler(command.name(), async () => {
       await container.resolve(GpuBotController).createGpuBids();
+    });
+  });
+
+program
+  .command("link-auth0-accounts")
+  .description("Interactively link a secondary Auth0 account into a primary one (Auth0 only, no DB writes)")
+  .action(async (options, command) => {
+    await executeCliHandler(command.name(), async () => {
+      await container.resolve(Auth0AccountLinkerService).linkAccountsInteractively();
     });
   });
 

--- a/apps/api/src/auth/services/auth0-account-linker/auth0-account-linker.service.spec.ts
+++ b/apps/api/src/auth/services/auth0-account-linker/auth0-account-linker.service.spec.ts
@@ -1,0 +1,173 @@
+import type { GetUsers200ResponseOneOfInner } from "auth0";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { Auth0Service } from "@src/auth/services/auth0/auth0.service";
+import type { CliPromptService } from "@src/core/services/cli-prompt/cli-prompt.service";
+import { Auth0AccountLinkerService } from "./auth0-account-linker.service";
+
+import { createAuth0Identity, createAuth0User } from "@test/seeders";
+
+describe(Auth0AccountLinkerService.name, () => {
+  it("links the secondary root identity into the primary after confirmation", async () => {
+    const primary = createAuth0User({ user_id: "auth0|primary" });
+    const secondary = createAuth0User({
+      user_id: "google-oauth2|secondary",
+      identities: [createAuth0Identity({ provider: "google-oauth2", user_id: "secondary", connection: "google-oauth2" })]
+    });
+    const { service, auth0Service, prompt } = setup({ answers: ["primary@x.com", "1", "secondary@x.com", "1", "y"] });
+    auth0Service.getUsersByEmail
+      .mockResolvedValueOnce([primary] as GetUsers200ResponseOneOfInner[])
+      .mockResolvedValueOnce([secondary] as GetUsers200ResponseOneOfInner[]);
+
+    await service.linkAccountsInteractively();
+
+    expect(auth0Service.linkUsers).toHaveBeenCalledWith("auth0|primary", { provider: "google-oauth2", userId: "secondary" });
+    expect(prompt.close).toHaveBeenCalled();
+  });
+
+  it("selects the identity matching the account user_id rather than the first identity", async () => {
+    const primary = createAuth0User({ user_id: "auth0|primary" });
+    const secondary = createAuth0User({
+      user_id: "google-oauth2|root",
+      identities: [
+        createAuth0Identity({ provider: "auth0", user_id: "linked" }),
+        createAuth0Identity({ provider: "google-oauth2", user_id: "root", connection: "google-oauth2" })
+      ]
+    });
+    const { service, auth0Service } = setup({ answers: ["primary@x.com", "1", "secondary@x.com", "1", "y"] });
+    auth0Service.getUsersByEmail
+      .mockResolvedValueOnce([primary] as GetUsers200ResponseOneOfInner[])
+      .mockResolvedValueOnce([secondary] as GetUsers200ResponseOneOfInner[]);
+
+    await service.linkAccountsInteractively();
+
+    expect(auth0Service.linkUsers).toHaveBeenCalledWith("auth0|primary", { provider: "google-oauth2", userId: "root" });
+  });
+
+  it("does not link when the operator declines confirmation", async () => {
+    const primary = createAuth0User({ user_id: "auth0|primary" });
+    const secondary = createAuth0User({ user_id: "google-oauth2|secondary" });
+    const { service, auth0Service, prompt } = setup({ answers: ["primary@x.com", "1", "secondary@x.com", "1", "n"] });
+    auth0Service.getUsersByEmail
+      .mockResolvedValueOnce([primary] as GetUsers200ResponseOneOfInner[])
+      .mockResolvedValueOnce([secondary] as GetUsers200ResponseOneOfInner[]);
+
+    await service.linkAccountsInteractively();
+
+    expect(auth0Service.linkUsers).not.toHaveBeenCalled();
+    expect(prompt.writeLine).toHaveBeenCalledWith("Aborted. No changes made.");
+  });
+
+  it("re-prompts when no users are found for an email", async () => {
+    const primary = createAuth0User({ user_id: "auth0|primary" });
+    const secondary = createAuth0User({ user_id: "google-oauth2|secondary" });
+    const { service, auth0Service, prompt } = setup({ answers: ["missing@x.com", "primary@x.com", "1", "secondary@x.com", "1", "y"] });
+    auth0Service.getUsersByEmail
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([primary] as GetUsers200ResponseOneOfInner[])
+      .mockResolvedValueOnce([secondary] as GetUsers200ResponseOneOfInner[]);
+
+    await service.linkAccountsInteractively();
+
+    expect(prompt.writeLine).toHaveBeenCalledWith('No Auth0 users found for "missing@x.com". Try again.');
+    expect(auth0Service.linkUsers).toHaveBeenCalled();
+  });
+
+  it("re-prompts when the email lookup throws", async () => {
+    const primary = createAuth0User({ user_id: "auth0|primary" });
+    const secondary = createAuth0User({ user_id: "google-oauth2|secondary" });
+    const { service, auth0Service, prompt } = setup({ answers: ["bad-email", "primary@x.com", "1", "secondary@x.com", "1", "y"] });
+    auth0Service.getUsersByEmail
+      .mockRejectedValueOnce(new Error("invalid email"))
+      .mockResolvedValueOnce([primary] as GetUsers200ResponseOneOfInner[])
+      .mockResolvedValueOnce([secondary] as GetUsers200ResponseOneOfInner[]);
+
+    await service.linkAccountsInteractively();
+
+    expect(prompt.writeLine).toHaveBeenCalledWith('Lookup failed for "bad-email": invalid email. Try again.');
+    expect(auth0Service.linkUsers).toHaveBeenCalled();
+  });
+
+  it("re-prompts the secondary when it resolves to the same account as the primary", async () => {
+    const shared = createAuth0User({ user_id: "auth0|primary" });
+    const other = createAuth0User({ user_id: "google-oauth2|other" });
+    const { service, auth0Service } = setup({ answers: ["primary@x.com", "1", "same@x.com", "1", "other@x.com", "1", "y"] });
+    auth0Service.getUsersByEmail
+      .mockResolvedValueOnce([shared] as GetUsers200ResponseOneOfInner[])
+      .mockResolvedValueOnce([shared] as GetUsers200ResponseOneOfInner[])
+      .mockResolvedValueOnce([other] as GetUsers200ResponseOneOfInner[]);
+
+    await service.linkAccountsInteractively();
+
+    expect(auth0Service.linkUsers).toHaveBeenCalledWith("auth0|primary", { provider: "google-oauth2", userId: "other" });
+  });
+
+  it("re-prompts when the picked index is out of range", async () => {
+    const primary = createAuth0User({ user_id: "auth0|primary" });
+    const secondary = createAuth0User({ user_id: "google-oauth2|secondary" });
+    const { service, auth0Service, prompt } = setup({ answers: ["primary@x.com", "9", "1", "secondary@x.com", "1", "y"] });
+    auth0Service.getUsersByEmail
+      .mockResolvedValueOnce([primary] as GetUsers200ResponseOneOfInner[])
+      .mockResolvedValueOnce([secondary] as GetUsers200ResponseOneOfInner[]);
+
+    await service.linkAccountsInteractively();
+
+    expect(prompt.writeLine).toHaveBeenCalledWith("Enter a number between 1 and 1.");
+    expect(auth0Service.linkUsers).toHaveBeenCalled();
+  });
+
+  it("re-prompts when the email is empty", async () => {
+    const primary = createAuth0User({ user_id: "auth0|primary" });
+    const secondary = createAuth0User({ user_id: "google-oauth2|secondary" });
+    const { service, auth0Service, prompt } = setup({ answers: ["", "primary@x.com", "1", "secondary@x.com", "1", "y"] });
+    auth0Service.getUsersByEmail
+      .mockResolvedValueOnce([primary] as GetUsers200ResponseOneOfInner[])
+      .mockResolvedValueOnce([secondary] as GetUsers200ResponseOneOfInner[]);
+
+    await service.linkAccountsInteractively();
+
+    expect(prompt.writeLine).toHaveBeenCalledWith("Email cannot be empty. Try again.");
+    expect(auth0Service.getUsersByEmail).not.toHaveBeenCalledWith("");
+  });
+
+  it("throws and still closes the prompt when the secondary has no usable identity", async () => {
+    const primary = createAuth0User({ user_id: "auth0|primary" });
+    const secondary = createAuth0User({
+      user_id: "auth0|secondary",
+      identities: [createAuth0Identity({ provider: "google-oauth2", user_id: "mismatch" })]
+    });
+    const { service, auth0Service, prompt } = setup({ answers: ["primary@x.com", "1", "secondary@x.com", "1", "y"] });
+    auth0Service.getUsersByEmail
+      .mockResolvedValueOnce([primary] as GetUsers200ResponseOneOfInner[])
+      .mockResolvedValueOnce([secondary] as GetUsers200ResponseOneOfInner[]);
+
+    await expect(service.linkAccountsInteractively()).rejects.toThrow("no usable identity");
+
+    expect(auth0Service.linkUsers).not.toHaveBeenCalled();
+    expect(prompt.close).toHaveBeenCalled();
+  });
+
+  it("closes the prompt when linking fails", async () => {
+    const primary = createAuth0User({ user_id: "auth0|primary" });
+    const secondary = createAuth0User({ user_id: "google-oauth2|secondary" });
+    const { service, auth0Service, prompt } = setup({ answers: ["primary@x.com", "1", "secondary@x.com", "1", "y"] });
+    auth0Service.getUsersByEmail
+      .mockResolvedValueOnce([primary] as GetUsers200ResponseOneOfInner[])
+      .mockResolvedValueOnce([secondary] as GetUsers200ResponseOneOfInner[]);
+    auth0Service.linkUsers.mockRejectedValue(new Error("auth0 down"));
+
+    await expect(service.linkAccountsInteractively()).rejects.toThrow("auth0 down");
+
+    expect(prompt.close).toHaveBeenCalled();
+  });
+
+  function setup(input: { answers?: string[] } = {}) {
+    const auth0Service = mock<Auth0Service>();
+    const prompt = mock<CliPromptService>();
+    const answers = [...(input.answers ?? [])];
+    prompt.question.mockImplementation(() => Promise.resolve(answers.shift() ?? ""));
+    const service = new Auth0AccountLinkerService(auth0Service, prompt);
+    return { service, auth0Service, prompt };
+  }
+});

--- a/apps/api/src/auth/services/auth0-account-linker/auth0-account-linker.service.ts
+++ b/apps/api/src/auth/services/auth0-account-linker/auth0-account-linker.service.ts
@@ -1,0 +1,141 @@
+import type { GetUsers200ResponseOneOfInner, GetUsers200ResponseOneOfInnerIdentitiesInner } from "auth0";
+import { singleton } from "tsyringe";
+
+import { Auth0Service } from "@src/auth/services/auth0/auth0.service";
+import { CliPromptService } from "@src/core/services/cli-prompt/cli-prompt.service";
+
+/**
+ * Drives the interactive operator flow for folding a secondary Auth0 account
+ * into a primary one. Auth0 only — it performs no console DB writes.
+ */
+@singleton()
+export class Auth0AccountLinkerService {
+  constructor(
+    private readonly auth0Service: Auth0Service,
+    private readonly prompt: CliPromptService
+  ) {}
+
+  /**
+   * Prompts for a primary and a secondary account, prints a summary, and only
+   * links after explicit confirmation. Closes the prompt interface in a finally
+   * block.
+   */
+  async linkAccountsInteractively(): Promise<void> {
+    try {
+      const primary = await this.#promptAccount("primary");
+      const secondary = await this.#promptAccount("secondary", primary.user_id);
+
+      this.#printSummary(primary, secondary);
+
+      const confirmed = await this.#confirm("Link these accounts?");
+      if (!confirmed) {
+        this.prompt.writeLine("Aborted. No changes made.");
+        return;
+      }
+
+      const identity = this.#resolveRootIdentity(secondary);
+      if (!identity?.provider || !identity.user_id) {
+        throw new Error(`Secondary account ${secondary.user_id} has no usable identity to link`);
+      }
+
+      await this.auth0Service.linkUsers(primary.user_id as string, {
+        provider: identity.provider,
+        userId: String(identity.user_id)
+      });
+
+      this.prompt.writeLine(`\nLinked ${secondary.user_id} into ${primary.user_id}.`);
+    } finally {
+      this.prompt.close();
+    }
+  }
+
+  /**
+   * Prompts for an email, lists every matching Auth0 user, and returns the one
+   * the operator picks. Re-prompts on no matches or an invalid selection. When
+   * `excludeUserId` is set, rejects picking that same user (a user cannot link
+   * to itself).
+   */
+  async #promptAccount(label: string, excludeUserId?: string): Promise<GetUsers200ResponseOneOfInner> {
+    for (;;) {
+      const email = (await this.prompt.question(`\nEnter the ${label} account email: `)).trim();
+      if (!email) {
+        this.prompt.writeLine("Email cannot be empty. Try again.");
+        continue;
+      }
+
+      let users: GetUsers200ResponseOneOfInner[];
+      try {
+        users = await this.auth0Service.getUsersByEmail(email);
+      } catch (error) {
+        this.prompt.writeLine(`Lookup failed for "${email}": ${error instanceof Error ? error.message : String(error)}. Try again.`);
+        continue;
+      }
+
+      if (users.length === 0) {
+        this.prompt.writeLine(`No Auth0 users found for "${email}". Try again.`);
+        continue;
+      }
+
+      this.prompt.writeLine(`\nMatches for ${label} (${email}):`);
+      users.forEach((user, index) => this.prompt.writeLine(`  ${index + 1}) ${this.#describeAccount(user)}`));
+
+      const choice = await this.#pickIndex(`Pick the ${label} account [1-${users.length}]: `, users.length);
+      const selected = users[choice];
+
+      if (excludeUserId && selected.user_id === excludeUserId) {
+        this.prompt.writeLine("That is the same account as the primary. Pick a different one.");
+        continue;
+      }
+
+      return selected;
+    }
+  }
+
+  /**
+   * Prompts repeatedly until the operator enters a valid 1-based index,
+   * returning the corresponding 0-based array index.
+   */
+  async #pickIndex(prompt: string, count: number): Promise<number> {
+    for (;;) {
+      const raw = (await this.prompt.question(prompt)).trim();
+      const index = Number(raw);
+
+      if (Number.isInteger(index) && index >= 1 && index <= count) {
+        return index - 1;
+      }
+
+      this.prompt.writeLine(`Enter a number between 1 and ${count}.`);
+    }
+  }
+
+  /**
+   * Returns the account's root identity — the one whose `provider|user_id`
+   * reconstructs the top-level `user_id`. Auth0 stores the provider only in the
+   * composite top-level id; `identities[].user_id` holds just the id portion, so
+   * blindly taking `identities[0]` can pick the wrong identity once an account
+   * has more than one linked.
+   */
+  #resolveRootIdentity(user: GetUsers200ResponseOneOfInner): GetUsers200ResponseOneOfInnerIdentitiesInner | undefined {
+    return user.identities?.find(identity => `${identity.provider}|${identity.user_id}` === user.user_id);
+  }
+
+  /** Renders an account as `<connection> / <email> (<user_id>)` for list and summary output. */
+  #describeAccount(user: GetUsers200ResponseOneOfInner): string {
+    const connection = user.identities?.[0]?.connection ?? user.identities?.[0]?.provider ?? "unknown";
+    return `${connection} / ${user.email ?? "no-email"} (${user.user_id})`;
+  }
+
+  /** Prints the primary/secondary summary block shown before the confirmation prompt. */
+  #printSummary(primary: GetUsers200ResponseOneOfInner, secondary: GetUsers200ResponseOneOfInner): void {
+    this.prompt.writeLine("\n--- Summary ---");
+    this.prompt.writeLine(`Primary account:   ${this.#describeAccount(primary)}`);
+    this.prompt.writeLine(`Secondary account: ${this.#describeAccount(secondary)}`);
+    this.prompt.writeLine("The secondary account will be merged into the primary and will no longer exist on its own.\n");
+  }
+
+  /** Reads a y/N answer, treating only `y`/`yes` (case-insensitive) as confirmation. */
+  async #confirm(prompt: string): Promise<boolean> {
+    const answer = (await this.prompt.question(`${prompt} (y/N): `)).trim().toLowerCase();
+    return answer === "y" || answer === "yes";
+  }
+}

--- a/apps/api/src/auth/services/auth0/auth0.service.spec.ts
+++ b/apps/api/src/auth/services/auth0/auth0.service.spec.ts
@@ -2,6 +2,7 @@ import { faker } from "@faker-js/faker";
 import type { GetUsers200ResponseOneOfInner, ManagementClient } from "auth0";
 import type { Mock } from "vitest";
 import { vi } from "vitest";
+import { mock } from "vitest-mock-extended";
 
 import { Auth0Service } from "./auth0.service";
 
@@ -112,16 +113,62 @@ describe(Auth0Service.name, () => {
     });
   });
 
+  describe("getUsersByEmail", () => {
+    it("returns all users found for the email", async () => {
+      const email = faker.internet.email();
+      const mockUsers: Partial<GetUsers200ResponseOneOfInner>[] = [
+        createAuth0User({ email, email_verified: true }),
+        createAuth0User({ email, email_verified: false })
+      ];
+
+      const mockGetByEmail = vi.fn().mockResolvedValue({ data: mockUsers });
+      const { auth0Service } = setup({ usersByEmail: { getByEmail: mockGetByEmail } });
+
+      const result = await auth0Service.getUsersByEmail(email);
+
+      expect(result).toEqual(mockUsers);
+      expect(mockGetByEmail).toHaveBeenCalledWith({ email });
+    });
+
+    it("returns an empty array when no users are found", async () => {
+      const email = faker.internet.email();
+      const mockGetByEmail = vi.fn().mockResolvedValue({ data: [] });
+      const { auth0Service } = setup({ usersByEmail: { getByEmail: mockGetByEmail } });
+
+      const result = await auth0Service.getUsersByEmail(email);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("linkUsers", () => {
+    it("links the secondary identity into the primary user", async () => {
+      const link = vi.fn().mockResolvedValue({ data: [] });
+      const { auth0Service } = setup({ users: { link } });
+
+      await auth0Service.linkUsers("auth0|primary", { provider: "google-oauth2", userId: "google-oauth2|secondary" });
+
+      expect(link).toHaveBeenCalledWith({ id: "auth0|primary" }, { provider: "google-oauth2", user_id: "google-oauth2|secondary", connection_id: undefined });
+    });
+
+    it("passes connection_id when provided", async () => {
+      const link = vi.fn().mockResolvedValue({ data: [] });
+      const { auth0Service } = setup({ users: { link } });
+
+      await auth0Service.linkUsers("auth0|primary", { provider: "auth0", userId: "auth0|secondary", connectionId: "con_123" });
+
+      expect(link).toHaveBeenCalledWith({ id: "auth0|primary" }, { provider: "auth0", user_id: "auth0|secondary", connection_id: "con_123" });
+    });
+  });
+
   function setup(
     input: {
       jobs?: { verifyEmail: Mock };
-      users?: { update?: Mock; create?: Mock };
+      users?: { update?: Mock; create?: Mock; link?: Mock };
       usersByEmail?: { getByEmail: Mock };
     } = {}
   ) {
-    const mockManagementClient = {
-      ...input
-    } as unknown as ManagementClient;
+    const mockManagementClient = mock<ManagementClient>(input);
 
     const auth0Service = new Auth0Service(mockManagementClient);
 

--- a/apps/api/src/auth/services/auth0/auth0.service.ts
+++ b/apps/api/src/auth/services/auth0/auth0.service.ts
@@ -1,4 +1,4 @@
-import { GetUsers200ResponseOneOfInner, ManagementClient } from "auth0";
+import { GetUsers200ResponseOneOfInner, ManagementClient, PostIdentitiesRequestProviderEnum } from "auth0";
 import { singleton } from "tsyringe";
 
 export const AUTH0_DB_CONNECTION = "Username-Password-Authentication";
@@ -31,5 +31,21 @@ export class Auth0Service {
     }
 
     return users[0];
+  }
+
+  async getUsersByEmail(email: string): Promise<GetUsers200ResponseOneOfInner[]> {
+    const { data: users } = await this.managementClient.usersByEmail.getByEmail({ email });
+    return users;
+  }
+
+  async linkUsers(primaryUserId: string, secondary: { provider: string; userId: string; connectionId?: string }): Promise<void> {
+    await this.managementClient.users.link(
+      { id: primaryUserId },
+      {
+        provider: secondary.provider as PostIdentitiesRequestProviderEnum,
+        user_id: secondary.userId,
+        connection_id: secondary.connectionId
+      }
+    );
   }
 }

--- a/apps/api/src/core/services/cli-prompt/cli-prompt.service.spec.ts
+++ b/apps/api/src/core/services/cli-prompt/cli-prompt.service.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { CliPromptService } from "./cli-prompt.service";
+
+describe(CliPromptService.name, () => {
+  it("writes the message followed by a newline to stdout", () => {
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const service = setup();
+
+    service.writeLine("hello");
+
+    expect(writeSpy).toHaveBeenCalledWith("hello\n");
+    writeSpy.mockRestore();
+  });
+
+  it("does nothing on close when no interface was opened", () => {
+    const service = setup();
+
+    expect(() => service.close()).not.toThrow();
+  });
+
+  function setup() {
+    return new CliPromptService();
+  }
+});

--- a/apps/api/src/core/services/cli-prompt/cli-prompt.service.ts
+++ b/apps/api/src/core/services/cli-prompt/cli-prompt.service.ts
@@ -1,0 +1,32 @@
+import { createInterface, type Interface } from "node:readline/promises";
+import { singleton } from "tsyringe";
+
+/**
+ * Thin wrapper around `node:readline/promises` for interactive console commands.
+ * Lazily opens a single stdin/stdout interface and exposes question/output/close
+ * so command flows stay decoupled from the readline module and remain testable.
+ */
+@singleton()
+export class CliPromptService {
+  #rl?: Interface;
+
+  /** Asks a question on stdin and resolves with the operator's raw answer. */
+  question(query: string): Promise<string> {
+    return this.#getInterface().question(query);
+  }
+
+  /** Writes a single line of interactive UI output to stdout (terminal UI, not structured logging). */
+  writeLine(message: string): void {
+    process.stdout.write(`${message}\n`);
+  }
+
+  /** Closes the underlying readline interface if one was opened. */
+  close(): void {
+    this.#rl?.close();
+    this.#rl = undefined;
+  }
+
+  #getInterface(): Interface {
+    return (this.#rl ??= createInterface({ input: process.stdin, output: process.stdout }));
+  }
+}

--- a/apps/api/test/seeders/auth0-user.seeder.ts
+++ b/apps/api/test/seeders/auth0-user.seeder.ts
@@ -1,20 +1,48 @@
 import { faker } from "@faker-js/faker";
-import type { GetUsers200ResponseOneOfInner } from "auth0";
+import type { GetUsers200ResponseOneOfInner, GetUsers200ResponseOneOfInnerIdentitiesInner } from "auth0";
 
-export function createAuth0User({
-  user_id = faker.string.uuid(),
-  email = faker.internet.email(),
-  email_verified = faker.datatype.boolean(),
-  name = faker.person.fullName(),
-  created_at = faker.date.past().toISOString(),
-  updated_at = faker.date.recent().toISOString()
-}: Partial<GetUsers200ResponseOneOfInner> = {}): Partial<GetUsers200ResponseOneOfInner> {
+export function createAuth0Identity(overrides: Partial<GetUsers200ResponseOneOfInnerIdentitiesInner> = {}): GetUsers200ResponseOneOfInnerIdentitiesInner {
   return {
-    user_id,
-    email,
-    email_verified,
-    name,
-    created_at,
-    updated_at
+    connection: "Username-Password-Authentication",
+    provider: "auth0",
+    user_id: faker.string.uuid(),
+    isSocial: false,
+    ...overrides
+  } as GetUsers200ResponseOneOfInnerIdentitiesInner;
+}
+
+export function createAuth0User(overrides: Partial<GetUsers200ResponseOneOfInner> = {}): Partial<GetUsers200ResponseOneOfInner> {
+  const identities = overrides.identities ?? [identityFromUserId(overrides.user_id)];
+  if (!overrides.user_id && identities.length === 0) {
+    throw new Error("createAuth0User requires a user_id or at least one identity to derive it from");
+  }
+  const userId = overrides.user_id ?? `${identities[0].provider}|${identities[0].user_id}`;
+
+  return {
+    user_id: userId,
+    email: faker.internet.email(),
+    email_verified: faker.datatype.boolean(),
+    name: faker.person.fullName(),
+    created_at: faker.date.past().toISOString(),
+    updated_at: faker.date.recent().toISOString(),
+    identities,
+    ...overrides
   };
+}
+
+/**
+ * Builds a root identity consistent with a composite `provider|id` user_id so a
+ * seeded user's `identities[0]` reconstructs its top-level `user_id`. Defaults to
+ * a random `auth0` identity when no user_id is given.
+ */
+function identityFromUserId(userId?: string): GetUsers200ResponseOneOfInnerIdentitiesInner {
+  if (!userId) {
+    return createAuth0Identity();
+  }
+
+  const separatorIndex = userId.indexOf("|");
+  const provider = separatorIndex >= 0 ? userId.slice(0, separatorIndex) : "auth0";
+  const id = separatorIndex >= 0 ? userId.slice(separatorIndex + 1) : userId;
+
+  return createAuth0Identity({ provider, user_id: id, connection: provider === "auth0" ? "Username-Password-Authentication" : provider });
 }


### PR DESCRIPTION
## Why

When the same email exists under multiple Auth0 connections (e.g. a Google identity and an email/password identity) that were never linked, the user can authenticate with one but hits errors signing in with the other. Operators need a way to fold one account into the other so a single identity owns the email.

Related to CUST-8

## What

Adds an interactive `link-auth0-accounts` command to the existing API console CLI (`npm run console -- link-auth0-accounts`):

- Prompts for the **primary** account email, lists every matching Auth0 identity, and lets the operator pick one.
- Prompts for the **secondary** account the same way, rejecting a pick equal to the primary.
- Prints a summary (`<connection> / <email> (<user_id>)` for each) and links only after explicit `y/N` confirmation.
- Auth0 only — performs no console DB writes.

Backed by two new `Auth0Service` methods:
- `getUsersByEmail` — returns all matches for an email (existing `getUserByEmail` returns only the first).
- `linkUsers` — wraps `managementClient.users.link`.

The interactive flow lives in a dedicated `Auth0AccountLinkerService`. Unit tests cover the two new `Auth0Service` methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added a new interactive CLI command to link Auth0 accounts, guiding operators through selecting primary/secondary users and requiring confirmation before linking.

## Bug Fixes
- Enhanced Auth0 account lookup to return all users for a given email (not just the first result).
- Added explicit user-linking support to link a secondary Auth0 identity into a primary user.

## Tests
- Expanded Auth0 service test coverage for email lookup and user linking payloads.
- Added unit tests for the new CLI prompt utility and the interactive account-linking flow, including error/abort scenarios.
- Updated Auth0 user seeding helpers to support the new identity/linking test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->