### PR TITLE
fix(analytics): emit server-side account_created event on signup

### DIFF
--- a/apps/api/src/core/services/analytics/analytics.service.ts
+++ b/apps/api/src/core/services/analytics/analytics.service.ts
@@ -3,7 +3,7 @@ import { inject, singleton } from "tsyringe";
 import { AMPLITUDE, type Amplitude } from "@src/core/providers/amplitude.provider";
 import { LoggerService } from "@src/core/providers/logging.provider";
 
-type AnalyticsEvent = "user_registered" | "balance_top_up" | "balance_refund";
+type AnalyticsEvent = "user_registered" | "account_created" | "balance_top_up" | "balance_refund";
 
 @singleton()
 export class AnalyticsService {

--- a/apps/api/src/user/repositories/user/user.repository.integration.ts
+++ b/apps/api/src/user/repositories/user/user.repository.integration.ts
@@ -72,6 +72,31 @@ describe(UserRepository.name, () => {
     });
   });
 
+  describe("upsertOnExternalIdConflict", () => {
+    it("returns wasInserted true when the external user id is new", async () => {
+      const { userRepository, trackForCleanup } = setup();
+
+      const { user, wasInserted } = await userRepository.upsertOnExternalIdConflict(newUserInput());
+      trackForCleanup(user.id);
+
+      expect(wasInserted).toBe(true);
+    });
+
+    it("returns wasInserted false when the external user id already exists", async () => {
+      const { userRepository, trackForCleanup } = setup();
+      const input = newUserInput();
+
+      const first = await userRepository.upsertOnExternalIdConflict(input);
+      trackForCleanup(first.user.id);
+
+      const second = await userRepository.upsertOnExternalIdConflict({ ...input, email: faker.internet.email() });
+
+      expect(first.wasInserted).toBe(true);
+      expect(second.wasInserted).toBe(false);
+      expect(second.user.id).toBe(first.user.id);
+    });
+  });
+
   let cleanup: () => Promise<void>;
   afterEach(async () => {
     await cleanup?.();
@@ -81,6 +106,16 @@ describe(UserRepository.name, () => {
     const date = new Date();
     date.setHours(date.getHours() - hours);
     return date;
+  }
+
+  function newUserInput() {
+    return {
+      userId: faker.string.uuid(),
+      username: `testuser_${Date.now()}_${faker.string.alphanumeric(6)}`,
+      email: faker.internet.email(),
+      emailVerified: false,
+      subscribedToNewsletter: false
+    };
   }
 
   function setup() {
@@ -107,6 +142,12 @@ describe(UserRepository.name, () => {
       return user;
     }
 
-    return { userRepository, createTestUser };
+    return {
+      userRepository,
+      createTestUser,
+      trackForCleanup: (id: string) => {
+        createdUserIds.push(id);
+      }
+    };
   }
 });

--- a/apps/api/src/user/repositories/user/user.repository.integration.ts
+++ b/apps/api/src/user/repositories/user/user.repository.integration.ts
@@ -131,11 +131,8 @@ describe(UserRepository.name, () => {
     async function createTestUser(overrides: { lastActiveAt?: Date | null; lastIp?: string } = {}) {
       const user = await userRepository.create({
         id: faker.string.uuid(),
-        userId: faker.string.uuid(),
-        username: `testuser_${Date.now()}_${faker.string.alphanumeric(6)}`,
-        email: faker.internet.email(),
+        ...newUserInput(),
         emailVerified: faker.datatype.boolean(),
-        subscribedToNewsletter: false,
         ...overrides
       });
       createdUserIds.push(user.id);

--- a/apps/api/src/user/repositories/user/user.repository.ts
+++ b/apps/api/src/user/repositories/user/user.repository.ts
@@ -88,6 +88,10 @@ export class UserRepository extends BaseRepository<ApiPgTables["Users"], UserInp
 
     // Existing user: refresh the same mutable fields the previous upsert kept up to date.
     const [updated] = await this.cursor.update(this.table).set(withoutUsername).where(eq(this.table.userId, data.userId!)).returning();
+    if (!updated) {
+      // The row existed at INSERT time but is gone now — only possible via a concurrent delete.
+      throw new Error(`Failed to upsert user: no row to update for userId ${data.userId}`);
+    }
     return { user: this.toOutput(updated), wasInserted: false };
   }
 

--- a/apps/api/src/user/repositories/user/user.repository.ts
+++ b/apps/api/src/user/repositories/user/user.repository.ts
@@ -1,5 +1,5 @@
 import { Trace } from "@akashnetwork/instrumentation";
-import { and, eq, isNull, lt, ne, or, SQL, sql } from "drizzle-orm";
+import { and, eq, getTableColumns, isNull, lt, ne, or, SQL, sql } from "drizzle-orm";
 import { PgUpdateSetSource } from "drizzle-orm/pg-core";
 import { singleton } from "tsyringe";
 
@@ -71,8 +71,11 @@ export class UserRepository extends BaseRepository<ApiPgTables["Users"], UserInp
       );
   }
 
-  async upsertOnExternalIdConflict(data: UserInput): Promise<UserOutput> {
+  async upsertOnExternalIdConflict(data: UserInput): Promise<{ user: UserOutput; wasInserted: boolean }> {
     const { username, ...withoutUsername } = data;
+    // `xmax = 0` is true only for a freshly inserted row; an ON CONFLICT update yields a non-zero
+    // xmax. This lets callers act exactly once on first creation, atomically, without a race-prone
+    // read-before-write.
     const [item] = await this.cursor
       .insert(this.table)
       .values(this.toInput(data))
@@ -80,8 +83,9 @@ export class UserRepository extends BaseRepository<ApiPgTables["Users"], UserInp
         target: [this.table.userId],
         set: withoutUsername
       })
-      .returning();
-    return this.toOutput(item);
+      .returning({ ...getTableColumns(this.table), wasInserted: sql<boolean>`xmax = 0` });
+    const { wasInserted, ...user } = item;
+    return { user: this.toOutput(user), wasInserted };
   }
 
   async findTrialUsersByFingerprint(fingerprint: string, excludeUserId: string): Promise<{ id: string }[]> {

--- a/apps/api/src/user/repositories/user/user.repository.ts
+++ b/apps/api/src/user/repositories/user/user.repository.ts
@@ -1,5 +1,5 @@
 import { Trace } from "@akashnetwork/instrumentation";
-import { and, eq, getTableColumns, isNull, lt, ne, or, SQL, sql } from "drizzle-orm";
+import { and, eq, isNull, lt, ne, or, SQL, sql } from "drizzle-orm";
 import { PgUpdateSetSource } from "drizzle-orm/pg-core";
 import { singleton } from "tsyringe";
 
@@ -73,19 +73,22 @@ export class UserRepository extends BaseRepository<ApiPgTables["Users"], UserInp
 
   async upsertOnExternalIdConflict(data: UserInput): Promise<{ user: UserOutput; wasInserted: boolean }> {
     const { username, ...withoutUsername } = data;
-    // `xmax = 0` is true only for a freshly inserted row; an ON CONFLICT update yields a non-zero
-    // xmax. This lets callers act exactly once on first creation, atomically, without a race-prone
-    // read-before-write.
-    const [item] = await this.cursor
+
+    // ON CONFLICT DO NOTHING returns a row only to the call whose insert actually created it, so
+    // the unique constraint — not a race-prone read-before-write — decides who is the creator.
+    const [inserted] = await this.cursor
       .insert(this.table)
       .values(this.toInput(data))
-      .onConflictDoUpdate({
-        target: [this.table.userId],
-        set: withoutUsername
-      })
-      .returning({ ...getTableColumns(this.table), wasInserted: sql<boolean>`xmax = 0` });
-    const { wasInserted, ...user } = item;
-    return { user: this.toOutput(user), wasInserted };
+      .onConflictDoNothing({ target: [this.table.userId] })
+      .returning();
+
+    if (inserted) {
+      return { user: this.toOutput(inserted), wasInserted: true };
+    }
+
+    // Existing user: refresh the same mutable fields the previous upsert kept up to date.
+    const [updated] = await this.cursor.update(this.table).set(withoutUsername).where(eq(this.table.userId, data.userId!)).returning();
+    return { user: this.toOutput(updated), wasInserted: false };
   }
 
   async findTrialUsersByFingerprint(fingerprint: string, excludeUserId: string): Promise<{ id: string }[]> {

--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -20,7 +20,7 @@ describe(UserService.name, () => {
       const user = createUser({ emailVerified: false, email: "test@example.com" });
       const { service, emailVerificationCodeService, userRepository, notificationService } = setup();
 
-      userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: true });
       notificationService.createDefaultChannel.mockResolvedValue(undefined);
       emailVerificationCodeService.sendCode.mockResolvedValue({ codeSentAt: new Date().toISOString() });
 
@@ -33,7 +33,7 @@ describe(UserService.name, () => {
       const user = createUser({ emailVerified: true, email: "test@example.com" });
       const { service, emailVerificationCodeService, userRepository, notificationService } = setup();
 
-      userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: true });
       notificationService.createDefaultChannel.mockResolvedValue(undefined);
 
       await service.registerUser(createRegisterInput({ emailVerified: true }));
@@ -46,7 +46,7 @@ describe(UserService.name, () => {
       const { service, emailVerificationCodeService, userRepository, notificationService, logger } = setup();
       const sendError = new Error("Send failed");
 
-      userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: true });
       notificationService.createDefaultChannel.mockResolvedValue(undefined);
       emailVerificationCodeService.sendCode.mockRejectedValue(sendError);
 
@@ -56,12 +56,11 @@ describe(UserService.name, () => {
       expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "FAILED_TO_SEND_INITIAL_VERIFICATION_CODE", id: user.id, error: sendError }));
     });
 
