### PR TITLE
refactor: removes provider attribute from provider_inventory_stream_messages_total

### DIFF
--- a/apps/provider-inventory/src/metrics/metrics.ts
+++ b/apps/provider-inventory/src/metrics/metrics.ts
@@ -10,12 +10,9 @@ export const providersGauge = meter.createGauge<{ state: ProviderState }>("provi
     "Number of providers by state. total/dead are sampled per discovery tick; online/monitored is updated in real time as streams connect and disconnect"
 });
 
-export const providerInventoryStreamUpdates = meter.createCounter<{ provider: string; result: StreamMessageResult }>(
-  "provider_inventory_stream_messages_total",
-  {
-    description: "Post-throttle provider inventory stream updates by processing result"
-  }
-);
+export const providerInventoryStreamUpdates = meter.createCounter<{ result: StreamMessageResult }>("provider_inventory_stream_messages_total", {
+  description: "Post-throttle provider inventory stream updates by processing result"
+});
 
 const CANDIDATE_COUNT_BUCKETS = [0, 1, 2, 5, 10, 25, 50, 75, 100, 250, 500];
 

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
@@ -1,4 +1,5 @@
 import type { LoggerService } from "@akashnetwork/logging";
+import { getEventListeners } from "node:events";
 import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mock, type MockProxy } from "vitest-mock-extended";
@@ -553,6 +554,66 @@ describe(StreamLifecycleManagerService.name, () => {
       manager.start(createProvider());
 
       await vi.waitFor(() => expect(writer.updateInventory).toHaveBeenCalledTimes(2));
+    });
+  });
+
+  // Deterministic, GC-free leak guards. The service registers an abort listener on the caller-provided
+  // (long-lived) signal and tracks each stream in #activeStreams; both must return to baseline once a
+  // stream ends, is replaced, or is shut down — otherwise listeners/entries accumulate per provider over
+  // the process lifetime. We assert observable invariants (parent-signal listener count and registry
+  // size), never reaching into GC.
+  describe("memory safety", () => {
+    it("releases the parent-signal listener, empties the registry, and disposes the SDK once streams give up", async () => {
+      const parent = new AbortController();
+      const streamFactory = mock<ProviderStreamFactory>();
+      streamFactory.disposeProvider.mockResolvedValue();
+      streamFactory.openStatusStream.mockImplementation(() => throwingStream(new Error("connection lost")));
+      const { manager, logger } = setup({ streamFactory });
+      const giveUps = () => logger.error.mock.calls.filter(([arg]) => (arg as { event?: string })?.event === "STREAM_GAVE_UP").length;
+      const providers = [
+        createProvider({ owner: "a", hostUri: "https://a:8443" }),
+        createProvider({ owner: "b", hostUri: "https://b:8443" }),
+        createProvider({ owner: "c", hostUri: "https://c:8443" })
+      ];
+
+      for (const provider of providers) manager.start(provider, parent.signal);
+
+      await vi.waitFor(() => expect(giveUps()).toBe(providers.length), { timeout: 5000 });
+
+      expect(getEventListeners(parent.signal, "abort")).toHaveLength(0);
+      expect(manager.getRegistry().size).toBe(0);
+      for (const provider of providers) expect(streamFactory.disposeProvider).toHaveBeenCalledWith(provider.hostUri);
+    });
+
+    it("does not accumulate registry entries or parent-signal listeners across repeated restarts of one owner", async () => {
+      const parent = new AbortController();
+      const hostUris = ["https://h0:8443", "https://h1:8443", "https://h2:8443", "https://h3:8443"];
+      const { manager, streamFactory } = setup({ streams: Object.fromEntries(hostUris.map(h => [h, msgsThenHang([createCluster()])])) });
+
+      manager.start(createProvider({ owner: "a", hostUri: hostUris[0] }), parent.signal);
+      for (let i = 1; i < hostUris.length; i++) {
+        manager.restart(createProvider({ owner: "a", hostUri: hostUris[i] }), parent.signal);
+        await vi.waitFor(() => expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(i + 1));
+      }
+
+      // one owner, many restarts -> exactly one live registry entry and one live abort listener
+      await vi.waitFor(() => expect(getEventListeners(parent.signal, "abort")).toHaveLength(1));
+      expect(manager.getRegistry().size).toBe(1);
+    });
+
+    it("removes every parent-signal listener and clears the registry on shutdown", async () => {
+      const parent = new AbortController();
+      const { manager, streamFactory } = setup({
+        streams: { "https://a:8443": msgsThenHang([createCluster()]), "https://b:8443": msgsThenHang([createCluster()]) }
+      });
+      manager.start(createProvider({ owner: "a", hostUri: "https://a:8443" }), parent.signal);
+      manager.start(createProvider({ owner: "b", hostUri: "https://b:8443" }), parent.signal);
+      await vi.waitFor(() => expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(2));
+
+      manager.shutdown();
+
+      expect(manager.getRegistry().size).toBe(0);
+      await vi.waitFor(() => expect(getEventListeners(parent.signal, "abort")).toHaveLength(0));
     });
   });
 

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -265,7 +265,7 @@ export class StreamLifecycleManagerService {
 
     if (cached && isEqualClusterState(cached, cluster)) {
       this.#logger.debug({ event: "STREAM_MESSAGE_SKIPPED_IDENTICAL", owner: provider.owner });
-      providerInventoryStreamUpdates.add(1, { provider: provider.owner, result: "noop" });
+      providerInventoryStreamUpdates.add(1, { result: "noop" });
       return;
     }
 
@@ -273,10 +273,10 @@ export class StreamLifecycleManagerService {
       await this.#inventoryRepo.updateInventory(provider, cluster);
       this.#logger.debug({ event: "PROVIDER_INVENTORY_UPDATED", owner: provider.owner });
       this.#lastInventoryPerProvider.set(provider.owner, cluster);
-      providerInventoryStreamUpdates.add(1, { provider: provider.owner, result: "updated" });
+      providerInventoryStreamUpdates.add(1, { result: "updated" });
     } catch (error) {
       this.#logger.error({ event: "STREAM_PROVIDER_WRITE_ERROR", owner: provider.owner, error });
-      providerInventoryStreamUpdates.add(1, { provider: provider.owner, result: "error" });
+      providerInventoryStreamUpdates.add(1, { result: "error" });
     }
   }
 


### PR DESCRIPTION
## Why

ref CON-571

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added memory safety verification tests for stream lifecycle management to ensure proper resource cleanup and prevent listener accumulation in repeated operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->