### PR TITLE
fix(provider): apply region filter to marketplace before SDL exists

### DIFF
--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -76,6 +76,10 @@
                         "isTrialing": {
                           "type": "boolean"
                         },
+                        "topUpMinAmountUsd": {
+                          "type": "number",
+                          "description": "Minimum USD amount accepted by the next paid top-up for this wallet."
+                        },
                         "createdAt": {
                           "type": "string",
                           "nullable": true
@@ -103,6 +107,7 @@
                         "address",
                         "denom",
                         "isTrialing",
+                        "topUpMinAmountUsd",
                         "createdAt"
                       ],
                       "additionalProperties": false
@@ -146,6 +151,10 @@
                         "isTrialing": {
                           "type": "boolean"
                         },
+                        "topUpMinAmountUsd": {
+                          "type": "number",
+                          "description": "Minimum USD amount accepted by the next paid top-up for this wallet."
+                        },
                         "createdAt": {
                           "type": "string",
                           "nullable": true
@@ -173,6 +182,7 @@
                         "address",
                         "denom",
                         "isTrialing",
+                        "topUpMinAmountUsd",
                         "createdAt"
                       ],
                       "additionalProperties": false
@@ -248,6 +258,10 @@
                           "isTrialing": {
                             "type": "boolean"
                           },
+                          "topUpMinAmountUsd": {
+                            "type": "number",
+                            "description": "Minimum USD amount accepted by the next paid top-up for this wallet."
+                          },
                           "createdAt": {
                             "type": "string",
                             "nullable": true
@@ -275,6 +289,7 @@
                           "address",
                           "denom",
                           "isTrialing",
+                          "topUpMinAmountUsd",
                           "createdAt"
                         ]
                       }
@@ -608,1270 +623,6 @@
         }
       }
     },
