### PR TITLE
refactor: uses provider incidents to detect dead providers

### DIFF
--- a/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
+++ b/apps/api/src/bid-screening/http-schemas/bid-screening.schema.ts
@@ -96,7 +96,12 @@ export const BidScreeningRequestSchema = z.object({
   timezone: z
     .string()
     .refine(val => SUPPORTED_TIMEZONES.has(val), { message: "Timezone is not supported" })
-    .openapi({ description: "Client timezone, validated against supported Node.js Intl timezones", example: "America/Chicago" })
+    .openapi({ description: "Client timezone, validated against supported Node.js Intl timezones", example: "America/Chicago" }),
+  reclamationWindow: z.number().int().positive().optional().openapi({
+    description:
+      "Optional reclamation window in seconds; if provided, only providers with a reclamationWindow greater than or equal to this value will be considered",
+    example: 3600
+  })
 });
 export type BidScreeningRequest = z.infer<typeof BidScreeningRequestSchema>;
 

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -2745,6 +2745,13 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
             "application/json": {
               "schema": {
                 "properties": {
+                  "reclamationWindow": {
+                    "description": "Optional reclamation window in seconds; if provided, only providers with a reclamationWindow greater than or equal to this value will be considered",
+                    "example": 3600,
+                    "exclusiveMinimum": true,
+                    "minimum": 0,
+                    "type": "integer",
+                  },
                   "requirements": {
                     "default": {},
                     "properties": {

--- a/apps/provider-inventory/docs/adr/0001-streamer-fed-provider-inventory.md
+++ b/apps/provider-inventory/docs/adr/0001-streamer-fed-provider-inventory.md
@@ -99,13 +99,13 @@ Attribute columns (`self_attributes`, `signed_attributes`, `audited_by`) are not
 
 ## Lifecycle scenarios
 
-- **Cold boot.** Streamer starts → `UPDATE provider_inventory SET is_online_since = NULL` (drops every row from the prefilter index) → **online warm-up** fires `streamStatus` connections to every owner with `is_online = true` (cached host_uri) → **discovery loop fires immediately** in parallel (chain queries for providers + attributes) → the discovery tick sees warm-up owners already in the registry and only opens streams for the rest; hostUri-changed owners are `restart`'d, chain-absent owners are `stopAndDelete`'d → first message per provider re-asserts `is_online_since = now()`. Because warm-up's `lifecycle.start` calls reach the stream-connection semaphore before the discovery tick's chain RPC returns, the ~83 reachable providers acquire permits ahead of the ~1877 dead ones from chain — the prefilter index repopulates in seconds rather than minutes. The next discovery tick is scheduled 10 min after the first one finishes, via recursive `setTimeout`.
+- **Cold boot.** streamer doesn't reset online status of providers because for us it's better to have stale response rather than not having it at all → **online warm-up** fires `streamStatus` connections to every owner with `is_online = true` (cached host_uri) → **discovery loop fires immediately** in parallel (chain queries for providers + attributes) → the discovery tick sees warm-up owners already in the registry and only opens streams for the rest; hostUri-changed owners are `restart`'d, chain-absent owners are `stopAndDelete`'d → first message per provider re-asserts `is_online_since = now()`. Because warm-up's `lifecycle.start` calls reach the stream-connection semaphore before the discovery tick's chain RPC returns, the ~83 reachable providers acquire permits ahead of the ~1877 dead ones from chain — the prefilter index repopulates in seconds rather than minutes. The next discovery tick is scheduled 10 min after the first one finishes, via recursive `setTimeout`.
 - **Stream disconnect.** Diff cache for that provider is cleared. Reconnect attempts: t=0, +1s, +2s, +4s (full jitter). After 3rd failure, `is_online = false, is_online_since = NULL`. Continued retries with cap ~5 min until success.
 - **Reconnect after disconnect.** First message is full state — written through unconditionally because the diff cache was cleared. `is_online`/`is_online_since` flip back.
 - **Provider hostUri changes** (`MsgUpdateProvider`). Discovery loop sees diff on next tick (≤10 min), closes old stream, opens new one against the new hostUri.
 - **Provider deleted on chain.** Discovery loop sees the provider absent from the next `Provider/Providers` result, closes stream, deletes row from `provider_inventory`.
 - **Two providers share hostUri.** Discovery loop dedupes by hostUri keeping the latest `createdHeight`. The "loser" has no row in `provider_inventory`; bid-screening cannot route to it.
-- **Worker crash.** Rows persist with `is_online = true, is_online_since = <pre-crash time>` until restart. Cold-boot ritual nulls `is_online_since`, prefilter rejects them, no stale data is served.
+- **Worker crash.** Rows persist with `is_online = true, is_online_since = <pre-crash time>` until restart.
 
 ## Migration plan
 
@@ -141,7 +141,7 @@ Attribute columns (`self_attributes`, `signed_attributes`, `audited_by`) are not
 
 ## Consequences
 
-- The streamer is the **single writer** to `provider_inventory`. Streamer death = up to ~10 s window of stale rows for active deployments. Mitigated by the **`is_online_since` startup ritual**: before opening any streams, the streamer runs `UPDATE provider_inventory SET is_online_since = NULL`, which empties the partial prefilter index until each stream's first message re-asserts liveness.
+- The streamer is the **single writer** to `provider_inventory`. Streamer death = up to ~10 s window of stale rows for active deployments. Staleness is ok for us, since having some results for bid screening is better than not having them at all
 - The prefilter is **intentionally lossy**. The JS bin-packer is the strict check. False positives are acceptable; false negatives are bugs.
 - **HOT updates are preserved.** The only index is partial on `WHERE is_online AND is_online_since IS NOT NULL`. `is_online` flips rarely (only on connect / 3-strike disconnect). High-frequency inventory updates touch no indexed column. `FILLFACTOR = 70` keeps page-local update space available.
 - **TOAST behaviour.** Large per-provider inventories (many nodes + GPUs) push `inventory` JSONB into TOAST. TOAST has its own MVCC and vacuum; updates rewrite the TOAST tuple but do not break HOT in the heap. Acceptable at current scale.

--- a/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
+++ b/apps/provider-inventory/src/http-schemas/bid-screening.schema.ts
@@ -98,7 +98,8 @@ export const BidScreeningRequestSchema = z.object({
     .refine(val => SUPPORTED_TIMEZONES.has(val), { message: "Timezone is not supported" })
     .openapi({ description: "Client timezone, validated against supported Node.js Intl timezones", example: "America/Chicago" }),
   reclamationWindow: z.number().int().positive().optional().openapi({
-    description: "Optional reclamation window in seconds; if provided, only providers with a matching reclamation window will be considered",
+    description:
+      "Optional reclamation window in seconds; if provided, only providers with a reclamationWindow greater than or equal to this value will be considered",
     example: 3600
   })
 });

--- a/apps/provider-inventory/src/providers-sync-app.ts
+++ b/apps/provider-inventory/src/providers-sync-app.ts
@@ -5,8 +5,6 @@ import { Hono } from "hono";
 import { container } from "tsyringe";
 
 import { APP_CONFIG } from "@src/providers/app-config.provider";
-import { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
-import { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
 import { healthzRouter } from "@src/routes";
 import { DiscoverySchedulerService } from "@src/services/discovery-scheduler/discovery-scheduler.service";
 import { HonoErrorHandlerService } from "@src/services/hono-error-handler/hono-error-handler.service";
@@ -22,20 +20,7 @@ export async function bootstrap(): Promise<void> {
 
   const appLogger = createOtelLogger({ context: "PROVIDERS_SYNC" });
   const server = await startServer(app, appLogger, process, {
-    port: container.resolve(APP_CONFIG).PORT,
-    beforeStart: async () => {
-      await Promise.all([
-        // keep new line
-        container
-          .resolve(ProviderInventoryRepository)
-          .resetOnlineSince()
-          .then(() => appLogger.info({ event: "ONLINE_SINCE_RESET" })),
-        container
-          .resolve(ProviderIncidentRepository)
-          .closeAllOpen()
-          .then(() => appLogger.info({ event: "OPEN_INCIDENTS_CLOSED" }))
-      ]);
-    }
+    port: container.resolve(APP_CONFIG).PORT
   });
 
   if (server) {

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.integration.ts
@@ -105,20 +105,52 @@ describe(ProviderIncidentRepository.name, () => {
     });
   });
 
-  describe("closeAllOpen", () => {
-    it("closes every open row and leaves already-closed rows untouched", async () => {
+  describe("getOfflineSince", () => {
+    it("returns the open incident's started_at for a provider with an open incident", async () => {
       const { repository, db } = setup();
-      await repository.openIncident("akash1a");
-      await repository.openIncident("akash1b");
-      await seedClosed(db, { provider: "akash1c", endedAt: new Date("2026-01-01T00:05:00Z") });
+      const startedAt = new Date("2026-01-01T00:00:00Z");
+      await seedIncident(db, { provider: "akash1a", startedAt, endedAt: null });
 
-      await repository.closeAllOpen();
+      const result = await repository.getOfflineSince(["akash1a"]);
 
-      const rows = await db.select().from(providerIncidents);
-      const byProvider = Object.fromEntries(rows.map(r => [r.provider, r.endedAt]));
-      expect(byProvider["akash1a"]).toBeInstanceOf(Date);
-      expect(byProvider["akash1b"]).toBeInstanceOf(Date);
-      expect(byProvider["akash1c"]?.toISOString()).toBe("2026-01-01T00:05:00.000Z");
+      expect(result.get("akash1a")?.toISOString()).toBe(startedAt.toISOString());
+    });
+
+    it("returns the open incident's started_at even when an earlier closed incident exists", async () => {
+      const { repository, db } = setup();
+      const openStartedAt = new Date("2026-02-01T00:00:00Z");
+      await seedClosed(db, { provider: "akash1a", startedAt: new Date("2026-01-01T00:00:00Z"), endedAt: new Date("2026-01-01T00:05:00Z") });
+      await seedIncident(db, { provider: "akash1a", startedAt: openStartedAt, endedAt: null });
+
+      const result = await repository.getOfflineSince(["akash1a"]);
+
+      expect(result.get("akash1a")?.toISOString()).toBe(openStartedAt.toISOString());
+    });
+
+    it("omits providers whose only incident is already closed", async () => {
+      const { repository, db } = setup();
+      await seedClosed(db, { provider: "akash1a", endedAt: new Date("2026-01-01T00:05:00Z") });
+
+      const result = await repository.getOfflineSince(["akash1a"]);
+
+      expect(result.has("akash1a")).toBe(false);
+    });
+
+    it("omits requested providers that have no incident at all", async () => {
+      const { repository, db } = setup();
+      await seedIncident(db, { provider: "akash1a", startedAt: new Date("2026-01-01T00:00:00Z"), endedAt: null });
+
+      const result = await repository.getOfflineSince(["akash1a", "akash1unknown"]);
+
+      expect([...result.keys()]).toEqual(["akash1a"]);
+    });
+
+    it("returns an empty map for an empty list", async () => {
+      const { repository } = setup();
+
+      const result = await repository.getOfflineSince([]);
+
+      expect(result.size).toBe(0);
     });
   });
 

--- a/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-incident/provider-incident.repository.ts
@@ -88,12 +88,20 @@ export class ProviderIncidentRepository {
       .where(and(where, isNull(providerIncidents.endedAt)));
   }
 
-  async closeAllOpen(): Promise<void> {
-    await this.driver
+  async getOfflineSince(providers: string[]): Promise<Map<string, Date>> {
+    if (providers.length === 0) return new Map();
+
+    const rows = await this.driver
       .getDb()
-      .update(providerIncidents)
-      .set({ endedAt: sql`now()` })
-      .where(isNull(providerIncidents.endedAt));
+      .select({ provider: providerIncidents.provider, startedAt: providerIncidents.startedAt })
+      .from(providerIncidents)
+      .where(and(inArray(providerIncidents.provider, providers), isNull(providerIncidents.endedAt)));
+
+    const result = new Map<string, Date>();
+    for (const row of rows) {
+      result.set(row.provider, row.startedAt);
+    }
+    return result;
   }
 
   async deleteEndedBefore(retentionDays: number): Promise<number> {

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.integration.ts
@@ -279,11 +279,10 @@ describe(ProviderInventoryRepository.name, () => {
       expect(row.updatedAt.toISOString()).toBe(updatedAt.toISOString());
     });
 
-    it("re-stamps isOnlineSince for a provider left online by the boot-time resetOnlineSince ritual", async () => {
+    it("re-stamps isOnlineSince for a provider that is online but has a null isOnlineSince", async () => {
       const { repository, db } = setup();
-      await seed(db, { owner: "akash1a", isOnline: true, isOnlineSince: new Date("2026-01-01T00:00:00Z") });
+      await seed(db, { owner: "akash1a", isOnline: true, isOnlineSince: null });
 
-      await repository.resetOnlineSince();
       await repository.markAsOnline("akash1a");
 
       const [row] = await db.select().from(providerInventory).where(eq(providerInventory.owner, "akash1a"));
@@ -363,47 +362,6 @@ describe(ProviderInventoryRepository.name, () => {
         .orderBy(providerInventory.owner);
       expect(rowA.isOnline).toBe(false);
       expect(rowB.isOnline).toBe(true);
-    });
-  });
-
-  describe("getInventoryLastUpdatedPerOfflineProvider", () => {
-    it("returns the updatedAt timestamp for each offline provider in the list", async () => {
-      const { repository, db } = setup();
-      const updatedAt = new Date("2026-01-01T00:00:00Z");
-      await seed(db, { owner: "akash1a", isOnline: false, isOnlineSince: null, updatedAt });
-
-      const result = await repository.getInventoryLastUpdatedPerOfflineProvider(["akash1a"]);
-
-      expect(result.get("akash1a")?.toISOString()).toBe(updatedAt.toISOString());
-    });
-
-    it("excludes providers that are currently online", async () => {
-      const { repository, db } = setup();
-      await seed(db, { owner: "akash1online", isOnline: true, isOnlineSince: new Date() });
-      await seed(db, { owner: "akash1offline", isOnline: false, isOnlineSince: null });
-
-      const result = await repository.getInventoryLastUpdatedPerOfflineProvider(["akash1online", "akash1offline"]);
-
-      expect(result.has("akash1online")).toBe(false);
-      expect(result.has("akash1offline")).toBe(true);
-    });
-
-    it("excludes owners that are not in the requested list", async () => {
-      const { repository, db } = setup();
-      await seed(db, { owner: "akash1a", isOnline: false, isOnlineSince: null });
-      await seed(db, { owner: "akash1b", isOnline: false, isOnlineSince: null });
-
-      const result = await repository.getInventoryLastUpdatedPerOfflineProvider(["akash1a"]);
-
-      expect([...result.keys()]).toEqual(["akash1a"]);
-    });
-
-    it("returns an empty map for an empty list", async () => {
-      const { repository } = setup();
-
-      const result = await repository.getInventoryLastUpdatedPerOfflineProvider([]);
-
-      expect(result.size).toBe(0);
     });
   });
 

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
@@ -21,10 +21,6 @@ export class ProviderInventoryRepository {
     this.#driver = dbDriver;
   }
 
-  async resetOnlineSince(): Promise<void> {
-    await this.#driver.getDb().update(providerInventory).set({ isOnlineSince: null });
-  }
-
   async *streamOnlineProviders(options?: { batchSize?: number }): AsyncGenerator<Pick<ProviderInventory, "owner" | "hostUri">> {
     const batchSize = options?.batchSize ?? DEFAULT_ONLINE_STREAM_BATCH_SIZE;
     const baseQuery = this.#driver
@@ -107,8 +103,8 @@ export class ProviderInventoryRepository {
       .where(eq(providerInventory.owner, provider.owner));
   }
 
-  async bulkUpsertProviders(providers: ChainProvider[]): Promise<void> {
-    if (providers.length === 0) return;
+  async bulkUpsertProviders(providers: ChainProvider[]): Promise<Pick<ProviderInventory, "owner">[]> {
+    if (providers.length === 0) return [];
 
     const NOW_SQL = rawSql`now()`;
     const rows = providers.map(provider => {
@@ -128,7 +124,7 @@ export class ProviderInventoryRepository {
       rawSql` OR `
     );
 
-    await this.#driver
+    return this.#driver
       .getDb()
       .insert(providerInventory)
       .values(rows)
@@ -142,23 +138,7 @@ export class ProviderInventoryRepository {
           updatedAt: NOW_SQL
         },
         setWhere: hasChanges
-      });
-  }
-
-  async getInventoryLastUpdatedPerOfflineProvider(providers: string[]): Promise<Map<string, Date | null>> {
-    if (providers.length === 0) return new Map();
-    const db = this.#driver.getDb();
-    const rows = await db
-      .select({
-        owner: providerInventory.owner,
-        updatedAt: providerInventory.updatedAt
       })
-      .from(providerInventory)
-      .where(and(inArray(providerInventory.owner, providers), eq(providerInventory.isOnline, false)));
-    const result = new Map<string, Date | null>();
-    for (const row of rows) {
-      result.set(row.owner, new Date(row.updatedAt));
-    }
-    return result;
+      .returning({ owner: providerInventory.owner });
   }
 }

--- a/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.spec.ts
+++ b/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.spec.ts
@@ -77,23 +77,23 @@ describe(DiscoverySchedulerService.name, () => {
 
     expect(lifecycle.getRegistry).toHaveBeenCalled();
     expect(writer.bulkUpsertProviders).toHaveBeenCalledWith([fresh]);
-    expect(lifecycle.start).toHaveBeenCalledWith({ ...fresh, lastUpdated: null }, expect.any(AbortSignal));
+    expect(lifecycle.start).toHaveBeenCalledWith({ ...fresh, offlineSince: null }, expect.any(AbortSignal));
   });
 
-  it("forwards the offline provider's last-updated timestamp to lifecycle.start", async () => {
+  it("forwards the provider's offline-since timestamp to lifecycle.start", async () => {
     const offline = createProvider({ owner: "offline", hostUri: "https://offline:8443" });
-    const lastUpdated = new Date(Date.now() - 60_000);
-    const { lifecycle } = setup({ providers: [offline], lastUpdated: new Map([[offline.owner, lastUpdated]]) });
+    const offlineSince = new Date(Date.now() - 60_000);
+    const { lifecycle } = setup({ providers: [offline], offlineSince: new Map([[offline.owner, offlineSince]]) });
 
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(lifecycle.start).toHaveBeenCalledWith({ ...offline, lastUpdated }, expect.any(AbortSignal));
+    expect(lifecycle.start).toHaveBeenCalledWith({ ...offline, offlineSince }, expect.any(AbortSignal));
   });
 
-  it("skips a provider whose inventory has not been updated past the dead-provider threshold", async () => {
+  it("skips a provider whose open incident is older than the dead-provider threshold", async () => {
     const dead = createProvider({ owner: "dead", hostUri: "https://dead:8443" });
-    const lastUpdated = new Date(Date.now() - DEAD_PROVIDER_UPDATED_THRESHOLD_MS - 1_000);
-    const { lifecycle, logger } = setup({ providers: [dead], lastUpdated: new Map([[dead.owner, lastUpdated]]) });
+    const offlineSince = new Date(Date.now() - DEAD_PROVIDER_UPDATED_THRESHOLD_MS - 1_000);
+    const { lifecycle, logger } = setup({ providers: [dead], offlineSince: new Map([[dead.owner, offlineSince]]) });
 
     await vi.advanceTimersByTimeAsync(0);
 
@@ -101,18 +101,42 @@ describe(DiscoverySchedulerService.name, () => {
     expect(logger.debug).toHaveBeenCalledWith(expect.objectContaining({ event: "DISCOVERY_SKIP_PROVIDER", owner: "dead" }));
   });
 
-  it("forwards the last-updated timestamp to lifecycle.restart when an observed provider changes hostUri", async () => {
+  it("retries a dead provider instead of skipping it when its on-chain record changed this tick", async () => {
+    const dead = createProvider({ owner: "dead", hostUri: "https://dead:8443" });
+    const offlineSince = new Date(Date.now() - DEAD_PROVIDER_UPDATED_THRESHOLD_MS - 1_000);
+    const { writer, lifecycle, logger } = setup({ providers: [dead], offlineSince: new Map([[dead.owner, offlineSince]]) });
+    writer.bulkUpsertProviders.mockResolvedValue([{ owner: dead.owner }]);
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(lifecycle.start).toHaveBeenCalledWith({ ...dead, offlineSince }, expect.any(AbortSignal));
+    expect(logger.debug).not.toHaveBeenCalledWith(expect.objectContaining({ event: "DISCOVERY_SKIP_PROVIDER" }));
+  });
+
+  it("starts a provider that has no open incident instead of flagging it dead", async () => {
+    // dead detection keys off open incidents only — a provider with no open incident is never skipped,
+    // regardless of how stale its inventory row is
+    const provider = createProvider({ owner: "healthy", hostUri: "https://healthy:8443" });
+    const { lifecycle, logger } = setup({ providers: [provider], offlineSince: new Map() });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(lifecycle.start).toHaveBeenCalledWith({ ...provider, offlineSince: null }, expect.any(AbortSignal));
+    expect(logger.debug).not.toHaveBeenCalledWith(expect.objectContaining({ event: "DISCOVERY_SKIP_PROVIDER" }));
+  });
+
+  it("forwards the offline-since timestamp to lifecycle.restart when an observed provider changes hostUri", async () => {
     const updated = createProvider({ owner: "moving", hostUri: "https://new:8443" });
-    const lastUpdated = new Date(Date.now() - 60_000);
+    const offlineSince = new Date(Date.now() - 60_000);
     const { lifecycle } = setup({
       providers: [updated],
       watched: new Map([["moving", { hostUri: "https://old:8443" }]]),
-      lastUpdated: new Map([[updated.owner, lastUpdated]])
+      offlineSince: new Map([[updated.owner, offlineSince]])
     });
 
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(lifecycle.restart).toHaveBeenCalledWith({ ...updated, lastUpdated }, expect.any(AbortSignal));
+    expect(lifecycle.restart).toHaveBeenCalledWith({ ...updated, offlineSince }, expect.any(AbortSignal));
   });
 
   it("continues after a poll error and re-arms the next tick", async () => {
@@ -281,7 +305,7 @@ describe(DiscoverySchedulerService.name, () => {
     onlineOwners?: Pick<ProviderInventory, "owner" | "hostUri">[];
     autoStart?: boolean;
     watched?: Map<string, { hostUri: string }>;
-    lastUpdated?: Map<string, Date>;
+    offlineSince?: Map<string, Date>;
   }) {
     const poller = mock<ChainProviderPollerService>();
     const writer = mock<ProviderInventoryRepository>();
@@ -290,8 +314,8 @@ describe(DiscoverySchedulerService.name, () => {
     lifecycle.getRegistry.mockReturnValue(input?.watched ?? new Map());
     lifecycle.stopAndDelete.mockResolvedValue();
     lifecycle.waitForPendingConnections.mockResolvedValue();
-    writer.bulkUpsertProviders.mockResolvedValue();
-    writer.getInventoryLastUpdatedPerOfflineProvider.mockResolvedValue(input?.lastUpdated ?? new Map());
+    writer.bulkUpsertProviders.mockResolvedValue([]);
+    incidentRepository.getOfflineSince.mockResolvedValue(input?.offlineSince ?? new Map());
     incidentRepository.deleteEndedBefore.mockResolvedValue(0);
 
     const onlineOwners = input?.onlineOwners ?? [];

--- a/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
+++ b/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
@@ -52,7 +52,7 @@ export class DiscoverySchedulerService {
           selfAttributes: EMPTY_ARRAY,
           signedAttributes: EMPTY_ARRAY,
           auditedBy: EMPTY_ARRAY,
-          lastUpdated: null
+          offlineSince: null
         },
         signal
       );
@@ -105,28 +105,36 @@ export class DiscoverySchedulerService {
 
         // important to upsert before starting new stream,
         // otherwise stream will have nothing to update in the db
-        const [isUpsertedBatch, lastUpdatedPerProvider] = await Promise.all([
+        const [updatedProviders, offlineSincePerProvider] = await Promise.all([
           this.#upsertProviders(providers),
-          this.#repository.getInventoryLastUpdatedPerOfflineProvider(providers.map(p => p.owner))
+          this.#incidentRepository.getOfflineSince(providers.map(p => p.owner))
         ]);
         for (const provider of providers) {
           totalProviders++;
           const observedProvider = watchedProviders.get(provider.owner);
-          const lastUpdated = lastUpdatedPerProvider.get(provider.owner);
+          const offlineSince = offlineSincePerProvider.get(provider.owner);
 
-          if (lastUpdated && Date.now() - lastUpdated.getTime() >= this.#config.DEAD_PROVIDER_UPDATED_THRESHOLD_MS) {
-            this.#logger.debug({ event: "DISCOVERY_SKIP_PROVIDER", owner: provider.owner, reason: "provider inventory has not been updated for a long time" });
+          if (
+            !updatedProviders?.has(provider.owner) &&
+            offlineSince &&
+            Date.now() - offlineSince.getTime() >= this.#config.DEAD_PROVIDER_UPDATED_THRESHOLD_MS
+          ) {
+            this.#logger.debug({
+              event: "DISCOVERY_SKIP_PROVIDER",
+              owner: provider.owner,
+              reason: "provider has an open incident older than the dead-provider threshold"
+            });
             deadProvidersCount++;
             continue;
           }
 
           if (!observedProvider) {
-            if (isUpsertedBatch) {
-              this.#lifecycle.start({ ...provider, lastUpdated: lastUpdated ?? null }, signal);
+            if (updatedProviders) {
+              this.#lifecycle.start({ ...provider, offlineSince: offlineSince ?? null }, signal);
               startedProvidersCount++;
             }
           } else if (observedProvider.hostUri !== provider.hostUri) {
-            this.#lifecycle.restart({ ...provider, lastUpdated: lastUpdated ?? null }, signal);
+            this.#lifecycle.restart({ ...provider, offlineSince: offlineSince ?? null }, signal);
             restartedProvidersCount++;
           }
 
@@ -201,15 +209,15 @@ export class DiscoverySchedulerService {
     }
   }
 
-  async #upsertProviders(providers: ChainProvider[]): Promise<boolean> {
+  async #upsertProviders(providers: ChainProvider[]) {
     const owners = providers.map(p => p.owner);
     try {
-      await this.#repository.bulkUpsertProviders(providers);
+      const updatedProviders = await this.#repository.bulkUpsertProviders(providers);
       this.#logger.debug({ event: "UPSERT_PROVIDERS_UPSERTED", owners });
-      return true;
+      return new Set(updatedProviders?.map(p => p.owner) ?? []);
     } catch (error) {
       this.#logger.error({ event: "UPSERT_PROVIDERS_ERROR", owners, error });
-      return false;
+      return null;
     }
   }
 }

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
@@ -8,7 +8,7 @@ import type { LoggerFactory } from "@src/providers/logger-factory.provider";
 import type { DbDriver } from "@src/repositories/db-driver/db-driver";
 import type { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import type { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
-import type { ChainProvider, ChainProviderWithLastUpdated } from "@src/types/chain-provider";
+import type { ChainProvider, ChainProviderWithOfflineSince } from "@src/types/chain-provider";
 import type { ClusterState, NodeState } from "@src/types/inventory";
 import type { ProviderStreamFactory } from "../provider-stream-factory/provider-stream-factory.sevice";
 import { StreamLifecycleManagerService } from "./stream-lifecycle-manager.service";
@@ -386,7 +386,7 @@ describe(StreamLifecycleManagerService.name, () => {
       streamFactory.disposeProvider.mockResolvedValue();
       streamFactory.openStatusStream.mockImplementation(() => throwingStream(new Error("connection lost")));
       const { manager, incidents, logger } = setup({ streamFactory });
-      const longDead = createProvider({ lastUpdated: new Date(Date.now() - 10_000) });
+      const longDead = createProvider({ offlineSince: new Date(Date.now() - 10_000) });
 
       manager.start(longDead);
 
@@ -404,7 +404,7 @@ describe(StreamLifecycleManagerService.name, () => {
       const { manager, logger } = setup({ streamFactory });
       const countReconnects = () => logger.warn.mock.calls.filter(([arg]) => (arg as { event?: string })?.event === "STREAM_RECONNECTING").length;
 
-      manager.start(createProvider({ lastUpdated: new Date(Date.now() - 10_000) }));
+      manager.start(createProvider({ offlineSince: new Date(Date.now() - 10_000) }));
 
       await vi.waitFor(() => expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_GAVE_UP" })), { timeout: 5000 });
       expect(countReconnects()).toBe(1);
@@ -416,7 +416,7 @@ describe(StreamLifecycleManagerService.name, () => {
       streamFactory.openStatusStream.mockImplementation(() => throwingStream(new Error("connection lost")));
       const { manager, logger } = setup({ streamFactory });
 
-      manager.start(createProvider({ lastUpdated: new Date(Date.now() - 100) }));
+      manager.start(createProvider({ offlineSince: new Date(Date.now() - 100) }));
 
       await vi.waitFor(() => expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_GAVE_UP" })), { timeout: 5000 });
       expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(6);
@@ -433,7 +433,7 @@ describe(StreamLifecycleManagerService.name, () => {
       });
       const { manager, writer } = setup({ streamFactory });
 
-      manager.start(createProvider({ lastUpdated: new Date(Date.now() - 10_000) }));
+      manager.start(createProvider({ offlineSince: new Date(Date.now() - 10_000) }));
 
       await vi.waitFor(() => expect(writer.updateInventory).toHaveBeenCalledTimes(1), { timeout: 5000 });
     });
@@ -578,14 +578,14 @@ describe(StreamLifecycleManagerService.name, () => {
   }
 });
 
-function createProvider(overrides?: Partial<ChainProviderWithLastUpdated>): ChainProviderWithLastUpdated {
+function createProvider(overrides?: Partial<ChainProviderWithOfflineSince>): ChainProviderWithOfflineSince {
   return {
     owner: "akash1owner",
     hostUri: "https://p1:8443",
     selfAttributes: [],
     signedAttributes: [],
     auditedBy: [],
-    lastUpdated: null,
+    offlineSince: null,
     ...overrides
   };
 }

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -16,7 +16,7 @@ import { LOGGER_FACTORY } from "@src/providers/logger-factory.provider";
 import { DbDriver } from "@src/repositories/db-driver/db-driver";
 import { ProviderIncidentRepository } from "@src/repositories/provider-incident/provider-incident.repository";
 import { ProviderInventoryRepository } from "@src/repositories/provider-inventory/provider-inventory.repository";
-import type { ChainProviderWithLastUpdated } from "@src/types/chain-provider";
+import type { ChainProviderWithOfflineSince } from "@src/types/chain-provider";
 import type { ClusterState } from "@src/types/inventory";
 import { ProviderStreamFactory } from "../provider-stream-factory/provider-stream-factory.sevice";
 
@@ -92,7 +92,7 @@ export class StreamLifecycleManagerService {
     return this.#activeStreams;
   }
 
-  start(provider: ChainProviderWithLastUpdated, signal?: AbortSignal): void {
+  start(provider: ChainProviderWithOfflineSince, signal?: AbortSignal): void {
     if (signal?.aborted) {
       this.#logger.warn({ event: "STREAM_START_ABORTED", owner: provider.owner, reason: "Received already aborted signal" });
       return;
@@ -113,7 +113,7 @@ export class StreamLifecycleManagerService {
     void this.#runStream(provider, controller.signal, firstAttempt.resolve).finally(() => signal?.removeEventListener("abort", abortProviderStream));
   }
 
-  restart(provider: ChainProviderWithLastUpdated, signal?: AbortSignal): void {
+  restart(provider: ChainProviderWithOfflineSince, signal?: AbortSignal): void {
     const previousHostUri = this.#activeStreams.get(provider.owner)?.hostUri;
     this.#abortIfActive(provider.owner, "STREAM_STOPPED_HOSTURI_CHANGE");
     if (previousHostUri && previousHostUri !== provider.hostUri) {
@@ -148,11 +148,11 @@ export class StreamLifecycleManagerService {
     this.#logger.info({ event, owner });
   }
 
-  async #runStream(provider: ChainProviderWithLastUpdated, signal: AbortSignal, onFirstAttemptSettled: () => void): Promise<void> {
+  async #runStream(provider: ChainProviderWithOfflineSince, signal: AbortSignal, onFirstAttemptSettled: () => void): Promise<void> {
     const onSettleAttempt = once(onFirstAttemptSettled);
     try {
       const isPotentiallyDeadProvider =
-        provider.lastUpdated && Date.now() - provider.lastUpdated.getTime() > this.#config.DEAD_PROVIDER_UPDATED_THRESHOLD_MS / 2;
+        provider.offlineSince && Date.now() - provider.offlineSince.getTime() > this.#config.DEAD_PROVIDER_UPDATED_THRESHOLD_MS / 2;
       const retryPolicy = isPotentiallyDeadProvider ? this.#potentiallyDeadProviderRetryStreamPolicy : this.#healthyProviderRetryStreamPolicy;
       await retryPolicy.execute(ctx => {
         if (signal.aborted) return;
@@ -189,7 +189,7 @@ export class StreamLifecycleManagerService {
     }
   }
 
-  async #runAttempt(provider: ChainProviderWithLastUpdated, outerSignal: AbortSignal, onAttemptSettled: () => void): Promise<void> {
+  async #runAttempt(provider: ChainProviderWithOfflineSince, outerSignal: AbortSignal, onAttemptSettled: () => void): Promise<void> {
     if (outerSignal.aborted) return;
 
     this.#lastInventoryPerProvider.delete(provider.owner);
@@ -237,7 +237,7 @@ export class StreamLifecycleManagerService {
     }
   }
 
-  async #updateProviderInventory(provider: ChainProviderWithLastUpdated, cluster: ClusterState): Promise<void> {
+  async #updateProviderInventory(provider: ChainProviderWithOfflineSince, cluster: ClusterState): Promise<void> {
     const cached = this.#lastInventoryPerProvider.get(provider.owner);
 
     if (!this.#onlineStatePerProvider.get(provider.owner)) {

--- a/apps/provider-inventory/src/types/chain-provider.ts
+++ b/apps/provider-inventory/src/types/chain-provider.ts
@@ -17,6 +17,6 @@ export interface ChainProvider {
   auditedBy: string[];
 }
 
-export interface ChainProviderWithLastUpdated extends ChainProvider {
-  lastUpdated: Date | null;
+export interface ChainProviderWithOfflineSince extends ChainProvider {
+  offlineSince: Date | null;
 }


### PR DESCRIPTION
## Why

ref CON-547


## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `reclamationWindow` (positive integer, seconds) to bid screening requests.
* **Bug Fixes**
  * Improved provider offline detection and stream start/restart retry behavior by deriving “offline since” from open incidents instead of inventory last-updated timing.
* **Refactor**
  * Simplified server startup by removing extra initialization side effects.
  * Updated internal lifecycle flow to consistently use the new offline-since timestamp.
* **Documentation**
  * Updated cold boot lifecycle guidance in the relevant ADR.
* **Tests**
  * Refreshed and expanded coverage for offline-since behavior (including new repository integration tests).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->