### PR TITLE
fix: ensure reclamation window is taken into account durin cache comparison

### DIFF
--- a/apps/provider-inventory/src/domain/is-equal-cluster-state/is-equal-cluster-state.spec.ts
+++ b/apps/provider-inventory/src/domain/is-equal-cluster-state/is-equal-cluster-state.spec.ts
@@ -19,11 +19,15 @@ describe(isEqualClusterState.name, () => {
     it("considers two structurally identical fully-populated rows equal", () => {
       const a = buildCluster({
         nodes: [buildNode({ name: "node-1" }), buildNode({ name: "node-2" })],
-        storage: storageMap([{ class: "beta2", allocatable: 100n }])
+        storage: storageMap([{ class: "beta2", allocatable: 100n }]),
+        leasedIp: { allocatable: 10n, allocated: 2n },
+        reclamationWindow: 60
       });
       const b = buildCluster({
         nodes: [buildNode({ name: "node-1" }), buildNode({ name: "node-2" })],
-        storage: storageMap([{ class: "beta2", allocatable: 100n }])
+        storage: storageMap([{ class: "beta2", allocatable: 100n }]),
+        leasedIp: { allocatable: 10n, allocated: 2n },
+        reclamationWindow: 60
       });
 
       expect(isEqualClusterState(a, b)).toBe(true);
@@ -96,6 +100,30 @@ describe(isEqualClusterState.name, () => {
       const b = buildCluster({ nodes: [buildNode({ name: "node-1" }), buildNode({ name: "node-2" })] });
       expect(isEqualClusterState(a, b)).toBe(false);
     });
+
+    it("returns false when leasedIp allocatable differs", () => {
+      const a = buildCluster({ leasedIp: { allocatable: 10n, allocated: 0n } });
+      const b = buildCluster({ leasedIp: { allocatable: 20n, allocated: 0n } });
+      expect(isEqualClusterState(a, b)).toBe(false);
+    });
+
+    it("returns false when leasedIp allocated differs", () => {
+      const a = buildCluster({ leasedIp: { allocatable: 10n, allocated: 0n } });
+      const b = buildCluster({ leasedIp: { allocatable: 10n, allocated: 5n } });
+      expect(isEqualClusterState(a, b)).toBe(false);
+    });
+
+    it("returns false when reclamationWindow differs", () => {
+      const a = buildCluster({ reclamationWindow: 60 });
+      const b = buildCluster({ reclamationWindow: 120 });
+      expect(isEqualClusterState(a, b)).toBe(false);
+    });
+
+    it("returns false when reclamationWindow is set on only one side", () => {
+      const a = buildCluster({ reclamationWindow: 60 });
+      const b = buildCluster();
+      expect(isEqualClusterState(a, b)).toBe(false);
+    });
   });
 
   describe("order-insensitive comparison", () => {
@@ -132,7 +160,9 @@ function storageMap(pools: { class: string; allocatable: bigint; allocated?: big
 function buildCluster(overrides: Partial<ClusterState> = {}) {
   const cluster: ClusterState = {
     nodes: overrides.nodes ?? [],
-    storage: overrides.storage ?? Object.create(null)
+    storage: overrides.storage ?? Object.create(null),
+    leasedIp: overrides.leasedIp,
+    reclamationWindow: overrides.reclamationWindow
   };
   return cluster;
 }

--- a/apps/provider-inventory/src/domain/is-equal-cluster-state/is-equal-cluster-state.ts
+++ b/apps/provider-inventory/src/domain/is-equal-cluster-state/is-equal-cluster-state.ts
@@ -4,7 +4,12 @@ const EMPTY_PAIR: RawPair = { allocatable: 0n, allocated: 0n };
 
 export function isEqualClusterState(a: ClusterState, b: ClusterState): boolean {
   if (a === b) return true;
-  return clusterStorageEqual(a.storage, b.storage) && nodesEqual(a.nodes, b.nodes) && pairEqual(a.leasedIp ?? EMPTY_PAIR, b.leasedIp ?? EMPTY_PAIR);
+  return (
+    a.reclamationWindow === b.reclamationWindow &&
+    clusterStorageEqual(a.storage, b.storage) &&
+    nodesEqual(a.nodes, b.nodes) &&
+    pairEqual(a.leasedIp ?? EMPTY_PAIR, b.leasedIp ?? EMPTY_PAIR)
+  );
 }
 
 function nodesEqual(a: readonly NodeState[] | undefined, b: readonly NodeState[] | undefined): boolean {


### PR DESCRIPTION
## Why

ref CON-549

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for cluster state comparisons, including additional validation scenarios for cluster-level attributes.

* **Refactor**
  * Improved code readability in cluster state equality comparison logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->