### PR TITLE
feat(deployment): pace marketplace screening while editing

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -105,6 +105,12 @@ describe(ConfigureDeploymentForm.name, () => {
     expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ sdl: VALID_SDL }), expect.anything());
   });
 
+  it("threads both the live sdl and the debounced preview sdl into the panes", () => {
+    const { ConfigureDeploymentPanes } = setup({ initialSdl: VALID_SDL });
+
+    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ sdl: VALID_SDL, previewSdl: VALID_SDL }), expect.anything());
+  });
+
   it("falls back to a default deployment when the carried-in SDL has no services", () => {
     const { ConfigureDeploymentPanes, enqueueSnackbar } = setup({ initialSdl: 'version: "2.0"' });
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { Snackbar } from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
-import debounce from "lodash/debounce";
 import { NextSeo } from "next-seo";
 import { useSnackbar } from "notistack";
 
@@ -20,7 +19,7 @@ import { ConfigureDeploymentPanes } from "../ConfigureDeploymentPanes/ConfigureD
 
 export const DEPENDENCIES = { Layout, NextSeo, ConfigureDeploymentHeader, ConfigureDeploymentPanes, useSnackbar, Snackbar };
 
-/** Delay between a form edit and regenerating the SDL preview. */
+/** Delay between a form edit and updating the debounced SDL preview. */
 const SDL_SYNC_DEBOUNCE_MS = 300;
 
 type Props = {
@@ -30,7 +29,8 @@ type Props = {
 
 export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, dependencies: d = DEPENDENCIES }) => {
   const [initialState] = useState(() => getInitialState(initialSdl));
-  const [sdl, setSdl] = useState(initialState.sdl);
+  const [liveSdl, setLiveSdl] = useState(initialState.sdl);
+  const [previewSdl, setPreviewSdl] = useState(initialState.sdl);
   const [selectedServiceId, setSelectedServiceId] = useState<string>(initialState.selectedServiceId);
   const { enqueueSnackbar } = d.useSnackbar();
   const form = useForm<SdlBuilderFormValuesType>({
@@ -53,17 +53,23 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, dependencies: d
   );
 
   useEffect(
-    function syncSdlPreview() {
-      const writeSdl = debounce((values: unknown) => {
-        setSdl(previous => regenerateSdl(values as SdlBuilderFormValuesType, previous));
-      }, SDL_SYNC_DEBOUNCE_MS);
-      const subscription = form.watch(values => writeSdl(values));
-      return function teardownSdlSync() {
-        writeSdl.cancel();
+    function syncLiveSdl() {
+      const subscription = form.watch(values => setLiveSdl(previous => regenerateSdl(values as SdlBuilderFormValuesType, previous)));
+      return function teardownLiveSync() {
         subscription.unsubscribe();
       };
     },
     [form]
+  );
+
+  useEffect(
+    function debouncePreviewSdl() {
+      const timeout = setTimeout(() => setPreviewSdl(liveSdl), SDL_SYNC_DEBOUNCE_MS);
+      return function cancelPreviewDebounce() {
+        clearTimeout(timeout);
+      };
+    },
+    [liveSdl]
   );
 
   useEffect(
@@ -87,7 +93,8 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, dependencies: d
         </div>
         <div className="mt-6 flex min-h-0 flex-1">
           <d.ConfigureDeploymentPanes
-            sdl={sdl}
+            sdl={liveSdl}
+            previewSdl={previewSdl}
             selectedServiceId={selectedServiceId}
             selectedPlacementName={selectedPlacement.name}
             selectedPlacementRegion={selectedPlacement.region}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
@@ -61,8 +61,8 @@ describe("ConfigureDeploymentPanes", () => {
     expect(screen.queryByTestId("sdl-preview-pane-mock")).not.toBeInTheDocument();
   });
 
-  it("renders the preview pane closed with the sdl when the flag is enabled", () => {
-    const { SdlPreviewPane } = setup({ isSdlPreviewEnabled: true, sdl: 'version: "2.0"' });
+  it("renders the preview pane closed with the preview sdl when the flag is enabled", () => {
+    const { SdlPreviewPane } = setup({ isSdlPreviewEnabled: true, previewSdl: 'version: "2.0"' });
 
     expect(SdlPreviewPane).toHaveBeenCalledWith(expect.objectContaining({ isOpen: false, sdl: 'version: "2.0"' }), expect.anything());
   });
@@ -110,6 +110,7 @@ describe("ConfigureDeploymentPanes", () => {
     input: {
       isSdlPreviewEnabled?: boolean;
       sdl?: string;
+      previewSdl?: string;
       preserveStorage?: boolean;
       selectedServiceId?: string;
       selectedPlacementName?: string;
@@ -142,6 +143,7 @@ describe("ConfigureDeploymentPanes", () => {
       <JotaiStoreProvider store={createStore()}>
         <ConfigureDeploymentPanes
           sdl={input.sdl ?? ""}
+          previewSdl={input.previewSdl ?? ""}
           selectedServiceId={input.selectedServiceId ?? ""}
           selectedPlacementName={input.selectedPlacementName ?? "dcloud"}
           selectedPlacementRegion={input.selectedPlacementRegion}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
@@ -16,6 +16,7 @@ export const DEPENDENCIES = { DeploymentPane, ConfigurationPane, MarketplacePane
 
 type Props = {
   sdl: string;
+  previewSdl: string;
   selectedServiceId: string;
   selectedPlacementName: string;
   selectedPlacementRegion?: string;
@@ -25,6 +26,7 @@ type Props = {
 
 export const ConfigureDeploymentPanes: FC<Props> = ({
   sdl,
+  previewSdl,
   selectedServiceId,
   selectedPlacementName,
   selectedPlacementRegion,
@@ -48,7 +50,7 @@ export const ConfigureDeploymentPanes: FC<Props> = ({
           <d.MarketplacePane sdl={sdl} placementName={selectedPlacementName} region={selectedPlacementRegion} />
         </div>
         {isSdlPreviewEnabled && (
-          <d.SdlPreviewPane sdl={sdl} isOpen={isSdlPreviewOpen} onOpen={() => setIsSdlPreviewOpen(true)} onClose={() => setIsSdlPreviewOpen(false)} />
+          <d.SdlPreviewPane sdl={previewSdl} isOpen={isSdlPreviewOpen} onOpen={() => setIsSdlPreviewOpen(true)} onClose={() => setIsSdlPreviewOpen(false)} />
         )}
       </div>
 

--- a/apps/deploy-web/src/hooks/usePacedValue/usePacedValue.spec.ts
+++ b/apps/deploy-web/src/hooks/usePacedValue/usePacedValue.spec.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePacedValue } from "./usePacedValue";
+
+import { act, renderHook } from "@testing-library/react";
+
+describe(usePacedValue.name, () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("emits the first value immediately, without waiting", () => {
+    const { result } = setup({ value: "a" });
+
+    expect(result.current).toBe("a");
+  });
+
+  it("collapses a burst of changes into the last value once edits settle", () => {
+    const { result, rerender } = setup({ value: "a" });
+
+    rerender({ value: "b", wait: 200, maxWait: 2000 });
+    rerender({ value: "c", wait: 200, maxWait: 2000 });
+    expect(result.current).toBe("a");
+
+    act(() => vi.advanceTimersByTime(200));
+
+    expect(result.current).toBe("c");
+  });
+
+  it("emits at the maxWait ceiling even when changes never settle", () => {
+    const { result, rerender } = setup({ value: "v0", wait: 200, maxWait: 500 });
+
+    for (let edit = 1; edit <= 4; edit++) {
+      act(() => vi.advanceTimersByTime(150));
+      rerender({ value: `v${edit}`, wait: 200, maxWait: 500 });
+    }
+
+    expect(result.current).not.toBe("v0");
+  });
+
+  it("does not emit a pending change after unmount", () => {
+    const { result, rerender, unmount } = setup({ value: "a" });
+
+    rerender({ value: "b", wait: 200, maxWait: 2000 });
+    unmount();
+    act(() => vi.advanceTimersByTime(200));
+
+    expect(result.current).toBe("a");
+  });
+
+  function setup(initial: { value: string; wait?: number; maxWait?: number }) {
+    return renderHook(({ value, wait, maxWait }) => usePacedValue(value, { wait, maxWait }), {
+      initialProps: { value: initial.value, wait: initial.wait ?? 200, maxWait: initial.maxWait ?? 2000 }
+    });
+  }
+});

--- a/apps/deploy-web/src/hooks/usePacedValue/usePacedValue.ts
+++ b/apps/deploy-web/src/hooks/usePacedValue/usePacedValue.ts
@@ -1,0 +1,38 @@
+import { useEffect, useMemo, useState } from "react";
+import debounce from "lodash/debounce";
+
+interface PacingOptions {
+  /** Quiet period after the last change before the value is committed. */
+  wait: number;
+  /** Hard ceiling so a never-settling stream of changes still commits at least this often. */
+  maxWait: number;
+}
+
+/**
+ * Returns a paced copy of `value`: the first value is committed immediately, and every later change
+ * is debounced by `wait` with a `maxWait` ceiling. Pass a referentially-stable `value` (e.g. a memoized
+ * object) so renders that don't change it don't reschedule the commit. Pacing the value that drives a
+ * query key is how an expensive endpoint is shielded from per-keystroke requests.
+ */
+export function usePacedValue<T>(value: T, { wait, maxWait }: PacingOptions): T {
+  const [paced, setPaced] = useState(value);
+  const commit = useMemo(() => debounce(setPaced, wait, { maxWait }), [wait, maxWait]);
+
+  useEffect(
+    function paceValue() {
+      commit(value);
+    },
+    [commit, value]
+  );
+
+  useEffect(
+    function cancelPendingOnUnmount() {
+      return function cancelPending() {
+        commit.cancel();
+      };
+    },
+    [commit]
+  );
+
+  return paced;
+}

--- a/apps/deploy-web/src/queries/useScreenedProviders.spec.tsx
+++ b/apps/deploy-web/src/queries/useScreenedProviders.spec.tsx
@@ -1,12 +1,14 @@
-import type { UseQueryResult } from "@tanstack/react-query";
+import { createProxy } from "@akashnetwork/react-query-proxy";
+import { keepPreviousData, type UseQueryResult } from "@tanstack/react-query";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { AUDITOR } from "@src/utils/deploymentData/v1beta3";
 import { setupQuery } from "../../tests/unit/query-client";
 import type { ScreenedProvider, ScreenedProvidersResponse } from "./useScreenedProviders";
-import { buildCatalogScreeningRequest, buildPlacementScreeningRequest, useScreenedProviders } from "./useScreenedProviders";
+import { buildCatalogScreeningRequest, buildPlacementScreeningRequest, SCREENING_DEBOUNCE_MS, useScreenedProviders } from "./useScreenedProviders";
 
+import { act, waitFor } from "@testing-library/react";
 import { buildScreenedProvider } from "@tests/seeders/screenedProvider";
 
 const HELLO_WORLD_SDL = `---
@@ -50,28 +52,35 @@ describe("useScreenedProviders", () => {
       expect.objectContaining({
         requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [] },
         resources: expect.arrayContaining([expect.objectContaining({ count: 1 })])
-      })
+      }),
+      expect.anything()
     );
   });
 
   it("falls back to the full audited catalog (empty resources) when the SDL is invalid", () => {
     const { useQuery } = setup({ sdl: "foo: [unclosed", placementName: "dcloud" });
 
-    expect(useQuery).toHaveBeenCalledWith({
-      requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [] },
-      resources: [],
-      timezone: expect.any(String)
-    });
+    expect(useQuery).toHaveBeenCalledWith(
+      {
+        requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [] },
+        resources: [],
+        timezone: expect.any(String)
+      },
+      expect.anything()
+    );
   });
 
   it("keeps the selected region as a location-region filter on the catalog fallback when the SDL is invalid", () => {
     const { useQuery } = setup({ sdl: "foo: [unclosed", placementName: "dcloud", region: "na-us-west" });
 
-    expect(useQuery).toHaveBeenCalledWith({
-      requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [{ key: "location-region", value: "na-us-west" }] },
-      resources: [],
-      timezone: expect.any(String)
-    });
+    expect(useQuery).toHaveBeenCalledWith(
+      {
+        requirements: { signedBy: { allOf: [AUDITOR] }, attributes: [{ key: "location-region", value: "na-us-west" }] },
+        resources: [],
+        timezone: expect.any(String)
+      },
+      expect.anything()
+    );
   });
 
   it("returns the screened providers from the query result", () => {
@@ -79,6 +88,36 @@ describe("useScreenedProviders", () => {
     const { result } = setup({ placementName: "dcloud", providers });
 
     expect(result.current.providers).toEqual(providers);
+  });
+
+  it("requests the previous data as a placeholder so the list refines in place instead of blanking", () => {
+    const { useQuery } = setup({ placementName: "dcloud" });
+
+    expect(useQuery).toHaveBeenLastCalledWith(expect.anything(), expect.objectContaining({ placeholderData: keepPreviousData }));
+  });
+
+  it("screens the first spec immediately, without waiting for the debounce", () => {
+    const { useQuery } = setup({ placementName: "dcloud" });
+
+    expect(useQuery).toHaveBeenCalledTimes(1);
+    expect(lastRequest(useQuery).resources.length).toBeGreaterThan(0);
+  });
+
+  it("paces input changes so rapid edits do not change the screening request until they settle", () => {
+    vi.useFakeTimers();
+    try {
+      const { useQuery, rerender } = setup({ sdl: "foo: [unclosed", placementName: "dcloud", region: "old" });
+      expect(regionOf(lastRequest(useQuery))).toBe("old");
+
+      rerender({ region: "new" });
+      expect(regionOf(lastRequest(useQuery))).toBe("old");
+
+      act(() => vi.advanceTimersByTime(SCREENING_DEBOUNCE_MS));
+
+      expect(regionOf(lastRequest(useQuery))).toBe("new");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   function setup(input: { placementName: string; sdl?: string; region?: string; providers?: ScreenedProvider[] }) {
@@ -93,10 +132,16 @@ describe("useScreenedProviders", () => {
       NonNullable<NonNullable<NonNullable<Parameters<typeof setupQuery>[1]>["services"]>["api"]>
     >;
 
-    const { result } = setupQuery(() => useScreenedProviders({ sdl: input.sdl ?? HELLO_WORLD_SDL, placementName: input.placementName, region: input.region }), {
-      services: { api: () => api }
-    });
-    return { result, useQuery };
+    const current = { sdl: input.sdl ?? HELLO_WORLD_SDL, placementName: input.placementName, region: input.region };
+    const view = setupQuery(() => useScreenedProviders({ ...current }), { services: { api: () => api } });
+
+    function rerender(next: { sdl?: string; region?: string }) {
+      if (next.sdl !== undefined) current.sdl = next.sdl;
+      if ("region" in next) current.region = next.region;
+      view.rerender();
+    }
+
+    return { result: view.result, useQuery, rerender };
   }
 });
 
@@ -132,3 +177,62 @@ describe("buildCatalogScreeningRequest", () => {
     });
   });
 });
+
+describe("useScreenedProviders — newest result wins", () => {
+  it("never lets a slow response for a superseded spec overwrite the current providers", async () => {
+    const newProvider = buildScreenedProvider({ hostUri: "https://new.example:8443" });
+    const oldProvider = buildScreenedProvider({ hostUri: "https://old.example:8443" });
+    const { result, screenForRegion, rerender } = setup();
+
+    await waitFor(() => expect(screenForRegion("old")).toBeDefined());
+
+    rerender("new");
+    await waitFor(() => expect(screenForRegion("new")).toBeDefined());
+
+    act(() => screenForRegion("new")!({ providers: [newProvider] }));
+    await waitFor(() => expect(result.current.providers).toEqual([newProvider]));
+
+    act(() => screenForRegion("old")!({ providers: [oldProvider] }));
+    await waitFor(() => expect(screenForRegion("old")).toBeDefined());
+
+    expect(result.current.providers).toEqual([newProvider]);
+  });
+
+  function setup() {
+    const resolvers = new Map<string, (response: ScreenedProvidersResponse) => void>();
+    const screenProviders = vi.fn(
+      (request: { requirements: { attributes: Array<{ key: string; value: string }> } }) =>
+        new Promise<ScreenedProvidersResponse>(resolve => {
+          const region = request.requirements.attributes.find(attribute => attribute.key === "location-region")!.value;
+          resolvers.set(region, resolve);
+        })
+    );
+    const api = createProxy({ v1: { screenProviders } }) as unknown as ReturnType<
+      NonNullable<NonNullable<NonNullable<Parameters<typeof setupQuery>[1]>["services"]>["api"]>
+    >;
+
+    const current = { region: "old" };
+    const view = setupQuery(() => useScreenedProviders({ sdl: "foo: [unclosed", placementName: "dcloud", region: current.region }), {
+      services: { api: () => api }
+    });
+
+    return {
+      result: view.result,
+      rerender(region: string) {
+        current.region = region;
+        view.rerender();
+      },
+      screenForRegion: (region: string) => resolvers.get(region)
+    };
+  }
+});
+
+/** The request object handed to react-query on the most recent render. */
+function lastRequest(useQuery: ReturnType<typeof vi.fn>) {
+  return useQuery.mock.lastCall![0] as { resources: unknown[]; requirements: { attributes: Array<{ key: string; value: string }> } };
+}
+
+/** The selected region encoded on a catalog-fallback request, or undefined when unset. */
+function regionOf(request: ReturnType<typeof lastRequest>): string | undefined {
+  return request.requirements.attributes.find(attribute => attribute.key === "location-region")?.value;
+}

--- a/apps/deploy-web/src/queries/useScreenedProviders.ts
+++ b/apps/deploy-web/src/queries/useScreenedProviders.ts
@@ -1,8 +1,10 @@
 import { useMemo } from "react";
 import { GroupSpec } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
 import type { paths } from "@akashnetwork/console-api-types";
+import { keepPreviousData } from "@tanstack/react-query";
 
 import { useServices } from "@src/context/ServicesProvider";
+import { usePacedValue } from "@src/hooks/usePacedValue/usePacedValue";
 import { DeploymentGroups } from "@src/utils/deploymentData/helpers";
 import { AUDITOR } from "@src/utils/deploymentData/v1beta3";
 
@@ -27,6 +29,11 @@ interface UseScreenedProvidersResult {
   isError: boolean;
 }
 
+/** Quiet period after the last spec edit before the current spec is screened. */
+export const SCREENING_DEBOUNCE_MS = 400;
+/** Hard ceiling so continuous editing still screens the spec at most ~once per this window. */
+export const SCREENING_MAX_WAIT_MS = 2000;
+
 /**
  * Screens providers for the given placement's group spec. The marketplace is placement-scoped: it converts
  * the current SDL to group specs and queries the one matching `placementName`. While the SDL is mid-edit or
@@ -39,7 +46,8 @@ export function useScreenedProviders({ sdl, placementName, region }: UseScreened
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     return { ...(buildPlacementScreeningRequest(sdl, placementName) ?? buildCatalogScreeningRequest(region)), timezone };
   }, [sdl, placementName, region]);
-  const query = api.v1.screenProviders.useQuery(request);
+  const pacedRequest = usePacedValue(request, { wait: SCREENING_DEBOUNCE_MS, maxWait: SCREENING_MAX_WAIT_MS });
+  const query = api.v1.screenProviders.useQuery(pacedRequest, { placeholderData: keepPreviousData });
 
   return {
     providers: query.data?.providers ?? [],


### PR DESCRIPTION
## Why

The marketplace list should always reflect the spec being edited, without flooding the screening service on every keystroke.

Fixes CON-474

## What

Reworks how spec edits flow to the marketplace so the list tracks the live spec while screening requests stay paced:

- **Live vs. preview SDL split** — the form now regenerates a `liveSdl` immediately on every edit (feeding the marketplace pane) and keeps a separate `previewSdl`, which retains the 300ms debounce and drives only the SDL preview pane. Pacing is no longer applied form-wide.
- **Pacing at the query layer** — a new reusable `usePacedValue` hook (debounce `wait` + `maxWait` ceiling) paces the screening request key in `useScreenedProviders` (400ms quiet period, 2000ms hard ceiling), so rapid consecutive edits produce a paced request stream rather than one request per keystroke.
- **No stale overwrites** — `keepPreviousData` keeps the current provider list visible during refetch, and react-query's keyed caching ensures a stale in-flight response never overwrites a newer result.

Still display-only screening — no uptime or price data (those arrive with bids).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployment configuration now updates the SDL panes immediately as you edit, with a separately debounced SDL preview refreshing after a short delay.
  * Provider screening now delays outgoing screening requests during rapid changes, while keeping results responsive via in-place refinement.

* **Tests**
  * Added and updated unit tests to verify correct live-vs-preview SDL synchronization, paced timing behavior, and “newest result wins” handling for out-of-order responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->