### PR TITLE
fix: unref retry policies to unblock process shutdown without waiting  for them

### DIFF
--- a/apps/provider-inventory/package.json
+++ b/apps/provider-inventory/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint .",
     "migration:exec": "node dist/db-migrate.js",
     "migration:gen": "drizzle-kit generate",
-    "prod": "node --max-old-space-size=2300 --permission --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --heapsnapshot-near-heap-limit=2 --diagnostic-dir=/tmp --allow-fs-write=/tmp --enable-source-maps --require ./dist/instrumentation.js ./dist/server.js",
+    "prod": "node --permission --allow-fs-read=./dist/ --allow-fs-read=./env/ --allow-fs-read=./node_modules/ --allow-fs-read=../../node_modules/ --allow-fs-read=../../packages/env-loader/ --allow-fs-write=/tmp --enable-source-maps --require ./dist/instrumentation.js ./dist/server.js",
     "start": "tsup --watch",
     "test": "vitest run --project unit --project integration --project functional",
     "test:ci-setup": "dc up -d --wait --wait-timeout 60 db",

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -69,14 +69,14 @@ export class StreamLifecycleManagerService {
         initialDelay: this.#config.STREAM_RECONNECT_INITIAL_DELAY_MS,
         maxDelay: this.#config.STREAM_RECONNECT_MAX_DELAY_MS
       })
-    });
+    }).dangerouslyUnref();
     this.#potentiallyDeadProviderRetryStreamPolicy = retry(handleAll, {
       maxAttempts: 1,
       backoff: new ExponentialBackoff({
         initialDelay: this.#config.STREAM_RECONNECT_INITIAL_DELAY_MS,
         maxDelay: this.#config.STREAM_RECONNECT_MAX_DELAY_MS
       })
-    });
+    }).dangerouslyUnref();
     this.#offlineDataloader = new Dataloader(
       async keys => {
         if (this.#isShutDown) return Array.from(keys, () => false);


### PR DESCRIPTION
## Why

ref CON-571

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js security permissions configuration in the provider inventory service.
  * Optimized stream connection retry management for improved resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->