### PR TITLE
fix: clears postgres connections on provider-inventory shutdown

### DIFF
--- a/apps/provider-inventory/src/providers/drizzle.provider.ts
+++ b/apps/provider-inventory/src/providers/drizzle.provider.ts
@@ -4,10 +4,14 @@ import type { InjectionToken } from "tsyringe";
 import { container, instancePerContainerCachingFactory } from "tsyringe";
 
 import { parseJsonb, serializeJsonb } from "@src/lib/jsonb-bigint/jsonb-bigint";
-import { DB_LOGGER, JSON_OIDS, PG_CLIENT } from "@src/providers/postgres.provider";
+import { type Database, DB_LOGGER, JSON_OIDS, PG_CLIENT } from "@src/providers/postgres.provider";
+import { APP_INITIALIZER, ON_APP_START, ON_APP_STOP } from "@src/services/start-server/app-initializer";
 import * as modelsSchema from "../model-schemas";
 
-export const DRIZZLE_DB: InjectionToken<PostgresJsDatabase> = Symbol("DRIZZLE_DB");
+export type DrizzleDb = PostgresJsDatabase & {
+  $client: Database;
+};
+export const DRIZZLE_DB: InjectionToken<DrizzleDb> = Symbol("DRIZZLE_DB");
 
 container.register(DRIZZLE_DB, {
   useFactory: instancePerContainerCachingFactory(c => {
@@ -28,5 +32,15 @@ container.register(DRIZZLE_DB, {
     }
 
     return db;
+  })
+});
+
+container.register(APP_INITIALIZER, {
+  useFactory: instancePerContainerCachingFactory(c => {
+    const db = c.resolve<DrizzleDb>(DRIZZLE_DB);
+    return {
+      [ON_APP_START]: () => {},
+      [ON_APP_STOP]: () => db.$client.end({ timeout: 5 })
+    };
   })
 });

--- a/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.ts
+++ b/apps/provider-inventory/src/repositories/bid-screening/bid-screening.repository.ts
@@ -1,5 +1,4 @@
 import { getTableName } from "drizzle-orm";
-import type postgres from "postgres";
 import { inject, singleton } from "tsyringe";
 
 import { providerInventory } from "@src/model-schemas/provider-inventory/provider-inventory.schema";
@@ -37,7 +36,7 @@ export class BidScreeningRepository {
   async findCandidates(resourceUnits: RequestedResourceUnit[], requirements: PlacementRequirements): Promise<BidScreeningCandidate[]> {
     const sql = this.#sql;
     const criteria = aggregateCriteria(resourceUnits, requirements);
-    const where = this.#joinAnd(this.#buildWhere(criteria));
+    const where = this.#buildWhere(criteria);
 
     const rows = await sql<Array<{ owner: string; updatedAt: string }>>`
       SELECT
@@ -95,6 +94,7 @@ export class BidScreeningRepository {
 
   #buildWhere(criteria: BidScreeningCriteria) {
     const sql = this.#sql;
+    const AND = sql`AND`;
     /**
      * Ensure that total* are enough to cover resource request (may have false positives),
      * and that the largest service can be placed on at least one node (prevents false positives due to fragmentation).
@@ -114,43 +114,37 @@ export class BidScreeningRepository {
     ];
 
     if (criteria.reclamationWindow !== undefined) {
-      conditions.push(sql`${sql(providerInventory.reclamationWindow.name)} >= ${criteria.reclamationWindow}`);
+      conditions.push(AND, sql`${sql(providerInventory.reclamationWindow.name)} >= ${criteria.reclamationWindow}`);
     }
 
     for (const unit of criteria.units) {
       if (unit.gpuTokens.length > 0) {
-        conditions.push(sql`${sql(providerInventory.gpuModels.name)} && ${unit.gpuTokens}::text[]`);
+        conditions.push(AND, sql`${sql(providerInventory.gpuModels.name)} && ${unit.gpuTokens}::text[]`);
       }
 
       if (unit.persistentClasses.length > 0) {
-        conditions.push(sql`${sql(providerInventory.storageClasses.name)} @> ${unit.persistentClasses}::text[]`);
+        conditions.push(AND, sql`${sql(providerInventory.storageClasses.name)} @> ${unit.persistentClasses}::text[]`);
       }
     }
 
     if (criteria.attributes.length > 0) {
-      conditions.push(sql`${sql(providerInventory.selfAttributes.name)} @> ${sql.json(criteria.attributes)}::jsonb`);
+      conditions.push(AND, sql`${sql(providerInventory.selfAttributes.name)} @> ${sql.json(criteria.attributes)}::jsonb`);
     }
 
     for (const glob of criteria.globAttributes) {
       conditions.push(
+        AND,
         sql`EXISTS (SELECT 1 FROM jsonb_array_elements(${sql(providerInventory.selfAttributes.name)}) AS sa WHERE sa->>'key' ~* ${glob.keyPattern} AND sa->>'value' = ${glob.value})`
       );
     }
 
     if (criteria.signedBy.allOf.length > 0) {
-      conditions.push(sql`${sql(providerInventory.auditedBy.name)} @> ${criteria.signedBy.allOf}::text[]`);
+      conditions.push(AND, sql`${sql(providerInventory.auditedBy.name)} @> ${criteria.signedBy.allOf}::text[]`);
     }
     if (criteria.signedBy.anyOf.length > 0) {
-      conditions.push(sql`${sql(providerInventory.auditedBy.name)} && ${criteria.signedBy.anyOf}::text[]`);
+      conditions.push(AND, sql`${sql(providerInventory.auditedBy.name)} && ${criteria.signedBy.anyOf}::text[]`);
     }
 
     return conditions;
   }
-
-  #joinAnd(conditions: SqlFragment[]): SqlFragment {
-    const sql = this.#sql;
-    return conditions.reduce((acc, condition) => sql`${acc} AND ${condition}`);
-  }
 }
-
-type SqlFragment = postgres.PendingQuery<postgres.Row[]>;

--- a/apps/provider-inventory/src/repositories/db-driver/db-driver.ts
+++ b/apps/provider-inventory/src/repositories/db-driver/db-driver.ts
@@ -1,20 +1,19 @@
 import type { ExtractTablesWithRelations } from "drizzle-orm";
 import type { PgTransaction } from "drizzle-orm/pg-core";
-import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import { PostgresJsQueryResultHKT } from "drizzle-orm/postgres-js/session";
 import { AsyncLocalStorage } from "node:async_hooks";
 import { inject, singleton } from "tsyringe";
 
-import { DRIZZLE_DB } from "@src/providers/drizzle.provider";
+import { DRIZZLE_DB, type DrizzleDb } from "@src/providers/drizzle.provider";
 
 @singleton()
 export class DbDriver {
   readonly #storage = new AsyncLocalStorage<
     Map<"PG_TX", PgTransaction<PostgresJsQueryResultHKT, Record<string, never>, ExtractTablesWithRelations<Record<string, never>>>>
   >();
-  readonly #db: PostgresJsDatabase;
+  readonly #db: DrizzleDb;
 
-  constructor(@inject(DRIZZLE_DB) db: PostgresJsDatabase) {
+  constructor(@inject(DRIZZLE_DB) db: DrizzleDb) {
     this.#db = db;
   }
 

--- a/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
+++ b/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
@@ -147,6 +147,7 @@ export class DiscoverySchedulerService {
       }
 
       for (const chunk of chunkify(providersToStop, 100)) {
+        if (signal?.aborted) break;
         await this.#lifecycle.stopAndDelete(chunk as string[]);
       }
 
@@ -176,7 +177,9 @@ export class DiscoverySchedulerService {
       this.#logger.error({ event: "DISCOVERY_TICK_ERROR", error });
     }
 
-    await this.#cleanupOldIncidents();
+    if (!signal?.aborted) {
+      await this.#cleanupOldIncidents();
+    }
   }
 
   async #cleanupOldIncidents(): Promise<void> {

--- a/apps/provider-inventory/src/services/provider-stream-factory/provider-stream-factory.sevice.ts
+++ b/apps/provider-inventory/src/services/provider-stream-factory/provider-stream-factory.sevice.ts
@@ -62,6 +62,7 @@ export class ProviderStreamFactory {
   }
 
   async dispose(): Promise<void> {
+    this.#logger.debug({ event: "PROVIDER_STREAM_FACTORY_START_DISPOSE" });
     await Promise.all(Array.from(this.#sdks.values(), sdk => sdk[Symbol.asyncDispose]()));
     this.#sdks.clear();
     this.#logger.debug({ event: "PROVIDER_STREAM_FACTORY_DISPOSED" });

--- a/apps/provider-inventory/src/services/start-server/app-initializer.ts
+++ b/apps/provider-inventory/src/services/start-server/app-initializer.ts
@@ -2,7 +2,18 @@ import type { InjectionToken } from "tsyringe";
 
 export const APP_INITIALIZER: InjectionToken<AppInitializer> = Symbol("APP_INITIALIZER");
 export const ON_APP_START = Symbol("ON_APP_START");
+export const ON_APP_STOP = Symbol("ON_APP_STOP");
 
 export interface AppInitializer {
-  [ON_APP_START](): Promise<void>;
+  /**
+   * Called when the app is starting up. This is called before the server starts listening for requests.
+   * This is a good place to initialize any resources that need to be available before the server starts.
+   * This method should not throw an error. If it does, the app will not start.
+   */
+  [ON_APP_START](): Promise<void> | void;
+
+  /**
+   * Called when the app is shutting down. This is called after the server stops listening for requests and after services are disposed.
+   */
+  [ON_APP_STOP]?(): Promise<void> | void;
 }

--- a/apps/provider-inventory/src/services/start-server/start-server.spec.ts
+++ b/apps/provider-inventory/src/services/start-server/start-server.spec.ts
@@ -162,7 +162,7 @@ describe("startServer", () => {
   });
 
   let startedServer: ServerType | undefined;
-  function setup(input?: { beforeStart?: () => Promise<void>; port?: number; initializers?: Array<{ [ON_APP_START]: () => Promise<void> }> }) {
+  function setup(input?: { beforeStart?: () => Promise<void>; port?: number; initializers?: AppInitializer[] }) {
     const app = mock<Hono<any>>();
     const logger = mock<LoggerService>();
     const processEvents = new EventEmitter();

--- a/apps/provider-inventory/src/services/start-server/start-server.ts
+++ b/apps/provider-inventory/src/services/start-server/start-server.ts
@@ -8,7 +8,7 @@ import type { DependencyContainer } from "tsyringe";
 import { container as rootContainer } from "tsyringe";
 
 import { shutdownServer } from "../shutdown-server/shutdown-server";
-import { APP_INITIALIZER, ON_APP_START } from "./app-initializer";
+import { APP_INITIALIZER, ON_APP_START, ON_APP_STOP } from "./app-initializer";
 
 /**
  * Runs registered in container `APP_INITIALIZER`s
@@ -28,9 +28,14 @@ export async function startServer(
   const container = options.container ?? rootContainer;
   const disposeContainerOnce = once(() => {
     logger.info({ event: "DISPOSING_CONTAINER" });
-    return Promise.resolve(container.dispose()).catch(error => {
-      logger.error({ event: "CONTAINER_DISPOSE_ERROR", error });
-    });
+    const initializers = container.isRegistered(APP_INITIALIZER, true) ? container.resolveAll(APP_INITIALIZER) : [];
+    return Promise.resolve(container.dispose())
+      .then(async () => {
+        await Promise.allSettled(initializers.map(initializer => initializer[ON_APP_STOP]?.()));
+      })
+      .catch(error => {
+        logger.error({ event: "CONTAINER_DISPOSE_ERROR", error });
+      });
   });
 
   let server: ServerType | undefined;

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -43,6 +43,7 @@ export class StreamLifecycleManagerService {
   readonly #startStreamSemaphore: Sema;
   readonly #pendingFirstAttempts = new Set<Promise<void>>();
   readonly #dbDriver: DbDriver;
+  #isShutDown = false;
 
   constructor(
     streamFactory: ProviderStreamFactory,
@@ -74,6 +75,7 @@ export class StreamLifecycleManagerService {
     });
     this.#offlineDataloader = new Dataloader(
       async keys => {
+        if (this.#isShutDown) return Array.from(keys, () => false);
         const owners = keys.map(k => k.owner);
         const results = await this.#inventoryRepo.bulkMarkOffline(owners, keys[0].requestedAt);
         const updatedOwners = new Set(results.map(r => r.owner));
@@ -217,7 +219,7 @@ export class StreamLifecycleManagerService {
 
       for await (const message of throttled) {
         this.#logger.debug({ event: "STREAM_MESSAGE_RECEIVED", owner: provider.owner });
-        if (outerSignal.aborted) return;
+        if (attemptController.signal.aborted) return;
         releasePermit();
         await this.#updateProviderInventory(provider, message);
       }
@@ -332,6 +334,7 @@ export class StreamLifecycleManagerService {
     this.#onlineProvidersCount = 0;
     this.#recordMonitoredCount();
     providersGauge.record(0, { state: "online" });
+    this.#isShutDown = true;
   }
 
   dispose(): void {


### PR DESCRIPTION
## Why

ref CON-571

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved shutdown lifecycle handling by adding a dedicated app stop hook, ensuring services finalize cleanly and database connections close with a timeout.
  * Enhanced cancellation behavior during provider discovery so aborted runs stop immediately and skip cleanup that shouldn’t run after abort.
  * Fixed stream teardown so providers aren’t marked offline during shutdown and cancellation aligns with the active attempt.

* **Chores**
  * Refined database wiring and query building for simpler SQL condition construction and improved type consistency.
  * Added an extra debug event when disposing the provider stream factory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->