### PR TITLE
feat: adds automatic provider incidents cleanup

### DIFF
--- a/apps/provider-inventory/src/config/env.config.ts
+++ b/apps/provider-inventory/src/config/env.config.ts
@@ -20,7 +20,12 @@ export const envSchema = z.object({
   STREAM_FIRST_MESSAGE_TIMEOUT_MS: z.number({ coerce: true }).default(10_000),
   STREAM_UPDATE_THROTTLE_MS: z.number({ coerce: true }).nonnegative().default(1000),
   REST_API_NODE_URL: z.string().url(),
-  DEAD_PROVIDER_UPDATED_THRESHOLD_MS: z.number({ coerce: true }).default(10 * 24 * 60 * ONE_MINUTE)
+  DEAD_PROVIDER_UPDATED_THRESHOLD_MS: z.number({ coerce: true }).default(10 * 24 * 60 * ONE_MINUTE),
+  INCIDENT_RETENTION_DAYS: z.number({ coerce: true }).int().positive().default(31),
+  INCIDENT_CLEANUP_INTERVAL_MS: z
+    .number({ coerce: true })
+    .nonnegative()
+    .default(24 * 60 * ONE_MINUTE)
 });
 
 export type EnvConfig = z.infer<typeof envSchema>;

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.integration.ts
@@ -122,6 +122,43 @@ describe(ProviderIncidentRepository.name, () => {
     });
   });
 
