### PR TITLE
feat(deployment): add RAM and persistent storage configure cards

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
@@ -8,10 +8,14 @@ import { MockComponents } from "@tests/unit/mocks";
 describe(HardwareSection.name, () => {
   it("renders each hardware row for the selected service", () => {
     const ComputeResourcesCard = vi.fn(() => null);
+    const PersistentStorageCard = vi.fn(() => null);
+    const RamStorageCard = vi.fn(() => null);
 
-    setup({ serviceIndex: 2, dependencies: { ComputeResourcesCard } });
+    setup({ serviceIndex: 2, dependencies: { ComputeResourcesCard, PersistentStorageCard, RamStorageCard } });
 
     expect(ComputeResourcesCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
+    expect(PersistentStorageCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
+    expect(RamStorageCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
   });
 
   function setup(input: { serviceIndex?: number; dependencies?: Partial<typeof DEPENDENCIES> }) {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
@@ -2,12 +2,29 @@ import type { FC } from "react";
 import { CollapsibleCard } from "@akashnetwork/ui/components";
 import { CpuIcon } from "lucide-react";
 
+import { useRevalidateUniqueness } from "../../DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness";
 import { computeResourcesTooltip } from "../cardTooltips";
 import { ComputeResourcesCard } from "../ComputeResourcesCard/ComputeResourcesCard";
+import { PersistentStorageCard } from "../PersistentStorageCard/PersistentStorageCard";
+import { RamStorageCard } from "../RamStorageCard/RamStorageCard";
+
+type StorageVolume = { name?: string; mount?: string };
+
+/**
+ * Uniqueness key for a storage volume. The space separator is load-bearing:
+ * without it `name`+`mount` of two different volumes can concatenate to the same
+ * string (e.g. `"ab"`+`"c"` vs `"a"`+`"bc"`), which would let the revalidation
+ * effect skip a real conflict. Exported so the test harness keys volumes the same
+ * way the component does and cannot silently drift from it.
+ */
+export const storageUniquenessKey = (storage: StorageVolume) => `${storage.name ?? ""} ${storage.mount ?? ""}`;
 
 export const DEPENDENCIES = {
   CollapsibleCard,
-  ComputeResourcesCard
+  ComputeResourcesCard,
+  RamStorageCard,
+  PersistentStorageCard,
+  useRevalidateUniqueness
 };
 
 type Props = {
@@ -16,11 +33,20 @@ type Props = {
 };
 
 /**
- * The "HARDWARE" section of the Configuration pane for the selected service.
- * Each card edits `services.${serviceIndex}.profile.*` on the shared deployment
- * model.
+ * The "HARDWARE" section of the Configuration pane for the selected service:
+ * CPU (with memory & ephemeral storage), RAM-backed storage and Persistent
+ * Storage cards. Each card edits `services.${serviceIndex}.profile.*` on the
+ * shared deployment model. The RAM and Persistent Storage cards own their own
+ * card shell because they carry a header switch.
+ *
+ * Persistent and RAM volumes share `profile.storage` and must each have a unique
+ * name and mount; re-validating the whole array on any name or mount change keeps
+ * the "must be unique" error in sync across every conflicting row, not just the
+ * edited one.
  */
 export const HardwareSection: FC<Props> = ({ serviceIndex, dependencies: d = DEPENDENCIES }) => {
+  d.useRevalidateUniqueness(`services.${serviceIndex}.profile.storage`, storageUniquenessKey);
+
   return (
     <div className="flex flex-col gap-2 px-4">
       <p className="font-mono text-xs uppercase text-muted-foreground">Hardware</p>
@@ -28,6 +54,10 @@ export const HardwareSection: FC<Props> = ({ serviceIndex, dependencies: d = DEP
         <d.CollapsibleCard title="Compute Resources" icon={<CpuIcon className="h-4 w-4" />} infoTooltip={computeResourcesTooltip}>
           <d.ComputeResourcesCard serviceIndex={serviceIndex} />
         </d.CollapsibleCard>
+
+        <d.RamStorageCard serviceIndex={serviceIndex} />
+
+        <d.PersistentStorageCard serviceIndex={serviceIndex} />
       </div>
     </div>
   );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PersistentStorageCard/PersistentStorageCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PersistentStorageCard/PersistentStorageCard.spec.tsx
@@ -1,0 +1,326 @@
+import type { PropsWithChildren } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { describe, expect, it } from "vitest";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { SdlBuilderFormValuesSchema } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { DEPENDENCIES, PersistentStorageCard } from "./PersistentStorageCard";
+
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const EPHEMERAL = { size: 1, unit: "Gi", isPersistent: false, type: "beta2" };
+const PERSISTENT = { size: 10, unit: "Gi", isPersistent: true, type: "beta3", name: "data", mount: "/mnt/data", isReadOnly: false };
+const RAM = { size: 10, unit: "Gi", isPersistent: false, type: "ram", name: "shm", mount: "/dev/shm", isReadOnly: false };
+
+describe(PersistentStorageCard.name, () => {
+  it("hides the body when disabled", () => {
+    setup({ count: 0 });
+
+    expect(screen.getByRole("switch", { name: "Enable persistent storage" })).not.toBeChecked();
+    expect(screen.queryByLabelText("Storage name")).not.toBeInTheDocument();
+  });
+
+  it("appends a persistent storage entry when toggled on", async () => {
+    const { getValues } = setup({ count: 0 });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable persistent storage" }));
+
+    const storage = getValues().services[0].profile.storage;
+    expect(storage).toHaveLength(2);
+    expect(storage[1]).toMatchObject({ isPersistent: true, type: "beta3", name: "data", mount: "/mnt/data" });
+    expect(screen.getByLabelText("Storage name")).toHaveValue("data");
+  });
+
+  it("only offers persistent storage types", async () => {
+    setup({ count: 1 });
+
+    await userEvent.click(screen.getByRole("combobox", { name: "Storage type" }));
+
+    expect(screen.getByRole("option", { name: "NVMe" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "RAM" })).not.toBeInTheDocument();
+  });
+
+  it("removes every persistent storage entry when toggled off", async () => {
+    const { getValues } = setup({ count: 2 });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable persistent storage" }));
+
+    expect(getValues().services[0].profile.storage).toHaveLength(1);
+  });
+
+  it("edits the persistent storage name", async () => {
+    const { getValues } = setup({ count: 1 });
+
+    const input = screen.getByLabelText("Storage name");
+    await userEvent.clear(input);
+    await userEvent.type(input, "data");
+
+    expect(getValues().services[0].profile.storage[1].name).toBe("data");
+  });
+
+  it("toggles the read only flag for a persistent entry", async () => {
+    const { getValues } = setup({ count: 1 });
+
+    await userEvent.click(within(screen.getByRole("group", { name: "Persistent Storage 1" })).getByRole("checkbox", { name: "Read only" }));
+
+    expect(getValues().services[0].profile.storage[1].isReadOnly).toBe(true);
+  });
+
+  it("appends another persistent entry when plus button is clicked", async () => {
+    const { getValues } = setup({ count: 1 });
+
+    await userEvent.click(screen.getByRole("button", { name: "Add persistent storage" }));
+
+    expect(await screen.findByRole("group", { name: "Persistent Storage 2" })).toBeInTheDocument();
+    expect(getValues().services[0].profile.storage).toHaveLength(3);
+    expect(screen.getByRole("button", { name: "Remove Persistent Storage 2" })).toBeInTheDocument();
+  });
+
+  it("increments the default name and mount when 'data' is already taken", async () => {
+    const { getValues } = setup({ count: 1 });
+
+    await userEvent.click(screen.getByRole("button", { name: "Add persistent storage" }));
+
+    expect(getValues().services[0].profile.storage[2]).toMatchObject({ name: "data-1", mount: "/mnt/data-1" });
+  });
+
+  it("keeps incrementing past 'data-1' to the next free name and mount", async () => {
+    const { getValues } = setup({
+      storage: [EPHEMERAL, { ...PERSISTENT, name: "data", mount: "/mnt/data" }, { ...PERSISTENT, name: "data-1", mount: "/mnt/data-1" }]
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Add persistent storage" }));
+
+    expect(getValues().services[0].profile.storage[3]).toMatchObject({ name: "data-2", mount: "/mnt/data-2" });
+  });
+
+  it("defaults a new entry against live edited names, not the stale field-array snapshot", async () => {
+    const { getValues } = setup({ count: 1 });
+
+    const nameInput = screen.getByLabelText("Storage name");
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "renamed");
+    const mountInput = screen.getByLabelText("Storage mount");
+    await userEvent.clear(mountInput);
+    await userEvent.type(mountInput, "/mnt/renamed");
+
+    await userEvent.click(screen.getByRole("button", { name: "Add persistent storage" }));
+
+    expect(getValues().services[0].profile.storage[2]).toMatchObject({ name: "data", mount: "/mnt/data" });
+  });
+
+  it("avoids a RAM volume's name and mount when defaulting a new persistent entry", async () => {
+    const { getValues } = setup({ storage: [EPHEMERAL, { ...RAM, name: "data", mount: "/mnt/data" }] });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable persistent storage" }));
+
+    expect(getValues().services[0].profile.storage.find(s => s.isPersistent)).toMatchObject({ name: "data-1", mount: "/mnt/data-1" });
+  });
+
+  it("does not offer a remove control when only one persistent entry exists", () => {
+    setup({ count: 1 });
+
+    expect(screen.queryByRole("button", { name: "Remove Persistent Storage 1" })).not.toBeInTheDocument();
+  });
+
+  it("offers a remove control on every entry, including the first, when more than one exists", () => {
+    setup({ count: 2 });
+
+    expect(screen.getByRole("button", { name: "Remove Persistent Storage 1" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove Persistent Storage 2" })).toBeInTheDocument();
+  });
+
+  it("removes the first persistent entry", async () => {
+    const { getValues } = setup({ storage: [EPHEMERAL, { ...PERSISTENT, name: "first" }, { ...PERSISTENT, name: "second" }] });
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove Persistent Storage 1" }));
+
+    const storage = getValues().services[0].profile.storage;
+    expect(storage).toHaveLength(2);
+    expect(screen.getByLabelText("Storage name")).toHaveValue("second");
+  });
+
+  it("removes a non-first persistent entry", async () => {
+    const { getValues } = setup({ count: 2 });
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove Persistent Storage 2" }));
+
+    const storage = getValues().services[0].profile.storage;
+    expect(storage).toHaveLength(2);
+    expect(screen.queryByRole("group", { name: "Persistent Storage 2" })).not.toBeInTheDocument();
+  });
+
+  it("hides the remove control again once a single entry remains", async () => {
+    setup({ count: 2 });
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove Persistent Storage 2" }));
+
+    expect(screen.queryByRole("button", { name: /Remove Persistent Storage/ })).not.toBeInTheDocument();
+  });
+
+  it("renders each persistent entry bound to its own storage", () => {
+    setup({
+      storage: [EPHEMERAL, { ...PERSISTENT, name: "first" }, { ...PERSISTENT, name: "second" }]
+    });
+
+    const first = screen.getByRole("group", { name: "Persistent Storage 1" });
+    const second = screen.getByRole("group", { name: "Persistent Storage 2" });
+    expect(within(first).getByLabelText("Storage name")).toHaveValue("first");
+    expect(within(second).getByLabelText("Storage name")).toHaveValue("second");
+  });
+
+  it("ignores RAM entries and stays disabled when only a RAM volume exists", () => {
+    setup({ storage: [EPHEMERAL, { ...RAM }] });
+
+    expect(screen.getByRole("switch", { name: "Enable persistent storage" })).not.toBeChecked();
+    expect(screen.queryByRole("group", { name: "Persistent Storage 1" })).not.toBeInTheDocument();
+  });
+
+  it("renders only the persistent entry when a RAM volume is also present", () => {
+    setup({ storage: [EPHEMERAL, { ...RAM }, { ...PERSISTENT, name: "data" }] });
+
+    expect(screen.getByRole("group", { name: "Persistent Storage 1" })).toBeInTheDocument();
+    expect(screen.queryByRole("group", { name: "Persistent Storage 2" })).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Storage name")).toHaveValue("data");
+  });
+
+  it("removes only persistent entries when toggled off, leaving the RAM volume", async () => {
+    const { getValues } = setup({ storage: [EPHEMERAL, { ...RAM }, { ...PERSISTENT }] });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable persistent storage" }));
+
+    const storage = getValues().services[0].profile.storage;
+    expect(storage).toHaveLength(2);
+    expect(storage.some(s => s.type === "ram")).toBe(true);
+    expect(storage.some(s => s.isPersistent)).toBe(false);
+  });
+
+  it("shows the card collapsed with the chevron visible when disabled", () => {
+    setup({ count: 0 });
+
+    expect(screen.getByRole("button", { name: "Expand Persistent Storage" })).toBeInTheDocument();
+  });
+
+  it("keeps configured values after collapsing and expanding while enabled", async () => {
+    setup({ count: 1 });
+
+    const nameInput = screen.getByLabelText("Storage name");
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "data");
+
+    await userEvent.click(screen.getByRole("button", { name: "Collapse Persistent Storage" }));
+    expect(screen.queryByLabelText("Storage name")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Expand Persistent Storage" }));
+
+    expect(screen.getByLabelText("Storage name")).toHaveValue("data");
+  });
+
+  it("re-expands the fields when toggled on after being collapsed", async () => {
+    setup({ count: 1 });
+
+    await userEvent.click(screen.getByRole("button", { name: "Collapse Persistent Storage" }));
+    expect(screen.queryByLabelText("Storage name")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable persistent storage" }));
+    await userEvent.click(screen.getByRole("switch", { name: "Enable persistent storage" }));
+
+    expect(screen.getByLabelText("Storage name")).toBeInTheDocument();
+  });
+
+  it("shows a uniqueness error under the name input when two persistent names collide", async () => {
+    const { trigger } = setupValidated([EPHEMERAL, { ...PERSISTENT, name: "data", mount: "/mnt/a" }, { ...PERSISTENT, name: "data", mount: "/mnt/b" }]);
+
+    await trigger();
+
+    await waitFor(() => {
+      const groups = screen.getAllByRole("group", { name: /Persistent Storage/ });
+      expect(within(groups[0]).getByText("Storage name must be unique")).toBeInTheDocument();
+      expect(within(groups[1]).getByText("Storage name must be unique")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a uniqueness error under the mount input when two persistent mounts collide", async () => {
+    const { trigger } = setupValidated([
+      EPHEMERAL,
+      { ...PERSISTENT, name: "data-a", mount: "/mnt/data" },
+      { ...PERSISTENT, name: "data-b", mount: "/mnt/data" }
+    ]);
+
+    await trigger();
+
+    await waitFor(() => {
+      const groups = screen.getAllByRole("group", { name: /Persistent Storage/ });
+      expect(within(groups[0]).getByText("Storage mount must be unique")).toBeInTheDocument();
+      expect(within(groups[1]).getByText("Storage mount must be unique")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a size error under the storage input when the size is missing", async () => {
+    const { trigger } = setupValidated([EPHEMERAL, { ...PERSISTENT, size: 0 }]);
+
+    await trigger();
+
+    await waitFor(() => {
+      expect(screen.getByText("Storage is required.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a type error under the type select when the type is missing", async () => {
+    const { trigger } = setupValidated([EPHEMERAL, { ...PERSISTENT, type: "" }]);
+
+    await trigger();
+
+    await waitFor(() => {
+      expect(screen.getByText("Storage type is required")).toBeInTheDocument();
+    });
+  });
+
+  function setup(input: { count?: number; storage?: SdlBuilderFormValuesType["services"][number]["profile"]["storage"] }) {
+    const storage = input.storage ?? [EPHEMERAL, ...Array.from({ length: input.count ?? 0 }, () => ({ ...PERSISTENT }))];
+
+    const values = defaultServiceWithPlacement({
+      profile: { cpu: 0.5, gpu: 1, gpuModels: [{ vendor: "nvidia" }], hasGpu: false, ram: 256, ramUnit: "Mi", storage }
+    });
+
+    let getValues: () => SdlBuilderFormValuesType = () => values;
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values, mode: "onChange" });
+      getValues = form.getValues;
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    render(
+      <Wrapper>
+        <PersistentStorageCard serviceIndex={0} dependencies={{ ...DEPENDENCIES }} />
+      </Wrapper>
+    );
+
+    return { getValues: () => getValues() };
+  }
+
+  function setupValidated(storage: SdlBuilderFormValuesType["services"][number]["profile"]["storage"]) {
+    const values = defaultServiceWithPlacement({
+      image: "nginx:latest",
+      profile: { cpu: 0.5, gpu: 1, gpuModels: [{ vendor: "nvidia" }], hasGpu: false, ram: 256, ramUnit: "Mi", storage }
+    });
+
+    let trigger: () => Promise<boolean> = async () => true;
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values, mode: "onChange", resolver: zodResolver(SdlBuilderFormValuesSchema) });
+      trigger = () => form.trigger();
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    render(
+      <Wrapper>
+        <PersistentStorageCard serviceIndex={0} dependencies={{ ...DEPENDENCIES }} />
+      </Wrapper>
+    );
+
+    return { trigger: () => trigger() };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PersistentStorageCard/PersistentStorageCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PersistentStorageCard/PersistentStorageCard.tsx
@@ -1,0 +1,232 @@
+import type { FC } from "react";
+import { useCallback } from "react";
+import { useController, useFieldArray, useFormContext } from "react-hook-form";
+import {
+  Button,
+  Checkbox,
+  CollapsibleCard,
+  Field,
+  FieldContent,
+  FieldError,
+  FieldLabel,
+  Input,
+  Label,
+  NumberUnitInput,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@akashnetwork/ui/components";
+import { HardDriveIcon, PlusIcon, TrashIcon } from "lucide-react";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { persistentStorageTypes, storageUnits } from "@src/utils/akash/units";
+import { defaultPersistentStorage } from "@src/utils/sdl/data";
+import { persistentStorageTooltip } from "../cardTooltips";
+import { SELECT_TRUNCATE_VALUE } from "../selectStyles";
+
+export const DEPENDENCIES = { CollapsibleCard, NumberUnitInput };
+
+type Props = {
+  serviceIndex: number;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/**
+ * Hardware "Persistent Storage" card. A header switch toggles the presence of
+ * persistent storage entries (`profile.storage[1..n]`, with `storage[0]` reserved
+ * for ephemeral root storage). Enabling appends one persistent-storage default;
+ * disabling drops every persistent entry. While enabled the body renders one
+ * editable block per persistent entry — type, size, name, mount and a read-only
+ * flag — plus an "Add more" button. Every block has its own remove control while
+ * more than one exists; the last remaining block hides it (removing the only
+ * persistent volume is done by toggling the switch off).
+ */
+export const PersistentStorageCard: FC<Props> = ({ serviceIndex, dependencies: d = DEPENDENCIES }) => {
+  const { control, getValues } = useFormContext<SdlBuilderFormValuesType>();
+  const { fields, append, remove } = useFieldArray({ control, name: `services.${serviceIndex}.profile.storage`, keyName: "key" });
+
+  const persistentFields = fields.map((field, index) => ({ field, index })).filter(({ field, index }) => index > 0 && field.type !== "ram");
+  const isEnabled = persistentFields.length > 0;
+
+  const appendPersistentStorage = useCallback(() => {
+    const storage = getValues(`services.${serviceIndex}.profile.storage`) ?? [];
+    const takenNames = new Set(storage.map(volume => volume.name).filter((value): value is string => !!value));
+    const takenMounts = new Set(storage.map(volume => volume.mount).filter((value): value is string => !!value));
+    append(
+      {
+        ...defaultPersistentStorage,
+        name: nextAvailableValue(defaultPersistentStorage.name, takenNames),
+        mount: nextAvailableValue(defaultPersistentStorage.mount, takenMounts)
+      },
+      { shouldFocus: false }
+    );
+  }, [append, getValues, serviceIndex]);
+
+  const togglePersistentStorage = useCallback(
+    (checked: boolean) => {
+      if (checked && !isEnabled) {
+        appendPersistentStorage();
+      } else if (!checked && isEnabled) {
+        remove(persistentFields.map(({ index }) => index));
+      }
+    },
+    [appendPersistentStorage, remove, persistentFields, isEnabled]
+  );
+
+  return (
+    <d.CollapsibleCard
+      title="Persistent Storage"
+      icon={<HardDriveIcon className="h-4 w-4" />}
+      infoTooltip={persistentStorageTooltip}
+      isToggled={isEnabled}
+      onToggle={togglePersistentStorage}
+      toggleAriaLabel="Enable persistent storage"
+    >
+      {isEnabled && (
+        <>
+          {persistentFields.map(({ field, index }, position) => (
+            <PersistentStorageFields
+              key={field.key}
+              serviceIndex={serviceIndex}
+              storageIndex={index}
+              label={position + 1}
+              dependencies={d}
+              onRemove={persistentFields.length > 1 ? () => remove(index) : undefined}
+            />
+          ))}
+
+          <div className="flex justify-end">
+            <button
+              type="button"
+              aria-label="Add persistent storage"
+              onClick={appendPersistentStorage}
+              className="flex w-full items-center justify-center rounded-md py-1.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+            >
+              <PlusIcon className="h-4 w-4" />
+            </button>
+          </div>
+        </>
+      )}
+    </d.CollapsibleCard>
+  );
+};
+
+type PersistentStorageFieldsProps = {
+  serviceIndex: number;
+  storageIndex: number;
+  label: number;
+  dependencies: typeof DEPENDENCIES;
+  onRemove?: () => void;
+};
+
+const PersistentStorageFields: FC<PersistentStorageFieldsProps> = ({ serviceIndex, storageIndex, label, dependencies: d, onRemove }) => {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const basePath = `services.${serviceIndex}.profile.storage.${storageIndex}` as const;
+
+  const type = useController({ control, name: `${basePath}.type` });
+  const size = useController({ control, name: `${basePath}.size` });
+  const unit = useController({ control, name: `${basePath}.unit` });
+  const name = useController({ control, name: `${basePath}.name` });
+  const mount = useController({ control, name: `${basePath}.mount` });
+  const isReadOnly = useController({ control, name: `${basePath}.isReadOnly` });
+
+  return (
+    <div role="group" aria-label={`Persistent Storage ${label}`} className="flex flex-col gap-3 rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium uppercase text-muted-foreground">Persistent Storage {label}</span>
+        {onRemove && (
+          <Button size="icon" type="button" variant="ghost" className="h-6 w-6" aria-label={`Remove Persistent Storage ${label}`} onClick={onRemove}>
+            <TrashIcon className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      <Field className="gap-2">
+        <FieldLabel>Type</FieldLabel>
+        <FieldContent>
+          <Select value={type.field.value ?? ""} onValueChange={type.field.onChange}>
+            <SelectTrigger aria-label="Storage type" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
+              <SelectValue placeholder="Select" />
+            </SelectTrigger>
+            <SelectContent>
+              {persistentStorageTypes.map(option => (
+                <SelectItem key={option.className} value={option.className}>
+                  {option.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <FieldError>{type.fieldState.error?.message}</FieldError>
+        </FieldContent>
+      </Field>
+
+      <Field className="gap-2">
+        <FieldLabel>Storage</FieldLabel>
+        <FieldContent>
+          <d.NumberUnitInput
+            label="Persistent storage"
+            units={storageUnits}
+            value={size.field.value ?? undefined}
+            unit={unit.field.value}
+            onValueChange={value => size.field.onChange(value ?? null)}
+            onUnitChange={unit.field.onChange}
+            error={size.fieldState.error?.message ?? unit.fieldState.error?.message}
+          />
+        </FieldContent>
+      </Field>
+
+      <Field className="gap-2">
+        <FieldLabel htmlFor={`storage-${serviceIndex}-${storageIndex}-name`}>Name</FieldLabel>
+        <FieldContent>
+          <Input
+            id={`storage-${serviceIndex}-${storageIndex}-name`}
+            aria-label="Storage name"
+            value={name.field.value ?? ""}
+            onChange={name.field.onChange}
+            inputClassName="h-9"
+          />
+          {name.fieldState.error && <p className="pl-1 text-xs text-destructive">{name.fieldState.error.message}</p>}
+        </FieldContent>
+      </Field>
+
+      <Field className="gap-2">
+        <FieldLabel htmlFor={`storage-${serviceIndex}-${storageIndex}-mount`}>Mount</FieldLabel>
+        <FieldContent>
+          <Input
+            id={`storage-${serviceIndex}-${storageIndex}-mount`}
+            aria-label="Storage mount"
+            value={mount.field.value ?? ""}
+            onChange={mount.field.onChange}
+            inputClassName="h-9"
+          />
+          {mount.fieldState.error && <p className="pl-1 text-xs text-destructive">{mount.fieldState.error.message}</p>}
+        </FieldContent>
+      </Field>
+
+      <div className="flex items-center gap-2">
+        <Checkbox id={`storage-${serviceIndex}-${storageIndex}-readonly`} checked={!!isReadOnly.field.value} onCheckedChange={isReadOnly.field.onChange} />
+        <Label htmlFor={`storage-${serviceIndex}-${storageIndex}-readonly`}>Read only</Label>
+      </div>
+    </div>
+  );
+};
+
+/**
+ * Returns the first non-colliding value built from `base`: `base`, then `base-1`,
+ * `base-2`, and so on. Used to default new persistent-storage name and mount
+ * fields so a fresh entry never duplicates an existing one (which the schema
+ * rejects). Works for both `data`/`data-1` and `/mnt/data`/`/mnt/data-1`.
+ */
+function nextAvailableValue(base: string, taken: Set<string>): string {
+  if (!taken.has(base)) {
+    return base;
+  }
+
+  let suffix = 1;
+  while (taken.has(`${base}-${suffix}`)) {
+    suffix++;
+  }
+  return `${base}-${suffix}`;
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RamStorageCard/RamStorageCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RamStorageCard/RamStorageCard.spec.tsx
@@ -1,0 +1,161 @@
+import type { PropsWithChildren } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { describe, expect, it } from "vitest";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { SdlBuilderFormValuesSchema } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { DEPENDENCIES, RamStorageCard } from "./RamStorageCard";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const EPHEMERAL = { size: 1, unit: "Gi", isPersistent: false, type: "beta2" };
+const RAM = { size: 10, unit: "Gi", isPersistent: false, type: "ram", name: "shm", mount: "/dev/shm", isReadOnly: false };
+const PERSISTENT = { size: 10, unit: "Gi", isPersistent: true, type: "beta3", name: "data", mount: "/mnt/data", isReadOnly: false };
+
+describe(RamStorageCard.name, () => {
+  it("hides the body when disabled", () => {
+    setup({ ram: false });
+
+    expect(screen.getByRole("switch", { name: "Enable RAM storage" })).not.toBeChecked();
+    expect(screen.queryByLabelText("RAM storage name")).not.toBeInTheDocument();
+  });
+
+  it("appends a RAM storage entry when toggled on", async () => {
+    const { getValues } = setup({ ram: false });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable RAM storage" }));
+
+    const storage = getValues().services[0].profile.storage;
+    expect(storage).toHaveLength(2);
+    expect(storage[1]).toMatchObject({ type: "ram", name: "shm", mount: "/dev/shm" });
+    expect(screen.getByLabelText("RAM storage name")).toHaveValue("shm");
+  });
+
+  it("removes the RAM storage entry when toggled off", async () => {
+    const { getValues } = setup({ ram: true });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable RAM storage" }));
+
+    expect(getValues().services[0].profile.storage).toHaveLength(1);
+    expect(getValues().services[0].profile.storage.some(s => s.type === "ram")).toBe(false);
+  });
+
+  it("edits the RAM storage name", async () => {
+    const { getValues } = setup({ ram: true });
+
+    const input = screen.getByLabelText("RAM storage name");
+    await userEvent.clear(input);
+    await userEvent.type(input, "cache");
+
+    expect(getValues().services[0].profile.storage.find(s => s.type === "ram")?.name).toBe("cache");
+  });
+
+  it("does not render a type select or read only checkbox", () => {
+    setup({ ram: true });
+
+    expect(screen.queryByRole("combobox", { name: "Storage type" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("checkbox", { name: "Read only" })).not.toBeInTheDocument();
+  });
+
+  it("does not offer an add-more or remove control", () => {
+    setup({ ram: true });
+
+    expect(screen.queryByRole("button", { name: "Add more" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Remove/ })).not.toBeInTheDocument();
+  });
+
+  it("only removes the RAM entry, leaving persistent storage untouched", async () => {
+    const { getValues } = setup({ storage: [EPHEMERAL, { ...PERSISTENT }, { ...RAM }] });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable RAM storage" }));
+
+    const storage = getValues().services[0].profile.storage;
+    expect(storage).toHaveLength(2);
+    expect(storage.some(s => s.type === "ram")).toBe(false);
+    expect(storage.some(s => s.isPersistent)).toBe(true);
+  });
+
+  it("binds the body to the RAM entry even when persistent storage precedes it", () => {
+    setup({ storage: [EPHEMERAL, { ...PERSISTENT }, { ...RAM, name: "shm" }] });
+
+    expect(screen.getByLabelText("RAM storage name")).toHaveValue("shm");
+  });
+
+  it("shows a uniqueness error under the name input when the RAM name collides with a persistent name", async () => {
+    const { trigger } = setupValidated([EPHEMERAL, { ...PERSISTENT, name: "shared" }, { ...RAM, name: "shared" }]);
+
+    await trigger();
+
+    await waitFor(() => {
+      expect(screen.getByText("Storage name must be unique")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a uniqueness error under the mount input when the RAM mount collides with a persistent mount", async () => {
+    const { trigger } = setupValidated([EPHEMERAL, { ...PERSISTENT, name: "data", mount: "/shared" }, { ...RAM, name: "shm", mount: "/shared" }]);
+
+    await trigger();
+
+    await waitFor(() => {
+      expect(screen.getByText("Storage mount must be unique")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a size error under the storage input when the RAM size is missing", async () => {
+    const { trigger } = setupValidated([EPHEMERAL, { ...PERSISTENT, name: "data", mount: "/mnt/data" }, { ...RAM, size: 0 }]);
+
+    await trigger();
+
+    await waitFor(() => {
+      expect(screen.getByText("Storage is required.")).toBeInTheDocument();
+    });
+  });
+
+  function setup(input: { ram?: boolean; storage?: SdlBuilderFormValuesType["services"][number]["profile"]["storage"] }) {
+    const storage = input.storage ?? (input.ram ? [EPHEMERAL, { ...RAM }] : [EPHEMERAL]);
+
+    const values = defaultServiceWithPlacement({
+      profile: { cpu: 0.5, gpu: 1, gpuModels: [{ vendor: "nvidia" }], hasGpu: false, ram: 256, ramUnit: "Mi", storage }
+    });
+
+    let getValues: () => SdlBuilderFormValuesType = () => values;
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values, mode: "onChange" });
+      getValues = form.getValues;
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    render(
+      <Wrapper>
+        <RamStorageCard serviceIndex={0} dependencies={{ ...DEPENDENCIES }} />
+      </Wrapper>
+    );
+
+    return { getValues: () => getValues() };
+  }
+
+  function setupValidated(storage: SdlBuilderFormValuesType["services"][number]["profile"]["storage"]) {
+    const values = defaultServiceWithPlacement({
+      image: "nginx:latest",
+      profile: { cpu: 0.5, gpu: 1, gpuModels: [{ vendor: "nvidia" }], hasGpu: false, ram: 256, ramUnit: "Mi", storage }
+    });
+
+    let trigger: () => Promise<boolean> = async () => true;
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values, mode: "onChange", resolver: zodResolver(SdlBuilderFormValuesSchema) });
+      trigger = () => form.trigger();
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    render(
+      <Wrapper>
+        <RamStorageCard serviceIndex={0} dependencies={{ ...DEPENDENCIES }} />
+      </Wrapper>
+    );
+
+    return { trigger: () => trigger() };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RamStorageCard/RamStorageCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RamStorageCard/RamStorageCard.tsx
@@ -1,0 +1,120 @@
+import type { FC } from "react";
+import { useCallback } from "react";
+import { useController, useFieldArray, useFormContext } from "react-hook-form";
+import { CollapsibleCard, Field, FieldContent, FieldLabel, Input, NumberUnitInput } from "@akashnetwork/ui/components";
+import { MicrochipIcon } from "lucide-react";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { storageUnits } from "@src/utils/akash/units";
+import { defaultRamStorage } from "@src/utils/sdl/data";
+import { ramStorageTooltip } from "../cardTooltips";
+
+export const DEPENDENCIES = { CollapsibleCard, NumberUnitInput };
+
+type Props = {
+  serviceIndex: number;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/**
+ * Hardware "RAM Storage" card. A header switch toggles the presence of a single
+ * RAM volume (`type === "ram"`) inside the shared `profile.storage` array, where
+ * `storage[0]` is the ephemeral root and the remaining entries are persistent or
+ * RAM volumes. Unlike persistent storage there is at most one RAM entry, its type
+ * is fixed, and it carries no read-only flag — so the body just edits the volume's
+ * size, name and mount.
+ */
+export const RamStorageCard: FC<Props> = ({ serviceIndex, dependencies: d = DEPENDENCIES }) => {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const { fields, append, remove } = useFieldArray({ control, name: `services.${serviceIndex}.profile.storage`, keyName: "key" });
+
+  const ramIndex = fields.findIndex((field, index) => index > 0 && field.type === "ram");
+  const isEnabled = ramIndex !== -1;
+
+  const toggleRamStorage = useCallback(
+    (checked: boolean) => {
+      if (checked && !isEnabled) {
+        append({ ...defaultRamStorage }, { shouldFocus: false });
+      } else if (!checked && isEnabled) {
+        remove(ramIndex);
+      }
+    },
+    [append, remove, ramIndex, isEnabled]
+  );
+
+  return (
+    <d.CollapsibleCard
+      title="RAM Storage"
+      icon={<MicrochipIcon className="h-4 w-4" />}
+      infoTooltip={ramStorageTooltip}
+      isToggled={isEnabled}
+      onToggle={toggleRamStorage}
+      toggleAriaLabel="Enable RAM storage"
+    >
+      {isEnabled && <RamStorageFields serviceIndex={serviceIndex} storageIndex={ramIndex} dependencies={d} />}
+    </d.CollapsibleCard>
+  );
+};
+
+type RamStorageFieldsProps = {
+  serviceIndex: number;
+  storageIndex: number;
+  dependencies: typeof DEPENDENCIES;
+};
+
+const RamStorageFields: FC<RamStorageFieldsProps> = ({ serviceIndex, storageIndex, dependencies: d }) => {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const basePath = `services.${serviceIndex}.profile.storage.${storageIndex}` as const;
+
+  const size = useController({ control, name: `${basePath}.size` });
+  const unit = useController({ control, name: `${basePath}.unit` });
+  const name = useController({ control, name: `${basePath}.name` });
+  const mount = useController({ control, name: `${basePath}.mount` });
+
+  return (
+    <>
+      <Field className="gap-2">
+        <FieldLabel>Storage</FieldLabel>
+        <FieldContent>
+          <d.NumberUnitInput
+            label="RAM storage"
+            units={storageUnits}
+            value={size.field.value ?? undefined}
+            unit={unit.field.value}
+            onValueChange={value => size.field.onChange(value ?? null)}
+            onUnitChange={unit.field.onChange}
+            error={size.fieldState.error?.message ?? unit.fieldState.error?.message}
+          />
+        </FieldContent>
+      </Field>
+
+      <Field className="gap-2">
+        <FieldLabel htmlFor={`ram-storage-${serviceIndex}-name`}>Name</FieldLabel>
+        <FieldContent>
+          <Input
+            id={`ram-storage-${serviceIndex}-name`}
+            aria-label="RAM storage name"
+            value={name.field.value ?? ""}
+            onChange={name.field.onChange}
+            inputClassName="h-9"
+          />
+          {name.fieldState.error && <p className="pl-1 text-xs text-destructive">{name.fieldState.error.message}</p>}
+        </FieldContent>
+      </Field>
+
+      <Field className="gap-2">
+        <FieldLabel htmlFor={`ram-storage-${serviceIndex}-mount`}>Mount</FieldLabel>
+        <FieldContent>
+          <Input
+            id={`ram-storage-${serviceIndex}-mount`}
+            aria-label="RAM storage mount"
+            value={mount.field.value ?? ""}
+            onChange={mount.field.onChange}
+            inputClassName="h-9"
+          />
+          {mount.fieldState.error && <p className="pl-1 text-xs text-destructive">{mount.fieldState.error.message}</p>}
+        </FieldContent>
+      </Field>
+    </>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/cardTooltips.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/cardTooltips.tsx
@@ -20,6 +20,29 @@ export const computeResourcesTooltip = (
   </>
 );
 
+export const ramStorageTooltip = (
+  <>
+    The amount of RAM-backed storage required for this workload.
+    <br />
+    <br />
+    This volume is mounted in memory, so it is fast but ephemeral — its contents are lost when the container restarts.
+  </>
+);
+
+export const persistentStorageTooltip = (
+  <>
+    The amount of persistent storage required for this workload.
+    <br />
+    <br />
+    This storage is mounted on a persistent volume and persistent through the lifetime of the deployment
+    <br />
+    <br />
+    <a href="https://akash.network/docs/developers/deployment/akash-sdl/advanced-features/#persistent-storage" target="_blank" rel="noopener">
+      View official documentation
+    </a>
+  </>
+);
+
 export const imageRuntimeTooltip = (
   <>
     Docker image of the container.

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness.spec.tsx
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { SdlBuilderFormValuesSchema } from "@src/types";
 import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { storageUniquenessKey } from "../../ConfigurationPane/HardwareSection/HardwareSection";
 import { useRevalidateUniqueness } from "./useRevalidateUniqueness";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -94,6 +95,82 @@ describe(useRevalidateUniqueness.name, () => {
     });
   });
 
+  it("shows the uniqueness error on every conflicting storage row when names collide", async () => {
+    setupStorage([
+      { size: 1, unit: "Gi", isPersistent: false, type: "beta2" },
+      { size: 1, unit: "Gi", isPersistent: true, type: "beta3", name: "data", mount: "/mnt/a" },
+      { size: 1, unit: "Gi", isPersistent: true, type: "beta3", name: "data-2", mount: "/mnt/b" }
+    ]);
+
+    const secondNameInput = screen.getByLabelText("storage-2-name");
+    fireEvent.change(secondNameInput, { target: { value: "data" } });
+    fireEvent.blur(secondNameInput);
+
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Storage name must be unique")).toHaveLength(2);
+    });
+  });
+
+  it("clears the stale error on a sibling storage row once the conflict is resolved elsewhere", async () => {
+    setupStorage([
+      { size: 1, unit: "Gi", isPersistent: false, type: "beta2" },
+      { size: 1, unit: "Gi", isPersistent: true, type: "beta3", name: "data", mount: "/mnt/a" },
+      { size: 1, unit: "Gi", isPersistent: true, type: "beta3", name: "data", mount: "/mnt/b" }
+    ]);
+
+    submitForm();
+
+    await waitFor(() => expect(screen.getAllByText("Storage name must be unique")).toHaveLength(2));
+
+    const firstNameInput = screen.getByLabelText("storage-1-name");
+    fireEvent.change(firstNameInput, { target: { value: "data-renamed" } });
+    fireEvent.blur(firstNameInput);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Storage name must be unique")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows the uniqueness error on every conflicting storage row when mounts collide", async () => {
+    setupStorage([
+      { size: 1, unit: "Gi", isPersistent: false, type: "beta2" },
+      { size: 1, unit: "Gi", isPersistent: true, type: "beta3", name: "data-a", mount: "/mnt/data" },
+      { size: 1, unit: "Gi", isPersistent: true, type: "beta3", name: "data-b", mount: "/mnt/other" }
+    ]);
+
+    const secondMountInput = screen.getByLabelText("storage-2-mount");
+    fireEvent.change(secondMountInput, { target: { value: "/mnt/data" } });
+    fireEvent.blur(secondMountInput);
+
+    submitForm();
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Storage mount must be unique")).toHaveLength(2);
+    });
+  });
+
+  it("clears the stale mount error on a sibling storage row once the conflict is resolved elsewhere", async () => {
+    setupStorage([
+      { size: 1, unit: "Gi", isPersistent: false, type: "beta2" },
+      { size: 1, unit: "Gi", isPersistent: true, type: "beta3", name: "data-a", mount: "/mnt/data" },
+      { size: 1, unit: "Gi", isPersistent: true, type: "beta3", name: "data-b", mount: "/mnt/data" }
+    ]);
+
+    submitForm();
+
+    await waitFor(() => expect(screen.getAllByText("Storage mount must be unique")).toHaveLength(2));
+
+    const firstMountInput = screen.getByLabelText("storage-1-mount");
+    fireEvent.change(firstMountInput, { target: { value: "/mnt/data-renamed" } });
+    fireEvent.blur(firstMountInput);
+
+    await waitFor(() => {
+      expect(screen.queryByText("Storage mount must be unique")).not.toBeInTheDocument();
+    });
+  });
+
   function duplicateSecondRowOnto(name: FieldArrayName, value: string) {
     editRow(name, 1, value);
   }
@@ -106,6 +183,34 @@ describe(useRevalidateUniqueness.name, () => {
     const input = screen.getByLabelText(`${name}-${index}`);
     fireEvent.change(input, { target: { value } });
     fireEvent.blur(input);
+  }
+
+  function setupStorage(storage: SdlBuilderFormValuesType["services"][number]["profile"]["storage"]) {
+    const values = defaultServiceWithPlacement({
+      image: "nginx:latest",
+      profile: { cpu: 0.5, gpu: 1, gpuModels: [{ vendor: "nvidia" }], hasGpu: false, ram: 256, ramUnit: "Mi", storage }
+    });
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({
+        defaultValues: values,
+        mode: "onSubmit",
+        reValidateMode: "onChange",
+        resolver: zodResolver(SdlBuilderFormValuesSchema)
+      });
+      return (
+        <FormProvider {...form}>
+          <form onSubmit={form.handleSubmit(() => undefined)}>
+            {children}
+            <button type="submit">submit</button>
+          </form>
+        </FormProvider>
+      );
+    };
+    render(
+      <Wrapper>
+        <StorageHarness serviceIndex={0} />
+      </Wrapper>
+    );
   }
 
   function setup<TName extends FieldArrayName>(input: {
@@ -167,6 +272,42 @@ function Harness<TName extends FieldArrayName>({
             </div>
           )}
         />
+      ))}
+    </>
+  );
+}
+
+function StorageHarness({ serviceIndex }: { serviceIndex: number }) {
+  useRevalidateUniqueness(`services.${serviceIndex}.profile.storage`, storageUniquenessKey);
+
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const items = (useWatch({ control, name: `services.${serviceIndex}.profile.storage` }) ?? []) as unknown[];
+
+  return (
+    <>
+      {items.map((_, index) => (
+        <div key={index}>
+          <Controller
+            control={control}
+            name={`services.${serviceIndex}.profile.storage.${index}.name` as Path<SdlBuilderFormValuesType>}
+            render={({ field, fieldState }) => (
+              <div>
+                <input aria-label={`storage-${index}-name`} value={(field.value as string) ?? ""} onChange={event => field.onChange(event.target.value)} />
+                {fieldState.error && <span>{fieldState.error.message}</span>}
+              </div>
+            )}
+          />
+          <Controller
+            control={control}
+            name={`services.${serviceIndex}.profile.storage.${index}.mount` as Path<SdlBuilderFormValuesType>}
+            render={({ field, fieldState }) => (
+              <div>
+                <input aria-label={`storage-${index}-mount`} value={(field.value as string) ?? ""} onChange={event => field.onChange(event.target.value)} />
+                {fieldState.error && <span>{fieldState.error.message}</span>}
+              </div>
+            )}
+          />
+        </div>
       ))}
     </>
   );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness.ts
@@ -3,8 +3,23 @@ import { useFormContext, useFormState, useWatch } from "react-hook-form";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
 
-/** Field arrays whose rows are validated for a unique key (name/title). */
-type UniqueFieldArrayName = "placements" | "services" | "endpoints";
+type ServiceStorage = SdlBuilderFormValuesType["services"][number]["profile"]["storage"][number];
+
+/**
+ * RHF paths to field arrays whose rows are validated for a unique key
+ * (name/title). Top-level arrays plus the per-service storage array, whose
+ * persistent and RAM volumes must each carry a unique name and mount.
+ */
+type UniqueFieldArrayName = "placements" | "services" | "endpoints" | `services.${number}.profile.storage`;
+
+/** Resolves the row item type for a given field-array path so `selectKey` stays typed. */
+type UniqueFieldArrayItem<TName extends UniqueFieldArrayName> = TName extends "placements"
+  ? SdlBuilderFormValuesType["placements"][number]
+  : TName extends "services"
+    ? SdlBuilderFormValuesType["services"][number]
+    : TName extends "endpoints"
+      ? NonNullable<SdlBuilderFormValuesType["endpoints"]>[number]
+      : ServiceStorage;
 
 /**
  * Re-runs validation for the `name` field array whenever the `selectKey` value
@@ -25,14 +40,15 @@ type UniqueFieldArrayName = "placements" | "services" | "endpoints";
  * validate-on-submit mode. Before the first submit there is nothing on screen to
  * keep fresh; once submitted, this keeps sibling uniqueness errors consistent as
  * rows are renamed, added or removed.
+ *
+ * `useWatch` widens its return to the union of every possible field value when
+ * `name` is a generic path, so its result is narrowed back to this path's row
+ * type — the one place RHF's types can't track a generic path to its element.
  */
-export const useRevalidateUniqueness = <TName extends UniqueFieldArrayName>(
-  name: TName,
-  selectKey: (item: SdlBuilderFormValuesType[TName][number]) => string
-) => {
+export const useRevalidateUniqueness = <TName extends UniqueFieldArrayName>(name: TName, selectKey: (item: UniqueFieldArrayItem<TName>) => string) => {
   const { control, trigger } = useFormContext<SdlBuilderFormValuesType>();
   const { isSubmitted } = useFormState({ control });
-  const items = useWatch({ control, name }) as SdlBuilderFormValuesType[TName] | undefined;
+  const items = useWatch({ control, name }) as UniqueFieldArrayItem<TName>[] | undefined;
   const key = (items ?? []).map(selectKey).join("\u0000");
 
   useEffect(

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.spec.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from "vitest";
 
-import { CredentialsSchema, EndpointSchema, EnvironmentVariableSchema, SdlBuilderFormValuesSchema, ServiceSchema } from "./sdlBuilder";
+import { CredentialsSchema, EndpointSchema, EnvironmentVariableSchema, SdlBuilderFormValuesSchema, ServiceSchema, ServiceStorageSchema } from "./sdlBuilder";
+
+describe("ServiceStorageSchema", () => {
+  it("surfaces a friendly required message instead of the raw type error when size is cleared", () => {
+    const result = ServiceStorageSchema.safeParse({ size: null, unit: "Gi" });
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues).toContainEqual(expect.objectContaining({ path: ["size"], message: "Storage is required." }));
+    expect(result.error.issues.some(issue => /received null/i.test(issue.message))).toBe(false);
+  });
+});
 
 describe("ServiceSchema", () => {
   it("validates a minimal valid service", () => {

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -41,7 +41,7 @@ export const ProfileGpuModelSchema = z.object({
 });
 
 export const ServiceStorageSchema = z.object({
-  size: z.number().min(1, { message: "Storage is required." }).default(1),
+  size: z.number({ invalid_type_error: "Storage is required.", required_error: "Storage is required." }).min(1, { message: "Storage is required." }).default(1),
   unit: z.string().min(1, { message: "Storage unit is required." }).default("Gi"),
   isPersistent: z.boolean().optional().default(false),
   name: z


### PR DESCRIPTION
## Why

Part of CON-411. Adds named-volume storage to the Configuration pane on top of the core cards from PR 1 (#3340). Second of the three stacked PRs.

## What

- **RAM Storage card** and **Persistent Storage card** — named volumes on `profile.storage` (size/unit, type, name, mount, read-only), each with an enable toggle. Wired into the Hardware section.
- **Name/mount uniqueness revalidation** — the `useRevalidateUniqueness` hook keeps the "must be unique" error in sync across every conflicting volume row, not just the edited one.
- Tests for both cards and the uniqueness hook.

### Bug fixes surfaced while validating the cards

- **Only-block removal** — the first persistent block could never be removed; now every block is removable while more than one exists, and only the *sole* remaining block hides its trash control (remove it by toggling the card off).
- **Friendly required message** — clearing a storage size leaked the raw `"Expected number, received null"` Zod error; the size schema now emits `"Storage is required."`.
- **Live-value dedup** — new volumes deduped against the `useFieldArray` snapshot, so a volume renamed via its input could be handed a colliding default; dedup now reads live values via `getValues`.
<img width="339" height="1238" alt="image" src="https://github.com/user-attachments/assets/d2468fd3-6026-4a9b-8f41-242d507796a7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dedicated RAM and persistent storage management cards to the deployment configuration interface
  * Added informational tooltips explaining RAM and persistent storage options

* **Bug Fixes**
  * Improved storage validation error messages for better clarity
  * Prevent duplicate storage names and mount paths by revalidating storage uniqueness across the configuration
  * Enhanced storage uniqueness behavior and coverage with expanded automated tests for RAM, persistent storage, and revalidation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->