### PR TITLE
feat(deployment): add provider search to marketplace pane

### DIFF
--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -15504,6 +15504,12 @@
                             "description": "Provider region from the location-region attribute (signed preferred, else self-declared); null if unset",
                             "example": "us-west"
                           },
+                          "organization": {
+                            "type": "string",
+                            "nullable": true,
+                            "description": "Provider organization from the organization attribute (signed preferred, else self-declared); null if unset",
+                            "example": "Akash"
+                          },
                           "incidents": {
                             "type": "array",
                             "items": {
@@ -15543,6 +15549,7 @@
                           "isAudited",
                           "createdAt",
                           "location",
+                          "organization",
                           "incidents"
                         ]
                       }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
+import { ProviderSearchInput } from "./ProviderSearchInput/ProviderSearchInput";
 import type { DEPENDENCIES } from "./MarketplacePane";
 import { MarketplacePane } from "./MarketplacePane";
 
@@ -42,21 +43,56 @@ describe("MarketplacePane", () => {
     expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ providers }), expect.anything());
   });
 
+  it("renders the provider search input in the header", () => {
+    setup({ providers: [buildScreenedProvider()] });
+
+    expect(screen.getByRole("searchbox", { name: /search providers/i })).toBeInTheDocument();
+  });
+
+  it("passes the filtered providers and search props to the table", () => {
+    const providers = [buildScreenedProvider(), buildScreenedProvider()];
+    const filteredProviders = [providers[0]];
+    const { MarketplaceProvidersTable } = setup({ providers, filteredProviders, isSearchActive: true });
+
+    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(
+      expect.objectContaining({ providers: filteredProviders, isSearchActive: true, onClearSearch: expect.any(Function) }),
+      expect.anything()
+    );
+  });
+
   function setup(
-    input: { sdl?: string; placementName?: string; region?: string; providers?: ScreenedProvider[]; isLoading?: boolean; isError?: boolean } = {}
+    input: {
+      sdl?: string;
+      placementName?: string;
+      region?: string;
+      providers?: ScreenedProvider[];
+      filteredProviders?: ScreenedProvider[];
+      isLoading?: boolean;
+      isError?: boolean;
+      isSearchActive?: boolean;
+    } = {}
   ) {
     const useScreenedProviders = vi.fn(() => ({
       providers: input.providers ?? [],
       isLoading: input.isLoading ?? false,
       isError: input.isError ?? false
     }));
+    const useProviderSearch = vi.fn((providers: ScreenedProvider[]) => ({
+      query: "",
+      setQuery: vi.fn(),
+      clear: vi.fn(),
+      filteredProviders: input.filteredProviders ?? providers,
+      isSearchActive: input.isSearchActive ?? false
+    }));
     const MarketplaceProvidersTable = vi.fn(() => <div data-testid="marketplace-table-mock" />);
     const dependencies: typeof DEPENDENCIES = {
       useScreenedProviders: useScreenedProviders as never,
-      MarketplaceProvidersTable: MarketplaceProvidersTable as never
+      useProviderSearch: useProviderSearch as never,
+      MarketplaceProvidersTable: MarketplaceProvidersTable as never,
+      ProviderSearchInput
     };
 
     render(<MarketplacePane sdl={input.sdl ?? ""} placementName={input.placementName ?? "dcloud"} region={input.region} dependencies={dependencies} />);
-    return { useScreenedProviders, MarketplaceProvidersTable };
+    return { useScreenedProviders, useProviderSearch, MarketplaceProvidersTable };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
@@ -2,8 +2,10 @@ import type { FC } from "react";
 
 import { useScreenedProviders } from "@src/queries/useScreenedProviders";
 import { MarketplaceProvidersTable } from "./MarketplaceProvidersTable/MarketplaceProvidersTable";
+import { useProviderSearch } from "./MarketplaceProvidersTable/useProviderSearch/useProviderSearch";
+import { ProviderSearchInput } from "./ProviderSearchInput/ProviderSearchInput";
 
-export const DEPENDENCIES = { useScreenedProviders, MarketplaceProvidersTable };
+export const DEPENDENCIES = { useScreenedProviders, useProviderSearch, MarketplaceProvidersTable, ProviderSearchInput };
 
 interface Props {
   sdl: string;
@@ -14,15 +16,19 @@ interface Props {
 
 export const MarketplacePane: FC<Props> = ({ sdl, placementName, region, dependencies: d = DEPENDENCIES }) => {
   const { providers, isLoading, isError } = d.useScreenedProviders({ sdl, placementName, region });
+  const { query, setQuery, clear, filteredProviders, isSearchActive } = d.useProviderSearch(providers);
   const hasFailedWithoutData = isError && providers.length === 0;
 
   return (
     <section aria-labelledby="configure-marketplace-pane-heading" className="flex h-full min-h-0 flex-col">
-      <header className="hidden h-[52px] shrink-0 items-center border-b border-zinc-300 px-4 md:flex dark:border-zinc-700">
-        <h2 id="configure-marketplace-pane-heading" className="font-mono text-sm font-medium uppercase text-muted-foreground">
-          3. Compute Marketplace
-        </h2>
-        <span className="ml-2 font-mono text-sm font-semibold text-blue-500">• {placementName}</span>
+      <header className="flex h-[52px] shrink-0 items-center justify-between gap-4 px-4 md:border-b md:border-zinc-300 md:dark:border-zinc-700">
+        <div className="hidden items-center md:flex">
+          <h2 id="configure-marketplace-pane-heading" className="font-mono text-sm font-medium uppercase text-muted-foreground">
+            3. Compute Marketplace
+          </h2>
+          <span className="ml-2 font-mono text-sm font-semibold text-blue-500">• {placementName}</span>
+        </div>
+        <d.ProviderSearchInput value={query} onChange={setQuery} onClear={clear} />
       </header>
       <div className="flex-1 overflow-y-auto p-4">
         {hasFailedWithoutData ? (
@@ -30,7 +36,7 @@ export const MarketplacePane: FC<Props> = ({ sdl, placementName, region, depende
             Failed to load providers. Please try again.
           </p>
         ) : (
-          <d.MarketplaceProvidersTable providers={providers} isLoading={isLoading} />
+          <d.MarketplaceProvidersTable providers={filteredProviders} isLoading={isLoading} isSearchActive={isSearchActive} onClearSearch={clear} />
         )}
       </div>
     </section>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
@@ -1,7 +1,7 @@
 import { IntlProvider } from "react-intl";
 import { TooltipProvider } from "@akashnetwork/ui/components";
 import { format, subDays } from "date-fns";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
 import { MarketplaceProvidersTable } from "./MarketplaceProvidersTable";
@@ -72,11 +72,51 @@ describe("MarketplaceProvidersTable", () => {
     expect(within(rows[2]).getByText("up.example")).toBeInTheDocument();
   });
 
-  function setup(input: { providers: ScreenedProvider[] }) {
+  it("displays the organization name when present", () => {
+    setup({ providers: [buildScreenedProvider({ organization: "Polaris Compute", hostUri: "https://a.example:8443" })] });
+
+    expect(screen.getByText("Polaris Compute")).toBeInTheDocument();
+  });
+
+  it("falls back to the host name when organization is absent", () => {
+    setup({ providers: [buildScreenedProvider({ organization: null, hostUri: "https://a.example:8443" })] });
+
+    expect(screen.getByText("a.example")).toBeInTheDocument();
+  });
+
+  it("shows a search empty state with a clear action when a search excludes all rows", async () => {
+    const onClearSearch = vi.fn();
+    setup({ providers: [], isSearchActive: true, onClearSearch });
+
+    expect(screen.getByText(/no providers match/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /clear search/i }));
+    expect(onClearSearch).toHaveBeenCalled();
+  });
+
+  it("shows the plain empty state when not searching and there are no providers", () => {
+    setup({ providers: [], isSearchActive: false });
+
+    expect(screen.getByText("No providers found.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /clear search/i })).not.toBeInTheDocument();
+  });
+
+  it("omits the clear action in the search empty state when no clear handler is provided", () => {
+    setup({ providers: [], isSearchActive: true });
+
+    expect(screen.getByText(/no providers match/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /clear search/i })).not.toBeInTheDocument();
+  });
+
+  function setup(input: { providers: ScreenedProvider[]; isLoading?: boolean; isSearchActive?: boolean; onClearSearch?: () => void }) {
     return render(
       <IntlProvider locale="en">
         <TooltipProvider>
-          <MarketplaceProvidersTable providers={input.providers} />
+          <MarketplaceProvidersTable
+            providers={input.providers}
+            isLoading={input.isLoading}
+            isSearchActive={input.isSearchActive}
+            onClearSearch={input.onClearSearch}
+          />
         </TooltipProvider>
       </IntlProvider>
     );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
@@ -1,6 +1,6 @@
 import type { FC } from "react";
 import { useMemo, useState } from "react";
-import { Spinner, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@akashnetwork/ui/components";
+import { Button, Spinner, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@akashnetwork/ui/components";
 import type { Column, SortingState } from "@tanstack/react-table";
 import { createColumnHelper, flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
 import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react";
@@ -23,9 +23,11 @@ const HEALTHY_UPTIME: ProviderUptime = { percent: 1, buckets: [] };
 interface Props {
   providers: ScreenedProvider[];
   isLoading?: boolean;
+  isSearchActive?: boolean;
+  onClearSearch?: () => void;
 }
 
-export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading }) => {
+export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading, isSearchActive, onClearSearch }) => {
   const [sorting, setSorting] = useState<SortingState>([]);
 
   const uptimeByOwner = useProvidersUptime(providers);
@@ -49,6 +51,18 @@ export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading }) =
   }
 
   if (providers.length === 0) {
+    if (isSearchActive) {
+      return (
+        <div className="flex flex-col items-start gap-2 p-4">
+          <p className="text-sm text-muted-foreground">No providers match your search.</p>
+          {onClearSearch && (
+            <Button variant="outline" size="sm" onClick={onClearSearch}>
+              Clear search
+            </Button>
+          )}
+        </div>
+      );
+    }
     return <p className="p-4 text-sm text-muted-foreground">No providers found.</p>;
   }
 
@@ -106,7 +120,7 @@ function SortableHeader({ column, title }: { column: Column<ScreenedProvider, un
 /** Builds the table columns, closing over the per-provider uptime derived once in the component. */
 function buildColumns(uptimeByOwner: Map<string, ProviderUptime>) {
   return [
-    columnHelper.accessor(provider => getProviderNameFromUri(provider.hostUri), {
+    columnHelper.accessor(provider => provider.organization?.trim() || getProviderNameFromUri(provider.hostUri), {
       id: "hostUri",
       header: ({ column }) => <SortableHeader column={column} title="Provider" />,
       cell: info => <ShortenedValue value={info.getValue()} maxLength={40} headLength={14} />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/useProviderSearch/useProviderSearch.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/useProviderSearch/useProviderSearch.spec.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useProviderSearch } from "./useProviderSearch";
+
+import { act, renderHook } from "@testing-library/react";
+import { buildScreenedProvider } from "@tests/seeders/screenedProvider";
+
+describe(useProviderSearch.name, () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("returns all providers and is inactive with an empty query", () => {
+    const { providers, result } = setup();
+
+    expect(result.current.filteredProviders).toEqual(providers);
+    expect(result.current.isSearchActive).toBe(false);
+  });
+
+  it("filters by organization name, case-insensitively, after the debounce", () => {
+    const akash = buildScreenedProvider({ organization: "Akash Org", hostUri: "https://a.example:8443" });
+    const other = buildScreenedProvider({ organization: "Other Co", hostUri: "https://b.example:8443" });
+    const { result } = setup({ providers: [akash, other] });
+
+    act(() => result.current.setQuery("akash"));
+    act(() => vi.advanceTimersByTime(300));
+
+    expect(result.current.filteredProviders).toEqual([akash]);
+    expect(result.current.isSearchActive).toBe(true);
+  });
+
+  it("filters by raw host URI when organization is absent", () => {
+    const match = buildScreenedProvider({ organization: null, hostUri: "https://needle.example:8443" });
+    const miss = buildScreenedProvider({ organization: null, hostUri: "https://other.example:8443" });
+    const { result } = setup({ providers: [match, miss] });
+
+    act(() => result.current.setQuery("NEEDLE"));
+    act(() => vi.advanceTimersByTime(300));
+
+    expect(result.current.filteredProviders).toEqual([match]);
+  });
+
+  it("does not apply the query until the debounce elapses", () => {
+    const a = buildScreenedProvider({ organization: "Aaa" });
+    const b = buildScreenedProvider({ organization: "Bbb" });
+    const { result } = setup({ providers: [a, b] });
+
+    act(() => result.current.setQuery("aaa"));
+    expect(result.current.filteredProviders).toHaveLength(2);
+
+    act(() => vi.advanceTimersByTime(300));
+    expect(result.current.filteredProviders).toEqual([a]);
+  });
+
+  it("clears immediately and restores the full list", () => {
+    const a = buildScreenedProvider({ organization: "Aaa" });
+    const b = buildScreenedProvider({ organization: "Bbb" });
+    const { providers, result } = setup({ providers: [a, b] });
+
+    act(() => result.current.setQuery("aaa"));
+    act(() => vi.advanceTimersByTime(300));
+    expect(result.current.filteredProviders).toEqual([a]);
+
+    act(() => result.current.clear());
+
+    expect(result.current.filteredProviders).toEqual(providers);
+    expect(result.current.isSearchActive).toBe(false);
+  });
+
+  function setup(input: { providers?: ReturnType<typeof buildScreenedProvider>[] } = {}) {
+    const providers = input.providers ?? [buildScreenedProvider(), buildScreenedProvider()];
+    const { result } = renderHook(() => useProviderSearch(providers));
+    return { providers, result };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/useProviderSearch/useProviderSearch.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/useProviderSearch/useProviderSearch.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
+
+/** Delay before a typed query is applied; clearing bypasses it. Matches the SDL-sync precedent. */
+const SEARCH_DEBOUNCE_MS = 300;
+
+interface UseProviderSearchResult {
+  query: string;
+  setQuery: (value: string) => void;
+  clear: () => void;
+  filteredProviders: ScreenedProvider[];
+  isSearchActive: boolean;
+}
+
+/**
+ * Presentation-only narrowing of the screened list by organization name and host URI. The typed
+ * query is debounced; an empty query applies immediately so clearing snaps the full list back.
+ */
+export function useProviderSearch(providers: ScreenedProvider[]): UseProviderSearchResult {
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+
+  useEffect(
+    function debounceQuery() {
+      if (query === "") {
+        setDebouncedQuery("");
+        return;
+      }
+      const timeout = setTimeout(() => setDebouncedQuery(query), SEARCH_DEBOUNCE_MS);
+      return function cancelDebounce() {
+        clearTimeout(timeout);
+      };
+    },
+    [query]
+  );
+
+  const normalizedQuery = debouncedQuery.trim().toLowerCase();
+  const isSearchActive = normalizedQuery.length > 0;
+
+  const filteredProviders = useMemo(
+    function filterProviders() {
+      if (!isSearchActive) return providers;
+      return providers.filter(provider => matchesQuery(provider, normalizedQuery));
+    },
+    [providers, normalizedQuery, isSearchActive]
+  );
+
+  const clear = useCallback(function clearQuery() {
+    setQuery("");
+  }, []);
+
+  return { query, setQuery, clear, filteredProviders, isSearchActive };
+}
+
+/** Case-insensitive substring match against the organization name (when set) and the raw host URI. */
+function matchesQuery(provider: ScreenedProvider, normalizedQuery: string): boolean {
+  const organization = provider.organization?.toLowerCase() ?? "";
+  return organization.includes(normalizedQuery) || provider.hostUri.toLowerCase().includes(normalizedQuery);
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/ProviderSearchInput/ProviderSearchInput.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/ProviderSearchInput/ProviderSearchInput.spec.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ProviderSearchInput } from "./ProviderSearchInput";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(ProviderSearchInput.name, () => {
+  it("calls onChange with the typed value", async () => {
+    const { onChange } = setup({ value: "" });
+
+    await userEvent.type(screen.getByRole("searchbox", { name: /search providers/i }), "a");
+
+    expect(onChange).toHaveBeenCalledWith("a");
+  });
+
+  it("hides the clear button when empty", () => {
+    setup({ value: "" });
+
+    expect(screen.queryByRole("button", { name: /clear search/i })).not.toBeInTheDocument();
+  });
+
+  it("shows a clear button when there is a value and calls onClear", async () => {
+    const { onClear } = setup({ value: "abc" });
+
+    await userEvent.click(screen.getByRole("button", { name: /clear search/i }));
+
+    expect(onClear).toHaveBeenCalled();
+  });
+
+  function setup(input: { value?: string }) {
+    const onChange = vi.fn();
+    const onClear = vi.fn();
+    render(<ProviderSearchInput value={input.value ?? ""} onChange={onChange} onClear={onClear} />);
+    return { onChange, onClear };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/ProviderSearchInput/ProviderSearchInput.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/ProviderSearchInput/ProviderSearchInput.tsx
@@ -1,0 +1,31 @@
+import type { FC } from "react";
+import { Input } from "@akashnetwork/ui/components";
+import { Search, X } from "lucide-react";
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  onClear: () => void;
+}
+
+export const ProviderSearchInput: FC<Props> = ({ value, onChange, onClear }) => {
+  return (
+    <Input
+      type="search"
+      aria-label="Search providers"
+      placeholder="Search providers..."
+      value={value}
+      onChange={event => onChange(event.target.value)}
+      className="w-full md:w-64"
+      inputClassName="h-9 [&::-ms-clear]:hidden [&::-webkit-search-cancel-button]:appearance-none"
+      startIcon={<Search className="ml-3 h-4 w-4 text-muted-foreground" />}
+      endIcon={
+        value ? (
+          <button type="button" aria-label="Clear search" onClick={onClear} className="mr-3 text-muted-foreground hover:text-foreground">
+            <X className="h-4 w-4" />
+          </button>
+        ) : undefined
+      }
+    />
+  );
+};

--- a/apps/deploy-web/tests/seeders/screenedProvider.ts
+++ b/apps/deploy-web/tests/seeders/screenedProvider.ts
@@ -10,6 +10,7 @@ export function buildScreenedProvider(overrides?: Partial<ScreenedProvider>): Sc
     isAudited: faker.datatype.boolean(),
     createdAt: faker.date.past().toISOString(),
     location: faker.location.state({ abbreviated: true }),
+    organization: null,
     incidents: [],
     ...overrides
   };

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -7968,6 +7968,11 @@ export interface operations {
                * @example us-west
                */
               location: string | null;
+              /**
+               * @description Provider organization from the organization attribute (signed preferred, else self-declared); null if unset
+               * @example Akash
+               */
+              organization: string | null;
               /** @description Per-day downtime over a rolling 7-day window */
               incidents: {
                 /**


### PR DESCRIPTION
## Why

Users browsing providers in the marketplace pane had no way to narrow down the list. This adds a search input so providers can be filtered by name, organization, and region.

Closes CON-422

## What

- Adds a `ProviderSearchInput` to the marketplace provider table.
- Adds a `useProviderSearch` hook that filters providers by name, organization, and region.
- Surfaces the provider `organization` attribute through the bid screening response and the generated SDK schema/openapi spec.
<img width="683" height="261" alt="image" src="https://github.com/user-attachments/assets/99881b63-c211-4533-a44b-659877b95b91" />
<img width="703" height="212" alt="image" src="https://github.com/user-attachments/assets/022bf81e-fb19-4f54-93c4-0dd096214110" />
<img width="681" height="197" alt="image" src="https://github.com/user-attachments/assets/5afe1a9b-92d7-493f-b3a2-d14874d4df83" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added provider search functionality to the marketplace with real-time filtering by organization or host name
  * Providers now display organization names, with host names as fallback
  * Added empty-state message with "Clear search" option when no providers match the search query

* **Improvements**
  * Provider search includes 300ms debounce for optimal performance
  * Organization field added to provider API response

* **Tests**
  * Expanded test coverage for provider search and table display functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->