### PR TITLE
refactor: return aggregated incidents details instead of raw data for bid screening requests

### DIFF
--- a/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
+++ b/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
@@ -2,20 +2,20 @@ import { z } from "@hono/zod-openapi";
 
 const UIntStringSchema = z.string().regex(/^\d+$/, "Must be an unsigned integer string");
 
-/**
- * Validates the resource value but does NOT transform it. This service only proxies the request to
- * provider-inventory, which parses the value itself; transforming to BigInt here would break the
- * `JSON.stringify` forward in the controller. Value is a non-negative integer string or its
- * protobuf base64-encoded representation.
- */
 const ResourceValueSchema = z.object({
   val: z
     .string()
     .max(80)
-    .refine(str => {
-      const decoded = /^\d+$/.test(str) ? str : Buffer.from(str, "base64").toString("utf-8");
-      return /^\d+$/.test(decoded);
-    }, "Must be a non-negative integer or its protobuf base64-encoded representation")
+    .transform(str => {
+      if (/^\d+$/.test(str)) return BigInt(str);
+      const parsed = Buffer.from(str, "base64").toString("utf-8");
+      if (/^\d+$/.test(parsed)) return BigInt(parsed);
+      return NaN;
+    })
+    .refine(
+      (val): val is bigint => !Number.isFinite(val) && typeof val === "bigint" && val >= 0n,
+      "Must be a non-negative integer or its protobuf base64-encoded representation"
+    )
 });
 
 // Mirrors AttributeNameRegexpStringWildcard in akash-network/chain-sdk
@@ -89,10 +89,14 @@ const RequirementsSchema = z.object({
   attributes: z.array(AttributeSchema).default([])
 });
 
+const SUPPORTED_TIMEZONES = new Set(Intl.supportedValuesOf("timeZone"));
 export const BidScreeningRequestSchema = z.object({
-  name: z.string().openapi({ description: "Group name", example: "westcoast" }),
   requirements: RequirementsSchema.default({}),
-  resources: z.array(ResourceUnitSchema).openapi({ description: "Resource units with replica counts" })
+  resources: z.array(ResourceUnitSchema).openapi({ description: "Resource units with replica counts" }),
+  timezone: z
+    .string()
+    .refine(val => SUPPORTED_TIMEZONES.has(val), { message: "Timezone is not supported" })
+    .openapi({ description: "Client timezone, validated against supported Node.js Intl timezones", example: "America/Chicago" })
 });
 export type BidScreeningRequest = z.infer<typeof BidScreeningRequestSchema>;
 