+  describe("deleteEndedBefore", () => {
+    it("deletes incidents that ended before the retention window and reports the deleted count", async () => {
+      const { repository, db } = setup();
+      await seedClosed(db, { provider: "akash1a", endedAt: atDaysAgoUtc(40, 10) });
+      await seedClosed(db, { provider: "akash1b", endedAt: atDaysAgoUtc(35, 10) });
+
+      const deletedCount = await repository.deleteEndedBefore(31);
+
+      expect(deletedCount).toBe(2);
+      const rows = await db.select().from(providerIncidents);
+      expect(rows).toHaveLength(0);
+    });
+
+    it("keeps incidents that ended within the retention window", async () => {
+      const { repository, db } = setup();
+      await seedClosed(db, { provider: "akash1a", endedAt: atDaysAgoUtc(10, 10) });
+
+      const deletedCount = await repository.deleteEndedBefore(31);
+
+      expect(deletedCount).toBe(0);
+      const rows = await db.select().from(providerIncidents);
+      expect(rows).toHaveLength(1);
+      expect(rows[0].provider).toBe("akash1a");
+    });
+
+    it("never deletes still-open incidents regardless of how long ago they started", async () => {
+      const { repository, db } = setup();
+      await seedIncident(db, { provider: "akash1a", startedAt: atDaysAgoUtc(90, 10), endedAt: null });
+
+      const deletedCount = await repository.deleteEndedBefore(31);
+
+      expect(deletedCount).toBe(0);
+      const [row] = await db.select().from(providerIncidents);
+      expect(row).toMatchObject({ provider: "akash1a", endedAt: null });
+    });
+  });
+
   describe("findDailyDowntimeByProviders", () => {
     it("returns an empty array when called with no providers", async () => {
       const { repository } = setup();

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
@@ -1,4 +1,4 @@
-import { and, eq, getTableName, inArray, isNull, sql } from "drizzle-orm";
+import { and, eq, getTableName, inArray, isNotNull, isNull, lt, sql } from "drizzle-orm";
 import { inject, singleton } from "tsyringe";
 
 import { providerIncidents } from "@src/model-schemas/provider-incident/provider-incident.schema";
@@ -31,12 +31,6 @@ export class ProviderIncidentRepository {
     this.#sql = sql;
   }
 
-  /**
-   * Per-provider, per-day downtime over a rolling 7-day window (today + 6 prior days),
-   * with calendar-day boundaries computed in `timeZone` (default UTC).
-   * `hasOpenIncident` is provider-wide (true if any incident is still open now).
-   * Rows are ordered by `(provider, date ASC)`.
-   */
   async findDailyDowntimeByProviders(providers: string[], timeZone = "UTC"): Promise<DailyDowntimeRow[]> {
     if (providers.length === 0) return [];
 
@@ -100,5 +94,15 @@ export class ProviderIncidentRepository {
       .update(providerIncidents)
       .set({ endedAt: sql`now()` })
       .where(isNull(providerIncidents.endedAt));
+  }
+
+  async deleteEndedBefore(retentionDays: number): Promise<number> {
+    const deleted = await this.driver
+      .getDb()
+      .delete(providerIncidents)
+      .where(and(isNotNull(providerIncidents.endedAt), lt(providerIncidents.endedAt, sql`now() - make_interval(days => ${retentionDays})`)))
+      .returning({ provider: providerIncidents.provider });
+
+    return deleted.length;
   }
 }

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
@@ -100,9 +100,8 @@ export class ProviderIncidentRepository {
     const deleted = await this.driver
       .getDb()
       .delete(providerIncidents)
-      .where(and(isNotNull(providerIncidents.endedAt), lt(providerIncidents.endedAt, sql`now() - make_interval(days => ${retentionDays})`)))
-      .returning({ provider: providerIncidents.provider });
+      .where(and(isNotNull(providerIncidents.endedAt), lt(providerIncidents.endedAt, sql`now() - make_interval(days => ${retentionDays})`)));
 
-    return deleted.length;
+    return deleted.count;
   }
 }

--- a/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.spec.ts
+++ b/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.spec.ts
@@ -3,6 +3,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { EnvConfig } from "@src/providers/app-config.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
+import type { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import type { ProviderInventory, ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import type { ChainProviderPollerService } from "@src/services/chain-provider-poller/chain-provider-poller.service";
 import type { StreamLifecycleManagerService } from "@src/services/stream-lifecycle-manager/stream-lifecycle-manager.service";
@@ -136,6 +137,55 @@ describe(DiscoverySchedulerService.name, () => {
     expect(lifecycle.start).not.toHaveBeenCalled();
   });
 
+  it("prunes incidents older than the configured retention window on the first tick", async () => {
+    const { incidentRepository, config } = setup();
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(incidentRepository.deleteEndedBefore).toHaveBeenCalledTimes(1);
+    expect(incidentRepository.deleteEndedBefore).toHaveBeenCalledWith(config.INCIDENT_RETENTION_DAYS);
+  });
+
+  it("does not prune again on subsequent ticks within the cleanup interval", async () => {
+    const { incidentRepository, config } = setup();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(incidentRepository.deleteEndedBefore).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(config.DISCOVERY_INTERVAL_MS * 5);
+    expect(incidentRepository.deleteEndedBefore).toHaveBeenCalledTimes(1);
+  });
+
+  it("prunes again once the cleanup interval has elapsed", async () => {
+    const { incidentRepository, config } = setup();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(incidentRepository.deleteEndedBefore).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(config.INCIDENT_CLEANUP_INTERVAL_MS);
+    expect(incidentRepository.deleteEndedBefore).toHaveBeenCalledTimes(2);
+  });
+
+  it("still prunes incidents when the poll fails so cleanup is not blocked by a tick error", async () => {
+    const { incidentRepository } = setup({ pollError: new Error("chain RPC unavailable") });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(incidentRepository.deleteEndedBefore).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the prune on the next tick when cleanup fails rather than waiting a full interval", async () => {
+    const { incidentRepository, poller, config, logger } = setup();
+    incidentRepository.deleteEndedBefore.mockRejectedValueOnce(new Error("DB down"));
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "DISCOVERY_INCIDENTS_CLEANUP_ERROR" }));
+
+    await vi.advanceTimersByTimeAsync(config.DISCOVERY_INTERVAL_MS);
+    expect(poller.poll).toHaveBeenCalledTimes(2);
+    expect(incidentRepository.deleteEndedBefore).toHaveBeenCalledTimes(2);
+  });
+
   it("stops scheduling after stop is called", async () => {
     const { scheduler, poller, config } = setup();
 
@@ -235,12 +285,14 @@ describe(DiscoverySchedulerService.name, () => {
   }) {
     const poller = mock<ChainProviderPollerService>();
     const writer = mock<ProviderInventoryRepository>();
+    const incidentRepository = mock<ProviderIncidentRepository>();
     const lifecycle = mock<StreamLifecycleManagerService>();
     lifecycle.getRegistry.mockReturnValue(input?.watched ?? new Map());
     lifecycle.stopAndDelete.mockResolvedValue();
     lifecycle.waitForPendingConnections.mockResolvedValue();
     writer.bulkUpsertProviders.mockResolvedValue();
     writer.getInventoryLastUpdatedPerOfflineProvider.mockResolvedValue(input?.lastUpdated ?? new Map());
+    incidentRepository.deleteEndedBefore.mockResolvedValue(0);
 
     const onlineOwners = input?.onlineOwners ?? [];
     writer.streamOnlineProviders.mockReturnValue(
@@ -262,7 +314,9 @@ describe(DiscoverySchedulerService.name, () => {
       STREAM_RECONNECT_MAX_DELAY_MS: 300_000,
       STREAM_FIRST_MESSAGE_TIMEOUT_MS: 10_000,
       DEAD_PROVIDER_UPDATED_THRESHOLD_MS,
-      REST_API_NODE_URL: "http://localhost:1317"
+      REST_API_NODE_URL: "http://localhost:1317",
+      INCIDENT_RETENTION_DAYS: 31,
+      INCIDENT_CLEANUP_INTERVAL_MS: 24 * 60 * 60 * 1000
     } as EnvConfig;
 
     if (input?.pollError) {
@@ -287,10 +341,10 @@ describe(DiscoverySchedulerService.name, () => {
       });
     }
 
-    const scheduler = new DiscoverySchedulerService(poller, writer, lifecycle, config, loggerFactory);
+    const scheduler = new DiscoverySchedulerService(poller, writer, incidentRepository, lifecycle, config, loggerFactory);
     if (input?.autoStart !== false) scheduler.start();
 
-    return { scheduler, poller, writer, lifecycle, config, logger };
+    return { scheduler, poller, writer, incidentRepository, lifecycle, config, logger };
   }
 });
 

--- a/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
+++ b/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
@@ -7,6 +7,7 @@ import type { EnvConfig } from "@src/providers/app-config.provider";
 import { APP_CONFIG } from "@src/providers/app-config.provider";
 import type { LoggerFactory } from "@src/providers/logger-factory.provider";
 import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
+import { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import { ChainProviderPollerService } from "@src/services/chain-provider-poller/chain-provider-poller.service";
 import { StreamLifecycleManagerService } from "@src/services/stream-lifecycle-manager/stream-lifecycle-manager.service";
@@ -17,19 +18,23 @@ export class DiscoverySchedulerService {
   readonly #logger: LoggerService;
   readonly #poller: ChainProviderPollerService;
   readonly #repository: ProviderInventoryRepository;
+  readonly #incidentRepository: ProviderIncidentRepository;
   readonly #lifecycle: StreamLifecycleManagerService;
   readonly #config: EnvConfig;
   #abortController: AbortController | null = null;
+  #lastIncidentCleanupAt: number | null = null;
 
   constructor(
     poller: ChainProviderPollerService,
     repository: ProviderInventoryRepository,
+    incidentRepository: ProviderIncidentRepository,
     lifecycle: StreamLifecycleManagerService,
     @inject(APP_CONFIG) config: EnvConfig,
     @inject(LOGGER_FACTORY) loggerFactory: LoggerFactory
   ) {
     this.#poller = poller;
     this.#repository = repository;
+    this.#incidentRepository = incidentRepository;
     this.#lifecycle = lifecycle;
     this.#config = config;
     this.#logger = loggerFactory({ context: "DiscoveryScheduler" });
@@ -157,6 +162,24 @@ export class DiscoverySchedulerService {
       });
     } catch (error) {
       this.#logger.error({ event: "DISCOVERY_TICK_ERROR", error });
+    }
+
+    await this.#cleanupOldIncidents();
+  }
+
+  async #cleanupOldIncidents(): Promise<void> {
+    const now = Date.now();
+    if (this.#lastIncidentCleanupAt !== null && now - this.#lastIncidentCleanupAt < this.#config.INCIDENT_CLEANUP_INTERVAL_MS) {
+      return;
+    }
+
+    const retentionDays = this.#config.INCIDENT_RETENTION_DAYS;
+    try {
+      const deletedCount = await this.#incidentRepository.deleteEndedBefore(retentionDays);
+      this.#lastIncidentCleanupAt = now;
+      this.#logger.info({ event: "DISCOVERY_INCIDENTS_CLEANUP", retentionDays, deletedCount });
+    } catch (error) {
+      this.#logger.error({ event: "DISCOVERY_INCIDENTS_CLEANUP_ERROR", retentionDays, error });
     }
   }
 


### PR DESCRIPTION
## Why

ref CON-545

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The discovery scheduler now periodically prunes resolved incidents older than the configured retention period, improving long-term database hygiene.

* **Chores**
  * Added `INCIDENT_RETENTION_DAYS` and `INCIDENT_CLEANUP_INTERVAL_MS` configuration to control how long incidents are kept and how often cleanup runs.

* **Tests**
  * Expanded integration and service tests to confirm pruning behavior, including correct retention filtering, cleanup rate-limiting between runs, and retry behavior after cleanup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->