### PR TITLE
feat: adds organization field to bid screening response

### DIFF
--- a/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
+++ b/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
@@ -112,6 +112,10 @@ const ProviderResultSchema = z.object({
     description: "Provider region from the location-region attribute (signed preferred, else self-declared); null if unset",
     example: "us-west"
   }),
+  organization: z.string().nullable().openapi({
+    description: "Provider organization from the organization attribute (signed preferred, else self-declared); null if unset",
+    example: "Akash"
+  }),
   incidents: z
     .array(
       z.object({

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -3122,6 +3122,12 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                             "nullable": true,
                             "type": "string",
                           },
+                          "organization": {
+                            "description": "Provider organization from the organization attribute (signed preferred, else self-declared); null if unset",
+                            "example": "Akash",
+                            "nullable": true,
+                            "type": "string",
+                          },
                           "owner": {
                             "description": "Provider address",
                             "example": "akash1q7spv2cw06yszgfp4f9ed59lkka6ytn8g4tkjf",
@@ -3134,6 +3140,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           "isAudited",
                           "createdAt",
                           "location",
+                          "organization",
                           "incidents",
                         ],
                         "type": "object",

--- a/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
+++ b/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
@@ -112,6 +112,10 @@ const ProviderResultSchema = z.object({
     description: "Provider region from the location-region attribute (signed preferred, else self-declared); null if unset",
     example: "us-west"
   }),
+  organization: z.string().nullable().openapi({
+    description: "Provider organization from the organization attribute (signed preferred, else self-declared); null if unset",
+    example: "Akash"
+  }),
   incidents: z
     .array(
       z.object({

--- a/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.integration.ts
@@ -224,6 +224,40 @@ describe(BidScreeningRepository.name, () => {
     });
   });
 
+  describe("organization projection", () => {
+    it("prefers organization from signed_attributes when both sets define it", async () => {
+      await seed({
+        owner: "akash1signedorg",
+        selfAttributes: [{ key: "organization", value: "self-org" }],
+        signedAttributes: [{ key: "organization", value: "signed-org", auditor: AUDITOR }]
+      });
+
+      const [row] = await repository.findCandidates([unit({})], requirements());
+
+      expect(row.organization).toBe("signed-org");
+    });
+
+    it("falls back to self_attributes when signed_attributes has no organization", async () => {
+      await seed({
+        owner: "akash1selforg",
+        selfAttributes: [{ key: "organization", value: "self-org" }],
+        signedAttributes: [{ key: "country", value: "us", auditor: AUDITOR }]
+      });
+
+      const [row] = await repository.findCandidates([unit({})], requirements());
+
+      expect(row.organization).toBe("self-org");
+    });
+
+    it("returns null when neither attribute set defines organization", async () => {
+      await seed({ owner: "akash1noorg", selfAttributes: [{ key: "country", value: "us" }] });
+
+      const [row] = await repository.findCandidates([unit({})], requirements());
+
+      expect(row.organization).toBeNull();
+    });
+  });
+
   describe("gpu_models filter", () => {
     it("vendor-only request matches mixed-model providers via the vendor token", async () => {
       await seed({ owner: "akash1nvidiaA100", gpuModels: ["nvidia", "nvidia/a100"], totalAvailableGpu: 8n, maxNodeFreeGpu: 8n });

--- a/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.ts
+++ b/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.ts
@@ -18,6 +18,7 @@ export interface BidScreeningCandidate {
   createdAt: string;
   updatedAt: string;
   location: string | null;
+  organization: string | null;
 }
 
 const TABLE = getTableName(providerInventory);
@@ -73,7 +74,11 @@ export class BidScreeningRepository {
           COALESCE(
             (SELECT sa->>'value' FROM jsonb_array_elements(${sql(providerInventory.signedAttributes.name)}) AS sa WHERE sa->>'key' = 'location-region' LIMIT 1),
             (SELECT sa->>'value' FROM jsonb_array_elements(${sql(providerInventory.selfAttributes.name)}) AS sa WHERE sa->>'key' = 'location-region' LIMIT 1)
-          ) AS location
+          ) AS location,
+          COALESCE(
+            (SELECT sa->>'value' FROM jsonb_array_elements(${sql(providerInventory.signedAttributes.name)}) AS sa WHERE sa->>'key' = 'organization' LIMIT 1),
+            (SELECT sa->>'value' FROM jsonb_array_elements(${sql(providerInventory.selfAttributes.name)}) AS sa WHERE sa->>'key' = 'organization' LIMIT 1)
+          ) AS organization
         FROM ${sql(TABLE)}
         WHERE ${sql(providerInventory.owner.name)} = ANY(${ownersToFetch}::text[])
       `;

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.spec.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.spec.ts
@@ -24,6 +24,7 @@ describe(BidScreeningService.name, () => {
           isAudited: false,
           createdAt: "2026-01-01T00:00:00.000Z",
           location: null,
+          organization: null,
           incidents: []
         }
       ]);
@@ -37,6 +38,16 @@ describe(BidScreeningService.name, () => {
       const results = await service.findMatchingProviders(makeRequest());
 
       expect(results[0].location).toBe("us-west");
+    });
+
+    it("threads candidate.organization through to the result", async () => {
+      const { service, repository, matcher } = setup();
+      repository.findCandidates.mockResolvedValue([makeCandidate("akash1abc", { organization: "Akash" })]);
+      matcher.match.mockReturnValue({ matched: true });
+
+      const results = await service.findMatchingProviders(makeRequest());
+
+      expect(results[0].organization).toBe("Akash");
     });
 
     it("filters out candidates that fail matching", async () => {
@@ -234,7 +245,10 @@ function makeDowntimeRow(provider: string, overrides?: Partial<DailyDowntimeRow>
   return { provider, date: "2026-06-01", hasOpenIncident: false, incidentCount: 1, downtimeSeconds: 3600, ...overrides };
 }
 
-function makeCandidate(owner: string, overrides?: { isAudited?: boolean; createdAt?: string; location?: string | null }): BidScreeningCandidate {
+function makeCandidate(
+  owner: string,
+  overrides?: { isAudited?: boolean; createdAt?: string; location?: string | null; organization?: string | null }
+): BidScreeningCandidate {
   return {
     owner,
     hostUri: "https://provider.example.com:8443",
@@ -242,6 +256,7 @@ function makeCandidate(owner: string, overrides?: { isAudited?: boolean; created
     createdAt: overrides?.createdAt ?? "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
     location: overrides?.location ?? null,
+    organization: overrides?.organization ?? null,
     cluster: {
       nodes: [
         {

--- a/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
+++ b/apps/provider-inventory/src/services/bid-screening/bid-screening.service.ts
@@ -107,6 +107,7 @@ export class BidScreeningService {
       isAudited: candidate.isAudited,
       createdAt: candidate.createdAt,
       location: candidate.location,
+      organization: candidate.organization,
       incidents: incidentsByOwner[candidate.owner] ?? []
     };
   }

--- a/apps/provider-inventory/src/types/inventory.ts
+++ b/apps/provider-inventory/src/types/inventory.ts
@@ -72,6 +72,7 @@ export interface BidScreeningResult {
   isAudited: boolean;
   createdAt: string;
   location: string | null;
+  organization: string | null;
   incidents: Omit<DailyDowntimeRow, "provider">[];
 }
 


### PR DESCRIPTION
## Why

Exposing this information for UI. Closes CON-511. Depends on https://github.com/akash-network/console/pull/3322

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider search results now include an organization field to display each provider's organization name. The organization information is sourced from provider-signed attributes first, with a fallback to self-declared attributes when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->