-    "/v1/stripe/prices": {
-      "get": {
-        "summary": "Get available Stripe pricing options",
-        "description": "Retrieves the list of available pricing options for wallet top-ups, including custom amounts and standard pricing tiers",
-        "tags": [
-          "Payment"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Available pricing options retrieved successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "currency": {
-                            "type": "string"
-                          },
-                          "unitAmount": {
-                            "type": "number"
-                          },
-                          "isCustom": {
-                            "type": "boolean"
-                          }
-                        },
-                        "required": [
-                          "currency",
-                          "unitAmount",
-                          "isCustom"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "data"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/stripe/coupons/apply": {
-      "post": {
-        "summary": "Apply a coupon to the current user",
-        "tags": [
-          "Payment"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "data": {
-                    "type": "object",
-                    "properties": {
-                      "couponId": {
-                        "type": "string"
-                      },
-                      "userId": {
-                        "type": "string"
-                      },
-                      "awaitResolved": {
-                        "type": "boolean"
-                      }
-                    },
-                    "required": [
-                      "couponId",
-                      "userId"
-                    ]
-                  }
-                },
-                "required": [
-                  "data"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Coupon applied successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "coupon": {
-                          "type": "object",
-                          "nullable": true,
-                          "properties": {
-                            "id": {
-                              "type": "string"
-                            },
-                            "percent_off": {
-                              "type": "number",
-                              "nullable": true
-                            },
-                            "amount_off": {
-                              "type": "number",
-                              "nullable": true
-                            },
-                            "valid": {
-                              "type": "boolean",
-                              "nullable": true
-                            },
-                            "name": {
-                              "type": "string",
-                              "nullable": true
-                            },
-                            "description": {
-                              "type": "string",
-                              "nullable": true
-                            }
-                          },
-                          "required": [
-                            "id"
-                          ]
-                        },
-                        "amountAdded": {
-                          "type": "number"
-                        },
-                        "transactionId": {
-                          "type": "string"
-                        },
-                        "transactionStatus": {
-                          "type": "string",
-                          "enum": [
-                            "created",
-                            "pending",
-                            "requires_action",
-                            "succeeded",
-                            "failed",
-                            "refunded",
-                            "canceled"
-                          ]
-                        },
-                        "error": {
-                          "type": "object",
-                          "properties": {
-                            "message": {
-                              "type": "string"
-                            },
-                            "code": {
-                              "type": "string"
-                            },
-                            "type": {
-                              "type": "string"
-                            }
-                          },
-                          "required": [
-                            "message"
-                          ]
-                        }
-                      }
-                    }
-                  },
-                  "required": [
-                    "data"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/stripe/customers/organization": {
-      "put": {
-        "summary": "Update customer organization",
-        "description": "Updates the organization/business name for the current user's Stripe customer account",
-        "tags": [
-          "Payment"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "organization": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "organization"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "204": {
-            "description": "Organization updated successfully"
-          }
-        }
-      }
-    },
-    "/v1/stripe/payment-methods/setup": {
-      "post": {
-        "summary": "Create a Stripe SetupIntent for adding a payment method",
-        "description": "Creates a Stripe SetupIntent that allows users to securely add payment methods to their account. The SetupIntent provides a client secret that can be used with Stripe's frontend SDKs to collect payment method details.",
-        "tags": [
-          "Payment"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "SetupIntent created successfully with client secret",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "clientSecret": {
-                          "type": "string",
-                          "nullable": true
-                        }
-                      },
-                      "required": [
-                        "clientSecret"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "data"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/stripe/payment-methods/default": {
-      "post": {
-        "summary": "Marks a payment method as the default.",
-        "tags": [
-          "Payment"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "data": {
-                    "type": "object",
-                    "properties": {
-                      "id": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "id"
-                    ]
-                  }
-                },
-                "required": [
-                  "data"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Payment method is marked as the default successfully."
-          }
-        }
-      },
-      "get": {
-        "summary": "Get the default payment method for the current user",
-        "description": "Retrieves the default payment method associated with the current user's account, including card details, validation status, and billing information.",
-        "tags": [
-          "Payment"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Default payment method retrieved successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "type": {
-                          "type": "string"
-                        },
-                        "validated": {
-                          "type": "boolean"
-                        },
-                        "isDefault": {
-                          "type": "boolean"
-                        },
-                        "card": {
-                          "type": "object",
-                          "nullable": true,
-                          "properties": {
-                            "brand": {
-                              "type": "string",
-                              "nullable": true
-                            },
-                            "last4": {
-                              "type": "string",
-                              "nullable": true
-                            },
-                            "exp_month": {
-                              "type": "number"
-                            },
-                            "exp_year": {
-                              "type": "number"
-                            },
-                            "funding": {
-                              "type": "string",
-                              "nullable": true
-                            },
-                            "country": {
-                              "type": "string",
-                              "nullable": true
-                            },
-                            "network": {
-                              "type": "string",
-                              "nullable": true
-                            },
-                            "three_d_secure_usage": {
-                              "type": "object",
-                              "nullable": true,
-                              "properties": {
-                                "supported": {
-                                  "type": "boolean",
-                                  "nullable": true
-                                }
-                              }
-                            }
-                          },
-                          "required": [
-                            "brand",
-                            "last4",
-                            "exp_month",
-                            "exp_year"
-                          ]
-                        },
-                        "link": {
-                          "type": "object",
-                          "nullable": true,
-                          "properties": {
-                            "email": {
-                              "type": "string",
-                              "nullable": true
-                            }
-                          }
-                        },
-                        "billing_details": {
-                          "type": "object",
-                          "properties": {
-                            "address": {
-                              "type": "object",
-                              "nullable": true,
-                              "properties": {
-                                "city": {
-                                  "type": "string",
-                                  "nullable": true
-                                },
-                                "country": {
-                                  "type": "string",
-                                  "nullable": true
-                                },
-                                "line1": {
-                                  "type": "string",
-                                  "nullable": true
-                                },
-                                "line2": {
-                                  "type": "string",
-                                  "nullable": true
-                                },
-                                "postal_code": {
-                                  "type": "string",
-                                  "nullable": true
-                                },
-                                "state": {
-                                  "type": "string",
-                                  "nullable": true
-                                }
-                              },
-                              "required": [
-                                "city",
-                                "country",
-                                "line1",
-                                "line2",
-                                "postal_code",
-                                "state"
-                              ]
-                            },
-                            "email": {
-                              "type": "string",
-                              "nullable": true
-                            },
-                            "name": {
-                              "type": "string",
-                              "nullable": true
-                            },
-                            "phone": {
-                              "type": "string",
-                              "nullable": true
-                            }
-                          }
-                        }
-                      },
-                      "required": [
-                        "type"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "data"
-                  ]
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Default payment method not found"
-          }
-        }
-      }
-    },
-    "/v1/stripe/payment-methods": {
-      "get": {
-        "summary": "Get all payment methods for the current user",
-        "description": "Retrieves all saved payment methods associated with the current user's account, including card details, validation status, and billing information.",
-        "tags": [
-          "Payment"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Payment methods retrieved successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "type": {
-                            "type": "string"
-                          },
-                          "validated": {
-                            "type": "boolean"
-                          },
-                          "isDefault": {
-                            "type": "boolean"
-                          },
-                          "card": {
-                            "type": "object",
-                            "nullable": true,
-                            "properties": {
-                              "brand": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "last4": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "exp_month": {
-                                "type": "number"
-                              },
-                              "exp_year": {
-                                "type": "number"
-                              },
-                              "funding": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "country": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "network": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "three_d_secure_usage": {
-                                "type": "object",
-                                "nullable": true,
-                                "properties": {
-                                  "supported": {
-                                    "type": "boolean",
-                                    "nullable": true
-                                  }
-                                }
-                              }
-                            },
-                            "required": [
-                              "brand",
-                              "last4",
-                              "exp_month",
-                              "exp_year"
-                            ]
-                          },
-                          "link": {
-                            "type": "object",
-                            "nullable": true,
-                            "properties": {
-                              "email": {
-                                "type": "string",
-                                "nullable": true
-                              }
-                            }
-                          },
-                          "billing_details": {
-                            "type": "object",
-                            "properties": {
-                              "address": {
-                                "type": "object",
-                                "nullable": true,
-                                "properties": {
-                                  "city": {
-                                    "type": "string",
-                                    "nullable": true
-                                  },
-                                  "country": {
-                                    "type": "string",
-                                    "nullable": true
-                                  },
-                                  "line1": {
-                                    "type": "string",
-                                    "nullable": true
-                                  },
-                                  "line2": {
-                                    "type": "string",
-                                    "nullable": true
-                                  },
-                                  "postal_code": {
-                                    "type": "string",
-                                    "nullable": true
-                                  },
-                                  "state": {
-                                    "type": "string",
-                                    "nullable": true
-                                  }
-                                },
-                                "required": [
-                                  "city",
-                                  "country",
-                                  "line1",
-                                  "line2",
-                                  "postal_code",
-                                  "state"
-                                ]
-                              },
-                              "email": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "name": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "phone": {
-                                "type": "string",
-                                "nullable": true
-                              }
-                            }
-                          }
-                        },
-                        "required": [
-                          "type"
-                        ]
-                      }
-                    }
-                  },
-                  "required": [
-                    "data"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/stripe/payment-methods/{paymentMethodId}": {
-      "delete": {
-        "summary": "Remove a payment method",
-        "description": "Permanently removes a saved payment method from the user's account. This action cannot be undone.",
-        "tags": [
-          "Payment"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "description": "The unique identifier of the payment method to remove",
-              "example": "pm_1234567890"
-            },
-            "required": true,
-            "name": "paymentMethodId",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Payment method removed successfully"
-          }
-        }
-      }
-    },
-    "/v1/stripe/payment-methods/validate": {
-      "post": {
-        "summary": "Validates a payment method after 3D Secure authentication",
-        "description": "Completes the validation process for a payment method that required 3D Secure authentication. This endpoint should be called after the user completes the 3D Secure challenge.",
-        "tags": [
-          "Payment"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "data": {
-                    "type": "object",
-                    "properties": {
-                      "paymentMethodId": {
-                        "type": "string"
-                      },
-                      "paymentIntentId": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "paymentMethodId",
-                      "paymentIntentId"
-                    ]
-                  }
-                },
-                "required": [
-                  "data"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Payment method validated successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    }
-                  },
-                  "required": [
-                    "success"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/stripe/transactions/confirm": {
-      "post": {
-        "summary": "Confirm a payment using a saved payment method",
-        "description": "Processes a payment using a previously saved payment method. This endpoint handles wallet top-ups and may require 3D Secure authentication for certain payment methods or amounts.",
-        "tags": [
-          "Payment"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "data": {
-                    "type": "object",
-                    "properties": {
-                      "userId": {
-                        "type": "string"
-                      },
-                      "paymentMethodId": {
-                        "type": "string"
-                      },
-                      "amount": {
-                        "type": "number",
-                        "minimum": 20
-                      },
-                      "currency": {
-                        "type": "string"
-                      },
-                      "awaitResolved": {
-                        "type": "boolean"
-                      }
-                    },
-                    "required": [
-                      "userId",
-                      "paymentMethodId",
-                      "amount",
-                      "currency"
-                    ]
-                  }
-                },
-                "required": [
-                  "data"
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Payment processed successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "success": {
-                          "type": "boolean"
-                        },
-                        "requiresAction": {
-                          "type": "boolean"
-                        },
-                        "clientSecret": {
-                          "type": "string"
-                        },
-                        "paymentIntentId": {
-                          "type": "string"
-                        },
-                        "transactionId": {
-                          "type": "string"
-                        },
-                        "transactionStatus": {
-                          "type": "string",
-                          "enum": [
-                            "created",
-                            "pending",
-                            "requires_action",
-                            "succeeded",
-                            "failed",
-                            "refunded",
-                            "canceled"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "success",
-                        "transactionId"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "data"
-                  ]
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "3D Secure authentication required to complete payment",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "success": {
-                          "type": "boolean"
-                        },
-                        "requiresAction": {
-                          "type": "boolean"
-                        },
-                        "clientSecret": {
-                          "type": "string"
-                        },
-                        "paymentIntentId": {
-                          "type": "string"
-                        },
-                        "transactionId": {
-                          "type": "string"
-                        },
-                        "transactionStatus": {
-                          "type": "string",
-                          "enum": [
-                            "created",
-                            "pending",
-                            "requires_action",
-                            "succeeded",
-                            "failed",
-                            "refunded",
-                            "canceled"
-                          ]
-                        }
-                      },
-                      "required": [
-                        "success",
-                        "transactionId"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "data"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/stripe/transactions": {
-      "get": {
-        "summary": "Get transaction history for the current customer",
-        "tags": [
-          "Payment"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "number",
-              "description": "Number of transactions to return",
-              "minimum": 1,
-              "maximum": 100,
-              "example": 100,
-              "default": 100
-            },
-            "required": false,
-            "name": "limit",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "ID of the last transaction from the previous page (if paginating forwards)",
-              "example": "ch_1234567890"
-            },
-            "required": false,
-            "name": "startingAfter",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "description": "ID of the first transaction from the previous page (if paginating backwards)",
-              "example": "ch_0987654321"
-            },
-            "required": false,
-            "name": "endingBefore",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "format": "date-time",
-              "description": "Start date for filtering transactions (inclusive)",
-              "example": "2025-01-01T00:00:00Z"
-            },
-            "required": false,
-            "name": "startDate",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "format": "date-time",
-              "description": "End date for filtering transactions (inclusive)",
-              "example": "2025-01-02T00:00:00Z"
-            },
-            "required": false,
-            "name": "endDate",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Customer transactions retrieved successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "type": "object",
-                      "properties": {
-                        "transactions": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "id": {
-                                "type": "string"
-                              },
-                              "amount": {
-                                "type": "number"
-                              },
-                              "currency": {
-                                "type": "string"
-                              },
-                              "status": {
-                                "type": "string"
-                              },
-                              "created": {
-                                "type": "number"
-                              },
-                              "paymentMethod": {
-                                "type": "object",
-                                "nullable": true,
-                                "properties": {
-                                  "type": {
-                                    "type": "string"
-                                  },
-                                  "validated": {
-                                    "type": "boolean"
-                                  },
-                                  "isDefault": {
-                                    "type": "boolean"
-                                  },
-                                  "card": {
-                                    "type": "object",
-                                    "nullable": true,
-                                    "properties": {
-                                      "brand": {
-                                        "type": "string",
-                                        "nullable": true
-                                      },
-                                      "last4": {
-                                        "type": "string",
-                                        "nullable": true
-                                      },
-                                      "exp_month": {
-                                        "type": "number"
-                                      },
-                                      "exp_year": {
-                                        "type": "number"
-                                      },
-                                      "funding": {
-                                        "type": "string",
-                                        "nullable": true
-                                      },
-                                      "country": {
-                                        "type": "string",
-                                        "nullable": true
-                                      },
-                                      "network": {
-                                        "type": "string",
-                                        "nullable": true
-                                      },
-                                      "three_d_secure_usage": {
-                                        "type": "object",
-                                        "nullable": true,
-                                        "properties": {
-                                          "supported": {
-                                            "type": "boolean",
-                                            "nullable": true
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "required": [
-                                      "brand",
-                                      "last4",
-                                      "exp_month",
-                                      "exp_year"
-                                    ]
-                                  },
-                                  "link": {
-                                    "type": "object",
-                                    "nullable": true,
-                                    "properties": {
-                                      "email": {
-                                        "type": "string",
-                                        "nullable": true
-                                      }
-                                    }
-                                  },
-                                  "billing_details": {
-                                    "type": "object",
-                                    "properties": {
-                                      "address": {
-                                        "type": "object",
-                                        "nullable": true,
-                                        "properties": {
-                                          "city": {
-                                            "type": "string",
-                                            "nullable": true
-                                          },
-                                          "country": {
-                                            "type": "string",
-                                            "nullable": true
-                                          },
-                                          "line1": {
-                                            "type": "string",
-                                            "nullable": true
-                                          },
-                                          "line2": {
-                                            "type": "string",
-                                            "nullable": true
-                                          },
-                                          "postal_code": {
-                                            "type": "string",
-                                            "nullable": true
-                                          },
-                                          "state": {
-                                            "type": "string",
-                                            "nullable": true
-                                          }
-                                        },
-                                        "required": [
-                                          "city",
-                                          "country",
-                                          "line1",
-                                          "line2",
-                                          "postal_code",
-                                          "state"
-                                        ]
-                                      },
-                                      "email": {
-                                        "type": "string",
-                                        "nullable": true
-                                      },
-                                      "name": {
-                                        "type": "string",
-                                        "nullable": true
-                                      },
-                                      "phone": {
-                                        "type": "string",
-                                        "nullable": true
-                                      }
-                                    }
-                                  }
-                                },
-                                "required": [
-                                  "type"
-                                ]
-                              },
-                              "receiptUrl": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "description": {
-                                "type": "string",
-                                "nullable": true
-                              },
-                              "metadata": {
-                                "type": "object",
-                                "nullable": true,
-                                "additionalProperties": {
-                                  "type": "string"
-                                }
-                              }
-                            },
-                            "required": [
-                              "id",
-                              "amount",
-                              "currency",
-                              "status",
-                              "created",
-                              "paymentMethod"
-                            ]
-                          }
-                        },
-                        "hasMore": {
-                          "type": "boolean"
-                        },
-                        "nextPage": {
-                          "type": "string",
-                          "nullable": true
-                        }
-                      },
-                      "required": [
-                        "transactions",
-                        "hasMore"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "data"
-                  ]
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v1/stripe/transactions/export": {
-      "get": {
-        "summary": "Export transaction history as CSV for the current customer",
-        "tags": [
-          "Payment"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "ApiKeyAuth": []
-          }
-        ],
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "description": "Timezone for date formatting in the CSV",
-              "example": "America/New_York"
-            },
-            "required": true,
-            "name": "timezone",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "format": "date-time",
-              "description": "Start date for filtering transactions (inclusive)",
-              "example": "2025-01-01T00:00:00Z"
-            },
-            "required": true,
-            "name": "startDate",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "format": "date-time",
-              "description": "End date for filtering transactions (inclusive)",
-              "example": "2025-01-02T00:00:00Z"
-            },
-            "required": true,
-            "name": "endDate",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "CSV file with transaction data",
-            "content": {
-              "text/csv": {
-                "schema": {
-                  "type": "string",
-                  "format": "binary"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/v1/usage/history": {
       "get": {
         "summary": "Get historical data of billing and usage for a wallet address.",
@@ -1905,7 +656,7 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "default": "2026-05-20",
+              "default": "2026-06-17",
               "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
               "example": "2024-01-31"
             },
@@ -2031,7 +782,7 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "default": "2026-05-20",
+              "default": "2026-06-17",
               "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
               "example": "2024-01-31"
             },
@@ -9097,6 +7848,9 @@
                                     "count"
                                   ]
                                 }
