### PR TITLE
feat(deployment): add live resource summary to configure header

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
@@ -2,7 +2,11 @@ import type { FC } from "react";
 import { Button } from "@akashnetwork/ui/components";
 import { Send } from "iconoir-react";
 
+import { useDeploymentResourceSummary } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
+
 export const ConfigureDeploymentHeader: FC = () => {
+  const deploymentSummary = useDeploymentResourceSummary();
+
   return (
     <header className="flex flex-row items-center justify-between gap-3 md:items-end">
       <div className="flex min-w-0 flex-1 flex-col gap-1 md:gap-2">
@@ -13,7 +17,7 @@ export const ConfigureDeploymentHeader: FC = () => {
       </div>
 
       <div className="flex shrink-0 items-center gap-3 md:gap-6">
-        <DeploymentSummaryBlock label="Deployment" value="—" />
+        <DeploymentSummaryBlock label="Your deployment" value={deploymentSummary} />
         <div className="hidden h-12 w-px self-stretch bg-border md:block" aria-hidden="true" />
         <DeploymentSummaryBlock label="Cost" value="—" suffix="/hr" />
         <Button disabled className="h-9 shrink-0 px-3 md:h-10 md:px-8">

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/deploymentResources.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/deploymentResources.spec.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ServiceType } from "@src/types";
+import type { DeploymentResourceTotals } from "./deploymentResources";
+import { aggregateDeploymentResources, formatDeploymentResources } from "./deploymentResources";
+
+const MI = 1024 ** 2;
+const GI = 1024 ** 3;
+
+describe("aggregateDeploymentResources", () => {
+  it("aggregates a single default service (cpu 0.1, 512 Mi ram, 1 Gi ephemeral)", () => {
+    const { services } = setup({ services: [{ cpu: 0.1, ram: 512, ramUnit: "Mi", storage: [{ size: 1, unit: "Gi" }] }] });
+
+    expect(aggregateDeploymentResources(services)).toEqual({
+      cpu: 0.1,
+      gpu: 0,
+      memoryBytes: 512 * MI,
+      ephemeralBytes: 1 * GI,
+      persistentBytes: 0
+    });
+  });
+
+  it("multiplies every resource by the service replica count", () => {
+    const { services } = setup({ services: [{ cpu: 0.5, ram: 1, ramUnit: "Gi", storage: [{ size: 2, unit: "Gi" }], count: 3 }] });
+
+    expect(aggregateDeploymentResources(services)).toEqual({
+      cpu: 1.5,
+      gpu: 0,
+      memoryBytes: 3 * GI,
+      ephemeralBytes: 6 * GI,
+      persistentBytes: 0
+    });
+  });
+
+  it("sums resources across multiple services with mixed units", () => {
+    const { services } = setup({
+      services: [
+        { cpu: 1, ram: 512, ramUnit: "Mi", storage: [{ size: 1, unit: "Gi" }] },
+        { cpu: 2, ram: 1, ramUnit: "Gi", storage: [{ size: 1024, unit: "Mi" }] }
+      ]
+    });
+
+    const totals = aggregateDeploymentResources(services);
+
+    expect(totals.cpu).toBe(3);
+    expect(totals.memoryBytes).toBe(512 * MI + 1 * GI);
+    expect(totals.ephemeralBytes).toBe(1 * GI + 1024 * MI);
+  });
+
+  it("counts gpu only when hasGpu is set", () => {
+    const { services } = setup({
+      services: [
+        { cpu: 1, hasGpu: true, gpu: 2, count: 2 },
+        { cpu: 1, hasGpu: false, gpu: 4 }
+      ]
+    });
+
+    expect(aggregateDeploymentResources(services).gpu).toBe(4);
+  });
+
+  it("splits storage into ephemeral and persistent by isPersistent", () => {
+    const { services } = setup({
+      services: [{ cpu: 1, storage: [{ size: 1, unit: "Gi" }, { size: 10, unit: "Gi", isPersistent: true }] }]
+    });
+
+    const totals = aggregateDeploymentResources(services);
+
+    expect(totals.ephemeralBytes).toBe(1 * GI);
+    expect(totals.persistentBytes).toBe(10 * GI);
+  });
+
+  function setup(input: {
+    services: Array<{
+      cpu?: number;
+      ram?: number;
+      ramUnit?: string;
+      hasGpu?: boolean;
+      gpu?: number;
+      count?: number;
+      storage?: Array<{ size: number; unit: string; isPersistent?: boolean }>;
+    }>;
+  }) {
+    const services = input.services.map(s =>
+      mock<ServiceType>({
+        count: s.count ?? 1,
+        profile: {
+          cpu: s.cpu ?? 0,
+          hasGpu: s.hasGpu ?? false,
+          gpu: s.gpu ?? 0,
+          ram: s.ram ?? 0,
+          ramUnit: s.ramUnit ?? "Mi",
+          storage: (s.storage ?? [{ size: 0, unit: "Gi" }]).map(st => ({
+            size: st.size,
+            unit: st.unit,
+            isPersistent: st.isPersistent ?? false
+          }))
+        }
+      })
+    );
+    return { services };
+  }
+});
+
+describe("formatDeploymentResources", () => {
+  it("formats cpu, memory and ephemeral storage in binary units", () => {
+    expect(formatDeploymentResources(setup({ cpu: 0.1, memoryBytes: 512 * MI, ephemeralBytes: 1 * GI }))).toBe("0.1 vCPU · 512MiB · 1GiB");
+  });
+
+  it("inserts the gpu segment right after cpu when gpu is present", () => {
+    expect(formatDeploymentResources(setup({ cpu: 2, gpu: 1, memoryBytes: 8 * GI, ephemeralBytes: 100 * GI }))).toBe("2 vCPU · 1 GPU · 8GiB · 100GiB");
+  });
+
+  it("appends a labeled persistent segment when persistent storage is present", () => {
+    expect(formatDeploymentResources(setup({ cpu: 1, memoryBytes: 1 * GI, ephemeralBytes: 1 * GI, persistentBytes: 10 * GI }))).toBe(
+      "1 vCPU · 1GiB · 1GiB · 10GiB persistent"
+    );
+  });
+
+  it("rounds fractional byte values to two decimals", () => {
+    expect(formatDeploymentResources(setup({ cpu: 1, memoryBytes: 1536 * MI, ephemeralBytes: 1 * GI }))).toBe("1 vCPU · 1.5GiB · 1GiB");
+  });
+
+  it("falls back to an em dash when the spec has no resources", () => {
+    expect(formatDeploymentResources(setup({}))).toBe("—");
+  });
+
+  function setup(input: Partial<DeploymentResourceTotals>) {
+    return { cpu: 0, gpu: 0, memoryBytes: 0, ephemeralBytes: 0, persistentBytes: 0, ...input };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/deploymentResources.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/deploymentResources.ts
@@ -1,0 +1,75 @@
+import type { ServiceType } from "@src/types";
+import { memoryUnits, storageUnits } from "@src/utils/akash/units";
+import { roundDecimal } from "@src/utils/mathHelpers";
+import { bytesToShrink } from "@src/utils/unitUtils";
+
+export interface DeploymentResourceTotals {
+  cpu: number;
+  gpu: number;
+  memoryBytes: number;
+  ephemeralBytes: number;
+  persistentBytes: number;
+}
+
+/** Converts a sized resource entry to bytes using the matching unit multiplier; an unknown unit contributes 0. */
+function toBytes(size: number, unit: string, units: ReadonlyArray<{ suffix: string; value: number }>): number {
+  const match = units.find(candidate => candidate.suffix.toLowerCase() === unit?.toLowerCase());
+  return (size || 0) * (match?.value ?? 0);
+}
+
+/** Sums per-replica resources (× count) across every service into a single totals object, in bytes. */
+export function aggregateDeploymentResources(services: ServiceType[]): DeploymentResourceTotals {
+  return services.reduce<DeploymentResourceTotals>(
+    (totals, service) => {
+      const count = service.count || 0;
+      const { profile } = service;
+
+      totals.cpu += (profile.cpu || 0) * count;
+      if (profile.hasGpu) {
+        totals.gpu += (profile.gpu || 0) * count;
+      }
+      totals.memoryBytes += toBytes(profile.ram, profile.ramUnit, memoryUnits) * count;
+
+      for (const storage of profile.storage) {
+        const bytes = toBytes(storage.size, storage.unit, storageUnits) * count;
+        if (storage.isPersistent) {
+          totals.persistentBytes += bytes;
+        } else {
+          totals.ephemeralBytes += bytes;
+        }
+      }
+
+      return totals;
+    },
+    { cpu: 0, gpu: 0, memoryBytes: 0, ephemeralBytes: 0, persistentBytes: 0 }
+  );
+}
+
+/** Formats a byte total to a binary unit string with no separating space, e.g. `512MiB`. */
+function formatBytes(bytes: number): string {
+  const { value, unit } = bytesToShrink(bytes, true);
+  return `${roundDecimal(value, 2)}${unit}`;
+}
+
+/**
+ * Builds the header summary string: `{cpu} vCPU · [{gpu} GPU ·] {memory} · {ephemeral} [· {persistent} persistent]`.
+ * GPU and persistent segments appear only when present. Returns an em dash when the spec has no resources.
+ */
+export function formatDeploymentResources(totals: DeploymentResourceTotals): string {
+  const hasResources = totals.cpu > 0 || totals.gpu > 0 || totals.memoryBytes > 0 || totals.ephemeralBytes > 0 || totals.persistentBytes > 0;
+  if (!hasResources) {
+    return "—";
+  }
+
+  const segments = [`${roundDecimal(totals.cpu, 2)} vCPU`];
+  if (totals.gpu > 0) {
+    segments.push(`${totals.gpu} GPU`);
+  }
+  segments.push(formatBytes(totals.memoryBytes));
+  segments.push(formatBytes(totals.ephemeralBytes));
+  if (totals.persistentBytes > 0) {
+    segments.push(`${formatBytes(totals.persistentBytes)} persistent`);
+  }
+
+  return segments.join(" · ");
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.ts
@@ -1,0 +1,12 @@
+import { useMemo } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { aggregateDeploymentResources, formatDeploymentResources } from "./deploymentResources";
+
+/** Returns the live "Your deployment" resource summary string derived from the current form spec. */
+export function useDeploymentResourceSummary(): string {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const services = useWatch({ control, name: "services" });
+  return useMemo(() => formatDeploymentResources(aggregateDeploymentResources(services ?? [])), [services]);
+}


### PR DESCRIPTION
## Why

The "Your deployment" header should give users a running, at-a-glance total of the compute they've specified — CPU, memory, storage (and GPU) — so they always know the size of what they're configuring, before any pricing exists.

Fixes CON-521

## What

Adds a live, display-only resource summary to the configure-step header:

- Aggregates CPU · memory · ephemeral storage across all placements/services, plus GPU and persistent storage when present
- Totals update immediately as the spec changes (hardware, services, placements)
- Derived entirely from the deployment model — no backend calls
- Renders a sensible default for an empty/zero spec

> Stacked on top of #3329 — review/merge that first. This PR's base is `feat/deployment-marketplace-provider-search`; the diff is the single resource-summary commit.
<img width="679" height="222" alt="image" src="https://github.com/user-attachments/assets/61c4eac8-211f-4b32-aa03-d8378f54fa07" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deployment configuration header now displays actual resource totals dynamically, calculating CPU, memory, storage, and GPU across services with proper replica multiplication and human-readable formatting.

* **Tests**
  * Added comprehensive test suite for resource aggregation and formatting functionality, covering multiple services, unit conversions, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->