### PR TITLE
feat(deployment): support confidential compute in managed-wallet deployments

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -241,6 +241,82 @@ deployment:
       count: 1
 `;
 
+const SDL_WITH_TEE = (tee: string) => `
+version: "2.0"
+services:
+  web:
+    image: nginx
+    params:
+      tee: ${tee}
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 1Gi
+  placement:
+    westcoast:
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1
+`;
+
+const SDL_WITH_TEE_AND_GPU = (tee: string) => `
+version: "2.0"
+services:
+  web:
+    image: nginx
+    params:
+      tee: ${tee}
+    expose:
+      - port: 80
+        as: 80
+        to:
+          - global: true
+profiles:
+  compute:
+    web:
+      resources:
+        cpu:
+          units: 0.5
+        memory:
+          size: 512Mi
+        storage:
+          size: 1Gi
+        gpu:
+          units: 1
+          attributes:
+            vendor:
+              nvidia:
+                - model: h100
+  placement:
+    westcoast:
+      pricing:
+        web:
+          denom: uakt
+          amount: 1000
+deployment:
+  web:
+    westcoast:
+      profile: web
+      count: 1
+`;
+
 describe(SdlService.name, () => {
   describe("generateManifest", () => {
     it("parses SDL containing template variables without throwing", () => {
@@ -359,6 +435,38 @@ describe(SdlService.name, () => {
 
       expect(result.ok).toBe(true);
     });
+
+    describe("confidential compute (tee)", () => {
+      it("projects a cpu tee selection into the manifest sent to the provider", () => {
+        const { result } = setup({ sdl: SDL_WITH_TEE("cpu") });
+
+        expect(result.ok).toBe(true);
+        expect(getManifestService(result, "westcoast", "web").params?.tee).toEqual({ type: "cpu", attestation: true });
+      });
+
+      it("projects a cpu-gpu tee selection into the manifest when gpu resources are present", () => {
+        const { result } = setup({ sdl: SDL_WITH_TEE_AND_GPU("cpu-gpu") });
+
+        expect(result.ok).toBe(true);
+        expect(getManifestService(result, "westcoast", "web").params?.tee).toEqual({ type: "cpu-gpu", attestation: true });
+      });
+
+      it("rejects a cpu-gpu tee selection without gpu resources", () => {
+        const { result } = setup({ sdl: SDL_WITH_TEE("cpu-gpu") });
+
+        expect(result).toMatchObject({
+          ok: false,
+          value: [expect.objectContaining({ message: expect.stringContaining("tee type requires gpu") })]
+        });
+      });
+
+      it("leaves manifest service params untouched when no tee is selected", () => {
+        const { result } = setup({ sdl: VALID_SDL });
+
+        expect(result.ok).toBe(true);
+        expect(getManifestService(result, "westcoast", "web").params?.tee).toBeUndefined();
+      });
+    });
   });
 
   function setup(input?: { sdl?: string; allowedAuditors?: string[]; deploymentGrantDenom?: string; blockedGpuModels?: string[]; isTrialing?: boolean }) {
@@ -390,5 +498,14 @@ describe(SdlService.name, () => {
 
   function getPrice(result: ReturnType<SdlService["generateManifest"]>, placementName: string) {
     return getGroupSpec(result, placementName).resources[0].price!;
+  }
+
+  function getManifestService(result: ReturnType<SdlService["generateManifest"]>, groupName: string, serviceName: string) {
+    if (!result.ok) throw new Error("Expected ok result");
+    const group = result.value.groups.find(g => g.name === groupName);
+    if (!group) throw new Error(`Manifest group "${groupName}" not found`);
+    const service = group.services.find(s => s.name === serviceName);
+    if (!service) throw new Error(`Manifest service "${serviceName}" not found`);
+    return service;
   }
 });

--- a/apps/deploy-web/package.json
+++ b/apps/deploy-web/package.json
@@ -26,7 +26,7 @@
     "type-check": "tsc"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
     "@akashnetwork/console-api-types": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
     "@akashnetwork/database": "*",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/notifications/package.json
+++ b/apps/notifications/package.json
@@ -36,7 +36,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -24,7 +24,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/provider-proxy/package.json
+++ b/apps/provider-proxy/package.json
@@ -20,7 +20,7 @@
     "test:unit": "vitest run --project unit"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/instrumentation": "*",
     "@akashnetwork/logging": "*",

--- a/apps/stats-web/package.json
+++ b/apps/stats-web/package.json
@@ -14,7 +14,7 @@
     "test:unit": "NODE_ENV=test vitest run"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/logging": "*",
     "@akashnetwork/network-store": "*",

--- a/apps/tx-signer/package.json
+++ b/apps/tx-signer/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@akashnetwork/akash-api": "1.4.3",
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
     "@akashnetwork/env-loader": "*",
     "@akashnetwork/http-sdk": "*",
     "@akashnetwork/instrumentation": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
@@ -527,7 +527,7 @@
       "version": "3.31.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
         "@akashnetwork/console-api-types": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
@@ -2146,7 +2146,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
         "@akashnetwork/database": "*",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
@@ -2524,7 +2524,7 @@
       "version": "2.16.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -3669,7 +3669,7 @@
       "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4009,7 +4009,7 @@
       "version": "2.10.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/instrumentation": "*",
         "@akashnetwork/logging": "*",
@@ -4186,7 +4186,7 @@
       "name": "@akashnetwork/stats-web",
       "version": "1.14.1",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/logging": "*",
         "@akashnetwork/network-store": "*",
@@ -4951,7 +4951,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@akashnetwork/akash-api": "1.4.3",
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
         "@akashnetwork/env-loader": "*",
         "@akashnetwork/http-sdk": "*",
         "@akashnetwork/instrumentation": "*",
@@ -5178,9 +5178,9 @@
       }
     },
     "node_modules/@akashnetwork/chain-sdk": {
-      "version": "1.0.0-alpha.35",
-      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.35.tgz",
-      "integrity": "sha512-Fm/N1g/vV0VAc7U4d8jFQe5CcsWk83QdFwKW9SMOcQQYTpyLyiXOaBxj4oK1L0zzjtcU0b11MPa5TGrnCdtDhA==",
+      "version": "1.0.0-alpha.36",
+      "resolved": "https://registry.npmjs.org/@akashnetwork/chain-sdk/-/chain-sdk-1.0.0-alpha.36.tgz",
+      "integrity": "sha512-C616Lc4idYMXUMPQXcSxOuer8Tt9F3J7XC9DOBU5p+RUqyPxu4rMkAYBYNyyj8NBOqneuNGi1NV2cUIaCFATDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
@@ -45087,7 +45087,7 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+        "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
         "@akashnetwork/net": "*",
         "jotai": "^2.9.2"
       }

--- a/packages/network-store/package.json
+++ b/packages/network-store/package.json
@@ -18,7 +18,7 @@
     "validate:types": "tsc --noEmit && echo"
   },
   "dependencies": {
-    "@akashnetwork/chain-sdk": "1.0.0-alpha.35",
+    "@akashnetwork/chain-sdk": "1.0.0-alpha.36",
     "@akashnetwork/net": "*",
     "jotai": "^2.9.2"
   }


### PR DESCRIPTION
## Why

Adopts the TEE-capable `@akashnetwork/chain-sdk` (bumped `1.0.0-alpha.35` to `1.0.0-alpha.36`, the release published from CON-551) so a managed-wallet tenant's Confidential Compute selection actually reaches the provider. Until now the API ran against an SDK with no notion of `tee`, so a `params.tee` selection would be silently dropped before it ever reached a provider.

Closes CON-463

## What

- Bumps `@akashnetwork/chain-sdk` to `1.0.0-alpha.36` across all 9 consuming workspaces; lockfile updated surgically (chain-sdk only, no unrelated churn).
- No functional code change needed: `SdlService.generateManifest` already forwards the parsed SDL untouched to the SDK, so `params.tee` now projects into the generated manifest as `{ type, attestation: true }`. That manifest is exactly what `ProviderService.sendManifest` serializes and sends to the provider.
- Adds tests in `sdl.service.spec.ts` proving:
  - `cpu` and `cpu-gpu` (with GPU resources) selections are projected into the manifest
  - `cpu-gpu` without GPU resources is rejected (AEP-83 rule)
  - deployments with no Confidential Compute selection are unchanged

### Notes for reviewers
- alpha.36 is purely additive (new optional `tee` field, new `TEEParams` type); runtime dependencies are identical to alpha.35, so the bump is non-breaking.
- alpha.36 was published within the repo's 7-day `min-release-age` window, so the lockfile was pinned without a full `npm install` re-resolve (which would have pulled an unrelated `@types/react-dom` drift). `npm ci` installs it from the lockfile fine, so CI is unaffected.
- Verified: full api unit suite (980 tests) green; api/packages/provider-proxy/notifications/indexer production typechecks clean; deploy-web production code typechecks clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test suite with comprehensive coverage for confidential compute (trusted execution environment) configurations, including GPU resource validation and error handling scenarios.

* **Chores**
  * Updated chain SDK dependency to the latest alpha version across all platform applications and packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->