-    it("tracks account_created when the user did not previously exist", async () => {
+    it("tracks account_created when the user was newly created", async () => {
       const user = createUser({ emailVerified: true, email: "test@example.com" });
       const { service, userRepository, analyticsService, notificationService } = setup();
 
-      userRepository.findByUserId.mockResolvedValue(undefined);
-      userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: true });
       notificationService.createDefaultChannel.mockResolvedValue(undefined);
 
       await service.registerUser(createRegisterInput({ emailVerified: true }));
@@ -69,12 +68,11 @@ describe(UserService.name, () => {
       expect(analyticsService.track).toHaveBeenCalledWith(user.id, "account_created", { category: "user" });
     });
 
-    it("does not track account_created when the user already exists", async () => {
+    it("does not track account_created when the user already existed", async () => {
       const user = createUser({ emailVerified: true, email: "test@example.com" });
       const { service, userRepository, analyticsService, notificationService } = setup();
 
-      userRepository.findByUserId.mockResolvedValue(user);
-      userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue({ user, wasInserted: false });
       notificationService.createDefaultChannel.mockResolvedValue(undefined);
 
       await service.registerUser(createRegisterInput({ emailVerified: true }));

--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -55,6 +55,32 @@ describe(UserService.name, () => {
       expect(result.id).toBe(user.id);
       expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "FAILED_TO_SEND_INITIAL_VERIFICATION_CODE", id: user.id, error: sendError }));
     });
+
+    it("tracks account_created when the user did not previously exist", async () => {
+      const user = createUser({ emailVerified: true, email: "test@example.com" });
+      const { service, userRepository, analyticsService, notificationService } = setup();
+
+      userRepository.findByUserId.mockResolvedValue(undefined);
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
+      notificationService.createDefaultChannel.mockResolvedValue(undefined);
+
+      await service.registerUser(createRegisterInput({ emailVerified: true }));
+
+      expect(analyticsService.track).toHaveBeenCalledWith(user.id, "account_created", { category: "user" });
+    });
+
+    it("does not track account_created when the user already exists", async () => {
+      const user = createUser({ emailVerified: true, email: "test@example.com" });
+      const { service, userRepository, analyticsService, notificationService } = setup();
+
+      userRepository.findByUserId.mockResolvedValue(user);
+      userRepository.upsertOnExternalIdConflict.mockResolvedValue(user);
+      notificationService.createDefaultChannel.mockResolvedValue(undefined);
+
+      await service.registerUser(createRegisterInput({ emailVerified: true }));
+
+      expect(analyticsService.track).not.toHaveBeenCalled();
+    });
   });
 
   function setup() {

--- a/apps/api/src/user/services/user/user.service.ts
+++ b/apps/api/src/user/services/user/user.service.ts
@@ -44,9 +44,7 @@ export class UserService {
       lastFingerprint: data.fingerprint
     };
 
-    const existingUser = await this.userRepository.findByUserId(data.userId);
-
-    const user = await this.upsertUser({
+    const { user, wasInserted } = await this.upsertUser({
       ...userDetails,
       username: data.wantedUsername
     });
@@ -57,7 +55,7 @@ export class UserService {
       email: user.email
     });
 
-    if (!existingUser) {
+    if (wasInserted) {
       this.analyticsService.track(user.id, "account_created", { category: "user" });
     }
 
@@ -91,7 +89,7 @@ export class UserService {
     } as Awaited<ReturnType<this["registerUser"]>>;
   }
 
-  private async upsertUser(userDetails: UpdateUserInput, attempt = 0): Promise<UserOutput> {
+  private async upsertUser(userDetails: UpdateUserInput, attempt = 0): Promise<{ user: UserOutput; wasInserted: boolean }> {
     try {
       return await this.userRepository.upsertOnExternalIdConflict(userDetails);
     } catch (error) {

--- a/apps/api/src/user/services/user/user.service.ts
+++ b/apps/api/src/user/services/user/user.service.ts
@@ -44,6 +44,8 @@ export class UserService {
       lastFingerprint: data.fingerprint
     };
 
+    const existingUser = await this.userRepository.findByUserId(data.userId);
+
     const user = await this.upsertUser({
       ...userDetails,
       username: data.wantedUsername
@@ -54,6 +56,10 @@ export class UserService {
       username: user.username,
       email: user.email
     });
+
+    if (!existingUser) {
+      this.analyticsService.track(user.id, "account_created", { category: "user" });
+    }
 
     const result = await this.notificationService.createDefaultChannel(user).catch(error => ({ error }));
 


### PR DESCRIPTION
## Why

The embedded **passwordless** auth rollout (`console_auth_passwordless`, ~June 3) broke new-user signup tracking: the client `onboarding_account_created` event only ever fired when `OnboardingContainer` loaded with `?fromSignup=true`, and that param was only set by the anonymous branch of `handleStartTrial`. With passwordless + the login gate, users authenticate **before** reaching onboarding, so the logged-in branch runs, `fromSignup` is never set, and the event never fires — we lost the "new account created" step of the signup funnel.

This restores that signal **server-side** so it's flow-independent and survives future auth/onboarding changes.

Fixes CON-523

## What

- Add `account_created` to the server `AnalyticsEvent` union (`apps/api/src/core/services/analytics/analytics.service.ts`).
- Emit `account_created` from `UserService.registerUser` — the universal user-creation chokepoint for **both** passwordless (`email-code-verify`) and Auth0-callback flows (both go through `createLocalUser` → `POST /v1/register-user`).
  - `registerUser` runs an idempotent upsert on **every login**, so the event is gated on an existence pre-check (`findByUserId`) to fire **only on true first-creation**.
  - It's keyed on the same internal `user.id` the client uses for `setUserId`, so it stitches into the existing signup funnel alongside `trial_started` / `onboarding_*`.
- Unit tests: fires `account_created` for a never-seen user; does **not** fire for an existing user (re-logins don't over-count).

**Out of scope** (per the issue's "also regressed" notes + confirmed scope): `onboarding_email_verified` death under passwordless, and new-vs-returning segmentation on the auth-init events (client-side, no reliable Auth0 new-user signal).

### Verification
- `npm run test:unit -- user.service` → 5 passed (3 existing + 2 new)
- `eslint` on changed files → clean
- No new `tsc` errors (the `vi`/`import.meta` errors are pre-existing on `main`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced analytics tracking for user registrations by supporting the new `account_created` event.

* **Bug Fixes**
  * Analytics now emits `account_created` only when a registration results in a newly created account, and avoids emitting it when an existing user is returned.

* **Tests**
  * Updated registration unit tests to validate analytics behavior for both newly inserted and existing-user outcomes.
  * Added integration tests for external ID upserts to cover insert vs. conflict update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->