### PR TITLE
feat(sdl): preserve TEE param through builder round-trip

### DIFF
--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -419,9 +419,13 @@ export const ServiceSchema = z
     sshPubKey: z.string().optional(),
     params: z
       .object({
-        permissions: z.object({
-          read: z.array(z.enum(["deployment", "logs", "events"]))
-        })
+        permissions: z
+          .object({
+            read: z.array(z.enum(["deployment", "logs", "events"]))
+          })
+          .optional(),
+        // Preserved verbatim through the builder round-trip; not yet editable in the form UI.
+        tee: z.enum(["cpu", "cpu-gpu"]).optional()
       })
       .optional()
   })

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
@@ -25,6 +25,23 @@ describe("sdlGenerator", () => {
       expect(parsed.services["web"].params).toBeUndefined();
     });
 
+    it("preserves params.tee carried on the service model", () => {
+      const result = generateSdl(buildFormValues(buildLogCollectorService({ title: "web", image: "nginx:latest", params: { tee: "cpu" } })));
+      const parsed = yaml.load(result) as { services: Record<string, { params?: { tee?: string } }> };
+
+      expect(parsed.services.web.params?.tee).toBe("cpu");
+    });
+
+    it("merges params.tee alongside log-collector permissions", () => {
+      const result = generateSdl(buildFormValues(buildLogCollectorService({ params: { tee: "cpu-gpu" } })));
+      const parsed = yaml.load(result) as { services: Record<string, { params?: { tee?: string; permissions?: unknown } }> };
+
+      expect(parsed.services["web-log-collector"].params).toEqual({
+        permissions: { read: ["deployment", "logs", "events"] },
+        tee: "cpu-gpu"
+      });
+    });
+
     it("injects location-region attribute when placement.region is set", () => {
       const formValues = buildFormValues(buildLogCollectorService({ title: "web", image: "nginx:latest" }));
       formValues.placements[0].region = "us-west";

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
@@ -206,6 +206,14 @@ export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
       };
     }
 
+    // Preserve the TEE param through the round-trip even though the builder UI cannot edit it yet.
+    if (service.params?.tee) {
+      sdl.services[service.title].params = {
+        ...sdl.services[service.title].params,
+        tee: service.params.tee
+      };
+    }
+
     sdl.profiles.placement[placement.name].pricing[service.title] = {
       denom: service.pricing.denom,
       amount: service.pricing.amount

--- a/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
@@ -195,9 +195,29 @@ describe("sdlImport", () => {
         "      count: 1"
       ].join("\n");
     }
+    it("captures params.tee onto the service model", () => {
+      const { services } = importSimpleSdl(teeSdl("cpu-gpu"));
+
+      expect(services[0].params?.tee).toBe("cpu-gpu");
+    });
+
+    it("leaves params undefined when the service has no tee param", () => {
+      const yml = fs.readFileSync(path.resolve(__dirname, "../../../tests/mocks/two-services-sdl.yml"), "utf8");
+
+      const { services } = importSimpleSdl(yml);
+
+      expect(services[0].params).toBeUndefined();
+    });
   });
 
   describe("SDL roundtrip", () => {
+    it("preserves params.tee when importing then regenerating the SDL", () => {
+      const regenerated = generateSdl(importSimpleSdl(teeSdl("cpu")));
+      const parsed = yaml.load(regenerated) as { services: Record<string, { params?: { tee?: string } }> };
+
+      expect(parsed.services.web.params?.tee).toBe("cpu");
+    });
+
     it("imports an SDL, regenerates it, and produces semantically equal output", () => {
       const yml = fs.readFileSync(path.resolve(__dirname, "../../../tests/mocks/two-services-sdl.yml"), "utf8");
       const formValues = importSimpleSdl(yml);
@@ -271,6 +291,42 @@ describe("sdlImport", () => {
     });
   });
 });
+
+const teeSdl = (tee: "cpu" | "cpu-gpu") =>
+  [
+    "version: '2.1'",
+    "services:",
+    "  web:",
+    "    image: nginx:latest",
+    "    expose:",
+    "      - port: 80",
+    "        as: 80",
+    "        to:",
+    "          - global: true",
+    "    params:",
+    `      tee: ${tee}`,
+    "profiles:",
+    "  compute:",
+    "    web:",
+    "      resources:",
+    "        cpu:",
+    "          units: 0.5",
+    "        memory:",
+    "          size: 512Mi",
+    "        storage:",
+    "          - size: 512Mi",
+    "  placement:",
+    "    dcloud:",
+    "      pricing:",
+    "        web:",
+    "          denom: uakt",
+    "          amount: 1000",
+    "deployment:",
+    "  web:",
+    "    dcloud:",
+    "      profile: web",
+    "      count: 1"
+  ].join("\n");
 
 describe("importSimpleSdl endpoints", () => {
   it("round-trips a declared endpoint back into the form model", () => {

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -171,6 +171,11 @@ export const importSimpleSdl = (yamlStr: string, { placementPerService = false }
 
       service.count = deployment.count;
 
+      // Preserve the TEE param through the round-trip even though the builder UI cannot edit it yet.
+      if (svc.params?.tee) {
+        service.params = { ...service.params, tee: svc.params.tee };
+      }
+
       services.push(service as ServiceType);
     });
 


### PR DESCRIPTION
Refs CON-463

## Problem

The SDL builder's form model only mirrors a subset of service `params` (just `permissions`). Switching from the YAML editor to the SDL builder and back **dropped `params.tee`** — the TEE / confidential-compute field. Users authoring `tee` in YAML lost it the moment they touched the visual builder.

## Fix

Round-trip `params.tee` through the builder without exposing it in the form UI (which doesn't support editing it yet):

- **`sdlBuilder.ts`** — add `tee: "cpu" | "cpu-gpu"` to the `params` zod schema, and make `permissions` optional so a `tee`-only service still validates.
- **`sdlImport.ts`** — capture `svc.params.tee` onto the service model on import.
- **`sdlGenerator.ts`** — re-emit `params.tee` on generate, merged with any existing `params` (e.g. log-collector `permissions`).

The builder UI is untouched — `tee` is preserved invisibly.

## Tests

Added test-first (TDD); new specs:
- generator emits `tee` (standalone, and merged alongside log-collector permissions)
- import captures `tee` onto the service model
- no-`tee` baseline leaves `params` undefined
- full import → regenerate round-trip preserves `tee`

All sdl/builder specs green (63 passing). eslint clean; `tsc` introduces no new errors (the repo's pre-existing 87 unrelated errors in auth/api-keys specs are unchanged).

## Note

This mirrors the same fix landed on the `console-air` fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional TEE (Trusted Execution Environment) parameter for services, supporting **CPU** and **CPU-GPU** modes.
  * Made service **permissions** optional to allow more flexible service configuration.
* **Improved SDL Handling**
  * SDL import/export now preserves **TEE** (and existing `params`) across round-trips, including when permissions are present.
* **Tests**
  * Added unit test coverage for SDL import and regeneration behavior related to `params.tee`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->