+                              },
+                              "reclamation_window": {
+                                "type": "string"
                               }
                             },
                             "required": [
@@ -9542,6 +8296,9 @@
                                     "count"
                                   ]
                                 }
+                              },
+                              "reclamation_window": {
+                                "type": "string"
                               }
                             },
                             "required": [
@@ -15712,6 +14469,7 @@
           {
             "schema": {
               "type": "string",
+              "pattern": "^[^/\\\\]+$",
               "description": "Template ID",
               "example": "akash-network-cosmos-omnibus-agoric"
             },
@@ -15791,6 +14549,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Invalid template ID"
           },
           "404": {
             "description": "Template not found"
@@ -16390,11 +15151,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "Group name",
-                    "example": "westcoast"
-                  },
                   "requirements": {
                     "type": "object",
                     "properties": {
@@ -16693,13 +15449,17 @@
                         "price"
                       ]
                     },
-                    "minItems": 1,
                     "description": "Resource units with replica counts"
+                  },
+                  "timezone": {
+                    "type": "string",
+                    "description": "Client timezone, validated against supported Node.js Intl timezones",
+                    "example": "America/Chicago"
                   }
                 },
                 "required": [
-                  "name",
-                  "resources"
+                  "resources",
+                  "timezone"
                 ]
               }
             }
@@ -16740,9 +15500,41 @@
                           },
                           "location": {
                             "type": "string",
+                            "nullable": true,
                             "description": "Provider region from the location-region attribute (signed preferred, else self-declared); null if unset",
-                            "example": "us-west",
-                            "nullable": true
+                            "example": "us-west"
+                          },
+                          "incidents": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "date": {
+                                  "type": "string",
+                                  "description": "Local calendar day, YYYY-MM-DD",
+                                  "example": "2026-06-01"
+                                },
+                                "hasOpenIncident": {
+                                  "type": "boolean",
+                                  "description": "True if the provider currently has any open incident"
+                                },
+                                "incidentCount": {
+                                  "type": "integer",
+                                  "description": "Number of incident intervals overlapping that day"
+                                },
+                                "downtimeSeconds": {
+                                  "type": "integer",
+                                  "description": "Downtime clipped to that day, in seconds (max 86400)"
+                                }
+                              },
+                              "required": [
+                                "date",
+                                "hasOpenIncident",
+                                "incidentCount",
+                                "downtimeSeconds"
+                              ]
+                            },
+                            "description": "Per-day downtime over a rolling 7-day window"
                           }
                         },
                         "required": [
@@ -16750,7 +15542,8 @@
                           "hostUri",
                           "isAudited",
                           "createdAt",
-                          "location"
+                          "location",
+                          "incidents"
                         ]
                       }
                     }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -40,7 +40,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, dependencies: d
   });
   const services = useWatch({ control: form.control, name: "services" });
   const placements = useWatch({ control: form.control, name: "placements" });
-  const selectedPlacementName = resolveSelectedPlacementName(services, placements, selectedServiceId);
+  const selectedPlacement = resolveSelectedPlacement(services, placements, selectedServiceId);
 
   useEffect(
     function notifyOnImportError() {
@@ -89,7 +89,8 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, dependencies: d
           <d.ConfigureDeploymentPanes
             sdl={sdl}
             selectedServiceId={selectedServiceId}
-            selectedPlacementName={selectedPlacementName}
+            selectedPlacementName={selectedPlacement.name}
+            selectedPlacementRegion={selectedPlacement.region}
             onSelectService={setSelectedServiceId}
           />
         </div>
@@ -165,19 +166,19 @@ function regenerateSdl(values: SdlBuilderFormValuesType, previous: string): stri
 
 /**
  * Resolves the placement the marketplace is scoped to. There is always a placement and a service, so this
- * returns a name rather than null: it uses the selected service when present, otherwise the first visible
+ * returns a placement rather than null: it uses the selected service when present, otherwise the first visible
  * service (which also covers the brief window after a removal, before the reselect effect runs), and falls
- * back to the first placement.
+ * back to the first placement. The placement carries the region the marketplace filters by — kept independent
+ * of the SDL so it still applies before the deployment is valid.
  */
-function resolveSelectedPlacementName(
+function resolveSelectedPlacement(
   services: SdlBuilderFormValuesType["services"],
   placements: SdlBuilderFormValuesType["placements"],
   selectedServiceId: string
-): string {
+): SdlBuilderFormValuesType["placements"][number] {
   const selected = services.find(candidate => candidate.id === selectedServiceId);
   const service = selected ?? services.find(candidate => !isLogCollectorService(candidate));
-  const placement = (service && placements.find(candidate => candidate.id === service.placementId)) || placements[0];
-  return placement.name;
+  return (service && placements.find(candidate => candidate.id === service.placementId)) || placements[0];
 }
 
 /** Keeps the selection on an existing service, falling back to the first visible one after a removal. */

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
@@ -97,10 +97,13 @@ describe("ConfigureDeploymentPanes", () => {
     expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ selectedServiceId: "svc-1" }), expect.anything());
   });
 
