### PR TITLE
fix: make BME settlement polling abortable

### DIFF
--- a/packages/http-sdk/src/bme/bme-http.service.spec.ts
+++ b/packages/http-sdk/src/bme/bme-http.service.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { HttpClient } from "../utils/httpClient";
+import { BmeHttpService } from "./bme-http.service";
+
+describe(BmeHttpService.name, () => {
+  describe("waitForLedgerRecordsSettlement", () => {
+    it("stops waiting immediately when aborted during the poll interval", async () => {
+      vi.useFakeTimers();
+
+      try {
+        const { service, httpClient } = setup();
+        const abortController = new AbortController();
+
+        httpClient.get.mockResolvedValue({
+          data: {
+            records: [{ status: "ledger_record_status_pending" }],
+            pagination: { next_key: null, total: "1" }
+          }
+        });
+
+        const result = service.waitForLedgerRecordsSettlement("akash1abc", {
+          pollIntervalMs: 30_000,
+          maxAttempts: 2,
+          signal: abortController.signal
+        });
+
+        await vi.waitFor(() => expect(httpClient.get).toHaveBeenCalledTimes(1));
+        abortController.abort();
+
+        await expect(result).resolves.toBe(false);
+        expect(httpClient.get).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  function setup() {
+    const httpClient = {
+      get: vi.fn()
+    } as unknown as HttpClient & { get: ReturnType<typeof vi.fn> };
+
+    const service = new BmeHttpService(httpClient);
+
+    return { service, httpClient };
+  }
+});

--- a/packages/http-sdk/src/bme/bme-http.service.ts
+++ b/packages/http-sdk/src/bme/bme-http.service.ts
@@ -42,9 +42,32 @@ export class BmeHttpService {
 
       if (records.length === 0) return true;
 
-      await new Promise(resolve => setTimeout(resolve, pollInterval));
+      if (!(await waitForPollInterval(pollInterval, options?.signal))) return false;
     }
 
     return false;
   }
+}
+
+function waitForPollInterval(pollInterval: number, signal?: AbortSignal): Promise<boolean> {
+  if (signal?.aborted) return Promise.resolve(false);
+
+  return new Promise(resolve => {
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve(true);
+    }, pollInterval);
+
+    const onAbort = () => {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+      resolve(false);
+    };
+
+    signal?.addEventListener("abort", onAbort, { once: true });
+
+    if (signal?.aborted) {
+      onAbort();
+    }
+  });
 }


### PR DESCRIPTION
## Summary
- Stop `waitForLedgerRecordsSettlement` immediately when its abort signal fires during the poll interval.
- Clear the pending timeout and return `false` instead of waiting for the full interval before observing cancellation.
- Add a regression test covering abort during the sleep between polling attempts.

## Testing
- `npm test --workspace packages/http-sdk -- --run src/bme/bme-http.service.spec.ts`
- `npm run validate:types --workspace packages/http-sdk`
- `npm run lint --workspace packages/http-sdk -- src/bme/bme-http.service.ts src/bme/bme-http.service.spec.ts` (passes with existing warnings elsewhere in `packages/http-sdk`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ledger settlement polling to support proper cancellation during polling intervals. Operations can now be aborted without waiting for the current interval to complete, providing better responsiveness when cancelling ledger verification processes.

* **Tests**
  * Added unit tests for ledger settlement polling cancellation behavior with abort signal verification to ensure correct behavior under interruption scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->