@@ -111,11 +115,13 @@ const ProviderResultSchema = z.object({
   incidents: z
     .array(
       z.object({
-        startedAt: z.string().datetime(),
-        endedAt: z.string().datetime().nullable()
+        date: z.string().openapi({ description: "Local calendar day, YYYY-MM-DD", example: "2026-06-01" }),
+        hasOpenIncident: z.boolean().openapi({ description: "True if the provider currently has any open incident" }),
+        incidentCount: z.number().int().openapi({ description: "Number of incident intervals overlapping that day" }),
+        downtimeSeconds: z.number().int().openapi({ description: "Downtime clipped to that day, in seconds (max 86400)" })
       })
     )
-    .openapi({ description: "Provider incident intervals within the last ~8 days; endedAt null = ongoing" })
+    .openapi({ description: "Per-day downtime over a rolling 7-day window" })
 });
 
 export const BidScreeningResponseSchema = z.object({

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -2745,11 +2745,6 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "application/json": {
               "schema": {
                 "properties": {
-                  "name": {
-                    "description": "Group name",
-                    "example": "westcoast",
-                    "type": "string",
-                  },
                   "requirements": {
                     "default": {},
                     "properties": {
@@ -3050,10 +3045,15 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     },
                     "type": "array",
                   },
+                  "timezone": {
+                    "description": "Client timezone, validated against supported Node.js Intl timezones",
+                    "example": "America/Chicago",
+                    "type": "string",
+                  },
                 },
                 "required": [
-                  "name",
                   "resources",
+                  "timezone",
                 ],
                 "type": "object",
               },
@@ -3081,22 +3081,32 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "type": "string",
                           },
                           "incidents": {
-                            "description": "Provider incident intervals within the last ~8 days; endedAt null = ongoing",
+                            "description": "Per-day downtime over a rolling 7-day window",
                             "items": {
                               "properties": {
-                                "endedAt": {
-                                  "format": "date-time",
-                                  "nullable": true,
+                                "date": {
+                                  "description": "Local calendar day, YYYY-MM-DD",
+                                  "example": "2026-06-01",
                                   "type": "string",
                                 },
-                                "startedAt": {
-                                  "format": "date-time",
-                                  "type": "string",
+                                "downtimeSeconds": {
+                                  "description": "Downtime clipped to that day, in seconds (max 86400)",
+                                  "type": "integer",
+                                },
+                                "hasOpenIncident": {
+                                  "description": "True if the provider currently has any open incident",
+                                  "type": "boolean",
+                                },
+                                "incidentCount": {
+                                  "description": "Number of incident intervals overlapping that day",
+                                  "type": "integer",
                                 },
                               },
                               "required": [
-                                "startedAt",
-                                "endedAt",
+                                "date",
+                                "hasOpenIncident",
+                                "incidentCount",
+                                "downtimeSeconds",
                               ],
                               "type": "object",
                             },

--- a/apps/provider-inventory/src/controllers/bid-screening/bid-screening.controller.ts
+++ b/apps/provider-inventory/src/controllers/bid-screening/bid-screening.controller.ts
@@ -1,8 +1,7 @@
 import type { Abortable } from "node:events";
 import { inject, singleton } from "tsyringe";
 
-import type { GroupSpecJSON } from "@src/mappers/groupspec-mapper/groupspec-mapper";
-import { BidScreeningService } from "@src/services/bid-screening/bid-screening.service";
+import { BidScreeningInput, BidScreeningService } from "@src/services/bid-screening/bid-screening.service";
 import type { BidScreeningRequest, BidScreeningResponse } from "../../http-schemas/bid-screening.schema";
 
 @singleton()
@@ -14,7 +13,7 @@ export class BidScreeningController {
   }
 
   async screenProviders(request: BidScreeningRequest, options?: Abortable): Promise<BidScreeningResponse> {
-    const results = await this.#bidScreeningService.findMatchingProviders(request as GroupSpecJSON, options);
+    const results = await this.#bidScreeningService.findMatchingProviders(request as BidScreeningInput, options);
     return { providers: results };
   }
 }

--- a/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
+++ b/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
@@ -89,10 +89,14 @@ const RequirementsSchema = z.object({
   attributes: z.array(AttributeSchema).default([])
 });
 
+const SUPPORTED_TIMEZONES = new Set(Intl.supportedValuesOf("timeZone"));
 export const BidScreeningRequestSchema = z.object({
-  name: z.string().openapi({ description: "Group name", example: "westcoast" }),
   requirements: RequirementsSchema.default({}),
-  resources: z.array(ResourceUnitSchema).openapi({ description: "Resource units with replica counts" })
+  resources: z.array(ResourceUnitSchema).openapi({ description: "Resource units with replica counts" }),
+  timezone: z
+    .string()
+    .refine(val => SUPPORTED_TIMEZONES.has(val), { message: "Timezone is not supported" })
+    .openapi({ description: "Client timezone, validated against supported Node.js Intl timezones", example: "America/Chicago" })
 });
 export type BidScreeningRequest = z.infer<typeof BidScreeningRequestSchema>;
 
@@ -111,11 +115,13 @@ const ProviderResultSchema = z.object({
   incidents: z
     .array(
       z.object({
-        startedAt: z.string().datetime(),
-        endedAt: z.string().datetime().nullable()
+        date: z.string().openapi({ description: "Local calendar day, YYYY-MM-DD", example: "2026-06-01" }),
+        hasOpenIncident: z.boolean().openapi({ description: "True if the provider currently has any open incident" }),
+        incidentCount: z.number().int().openapi({ description: "Number of incident intervals overlapping that day" }),
+        downtimeSeconds: z.number().int().openapi({ description: "Downtime clipped to that day, in seconds (max 86400)" })
       })
     )
-    .openapi({ description: "Provider incident intervals within the last ~8 days; endedAt null = ongoing" })
+    .openapi({ description: "Per-day downtime over a rolling 7-day window" })
 });
 
 export const BidScreeningResponseSchema = z.object({

--- a/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
+++ b/apps/provider-inventory/src/mappers/groupspec-mapper/groupspec-mapper.ts
@@ -4,7 +4,7 @@ import type { RequestedResourceUnit, RequestedStorage, ResourceAttribute, ToJSON
 import { parseGPUAttributes } from "../gpu-attribute-parser/gpu-attribute-parser";
 import { parseStorageAttributes } from "../storage-attribute-parser/storage-attribute-parser";
 
-export function mapGroupSpecToResourceUnits(request: GroupSpecJSON): RequestedResourceUnit[] {
+export function mapGroupSpecToResourceUnits(request: Omit<GroupSpecJSON, "name">): RequestedResourceUnit[] {
   return request.resources.map(unit => {
     const resource = unit.resource;
 

--- a/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.ts
+++ b/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.ts
@@ -75,7 +75,7 @@ export class BidScreeningRepository {
             (SELECT sa->>'value' FROM jsonb_array_elements(${sql(providerInventory.selfAttributes.name)}) AS sa WHERE sa->>'key' = 'location-region' LIMIT 1)
           ) AS location
         FROM ${sql(TABLE)}
-        WHERE ${sql(providerInventory.owner.name)} IN${sql(ownersToFetch)}
+        WHERE ${sql(providerInventory.owner.name)} = ANY(${ownersToFetch}::text[])
       `;
       for (const candidate of candidates) {
         this.#providersInventory.set(candidate.owner, candidate);

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.integration.ts
@@ -7,6 +7,8 @@ import { providerIncidents } from "@src/model-schemas/provider-incident/provider
 import { DRIZZLE_DB } from "@src/providers/drizzle.provider";
 import { ProviderIncidentRepository } from "./provider-incident.repository";
 
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
 describe(ProviderIncidentRepository.name, () => {
   describe("openIncident", () => {
     it("inserts an open row when no prior incident exists for the provider", async () => {
@@ -120,79 +122,77 @@ describe(ProviderIncidentRepository.name, () => {
     });
   });
 
-  describe("findRecentByProviders", () => {
-    it("returns an empty array when called with no owners", async () => {
+  describe("findDailyDowntimeByProviders", () => {
+    it("returns an empty array when called with no providers", async () => {
       const { repository } = setup();
 
-      const rows = await repository.findRecentByProviders([]);
+      const rows = await repository.findDailyDowntimeByProviders([]);
 
       expect(rows).toEqual([]);
     });
 
-    it("returns a closed incident inside the window", async () => {
+    it("reports a single closed within-day incident as one row with its exact duration", async () => {
       const { repository, db } = setup();
-      await seedIncident(db, { provider: "akash1a", startedAt: daysAgo(2), endedAt: daysAgo(1) });
+      const startedAt = atDaysAgoUtc(2, 10);
+      const endedAt = atDaysAgoUtc(2, 10, 5);
+      await seedIncident(db, { provider: "akash1a", startedAt, endedAt });
 
-      const rows = await repository.findRecentByProviders(["akash1a"]);
+      const rows = await repository.findDailyDowntimeByProviders(["akash1a"]);
 
-      expect(rows).toHaveLength(1);
-      expect(rows[0].provider).toBe("akash1a");
-      expect(rows[0].startedAt).toMatch(ISO_MS);
-      expect(rows[0].endedAt).toMatch(ISO_MS);
+      expect(rows).toEqual([
+        {
+          provider: "akash1a",
+          date: utcDate(startedAt),
+          hasOpenIncident: false,
+          incidentCount: 1,
+          downtimeSeconds: 5 * 60
+        }
+      ]);
     });
 
-    it("returns an ongoing incident with endedAt null", async () => {
+    it("flags every row of a provider with a currently-open incident", async () => {
       const { repository, db } = setup();
-      await seedIncident(db, { provider: "akash1a", startedAt: daysAgo(3), endedAt: null });
+      await seedIncident(db, { provider: "akash1a", startedAt: atDaysAgoUtc(2, 10), endedAt: null });
 
-      const rows = await repository.findRecentByProviders(["akash1a"]);
+      const rows = await repository.findDailyDowntimeByProviders(["akash1a"]);
 
-      expect(rows).toHaveLength(1);
-      expect(rows[0].endedAt).toBeNull();
+      expect(rows.length).toBeGreaterThan(0);
+      expect(rows.every(r => r.hasOpenIncident)).toBe(true);
     });
 
-    it("includes an incident at the inner edge of the window and excludes one beyond it", async () => {
+    it("treats the open flag as provider-wide when a closed and an open incident coexist", async () => {
       const { repository, db } = setup();
-      await seedIncident(db, { provider: "akash1in", startedAt: daysAgo(7.6), endedAt: daysAgo(7.5) });
-      await seedIncident(db, { provider: "akash1out", startedAt: daysAgo(9.1), endedAt: daysAgo(9) });
+      await seedIncident(db, { provider: "akash1a", startedAt: atDaysAgoUtc(4, 10), endedAt: atDaysAgoUtc(4, 10, 5) });
+      await seedIncident(db, { provider: "akash1a", startedAt: atDaysAgoUtc(2, 10), endedAt: null });
 
-      const rows = await repository.findRecentByProviders(["akash1in", "akash1out"]);
+      const rows = await repository.findDailyDowntimeByProviders(["akash1a"]);
 
-      expect(rows.map(r => r.provider)).toEqual(["akash1in"]);
+      expect(rows.every(r => r.hasOpenIncident)).toBe(true);
     });
 
-    it("orders multiple incidents for one provider by startedAt ascending", async () => {
+    it("clips an incident crossing UTC midnight into one row per day", async () => {
       const { repository, db } = setup();
-      await seedIncident(db, { provider: "akash1a", startedAt: daysAgo(1), endedAt: daysAgo(0.5) });
-      await seedIncident(db, { provider: "akash1a", startedAt: daysAgo(5), endedAt: daysAgo(4) });
-      await seedIncident(db, { provider: "akash1a", startedAt: daysAgo(3), endedAt: daysAgo(2) });
+      const startedAt = atDaysAgoUtc(2, 23);
+      const endedAt = atDaysAgoUtc(1, 1);
+      await seedIncident(db, { provider: "akash1a", startedAt, endedAt });
 
-      const rows = await repository.findRecentByProviders(["akash1a"]);
+      const rows = await repository.findDailyDowntimeByProviders(["akash1a"]);
 
-      expect(rows).toHaveLength(3);
-      const startedAts = rows.map(r => r.startedAt);
-      expect(startedAts).toEqual([...startedAts].sort());
+      expect(rows.map(r => r.date)).toEqual([utcDate(startedAt), utcDate(endedAt)]);
+      expect(rows.map(r => r.downtimeSeconds)).toEqual([60 * 60, 60 * 60]);
+      expect(rows.reduce((sum, r) => sum + r.downtimeSeconds, 0)).toBe(2 * 60 * 60);
     });
 
-    it("returns only the real incident for a recently enrolled provider without fabricating pre-enrollment rows", async () => {
+    it("groups and filters by provider across a batched call, ordered by provider then date", async () => {
       const { repository, db } = setup();
-      await seedIncident(db, { provider: "akash1a", startedAt: daysAgo(2), endedAt: daysAgo(1) });
+      await seedIncident(db, { provider: "akash1b", startedAt: atDaysAgoUtc(3, 10), endedAt: atDaysAgoUtc(3, 10, 5) });
+      await seedIncident(db, { provider: "akash1a", startedAt: atDaysAgoUtc(2, 10), endedAt: atDaysAgoUtc(2, 10, 5) });
+      await seedIncident(db, { provider: "akash1c", startedAt: atDaysAgoUtc(2, 10), endedAt: atDaysAgoUtc(2, 10, 5) });
 
-      const rows = await repository.findRecentByProviders(["akash1a"]);
+      const rows = await repository.findDailyDowntimeByProviders(["akash1a", "akash1b"]);
 
-      expect(rows).toHaveLength(1);
-    });
-
-    it("groups and filters incidents by provider across a batched call", async () => {
-      const { repository, db } = setup();
-      await seedIncident(db, { provider: "akash1a", startedAt: daysAgo(2), endedAt: daysAgo(1) });
-      await seedIncident(db, { provider: "akash1b", startedAt: daysAgo(3), endedAt: null });
-      await seedIncident(db, { provider: "akash1c", startedAt: daysAgo(1), endedAt: daysAgo(0.5) });
-
-      const rows = await repository.findRecentByProviders(["akash1a", "akash1b"]);
-
-      const byProvider = rows.reduce<Record<string, number>>((acc, r) => ({ ...acc, [r.provider]: (acc[r.provider] ?? 0) + 1 }), {});
-      expect(byProvider).toEqual({ akash1a: 1, akash1b: 1 });
+      expect(rows.map(r => r.provider)).toEqual(["akash1a", "akash1b"]);
+      expect([...rows].sort(byProviderThenDate)).toEqual(rows);
     });
   });
 
@@ -203,7 +203,21 @@ describe(ProviderIncidentRepository.name, () => {
   }
 });
 
-const ISO_MS = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+function byProviderThenDate(a: { provider: string; date: string }, b: { provider: string; date: string }): number {
+  return a.provider === b.provider ? a.date.localeCompare(b.date) : a.provider.localeCompare(b.provider);
+}
+
+// A timestamp `daysAgo` whole UTC days back, pinned to a fixed UTC wall-clock time so single-day
+// intervals stay comfortably away from midnight and land on a deterministic calendar day.
+function atDaysAgoUtc(daysAgo: number, hour: number, minute = 0): Date {
+  const date = new Date(Date.now() - daysAgo * SECONDS_PER_DAY * 1000);
+  date.setUTCHours(hour, minute, 0, 0);
+  return date;
+}
+
+function utcDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
 
 interface SeedClosedInput {
   provider: string;
@@ -217,10 +231,6 @@ async function seedClosed(db: PostgresJsDatabase, input: SeedClosedInput): Promi
     startedAt: input.startedAt ?? new Date(input.endedAt.getTime() - 60_000),
     endedAt: input.endedAt
   });
-}
-
-function daysAgo(days: number): Date {
-  return new Date(Date.now() - days * 24 * 60 * 60 * 1000);
 }
 
 async function seedIncident(db: PostgresJsDatabase, input: { provider: string; startedAt: Date; endedAt: Date | null }): Promise<void> {

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
@@ -13,6 +13,14 @@ export interface RecentIncidentRow {
   endedAt: string | null;
 }
 
+export interface DailyDowntimeRow {
+  provider: string;
+  date: string; // local calendar date, "YYYY-MM-DD"
+  hasOpenIncident: boolean; // true if the provider has ANY currently-open incident
+  incidentCount: number; // incident intervals overlapping that day
+  downtimeSeconds: number; // clipped-to-day downtime in seconds (max 86400/day)
+}
+
 @singleton()
 export class ProviderIncidentRepository {
   readonly driver: DbDriver;
@@ -24,23 +32,49 @@ export class ProviderIncidentRepository {
   }
 
   /**
-   * Returns raw incident intervals for the given providers within the rolling window (default 8 days).
-   * Ongoing incidents (`ended_at IS NULL`) are always included with `endedAt: null`.
-   * Rows are flat and ordered by `(provider, started_at ASC)` so callers can group in returned order.
+   * Per-provider, per-day downtime over a rolling 7-day window (today + 6 prior days),
+   * with calendar-day boundaries computed in `timeZone` (default UTC).
+   * `hasOpenIncident` is provider-wide (true if any incident is still open now).
+   * Rows are ordered by `(provider, date ASC)`.
    */
-  async findRecentByProviders(owners: string[], days = 8): Promise<RecentIncidentRow[]> {
-    if (owners.length === 0) return [];
+  async findDailyDowntimeByProviders(providers: string[], timeZone = "UTC"): Promise<DailyDowntimeRow[]> {
+    if (providers.length === 0) return [];
 
+    const daysAgo = 7; // 7-day rolling window (today + 6 prior days)
     const sql = this.#sql;
-    return sql<RecentIncidentRow[]>`
+    return sql<DailyDowntimeRow[]>`
+      WITH day_bounds AS MATERIALIZED (
+        SELECT
+          (date_trunc('day', now() AT TIME ZONE ${timeZone}::text) - make_interval(days => g.idx))::date AS day,
+          (date_trunc('day', now() AT TIME ZONE ${timeZone}::text) - make_interval(days => g.idx)) AT TIME ZONE ${timeZone}::text AS day_start,
+          (date_trunc('day', now() AT TIME ZONE ${timeZone}::text) - make_interval(days => g.idx) + interval '1 day') AT TIME ZONE ${timeZone}::text AS day_end
+        FROM generate_series(0, ${daysAgo - 1}) AS g(idx)
+      ),
+      recent AS (
+        SELECT
+          ${sql(providerIncidents.provider.name)} AS provider,
+          ${sql(providerIncidents.startedAt.name)} AS started_at,
+          ${sql(providerIncidents.endedAt.name)} IS NULL AS is_open,
+          COALESCE(${sql(providerIncidents.endedAt.name)}, now()) AS ended_at
+        FROM ${sql(INCIDENTS_TABLE)}
+        WHERE ${sql(providerIncidents.provider.name)} IN ${sql(providers)}
+          AND (${sql(providerIncidents.endedAt.name)} IS NULL
+               OR ${sql(providerIncidents.endedAt.name)} >= (date_trunc('day', now() AT TIME ZONE ${timeZone}::text) - make_interval(days => 6)) AT TIME ZONE ${timeZone}::text)
+      )
       SELECT
-        ${sql(providerIncidents.provider.name)} AS provider,
-        to_char(${sql(providerIncidents.startedAt.name)} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS "startedAt",
-        to_char(${sql(providerIncidents.endedAt.name)} AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS "endedAt"
-      FROM ${sql(INCIDENTS_TABLE)}
-      WHERE ${sql(providerIncidents.provider.name)} IN ${sql(owners)}
-        AND (${sql(providerIncidents.endedAt.name)} IS NULL OR ${sql(providerIncidents.endedAt.name)} >= now() - make_interval(days => ${days}))
-      ORDER BY ${sql(providerIncidents.provider.name)}, ${sql(providerIncidents.startedAt.name)} ASC
+        i.provider,
+        to_char(d.day, 'YYYY-MM-DD') AS "date",
+        bool_or(bool_or(i.is_open)) OVER (PARTITION BY i.provider) AS "hasOpenIncident",
+        count(*)::int AS "incidentCount",
+        SUM(EXTRACT(EPOCH FROM (
+          LEAST(i.ended_at, d.day_end) - GREATEST(i.started_at, d.day_start)
+        )))::int AS "downtimeSeconds"
+      FROM recent i
+      JOIN day_bounds d
+        ON i.started_at < d.day_end
+       AND i.ended_at  > d.day_start
+      GROUP BY i.provider, d.day
+      ORDER BY i.provider, d.day
     `;
   }
 

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.spec.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.spec.ts
@@ -2,10 +2,10 @@ import type { LoggerService } from "@akashnetwork/logging";
 import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { GroupSpecJSON } from "@src/mappers/groupspec-mapper/groupspec-mapper";
 import type { BidScreeningCandidate, BidScreeningRepository } from "@src/repositories/bid-screening/bid-screening.repository";
-import type { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
+import type { DailyDowntimeRow, ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import type { ClusterInventoryMatcherService } from "../cluster-inventory-matcher/cluster-inventory-matcher.service";
+import type { BidScreeningInput } from "./bid-screening.service";
 import { BidScreeningService } from "./bid-screening.service";
 
 describe(BidScreeningService.name, () => {
@@ -107,26 +107,28 @@ describe(BidScreeningService.name, () => {
       const { service, repository, incidentRepository, matcher } = setup();
       repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc"), makeCandidate("akash1def")]);
       matcher.match.mockReturnValue({ matched: true });
-      incidentRepository.findRecentByProviders.mockResolvedValue([
-        { provider: "akash1abc", startedAt: "2026-06-01T00:00:00.000Z", endedAt: "2026-06-01T01:00:00.000Z" },
-        { provider: "akash1abc", startedAt: "2026-06-03T00:00:00.000Z", endedAt: null },
-        { provider: "akash1def", startedAt: "2026-06-02T00:00:00.000Z", endedAt: "2026-06-02T02:00:00.000Z" }
+      incidentRepository.findDailyDowntimeByProviders.mockResolvedValue([
+        makeDowntimeRow("akash1abc", { date: "2026-06-01", downtimeSeconds: 3600 }),
+        makeDowntimeRow("akash1abc", { date: "2026-06-03", hasOpenIncident: true, downtimeSeconds: 7200 }),
+        makeDowntimeRow("akash1def", { date: "2026-06-02", downtimeSeconds: 7200 })
       ]);
 
       const results = await service.findMatchingProviders(makeRequest());
 
       expect(results.find(r => r.owner === "akash1abc")?.incidents).toEqual([
-        { startedAt: "2026-06-01T00:00:00.000Z", endedAt: "2026-06-01T01:00:00.000Z" },
-        { startedAt: "2026-06-03T00:00:00.000Z", endedAt: null }
+        { date: "2026-06-01", hasOpenIncident: false, incidentCount: 1, downtimeSeconds: 3600 },
+        { date: "2026-06-03", hasOpenIncident: true, incidentCount: 1, downtimeSeconds: 7200 }
       ]);
-      expect(results.find(r => r.owner === "akash1def")?.incidents).toEqual([{ startedAt: "2026-06-02T00:00:00.000Z", endedAt: "2026-06-02T02:00:00.000Z" }]);
+      expect(results.find(r => r.owner === "akash1def")?.incidents).toEqual([
+        { date: "2026-06-02", hasOpenIncident: false, incidentCount: 1, downtimeSeconds: 7200 }
+      ]);
     });
 
     it("defaults incidents to an empty array for a matched provider with no incident rows", async () => {
       const { service, repository, incidentRepository, matcher } = setup();
       repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc")]);
       matcher.match.mockReturnValue({ matched: true });
-      incidentRepository.findRecentByProviders.mockResolvedValue([]);
+      incidentRepository.findDailyDowntimeByProviders.mockResolvedValue([]);
 
       const results = await service.findMatchingProviders(makeRequest());
 
@@ -141,20 +143,21 @@ describe(BidScreeningService.name, () => {
       const results = await service.findMatchingProviders(makeRequest());
 
       expect(results).toEqual([]);
-      expect(incidentRepository.findRecentByProviders).not.toHaveBeenCalled();
+      expect(incidentRepository.findDailyDowntimeByProviders).not.toHaveBeenCalled();
     });
 
     it("fetches incidents only for matched providers, not dropped candidates", async () => {
       const { service, repository, incidentRepository, matcher } = setup();
       repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc"), makeCandidate("akash1def")]);
       matcher.match.mockReturnValueOnce({ matched: true }).mockReturnValueOnce({ matched: false, error: "INSUFFICIENT_CAPACITY" });
-      incidentRepository.findRecentByProviders.mockResolvedValue([{ provider: "akash1abc", startedAt: "2026-06-01T00:00:00.000Z", endedAt: null }]);
+      incidentRepository.findDailyDowntimeByProviders.mockResolvedValue([makeDowntimeRow("akash1abc", { hasOpenIncident: true })]);
 
-      const results = await service.findMatchingProviders(makeRequest());
+      const request = makeRequest();
+      const results = await service.findMatchingProviders(request);
 
-      expect(incidentRepository.findRecentByProviders).toHaveBeenCalledWith(["akash1abc"]);
+      expect(incidentRepository.findDailyDowntimeByProviders).toHaveBeenCalledWith(["akash1abc"], request.timezone);
       expect(results).toHaveLength(1);
-      expect(results[0].incidents).toEqual([{ startedAt: "2026-06-01T00:00:00.000Z", endedAt: null }]);
+      expect(results[0].incidents).toEqual([{ date: "2026-06-01", hasOpenIncident: true, incidentCount: 1, downtimeSeconds: 3600 }]);
     });
 
     it("returns empty array without fetching candidates when the signal is already aborted", async () => {
@@ -167,7 +170,7 @@ describe(BidScreeningService.name, () => {
       expect(results).toEqual([]);
       expect(repository.findCandidates).not.toHaveBeenCalled();
       expect(matcher.match).not.toHaveBeenCalled();
-      expect(incidentRepository.findRecentByProviders).not.toHaveBeenCalled();
+      expect(incidentRepository.findDailyDowntimeByProviders).not.toHaveBeenCalled();
     });
 
     it("skips matching and incidents when the signal aborts during the candidates query", async () => {
@@ -182,7 +185,7 @@ describe(BidScreeningService.name, () => {
 
       expect(results).toEqual([]);
       expect(matcher.match).not.toHaveBeenCalled();
-      expect(incidentRepository.findRecentByProviders).not.toHaveBeenCalled();
+      expect(incidentRepository.findDailyDowntimeByProviders).not.toHaveBeenCalled();
     });
 
     it("returns matched providers with empty incidents when the signal aborts during matching", async () => {
@@ -199,32 +202,37 @@ describe(BidScreeningService.name, () => {
       expect(results).toHaveLength(1);
       expect(results[0].owner).toBe("akash1abc");
       expect(results[0].incidents).toEqual([]);
-      expect(incidentRepository.findRecentByProviders).not.toHaveBeenCalled();
+      expect(incidentRepository.findDailyDowntimeByProviders).not.toHaveBeenCalled();
     });
 
     it("runs the full pipeline when a non-aborted signal is provided", async () => {
       const { service, repository, incidentRepository, matcher } = setup();
       repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc")]);
       matcher.match.mockReturnValue({ matched: true });
-      incidentRepository.findRecentByProviders.mockResolvedValue([{ provider: "akash1abc", startedAt: "2026-06-01T00:00:00.000Z", endedAt: null }]);
+      incidentRepository.findDailyDowntimeByProviders.mockResolvedValue([makeDowntimeRow("akash1abc", { hasOpenIncident: true })]);
 
-      const results = await service.findMatchingProviders(makeRequest(), { signal: new AbortController().signal });
+      const request = makeRequest();
+      const results = await service.findMatchingProviders(request, { signal: new AbortController().signal });
 
-      expect(incidentRepository.findRecentByProviders).toHaveBeenCalledWith(["akash1abc"]);
-      expect(results[0].incidents).toEqual([{ startedAt: "2026-06-01T00:00:00.000Z", endedAt: null }]);
+      expect(incidentRepository.findDailyDowntimeByProviders).toHaveBeenCalledWith(["akash1abc"], request.timezone);
+      expect(results[0].incidents).toEqual([{ date: "2026-06-01", hasOpenIncident: true, incidentCount: 1, downtimeSeconds: 3600 }]);
     });
   });
 
   function setup() {
     const repository = mock<BidScreeningRepository>();
     const incidentRepository = mock<ProviderIncidentRepository>();
-    incidentRepository.findRecentByProviders.mockResolvedValue([]);
+    incidentRepository.findDailyDowntimeByProviders.mockResolvedValue([]);
     const matcher = mock<ClusterInventoryMatcherService>();
     const logger = mock<LoggerService>();
     const service = new BidScreeningService(repository, incidentRepository, matcher, () => logger);
     return { service, repository, incidentRepository, matcher, logger };
   }
 });
+
+function makeDowntimeRow(provider: string, overrides?: Partial<DailyDowntimeRow>): DailyDowntimeRow {
+  return { provider, date: "2026-06-01", hasOpenIncident: false, incidentCount: 1, downtimeSeconds: 3600, ...overrides };
+}
 
 function makeCandidate(owner: string, overrides?: { isAudited?: boolean; createdAt?: string; location?: string | null }): BidScreeningCandidate {
   return {
@@ -256,9 +264,9 @@ function makeRequest(
     attributes: { key: string; value: string }[];
     signedBy: { allOf: string[]; anyOf: string[] };
   }>
-): GroupSpecJSON {
+): BidScreeningInput {
   return {
-    name: "westcoast",
+    timezone: "America/Chicago",
     requirements: {
       signedBy: overrides?.signedBy ?? { allOf: [], anyOf: [] },
       attributes: overrides?.attributes ?? []

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
@@ -5,10 +5,10 @@ import { inject, singleton } from "tsyringe";
 import { bidScreeningBinPackerMatched, bidScreeningPrefilterCandidates } from "@src/metrics/metrics";
 import { LOGGER_FACTORY, type LoggerFactory, LoggerService } from "@src/providers/logger-factory.provider";
 import { type BidScreeningCandidate, BidScreeningRepository } from "@src/repositories/bid-screening/bid-screening.repository";
-import { ProviderIncidentRepository, RecentIncidentRow } from "@src/repositories/provider-incident/provider-incident.repository";
+import { DailyDowntimeRow, ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import type { GroupSpecJSON } from "../../mappers/groupspec-mapper/groupspec-mapper";
 import { mapGroupSpecToResourceUnits } from "../../mappers/groupspec-mapper/groupspec-mapper";
-import type { BidScreeningResult, Incident, RequestedResourceUnit } from "../../types/inventory";
+import type { BidScreeningResult, RequestedResourceUnit } from "../../types/inventory";
 import { ClusterInventoryMatcherService } from "../cluster-inventory-matcher/cluster-inventory-matcher.service";
 
 const EMPTY_OBJECT = Object.freeze(Object.create(null));
@@ -32,7 +32,7 @@ export class BidScreeningService {
     this.#logger = createLogger({ context: "BidScreeningService" });
   }
 
-  async findMatchingProviders(request: GroupSpecJSON, options?: Abortable): Promise<BidScreeningResult[]> {
+  async findMatchingProviders(request: BidScreeningInput, options?: Abortable): Promise<BidScreeningResult[]> {
     const resourceUnits = await withSpan("mapRequestToResourceUnits", async () => mapGroupSpecToResourceUnits(request));
 
     this.#logger.info({ event: "BID_SCREENING_START", resourceGroupCount: resourceUnits.length });
@@ -57,23 +57,29 @@ export class BidScreeningService {
       return items;
     });
 
-    const incidentsByOwner = await withSpan("fetchIncidentsForMatched", async ({ activeSpan }) => {
-      if (!matched.length || options?.signal?.aborted) return EMPTY_OBJECT;
-      const rows = await this.#incidentRepository.findRecentByProviders(matched.map(candidate => candidate.owner));
-      activeSpan.setAttribute("amountOfIncidents", rows.length);
+    const incidentsByOwner: Partial<Record<string, Omit<DailyDowntimeRow, "provider">[]>> = await withSpan(
+      "fetchIncidentsForMatched",
+      async ({ activeSpan }) => {
+        if (!matched.length || options?.signal?.aborted) return EMPTY_OBJECT;
+        const rows = await this.#incidentRepository.findDailyDowntimeByProviders(
+          matched.map(candidate => candidate.owner),
+          request.timezone
+        );
+        activeSpan.setAttribute("amountOfIncidents", rows.length);
 
-      const grouped = Object.create(null) as Partial<Record<string, Pick<RecentIncidentRow, "startedAt" | "endedAt">[]>>;
-      for (const row of rows) {
-        grouped[row.provider] ??= [];
-        grouped[row.provider]!.push({ startedAt: row.startedAt, endedAt: row.endedAt });
+        const grouped = Object.create(null);
+        for (const { provider, ...row } of rows) {
+          grouped[provider] ??= [];
+          grouped[provider]!.push(row);
+        }
+
+        this.#logger.info({
+          event: "BID_SCREENING_PROVIDER_INCIDENTS_FETCHED",
+          incidentsCount: rows.length
+        });
+        return grouped;
       }
-
-      this.#logger.info({
-        event: "BID_SCREENING_PROVIDER_INCIDENTS_FETCHED",
-        incidentsCount: rows.length
-      });
-      return grouped;
-    });
+    );
 
     return matched.map(candidate => this.#toResult(candidate, incidentsByOwner));
   }
@@ -94,7 +100,7 @@ export class BidScreeningService {
     return matched;
   }
 
-  #toResult(candidate: BidScreeningCandidate, incidentsByOwner: Record<string, Incident[]>): BidScreeningResult {
+  #toResult(candidate: BidScreeningCandidate, incidentsByOwner: Partial<Record<string, Omit<DailyDowntimeRow, "provider">[]>>): BidScreeningResult {
     return {
       owner: candidate.owner,
       hostUri: candidate.hostUri,
@@ -104,4 +110,8 @@ export class BidScreeningService {
       incidents: incidentsByOwner[candidate.owner] ?? []
     };
   }
+}
+
+export interface BidScreeningInput extends Omit<GroupSpecJSON, "name"> {
+  timezone: string;
 }

--- a/apps/provider-inventory/src/types/inventory.ts
+++ b/apps/provider-inventory/src/types/inventory.ts
@@ -1,3 +1,4 @@
+import type { DailyDowntimeRow } from "@src/repositories/provider-incident/provider-incident.repository";
 import type { ParsedGPUAttributes } from "../mappers/gpu-attribute-parser/gpu-attribute-parser";
 import type { ParsedStorageAttributes } from "../mappers/storage-attribute-parser/storage-attribute-parser";
 
@@ -65,18 +66,13 @@ export interface MatchResult {
   error?: "INSUFFICIENT_CAPACITY" | "GROUP_RESOURCE_MISMATCH";
 }
 
-export interface Incident {
-  startedAt: string;
-  endedAt: string | null;
-}
-
 export interface BidScreeningResult {
   owner: string;
   hostUri: string;
   isAudited: boolean;
   createdAt: string;
   location: string | null;
-  incidents: Incident[];
+  incidents: Omit<DailyDowntimeRow, "provider">[];
 }
 
 export type ToJSON<T> = T extends Uint8Array ? bigint : T extends object ? { -readonly [K in keyof T]: ToJSON<Exclude<T[K], undefined>> } : T;

--- a/packages/net/src/generated/netConfigData.ts
+++ b/packages/net/src/generated/netConfigData.ts
@@ -32,7 +32,7 @@ export const netConfigData = {
     ]
   },
   "sandbox-2": {
-    version: "v2.0.0",
+    version: "v2.1.0",
     faucetUrl: "http://faucet.sandbox-2.aksh.pw/",
     apiUrls: ["https://api.sandbox-2.aksh.pw:443"],
     rpcUrls: ["https://rpc.sandbox-2.aksh.pw:443"]


### PR DESCRIPTION
## Why

Currently bid screening endpoint returns raw incidents for the last 8 days. Flaky provider may have many incidents per day and this results in several inefficiencies:
- big response size (long time to serialize)
- big amount of objects, GC pressure 
- complicated aggregation on client side

## What

adds `?timezone` parameter and aggregate per day incident statistic for every provider.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Bid-screening requests now require a validated `timezone` field instead of `name`.
  * Provider incident reporting now returns rolling daily summaries (per provider) with `date`, `hasOpenIncident`, `incidentCount`, and `downtimeSeconds` (clipped to day boundaries), replacing interval-based `startedAt`/`endedAt`.
* **Behavior Updates**
  * Bid-screening provider matching now uses the new daily downtime reporting and groups results accordingly.
* **Tests**
  * Updated/added coverage to validate the new daily downtime semantics, timezone-aware day clipping, and stable result ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->