### PR TITLE
feat(provider): add marketplace provider uptime chart

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
@@ -1,4 +1,6 @@
+import { IntlProvider } from "react-intl";
 import { TooltipProvider } from "@akashnetwork/ui/components";
+import { format, subDays } from "date-fns";
 import { describe, expect, it } from "vitest";
 
 import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
@@ -53,11 +55,30 @@ describe("MarketplaceProvidersTable", () => {
     expect(within(rows[2]).getByText("zeta.example")).toBeInTheDocument();
   });
 
+  it("sorts rows by derived uptime when the Uptime header is toggled ascending", async () => {
+    const recentDay = format(subDays(new Date(), 2), "yyyy-MM-dd");
+    const downProvider = buildScreenedProvider({
+      owner: "akash1down",
+      hostUri: "https://down.example:8443",
+      incidents: [{ date: recentDay, hasOpenIncident: false, incidentCount: 1, downtimeSeconds: 24 * 60 * 60 }]
+    });
+    const upProvider = buildScreenedProvider({ owner: "akash1up", hostUri: "https://up.example:8443", incidents: [] });
+    setup({ providers: [upProvider, downProvider] });
+
+    await userEvent.click(screen.getByRole("button", { name: /Uptime/ }));
+
+    const rows = screen.getAllByRole("row");
+    expect(within(rows[1]).getByText("down.example")).toBeInTheDocument();
+    expect(within(rows[2]).getByText("up.example")).toBeInTheDocument();
+  });
+
   function setup(input: { providers: ScreenedProvider[] }) {
     return render(
-      <TooltipProvider>
-        <MarketplaceProvidersTable providers={input.providers} />
-      </TooltipProvider>
+      <IntlProvider locale="en">
+        <TooltipProvider>
+          <MarketplaceProvidersTable providers={input.providers} />
+        </TooltipProvider>
+      </IntlProvider>
     );
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Spinner, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@akashnetwork/ui/components";
 import type { Column, SortingState } from "@tanstack/react-table";
 import { createColumnHelper, flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
@@ -8,23 +8,17 @@ import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react";
 import { ShortenedValue } from "@src/components/shared/ShortenedValue";
 import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
 import { getProviderNameFromUri } from "@src/utils/providerUtils";
+import type { ProviderUptime } from "./ProviderUptimeCell/deriveProviderUptime";
+import { useProvidersUptime } from "./ProviderUptimeCell/deriveProviderUptime";
+import { ProviderUptimeCell } from "./ProviderUptimeCell/ProviderUptimeCell";
 
 const columnHelper = createColumnHelper<ScreenedProvider>();
 
 /** Shown when a provider has no region attribute. */
 const NO_REGION = "—";
 
-const columns = [
-  columnHelper.accessor(provider => getProviderNameFromUri(provider.hostUri), {
-    id: "hostUri",
-    header: ({ column }) => <SortableHeader column={column} title="Provider" />,
-    cell: info => <ShortenedValue value={info.getValue()} maxLength={40} headLength={14} />
-  }),
-  columnHelper.accessor("location", {
-    header: ({ column }) => <SortableHeader column={column} title="Region" />,
-    cell: info => info.getValue() ?? NO_REGION
-  })
-];
+/** Fallback uptime for a provider missing from the derived map; treated as fully healthy. */
+const HEALTHY_UPTIME: ProviderUptime = { percent: 1, buckets: [] };
 
 interface Props {
   providers: ScreenedProvider[];
@@ -33,6 +27,10 @@ interface Props {
 
 export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading }) => {
   const [sorting, setSorting] = useState<SortingState>([]);
+
+  const uptimeByOwner = useProvidersUptime(providers);
+  const columns = useMemo(() => buildColumns(uptimeByOwner), [uptimeByOwner]);
+
   const table = useReactTable({
     data: providers,
     columns,
@@ -103,4 +101,24 @@ function SortableHeader({ column, title }: { column: Column<ScreenedProvider, un
       )}
     </button>
   );
+}
+
+/** Builds the table columns, closing over the per-provider uptime derived once in the component. */
+function buildColumns(uptimeByOwner: Map<string, ProviderUptime>) {
+  return [
+    columnHelper.accessor(provider => getProviderNameFromUri(provider.hostUri), {
+      id: "hostUri",
+      header: ({ column }) => <SortableHeader column={column} title="Provider" />,
+      cell: info => <ShortenedValue value={info.getValue()} maxLength={40} headLength={14} />
+    }),
+    columnHelper.accessor("location", {
+      header: ({ column }) => <SortableHeader column={column} title="Region" />,
+      cell: info => info.getValue() ?? NO_REGION
+    }),
+    columnHelper.accessor(provider => (uptimeByOwner.get(provider.owner) ?? HEALTHY_UPTIME).percent, {
+      id: "uptime",
+      header: ({ column }) => <SortableHeader column={column} title="Uptime (7D)" />,
+      cell: info => <ProviderUptimeCell uptime={uptimeByOwner.get(info.row.original.owner) ?? HEALTHY_UPTIME} />
+    })
+  ];
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/ProviderUptimeCell/ProviderUptimeCell.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/ProviderUptimeCell/ProviderUptimeCell.spec.tsx
@@ -1,0 +1,99 @@
+import { IntlProvider } from "react-intl";
+import { TooltipProvider } from "@akashnetwork/ui/components";
+import { describe, expect, it } from "vitest";
+
+import type { BucketStatus, DayBucket, ProviderUptime } from "./deriveProviderUptime";
+import { ProviderUptimeCell } from "./ProviderUptimeCell";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe("ProviderUptimeCell", () => {
+  it("renders one bar per bucket, colored and sized by status", () => {
+    setup({ buckets: [bucket({ status: "online" }), bucket({ status: "partial" }), bucket({ status: "offline" })] });
+
+    const bars = screen.getAllByTestId("uptime-bar");
+    expect(bars).toHaveLength(3);
+    expect(bars[0]).toHaveClass("bg-emerald-500", "h-4");
+    expect(bars[1]).toHaveClass("bg-amber-500", "h-2.5");
+    expect(bars[2]).toHaveClass("bg-rose-500", "h-1");
+  });
+
+  it("renders a live-down bucket as full-height red regardless of the offline height", () => {
+    setup({ buckets: [bucket({ status: "offline", isLiveDown: true })] });
+
+    const bar = screen.getByTestId("uptime-bar");
+    expect(bar).toHaveClass("bg-rose-500", "h-4");
+    expect(bar).not.toHaveClass("h-1");
+  });
+
+  it("colors the percentage by uptime tier", () => {
+    setup({ percent: 0.9997, buckets: [] });
+    expect(screen.getByText("99.97%")).toHaveClass("text-emerald-500");
+  });
+
+  it("colors the percentage amber between 95% and 99%", () => {
+    setup({ percent: 0.97, buckets: [] });
+    expect(screen.getByText("97%")).toHaveClass("text-amber-500");
+  });
+
+  it("colors the percentage rose below 95%", () => {
+    setup({ percent: 0.9, buckets: [] });
+    expect(screen.getByText("90%")).toHaveClass("text-rose-500");
+  });
+
+  it("shows the day's incident count and downtime in a tooltip on hover", async () => {
+    setup({ buckets: [bucket({ date: "2026-06-12", status: "offline", incidentCount: 2, downtimeSeconds: 3 * 3600 + 12 * 60 })] });
+
+    await userEvent.hover(screen.getByTestId("uptime-bar"));
+
+    expect(await screen.findAllByText("Jun 12 — 2 incidents, 3h 12m down")).not.toHaveLength(0);
+  });
+
+  it("floors downtime minutes so it never renders an impossible 60-minute value", async () => {
+    setup({ buckets: [bucket({ date: "2026-06-12", status: "offline", incidentCount: 1, downtimeSeconds: 3600 + 3570 })] });
+
+    await userEvent.hover(screen.getByTestId("uptime-bar"));
+
+    expect(await screen.findAllByText("Jun 12 — 1 incident, 1h 59m down")).not.toHaveLength(0);
+  });
+
+  it("lists every day's stats in a single tooltip on hover", async () => {
+    setup({
+      buckets: [
+        bucket({ date: "2026-06-10", status: "online" }),
+        bucket({ date: "2026-06-11", status: "partial", incidentCount: 1, downtimeSeconds: 600 }),
+        bucket({ date: "2026-06-12", status: "offline", incidentCount: 2, downtimeSeconds: 3 * 3600 + 12 * 60 })
+      ]
+    });
+
+    await userEvent.hover(screen.getAllByTestId("uptime-bar")[0]);
+
+    expect(await screen.findAllByText("Jun 10 — no incidents")).not.toHaveLength(0);
+    expect(screen.getAllByText("Jun 11 — 1 incident, 10m down")).not.toHaveLength(0);
+    expect(screen.getAllByText("Jun 12 — 2 incidents, 3h 12m down")).not.toHaveLength(0);
+  });
+
+  it("labels a live-down day as currently down in the tooltip", async () => {
+    setup({ buckets: [bucket({ date: "2026-06-15", status: "offline", incidentCount: 1, downtimeSeconds: 60, isLiveDown: true })] });
+
+    await userEvent.hover(screen.getByTestId("uptime-bar"));
+
+    expect(await screen.findAllByText(/Jun 15 — currently down/)).not.toHaveLength(0);
+  });
+
+  function bucket(overrides: Partial<DayBucket> & { status: BucketStatus }): DayBucket {
+    return { date: "2026-06-10", incidentCount: 0, downtimeSeconds: 0, isLiveDown: false, ...overrides };
+  }
+
+  function setup(input: Partial<ProviderUptime> & { buckets: DayBucket[] }) {
+    render(
+      <IntlProvider locale="en">
+        <TooltipProvider delayDuration={0}>
+          <ProviderUptimeCell uptime={{ percent: input.percent ?? 1, buckets: input.buckets }} />
+        </TooltipProvider>
+      </IntlProvider>
+    );
+    return input;
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/ProviderUptimeCell/ProviderUptimeCell.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/ProviderUptimeCell/ProviderUptimeCell.tsx
@@ -1,0 +1,88 @@
+import type { FC } from "react";
+import { useIntl } from "react-intl";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
+import { format, parseISO } from "date-fns";
+
+import type { BucketStatus, DayBucket, ProviderUptime } from "./deriveProviderUptime";
+
+/** Bar background color per bucket health level, matching the Figma uptime cell. */
+const BAR_COLOR: Record<BucketStatus, string> = {
+  online: "bg-emerald-500",
+  partial: "bg-amber-500",
+  offline: "bg-rose-500"
+};
+
+/** Bar height per bucket health level: 16 / 10 / 4 px. */
+const BAR_HEIGHT: Record<BucketStatus, string> = {
+  online: "h-4",
+  partial: "h-2.5",
+  offline: "h-1"
+};
+
+interface Props {
+  uptime: ProviderUptime;
+}
+
+export const ProviderUptimeCell: FC<Props> = ({ uptime }) => {
+  const intl = useIntl();
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="flex items-center gap-1">
+          <span className={cn("w-[52px] whitespace-nowrap font-mono text-sm font-medium", percentColor(uptime.percent))}>
+            {intl.formatNumber(uptime.percent, { style: "percent", maximumFractionDigits: 2 })}
+          </span>
+          <div className="flex h-4 items-end gap-px overflow-clip">
+            {uptime.buckets.map(bucket => (
+              <div
+                key={bucket.date}
+                data-testid="uptime-bar"
+                className={cn("w-0.5", bucket.isLiveDown ? "h-4" : BAR_HEIGHT[bucket.status], BAR_COLOR[bucket.status])}
+              />
+            ))}
+          </div>
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div className="flex flex-col gap-0.5 text-muted-foreground">
+          {uptime.buckets.map(bucket => (
+            <span key={bucket.date}>{formatBucketTooltip(bucket)}</span>
+          ))}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
+/** Percentage text color tiers: healthy >= 99%, degraded >= 95%, else critical. */
+function percentColor(percent: number): string {
+  if (percent >= 0.99) return "text-emerald-500";
+  if (percent >= 0.95) return "text-amber-500";
+  return "text-rose-500";
+}
+
+/** Human summary of a day's health, one row per day in the cell tooltip. */
+function formatBucketTooltip(bucket: DayBucket): string {
+  const label = format(parseISO(bucket.date), "MMM d");
+  const detail = [
+    bucket.incidentCount > 0 ? `${bucket.incidentCount} incident${bucket.incidentCount === 1 ? "" : "s"}` : null,
+    formatDowntime(bucket.downtimeSeconds)
+  ]
+    .filter(Boolean)
+    .join(", ");
+
+  if (bucket.isLiveDown) return detail ? `${label} — currently down (${detail})` : `${label} — currently down`;
+  return detail ? `${label} — ${detail}` : `${label} — no incidents`;
+}
+
+/** Formats a downtime duration in seconds as a compact `Xh Ym` / `Xm` / `Xs` string, or null when zero. */
+function formatDowntime(downtimeSeconds: number): string | null {
+  if (downtimeSeconds === 0) return null;
+  const hours = Math.floor(downtimeSeconds / 3600);
+  const minutes = Math.floor((downtimeSeconds % 3600) / 60);
+  if (hours && minutes) return `${hours}h ${minutes}m down`;
+  if (hours) return `${hours}h down`;
+  if (minutes) return `${minutes}m down`;
+  return `${downtimeSeconds}s down`;
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/ProviderUptimeCell/deriveProviderUptime.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/ProviderUptimeCell/deriveProviderUptime.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveProviderUptime } from "./deriveProviderUptime";
+
+const NOW = Date.parse("2026-06-15T12:00:00.000Z");
+const SECONDS_PER_DAY = 24 * 60 * 60;
+const WINDOW_SECONDS = 7 * SECONDS_PER_DAY;
+
+/** Builds a per-day downtime row; fields default to a single, closed, low-downtime incident. */
+function day(overrides: { date: string; downtimeSeconds?: number; incidentCount?: number; hasOpenIncident?: boolean }) {
+  return { downtimeSeconds: 0, incidentCount: 1, hasOpenIncident: false, ...overrides };
+}
+
+describe("deriveProviderUptime", () => {
+  it("reports 100% uptime and 7 all-online buckets when there are no incidents", () => {
+    const result = deriveProviderUptime([], NOW, "UTC");
+
+    expect(result.percent).toBe(1);
+    expect(result.buckets).toHaveLength(7);
+    expect(result.buckets.every(bucket => bucket.status === "online")).toBe(true);
+  });
+
+  it("marks a fully-down day offline and drops the percentage accordingly", () => {
+    const result = deriveProviderUptime([day({ date: "2026-06-15", downtimeSeconds: SECONDS_PER_DAY })], NOW, "UTC");
+
+    expect(result.buckets[6].status).toBe("offline");
+    expect(result.percent).toBeCloseTo(1 - SECONDS_PER_DAY / WINDOW_SECONDS, 6);
+  });
+
+  it("ignores out-of-window rows when computing the percentage so it never diverges from the sparkline", () => {
+    const result = deriveProviderUptime(
+      [day({ date: "2026-06-15", downtimeSeconds: SECONDS_PER_DAY }), day({ date: "2026-06-01", downtimeSeconds: SECONDS_PER_DAY })],
+      NOW,
+      "UTC"
+    );
+
+    expect(result.buckets).toHaveLength(7);
+    expect(result.percent).toBeCloseTo(1 - SECONDS_PER_DAY / WINDOW_SECONDS, 6);
+  });
+
+  it("marks a day partial when downtime is below half the day", () => {
+    const result = deriveProviderUptime([day({ date: "2026-06-09", downtimeSeconds: 6 * 60 * 60 })], NOW, "UTC");
+
+    expect(result.buckets[0].status).toBe("partial");
+  });
+
+  it("treats days absent from the response as healthy and places downtime in its calendar bucket", () => {
+    const result = deriveProviderUptime([day({ date: "2026-06-13", downtimeSeconds: SECONDS_PER_DAY })], NOW, "UTC");
+
+    expect(result.buckets.map(bucket => bucket.status)).toEqual(["online", "online", "online", "online", "offline", "online", "online"]);
+  });
+
+  it("escalates a low-downtime but high-frequency (flapping) day to offline", () => {
+    const result = deriveProviderUptime([day({ date: "2026-06-12", downtimeSeconds: 60, incidentCount: 12 })], NOW, "UTC");
+
+    expect(result.buckets[3].status).toBe("offline");
+    expect(result.percent).toBeGreaterThan(0.99);
+  });
+
+  it("escalates a few incidents to partial even with negligible downtime", () => {
+    const result = deriveProviderUptime([day({ date: "2026-06-12", downtimeSeconds: 30, incidentCount: 3 })], NOW, "UTC");
+
+    expect(result.buckets[3].status).toBe("partial");
+  });
+
+  it("forces today's bucket into a full live-down state when an incident is open", () => {
+    const result = deriveProviderUptime([day({ date: "2026-06-15", downtimeSeconds: 60, incidentCount: 1, hasOpenIncident: true })], NOW, "UTC");
+
+    expect(result.buckets[6].isLiveDown).toBe(true);
+    expect(result.buckets[6].status).toBe("offline");
+  });
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/ProviderUptimeCell/deriveProviderUptime.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/ProviderUptimeCell/deriveProviderUptime.ts
@@ -1,0 +1,125 @@
+import { useMemo } from "react";
+
+export type BucketStatus = "online" | "partial" | "offline";
+
+export interface DayBucket {
+  /** Local calendar day, YYYY-MM-DD. */
+  date: string;
+  status: BucketStatus;
+  incidentCount: number;
+  downtimeSeconds: number;
+  /** True when the provider has an open incident and this is today's bucket; rendered full-height red. */
+  isLiveDown: boolean;
+}
+
+export interface ProviderUptime {
+  percent: number;
+  buckets: DayBucket[];
+}
+
+interface DailyIncident {
+  date: string;
+  hasOpenIncident: boolean;
+  incidentCount: number;
+  downtimeSeconds: number;
+}
+
+interface DeriveOptions {
+  windowDays?: number;
+}
+
+/**
+ * Derives 7-day uptime for every provider in one memoized pass, keyed by owner address. `now` and the
+ * client's time zone are resolved once per recompute so every provider's day buckets align to the same days.
+ */
+export function useProvidersUptime(providers: Array<{ owner: string; incidents: DailyIncident[] }>): Map<string, ProviderUptime> {
+  return useMemo(() => {
+    const now = Date.now();
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return new Map(providers.map(provider => [provider.owner, deriveProviderUptime(provider.incidents, now, timeZone)]));
+  }, [providers]);
+}
+
+/** Milliseconds in a day. */
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Seconds in a day; the backend clips each day's downtime to this maximum. */
+const SECONDS_PER_DAY = 24 * 60 * 60;
+
+/** A day is "offline" by downtime once it covers at least this fraction of the day, otherwise "partial". */
+const OFFLINE_FRACTION = 0.5;
+
+/** Per-day incident counts at/above these flag instability independently of total downtime (flapping). */
+const FLAPPING_PARTIAL_COUNT = 3;
+const FLAPPING_OFFLINE_COUNT = 10;
+
+/** Severity ordering used to combine the downtime and frequency signals into the worse of the two. */
+const SEVERITY: Record<BucketStatus, number> = { online: 0, partial: 1, offline: 2 };
+
+/**
+ * Derives a provider's 7-day uptime percentage and a per-day health sparkline from the backend's
+ * per-day downtime aggregates. The backend only returns days that had an incident, so absent days
+ * are healthy. Each day's status is the worse of two signals — how long it was down (downtime) and
+ * how often (incident frequency / flapping) — so a low-downtime but high-churn day still reads as
+ * unstable. An open incident forces today's bucket into a live-down state. The percentage stays
+ * purely downtime-based and is summed over the in-window buckets so it never diverges from the sparkline
+ * even if the backend returns out-of-window or duplicate rows. Day buckets align to the client's calendar
+ * days in `timeZone` (the zone sent on the request); `now` is injected so the result is deterministic.
+ */
+export function deriveProviderUptime(incidents: DailyIncident[], now: number, timeZone: string, { windowDays = 7 }: DeriveOptions = {}): ProviderUptime {
+  const byDate = new Map(incidents.map(incident => [incident.date, incident]));
+  const hasOpenIncident = incidents.some(incident => incident.hasOpenIncident);
+  const keys = dayKeysEndingToday(now, timeZone, windowDays);
+
+  const buckets = keys.map((date, index): DayBucket => {
+    const row = byDate.get(date);
+    const downtimeSeconds = row?.downtimeSeconds ?? 0;
+    const incidentCount = row?.incidentCount ?? 0;
+    const isLiveDown = index === keys.length - 1 && hasOpenIncident;
+    const status = isLiveDown ? "offline" : worstStatus(downtimeStatus(downtimeSeconds), frequencyStatus(incidentCount));
+    return { date, status, incidentCount, downtimeSeconds, isLiveDown };
+  });
+
+  const totalDowntime = buckets.reduce((sum, bucket) => sum + bucket.downtimeSeconds, 0);
+  const percent = 1 - totalDowntime / (windowDays * SECONDS_PER_DAY);
+
+  return { percent, buckets };
+}
+
+/** Health implied by how much of the day was down. */
+function downtimeStatus(downtimeSeconds: number): BucketStatus {
+  const fraction = downtimeSeconds / SECONDS_PER_DAY;
+  if (fraction === 0) return "online";
+  if (fraction < OFFLINE_FRACTION) return "partial";
+  return "offline";
+}
+
+/** Health implied by how many separate incidents hit the day (flapping). */
+function frequencyStatus(incidentCount: number): BucketStatus {
+  if (incidentCount >= FLAPPING_OFFLINE_COUNT) return "offline";
+  if (incidentCount >= FLAPPING_PARTIAL_COUNT) return "partial";
+  return "online";
+}
+
+/** The more severe of two statuses. */
+function worstStatus(a: BucketStatus, b: BucketStatus): BucketStatus {
+  return SEVERITY[a] >= SEVERITY[b] ? a : b;
+}
+
+/**
+ * The `count` calendar days ending today (oldest first) as `YYYY-MM-DD` strings in `timeZone`. Today's
+ * date is resolved in the zone, then anchored at noon UTC so stepping back whole days stays DST-safe and
+ * matches the backend's `to_char(day, 'YYYY-MM-DD')` keys.
+ */
+function dayKeysEndingToday(now: number, timeZone: string, count: number): string[] {
+  const todayKey = formatDayKey(now, timeZone);
+  const [year, month, day] = todayKey.split("-").map(Number);
+  const anchorNoonUtc = Date.UTC(year, month - 1, day, 12);
+
+  return Array.from({ length: count }, (_, index) => formatDayKey(anchorNoonUtc - (count - 1 - index) * DAY_MS, "UTC"));
+}
+
+/** Formats an instant as a `YYYY-MM-DD` calendar date in the given time zone. */
+function formatDayKey(instant: number, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone, year: "numeric", month: "2-digit", day: "2-digit" }).format(instant);
+}


### PR DESCRIPTION
## Why

The Compute Marketplace shows each provider's recent reliability. The `uptime7d` data is now available from the screening backend, so the per-provider 7-day uptime chart can render real data instead of a placeholder.

Closes CON-509

## What

- Render a 7-day uptime percentage and per-day health sparkline for each provider row in the marketplace table's "Uptime (7D)" column.
- Each day's status combines downtime and incident-frequency signals; a single cell tooltip lists every day's stats.
- Uptime is derived per owner via a colocated `useProvidersUptime` hook; color thresholds follow the Figma frame and sorting by the Uptime column continues to work.
<img width="909" height="492" alt="Screenshot 2026-06-17 at 12 38 52" src="https://github.com/user-attachments/assets/d0c9be94-2e4c-4854-8fbf-73f39dfc448b" />
<img width="932" height="499" alt="Screenshot 2026-06-17 at 12 39 01" src="https://github.com/user-attachments/assets/b886e421-7ddc-4635-b441-8dcd199df918" />
<img width="934" height="500" alt="Screenshot 2026-06-17 at 12 39 07" src="https://github.com/user-attachments/assets/e170add2-5ad1-4358-926d-855271585677" />
<img width="953" height="491" alt="Screenshot 2026-06-17 at 12 39 13" src="https://github.com/user-attachments/assets/8c0b98f6-e7e9-4a23-ac51-488c8a3d907c" />
<img width="996" height="477" alt="Screenshot 2026-06-17 at 12 39 20" src="https://github.com/user-attachments/assets/4ae08479-f6e8-4b4a-bf30-31ddd53aa35b" />
<img width="945" height="491" alt="Screenshot 2026-06-17 at 12 39 26" src="https://github.com/user-attachments/assets/b914856a-0762-4cf2-b766-4c1e6e78d3e9" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Uptime (7D)” column to the provider marketplace table, including a compact bar visualization and uptime percentage.
  * Providers can be sorted by the derived uptime metric via the “Uptime (7D)” header.
  * Hovering over the uptime visualization shows detailed daily downtime/incidents, including “currently down” context when applicable.

* **Tests**
  * Added coverage for uptime derivation logic, rendering (colors/heights/threshold text), tooltips, and sorting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->