-  it("threads the sdl and selected placement into the marketplace pane", () => {
-    const { MarketplacePane } = setup({ sdl: 'version: "2.0"', selectedPlacementName: "dcloud" });
+  it("threads the sdl, selected placement, and its region into the marketplace pane", () => {
+    const { MarketplacePane } = setup({ sdl: 'version: "2.0"', selectedPlacementName: "dcloud", selectedPlacementRegion: "na-us-west" });
 
-    expect(MarketplacePane).toHaveBeenCalledWith(expect.objectContaining({ sdl: 'version: "2.0"', placementName: "dcloud" }), expect.anything());
+    expect(MarketplacePane).toHaveBeenCalledWith(
+      expect.objectContaining({ sdl: 'version: "2.0"', placementName: "dcloud", region: "na-us-west" }),
+      expect.anything()
+    );
   });
 
   function setup(
@@ -110,6 +113,7 @@ describe("ConfigureDeploymentPanes", () => {
       preserveStorage?: boolean;
       selectedServiceId?: string;
       selectedPlacementName?: string;
+      selectedPlacementRegion?: string;
       onSelectService?: (serviceId: string) => void;
     } = {}
   ) {
@@ -140,6 +144,7 @@ describe("ConfigureDeploymentPanes", () => {
           sdl={input.sdl ?? ""}
           selectedServiceId={input.selectedServiceId ?? ""}
           selectedPlacementName={input.selectedPlacementName ?? "dcloud"}
+          selectedPlacementRegion={input.selectedPlacementRegion}
           onSelectService={input.onSelectService ?? vi.fn()}
           dependencies={dependencies}
         />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
@@ -18,11 +18,19 @@ type Props = {
   sdl: string;
   selectedServiceId: string;
   selectedPlacementName: string;
+  selectedPlacementRegion?: string;
   onSelectService: (serviceId: string) => void;
   dependencies?: typeof DEPENDENCIES;
 };
 
-export const ConfigureDeploymentPanes: FC<Props> = ({ sdl, selectedServiceId, selectedPlacementName, onSelectService, dependencies: d = DEPENDENCIES }) => {
+export const ConfigureDeploymentPanes: FC<Props> = ({
+  sdl,
+  selectedServiceId,
+  selectedPlacementName,
+  selectedPlacementRegion,
+  onSelectService,
+  dependencies: d = DEPENDENCIES
+}) => {
   const [activePane, setActivePane] = useState<ActivePane>("deployment");
   const [isSdlPreviewOpen, setIsSdlPreviewOpen] = useAtom(sdlStore.sdlPreviewOpen);
   const isSdlPreviewEnabled = d.useFlag("ui_sdl_preview_panel");
@@ -37,7 +45,7 @@ export const ConfigureDeploymentPanes: FC<Props> = ({ sdl, selectedServiceId, se
           <d.ConfigurationPane selectedServiceId={selectedServiceId} />
         </div>
         <div className={cn("min-h-0 md:block", { hidden: activePane !== "marketplace" })}>
-          <d.MarketplacePane sdl={sdl} placementName={selectedPlacementName} />
+          <d.MarketplacePane sdl={sdl} placementName={selectedPlacementName} region={selectedPlacementRegion} />
         </div>
         {isSdlPreviewEnabled && (
           <d.SdlPreviewPane sdl={sdl} isOpen={isSdlPreviewOpen} onOpen={() => setIsSdlPreviewOpen(true)} onClose={() => setIsSdlPreviewOpen(false)} />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
@@ -5,12 +5,13 @@ import type { DEPENDENCIES } from "./MarketplacePane";
 import { MarketplacePane } from "./MarketplacePane";
 
 import { render, screen } from "@testing-library/react";
+import { buildScreenedProvider } from "@tests/seeders/screenedProvider";
 
 describe("MarketplacePane", () => {
-  it("screens the given placement using the current sdl", () => {
-    const { useScreenedProviders } = setup({ sdl: "version: 2.0", placementName: "dcloud" });
+  it("screens the given placement using the current sdl and region", () => {
+    const { useScreenedProviders } = setup({ sdl: "version: 2.0", placementName: "dcloud", region: "na-us-west" });
 
-    expect(useScreenedProviders).toHaveBeenCalledWith({ sdl: "version: 2.0", placementName: "dcloud" });
+    expect(useScreenedProviders).toHaveBeenCalledWith({ sdl: "version: 2.0", placementName: "dcloud", region: "na-us-west" });
   });
 
   it("shows the placement name in the header", () => {
@@ -20,7 +21,7 @@ describe("MarketplacePane", () => {
   });
 
   it("passes screened providers and loading state to the table", () => {
-    const providers = [makeProvider()];
+    const providers = [buildScreenedProvider()];
     const { MarketplaceProvidersTable } = setup({ providers, isLoading: false });
 
     expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ providers, isLoading: false }), expect.anything());
@@ -34,18 +35,16 @@ describe("MarketplacePane", () => {
   });
 
   it("keeps the table when a refetch fails but providers are still cached", () => {
-    const providers = [makeProvider()];
+    const providers = [buildScreenedProvider()];
     const { MarketplaceProvidersTable } = setup({ isError: true, providers });
 
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ providers }), expect.anything());
   });
 
-  function makeProvider(): ScreenedProvider {
-    return { owner: "akash1a", hostUri: "https://a.example:8443", isAudited: true, location: "us-west", createdAt: "2026-01-01T00:00:00.000Z" };
-  }
-
-  function setup(input: { sdl?: string; placementName?: string; providers?: ScreenedProvider[]; isLoading?: boolean; isError?: boolean } = {}) {
+  function setup(
+    input: { sdl?: string; placementName?: string; region?: string; providers?: ScreenedProvider[]; isLoading?: boolean; isError?: boolean } = {}
+  ) {
     const useScreenedProviders = vi.fn(() => ({
       providers: input.providers ?? [],
       isLoading: input.isLoading ?? false,
@@ -57,7 +56,7 @@ describe("MarketplacePane", () => {
       MarketplaceProvidersTable: MarketplaceProvidersTable as never
     };
 
-    render(<MarketplacePane sdl={input.sdl ?? ""} placementName={input.placementName ?? "dcloud"} dependencies={dependencies} />);
+    render(<MarketplacePane sdl={input.sdl ?? ""} placementName={input.placementName ?? "dcloud"} region={input.region} dependencies={dependencies} />);
     return { useScreenedProviders, MarketplaceProvidersTable };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
@@ -8,11 +8,12 @@ export const DEPENDENCIES = { useScreenedProviders, MarketplaceProvidersTable };
 interface Props {
   sdl: string;
   placementName: string;
+  region?: string;
   dependencies?: typeof DEPENDENCIES;
 }
 
-export const MarketplacePane: FC<Props> = ({ sdl, placementName, dependencies: d = DEPENDENCIES }) => {
-  const { providers, isLoading, isError } = d.useScreenedProviders({ sdl, placementName });
+export const MarketplacePane: FC<Props> = ({ sdl, placementName, region, dependencies: d = DEPENDENCIES }) => {
+  const { providers, isLoading, isError } = d.useScreenedProviders({ sdl, placementName, region });
   const hasFailedWithoutData = isError && providers.length === 0;
 
   return (

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
@@ -6,13 +6,14 @@ import { MarketplaceProvidersTable } from "./MarketplaceProvidersTable";
 
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { buildScreenedProvider } from "@tests/seeders/screenedProvider";
 
 describe("MarketplaceProvidersTable", () => {
   it("renders a row per provider showing host and region", () => {
     setup({
       providers: [
-        makeProvider({ hostUri: "https://a.example:8443", location: "us-west" }),
-        makeProvider({ hostUri: "https://b.example:8443", location: "eu-central" })
+        buildScreenedProvider({ hostUri: "https://a.example:8443", location: "us-west" }),
+        buildScreenedProvider({ hostUri: "https://b.example:8443", location: "eu-central" })
       ]
     });
 
@@ -23,14 +24,14 @@ describe("MarketplaceProvidersTable", () => {
   });
 
   it("renders an em dash when region is null", () => {
-    setup({ providers: [makeProvider({ hostUri: "https://a.example:8443", location: null })] });
+    setup({ providers: [buildScreenedProvider({ hostUri: "https://a.example:8443", location: null })] });
 
     expect(screen.getByText("—")).toBeInTheDocument();
   });
 
   it("sorts rows by provider host when the Provider header is toggled ascending", async () => {
     setup({
-      providers: [makeProvider({ hostUri: "https://zeta.example:8443" }), makeProvider({ hostUri: "https://alpha.example:8443" })]
+      providers: [buildScreenedProvider({ hostUri: "https://zeta.example:8443" }), buildScreenedProvider({ hostUri: "https://alpha.example:8443" })]
     });
 
     await userEvent.click(screen.getByRole("button", { name: /Provider/ }));
@@ -42,7 +43,7 @@ describe("MarketplaceProvidersTable", () => {
 
   it("sorts by the displayed hostname regardless of scheme or port", async () => {
     setup({
-      providers: [makeProvider({ hostUri: "http://zeta.example:80" }), makeProvider({ hostUri: "https://alpha.example:8443" })]
+      providers: [buildScreenedProvider({ hostUri: "http://zeta.example:80" }), buildScreenedProvider({ hostUri: "https://alpha.example:8443" })]
     });
 
     await userEvent.click(screen.getByRole("button", { name: /Provider/ }));
@@ -51,17 +52,6 @@ describe("MarketplaceProvidersTable", () => {
     expect(within(rows[1]).getByText("alpha.example")).toBeInTheDocument();
     expect(within(rows[2]).getByText("zeta.example")).toBeInTheDocument();
   });
-
-  function makeProvider(overrides: Partial<ScreenedProvider>): ScreenedProvider {
-    return {
-      owner: "akash1a",
-      hostUri: "https://a.example:8443",
-      isAudited: true,
-      location: "us-west",
-      createdAt: "2026-01-01T00:00:00.000Z",
-      ...overrides
-    };
-  }
 
   function setup(input: { providers: ScreenedProvider[] }) {
     return render(

--- a/apps/deploy-web/src/queries/useScreenedProviders.spec.tsx
+++ b/apps/deploy-web/src/queries/useScreenedProviders.spec.tsx
@@ -5,7 +5,9 @@ import { mock } from "vitest-mock-extended";
 import { AUDITOR } from "@src/utils/deploymentData/v1beta3";
 import { setupQuery } from "../../tests/unit/query-client";
 import type { ScreenedProvider, ScreenedProvidersResponse } from "./useScreenedProviders";
-import { buildPlacementScreeningRequest, useScreenedProviders } from "./useScreenedProviders";
+import { buildCatalogScreeningRequest, buildPlacementScreeningRequest, useScreenedProviders } from "./useScreenedProviders";
+
+import { buildScreenedProvider } from "@tests/seeders/screenedProvider";
 
 const HELLO_WORLD_SDL = `---
 version: "2.0"
@@ -46,7 +48,6 @@ describe("useScreenedProviders", () => {
 
     expect(useQuery).toHaveBeenCalledWith(
       expect.objectContaining({
-        name: "dcloud",
         requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [] },
         resources: expect.arrayContaining([expect.objectContaining({ count: 1 })])
       })
@@ -57,24 +58,30 @@ describe("useScreenedProviders", () => {
     const { useQuery } = setup({ sdl: "foo: [unclosed", placementName: "dcloud" });
 
     expect(useQuery).toHaveBeenCalledWith({
-      name: "screening",
       requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [] },
-      resources: []
+      resources: [],
+      timezone: expect.any(String)
+    });
+  });
+
+  it("keeps the selected region as a location-region filter on the catalog fallback when the SDL is invalid", () => {
+    const { useQuery } = setup({ sdl: "foo: [unclosed", placementName: "dcloud", region: "na-us-west" });
+
+    expect(useQuery).toHaveBeenCalledWith({
+      requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [{ key: "location-region", value: "na-us-west" }] },
+      resources: [],
+      timezone: expect.any(String)
     });
   });
 
   it("returns the screened providers from the query result", () => {
-    const providers = [makeProvider()];
+    const providers = [buildScreenedProvider()];
     const { result } = setup({ placementName: "dcloud", providers });
 
     expect(result.current.providers).toEqual(providers);
   });
 
-  function makeProvider(): ScreenedProvider {
-    return { owner: "akash1a", hostUri: "https://a.example:8443", isAudited: true, location: "us-west", createdAt: "2026-01-01T00:00:00.000Z" };
-  }
-
-  function setup(input: { placementName: string; sdl?: string; providers?: ScreenedProvider[] }) {
+  function setup(input: { placementName: string; sdl?: string; region?: string; providers?: ScreenedProvider[] }) {
     const useQuery = vi.fn().mockReturnValue(
       mock<UseQueryResult<ScreenedProvidersResponse>>({
         data: { providers: input.providers ?? [] },
@@ -86,7 +93,7 @@ describe("useScreenedProviders", () => {
       NonNullable<NonNullable<NonNullable<Parameters<typeof setupQuery>[1]>["services"]>["api"]>
     >;
 
-    const { result } = setupQuery(() => useScreenedProviders({ sdl: input.sdl ?? HELLO_WORLD_SDL, placementName: input.placementName }), {
+    const { result } = setupQuery(() => useScreenedProviders({ sdl: input.sdl ?? HELLO_WORLD_SDL, placementName: input.placementName, region: input.region }), {
       services: { api: () => api }
     });
     return { result, useQuery };
@@ -97,7 +104,7 @@ describe("buildPlacementScreeningRequest", () => {
   it("builds an audited request from the matching placement group spec", () => {
     const request = buildPlacementScreeningRequest(HELLO_WORLD_SDL, "dcloud");
 
-    expect(request).toMatchObject({ name: "dcloud", requirements: { signedBy: { allOf: [AUDITOR] } } });
+    expect(request).toMatchObject({ requirements: { signedBy: { allOf: [AUDITOR] } } });
     expect(request?.resources[0].resource.cpu.units.val).toBeTruthy();
   });
 
@@ -107,5 +114,21 @@ describe("buildPlacementScreeningRequest", () => {
 
   it("returns null when the SDL is invalid", () => {
     expect(buildPlacementScreeningRequest("foo: [unclosed", "dcloud")).toBeNull();
+  });
+});
+
+describe("buildCatalogScreeningRequest", () => {
+  it("requests the full audited catalog with no attributes when no region is given (any region)", () => {
+    expect(buildCatalogScreeningRequest()).toEqual({
+      requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [] },
+      resources: []
+    });
+  });
+
+  it("adds the region as a location-region attribute constraint", () => {
+    expect(buildCatalogScreeningRequest("na-ca-central")).toEqual({
+      requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [{ key: "location-region", value: "na-ca-central" }] },
+      resources: []
+    });
   });
 });

--- a/apps/deploy-web/src/queries/useScreenedProviders.ts
+++ b/apps/deploy-web/src/queries/useScreenedProviders.ts
@@ -8,6 +8,9 @@ import { AUDITOR } from "@src/utils/deploymentData/v1beta3";
 
 type ScreeningRequest = NonNullable<paths["/v1/bid-screening"]["post"]["requestBody"]>["content"]["application/json"];
 
+/** The screening request minus `timezone`, which the hook attaches from the client's resolved locale. */
+type ScreeningRequestBody = Omit<ScreeningRequest, "timezone">;
+
 export type ScreenedProvidersResponse = paths["/v1/bid-screening"]["post"]["responses"][200]["content"]["application/json"];
 
 export type ScreenedProvider = ScreenedProvidersResponse["providers"][number];
@@ -15,6 +18,7 @@ export type ScreenedProvider = ScreenedProvidersResponse["providers"][number];
 interface UseScreenedProvidersInput {
   sdl: string;
   placementName: string;
+  region?: string;
 }
 
 interface UseScreenedProvidersResult {
@@ -23,27 +27,18 @@ interface UseScreenedProvidersResult {
   isError: boolean;
 }
 
-/** Group name required by the request but irrelevant to catalog matching when no placement resolves. */
-const SCREENING_GROUP_NAME = "screening";
-
-/**
- * Full audited catalog query, used before a deployment is configured (no SDL yet, mid-edit/invalid SDL,
- * or no placement selected). The screening endpoint returns every audited provider for an empty resource spec.
- */
-const EMPTY_CATALOG_REQUEST: ScreeningRequest = {
-  name: SCREENING_GROUP_NAME,
-  requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [] },
-  resources: []
-};
-
 /**
  * Screens providers for the given placement's group spec. The marketplace is placement-scoped: it converts
  * the current SDL to group specs and queries the one matching `placementName`. While the SDL is mid-edit or
- * invalid it falls back to the full audited catalog (empty resource spec). Audited-only via signedBy.
+ * invalid it falls back to the full audited catalog (empty resource spec). The selected `region` lives outside
+ * the SDL, so it is threaded in explicitly and still constrains the catalog fallback. Audited-only via signedBy.
  */
-export function useScreenedProviders({ sdl, placementName }: UseScreenedProvidersInput): UseScreenedProvidersResult {
+export function useScreenedProviders({ sdl, placementName, region }: UseScreenedProvidersInput): UseScreenedProvidersResult {
   const { api } = useServices();
-  const request = useMemo(() => buildPlacementScreeningRequest(sdl, placementName) ?? EMPTY_CATALOG_REQUEST, [sdl, placementName]);
+  const request = useMemo(() => {
+    const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return { ...(buildPlacementScreeningRequest(sdl, placementName) ?? buildCatalogScreeningRequest(region)), timezone };
+  }, [sdl, placementName, region]);
   const query = api.v1.screenProviders.useQuery(request);
 
   return {
@@ -60,7 +55,7 @@ export function useScreenedProviders({ sdl, placementName }: UseScreenedProvider
  * from the placement and carry the `location-region` filter (and any other declared attribute). The proto
  * JSON encodes resource values as base64 integer strings, which the screening endpoint accepts.
  */
-export function buildPlacementScreeningRequest(sdl: string, placementName: string): ScreeningRequest | null {
+export function buildPlacementScreeningRequest(sdl: string, placementName: string): ScreeningRequestBody | null {
   if (!sdl) return null;
 
   let groups: ReturnType<typeof DeploymentGroups>;
@@ -79,11 +74,28 @@ export function buildPlacementScreeningRequest(sdl: string, placementName: strin
   };
 
   return {
-    name: placementName,
     requirements: {
       signedBy: { allOf: [AUDITOR] },
       attributes: groupJson.requirements?.attributes ?? []
     },
     resources: groupJson.resources
+  };
+}
+
+/**
+ * Builds the full audited catalog request (empty resource spec) used before a deployment is configured (no
+ * SDL yet, mid-edit/invalid SDL, or no placement selected). Because the region is chosen independently of the
+ * SDL, it is honored here too: a selected region is added as a `location-region` attribute constraint. The
+ * region key comes from the provider-regions API, which derives it from the same provider attribute values
+ * being matched, so it is passed through verbatim. An empty/unset region means "any region", i.e. no
+ * constraint. Audited-only via signedBy.
+ */
+export function buildCatalogScreeningRequest(region?: string): ScreeningRequestBody {
+  return {
+    requirements: {
+      signedBy: { allOf: [AUDITOR] },
+      attributes: region ? [{ key: "location-region", value: region }] : []
+    },
+    resources: []
   };
 }

--- a/apps/deploy-web/tests/seeders/index.ts
+++ b/apps/deploy-web/tests/seeders/index.ts
@@ -11,6 +11,7 @@ export * from "./manifest";
 export * from "./notificationChannel";
 export * from "./payment";
 export * from "./provider";
+export * from "./screenedProvider";
 export * from "./usage";
 export * from "./user";
 export * from "./wallet";

--- a/apps/deploy-web/tests/seeders/screenedProvider.ts
+++ b/apps/deploy-web/tests/seeders/screenedProvider.ts
@@ -1,0 +1,16 @@
+import { faker } from "@faker-js/faker";
+
+import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
+import { genWalletAddress } from "./wallet";
+
+export function buildScreenedProvider(overrides?: Partial<ScreenedProvider>): ScreenedProvider {
+  return {
+    owner: genWalletAddress(),
+    hostUri: `https://${faker.internet.domainName()}:8443`,
+    isAudited: faker.datatype.boolean(),
+    createdAt: faker.date.past().toISOString(),
+    location: faker.location.state({ abbreviated: true }),
+    incidents: [],
+    ...overrides
+  };
+}

--- a/packages/console-api-types/src/operations.gen.ts
+++ b/packages/console-api-types/src/operations.gen.ts
@@ -19,8 +19,8 @@ export const operations = {
     createLease: { path: "/v1/leases", method: "post", operationId: "createLease", pathParams: [], queryParams: [], hasBody: true },
     listApiKeys: { path: "/v1/api-keys", method: "get", operationId: "listApiKeys", pathParams: [], queryParams: [], hasBody: false },
     listBids: { path: "/v1/bids", method: "get", operationId: "listBids", pathParams: [], queryParams: ["dseq"], hasBody: false },
-    screenProviders: { path: "/v1/bid-screening", method: "post", operationId: "screenProviders", pathParams: [], queryParams: [], hasBody: true },
     listGpuPrices: { path: "/v1/gpu-prices", method: "get", operationId: "listGpuPrices", pathParams: [], queryParams: [], hasBody: false },
+    screenProviders: { path: "/v1/bid-screening", method: "post", operationId: "screenProviders", pathParams: [], queryParams: [], hasBody: true },
     createAlert: { path: "/v1/alerts", method: "post", operationId: "createAlert", pathParams: [], queryParams: [], hasBody: true },
     listAlerts: {
       path: "/v1/alerts",

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -48,6 +48,8 @@ export interface paths {
                 address: string | null;
                 denom: string;
                 isTrialing: boolean;
+                /** @description Minimum USD amount accepted by the next paid top-up for this wallet. */
+                topUpMinAmountUsd: number;
                 createdAt: string | null;
                 requires3DS?: boolean;
                 clientSecret?: string | null;
@@ -71,6 +73,8 @@ export interface paths {
                 address: string | null;
                 denom: string;
                 isTrialing: boolean;
+                /** @description Minimum USD amount accepted by the next paid top-up for this wallet. */
+                topUpMinAmountUsd: number;
                 createdAt: string | null;
                 requires3DS?: boolean;
                 clientSecret?: string | null;
@@ -122,6 +126,8 @@ export interface paths {
                 address: string | null;
                 denom: string;
                 isTrialing: boolean;
+                /** @description Minimum USD amount accepted by the next paid top-up for this wallet. */
+                topUpMinAmountUsd: number;
                 createdAt: string | null;
                 requires3DS?: boolean;
                 clientSecret?: string | null;
@@ -358,732 +364,6 @@ export interface paths {
         };
       };
     };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/stripe-webhook": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Stripe Webhook Handler */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "text/plain": string;
-        };
-      };
-      responses: {
-        /** @description Webhook processed successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-        /** @description Stripe signature is required */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              error: string;
-            };
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/stripe/prices": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Get available Stripe pricing options
-     * @description Retrieves the list of available pricing options for wallet top-ups, including custom amounts and standard pricing tiers
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Available pricing options retrieved successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                currency: string;
-                unitAmount: number;
-                isCustom: boolean;
-              }[];
-            };
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/stripe/coupons/apply": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Apply a coupon to the current user */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": {
-            data: {
-              couponId: string;
-              userId: string;
-              awaitResolved?: boolean;
-            };
-          };
-        };
-      };
-      responses: {
-        /** @description Coupon applied successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                coupon?: {
-                  id: string;
-                  percent_off?: number | null;
-                  amount_off?: number | null;
-                  valid?: boolean | null;
-                  name?: string | null;
-                  description?: string | null;
-                } | null;
-                amountAdded?: number;
-                transactionId?: string;
-                /** @enum {string} */
-                transactionStatus?: "created" | "pending" | "requires_action" | "succeeded" | "failed" | "refunded" | "canceled";
-                error?: {
-                  message: string;
-                  code?: string;
-                  type?: string;
-                };
-              };
-            };
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/stripe/customers/organization": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    /**
-     * Update customer organization
-     * @description Updates the organization/business name for the current user's Stripe customer account
-     */
-    put: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": {
-            organization: string;
-          };
-        };
-      };
-      responses: {
-        /** @description Organization updated successfully */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/stripe/payment-methods/setup": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * Create a Stripe SetupIntent for adding a payment method
-     * @description Creates a Stripe SetupIntent that allows users to securely add payment methods to their account. The SetupIntent provides a client secret that can be used with Stripe's frontend SDKs to collect payment method details.
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description SetupIntent created successfully with client secret */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                clientSecret: string | null;
-              };
-            };
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/stripe/payment-methods/default": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Get the default payment method for the current user
-     * @description Retrieves the default payment method associated with the current user's account, including card details, validation status, and billing information.
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Default payment method retrieved successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                type: string;
-                validated?: boolean;
-                isDefault?: boolean;
-                card?: {
-                  brand: string | null;
-                  last4: string | null;
-                  exp_month: number;
-                  exp_year: number;
-                  funding?: string | null;
-                  country?: string | null;
-                  network?: string | null;
-                  three_d_secure_usage?: {
-                    supported?: boolean | null;
-                  } | null;
-                } | null;
-                link?: {
-                  email?: string | null;
-                } | null;
-                billing_details?: {
-                  address?: {
-                    city: string | null;
-                    country: string | null;
-                    line1: string | null;
-                    line2: string | null;
-                    postal_code: string | null;
-                    state: string | null;
-                  } | null;
-                  email?: string | null;
-                  name?: string | null;
-                  phone?: string | null;
-                };
-              };
-            };
-          };
-        };
-        /** @description Default payment method not found */
-        404: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    put?: never;
-    /** Marks a payment method as the default. */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": {
-            data: {
-              id: string;
-            };
-          };
-        };
-      };
-      responses: {
-        /** @description Payment method is marked as the default successfully. */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/stripe/payment-methods": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Get all payment methods for the current user
-     * @description Retrieves all saved payment methods associated with the current user's account, including card details, validation status, and billing information.
-     */
-    get: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Payment methods retrieved successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                type: string;
-                validated?: boolean;
-                isDefault?: boolean;
-                card?: {
-                  brand: string | null;
-                  last4: string | null;
-                  exp_month: number;
-                  exp_year: number;
-                  funding?: string | null;
-                  country?: string | null;
-                  network?: string | null;
-                  three_d_secure_usage?: {
-                    supported?: boolean | null;
-                  } | null;
-                } | null;
-                link?: {
-                  email?: string | null;
-                } | null;
-                billing_details?: {
-                  address?: {
-                    city: string | null;
-                    country: string | null;
-                    line1: string | null;
-                    line2: string | null;
-                    postal_code: string | null;
-                    state: string | null;
-                  } | null;
-                  email?: string | null;
-                  name?: string | null;
-                  phone?: string | null;
-                };
-              }[];
-            };
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/stripe/payment-methods/{paymentMethodId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post?: never;
-    /**
-     * Remove a payment method
-     * @description Permanently removes a saved payment method from the user's account. This action cannot be undone.
-     */
-    delete: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path: {
-          paymentMethodId: string;
-        };
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Payment method removed successfully */
-        204: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/stripe/payment-methods/validate": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * Validates a payment method after 3D Secure authentication
-     * @description Completes the validation process for a payment method that required 3D Secure authentication. This endpoint should be called after the user completes the 3D Secure challenge.
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": {
-            data: {
-              paymentMethodId: string;
-              paymentIntentId: string;
-            };
-          };
-        };
-      };
-      responses: {
-        /** @description Payment method validated successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              success: boolean;
-            };
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/stripe/transactions/confirm": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * Confirm a payment using a saved payment method
-     * @description Processes a payment using a previously saved payment method. This endpoint handles wallet top-ups and may require 3D Secure authentication for certain payment methods or amounts.
-     */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": {
-            data: {
-              userId: string;
-              paymentMethodId: string;
-              amount: number;
-              currency: string;
-              awaitResolved?: boolean;
-            };
-          };
-        };
-      };
-      responses: {
-        /** @description Payment processed successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                success: boolean;
-                requiresAction?: boolean;
-                clientSecret?: string;
-                paymentIntentId?: string;
-                transactionId: string;
-                /** @enum {string} */
-                transactionStatus?: "created" | "pending" | "requires_action" | "succeeded" | "failed" | "refunded" | "canceled";
-              };
-            };
-          };
-        };
-        /** @description 3D Secure authentication required to complete payment */
-        202: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                success: boolean;
-                requiresAction?: boolean;
-                clientSecret?: string;
-                paymentIntentId?: string;
-                transactionId: string;
-                /** @enum {string} */
-                transactionStatus?: "created" | "pending" | "requires_action" | "succeeded" | "failed" | "refunded" | "canceled";
-              };
-            };
-          };
-        };
-      };
-    };
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/stripe/transactions": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get transaction history for the current customer */
-    get: {
-      parameters: {
-        query?: {
-          limit?: number;
-          startingAfter?: string;
-          endingBefore?: string;
-          startDate?: string;
-          endDate?: string;
-        };
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description Customer transactions retrieved successfully */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              data: {
-                transactions: {
-                  id: string;
-                  amount: number;
-                  currency: string;
-                  status: string;
-                  created: number;
-                  paymentMethod: {
-                    type: string;
-                    validated?: boolean;
-                    isDefault?: boolean;
-                    card?: {
-                      brand: string | null;
-                      last4: string | null;
-                      exp_month: number;
-                      exp_year: number;
-                      funding?: string | null;
-                      country?: string | null;
-                      network?: string | null;
-                      three_d_secure_usage?: {
-                        supported?: boolean | null;
-                      } | null;
-                    } | null;
-                    link?: {
-                      email?: string | null;
-                    } | null;
-                    billing_details?: {
-                      address?: {
-                        city: string | null;
-                        country: string | null;
-                        line1: string | null;
-                        line2: string | null;
-                        postal_code: string | null;
-                        state: string | null;
-                      } | null;
-                      email?: string | null;
-                      name?: string | null;
-                      phone?: string | null;
-                    };
-                  } | null;
-                  receiptUrl?: string | null;
-                  description?: string | null;
-                  metadata?: {
-                    [key: string]: string;
-                  } | null;
-                }[];
-                hasMore: boolean;
-                nextPage?: string | null;
-              };
-            };
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/stripe/transactions/export": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Export transaction history as CSV for the current customer */
-    get: {
-      parameters: {
-        query: {
-          timezone: string;
-          startDate: string;
-          endDate: string;
-        };
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: never;
-      responses: {
-        /** @description CSV file with transaction data */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "text/csv": string;
-          };
-        };
-      };
-    };
-    put?: never;
-    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -3708,6 +2988,7 @@ export interface paths {
                     };
                     count: number;
                   }[];
+                  reclamation_window?: string;
                 };
                 escrow_account: {
                   id: {
@@ -6488,6 +5769,13 @@ export interface paths {
             };
           };
         };
+        /** @description Invalid template ID */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
         /** @description Template not found */
         404: {
           headers: {
@@ -6789,201 +6077,7 @@ export interface paths {
     get?: never;
     put?: never;
     /** Screen providers by deployment resource requirements */
-    post: {
-      parameters: {
-        query?: never;
-        header?: never;
-        path?: never;
-        cookie?: never;
-      };
-      requestBody?: {
-        content: {
-          "application/json": {
-            /**
-             * @description Group name
-             * @example westcoast
-             */
-            name: string;
-            /** @default {} */
-            requirements?: {
-              /** @default {} */
-              signedBy?: {
-                /** @default [] */
-                allOf?: string[];
-                /** @default [] */
-                anyOf?: string[];
-              };
-              /** @default [] */
-              attributes?: {
-                /**
-                 * @description Attribute key
-                 * @example persistent
-                 */
-                key: string;
-                /**
-                 * @description Attribute value
-                 * @example false
-                 */
-                value: string;
-              }[];
-            };
-            /** @description Resource units with replica counts */
-            resources: {
-              resource: {
-                /**
-                 * @description Resource unit ID
-                 * @example 1
-                 */
-                id: number;
-                cpu: {
-                  units: {
-                    /**
-                     * @description String-encoded integer value
-                     * @example 1000
-                     */
-                    val: string;
-                  };
-                  attributes: {
-                    /**
-                     * @description Attribute key
-                     * @example persistent
-                     */
-                    key: string;
-                    /**
-                     * @description Attribute value
-                     * @example false
-                     */
-                    value: string;
-                  }[];
-                };
-                memory: {
-                  quantity: {
-                    /**
-                     * @description String-encoded integer value
-                     * @example 1000
-                     */
-                    val: string;
-                  };
-                  attributes: {
-                    /**
-                     * @description Attribute key
-                     * @example persistent
-                     */
-                    key: string;
-                    /**
-                     * @description Attribute value
-                     * @example false
-                     */
-                    value: string;
-                  }[];
-                };
-                gpu: {
-                  units: {
-                    /**
-                     * @description String-encoded integer value
-                     * @example 1000
-                     */
-                    val: string;
-                  };
-                  attributes: {
-                    /**
-                     * @description Attribute key
-                     * @example persistent
-                     */
-                    key: string;
-                    /**
-                     * @description Attribute value
-                     * @example false
-                     */
-                    value: string;
-                  }[];
-                };
-                storage: {
-                  /**
-                   * @description Storage volume name
-                   * @example default
-                   */
-                  name: string;
-                  quantity: {
-                    /**
-                     * @description String-encoded integer value
-                     * @example 1000
-                     */
-                    val: string;
-                  };
-                  attributes: {
-                    /**
-                     * @description Attribute key
-                     * @example persistent
-                     */
-                    key: string;
-                    /**
-                     * @description Attribute value
-                     * @example false
-                     */
-                    value: string;
-                  }[];
-                }[];
-                endpoints?: unknown[];
-              };
-              /**
-               * @description Replica count
-               * @example 1
-               */
-              count: number;
-              price: {
-                denom: string;
-                amount: string;
-              };
-            }[];
-          };
-        };
-      };
-      responses: {
-        /** @description Returns matching providers */
-        200: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content: {
-            "application/json": {
-              providers: {
-                /**
-                 * @description Provider address
-                 * @example akash1q7spv2cw06yszgfp4f9ed59lkka6ytn8g4tkjf
-                 */
-                owner: string;
-                /**
-                 * @description Provider HTTPS endpoint
-                 * @example https://provider.europlots.com:8443
-                 */
-                hostUri: string;
-                /** @description True if signed by a known auditor */
-                isAudited: boolean;
-                /**
-                 * Format: date-time
-                 * @description ISO 8601 timestamp marking when the provider was first enrolled in the inventory
-                 * @example 2026-01-01T00:00:00.000Z
-                 */
-                createdAt: string;
-                /**
-                 * @description Provider region from the location-region attribute (signed preferred, else self-declared); null if unset
-                 * @example us-west
-                 */
-                location: string | null;
-              }[];
-            };
-          };
-        };
-        /** @description Invalid request body */
-        400: {
-          headers: {
-            [name: string]: unknown;
-          };
-          content?: never;
-        };
-      };
-    };
+    post: operations["screenProviders"];
     delete?: never;
     options?: never;
     head?: never;
@@ -8624,6 +7718,7 @@ export interface operations {
                   };
                   count: number;
                 }[];
+                reclamation_window?: string;
               };
               escrow_account: {
                 id: {
@@ -8704,6 +7799,199 @@ export interface operations {
             }[];
           };
         };
+      };
+    };
+  };
+  screenProviders: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          /** @default {} */
+          requirements?: {
+            /** @default {} */
+            signedBy?: {
+              /** @default [] */
+              allOf?: string[];
+              /** @default [] */
+              anyOf?: string[];
+            };
+            /** @default [] */
+            attributes?: {
+              /**
+               * @description Attribute key
+               * @example persistent
+               */
+              key: string;
+              /**
+               * @description Attribute value
+               * @example false
+               */
+              value: string;
+            }[];
+          };
+          /** @description Resource units with replica counts */
+          resources: {
+            resource: {
+              /**
+               * @description Resource unit ID
+               * @example 1
+               */
+              id: number;
+              cpu: {
+                units: {
+                  val: string;
+                };
+                attributes?: {
+                  /**
+                   * @description Attribute key
+                   * @example persistent
+                   */
+                  key: string;
+                  /**
+                   * @description Attribute value
+                   * @example false
+                   */
+                  value: string;
+                }[];
+              };
+              memory: {
+                quantity: {
+                  val: string;
+                };
+                attributes?: {
+                  /**
+                   * @description Attribute key
+                   * @example persistent
+                   */
+                  key: string;
+                  /**
+                   * @description Attribute value
+                   * @example false
+                   */
+                  value: string;
+                }[];
+              };
+              gpu: {
+                units: {
+                  val: string;
+                };
+                attributes?: {
+                  /**
+                   * @description Attribute key
+                   * @example persistent
+                   */
+                  key: string;
+                  /**
+                   * @description Attribute value
+                   * @example false
+                   */
+                  value: string;
+                }[];
+              };
+              storage: {
+                /**
+                 * @description Storage volume name
+                 * @example default
+                 */
+                name: string;
+                quantity: {
+                  val: string;
+                };
+                attributes?: {
+                  /**
+                   * @description Attribute key
+                   * @example persistent
+                   */
+                  key: string;
+                  /**
+                   * @description Attribute value
+                   * @example false
+                   */
+                  value: string;
+                }[];
+              }[];
+              endpoints?: unknown[];
+            };
+            /**
+             * @description Replica count
+             * @example 1
+             */
+            count: number;
+            price: {
+              denom: string;
+              amount: string;
+            };
+          }[];
+          /**
+           * @description Client timezone, validated against supported Node.js Intl timezones
+           * @example America/Chicago
+           */
+          timezone: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Returns matching providers */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            providers: {
+              /**
+               * @description Provider address
+               * @example akash1q7spv2cw06yszgfp4f9ed59lkka6ytn8g4tkjf
+               */
+              owner: string;
+              /**
+               * @description Provider HTTPS endpoint
+               * @example https://provider.europlots.com:8443
+               */
+              hostUri: string;
+              /** @description True if signed by a known auditor */
+              isAudited: boolean;
+              /**
+               * Format: date-time
+               * @description ISO 8601 timestamp marking when the provider was first enrolled in the inventory
+               * @example 2026-01-01T00:00:00.000Z
+               */
+              createdAt: string;
+              /**
+               * @description Provider region from the location-region attribute (signed preferred, else self-declared); null if unset
+               * @example us-west
+               */
+              location: string | null;
+              /** @description Per-day downtime over a rolling 7-day window */
+              incidents: {
+                /**
+                 * @description Local calendar day, YYYY-MM-DD
+                 * @example 2026-06-01
+                 */
+                date: string;
+                /** @description True if the provider currently has any open incident */
+                hasOpenIncident: boolean;
+                /** @description Number of incident intervals overlapping that day */
+                incidentCount: number;
+                /** @description Downtime clipped to that day, in seconds (max 86400) */
+                downtimeSeconds: number;
+              }[];
+            }[];
+          };
+        };
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };


