### PR TITLE
refactor(dx): include public-doc-hidden routes in the internal typed SDK

### DIFF
--- a/apps/api/src/billing/routes/stripe-coupons/stripe-coupons.router.ts
+++ b/apps/api/src/billing/routes/stripe-coupons/stripe-coupons.router.ts
@@ -10,6 +10,7 @@ export const stripeCouponsRouter = new OpenApiHonoHandler();
 
 const applyCouponRoute = createRoute({
   method: "post",
+  operationId: "applyStripeCoupon",
   path: "/v1/stripe/coupons/apply",
   summary: "Apply a coupon to the current user",
   tags: ["Payment"],

--- a/apps/api/src/billing/routes/stripe-customers/stripe-customers.router.ts
+++ b/apps/api/src/billing/routes/stripe-customers/stripe-customers.router.ts
@@ -10,6 +10,7 @@ export const stripeCustomersRouter = new OpenApiHonoHandler();
 
 const updateCustomerOrganizationRoute = createRoute({
   method: "put",
+  operationId: "updateStripeCustomerOrganization",
   path: "/v1/stripe/customers/organization",
   summary: "Update customer organization",
   description: "Updates the organization/business name for the current user's Stripe customer account",

--- a/apps/api/src/billing/routes/stripe-payment-methods/stripe-payment-methods.router.ts
+++ b/apps/api/src/billing/routes/stripe-payment-methods/stripe-payment-methods.router.ts
@@ -18,6 +18,7 @@ export const stripePaymentMethodsRouter = new OpenApiHonoHandler();
 
 const setupIntentRoute = createRoute({
   method: "post",
+  operationId: "createSetupIntent",
   path: "/v1/stripe/payment-methods/setup",
   summary: "Create a Stripe SetupIntent for adding a payment method",
   description:
@@ -45,6 +46,9 @@ stripePaymentMethodsRouter.openapi(setupIntentRoute, async function createSetupI
 
 const markAsDefaultRoute = createRoute({
   method: "post",
+  // /default is a named singleton, not a collection; operation-id-format only recognises {id} singletons.
+  // eslint-disable-next-line akash/operation-id-format
+  operationId: "setDefaultPaymentMethod",
   path: "/v1/stripe/payment-methods/default",
   summary: "Marks a payment method as the default.",
   tags: ["Payment"],
@@ -73,6 +77,9 @@ stripePaymentMethodsRouter.openapi(markAsDefaultRoute, async function markAsDefa
 
 const getDefaultPaymentMethodRoute = createRoute({
   method: "get",
+  // /default is a named singleton, not a collection; operation-id-format only recognises {id} singletons.
+  // eslint-disable-next-line akash/operation-id-format
+  operationId: "getDefaultPaymentMethod",
   path: "/v1/stripe/payment-methods/default",
   summary: "Get the default payment method for the current user",
   description:
@@ -103,6 +110,7 @@ stripePaymentMethodsRouter.openapi(getDefaultPaymentMethodRoute, async function 
 
 const paymentMethodsRoute = createRoute({
   method: "get",
+  operationId: "listPaymentMethods",
   path: "/v1/stripe/payment-methods",
   summary: "Get all payment methods for the current user",
   description:
@@ -130,6 +138,7 @@ stripePaymentMethodsRouter.openapi(paymentMethodsRoute, async function getPaymen
 
 const removePaymentMethodRoute = createRoute({
   method: "delete",
+  operationId: "deletePaymentMethod",
   path: "/v1/stripe/payment-methods/{paymentMethodId}",
   summary: "Remove a payment method",
   description: "Permanently removes a saved payment method from the user's account. This action cannot be undone.",
@@ -154,6 +163,7 @@ stripePaymentMethodsRouter.openapi(removePaymentMethodRoute, async function remo
 
 const validatePaymentMethodRoute = createRoute({
   method: "post",
+  operationId: "validatePaymentMethod",
   path: "/v1/stripe/payment-methods/validate",
   summary: "Validates a payment method after 3D Secure authentication",
   description:

--- a/apps/api/src/billing/routes/stripe-prices/stripe-prices.router.ts
+++ b/apps/api/src/billing/routes/stripe-prices/stripe-prices.router.ts
@@ -22,6 +22,7 @@ export const stripePricesRouter = new OpenApiHonoHandler();
 
 const route = createRoute({
   method: "get",
+  operationId: "listStripePrices",
   path: "/v1/stripe/prices",
   summary: "Get available Stripe pricing options",
   description: "Retrieves the list of available pricing options for wallet top-ups, including custom amounts and standard pricing tiers",

--- a/apps/api/src/billing/routes/stripe-transactions/stripe-transactions.router.ts
+++ b/apps/api/src/billing/routes/stripe-transactions/stripe-transactions.router.ts
@@ -17,6 +17,7 @@ export const stripeTransactionsRouter = new OpenApiHonoHandler();
 
 const confirmPaymentRoute = createRoute({
   method: "post",
+  operationId: "confirmStripeTransaction",
   path: "/v1/stripe/transactions/confirm",
   summary: "Confirm a payment using a saved payment method",
   description:
@@ -70,6 +71,7 @@ stripeTransactionsRouter.openapi(confirmPaymentRoute, async function confirmPaym
 
 const getCustomerTransactionsRoute = createRoute({
   method: "get",
+  operationId: "listStripeTransactions",
   path: "/v1/stripe/transactions",
   summary: "Get transaction history for the current customer",
   tags: ["Payment"],
@@ -103,6 +105,7 @@ stripeTransactionsRouter.openapi(getCustomerTransactionsRoute, async function ge
 
 const exportTransactionsCsvRoute = createRoute({
   method: "get",
+  operationId: "exportStripeTransactions",
   path: "/v1/stripe/transactions/export",
   summary: "Export transaction history as CSV for the current customer",
   tags: ["Payment"],

--- a/apps/api/src/billing/routes/stripe-webhook/stripe-webhook.router.ts
+++ b/apps/api/src/billing/routes/stripe-webhook/stripe-webhook.router.ts
@@ -8,6 +8,7 @@ import { SECURITY_NONE } from "@src/core/services/openapi-docs/openapi-security"
 
 export const stripeWebhook = new OpenApiHonoHandler();
 
+// no operationId: excluded from the generated api.v1.* client; called server-to-server by Stripe.
 const route = createRoute({
   method: "post",
   path: "/v1/stripe-webhook",

--- a/apps/api/src/core/lib/create-route/create-route.spec.ts
+++ b/apps/api/src/core/lib/create-route/create-route.spec.ts
@@ -12,6 +12,8 @@ import { createRoute, HIDDEN_ROUTES } from "./create-route";
 describe(createRoute.name, () => {
   afterEach(() => {
     container.clearInstances();
+    // createRoute mutates the process-wide HIDDEN_ROUTES set; clear it so tests stay isolated.
+    HIDDEN_ROUTES.clear();
   });
 
   describe("when given GET config", () => {

--- a/apps/api/src/core/lib/create-route/create-route.spec.ts
+++ b/apps/api/src/core/lib/create-route/create-route.spec.ts
@@ -7,7 +7,7 @@ import { mock } from "vitest-mock-extended";
 
 import { AuthService } from "../../../auth/services/auth.service";
 import { SECURITY_NONE } from "../../services/openapi-docs/openapi-security";
-import { createRoute } from "./create-route";
+import { createRoute, HIDDEN_ROUTES } from "./create-route";
 
 describe(createRoute.name, () => {
   afterEach(() => {
@@ -216,6 +216,52 @@ describe(createRoute.name, () => {
       expect(middlewares).toHaveLength(2);
       expect(middlewares[1]).toBe(existingMiddleware);
     });
+  });
+
+  describe("when hiddenInOpenApiDocs is true", () => {
+    it("registers the explicit operationId (not the METHOD path) in HIDDEN_ROUTES so the served spec can strip it", () => {
+      createRoute({
+        method: "get",
+        path: "/hidden-resources",
+        operationId: "listHiddenResources",
+        summary: "Test",
+        tags: ["Test"],
+        security: SECURITY_NONE,
+        hiddenInOpenApiDocs: true,
+        responses: { 200: { description: "OK" } }
+      });
+
+      expect(HIDDEN_ROUTES.has("listHiddenResources")).toBe(true);
+      expect(HIDDEN_ROUTES.has("GET /hidden-resources")).toBe(false);
+    });
+
+    it("falls back to METHOD and path when no operationId is set", () => {
+      createRoute({
+        method: "post",
+        path: "/hidden-without-operation-id",
+        summary: "Test",
+        tags: ["Test"],
+        security: SECURITY_NONE,
+        hiddenInOpenApiDocs: true,
+        responses: { 200: { description: "OK" } }
+      });
+
+      expect(HIDDEN_ROUTES.has("POST /hidden-without-operation-id")).toBe(true);
+    });
+  });
+
+  it("does not register a route that is not hidden", () => {
+    createRoute({
+      method: "get",
+      path: "/visible-resources",
+      operationId: "listVisibleResources",
+      summary: "Test",
+      tags: ["Test"],
+      security: SECURITY_NONE,
+      responses: { 200: { description: "OK" } }
+    });
+
+    expect(HIDDEN_ROUTES.has("listVisibleResources")).toBe(false);
   });
 
   function setup(input: {

--- a/apps/api/src/core/services/openapi-docs/openapi-docs.service.spec.ts
+++ b/apps/api/src/core/services/openapi-docs/openapi-docs.service.spec.ts
@@ -9,27 +9,6 @@ import { OpenApiHonoHandler } from "../open-api-hono-handler/open-api-hono-handl
 import { OpenApiDocsService } from "./openapi-docs.service";
 import { SECURITY_NONE } from "./openapi-security";
 
-const visibleRoute = createRoute({
-  method: "get",
-  path: "/v1/test-visible",
-  operationId: "listTestVisible",
-  summary: "Visible test route",
-  tags: ["Test"],
-  security: SECURITY_NONE,
-  responses: { 200: { description: "OK" } }
-});
-
-const hiddenRoute = createRoute({
-  method: "get",
-  path: "/v1/test-hidden",
-  operationId: "listTestHidden",
-  summary: "Hidden test route",
-  tags: ["Test"],
-  security: SECURITY_NONE,
-  hiddenInOpenApiDocs: true,
-  responses: { 200: { description: "OK" } }
-});
-
 describe("OpenApiDocsService", () => {
   const fetchMock = vi.fn();
 
@@ -193,7 +172,30 @@ describe("OpenApiDocsService", () => {
     expect(publicDocs.paths["/v1/test-hidden"]).toBeUndefined();
   });
 
+  // Routes are built here rather than at module scope so createRoute's HIDDEN_ROUTES
+  // side effect happens per-test, not as an import-time global mutation.
   function buildHandler() {
+    const visibleRoute = createRoute({
+      method: "get",
+      path: "/v1/test-visible",
+      operationId: "listTestVisible",
+      summary: "Visible test route",
+      tags: ["Test"],
+      security: SECURITY_NONE,
+      responses: { 200: { description: "OK" } }
+    });
+
+    const hiddenRoute = createRoute({
+      method: "get",
+      path: "/v1/test-hidden",
+      operationId: "listTestHidden",
+      summary: "Hidden test route",
+      tags: ["Test"],
+      security: SECURITY_NONE,
+      hiddenInOpenApiDocs: true,
+      responses: { 200: { description: "OK" } }
+    });
+
     const handler = new OpenApiHonoHandler();
     handler.openapi(visibleRoute, c => c.body(null, 200));
     handler.openapi(hiddenRoute, c => c.body(null, 200));

--- a/apps/api/src/core/services/openapi-docs/openapi-docs.service.spec.ts
+++ b/apps/api/src/core/services/openapi-docs/openapi-docs.service.spec.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import { createRoute } from "../../lib/create-route/create-route";
+import { createRoute, HIDDEN_ROUTES } from "../../lib/create-route/create-route";
 import { OpenApiHonoHandler } from "../open-api-hono-handler/open-api-hono-handler";
 import { OpenApiDocsService } from "./openapi-docs.service";
 import { SECURITY_NONE } from "./openapi-security";
@@ -19,6 +19,8 @@ describe("OpenApiDocsService", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     fetchMock.mockReset();
+    // buildHandler mutates the process-wide HIDDEN_ROUTES set; clear it so tests stay isolated.
+    HIDDEN_ROUTES.clear();
   });
 
   it("loads the notifications spec from disk when source = file", async () => {

--- a/apps/api/src/core/services/openapi-docs/openapi-docs.service.spec.ts
+++ b/apps/api/src/core/services/openapi-docs/openapi-docs.service.spec.ts
@@ -4,7 +4,31 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { createRoute } from "../../lib/create-route/create-route";
+import { OpenApiHonoHandler } from "../open-api-hono-handler/open-api-hono-handler";
 import { OpenApiDocsService } from "./openapi-docs.service";
+import { SECURITY_NONE } from "./openapi-security";
+
+const visibleRoute = createRoute({
+  method: "get",
+  path: "/v1/test-visible",
+  operationId: "listTestVisible",
+  summary: "Visible test route",
+  tags: ["Test"],
+  security: SECURITY_NONE,
+  responses: { 200: { description: "OK" } }
+});
+
+const hiddenRoute = createRoute({
+  method: "get",
+  path: "/v1/test-hidden",
+  operationId: "listTestHidden",
+  summary: "Hidden test route",
+  tags: ["Test"],
+  security: SECURITY_NONE,
+  hiddenInOpenApiDocs: true,
+  responses: { 200: { description: "OK" } }
+});
 
 describe("OpenApiDocsService", () => {
   const fetchMock = vi.fn();
@@ -139,6 +163,42 @@ describe("OpenApiDocsService", () => {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
   });
+
+  it("excludes routes flagged hiddenInOpenApiDocs from the served spec by default", async () => {
+    const { service } = setup({});
+
+    const docs = await service.generateDocs([buildHandler()], { scope: "console" });
+
+    expect(docs.paths["/v1/test-visible"]).toBeDefined();
+    expect(docs.paths["/v1/test-hidden"]).toBeUndefined();
+  });
+
+  it("includes routes flagged hiddenInOpenApiDocs when includeHidden is true", async () => {
+    const { service } = setup({});
+
+    const docs = await service.generateDocs([buildHandler()], { scope: "console", includeHidden: true });
+
+    expect(docs.paths["/v1/test-visible"]).toBeDefined();
+    expect(docs.paths["/v1/test-hidden"]).toBeDefined();
+  });
+
+  it("does not serve a cached includeHidden spec to a subsequent public request", async () => {
+    const { service } = setup({});
+    const handler = buildHandler();
+
+    const sdkDocs = await service.generateDocs([handler], { scope: "console", includeHidden: true });
+    expect(sdkDocs.paths["/v1/test-hidden"]).toBeDefined();
+
+    const publicDocs = await service.generateDocs([handler], { scope: "console" });
+    expect(publicDocs.paths["/v1/test-hidden"]).toBeUndefined();
+  });
+
+  function buildHandler() {
+    const handler = new OpenApiHonoHandler();
+    handler.openapi(visibleRoute, c => c.body(null, 200));
+    handler.openapi(hiddenRoute, c => c.body(null, 200));
+    return handler;
+  }
 
   function setup(input: { notificationsSwaggerPath?: string }) {
     const service = new OpenApiDocsService(

--- a/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
+++ b/apps/api/src/core/services/openapi-docs/openapi-docs.service.ts
@@ -25,7 +25,7 @@ export class OpenApiDocsService {
   }
 
   generateDocs = memoizeAsync(
-    async (handlers: OpenApiHonoHandler[], options: { scope: string; source?: "file" | "http" }): Promise<OpenAPIObject> => {
+    async (handlers: OpenApiHonoHandler[], options: { scope: string; source?: "file" | "http"; includeHidden?: boolean }): Promise<OpenAPIObject> => {
       const source = options.source ?? "http";
       const version = "v1";
       const docs: OpenAPIObject & { components: NonNullable<OpenAPIObject["components"]> } = {
@@ -66,7 +66,10 @@ export class OpenApiDocsService {
             }
           });
 
-          Object.assign(docs.paths, this.#stripHiddenOperations(handlerDocs.paths));
+          // The committed openapi.json (SDK input) is generated with includeHidden:true so internal
+          // routes (e.g. Stripe) are typed and addressable via api.v1.*; the served /v1/doc keeps
+          // stripping them so the public Swagger surface stays clean.
+          Object.assign(docs.paths, options.includeHidden ? handlerDocs.paths : this.#stripHiddenOperations(handlerDocs.paths));
         } catch (error) {
           logger.error({
             name: `Error generating OpenAPI docs for handler, example path: ${handler.routes[0]?.path || "unknown"}`,
@@ -106,7 +109,7 @@ export class OpenApiDocsService {
     {
       ttl: 60 * 60 * 1000, // 1 hour
       cacheItemLimit: 10,
-      getCacheKey: (_, options) => `${options.scope}-${options.source ?? "http"}`
+      getCacheKey: (_, options) => `${options.scope}-${options.source ?? "http"}-${options.includeHidden ? "all" : "public"}`
     }
   );
 

--- a/apps/api/src/swagger-gen-app.ts
+++ b/apps/api/src/swagger-gen-app.ts
@@ -12,7 +12,9 @@ const logger = createOtelLogger({ context: "SwaggerGen" });
 export async function bootstrap() {
   try {
     const service = container.resolve(OpenApiDocsService);
-    const docs = await service.generateDocs(openApiHonoHandlers, { scope: "full", source: "file" });
+    // includeHidden:true keeps routes flagged hiddenInOpenApiDocs (e.g. Stripe) in the committed spec
+    // so they're generated into the internal typed SDK. The served /v1/doc still strips them.
+    const docs = await service.generateDocs(openApiHonoHandlers, { scope: "full", source: "file", includeHidden: true });
 
     logger.info({ event: "OPENAPI_SPEC_WRITING", path: OUT });
     await mkdir(dirname(OUT), { recursive: true });

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -623,6 +623,1320 @@
         }
       }
     },
+    "/v1/stripe-webhook": {
+      "post": {
+        "summary": "Stripe Webhook Handler",
+        "tags": [
+          "Payment"
+        ],
+        "security": [],
+        "requestBody": {
+          "content": {
+            "text/plain": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Webhook processed successfully",
+            "content": {}
+          },
+          "400": {
+            "description": "Stripe signature is required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/stripe/prices": {
+      "get": {
+        "operationId": "listStripePrices",
+        "summary": "Get available Stripe pricing options",
+        "description": "Retrieves the list of available pricing options for wallet top-ups, including custom amounts and standard pricing tiers",
+        "tags": [
+          "Payment"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Available pricing options retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "currency": {
+                            "type": "string"
+                          },
+                          "unitAmount": {
+                            "type": "number"
+                          },
+                          "isCustom": {
+                            "type": "boolean"
+                          }
+                        },
+                        "required": [
+                          "currency",
+                          "unitAmount",
+                          "isCustom"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/stripe/coupons/apply": {
+      "post": {
+        "operationId": "applyStripeCoupon",
+        "summary": "Apply a coupon to the current user",
+        "tags": [
+          "Payment"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "couponId": {
+                        "type": "string"
+                      },
+                      "userId": {
+                        "type": "string"
+                      },
+                      "awaitResolved": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "couponId",
+                      "userId"
+                    ]
+                  }
+                },
+                "required": [
+                  "data"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Coupon applied successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "coupon": {
+                          "type": "object",
+                          "nullable": true,
+                          "properties": {
+                            "id": {
+                              "type": "string"
+                            },
+                            "percent_off": {
+                              "type": "number",
+                              "nullable": true
+                            },
+                            "amount_off": {
+                              "type": "number",
+                              "nullable": true
+                            },
+                            "valid": {
+                              "type": "boolean",
+                              "nullable": true
+                            },
+                            "name": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "description": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          },
+                          "required": [
+                            "id"
+                          ]
+                        },
+                        "amountAdded": {
+                          "type": "number"
+                        },
+                        "transactionId": {
+                          "type": "string"
+                        },
+                        "transactionStatus": {
+                          "type": "string",
+                          "enum": [
+                            "created",
+                            "pending",
+                            "requires_action",
+                            "succeeded",
+                            "failed",
+                            "refunded",
+                            "canceled"
+                          ]
+                        },
+                        "error": {
+                          "type": "object",
+                          "properties": {
+                            "message": {
+                              "type": "string"
+                            },
+                            "code": {
+                              "type": "string"
+                            },
+                            "type": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "message"
+                          ]
+                        }
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/stripe/customers/organization": {
+      "put": {
+        "operationId": "updateStripeCustomerOrganization",
+        "summary": "Update customer organization",
+        "description": "Updates the organization/business name for the current user's Stripe customer account",
+        "tags": [
+          "Payment"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "organization": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "organization"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Organization updated successfully"
+          }
+        }
+      }
+    },
+    "/v1/stripe/payment-methods/setup": {
+      "post": {
+        "operationId": "createSetupIntent",
+        "summary": "Create a Stripe SetupIntent for adding a payment method",
+        "description": "Creates a Stripe SetupIntent that allows users to securely add payment methods to their account. The SetupIntent provides a client secret that can be used with Stripe's frontend SDKs to collect payment method details.",
+        "tags": [
+          "Payment"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SetupIntent created successfully with client secret",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "clientSecret": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "clientSecret"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/stripe/payment-methods/default": {
+      "post": {
+        "operationId": "setDefaultPaymentMethod",
+        "summary": "Marks a payment method as the default.",
+        "tags": [
+          "Payment"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id"
+                    ]
+                  }
+                },
+                "required": [
+                  "data"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Payment method is marked as the default successfully."
+          }
+        }
+      },
+      "get": {
+        "operationId": "getDefaultPaymentMethod",
+        "summary": "Get the default payment method for the current user",
+        "description": "Retrieves the default payment method associated with the current user's account, including card details, validation status, and billing information.",
+        "tags": [
+          "Payment"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default payment method retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "validated": {
+                          "type": "boolean"
+                        },
+                        "isDefault": {
+                          "type": "boolean"
+                        },
+                        "card": {
+                          "type": "object",
+                          "nullable": true,
+                          "properties": {
+                            "brand": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "last4": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "exp_month": {
+                              "type": "number"
+                            },
+                            "exp_year": {
+                              "type": "number"
+                            },
+                            "funding": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "country": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "network": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "three_d_secure_usage": {
+                              "type": "object",
+                              "nullable": true,
+                              "properties": {
+                                "supported": {
+                                  "type": "boolean",
+                                  "nullable": true
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "brand",
+                            "last4",
+                            "exp_month",
+                            "exp_year"
+                          ]
+                        },
+                        "link": {
+                          "type": "object",
+                          "nullable": true,
+                          "properties": {
+                            "email": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          }
+                        },
+                        "billing_details": {
+                          "type": "object",
+                          "properties": {
+                            "address": {
+                              "type": "object",
+                              "nullable": true,
+                              "properties": {
+                                "city": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "country": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "line1": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "line2": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "postal_code": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "state": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "required": [
+                                "city",
+                                "country",
+                                "line1",
+                                "line2",
+                                "postal_code",
+                                "state"
+                              ]
+                            },
+                            "email": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "name": {
+                              "type": "string",
+                              "nullable": true
+                            },
+                            "phone": {
+                              "type": "string",
+                              "nullable": true
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "type"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default payment method not found"
+          }
+        }
+      }
+    },
+    "/v1/stripe/payment-methods": {
+      "get": {
+        "operationId": "listPaymentMethods",
+        "summary": "Get all payment methods for the current user",
+        "description": "Retrieves all saved payment methods associated with the current user's account, including card details, validation status, and billing information.",
+        "tags": [
+          "Payment"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Payment methods retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "type": {
+                            "type": "string"
+                          },
+                          "validated": {
+                            "type": "boolean"
+                          },
+                          "isDefault": {
+                            "type": "boolean"
+                          },
+                          "card": {
+                            "type": "object",
+                            "nullable": true,
+                            "properties": {
+                              "brand": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "last4": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "exp_month": {
+                                "type": "number"
+                              },
+                              "exp_year": {
+                                "type": "number"
+                              },
+                              "funding": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "country": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "network": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "three_d_secure_usage": {
+                                "type": "object",
+                                "nullable": true,
+                                "properties": {
+                                  "supported": {
+                                    "type": "boolean",
+                                    "nullable": true
+                                  }
+                                }
+                              }
+                            },
+                            "required": [
+                              "brand",
+                              "last4",
+                              "exp_month",
+                              "exp_year"
+                            ]
+                          },
+                          "link": {
+                            "type": "object",
+                            "nullable": true,
+                            "properties": {
+                              "email": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            }
+                          },
+                          "billing_details": {
+                            "type": "object",
+                            "properties": {
+                              "address": {
+                                "type": "object",
+                                "nullable": true,
+                                "properties": {
+                                  "city": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "line1": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "line2": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "postal_code": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "state": {
+                                    "type": "string",
+                                    "nullable": true
+                                  }
+                                },
+                                "required": [
+                                  "city",
+                                  "country",
+                                  "line1",
+                                  "line2",
+                                  "postal_code",
+                                  "state"
+                                ]
+                              },
+                              "email": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "name": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "phone": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            }
+                          }
+                        },
+                        "required": [
+                          "type"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/stripe/payment-methods/{paymentMethodId}": {
+      "delete": {
+        "operationId": "deletePaymentMethod",
+        "summary": "Remove a payment method",
+        "description": "Permanently removes a saved payment method from the user's account. This action cannot be undone.",
+        "tags": [
+          "Payment"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "The unique identifier of the payment method to remove",
+              "example": "pm_1234567890"
+            },
+            "required": true,
+            "name": "paymentMethodId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Payment method removed successfully"
+          }
+        }
+      }
+    },
+    "/v1/stripe/payment-methods/validate": {
+      "post": {
+        "operationId": "validatePaymentMethod",
+        "summary": "Validates a payment method after 3D Secure authentication",
+        "description": "Completes the validation process for a payment method that required 3D Secure authentication. This endpoint should be called after the user completes the 3D Secure challenge.",
+        "tags": [
+          "Payment"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "paymentMethodId": {
+                        "type": "string"
+                      },
+                      "paymentIntentId": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "paymentMethodId",
+                      "paymentIntentId"
+                    ]
+                  }
+                },
+                "required": [
+                  "data"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Payment method validated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/stripe/transactions/confirm": {
+      "post": {
+        "operationId": "confirmStripeTransaction",
+        "summary": "Confirm a payment using a saved payment method",
+        "description": "Processes a payment using a previously saved payment method. This endpoint handles wallet top-ups and may require 3D Secure authentication for certain payment methods or amounts.",
+        "tags": [
+          "Payment"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "userId": {
+                        "type": "string"
+                      },
+                      "paymentMethodId": {
+                        "type": "string"
+                      },
+                      "amount": {
+                        "type": "number",
+                        "minimum": 20
+                      },
+                      "awaitResolved": {
+                        "type": "boolean"
+                      }
+                    },
+                    "required": [
+                      "userId",
+                      "paymentMethodId",
+                      "amount"
+                    ]
+                  }
+                },
+                "required": [
+                  "data"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Payment processed successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean"
+                        },
+                        "requiresAction": {
+                          "type": "boolean"
+                        },
+                        "clientSecret": {
+                          "type": "string"
+                        },
+                        "paymentIntentId": {
+                          "type": "string"
+                        },
+                        "transactionId": {
+                          "type": "string"
+                        },
+                        "transactionStatus": {
+                          "type": "string",
+                          "enum": [
+                            "created",
+                            "pending",
+                            "requires_action",
+                            "succeeded",
+                            "failed",
+                            "refunded",
+                            "canceled"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "success",
+                        "transactionId"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "3D Secure authentication required to complete payment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean"
+                        },
+                        "requiresAction": {
+                          "type": "boolean"
+                        },
+                        "clientSecret": {
+                          "type": "string"
+                        },
+                        "paymentIntentId": {
+                          "type": "string"
+                        },
+                        "transactionId": {
+                          "type": "string"
+                        },
+                        "transactionStatus": {
+                          "type": "string",
+                          "enum": [
+                            "created",
+                            "pending",
+                            "requires_action",
+                            "succeeded",
+                            "failed",
+                            "refunded",
+                            "canceled"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "success",
+                        "transactionId"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/stripe/transactions": {
+      "get": {
+        "operationId": "listStripeTransactions",
+        "summary": "Get transaction history for the current customer",
+        "tags": [
+          "Payment"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "number",
+              "description": "Number of transactions to return",
+              "minimum": 1,
+              "maximum": 100,
+              "example": 100,
+              "default": 100
+            },
+            "required": false,
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "ID of the last transaction from the previous page (if paginating forwards)",
+              "example": "ch_1234567890"
+            },
+            "required": false,
+            "name": "startingAfter",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "ID of the first transaction from the previous page (if paginating backwards)",
+              "example": "ch_0987654321"
+            },
+            "required": false,
+            "name": "endingBefore",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Start date for filtering transactions (inclusive)",
+              "example": "2025-01-01T00:00:00Z"
+            },
+            "required": false,
+            "name": "startDate",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "End date for filtering transactions (inclusive)",
+              "example": "2025-01-02T00:00:00Z"
+            },
+            "required": false,
+            "name": "endDate",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Customer transactions retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "transactions": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "string"
+                              },
+                              "amount": {
+                                "type": "number"
+                              },
+                              "currency": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "created": {
+                                "type": "number"
+                              },
+                              "paymentMethod": {
+                                "type": "object",
+                                "nullable": true,
+                                "properties": {
+                                  "type": {
+                                    "type": "string"
+                                  },
+                                  "validated": {
+                                    "type": "boolean"
+                                  },
+                                  "isDefault": {
+                                    "type": "boolean"
+                                  },
+                                  "card": {
+                                    "type": "object",
+                                    "nullable": true,
+                                    "properties": {
+                                      "brand": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "last4": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "exp_month": {
+                                        "type": "number"
+                                      },
+                                      "exp_year": {
+                                        "type": "number"
+                                      },
+                                      "funding": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "country": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "network": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "three_d_secure_usage": {
+                                        "type": "object",
+                                        "nullable": true,
+                                        "properties": {
+                                          "supported": {
+                                            "type": "boolean",
+                                            "nullable": true
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "required": [
+                                      "brand",
+                                      "last4",
+                                      "exp_month",
+                                      "exp_year"
+                                    ]
+                                  },
+                                  "link": {
+                                    "type": "object",
+                                    "nullable": true,
+                                    "properties": {
+                                      "email": {
+                                        "type": "string",
+                                        "nullable": true
+                                      }
+                                    }
+                                  },
+                                  "billing_details": {
+                                    "type": "object",
+                                    "properties": {
+                                      "address": {
+                                        "type": "object",
+                                        "nullable": true,
+                                        "properties": {
+                                          "city": {
+                                            "type": "string",
+                                            "nullable": true
+                                          },
+                                          "country": {
+                                            "type": "string",
+                                            "nullable": true
+                                          },
+                                          "line1": {
+                                            "type": "string",
+                                            "nullable": true
+                                          },
+                                          "line2": {
+                                            "type": "string",
+                                            "nullable": true
+                                          },
+                                          "postal_code": {
+                                            "type": "string",
+                                            "nullable": true
+                                          },
+                                          "state": {
+                                            "type": "string",
+                                            "nullable": true
+                                          }
+                                        },
+                                        "required": [
+                                          "city",
+                                          "country",
+                                          "line1",
+                                          "line2",
+                                          "postal_code",
+                                          "state"
+                                        ]
+                                      },
+                                      "email": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "name": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "phone": {
+                                        "type": "string",
+                                        "nullable": true
+                                      }
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "type"
+                                ]
+                              },
+                              "receiptUrl": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "description": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "metadata": {
+                                "type": "object",
+                                "nullable": true,
+                                "additionalProperties": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "required": [
+                              "id",
+                              "amount",
+                              "currency",
+                              "status",
+                              "created",
+                              "paymentMethod"
+                            ]
+                          }
+                        },
+                        "hasMore": {
+                          "type": "boolean"
+                        },
+                        "nextPage": {
+                          "type": "string",
+                          "nullable": true
+                        }
+                      },
+                      "required": [
+                        "transactions",
+                        "hasMore"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/stripe/transactions/export": {
+      "get": {
+        "operationId": "exportStripeTransactions",
+        "summary": "Export transaction history as CSV for the current customer",
+        "tags": [
+          "Payment"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "description": "Timezone for date formatting in the CSV",
+              "example": "America/New_York"
+            },
+            "required": true,
+            "name": "timezone",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "Start date for filtering transactions (inclusive)",
+              "example": "2025-01-01T00:00:00Z"
+            },
+            "required": true,
+            "name": "startDate",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "description": "End date for filtering transactions (inclusive)",
+              "example": "2025-01-02T00:00:00Z"
+            },
+            "required": true,
+            "name": "endDate",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CSV file with transaction data",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/usage/history": {
       "get": {
         "summary": "Get historical data of billing and usage for a wallet address.",

--- a/packages/console-api-types/src/operations.gen.ts
+++ b/packages/console-api-types/src/operations.gen.ts
@@ -3,6 +3,88 @@
 
 export const operations = {
   v1: {
+    listStripePrices: { path: "/v1/stripe/prices", method: "get", operationId: "listStripePrices", pathParams: [], queryParams: [], hasBody: false },
+    applyStripeCoupon: { path: "/v1/stripe/coupons/apply", method: "post", operationId: "applyStripeCoupon", pathParams: [], queryParams: [], hasBody: true },
+    updateStripeCustomerOrganization: {
+      path: "/v1/stripe/customers/organization",
+      method: "put",
+      operationId: "updateStripeCustomerOrganization",
+      pathParams: [],
+      queryParams: [],
+      hasBody: true
+    },
+    createSetupIntent: {
+      path: "/v1/stripe/payment-methods/setup",
+      method: "post",
+      operationId: "createSetupIntent",
+      pathParams: [],
+      queryParams: [],
+      hasBody: false
+    },
+    setDefaultPaymentMethod: {
+      path: "/v1/stripe/payment-methods/default",
+      method: "post",
+      operationId: "setDefaultPaymentMethod",
+      pathParams: [],
+      queryParams: [],
+      hasBody: true
+    },
+    getDefaultPaymentMethod: {
+      path: "/v1/stripe/payment-methods/default",
+      method: "get",
+      operationId: "getDefaultPaymentMethod",
+      pathParams: [],
+      queryParams: [],
+      hasBody: false
+    },
+    listPaymentMethods: {
+      path: "/v1/stripe/payment-methods",
+      method: "get",
+      operationId: "listPaymentMethods",
+      pathParams: [],
+      queryParams: [],
+      hasBody: false
+    },
+    deletePaymentMethod: {
+      path: "/v1/stripe/payment-methods/{paymentMethodId}",
+      method: "delete",
+      operationId: "deletePaymentMethod",
+      pathParams: ["paymentMethodId"],
+      queryParams: [],
+      hasBody: false
+    },
+    validatePaymentMethod: {
+      path: "/v1/stripe/payment-methods/validate",
+      method: "post",
+      operationId: "validatePaymentMethod",
+      pathParams: [],
+      queryParams: [],
+      hasBody: true
+    },
+    confirmStripeTransaction: {
+      path: "/v1/stripe/transactions/confirm",
+      method: "post",
+      operationId: "confirmStripeTransaction",
+      pathParams: [],
+      queryParams: [],
+      hasBody: true
+    },
+    listStripeTransactions: {
+      path: "/v1/stripe/transactions",
+      method: "get",
+      operationId: "listStripeTransactions",
+      pathParams: [],
+      queryParams: ["limit", "startingAfter", "endingBefore", "startDate", "endDate"],
+      hasBody: false
+    },
+    exportStripeTransactions: {
+      path: "/v1/stripe/transactions/export",
+      method: "get",
+      operationId: "exportStripeTransactions",
+      pathParams: [],
+      queryParams: ["timezone", "startDate", "endDate"],
+      hasBody: false
+    },
     getDeployment: { path: "/v1/deployments/{dseq}", method: "get", operationId: "getDeployment", pathParams: ["dseq"], queryParams: [], hasBody: false },
     closeDeployment: {
       path: "/v1/deployments/{dseq}",

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -370,6 +370,267 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/v1/stripe-webhook": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Stripe Webhook Handler */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          "text/plain": string;
+        };
+      };
+      responses: {
+        /** @description Webhook processed successfully */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content?: never;
+        };
+        /** @description Stripe signature is required */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            "application/json": {
+              error: string;
+            };
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/stripe/prices": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get available Stripe pricing options
+     * @description Retrieves the list of available pricing options for wallet top-ups, including custom amounts and standard pricing tiers
+     */
+    get: operations["listStripePrices"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/stripe/coupons/apply": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Apply a coupon to the current user */
+    post: operations["applyStripeCoupon"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/stripe/customers/organization": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /**
+     * Update customer organization
+     * @description Updates the organization/business name for the current user's Stripe customer account
+     */
+    put: operations["updateStripeCustomerOrganization"];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/stripe/payment-methods/setup": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Create a Stripe SetupIntent for adding a payment method
+     * @description Creates a Stripe SetupIntent that allows users to securely add payment methods to their account. The SetupIntent provides a client secret that can be used with Stripe's frontend SDKs to collect payment method details.
+     */
+    post: operations["createSetupIntent"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/stripe/payment-methods/default": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get the default payment method for the current user
+     * @description Retrieves the default payment method associated with the current user's account, including card details, validation status, and billing information.
+     */
+    get: operations["getDefaultPaymentMethod"];
+    put?: never;
+    /** Marks a payment method as the default. */
+    post: operations["setDefaultPaymentMethod"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/stripe/payment-methods": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get all payment methods for the current user
+     * @description Retrieves all saved payment methods associated with the current user's account, including card details, validation status, and billing information.
+     */
+    get: operations["listPaymentMethods"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/stripe/payment-methods/{paymentMethodId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /**
+     * Remove a payment method
+     * @description Permanently removes a saved payment method from the user's account. This action cannot be undone.
+     */
+    delete: operations["deletePaymentMethod"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/stripe/payment-methods/validate": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Validates a payment method after 3D Secure authentication
+     * @description Completes the validation process for a payment method that required 3D Secure authentication. This endpoint should be called after the user completes the 3D Secure challenge.
+     */
+    post: operations["validatePaymentMethod"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/stripe/transactions/confirm": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Confirm a payment using a saved payment method
+     * @description Processes a payment using a previously saved payment method. This endpoint handles wallet top-ups and may require 3D Secure authentication for certain payment methods or amounts.
+     */
+    post: operations["confirmStripeTransaction"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/stripe/transactions": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get transaction history for the current customer */
+    get: operations["listStripeTransactions"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/stripe/transactions/export": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Export transaction history as CSV for the current customer */
+    get: operations["exportStripeTransactions"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/v1/usage/history": {
     parameters: {
       query?: never;
@@ -6974,6 +7235,482 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  listStripePrices: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Available pricing options retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              currency: string;
+              unitAmount: number;
+              isCustom: boolean;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  applyStripeCoupon: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          data: {
+            couponId: string;
+            userId: string;
+            awaitResolved?: boolean;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Coupon applied successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              coupon?: {
+                id: string;
+                percent_off?: number | null;
+                amount_off?: number | null;
+                valid?: boolean | null;
+                name?: string | null;
+                description?: string | null;
+              } | null;
+              amountAdded?: number;
+              transactionId?: string;
+              /** @enum {string} */
+              transactionStatus?: "created" | "pending" | "requires_action" | "succeeded" | "failed" | "refunded" | "canceled";
+              error?: {
+                message: string;
+                code?: string;
+                type?: string;
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+  updateStripeCustomerOrganization: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          organization: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Organization updated successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  createSetupIntent: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description SetupIntent created successfully with client secret */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              clientSecret: string | null;
+            };
+          };
+        };
+      };
+    };
+  };
+  getDefaultPaymentMethod: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Default payment method retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              type: string;
+              validated?: boolean;
+              isDefault?: boolean;
+              card?: {
+                brand: string | null;
+                last4: string | null;
+                exp_month: number;
+                exp_year: number;
+                funding?: string | null;
+                country?: string | null;
+                network?: string | null;
+                three_d_secure_usage?: {
+                  supported?: boolean | null;
+                } | null;
+              } | null;
+              link?: {
+                email?: string | null;
+              } | null;
+              billing_details?: {
+                address?: {
+                  city: string | null;
+                  country: string | null;
+                  line1: string | null;
+                  line2: string | null;
+                  postal_code: string | null;
+                  state: string | null;
+                } | null;
+                email?: string | null;
+                name?: string | null;
+                phone?: string | null;
+              };
+            };
+          };
+        };
+      };
+      /** @description Default payment method not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  setDefaultPaymentMethod: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          data: {
+            id: string;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Payment method is marked as the default successfully. */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  listPaymentMethods: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Payment methods retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              type: string;
+              validated?: boolean;
+              isDefault?: boolean;
+              card?: {
+                brand: string | null;
+                last4: string | null;
+                exp_month: number;
+                exp_year: number;
+                funding?: string | null;
+                country?: string | null;
+                network?: string | null;
+                three_d_secure_usage?: {
+                  supported?: boolean | null;
+                } | null;
+              } | null;
+              link?: {
+                email?: string | null;
+              } | null;
+              billing_details?: {
+                address?: {
+                  city: string | null;
+                  country: string | null;
+                  line1: string | null;
+                  line2: string | null;
+                  postal_code: string | null;
+                  state: string | null;
+                } | null;
+                email?: string | null;
+                name?: string | null;
+                phone?: string | null;
+              };
+            }[];
+          };
+        };
+      };
+    };
+  };
+  deletePaymentMethod: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        paymentMethodId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Payment method removed successfully */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  validatePaymentMethod: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          data: {
+            paymentMethodId: string;
+            paymentIntentId: string;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Payment method validated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            success: boolean;
+          };
+        };
+      };
+    };
+  };
+  confirmStripeTransaction: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          data: {
+            userId: string;
+            paymentMethodId: string;
+            amount: number;
+            awaitResolved?: boolean;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Payment processed successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              success: boolean;
+              requiresAction?: boolean;
+              clientSecret?: string;
+              paymentIntentId?: string;
+              transactionId: string;
+              /** @enum {string} */
+              transactionStatus?: "created" | "pending" | "requires_action" | "succeeded" | "failed" | "refunded" | "canceled";
+            };
+          };
+        };
+      };
+      /** @description 3D Secure authentication required to complete payment */
+      202: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              success: boolean;
+              requiresAction?: boolean;
+              clientSecret?: string;
+              paymentIntentId?: string;
+              transactionId: string;
+              /** @enum {string} */
+              transactionStatus?: "created" | "pending" | "requires_action" | "succeeded" | "failed" | "refunded" | "canceled";
+            };
+          };
+        };
+      };
+    };
+  };
+  listStripeTransactions: {
+    parameters: {
+      query?: {
+        limit?: number;
+        startingAfter?: string;
+        endingBefore?: string;
+        startDate?: string;
+        endDate?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Customer transactions retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data: {
+              transactions: {
+                id: string;
+                amount: number;
+                currency: string;
+                status: string;
+                created: number;
+                paymentMethod: {
+                  type: string;
+                  validated?: boolean;
+                  isDefault?: boolean;
+                  card?: {
+                    brand: string | null;
+                    last4: string | null;
+                    exp_month: number;
+                    exp_year: number;
+                    funding?: string | null;
+                    country?: string | null;
+                    network?: string | null;
+                    three_d_secure_usage?: {
+                      supported?: boolean | null;
+                    } | null;
+                  } | null;
+                  link?: {
+                    email?: string | null;
+                  } | null;
+                  billing_details?: {
+                    address?: {
+                      city: string | null;
+                      country: string | null;
+                      line1: string | null;
+                      line2: string | null;
+                      postal_code: string | null;
+                      state: string | null;
+                    } | null;
+                    email?: string | null;
+                    name?: string | null;
+                    phone?: string | null;
+                  };
+                } | null;
+                receiptUrl?: string | null;
+                description?: string | null;
+                metadata?: {
+                  [key: string]: string;
+                } | null;
+              }[];
+              hasMore: boolean;
+              nextPage?: string | null;
+            };
+          };
+        };
+      };
+    };
+  };
+  exportStripeTransactions: {
+    parameters: {
+      query: {
+        timezone: string;
+        startDate: string;
+        endDate: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description CSV file with transaction data */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "text/csv": string;
+        };
+      };
+    };
+  };
   getDeployment: {
     parameters: {
       query?: never;

--- a/packages/dev-config/.eslintrc.base.js
+++ b/packages/dev-config/.eslintrc.base.js
@@ -39,7 +39,8 @@ module.exports = {
       "error",
       {
         additionalVerbs: {
-          post: { collection: ["deposit", "screen"] },
+          get: { collection: ["export"] },
+          post: { collection: ["deposit", "screen", "apply", "validate", "confirm"] },
           delete: { single: ["close"] }
         }
       }


### PR DESCRIPTION
## Why

`createRoute({ hiddenInOpenApiDocs: true })` conflated two concerns: hiding a route from the served public Swagger UI (wanted) and excluding it from our committed `apps/api/swagger/openapi.json` (not wanted). That committed spec is the input for the internal typed SDK (`@akashnetwork/console-api-types`) and the `api.v1.*` react-query proxy, so a fresh `sdk:gen` silently dropped every `/v1/stripe/*` route. Stripe routes also lacked an `operationId`, which the operations generator requires.

Closes CON-520

## What

Strip hidden routes only at serve time; keep them in the committed SDK input.

- **`OpenApiDocsService.generateDocs`** gains an `includeHidden` option (default `false`). The committed spec (`swagger-gen-app`) is generated with `includeHidden: true`; the runtime `/v1/doc` keeps stripping `hiddenInOpenApiDocs` routes, so the served public surface is unchanged. The memoize cache key now includes the flag so a public request can't be served a cached SDK spec (and vice-versa).
- **Added `operationId` to the 12 customer-facing `/v1/stripe/*` routes** so they're addressable via `api.v1.*` with full request/response types. The webhook (`POST /v1/stripe-webhook`) intentionally stays `operationId`-less — typed in `schema.d.ts` but not addressable; it's called server-to-server by Stripe (one-line comment explains why).
- **`operation-id-format` lint rule** (`packages/dev-config`): registered the `apply`/`validate`/`confirm`/`export` Stripe domain verbs in `additionalVerbs` (consistent with the existing `deposit`/`screen`/`close`). The two `/default` singleton endpoints (`getDefaultPaymentMethod`/`setDefaultPaymentMethod`) carry a documented `eslint-disable`: the rule's heuristic only recognizes `{id}` singletons, so `/default` is misclassified as a collection, and adding `get`/`set` to collections globally would defeat the rule's list-vs-get purpose.
- **Regenerated the SDK**: `openapi.json` (91 → 103 paths) and `console-api-types` (`schema.d.ts`, `operations.gen.ts`) now include Stripe. The diff is purely additive vs. `main`.

Invariant established: committed `openapi.json` = full server surface; served `/v1/doc` = strip `hiddenInOpenApiDocs`; `operations.gen.ts` / `api.v1.*` = gated purely by `operationId`.

Out of scope (future follow-up, per the issue): migrating deploy-web off its hand-written Stripe service onto `api.v1.*`.

### Verification

- `apps/api` unit suite: 974 passing, incl. new `OpenApiDocsService` strip + cache-key tests and `create-route` `HIDDEN_ROUTES` tests.
- `npm run validate:types -w packages/console-api-types` passes; `apps/api` production type-check (via `build:app` during `sdk:gen`) passes; lint clean on all changed files.
- Confirmed the committed `openapi.json` contains all 12 Stripe paths + the webhook, and that `/v1/doc`'s strip behavior is unit-pinned (no Stripe in the served public spec).
- deploy-web type-check is unaffected — its `console-api-types` consumption stays green; the pre-existing failures there are unrelated (additive schema changes only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded the Stripe billing API documentation with new webhook handling, Stripe price listing, coupon application, and updating the customer organization name.
  * Added payment-method APIs (SetupIntent creation, default payment method get/set, payment-method listing, deletion, and post–3D Secure validation).
  * Added transaction APIs (confirming saved payments, listing transactions with pagination/date filtering, and exporting transactions as CSV).

* **Tests**
  * Improved test coverage and isolation for hidden OpenAPI documentation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->