### PR TITLE
feat(deployment): surface declared confidential compute config on the deployment view

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfidentialComputeResources.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfidentialComputeResources.spec.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+import type { TeeServiceCarveout } from "@src/utils/confidentialCompute";
+import { ConfidentialComputeResources, DEPENDENCIES } from "./ConfidentialComputeResources";
+
+import { render, screen } from "@testing-library/react";
+import { MockComponents } from "@tests/unit/mocks";
+
+const MIB = 1024 * 1024;
+
+const cpuCarveout: TeeServiceCarveout = {
+  serviceName: "web",
+  teeType: "cpu",
+  requested: { cpu: 500, memory: 256 * MIB },
+  reserved: { cpu: 100, memory: 64 * MIB },
+  container: { cpu: 400, memory: 192 * MIB }
+};
+
+describe(ConfidentialComputeResources.name, () => {
+  it("renders nothing when there are no carve-outs", () => {
+    const { container } = setup({ carveouts: [] });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the requested, sidecar and available rows with formatted values", () => {
+    setup({ carveouts: [cpuCarveout] });
+
+    expect(screen.getByText("Requested")).toBeInTheDocument();
+    expect(screen.getByText("Attestation sidecar")).toBeInTheDocument();
+    expect(screen.getByText("Available to your container")).toBeInTheDocument();
+
+    expect(screen.getByText("0.5 CPU")).toBeInTheDocument();
+    expect(screen.getByText("256 MiB")).toBeInTheDocument();
+    expect(screen.getByText("0.1 CPU")).toBeInTheDocument();
+    expect(screen.getByText("64 MiB")).toBeInTheDocument();
+    expect(screen.getByText("0.4 CPU")).toBeInTheDocument();
+    expect(screen.getByText("192 MiB")).toBeInTheDocument();
+  });
+
+  it("warns when the declared resources are at or below the attestation sidecar reservation", () => {
+    const constrained: TeeServiceCarveout = {
+      serviceName: "web",
+      teeType: "cpu",
+      requested: { cpu: 100, memory: 64 * MIB },
+      reserved: { cpu: 100, memory: 64 * MIB },
+      container: { cpu: 10, memory: 16 * MIB }
+    };
+    setup({ carveouts: [constrained] });
+    expect(screen.getByText(/minimum/i)).toBeInTheDocument();
+  });
+
+  it("does not warn when the declared resources comfortably exceed the reservation", () => {
+    setup({ carveouts: [cpuCarveout] });
+    expect(screen.queryByText(/minimum/i)).not.toBeInTheDocument();
+  });
+
+  it("labels each service when more than one declares a TEE type", () => {
+    const second: TeeServiceCarveout = {
+      ...cpuCarveout,
+      serviceName: "api",
+      teeType: "cpu-gpu",
+      reserved: { cpu: 100, memory: 128 * MIB },
+      container: { cpu: 400, memory: 128 * MIB }
+    };
+    setup({ carveouts: [cpuCarveout, second] });
+
+    expect(screen.getByText("web")).toBeInTheDocument();
+    expect(screen.getByText("api")).toBeInTheDocument();
+  });
+
+  it("explains that billing is unaffected via the tooltip", () => {
+    const CustomTooltip = ({ title, children }: { title: React.ReactNode; children?: React.ReactNode }) => (
+      <>
+        {title}
+        {children}
+      </>
+    );
+    setup({ carveouts: [cpuCarveout], dependencies: { CustomTooltip } });
+
+    expect(screen.getByText(/still pay for the full/i)).toBeInTheDocument();
+  });
+
+  function setup(input: { carveouts: TeeServiceCarveout[]; dependencies?: Partial<typeof DEPENDENCIES> }) {
+    return render(<ConfidentialComputeResources carveouts={input.carveouts} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />);
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfidentialComputeResources.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfidentialComputeResources.spec.tsx
@@ -1,17 +1,20 @@
 import React from "react";
 import { describe, expect, it } from "vitest";
 
-import type { TeeServiceCarveout } from "@src/utils/confidentialCompute";
+import type { TeeResourceCarveout } from "@src/utils/confidentialCompute";
 import { ConfidentialComputeResources, DEPENDENCIES } from "./ConfidentialComputeResources";
 
 import { render, screen } from "@testing-library/react";
 import { MockComponents } from "@tests/unit/mocks";
 
 const MIB = 1024 * 1024;
+const GIB = 1024 * 1024 * 1024;
 
-const cpuCarveout: TeeServiceCarveout = {
-  serviceName: "web",
+const cpuCarveout: TeeResourceCarveout = {
+  id: "1",
   teeType: "cpu",
+  count: 1,
+  gpuUnits: 0,
   requested: { cpu: 500, memory: 256 * MIB },
   reserved: { cpu: 100, memory: 64 * MIB },
   container: { cpu: 400, memory: 192 * MIB }
@@ -39,9 +42,8 @@ describe(ConfidentialComputeResources.name, () => {
   });
 
   it("warns when the declared resources are at or below the attestation sidecar reservation", () => {
-    const constrained: TeeServiceCarveout = {
-      serviceName: "web",
-      teeType: "cpu",
+    const constrained: TeeResourceCarveout = {
+      ...cpuCarveout,
       requested: { cpu: 100, memory: 64 * MIB },
       reserved: { cpu: 100, memory: 64 * MIB },
       container: { cpu: 10, memory: 16 * MIB }
@@ -55,18 +57,30 @@ describe(ConfidentialComputeResources.name, () => {
     expect(screen.queryByText(/minimum/i)).not.toBeInTheDocument();
   });
 
-  it("labels each service when more than one declares a TEE type", () => {
-    const second: TeeServiceCarveout = {
+  it("labels each resource unit by its composition when more than one is present", () => {
+    const second: TeeResourceCarveout = {
       ...cpuCarveout,
-      serviceName: "api",
+      id: "2",
       teeType: "cpu-gpu",
+      gpuUnits: 1,
+      requested: { cpu: 8000, memory: 32 * GIB },
       reserved: { cpu: 100, memory: 128 * MIB },
-      container: { cpu: 400, memory: 128 * MIB }
+      container: { cpu: 7900, memory: 32 * GIB - 128 * MIB }
     };
     setup({ carveouts: [cpuCarveout, second] });
 
-    expect(screen.getByText("web")).toBeInTheDocument();
-    expect(screen.getByText("api")).toBeInTheDocument();
+    expect(screen.getByText("0.5 CPU · 256 MiB")).toBeInTheDocument();
+    expect(screen.getByText("8 CPU · 32 GiB · 1 GPU")).toBeInTheDocument();
+  });
+
+  it("notes the replica count when a resource unit runs more than one pod", () => {
+    setup({ carveouts: [{ ...cpuCarveout, count: 3 }] });
+    expect(screen.getByText(/3 replicas/i)).toBeInTheDocument();
+  });
+
+  it("does not note replicas for a single-pod resource unit", () => {
+    setup({ carveouts: [cpuCarveout] });
+    expect(screen.queryByText(/replicas/i)).not.toBeInTheDocument();
   });
 
   it("explains that billing is unaffected via the tooltip", () => {
@@ -81,7 +95,7 @@ describe(ConfidentialComputeResources.name, () => {
     expect(screen.getByText(/still pay for the full/i)).toBeInTheDocument();
   });
 
-  function setup(input: { carveouts: TeeServiceCarveout[]; dependencies?: Partial<typeof DEPENDENCIES> }) {
+  function setup(input: { carveouts: TeeResourceCarveout[]; dependencies?: Partial<typeof DEPENDENCIES> }) {
     return render(<ConfidentialComputeResources carveouts={input.carveouts} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />);
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfidentialComputeResources.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfidentialComputeResources.tsx
@@ -3,13 +3,13 @@ import * as React from "react";
 import { CustomTooltip } from "@akashnetwork/ui/components";
 import { Info } from "lucide-react";
 
-import type { TeeServiceCarveout } from "@src/utils/confidentialCompute";
+import type { TeeResourceCarveout } from "@src/utils/confidentialCompute";
 import { MIN_PRIMARY_CPU_MILLICORES, MIN_PRIMARY_MEMORY_BYTES } from "@src/utils/confidentialCompute";
 import { roundDecimal } from "@src/utils/mathHelpers";
 import { bytesToShrink } from "@src/utils/unitUtils";
 
 export type Props = {
-  carveouts: TeeServiceCarveout[];
+  carveouts: TeeResourceCarveout[];
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -20,6 +20,13 @@ const formatCpu = (millicores: number) => `${roundDecimal(millicores / 1000, 2)}
 const formatMemory = (bytes: number) => {
   const { value, unit } = bytesToShrink(bytes, true);
   return `${roundDecimal(value, 2)} ${unit}`;
+};
+
+/** Self-describing label for a resource unit (on-chain groups carry no service names). */
+const formatUnitLabel = (carveout: TeeResourceCarveout) => {
+  const parts = [formatCpu(carveout.requested.cpu), formatMemory(carveout.requested.memory)];
+  if (carveout.gpuUnits > 0) parts.push(`${carveout.gpuUnits} GPU`);
+  return parts.join(" · ");
 };
 
 function ResourceLine({ label, cpu, memory }: { label: string; cpu: number; memory: number }) {
@@ -56,15 +63,20 @@ export function ConfidentialComputeResources({ carveouts, dependencies: d = DEPE
           carveout.requested.memory - carveout.reserved.memory < MIN_PRIMARY_MEMORY_BYTES;
 
         return (
-          <div key={carveout.serviceName} className="space-y-1 rounded-md border p-3">
-            {multiple && <div className="text-sm font-medium">{carveout.serviceName}</div>}
+          <div key={carveout.id} className="space-y-1 rounded-md border p-3">
+            {(multiple || carveout.count > 1) && (
+              <div className="flex items-center justify-between gap-4 text-sm font-medium">
+                <span>{multiple ? formatUnitLabel(carveout) : null}</span>
+                {carveout.count > 1 && <span className="text-xs text-muted-foreground">× {carveout.count} replicas</span>}
+              </div>
+            )}
             <ResourceLine label="Requested" cpu={carveout.requested.cpu} memory={carveout.requested.memory} />
             <ResourceLine label="Attestation sidecar" cpu={carveout.reserved.cpu} memory={carveout.reserved.memory} />
             <ResourceLine label="Available to your container" cpu={carveout.container.cpu} memory={carveout.container.memory} />
             {isConstrained && (
               <p className="text-xs text-muted-foreground">
-                This service&apos;s declared resources are at or below the attestation sidecar&apos;s reservation, so the provider applies a minimum for your
-                container — the values above are not a direct subtraction. Consider increasing the declared CPU and memory.
+                These declared resources are at or below the attestation sidecar&apos;s reservation, so the provider applies a minimum for your container — the
+                values above are not a direct subtraction. Consider increasing the declared CPU and memory.
               </p>
             )}
           </div>

--- a/apps/deploy-web/src/components/deployments/ConfidentialComputeResources.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfidentialComputeResources.tsx
@@ -1,0 +1,75 @@
+"use client";
+import * as React from "react";
+import { CustomTooltip } from "@akashnetwork/ui/components";
+import { Info } from "lucide-react";
+
+import type { TeeServiceCarveout } from "@src/utils/confidentialCompute";
+import { MIN_PRIMARY_CPU_MILLICORES, MIN_PRIMARY_MEMORY_BYTES } from "@src/utils/confidentialCompute";
+import { roundDecimal } from "@src/utils/mathHelpers";
+import { bytesToShrink } from "@src/utils/unitUtils";
+
+export type Props = {
+  carveouts: TeeServiceCarveout[];
+  dependencies?: typeof DEPENDENCIES;
+};
+
+export const DEPENDENCIES = { CustomTooltip };
+
+const formatCpu = (millicores: number) => `${roundDecimal(millicores / 1000, 2)} CPU`;
+
+const formatMemory = (bytes: number) => {
+  const { value, unit } = bytesToShrink(bytes, true);
+  return `${roundDecimal(value, 2)} ${unit}`;
+};
+
+function ResourceLine({ label, cpu, memory }: { label: string; cpu: number; memory: number }) {
+  return (
+    <div className="flex items-center justify-between gap-4 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="flex items-center gap-2 font-medium">
+        <span>{formatCpu(cpu)}</span>
+        <span>{formatMemory(memory)}</span>
+      </span>
+    </div>
+  );
+}
+
+export function ConfidentialComputeResources({ carveouts, dependencies: d = DEPENDENCIES }: Props) {
+  if (carveouts.length === 0) return null;
+
+  const multiple = carveouts.length > 1;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-1 text-sm font-medium">
+        <span>Confidential compute resources</span>
+        <d.CustomTooltip title="The provider injects an attestation sidecar that reserves part of the resources you declared. You still pay for the full declared amount — the reserved slice is taken from what your container can use, not from your bill.">
+          <Info className="h-3 w-3 cursor-help text-muted-foreground" />
+        </d.CustomTooltip>
+      </div>
+
+      {carveouts.map(carveout => {
+        // When the declared budget is at/below the sidecar footprint the provider applies a minimum
+        // for the primary container, so the rows are no longer a clean subtraction — explain that.
+        const isConstrained =
+          carveout.requested.cpu - carveout.reserved.cpu < MIN_PRIMARY_CPU_MILLICORES ||
+          carveout.requested.memory - carveout.reserved.memory < MIN_PRIMARY_MEMORY_BYTES;
+
+        return (
+          <div key={carveout.serviceName} className="space-y-1 rounded-md border p-3">
+            {multiple && <div className="text-sm font-medium">{carveout.serviceName}</div>}
+            <ResourceLine label="Requested" cpu={carveout.requested.cpu} memory={carveout.requested.memory} />
+            <ResourceLine label="Attestation sidecar" cpu={carveout.reserved.cpu} memory={carveout.reserved.memory} />
+            <ResourceLine label="Available to your container" cpu={carveout.container.cpu} memory={carveout.container.memory} />
+            {isConstrained && (
+              <p className="text-xs text-muted-foreground">
+                This service&apos;s declared resources are at or below the attestation sidecar&apos;s reservation, so the provider applies a minimum for your
+                container — the values above are not a direct subtraction. Consider increasing the declared CPU and memory.
+              </p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
@@ -15,6 +15,7 @@ import { DeploymentAlerts } from "@src/components/deployments/DeploymentAlerts/D
 import { useServices } from "@src/context/ServicesProvider";
 import { useSettings } from "@src/context/SettingsProvider";
 import { useWallet } from "@src/context/WalletProvider";
+import { useDeclaredTeeTypes } from "@src/hooks/useDeclaredTeeTypes";
 import { useFlag } from "@src/hooks/useFlag";
 import { useNavigationGuard } from "@src/hooks/useNavigationGuard/useNavigationGuard";
 import { useUser } from "@src/hooks/useUser";
@@ -24,7 +25,6 @@ import { useDeploymentLeaseList } from "@src/queries/useLeaseQuery";
 import { useProviderList } from "@src/queries/useProvidersQuery";
 import { extractRepositoryUrl } from "@src/services/remote-deploy/env-var-manager.service";
 import { RouteStep } from "@src/types/route-steps.type";
-import { getDeclaredTeeTypes } from "@src/utils/confidentialCompute";
 import { isLeaseLive } from "@src/utils/reclamationUtils";
 import { UrlService } from "@src/utils/urlUtils";
 import Layout from "../layout/Layout";
@@ -104,7 +104,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq }) => {
   }, [deployment, dseq, getLeases, getProviders, address, deploymentLocalStorage]);
 
   const isActive = deployment?.state === "active" && leases?.some(isLeaseLive);
-  const declaredTeeTypes = useMemo(() => getDeclaredTeeTypes(deployment?.groups), [deployment?.groups]);
+  const declaredTeeTypes = useDeclaredTeeTypes(deployment);
 
   const tabs = useMemo(() => {
     const tabs: { label: string; value: Tab; badged?: boolean }[] = [

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
@@ -24,7 +24,7 @@ import { useDeploymentLeaseList } from "@src/queries/useLeaseQuery";
 import { useProviderList } from "@src/queries/useProvidersQuery";
 import { extractRepositoryUrl } from "@src/services/remote-deploy/env-var-manager.service";
 import { RouteStep } from "@src/types/route-steps.type";
-import { getDeclaredTeeTypesFromYaml } from "@src/utils/confidentialCompute";
+import { getDeclaredTeeTypes } from "@src/utils/confidentialCompute";
 import { isLeaseLive } from "@src/utils/reclamationUtils";
 import { UrlService } from "@src/utils/urlUtils";
 import Layout from "../layout/Layout";
@@ -104,7 +104,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq }) => {
   }, [deployment, dseq, getLeases, getProviders, address, deploymentLocalStorage]);
 
   const isActive = deployment?.state === "active" && leases?.some(isLeaseLive);
-  const declaredTeeTypes = useMemo(() => getDeclaredTeeTypesFromYaml(deploymentManifest), [deploymentManifest]);
+  const declaredTeeTypes = useMemo(() => getDeclaredTeeTypes(deployment?.groups), [deployment?.groups]);
 
   const tabs = useMemo(() => {
     const tabs: { label: string; value: Tab; badged?: boolean }[] = [

--- a/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetail.tsx
@@ -24,6 +24,7 @@ import { useDeploymentLeaseList } from "@src/queries/useLeaseQuery";
 import { useProviderList } from "@src/queries/useProvidersQuery";
 import { extractRepositoryUrl } from "@src/services/remote-deploy/env-var-manager.service";
 import { RouteStep } from "@src/types/route-steps.type";
+import { getDeclaredTeeTypesFromYaml } from "@src/utils/confidentialCompute";
 import { isLeaseLive } from "@src/utils/reclamationUtils";
 import { UrlService } from "@src/utils/urlUtils";
 import Layout from "../layout/Layout";
@@ -103,6 +104,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq }) => {
   }, [deployment, dseq, getLeases, getProviders, address, deploymentLocalStorage]);
 
   const isActive = deployment?.state === "active" && leases?.some(isLeaseLive);
+  const declaredTeeTypes = useMemo(() => getDeclaredTeeTypesFromYaml(deploymentManifest), [deploymentManifest]);
 
   const tabs = useMemo(() => {
     const tabs: { label: string; value: Tab; badged?: boolean }[] = [
@@ -242,7 +244,7 @@ export const DeploymentDetail: FC<DeploymentDetailProps> = ({ dseq }) => {
         <>
           <ReclamationBanner leases={leases} dseq={dseq} />
 
-          <DeploymentSubHeader deployment={deployment} leases={leases} />
+          <DeploymentSubHeader deployment={deployment} leases={leases} teeTypes={declaredTeeTypes} />
 
           <Tabs value={activeTab} onValueChange={value => changeTab(value as Tab)}>
             <TabsList

--- a/apps/deploy-web/src/components/deployments/DeploymentSubHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentSubHeader.tsx
@@ -5,6 +5,7 @@ import formatDistanceToNow from "date-fns/formatDistanceToNow";
 import isValid from "date-fns/isValid";
 import { WarningCircle } from "iconoir-react";
 
+import { ConfidentialComputeBadge } from "@src/components/shared/ConfidentialComputeBadge";
 import { CopyTextToClipboardButton } from "@src/components/shared/CopyTextToClipboardButton";
 import { LabelValue } from "@src/components/shared/LabelValue";
 import { PricePerTimeUnit } from "@src/components/shared/PricePerTimeUnit";
@@ -16,16 +17,18 @@ import { useWallet } from "@src/context/WalletProvider";
 import { useDeploymentMetrics } from "@src/hooks/useDeploymentMetrics";
 import { useTrialDeploymentTimeRemaining } from "@src/hooks/useTrialDeploymentTimeRemaining";
 import type { DeploymentDto, LeaseDto } from "@src/types/deployment";
+import type { TeeType } from "@src/utils/confidentialCompute";
 import { udenomToDenom } from "@src/utils/mathHelpers";
 import { isLeaseLive } from "@src/utils/reclamationUtils";
 
 type Props = {
   deployment: DeploymentDto;
   leases: LeaseDto[] | undefined | null;
+  teeTypes?: TeeType[];
   children?: ReactNode;
 };
 
-export const DeploymentSubHeader: React.FunctionComponent<Props> = ({ deployment, leases }) => {
+export const DeploymentSubHeader: React.FunctionComponent<Props> = ({ deployment, leases, teeTypes = [] }) => {
   const { deploymentCost, realTimeLeft } = useDeploymentMetrics({ deployment, leases });
   const isActive = deployment.state === "active";
   const hasLeases = !!leases && leases.length > 0;
@@ -99,6 +102,8 @@ export const DeploymentSubHeader: React.FunctionComponent<Props> = ({ deployment
             <div className="flex items-center space-x-2">
               <div>{deployment.state}</div>
               <StatusPill state={deployment.state} size="small" />
+
+              <ConfidentialComputeBadge teeTypes={teeTypes} />
 
               {isTrialing && <TrialDeploymentBadge createdHeight={deployment.createdAt} />}
             </div>

--- a/apps/deploy-web/src/components/deployments/LeaseRow.tsx
+++ b/apps/deploy-web/src/components/deployments/LeaseRow.tsx
@@ -25,7 +25,7 @@ import { useLeaseStatus } from "@src/queries/useLeaseQuery";
 import { useProviderStatus } from "@src/queries/useProvidersQuery";
 import type { LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
-import { getTeeServiceCarveouts } from "@src/utils/confidentialCompute";
+import { getTeeResourceCarveouts } from "@src/utils/confidentialCompute";
 import { copyTextToClipboard } from "@src/utils/copyClipboard";
 import { deploymentData } from "@src/utils/deploymentData";
 import { getGpusFromAttributes } from "@src/utils/deploymentUtils";
@@ -103,7 +103,9 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(
     }, [isLeaseActive, provider, providerCredentials.details, getLeaseStatus, getProviderStatus]);
 
     const parsedManifest = useMemo(() => yaml.load(deploymentManifest), [deploymentManifest]);
-    const teeCarveouts = useMemo(() => getTeeServiceCarveouts(parsedManifest), [parsedManifest]);
+    // TEE type + resources are declared on-chain (group placement requirement + group_spec.resources),
+    // so the carve-out is sourced from the lease's group rather than the locally stored SDL manifest.
+    const teeCarveouts = useMemo(() => getTeeResourceCarveouts(lease.group), [lease.group]);
 
     const checkIfServicesAreAvailable = (leaseStatus: LeaseStatusDto) => {
       const servicesNames = leaseStatus ? Object.keys(leaseStatus.services) : [];

--- a/apps/deploy-web/src/components/deployments/LeaseRow.tsx
+++ b/apps/deploy-web/src/components/deployments/LeaseRow.tsx
@@ -25,6 +25,7 @@ import { useLeaseStatus } from "@src/queries/useLeaseQuery";
 import { useProviderStatus } from "@src/queries/useProvidersQuery";
 import type { LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
+import { getTeeServiceCarveouts } from "@src/utils/confidentialCompute";
 import { copyTextToClipboard } from "@src/utils/copyClipboard";
 import { deploymentData } from "@src/utils/deploymentData";
 import { getGpusFromAttributes } from "@src/utils/deploymentUtils";
@@ -35,6 +36,7 @@ import { CopyTextToClipboardButton } from "../shared/CopyTextToClipboardButton";
 import { ManifestErrorSnackbar } from "../shared/ManifestErrorSnackbar/ManifestErrorSnackbar";
 import { ProviderName } from "../shared/ProviderName";
 import { ReclamationCard } from "./ReclamationCard/ReclamationCard";
+import { ConfidentialComputeResources } from "./ConfidentialComputeResources";
 
 type Props = {
   index: number;
@@ -101,6 +103,7 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(
     }, [isLeaseActive, provider, providerCredentials.details, getLeaseStatus, getProviderStatus]);
 
     const parsedManifest = useMemo(() => yaml.load(deploymentManifest), [deploymentManifest]);
+    const teeCarveouts = useMemo(() => getTeeServiceCarveouts(parsedManifest), [parsedManifest]);
 
     const checkIfServicesAreAvailable = (leaseStatus: LeaseStatusDto) => {
       const servicesNames = leaseStatus ? Object.keys(leaseStatus.services) : [];
@@ -208,6 +211,8 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(
                 size="medium"
               />
             </div>
+
+            <ConfidentialComputeResources carveouts={teeCarveouts} />
             <LabelValueOld
               label="Price:"
               value={

--- a/apps/deploy-web/src/components/deployments/LeaseRow.tsx
+++ b/apps/deploy-web/src/components/deployments/LeaseRow.tsx
@@ -19,13 +19,13 @@ import { SpecDetail } from "@src/components/shared/SpecDetail";
 import { StatusPill } from "@src/components/shared/StatusPill";
 import { useServices } from "@src/context/ServicesProvider";
 import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
+import { useTeeResourceCarveouts } from "@src/hooks/useTeeResourceCarveouts";
 import { useBidInfo } from "@src/queries/useBidQuery";
 import type { LeaseStatusDto } from "@src/queries/useLeaseQuery";
 import { useLeaseStatus } from "@src/queries/useLeaseQuery";
 import { useProviderStatus } from "@src/queries/useProvidersQuery";
 import type { LeaseDto } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
-import { getTeeResourceCarveouts } from "@src/utils/confidentialCompute";
 import { copyTextToClipboard } from "@src/utils/copyClipboard";
 import { deploymentData } from "@src/utils/deploymentData";
 import { getGpusFromAttributes } from "@src/utils/deploymentUtils";
@@ -103,9 +103,7 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(
     }, [isLeaseActive, provider, providerCredentials.details, getLeaseStatus, getProviderStatus]);
 
     const parsedManifest = useMemo(() => yaml.load(deploymentManifest), [deploymentManifest]);
-    // TEE type + resources are declared on-chain (group placement requirement + group_spec.resources),
-    // so the carve-out is sourced from the lease's group rather than the locally stored SDL manifest.
-    const teeCarveouts = useMemo(() => getTeeResourceCarveouts(lease.group), [lease.group]);
+    const teeCarveouts = useTeeResourceCarveouts(lease);
 
     const checkIfServicesAreAvailable = (leaseStatus: LeaseStatusDto) => {
       const servicesNames = leaseStatus ? Object.keys(leaseStatus.services) : [];

--- a/apps/deploy-web/src/components/shared/ConfidentialComputeBadge.spec.tsx
+++ b/apps/deploy-web/src/components/shared/ConfidentialComputeBadge.spec.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+import type { TeeType } from "@src/utils/confidentialCompute";
+import { ConfidentialComputeBadge, DEPENDENCIES } from "./ConfidentialComputeBadge";
+
+import { render, screen } from "@testing-library/react";
+import { MockComponents } from "@tests/unit/mocks";
+
+const TitleRenderingTooltip = ({ title, children }: { title: React.ReactNode; children?: React.ReactNode }) => (
+  <>
+    {title}
+    {children}
+  </>
+);
+
+describe(ConfidentialComputeBadge.name, () => {
+  it("renders a friendly CPU label and the TEE explanation for a single cpu TEE type", () => {
+    setup({ teeTypes: ["cpu"], dependencies: { CustomTooltip: TitleRenderingTooltip } });
+    expect(screen.getByText("Confidential Compute (CPU)")).toBeInTheDocument();
+    expect(screen.getByText(/Trusted Execution Environment/)).toBeInTheDocument();
+    expect(screen.getByText(/depends on the provider honoring the request and passing attestation/i)).toBeInTheDocument();
+  });
+
+  it("renders a friendly CPU + GPU label for a single cpu-gpu TEE type", () => {
+    setup({ teeTypes: ["cpu-gpu"], dependencies: { CustomTooltip: TitleRenderingTooltip } });
+    expect(screen.getByText("Confidential Compute (CPU + GPU)")).toBeInTheDocument();
+    expect(screen.getByText(/Trusted Execution Environment/)).toBeInTheDocument();
+  });
+
+  it("renders a typeless label and lists the distinct types in the tooltip for mixed deployments", () => {
+    setup({ teeTypes: ["cpu", "cpu-gpu"], dependencies: { CustomTooltip: TitleRenderingTooltip } });
+
+    expect(screen.getByText("Confidential Compute")).toBeInTheDocument();
+    expect(screen.getByText(/CPU, CPU \+ GPU/)).toBeInTheDocument();
+  });
+
+  it("renders nothing when no TEE types are declared", () => {
+    setup({ teeTypes: [] });
+    expect(screen.queryByText(/Confidential Compute/)).not.toBeInTheDocument();
+  });
+
+  function setup(input: { teeTypes: TeeType[]; dependencies?: Partial<typeof DEPENDENCIES> }) {
+    return render(<ConfidentialComputeBadge teeTypes={input.teeTypes} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />);
+  }
+});

--- a/apps/deploy-web/src/components/shared/ConfidentialComputeBadge.tsx
+++ b/apps/deploy-web/src/components/shared/ConfidentialComputeBadge.tsx
@@ -1,0 +1,47 @@
+"use client";
+import * as React from "react";
+import { Badge, CustomTooltip } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
+import { Info } from "lucide-react";
+
+import type { TeeType } from "@src/utils/confidentialCompute";
+import { formatTeeTypeLabel } from "@src/utils/confidentialCompute";
+
+export type Props = {
+  teeTypes: TeeType[];
+  className?: string;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+export const DEPENDENCIES = {
+  Badge,
+  CustomTooltip
+};
+
+export function ConfidentialComputeBadge({ teeTypes, className, dependencies: d = DEPENDENCIES }: Props) {
+  if (teeTypes.length === 0) return null;
+
+  const label = teeTypes.length === 1 ? `Confidential Compute (${formatTeeTypeLabel(teeTypes[0])})` : "Confidential Compute";
+
+  return (
+    <d.CustomTooltip
+      title={
+        <div className="max-w-xs space-y-2 text-sm">
+          <p>
+            One or more services in this deployment are configured to run in a Trusted Execution Environment (TEE), keeping their memory encrypted and isolated
+            from the provider. Confidentiality depends on the provider honoring the request and passing attestation.
+          </p>
+          <p>The provider automatically injects an attestation sidecar that reserves a small slice of the resources you declared.</p>
+          {teeTypes.length > 1 && <p>Declared types: {teeTypes.map(formatTeeTypeLabel).join(", ")}.</p>}
+        </div>
+      }
+    >
+      <div className="inline-flex items-center gap-1">
+        <d.Badge variant="secondary" className={cn("inline-flex cursor-help items-center gap-1", className)}>
+          <span>{label}</span>
+          <Info className="h-3 w-3" />
+        </d.Badge>
+      </div>
+    </d.CustomTooltip>
+  );
+}

--- a/apps/deploy-web/src/hooks/useDeclaredTeeTypes.spec.ts
+++ b/apps/deploy-web/src/hooks/useDeclaredTeeTypes.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentDto } from "@src/types/deployment";
+import { useDeclaredTeeTypes } from "./useDeclaredTeeTypes";
+
+import { renderHook } from "@testing-library/react";
+import { buildRpcDeployment } from "@tests/seeders";
+
+describe(useDeclaredTeeTypes.name, () => {
+  it("returns the distinct declared TEE types across the deployment's on-chain groups", () => {
+    const groups = buildRpcDeployment({
+      groups: [{ group_spec: { requirements: { attributes: [{ key: "tee/type", value: "cpu-gpu" }] } } }]
+    }).groups;
+    const { result } = setup({ deployment: mock<DeploymentDto>({ groups }) });
+    expect(result.current).toEqual(["cpu-gpu"]);
+  });
+
+  it("returns an empty array when the deployment is not loaded", () => {
+    const { result } = setup({ deployment: undefined });
+    expect(result.current).toEqual([]);
+  });
+
+  function setup(input: { deployment: DeploymentDto | undefined }) {
+    return renderHook(() => useDeclaredTeeTypes(input.deployment));
+  }
+});

--- a/apps/deploy-web/src/hooks/useDeclaredTeeTypes.ts
+++ b/apps/deploy-web/src/hooks/useDeclaredTeeTypes.ts
@@ -1,0 +1,10 @@
+import { useMemo } from "react";
+
+import type { DeploymentDto } from "@src/types/deployment";
+import type { TeeType } from "@src/utils/confidentialCompute";
+import { getDeclaredTeeTypes } from "@src/utils/confidentialCompute";
+
+/** Distinct Confidential Compute TEE types declared on the deployment's on-chain groups. */
+export function useDeclaredTeeTypes(deployment: DeploymentDto | undefined | null): TeeType[] {
+  return useMemo(() => getDeclaredTeeTypes(deployment?.groups), [deployment?.groups]);
+}

--- a/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.spec.tsx
+++ b/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.spec.tsx
@@ -66,7 +66,7 @@ describe(useProviderJwt.name, () => {
         ttl: 1800, // 30 * 60
         leases: {
           access: "scoped",
-          scope: ["status", "shell", "events", "logs", "send-manifest", "get-manifest"]
+          scope: ["status", "shell", "events", "logs", "send-manifest", "get-manifest", "attestation"]
         }
       }
     });

--- a/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.ts
+++ b/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.ts
@@ -62,7 +62,7 @@ export function useProviderJwt({ dependencies: d = DEPENDENCIES }: { dependencie
         ttl: 30 * 60,
         leases: {
           access: "scoped",
-          scope: ["status", "shell", "events", "logs", "send-manifest", "get-manifest"]
+          scope: ["status", "shell", "events", "logs", "send-manifest", "get-manifest", "attestation"]
         }
       }
     });

--- a/apps/deploy-web/src/hooks/useTeeResourceCarveouts.spec.ts
+++ b/apps/deploy-web/src/hooks/useTeeResourceCarveouts.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { LeaseDto } from "@src/types/deployment";
+import { useTeeResourceCarveouts } from "./useTeeResourceCarveouts";
+
+import { renderHook } from "@testing-library/react";
+import { buildRpcDeployment } from "@tests/seeders";
+
+describe(useTeeResourceCarveouts.name, () => {
+  it("returns a per-pod carve-out for each resource unit in the lease's on-chain group", () => {
+    const group = buildRpcDeployment({
+      groups: [{ group_spec: { requirements: { attributes: [{ key: "tee/type", value: "cpu" }] } } }]
+    }).groups[0];
+    const { result } = setup({ lease: mock<LeaseDto>({ group }) });
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].teeType).toBe("cpu");
+  });
+
+  it("returns an empty array when the lease has no matched group", () => {
+    const { result } = setup({ lease: mock<LeaseDto>({ group: undefined }) });
+    expect(result.current).toEqual([]);
+  });
+
+  function setup(input: { lease: LeaseDto }) {
+    return renderHook(() => useTeeResourceCarveouts(input.lease));
+  }
+});

--- a/apps/deploy-web/src/hooks/useTeeResourceCarveouts.ts
+++ b/apps/deploy-web/src/hooks/useTeeResourceCarveouts.ts
@@ -1,0 +1,14 @@
+import { useMemo } from "react";
+
+import type { LeaseDto } from "@src/types/deployment";
+import type { TeeResourceCarveout } from "@src/utils/confidentialCompute";
+import { getTeeResourceCarveouts } from "@src/utils/confidentialCompute";
+
+/**
+ * Per-pod attestation-sidecar carve-outs for each resource unit in the lease's on-chain group.
+ * TEE type and resources are declared on-chain (group placement requirement + group_spec.resources),
+ * so this is sourced from the lease's group rather than the locally stored SDL manifest.
+ */
+export function useTeeResourceCarveouts(lease: LeaseDto | undefined | null): TeeResourceCarveout[] {
+  return useMemo(() => getTeeResourceCarveouts(lease?.group), [lease?.group]);
+}

--- a/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
+++ b/apps/deploy-web/src/queries/useLeaseQuery.spec.tsx
@@ -12,7 +12,7 @@ import type { ApiProviderList } from "@src/types/provider";
 import { leaseToDto } from "@src/utils/deploymentDetailUtils";
 import { setupQuery } from "../../tests/unit/query-client";
 import { QueryKeys } from "./queryKeys";
-import { USE_LEASE_STATUS_DEPENDENCIES, useAllLeases, useDeploymentLeaseList, useLeaseStatus } from "./useLeaseQuery";
+import { type LeaseStatusDto, USE_LEASE_STATUS_DEPENDENCIES, useAllLeases, useDeploymentLeaseList, useLeaseStatus } from "./useLeaseQuery";
 
 import { act } from "@testing-library/react";
 import { buildProvider } from "@tests/seeders/provider";
@@ -353,11 +353,71 @@ describe("useLeaseQuery", () => {
       expect(result.current.data).toEqual(mockLeaseStatus);
     });
 
+    it("filters the attestation sidecar out of the returned services", async () => {
+      const provider = buildProvider();
+      const statusWithSidecar = {
+        forwarded_ports: {},
+        ips: {},
+        services: {
+          web: { name: "web", available: 1 },
+          "akash-attestation-sidecar": { name: "akash-attestation-sidecar", available: 1 }
+        }
+      };
+      const providerProxy = mock<ProviderProxyService>({
+        request: vi.fn().mockResolvedValue({ data: statusWithSidecar })
+      });
+      const { result } = setupLeaseStatus({
+        provider,
+        lease: mockLease,
+        services: {
+          providerProxy: () => providerProxy
+        }
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      expect(result.current.data?.services).toHaveProperty("web");
+      expect(result.current.data?.services).not.toHaveProperty("akash-attestation-sidecar");
+    });
+
+    it("composes a caller-provided select on top of the sidecar filter", async () => {
+      const statusWithSidecar = {
+        forwarded_ports: {},
+        ips: {},
+        services: {
+          web: { name: "web", available: 1 },
+          "akash-attestation-sidecar": { name: "akash-attestation-sidecar", available: 1 }
+        }
+      };
+      const providerProxy = mock<ProviderProxyService>({
+        request: vi.fn().mockResolvedValue({ data: statusWithSidecar })
+      });
+      const callerSelect = vi.fn((data: LeaseStatusDto | null) => data);
+      const { result } = setupLeaseStatus({
+        lease: mockLease,
+        select: callerSelect,
+        services: {
+          providerProxy: () => providerProxy
+        }
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+
+      const receivedServices = callerSelect.mock.calls[0][0]?.services ?? {};
+      expect(receivedServices).toHaveProperty("web");
+      expect(receivedServices).not.toHaveProperty("akash-attestation-sidecar");
+    });
+
     function setupLeaseStatus(input?: {
       provider?: ApiProviderList;
       lease?: LeaseDto;
       providerCredentials?: UseProviderCredentialsResult["details"];
       services?: ServicesProviderProps["services"];
+      select?: (data: LeaseStatusDto | null) => LeaseStatusDto | null;
     }) {
       const dependencies: typeof USE_LEASE_STATUS_DEPENDENCIES = {
         ...USE_LEASE_STATUS_DEPENDENCIES,
@@ -372,7 +432,7 @@ describe("useLeaseQuery", () => {
           ensureToken: vi.fn().mockResolvedValue("jwt-token")
         })
       };
-      return setupQuery(() => useLeaseStatus({ provider: input?.provider || buildProvider(), lease: input?.lease, dependencies }), {
+      return setupQuery(() => useLeaseStatus({ provider: input?.provider || buildProvider(), lease: input?.lease, dependencies, select: input?.select }), {
         services: {
           providerProxy: () => mock<ProviderProxyService>(),
           ...input?.services

--- a/apps/deploy-web/src/queries/useLeaseQuery.ts
+++ b/apps/deploy-web/src/queries/useLeaseQuery.ts
@@ -9,6 +9,7 @@ import { useScopedFetchProviderUrl } from "@src/hooks/useScopedFetchProviderUrl"
 import type { DeploymentDto, LeaseDto, RpcLease } from "@src/types/deployment";
 import type { ApiProviderList } from "@src/types/provider";
 import { ApiUrlService, loadWithPagination } from "@src/utils/apiUtils";
+import { omitAttestationSidecar } from "@src/utils/confidentialCompute";
 import { leaseToDto } from "@src/utils/deploymentDetailUtils";
 import { isLeaseLive } from "@src/utils/reclamationUtils";
 import { QueryKeys } from "./queryKeys";
@@ -77,7 +78,7 @@ export function useLeaseStatus(
     dependencies?: typeof USE_LEASE_STATUS_DEPENDENCIES;
   } & Omit<UseQueryOptions<LeaseStatusDto | null>, "queryKey" | "queryFn"> = {}
 ) {
-  const { provider, lease, dependencies: d = USE_LEASE_STATUS_DEPENDENCIES, ...options } = params;
+  const { provider, lease, dependencies: d = USE_LEASE_STATUS_DEPENDENCIES, select: callerSelect, ...options } = params;
   const providerCredentials = d.useProviderCredentials();
   const fetchProviderUrl = d.useScopedFetchProviderUrl(provider);
 
@@ -100,7 +101,14 @@ export function useLeaseStatus(
       return response.data;
     },
     ...options,
-    enabled: options.enabled !== false && providerCredentials.details.usable
+    enabled: options.enabled !== false && providerCredentials.details.usable,
+    // Defensive: the attestation sidecar is a pod container under the current provider design and
+    // never appears as a lease-status service, so this is a passthrough today. It keeps the sidecar
+    // out of every consumer (status list, logs/shell selectors) at one chokepoint if that changes.
+    select: data => {
+      const filtered = data ? omitAttestationSidecar(data) : data;
+      return callerSelect ? callerSelect(filtered) : filtered;
+    }
   });
 }
 export const USE_LEASE_STATUS_DEPENDENCIES = {

--- a/apps/deploy-web/src/utils/confidentialCompute.spec.ts
+++ b/apps/deploy-web/src/utils/confidentialCompute.spec.ts
@@ -1,156 +1,109 @@
+import type { QueryInput as DeepPartial } from "@akashnetwork/chain-sdk";
 import { describe, expect, it } from "vitest";
 
+import type { DeploymentGroup } from "@src/types/deployment";
 import {
   computeSidecarCarveout,
   formatTeeTypeLabel,
   getDeclaredTeeTypes,
-  getDeclaredTeeTypesFromYaml,
-  getServiceComputeResources,
-  getServiceTeeType,
-  getTeeServiceCarveouts,
+  getGroupTeeType,
+  getTeeResourceCarveouts,
   MIN_PRIMARY_CPU_MILLICORES,
   MIN_PRIMARY_MEMORY_BYTES,
   omitAttestationSidecar,
   SIDECAR_CPU_LIMIT_MILLICORES,
-  SIDECAR_MEMORY_LIMIT_BYTES
+  SIDECAR_MEMORY_LIMIT_BYTES,
+  type TeeType
 } from "./confidentialCompute";
+
+import { buildRpcDeployment } from "@tests/seeders";
 
 const MIB = 1024 * 1024;
 const GIB = 1024 * 1024 * 1024;
 
+/** Builds a single on-chain deployment group, seeded with realistic defaults and the given overrides. */
+function buildGroup(spec?: DeepPartial<DeploymentGroup>): DeploymentGroup {
+  return buildRpcDeployment(spec ? { groups: [spec] } : undefined).groups[0];
+}
+
+/** Builds a complete on-chain resource unit (the entries of group_spec.resources). */
+function buildResourceUnit(input: { id: number; cpuMillicores: number; memoryBytes: number; gpuUnits?: number; count?: number }) {
+  return {
+    resource: {
+      id: input.id,
+      cpu: { units: { val: String(input.cpuMillicores) }, attributes: [] },
+      memory: { quantity: { val: String(input.memoryBytes) }, attributes: [] },
+      storage: [{ name: "default", quantity: { val: String(512 * MIB) }, attributes: [] }],
+      gpu: { units: { val: String(input.gpuUnits ?? 0) }, attributes: [] },
+      endpoints: []
+    },
+    count: input.count ?? 1,
+    price: { denom: "uakt", amount: "10000" }
+  };
+}
+
+const teeRequirement = (teeType: TeeType) => ({ requirements: { attributes: [{ key: "tee/type", value: teeType }] } });
+
+describe(getGroupTeeType.name, () => {
+  it("returns the TEE type declared on the group's placement requirements", () => {
+    expect(getGroupTeeType(buildGroup({ group_spec: teeRequirement("cpu") }))).toBe("cpu");
+    expect(getGroupTeeType(buildGroup({ group_spec: teeRequirement("cpu-gpu") }))).toBe("cpu-gpu");
+  });
+
+  it("ignores other placement attributes and reads only tee/type", () => {
+    const group = buildGroup({
+      group_spec: {
+        requirements: {
+          attributes: [
+            { key: "region", value: "us-west" },
+            { key: "tee/type", value: "cpu-gpu" }
+          ]
+        }
+      }
+    });
+    expect(getGroupTeeType(group)).toBe("cpu-gpu");
+  });
+
+  it("returns undefined when no tee/type attribute is present", () => {
+    expect(getGroupTeeType(buildGroup({ group_spec: { requirements: { attributes: [{ key: "region", value: "us-west" }] } } }))).toBeUndefined();
+    expect(getGroupTeeType(buildGroup())).toBeUndefined();
+  });
+
+  it("returns undefined for an unrecognized tee/type value", () => {
+    expect(getGroupTeeType(buildGroup({ group_spec: { requirements: { attributes: [{ key: "tee/type", value: "sgx" }] } } }))).toBeUndefined();
+  });
+
+  it("returns undefined for a nullish or malformed group", () => {
+    expect(getGroupTeeType(undefined)).toBeUndefined();
+    expect(getGroupTeeType(null)).toBeUndefined();
+  });
+});
+
 describe(getDeclaredTeeTypes.name, () => {
-  it("returns an empty array for nullish or empty manifests", () => {
+  it("returns an empty array for nullish or empty group lists", () => {
     expect(getDeclaredTeeTypes(undefined)).toEqual([]);
     expect(getDeclaredTeeTypes(null)).toEqual([]);
-    expect(getDeclaredTeeTypes({})).toEqual([]);
-    expect(getDeclaredTeeTypes({ services: {} })).toEqual([]);
+    expect(getDeclaredTeeTypes([])).toEqual([]);
   });
 
-  it("returns the single declared type for a one-service deployment", () => {
-    expect(getDeclaredTeeTypes({ services: { web: { params: { tee: "cpu" } } } })).toEqual(["cpu"]);
-    expect(getDeclaredTeeTypes({ services: { web: { params: { tee: "cpu-gpu" } } } })).toEqual(["cpu-gpu"]);
+  it("returns the single declared type for a one-group deployment", () => {
+    expect(getDeclaredTeeTypes([buildGroup({ group_spec: teeRequirement("cpu") })])).toEqual(["cpu"]);
+    expect(getDeclaredTeeTypes([buildGroup({ group_spec: teeRequirement("cpu-gpu") })])).toEqual(["cpu-gpu"]);
   });
 
-  it("returns the distinct set in canonical order for mixed multi-service deployments", () => {
-    const manifest = {
-      services: {
-        gpuApp: { params: { tee: "cpu-gpu" } },
-        cpuApp: { params: { tee: "cpu" } }
-      }
-    };
-    expect(getDeclaredTeeTypes(manifest)).toEqual(["cpu", "cpu-gpu"]);
+  it("returns the distinct set in canonical order across mixed groups", () => {
+    const groups = [buildGroup({ group_spec: teeRequirement("cpu-gpu") }), buildGroup({ group_spec: teeRequirement("cpu") })];
+    expect(getDeclaredTeeTypes(groups)).toEqual(["cpu", "cpu-gpu"]);
   });
 
-  it("dedupes when several services declare the same type", () => {
-    const manifest = {
-      services: {
-        a: { params: { tee: "cpu" } },
-        b: { params: { tee: "cpu" } }
-      }
-    };
-    expect(getDeclaredTeeTypes(manifest)).toEqual(["cpu"]);
+  it("dedupes when several groups declare the same type", () => {
+    const groups = [buildGroup({ group_spec: teeRequirement("cpu") }), buildGroup({ group_spec: teeRequirement("cpu") })];
+    expect(getDeclaredTeeTypes(groups)).toEqual(["cpu"]);
   });
 
-  it("ignores services without a tee param and unknown tee values", () => {
-    const manifest = {
-      services: {
-        plain: { image: "nginx" },
-        bogus: { params: { tee: "quantum" } },
-        valid: { params: { tee: "cpu" } }
-      }
-    };
-    expect(getDeclaredTeeTypes(manifest)).toEqual(["cpu"]);
-  });
-
-  it("returns an empty array for malformed manifests instead of throwing", () => {
-    expect(getDeclaredTeeTypes({ services: "not-an-object" })).toEqual([]);
-    expect(getDeclaredTeeTypes("just a string")).toEqual([]);
-    expect(getDeclaredTeeTypes(42)).toEqual([]);
-  });
-});
-
-describe(getServiceTeeType.name, () => {
-  const manifest = {
-    services: {
-      web: { params: { tee: "cpu-gpu" } },
-      api: { image: "nginx" }
-    }
-  };
-
-  it("returns the declared type for a TEE service", () => {
-    expect(getServiceTeeType(manifest, "web")).toBe("cpu-gpu");
-  });
-
-  it("returns undefined for a service without a tee param", () => {
-    expect(getServiceTeeType(manifest, "api")).toBeUndefined();
-  });
-
-  it("returns undefined for an unknown service", () => {
-    expect(getServiceTeeType(manifest, "missing")).toBeUndefined();
-  });
-
-  it("returns undefined for malformed manifests", () => {
-    expect(getServiceTeeType(null, "web")).toBeUndefined();
-  });
-});
-
-describe(getServiceComputeResources.name, () => {
-  it("parses fractional cpu cores and mebibyte memory", () => {
-    const manifest = {
-      services: { web: { params: { tee: "cpu" } } },
-      profiles: { compute: { web: { resources: { cpu: { units: 0.5 }, memory: { size: "256Mi" } } } } }
-    };
-    expect(getServiceComputeResources(manifest, "web")).toEqual({ cpuMillicores: 500, memoryBytes: 256 * MIB });
-  });
-
-  it("parses millicore string cpu units", () => {
-    const manifest = {
-      profiles: { compute: { web: { resources: { cpu: { units: "500m" }, memory: { size: "1Gi" } } } } }
-    };
-    expect(getServiceComputeResources(manifest, "web")).toEqual({ cpuMillicores: 500, memoryBytes: GIB });
-  });
-
-  it("parses whole-core string and number cpu units", () => {
-    const stringManifest = {
-      profiles: { compute: { web: { resources: { cpu: { units: "0.5" }, memory: { size: "256Mi" } } } } }
-    };
-    expect(getServiceComputeResources(stringManifest, "web")?.cpuMillicores).toBe(500);
-
-    const intManifest = {
-      profiles: { compute: { web: { resources: { cpu: { units: 1 }, memory: { size: "256Mi" } } } } }
-    };
-    expect(getServiceComputeResources(intManifest, "web")?.cpuMillicores).toBe(1000);
-  });
-
-  it("parses a numeric (suffix-less) memory size as bytes", () => {
-    const manifest = {
-      profiles: { compute: { web: { resources: { cpu: { units: 1 }, memory: { size: 268435456 } } } } }
-    };
-    expect(getServiceComputeResources(manifest, "web")).toEqual({ cpuMillicores: 1000, memoryBytes: 268435456 });
-  });
-
-  it("returns undefined when the compute profile or resources are missing", () => {
-    expect(getServiceComputeResources({ profiles: { compute: {} } }, "web")).toBeUndefined();
-    expect(getServiceComputeResources(null, "web")).toBeUndefined();
-  });
-
-  it("returns undefined when the cpu units cannot be parsed", () => {
-    const manifest = {
-      profiles: { compute: { web: { resources: { cpu: { units: {} }, memory: { size: "256Mi" } } } } }
-    };
-    expect(getServiceComputeResources(manifest, "web")).toBeUndefined();
-  });
-
-  it("returns undefined when the memory size is unparseable or of an unexpected type", () => {
-    const garbage = {
-      profiles: { compute: { web: { resources: { cpu: { units: 1 }, memory: { size: "garbage" } } } } }
-    };
-    expect(getServiceComputeResources(garbage, "web")).toBeUndefined();
-
-    const objectSize = {
-      profiles: { compute: { web: { resources: { cpu: { units: 1 }, memory: { size: {} } } } } }
-    };
-    expect(getServiceComputeResources(objectSize, "web")).toBeUndefined();
+  it("ignores groups that declare no TEE type", () => {
+    const groups = [buildGroup({ group_spec: teeRequirement("cpu") }), buildGroup()];
+    expect(getDeclaredTeeTypes(groups)).toEqual(["cpu"]);
   });
 });
 
@@ -189,17 +142,21 @@ describe(computeSidecarCarveout.name, () => {
   });
 });
 
-describe(getTeeServiceCarveouts.name, () => {
-  it("returns a carve-out for each TEE service with resolvable resources", () => {
-    const manifest = {
-      services: { web: { params: { tee: "cpu" } } },
-      profiles: { compute: { web: { resources: { cpu: { units: 0.5 }, memory: { size: "256Mi" } } } } }
-    };
+describe(getTeeResourceCarveouts.name, () => {
+  it("returns a per-pod carve-out for each resource unit in a TEE group", () => {
+    const group = buildGroup({
+      group_spec: {
+        requirements: { attributes: [{ key: "tee/type", value: "cpu" }] },
+        resources: [buildResourceUnit({ id: 1, cpuMillicores: 500, memoryBytes: 256 * MIB })]
+      }
+    });
 
-    expect(getTeeServiceCarveouts(manifest)).toEqual([
+    expect(getTeeResourceCarveouts(group)).toEqual([
       {
-        serviceName: "web",
+        id: "1",
         teeType: "cpu",
+        count: 1,
+        gpuUnits: 0,
         requested: { cpu: 500, memory: 256 * MIB },
         reserved: { cpu: 100, memory: 64 * MIB },
         container: { cpu: 400, memory: 192 * MIB }
@@ -207,43 +164,64 @@ describe(getTeeServiceCarveouts.name, () => {
     ]);
   });
 
-  it("returns an empty array when no service declares a TEE type", () => {
-    const manifest = {
-      services: { web: { image: "nginx" } },
-      profiles: { compute: { web: { resources: { cpu: { units: 1 }, memory: { size: "1Gi" } } } } }
-    };
-    expect(getTeeServiceCarveouts(manifest)).toEqual([]);
+  it("returns an empty array when the group declares no TEE type", () => {
+    const group = buildGroup({ group_spec: { resources: [buildResourceUnit({ id: 1, cpuMillicores: 1000, memoryBytes: GIB })] } });
+    expect(getTeeResourceCarveouts(group)).toEqual([]);
   });
 
-  it("skips TEE services whose compute resources cannot be resolved", () => {
-    const manifest = {
-      services: { web: { params: { tee: "cpu" } } },
-      profiles: { compute: {} }
-    };
-    expect(getTeeServiceCarveouts(manifest)).toEqual([]);
-  });
-
-  it("returns carve-outs sorted by service name for mixed deployments", () => {
-    const manifest = {
-      services: {
-        zeta: { params: { tee: "cpu-gpu" } },
-        alpha: { params: { tee: "cpu" } }
-      },
-      profiles: {
-        compute: {
-          zeta: { resources: { cpu: { units: 1 }, memory: { size: "512Mi" } } },
-          alpha: { resources: { cpu: { units: 1 }, memory: { size: "512Mi" } } }
-        }
+  it("uses the group's TEE type for every resource unit and carries replica count and gpu units", () => {
+    const group = buildGroup({
+      group_spec: {
+        requirements: { attributes: [{ key: "tee/type", value: "cpu-gpu" }] },
+        resources: [
+          buildResourceUnit({ id: 1, cpuMillicores: 500, memoryBytes: 256 * MIB }),
+          buildResourceUnit({ id: 2, cpuMillicores: 8000, memoryBytes: 32 * GIB, gpuUnits: 1, count: 2 })
+        ]
       }
-    };
+    });
 
-    const result = getTeeServiceCarveouts(manifest);
-    expect(result.map(c => c.serviceName)).toEqual(["alpha", "zeta"]);
-    expect(result[1].reserved.memory).toBe(128 * MIB);
+    expect(getTeeResourceCarveouts(group)).toEqual([
+      {
+        id: "1",
+        teeType: "cpu-gpu",
+        count: 1,
+        gpuUnits: 0,
+        requested: { cpu: 500, memory: 256 * MIB },
+        reserved: { cpu: 100, memory: 128 * MIB },
+        container: { cpu: 400, memory: 128 * MIB }
+      },
+      {
+        id: "2",
+        teeType: "cpu-gpu",
+        count: 2,
+        gpuUnits: 1,
+        requested: { cpu: 8000, memory: 32 * GIB },
+        reserved: { cpu: 100, memory: 128 * MIB },
+        container: { cpu: 7900, memory: 32 * GIB - 128 * MIB }
+      }
+    ]);
   });
 
-  it("returns an empty array for malformed manifests", () => {
-    expect(getTeeServiceCarveouts(null)).toEqual([]);
+  it("skips resource units whose on-chain cpu or memory cannot be parsed", () => {
+    const group = buildGroup({
+      group_spec: {
+        requirements: { attributes: [{ key: "tee/type", value: "cpu" }] },
+        resources: [
+          {
+            ...buildResourceUnit({ id: 1, cpuMillicores: 0, memoryBytes: 0 }),
+            resource: { ...buildResourceUnit({ id: 1, cpuMillicores: 0, memoryBytes: 0 }).resource, cpu: { units: { val: "not-a-number" }, attributes: [] } }
+          },
+          buildResourceUnit({ id: 2, cpuMillicores: 1000, memoryBytes: GIB })
+        ]
+      }
+    });
+
+    expect(getTeeResourceCarveouts(group).map(c => c.id)).toEqual(["2"]);
+  });
+
+  it("returns an empty array for a nullish group", () => {
+    expect(getTeeResourceCarveouts(undefined)).toEqual([]);
+    expect(getTeeResourceCarveouts(null)).toEqual([]);
   });
 });
 
@@ -282,23 +260,6 @@ describe(omitAttestationSidecar.name, () => {
     const result = omitAttestationSidecar(leaseStatus);
     expect(result.services).toEqual({ web: { name: "web" } });
     expect(result).not.toBe(leaseStatus);
-  });
-});
-
-describe(getDeclaredTeeTypesFromYaml.name, () => {
-  it("parses a manifest YAML string and returns its declared TEE types", () => {
-    const manifestYaml = ["services:", "  web:", "    params:", "      tee: cpu-gpu"].join("\n");
-    expect(getDeclaredTeeTypesFromYaml(manifestYaml)).toEqual(["cpu-gpu"]);
-  });
-
-  it("returns an empty array for empty or nullish input", () => {
-    expect(getDeclaredTeeTypesFromYaml("")).toEqual([]);
-    expect(getDeclaredTeeTypesFromYaml(null)).toEqual([]);
-    expect(getDeclaredTeeTypesFromYaml(undefined)).toEqual([]);
-  });
-
-  it("returns an empty array for malformed YAML instead of throwing", () => {
-    expect(getDeclaredTeeTypesFromYaml("services: [unclosed")).toEqual([]);
   });
 });
 

--- a/apps/deploy-web/src/utils/confidentialCompute.spec.ts
+++ b/apps/deploy-web/src/utils/confidentialCompute.spec.ts
@@ -219,6 +219,23 @@ describe(getTeeResourceCarveouts.name, () => {
     expect(getTeeResourceCarveouts(group).map(c => c.id)).toEqual(["2"]);
   });
 
+  it("skips resource units whose on-chain cpu is a suffixed (non-integer) string", () => {
+    const group = buildGroup({
+      group_spec: {
+        requirements: { attributes: [{ key: "tee/type", value: "cpu" }] },
+        resources: [
+          {
+            ...buildResourceUnit({ id: 1, cpuMillicores: 500, memoryBytes: 256 * MIB }),
+            resource: { ...buildResourceUnit({ id: 1, cpuMillicores: 500, memoryBytes: 256 * MIB }).resource, cpu: { units: { val: "500Mi" }, attributes: [] } }
+          },
+          buildResourceUnit({ id: 2, cpuMillicores: 1000, memoryBytes: GIB })
+        ]
+      }
+    });
+
+    expect(getTeeResourceCarveouts(group).map(c => c.id)).toEqual(["2"]);
+  });
+
   it("returns an empty array for a nullish group", () => {
     expect(getTeeResourceCarveouts(undefined)).toEqual([]);
     expect(getTeeResourceCarveouts(null)).toEqual([]);

--- a/apps/deploy-web/src/utils/confidentialCompute.spec.ts
+++ b/apps/deploy-web/src/utils/confidentialCompute.spec.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeSidecarCarveout,
+  formatTeeTypeLabel,
+  getDeclaredTeeTypes,
+  getDeclaredTeeTypesFromYaml,
+  getServiceComputeResources,
+  getServiceTeeType,
+  getTeeServiceCarveouts,
+  MIN_PRIMARY_CPU_MILLICORES,
+  MIN_PRIMARY_MEMORY_BYTES,
+  omitAttestationSidecar,
+  SIDECAR_CPU_LIMIT_MILLICORES,
+  SIDECAR_MEMORY_LIMIT_BYTES
+} from "./confidentialCompute";
+
+const MIB = 1024 * 1024;
+const GIB = 1024 * 1024 * 1024;
+
+describe(getDeclaredTeeTypes.name, () => {
+  it("returns an empty array for nullish or empty manifests", () => {
+    expect(getDeclaredTeeTypes(undefined)).toEqual([]);
+    expect(getDeclaredTeeTypes(null)).toEqual([]);
+    expect(getDeclaredTeeTypes({})).toEqual([]);
+    expect(getDeclaredTeeTypes({ services: {} })).toEqual([]);
+  });
+
+  it("returns the single declared type for a one-service deployment", () => {
+    expect(getDeclaredTeeTypes({ services: { web: { params: { tee: "cpu" } } } })).toEqual(["cpu"]);
+    expect(getDeclaredTeeTypes({ services: { web: { params: { tee: "cpu-gpu" } } } })).toEqual(["cpu-gpu"]);
+  });
+
+  it("returns the distinct set in canonical order for mixed multi-service deployments", () => {
+    const manifest = {
+      services: {
+        gpuApp: { params: { tee: "cpu-gpu" } },
+        cpuApp: { params: { tee: "cpu" } }
+      }
+    };
+    expect(getDeclaredTeeTypes(manifest)).toEqual(["cpu", "cpu-gpu"]);
+  });
+
+  it("dedupes when several services declare the same type", () => {
+    const manifest = {
+      services: {
+        a: { params: { tee: "cpu" } },
+        b: { params: { tee: "cpu" } }
+      }
+    };
+    expect(getDeclaredTeeTypes(manifest)).toEqual(["cpu"]);
+  });
+
+  it("ignores services without a tee param and unknown tee values", () => {
+    const manifest = {
+      services: {
+        plain: { image: "nginx" },
+        bogus: { params: { tee: "quantum" } },
+        valid: { params: { tee: "cpu" } }
+      }
+    };
+    expect(getDeclaredTeeTypes(manifest)).toEqual(["cpu"]);
+  });
+
+  it("returns an empty array for malformed manifests instead of throwing", () => {
+    expect(getDeclaredTeeTypes({ services: "not-an-object" })).toEqual([]);
+    expect(getDeclaredTeeTypes("just a string")).toEqual([]);
+    expect(getDeclaredTeeTypes(42)).toEqual([]);
+  });
+});
+
+describe(getServiceTeeType.name, () => {
+  const manifest = {
+    services: {
+      web: { params: { tee: "cpu-gpu" } },
+      api: { image: "nginx" }
+    }
+  };
+
+  it("returns the declared type for a TEE service", () => {
+    expect(getServiceTeeType(manifest, "web")).toBe("cpu-gpu");
+  });
+
+  it("returns undefined for a service without a tee param", () => {
+    expect(getServiceTeeType(manifest, "api")).toBeUndefined();
+  });
+
+  it("returns undefined for an unknown service", () => {
+    expect(getServiceTeeType(manifest, "missing")).toBeUndefined();
+  });
+
+  it("returns undefined for malformed manifests", () => {
+    expect(getServiceTeeType(null, "web")).toBeUndefined();
+  });
+});
+
+describe(getServiceComputeResources.name, () => {
+  it("parses fractional cpu cores and mebibyte memory", () => {
+    const manifest = {
+      services: { web: { params: { tee: "cpu" } } },
+      profiles: { compute: { web: { resources: { cpu: { units: 0.5 }, memory: { size: "256Mi" } } } } }
+    };
+    expect(getServiceComputeResources(manifest, "web")).toEqual({ cpuMillicores: 500, memoryBytes: 256 * MIB });
+  });
+
+  it("parses millicore string cpu units", () => {
+    const manifest = {
+      profiles: { compute: { web: { resources: { cpu: { units: "500m" }, memory: { size: "1Gi" } } } } }
+    };
+    expect(getServiceComputeResources(manifest, "web")).toEqual({ cpuMillicores: 500, memoryBytes: GIB });
+  });
+
+  it("parses whole-core string and number cpu units", () => {
+    const stringManifest = {
+      profiles: { compute: { web: { resources: { cpu: { units: "0.5" }, memory: { size: "256Mi" } } } } }
+    };
+    expect(getServiceComputeResources(stringManifest, "web")?.cpuMillicores).toBe(500);
+
+    const intManifest = {
+      profiles: { compute: { web: { resources: { cpu: { units: 1 }, memory: { size: "256Mi" } } } } }
+    };
+    expect(getServiceComputeResources(intManifest, "web")?.cpuMillicores).toBe(1000);
+  });
+
+  it("parses a numeric (suffix-less) memory size as bytes", () => {
+    const manifest = {
+      profiles: { compute: { web: { resources: { cpu: { units: 1 }, memory: { size: 268435456 } } } } }
+    };
+    expect(getServiceComputeResources(manifest, "web")).toEqual({ cpuMillicores: 1000, memoryBytes: 268435456 });
+  });
+
+  it("returns undefined when the compute profile or resources are missing", () => {
+    expect(getServiceComputeResources({ profiles: { compute: {} } }, "web")).toBeUndefined();
+    expect(getServiceComputeResources(null, "web")).toBeUndefined();
+  });
+
+  it("returns undefined when the cpu units cannot be parsed", () => {
+    const manifest = {
+      profiles: { compute: { web: { resources: { cpu: { units: {} }, memory: { size: "256Mi" } } } } }
+    };
+    expect(getServiceComputeResources(manifest, "web")).toBeUndefined();
+  });
+
+  it("returns undefined when the memory size is unparseable or of an unexpected type", () => {
+    const garbage = {
+      profiles: { compute: { web: { resources: { cpu: { units: 1 }, memory: { size: "garbage" } } } } }
+    };
+    expect(getServiceComputeResources(garbage, "web")).toBeUndefined();
+
+    const objectSize = {
+      profiles: { compute: { web: { resources: { cpu: { units: 1 }, memory: { size: {} } } } } }
+    };
+    expect(getServiceComputeResources(objectSize, "web")).toBeUndefined();
+  });
+});
+
+describe(computeSidecarCarveout.name, () => {
+  it("reserves 100m CPU / 64Mi for the cpu TEE type and leaves the remainder to the container", () => {
+    const result = computeSidecarCarveout({ cpuMillicores: 500, memoryBytes: 256 * MIB, teeType: "cpu" });
+    expect(result).toEqual({
+      reserved: { cpu: 100, memory: 64 * MIB },
+      container: { cpu: 400, memory: 192 * MIB }
+    });
+  });
+
+  it("reserves 128Mi memory for the cpu-gpu TEE type", () => {
+    const result = computeSidecarCarveout({ cpuMillicores: 500, memoryBytes: 256 * MIB, teeType: "cpu-gpu" });
+    expect(result).toEqual({
+      reserved: { cpu: 100, memory: 128 * MIB },
+      container: { cpu: 400, memory: 128 * MIB }
+    });
+  });
+
+  it("floors the container CPU at the minimum when the declared CPU is below the reservation", () => {
+    const result = computeSidecarCarveout({ cpuMillicores: 50, memoryBytes: 256 * MIB, teeType: "cpu" });
+    expect(result.reserved.cpu).toBe(SIDECAR_CPU_LIMIT_MILLICORES);
+    expect(result.container.cpu).toBe(MIN_PRIMARY_CPU_MILLICORES);
+  });
+
+  it("floors the container memory at the minimum when the declared memory is below the reservation", () => {
+    const result = computeSidecarCarveout({ cpuMillicores: 500, memoryBytes: 32 * MIB, teeType: "cpu" });
+    expect(result.reserved.memory).toBe(SIDECAR_MEMORY_LIMIT_BYTES.cpu);
+    expect(result.container.memory).toBe(MIN_PRIMARY_MEMORY_BYTES);
+  });
+
+  it("subtracts the reservation cleanly for large declarations", () => {
+    const result = computeSidecarCarveout({ cpuMillicores: 4000, memoryBytes: GIB, teeType: "cpu" });
+    expect(result.container).toEqual({ cpu: 3900, memory: GIB - 64 * MIB });
+  });
+});
+
+describe(getTeeServiceCarveouts.name, () => {
+  it("returns a carve-out for each TEE service with resolvable resources", () => {
+    const manifest = {
+      services: { web: { params: { tee: "cpu" } } },
+      profiles: { compute: { web: { resources: { cpu: { units: 0.5 }, memory: { size: "256Mi" } } } } }
+    };
+
+    expect(getTeeServiceCarveouts(manifest)).toEqual([
+      {
+        serviceName: "web",
+        teeType: "cpu",
+        requested: { cpu: 500, memory: 256 * MIB },
+        reserved: { cpu: 100, memory: 64 * MIB },
+        container: { cpu: 400, memory: 192 * MIB }
+      }
+    ]);
+  });
+
+  it("returns an empty array when no service declares a TEE type", () => {
+    const manifest = {
+      services: { web: { image: "nginx" } },
+      profiles: { compute: { web: { resources: { cpu: { units: 1 }, memory: { size: "1Gi" } } } } }
+    };
+    expect(getTeeServiceCarveouts(manifest)).toEqual([]);
+  });
+
+  it("skips TEE services whose compute resources cannot be resolved", () => {
+    const manifest = {
+      services: { web: { params: { tee: "cpu" } } },
+      profiles: { compute: {} }
+    };
+    expect(getTeeServiceCarveouts(manifest)).toEqual([]);
+  });
+
+  it("returns carve-outs sorted by service name for mixed deployments", () => {
+    const manifest = {
+      services: {
+        zeta: { params: { tee: "cpu-gpu" } },
+        alpha: { params: { tee: "cpu" } }
+      },
+      profiles: {
+        compute: {
+          zeta: { resources: { cpu: { units: 1 }, memory: { size: "512Mi" } } },
+          alpha: { resources: { cpu: { units: 1 }, memory: { size: "512Mi" } } }
+        }
+      }
+    };
+
+    const result = getTeeServiceCarveouts(manifest);
+    expect(result.map(c => c.serviceName)).toEqual(["alpha", "zeta"]);
+    expect(result[1].reserved.memory).toBe(128 * MIB);
+  });
+
+  it("returns an empty array for malformed manifests", () => {
+    expect(getTeeServiceCarveouts(null)).toEqual([]);
+  });
+});
+
+describe(omitAttestationSidecar.name, () => {
+  it("returns the same reference when no attestation sidecar is present", () => {
+    const leaseStatus = {
+      services: { web: { name: "web" } },
+      forwarded_ports: { web: [] },
+      ips: {}
+    };
+    expect(omitAttestationSidecar(leaseStatus)).toBe(leaseStatus);
+  });
+
+  it("strips the attestation sidecar from services, forwarded_ports and ips when present", () => {
+    const leaseStatus = {
+      services: { web: { name: "web" }, "akash-attestation-sidecar": { name: "akash-attestation-sidecar" } },
+      forwarded_ports: { web: [], "akash-attestation-sidecar": [] },
+      ips: { "akash-attestation-sidecar": [] }
+    };
+
+    const result = omitAttestationSidecar(leaseStatus);
+
+    expect(result.services).toEqual({ web: { name: "web" } });
+    expect(result.forwarded_ports).toEqual({ web: [] });
+    expect(result.ips).toEqual({});
+    expect(result).not.toBe(leaseStatus);
+  });
+
+  it("does not throw when forwarded_ports or ips are absent", () => {
+    const leaseStatus = { services: { "akash-attestation-sidecar": { name: "akash-attestation-sidecar" } } };
+    expect(omitAttestationSidecar(leaseStatus).services).toEqual({});
+  });
+
+  it("strips an attestation sidecar entry even when its value is falsy", () => {
+    const leaseStatus = { services: { web: { name: "web" }, "akash-attestation-sidecar": null } };
+    const result = omitAttestationSidecar(leaseStatus);
+    expect(result.services).toEqual({ web: { name: "web" } });
+    expect(result).not.toBe(leaseStatus);
+  });
+});
+
+describe(getDeclaredTeeTypesFromYaml.name, () => {
+  it("parses a manifest YAML string and returns its declared TEE types", () => {
+    const manifestYaml = ["services:", "  web:", "    params:", "      tee: cpu-gpu"].join("\n");
+    expect(getDeclaredTeeTypesFromYaml(manifestYaml)).toEqual(["cpu-gpu"]);
+  });
+
+  it("returns an empty array for empty or nullish input", () => {
+    expect(getDeclaredTeeTypesFromYaml("")).toEqual([]);
+    expect(getDeclaredTeeTypesFromYaml(null)).toEqual([]);
+    expect(getDeclaredTeeTypesFromYaml(undefined)).toEqual([]);
+  });
+
+  it("returns an empty array for malformed YAML instead of throwing", () => {
+    expect(getDeclaredTeeTypesFromYaml("services: [unclosed")).toEqual([]);
+  });
+});
+
+describe(formatTeeTypeLabel.name, () => {
+  it("renders friendly labels for each TEE type", () => {
+    expect(formatTeeTypeLabel("cpu")).toBe("CPU");
+    expect(formatTeeTypeLabel("cpu-gpu")).toBe("CPU + GPU");
+  });
+});

--- a/apps/deploy-web/src/utils/confidentialCompute.ts
+++ b/apps/deploy-web/src/utils/confidentialCompute.ts
@@ -1,18 +1,20 @@
-import yaml from "js-yaml";
-
-import { parseSizeStr } from "./deploymentData/helpers";
+import type { DeploymentGroup } from "@src/types/deployment";
 
 /**
  * Confidential Compute (TEE) helpers for the deployment detail view.
  *
- * The declared TEE type lives only in the off-chain SDL manifest the user stored locally
- * (`services.<name>.params.tee`); it is not projected on-chain. The constants below mirror the
- * provider's attestation-sidecar resource footprint (akash-network/provider PR #396,
- * `cluster/kube/builder`) so we can show the tenant how much of their declared budget the
- * provider-injected sidecar reserves.
+ * The declared TEE type is an on-chain group placement requirement: `group_spec.requirements.attributes`
+ * carries a `tee/type` attribute (`cpu` | `cpu-gpu`) so only TEE-capable providers can bid/match. It is
+ * therefore authoritative and available for every deployment (Console, CLI or otherwise) without the
+ * stored SDL manifest. The constants below mirror the provider's attestation-sidecar resource footprint
+ * (akash-network/provider PR #396, `cluster/kube/builder`) so we can show the tenant how much of their
+ * declared per-pod budget the provider-injected sidecar reserves.
  */
 
 export type TeeType = "cpu" | "cpu-gpu";
+
+/** On-chain group placement attribute key carrying the declared TEE type. */
+export const TEE_TYPE_ATTRIBUTE_KEY = "tee/type";
 
 /** Exact container name the provider injects (akash-network/provider, webhook/sidecar.go). */
 export const ATTESTATION_SIDECAR_SERVICE_NAME = "akash-attestation-sidecar";
@@ -36,21 +38,33 @@ function isTeeType(value: unknown): value is TeeType {
   return typeof value === "string" && (TEE_TYPES as readonly string[]).includes(value);
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+/** Parses an on-chain integer-valued string (millicores, bytes, gpu units). Returns undefined on garbage. */
+function parseIntegerVal(value: unknown): number | undefined {
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
+  if (typeof value !== "string") return undefined;
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+/** Returns the TEE type declared on a group's on-chain placement requirements, or undefined when none/unknown. */
+export function getGroupTeeType(group: DeploymentGroup | undefined | null): TeeType | undefined {
+  const attributes = group?.group_spec?.requirements?.attributes;
+  if (!Array.isArray(attributes)) return undefined;
+  const value = attributes.find(attribute => attribute?.key === TEE_TYPE_ATTRIBUTE_KEY)?.value;
+  return isTeeType(value) ? value : undefined;
 }
 
 /**
- * Returns the distinct set of TEE types declared across all services, in canonical order.
- * Never throws — a malformed manifest yields an empty array so the deployment view stays intact.
+ * Returns the distinct set of TEE types declared across all of a deployment's groups, in canonical order.
+ * Never throws — a missing or malformed group list yields an empty array so the deployment view stays intact.
  */
-export function getDeclaredTeeTypes(parsedManifest: unknown): TeeType[] {
+export function getDeclaredTeeTypes(groups: DeploymentGroup[] | undefined | null): TeeType[] {
   const declared = new Set<TeeType>();
 
-  if (isRecord(parsedManifest) && isRecord(parsedManifest.services)) {
-    for (const service of Object.values(parsedManifest.services)) {
-      const tee = isRecord(service) && isRecord(service.params) ? service.params.tee : undefined;
-      if (isTeeType(tee)) declared.add(tee);
+  if (Array.isArray(groups)) {
+    for (const group of groups) {
+      const teeType = getGroupTeeType(group);
+      if (teeType) declared.add(teeType);
     }
   }
 
@@ -58,75 +72,9 @@ export function getDeclaredTeeTypes(parsedManifest: unknown): TeeType[] {
 }
 
 /**
- * Parses a stored SDL manifest (YAML string) and returns its declared TEE types. Never throws —
- * malformed YAML yields an empty array, keeping the deployment view safe (the feature has no flag).
- */
-export function getDeclaredTeeTypesFromYaml(manifestYaml: string | null | undefined): TeeType[] {
-  if (!manifestYaml) return [];
-  try {
-    return getDeclaredTeeTypes(yaml.load(manifestYaml));
-  } catch {
-    return [];
-  }
-}
-
-/** Returns the TEE type declared by a single service, or undefined when none/unknown. */
-export function getServiceTeeType(parsedManifest: unknown, serviceName: string): TeeType | undefined {
-  if (!isRecord(parsedManifest) || !isRecord(parsedManifest.services)) return undefined;
-  const service = parsedManifest.services[serviceName];
-  const tee = isRecord(service) && isRecord(service.params) ? service.params.tee : undefined;
-  return isTeeType(tee) ? tee : undefined;
-}
-
-function parseCpuToMillicores(units: unknown): number | undefined {
-  if (typeof units === "number" && Number.isFinite(units)) return units * 1000;
-  if (typeof units === "string") {
-    const trimmed = units.trim();
-    if (trimmed.endsWith("m")) {
-      const millis = parseFloat(trimmed.slice(0, -1));
-      return Number.isFinite(millis) ? millis : undefined;
-    }
-    const cores = parseFloat(trimmed);
-    return Number.isFinite(cores) ? cores * 1000 : undefined;
-  }
-  return undefined;
-}
-
-/**
- * Resolves a service's per-container compute resources from its compute profile
- * (service name == compute-profile name, the console convention). Returns undefined when the
- * profile or resources cannot be resolved.
- */
-export function getServiceComputeResources(parsedManifest: unknown, serviceName: string): { cpuMillicores: number; memoryBytes: number } | undefined {
-  if (!isRecord(parsedManifest) || !isRecord(parsedManifest.profiles) || !isRecord(parsedManifest.profiles.compute)) return undefined;
-
-  const profile = parsedManifest.profiles.compute[serviceName];
-  const resources = isRecord(profile) ? profile.resources : undefined;
-  if (!isRecord(resources) || !isRecord(resources.cpu) || !isRecord(resources.memory)) return undefined;
-
-  const cpuMillicores = parseCpuToMillicores(resources.cpu.units);
-  if (cpuMillicores === undefined) return undefined;
-
-  // memory.size is normally a suffixed string ("256Mi"), but a hand-written SDL may use a raw byte
-  // count as a YAML number — accept both, mirroring how cpu.units accepts numbers and strings.
-  const memorySize = resources.memory.size;
-  let memoryBytes: number;
-  if (typeof memorySize === "string") {
-    memoryBytes = Number(parseSizeStr(memorySize));
-  } else if (typeof memorySize === "number") {
-    memoryBytes = memorySize;
-  } else {
-    return undefined;
-  }
-  if (!Number.isFinite(memoryBytes)) return undefined;
-
-  return { cpuMillicores, memoryBytes };
-}
-
-/**
  * Replicates the provider's resource split: the sidecar's fixed limits are reserved, and the
  * primary container keeps the remainder floored at the provider minimums. The lease's declared
- * (billed) resources are unchanged — this only describes how the pod's budget is divided.
+ * (billed) resources are unchanged — this only describes how a single pod's budget is divided.
  */
 export function computeSidecarCarveout(input: { cpuMillicores: number; memoryBytes: number; teeType: TeeType }): {
   reserved: { cpu: number; memory: number };
@@ -144,45 +92,52 @@ export function computeSidecarCarveout(input: { cpuMillicores: number; memoryByt
   };
 }
 
-export interface TeeServiceCarveout {
-  serviceName: string;
+export interface TeeResourceCarveout {
+  /** On-chain resource unit id, used as a stable React key. */
+  id: string;
   teeType: TeeType;
+  /** Number of pods (replicas) using this resource unit; each pod gets its own attestation sidecar. */
+  count: number;
+  /** GPU units per pod, used to disambiguate units when a lease declares more than one. */
+  gpuUnits: number;
+  /** Per-pod declared (billed) resources. */
   requested: { cpu: number; memory: number };
+  /** Per-pod resources reserved by the attestation sidecar. */
   reserved: { cpu: number; memory: number };
+  /** Per-pod resources left to the primary container after the sidecar reservation. */
   container: { cpu: number; memory: number };
 }
 
 /**
- * Builds the per-service resource carve-out for every TEE service in the manifest whose compute
- * resources can be resolved, sorted by service name. Services without a TEE type or with
- * unresolvable resources are omitted. Never throws on malformed input.
- *
- * Note: this gates on resolvable resources, while the header badge gates only on a declared
- * `params.tee` ({@link getDeclaredTeeTypes}). So a TEE service with an unresolvable compute profile
- * (e.g. a non-standard manifest) shows the badge but no carve-out row — an accepted divergence,
- * since console-generated SDLs always use the service-name == profile-name convention.
+ * Builds the per-pod resource carve-out for every resource unit in a TEE group. The `tee/type` attribute
+ * is a group-level placement requirement, so the provider injects the attestation sidecar into every pod
+ * of the group — each resource unit (and each of its `count` replicas) reserves the same sidecar footprint.
+ * Returns an empty array when the group declares no TEE type. Resource units whose on-chain cpu/memory
+ * cannot be parsed are skipped; never throws on malformed input.
  */
-export function getTeeServiceCarveouts(parsedManifest: unknown): TeeServiceCarveout[] {
-  if (!isRecord(parsedManifest) || !isRecord(parsedManifest.services)) return [];
+export function getTeeResourceCarveouts(group: DeploymentGroup | undefined | null): TeeResourceCarveout[] {
+  const teeType = getGroupTeeType(group);
+  const resources = group?.group_spec?.resources;
+  if (!teeType || !Array.isArray(resources)) return [];
 
-  const carveouts: TeeServiceCarveout[] = [];
+  const carveouts: TeeResourceCarveout[] = [];
 
-  for (const serviceName of Object.keys(parsedManifest.services).sort()) {
-    const teeType = getServiceTeeType(parsedManifest, serviceName);
-    if (!teeType) continue;
+  resources.forEach((entry, index) => {
+    const cpuMillicores = parseIntegerVal(entry?.resource?.cpu?.units?.val);
+    const memoryBytes = parseIntegerVal(entry?.resource?.memory?.quantity?.val);
+    if (cpuMillicores === undefined || memoryBytes === undefined) return;
 
-    const resources = getServiceComputeResources(parsedManifest, serviceName);
-    if (!resources) continue;
-
-    const { reserved, container } = computeSidecarCarveout({ cpuMillicores: resources.cpuMillicores, memoryBytes: resources.memoryBytes, teeType });
+    const { reserved, container } = computeSidecarCarveout({ cpuMillicores, memoryBytes, teeType });
     carveouts.push({
-      serviceName,
+      id: String(entry?.resource?.id ?? index),
       teeType,
-      requested: { cpu: resources.cpuMillicores, memory: resources.memoryBytes },
+      count: entry?.count ?? 1,
+      gpuUnits: parseIntegerVal(entry?.resource?.gpu?.units?.val) ?? 0,
+      requested: { cpu: cpuMillicores, memory: memoryBytes },
       reserved,
       container
     });
-  }
+  });
 
   return carveouts;
 }

--- a/apps/deploy-web/src/utils/confidentialCompute.ts
+++ b/apps/deploy-web/src/utils/confidentialCompute.ts
@@ -41,9 +41,10 @@ function isTeeType(value: unknown): value is TeeType {
 /** Parses an on-chain integer-valued string (millicores, bytes, gpu units). Returns undefined on garbage. */
 function parseIntegerVal(value: unknown): number | undefined {
   if (typeof value === "number") return Number.isFinite(value) ? value : undefined;
-  if (typeof value !== "string") return undefined;
-  const parsed = parseInt(value, 10);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  // Require an exact integer string: parseInt accepts prefixes ("500Mi" -> 500), which would treat
+  // a malformed on-chain value as a valid count instead of skipping it.
+  if (typeof value !== "string" || !/^-?\d+$/.test(value)) return undefined;
+  return parseInt(value, 10);
 }
 
 /** Returns the TEE type declared on a group's on-chain placement requirements, or undefined when none/unknown. */

--- a/apps/deploy-web/src/utils/confidentialCompute.ts
+++ b/apps/deploy-web/src/utils/confidentialCompute.ts
@@ -1,0 +1,228 @@
+import yaml from "js-yaml";
+
+import { parseSizeStr } from "./deploymentData/helpers";
+
+/**
+ * Confidential Compute (TEE) helpers for the deployment detail view.
+ *
+ * The declared TEE type lives only in the off-chain SDL manifest the user stored locally
+ * (`services.<name>.params.tee`); it is not projected on-chain. The constants below mirror the
+ * provider's attestation-sidecar resource footprint (akash-network/provider PR #396,
+ * `cluster/kube/builder`) so we can show the tenant how much of their declared budget the
+ * provider-injected sidecar reserves.
+ */
+
+export type TeeType = "cpu" | "cpu-gpu";
+
+/** Exact container name the provider injects (akash-network/provider, webhook/sidecar.go). */
+export const ATTESTATION_SIDECAR_SERVICE_NAME = "akash-attestation-sidecar";
+
+const MEGABYTES = 1024 * 1024;
+
+/** Sidecar resource limits the provider subtracts from the primary container (PR #396 builder constants). */
+export const SIDECAR_CPU_LIMIT_MILLICORES = 100;
+export const SIDECAR_MEMORY_LIMIT_BYTES: Record<TeeType, number> = {
+  cpu: 64 * MEGABYTES,
+  "cpu-gpu": 128 * MEGABYTES
+};
+
+/** Floors the provider applies to the primary container after subtraction. */
+export const MIN_PRIMARY_CPU_MILLICORES = 10;
+export const MIN_PRIMARY_MEMORY_BYTES = 16 * MEGABYTES;
+
+const TEE_TYPES: readonly TeeType[] = ["cpu", "cpu-gpu"];
+
+function isTeeType(value: unknown): value is TeeType {
+  return typeof value === "string" && (TEE_TYPES as readonly string[]).includes(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Returns the distinct set of TEE types declared across all services, in canonical order.
+ * Never throws — a malformed manifest yields an empty array so the deployment view stays intact.
+ */
+export function getDeclaredTeeTypes(parsedManifest: unknown): TeeType[] {
+  const declared = new Set<TeeType>();
+
+  if (isRecord(parsedManifest) && isRecord(parsedManifest.services)) {
+    for (const service of Object.values(parsedManifest.services)) {
+      const tee = isRecord(service) && isRecord(service.params) ? service.params.tee : undefined;
+      if (isTeeType(tee)) declared.add(tee);
+    }
+  }
+
+  return TEE_TYPES.filter(type => declared.has(type));
+}
+
+/**
+ * Parses a stored SDL manifest (YAML string) and returns its declared TEE types. Never throws —
+ * malformed YAML yields an empty array, keeping the deployment view safe (the feature has no flag).
+ */
+export function getDeclaredTeeTypesFromYaml(manifestYaml: string | null | undefined): TeeType[] {
+  if (!manifestYaml) return [];
+  try {
+    return getDeclaredTeeTypes(yaml.load(manifestYaml));
+  } catch {
+    return [];
+  }
+}
+
+/** Returns the TEE type declared by a single service, or undefined when none/unknown. */
+export function getServiceTeeType(parsedManifest: unknown, serviceName: string): TeeType | undefined {
+  if (!isRecord(parsedManifest) || !isRecord(parsedManifest.services)) return undefined;
+  const service = parsedManifest.services[serviceName];
+  const tee = isRecord(service) && isRecord(service.params) ? service.params.tee : undefined;
+  return isTeeType(tee) ? tee : undefined;
+}
+
+function parseCpuToMillicores(units: unknown): number | undefined {
+  if (typeof units === "number" && Number.isFinite(units)) return units * 1000;
+  if (typeof units === "string") {
+    const trimmed = units.trim();
+    if (trimmed.endsWith("m")) {
+      const millis = parseFloat(trimmed.slice(0, -1));
+      return Number.isFinite(millis) ? millis : undefined;
+    }
+    const cores = parseFloat(trimmed);
+    return Number.isFinite(cores) ? cores * 1000 : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Resolves a service's per-container compute resources from its compute profile
+ * (service name == compute-profile name, the console convention). Returns undefined when the
+ * profile or resources cannot be resolved.
+ */
+export function getServiceComputeResources(parsedManifest: unknown, serviceName: string): { cpuMillicores: number; memoryBytes: number } | undefined {
+  if (!isRecord(parsedManifest) || !isRecord(parsedManifest.profiles) || !isRecord(parsedManifest.profiles.compute)) return undefined;
+
+  const profile = parsedManifest.profiles.compute[serviceName];
+  const resources = isRecord(profile) ? profile.resources : undefined;
+  if (!isRecord(resources) || !isRecord(resources.cpu) || !isRecord(resources.memory)) return undefined;
+
+  const cpuMillicores = parseCpuToMillicores(resources.cpu.units);
+  if (cpuMillicores === undefined) return undefined;
+
+  // memory.size is normally a suffixed string ("256Mi"), but a hand-written SDL may use a raw byte
+  // count as a YAML number — accept both, mirroring how cpu.units accepts numbers and strings.
+  const memorySize = resources.memory.size;
+  let memoryBytes: number;
+  if (typeof memorySize === "string") {
+    memoryBytes = Number(parseSizeStr(memorySize));
+  } else if (typeof memorySize === "number") {
+    memoryBytes = memorySize;
+  } else {
+    return undefined;
+  }
+  if (!Number.isFinite(memoryBytes)) return undefined;
+
+  return { cpuMillicores, memoryBytes };
+}
+
+/**
+ * Replicates the provider's resource split: the sidecar's fixed limits are reserved, and the
+ * primary container keeps the remainder floored at the provider minimums. The lease's declared
+ * (billed) resources are unchanged — this only describes how the pod's budget is divided.
+ */
+export function computeSidecarCarveout(input: { cpuMillicores: number; memoryBytes: number; teeType: TeeType }): {
+  reserved: { cpu: number; memory: number };
+  container: { cpu: number; memory: number };
+} {
+  const reservedCpu = SIDECAR_CPU_LIMIT_MILLICORES;
+  const reservedMemory = SIDECAR_MEMORY_LIMIT_BYTES[input.teeType];
+
+  return {
+    reserved: { cpu: reservedCpu, memory: reservedMemory },
+    container: {
+      cpu: Math.max(input.cpuMillicores - reservedCpu, MIN_PRIMARY_CPU_MILLICORES),
+      memory: Math.max(input.memoryBytes - reservedMemory, MIN_PRIMARY_MEMORY_BYTES)
+    }
+  };
+}
+
+export interface TeeServiceCarveout {
+  serviceName: string;
+  teeType: TeeType;
+  requested: { cpu: number; memory: number };
+  reserved: { cpu: number; memory: number };
+  container: { cpu: number; memory: number };
+}
+
+/**
+ * Builds the per-service resource carve-out for every TEE service in the manifest whose compute
+ * resources can be resolved, sorted by service name. Services without a TEE type or with
+ * unresolvable resources are omitted. Never throws on malformed input.
+ *
+ * Note: this gates on resolvable resources, while the header badge gates only on a declared
+ * `params.tee` ({@link getDeclaredTeeTypes}). So a TEE service with an unresolvable compute profile
+ * (e.g. a non-standard manifest) shows the badge but no carve-out row — an accepted divergence,
+ * since console-generated SDLs always use the service-name == profile-name convention.
+ */
+export function getTeeServiceCarveouts(parsedManifest: unknown): TeeServiceCarveout[] {
+  if (!isRecord(parsedManifest) || !isRecord(parsedManifest.services)) return [];
+
+  const carveouts: TeeServiceCarveout[] = [];
+
+  for (const serviceName of Object.keys(parsedManifest.services).sort()) {
+    const teeType = getServiceTeeType(parsedManifest, serviceName);
+    if (!teeType) continue;
+
+    const resources = getServiceComputeResources(parsedManifest, serviceName);
+    if (!resources) continue;
+
+    const { reserved, container } = computeSidecarCarveout({ cpuMillicores: resources.cpuMillicores, memoryBytes: resources.memoryBytes, teeType });
+    carveouts.push({
+      serviceName,
+      teeType,
+      requested: { cpu: resources.cpuMillicores, memory: resources.memoryBytes },
+      reserved,
+      container
+    });
+  }
+
+  return carveouts;
+}
+
+interface LeaseStatusLike {
+  services: Record<string, unknown>;
+  forwarded_ports?: Record<string, unknown>;
+  ips?: Record<string, unknown> | null;
+}
+
+/**
+ * Strips the attestation sidecar from a lease status. Defensive: under the current provider design
+ * the sidecar is a pod container and never appears as a lease-status service, so this is a passthrough
+ * (returns the same reference) today. It guards against a future provider reporting it as a service.
+ */
+export function omitAttestationSidecar<T extends LeaseStatusLike>(leaseStatus: T): T {
+  if (!leaseStatus) return leaseStatus;
+
+  // Detect by key presence (not truthiness) so a sidecar entry with a falsy value is still stripped,
+  // staying consistent with the `omit` helper below.
+  const hasSidecar = (record: Record<string, unknown> | null | undefined): boolean => !!record && ATTESTATION_SIDECAR_SERVICE_NAME in record;
+  const present = hasSidecar(leaseStatus.services) || hasSidecar(leaseStatus.forwarded_ports) || hasSidecar(leaseStatus.ips);
+
+  if (!present) return leaseStatus;
+
+  const omit = <V>(record: Record<string, V> | null | undefined): Record<string, V> | null | undefined => {
+    if (!record || !(ATTESTATION_SIDECAR_SERVICE_NAME in record)) return record;
+    const { [ATTESTATION_SIDECAR_SERVICE_NAME]: _omitted, ...rest } = record;
+    return rest;
+  };
+
+  return {
+    ...leaseStatus,
+    services: omit(leaseStatus.services) as T["services"],
+    forwarded_ports: omit(leaseStatus.forwarded_ports),
+    ips: omit(leaseStatus.ips)
+  };
+}
+
+/** Human-readable label for a TEE type (bare "cpu" reads oddly as a TEE indicator). */
+export function formatTeeTypeLabel(teeType: TeeType): string {
+  return teeType === "cpu-gpu" ? "CPU + GPU" : "CPU";
+}

--- a/apps/deploy-web/src/utils/confidentialCompute.ts
+++ b/apps/deploy-web/src/utils/confidentialCompute.ts
@@ -156,24 +156,28 @@ interface LeaseStatusLike {
 export function omitAttestationSidecar<T extends LeaseStatusLike>(leaseStatus: T): T {
   if (!leaseStatus) return leaseStatus;
 
-  // Detect by key presence (not truthiness) so a sidecar entry with a falsy value is still stripped,
-  // staying consistent with the `omit` helper below.
-  const hasSidecar = (record: Record<string, unknown> | null | undefined): boolean => !!record && ATTESTATION_SIDECAR_SERVICE_NAME in record;
-  const present = hasSidecar(leaseStatus.services) || hasSidecar(leaseStatus.forwarded_ports) || hasSidecar(leaseStatus.ips);
-
-  if (!present) return leaseStatus;
-
+  // Strip by key presence (not truthiness) so a sidecar entry with a falsy value is still removed.
+  // Returns the same record reference when the key is absent, which lets an untouched status pass
+  // through unchanged below (referentially stable for React Query consumers).
   const omit = <V>(record: Record<string, V> | null | undefined): Record<string, V> | null | undefined => {
     if (!record || !(ATTESTATION_SIDECAR_SERVICE_NAME in record)) return record;
     const { [ATTESTATION_SIDECAR_SERVICE_NAME]: _omitted, ...rest } = record;
     return rest;
   };
 
+  const services = omit(leaseStatus.services);
+  const forwardedPorts = omit(leaseStatus.forwarded_ports);
+  const ips = omit(leaseStatus.ips);
+
+  if (services === leaseStatus.services && forwardedPorts === leaseStatus.forwarded_ports && ips === leaseStatus.ips) {
+    return leaseStatus;
+  }
+
   return {
     ...leaseStatus,
-    services: omit(leaseStatus.services) as T["services"],
-    forwarded_ports: omit(leaseStatus.forwarded_ports),
-    ips: omit(leaseStatus.ips)
+    services: services as T["services"],
+    forwarded_ports: forwardedPorts,
+    ips
   };
 }
 


### PR DESCRIPTION
## Why

Closes CON-451.

After deploying a Confidential Compute (TEE) workload, a tenant should be able to confirm from the deployment detail view that a TEE was actually requested, understand the resource slice the provider's attestation sidecar reserves, and not be confused by that sidecar. This is the deploy-web counterpart to the already-merged backend support (#3344 / CON-463).

The declared TEE type is recorded **on-chain** as a group placement requirement: `group_spec.requirements.attributes` carries a `tee/type` attribute (`cpu` | `cpu-gpu`) so only TEE-capable providers can bid and match. deploy-web already loads this for every deployment, so the surface reads it directly from the chain — it works for deployments created from any client (Console, CLI, SDK), not only those whose SDL manifest happens to be in this browser's localStorage.

## What

For deployments whose groups declare an on-chain `tee/type`:

- **Indicator** — a `Confidential Compute (CPU)` / `(CPU + GPU)` badge in the deployment sub-header, shown whenever any group declares `tee/type` (distinct types across groups listed in the tooltip for mixed deployments). The tooltip frames it as *declared intent* whose confidentiality depends on the provider honoring the request and passing attestation — not a verified runtime guarantee.
- **Resource carve-out** — in the lease view, a per-pod breakdown of `Requested → Attestation sidecar → Available to your container`, one entry per `group_spec.resources` unit (the sidecar is injected into every pod of a CC group), replicating the provider's subtraction + floors (sidecar limits: 100m CPU, 64Mi/128Mi memory; floors 10m / 16Mi — matching akash-network/provider#396). On-chain groups carry no service names, so each unit is labelled by its resource composition (e.g. `8 CPU · 32 GiB · 1 GPU`) when a lease declares more than one, with the replica count noted. A note appears when the declared budget is at/below the sidecar footprint (so the floored values aren't misread as broken arithmetic). Billing is unchanged — the slice comes out of the container, not the bill.
- **Defensive sidecar filter** — a single `select: omitAttestationSidecar` chokepoint on `useLeaseStatus`. The sidecar is a pod container today (never a `leaseStatus.services` key), so this is a documented passthrough that guards the pre-GA provider contract for the status/logs/shell selectors.

Notes for reviewers:
- **No dedicated feature flag** (deliberate deviation from the AC, agreed with product): every path self-gates on a declared on-chain `tee/type`, so non-CC deployments are completely unaffected. Trivially reversible by wrapping the new UI in `useFlag("ui_confidential_compute")`.
- All new logic is pure/unit-tested (utils, badge, carve-out, and a hook-level filter regression test). A live CC provider now exists on mainnet (`snp-gpu`), so the badge can be verified end-to-end against a real `cpu-gpu` deployment — this supersedes the earlier CON-459 "no CC provider yet" assumption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a Confidential Compute badge in deployment headers, driven by declared TEE types.
  * Added a “Confidential compute resources” section on lease rows showing Requested, Attestation sidecar reservation, and Available container CPU/Memory, with formatted units.

* **Bug Fixes**
  * Lease status shaping now hides attestation sidecar details while still honoring any custom data selection logic.

* **Tests**
  * Added unit tests for the badge, resources display, TEE utilities, and new TEE-related hooks.

* **Chores**
  * Expanded provider JWT generation to include the attestation scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