### PR DESCRIPTION
## Why

The marketplace provider list ignored the selected region until a valid SDL existed. Before a deployment is configured — no SDL yet, or mid-edit/invalid SDL — screening fell back to the full audited catalog and dropped the region filter entirely, so users saw providers outside their chosen region.

## What

- Thread the selected placement's `region` from `ConfigureDeploymentForm` → `ConfigureDeploymentPanes` → `MarketplacePane` → `useScreenedProviders`. The region lives outside the SDL, so it is passed explicitly rather than derived from group specs.
- Apply the region as a `location-region` attribute constraint on the audited-catalog fallback request (`buildCatalogScreeningRequest`), so it still filters before the deployment is valid. Empty/unset region means "any region".
- Include the required `timezone` on every screening request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added region-aware placement selection during deployment configuration, and threaded the selected placement region through the marketplace experience.
  * Marketplace provider screening now respects the selected region.
* **Bug Fixes**
  * Improved screening request construction so region and timezone are handled consistently, including fallback behavior.
* **API Updates**
  * Extended wallet and bid-screening API schemas (including `topUpMinAmountUsd`, required `timezone`, and incident/location fields), plus added `top-up` and template ID validation responses.
* **Tests**
  * Expanded unit tests and updated provider fixtures to verify region propagation and region-aware screening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->