### PR TITLE
refactor: reduces retry attempts for providers with open incident

### DIFF
--- a/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
+++ b/apps/provider-inventory/src/services/discovery-scheduler/discovery-scheduler.service.ts
@@ -93,6 +93,10 @@ export class DiscoverySchedulerService {
   }
 
   async discoverProviders(signal?: AbortSignal): Promise<void> {
+    return await this.#runDiscoveryTick(signal);
+  }
+
+  async #runDiscoveryTick(signal?: AbortSignal): Promise<void> {
     try {
       const watchedProviders = this.#lifecycle.getRegistry();
       const providersToStop = new Set(watchedProviders.keys());
@@ -172,6 +176,7 @@ export class DiscoverySchedulerService {
 
       this.#logger.info({
         event: "DISCOVERY_PROVIDERS_INVENTORY_CONNECTED",
+        connectedCount: this.#lifecycle.getRegistry().size,
         stoppedCount: providersToStop.size,
         startedCount: startedProvidersCount,
         restartedCount: restartedProvidersCount,
@@ -204,9 +209,9 @@ export class DiscoverySchedulerService {
 
   async #runDiscoveryLoop(signal: AbortSignal): Promise<void> {
     while (!signal.aborted) {
-      await this.discoverProviders(signal);
+      await this.#runDiscoveryTick(signal);
       if (signal.aborted) break;
-      await this.#timer.delay(this.#config.DISCOVERY_INTERVAL_MS, undefined, { signal }).catch(() => undefined);
+      await this.#timer.delay(this.#config.DISCOVERY_INTERVAL_MS, undefined, { signal, ref: false }).catch(() => undefined);
     }
   }
 

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.spec.ts
@@ -392,15 +392,15 @@ describe(StreamLifecycleManagerService.name, () => {
     });
   });
 
-  describe("dead provider retry policy", () => {
-    it("attempts a long-dead provider at most twice before giving up", async () => {
+  describe("offline provider retry policy", () => {
+    it("attempts a provider with an open incident at most twice before giving up", async () => {
       const streamFactory = mock<ProviderStreamFactory>();
       streamFactory.disposeProvider.mockResolvedValue();
       streamFactory.openStatusStream.mockImplementation(() => throwingStream(new Error("connection lost")));
       const { manager, incidents, logger } = setup({ streamFactory });
-      const longDead = createProvider({ offlineSince: new Date(Date.now() - 10_000) });
+      const offline = createProvider({ offlineSince: new Date(Date.now() - 10_000) });
 
-      manager.start(longDead);
+      manager.start(offline);
 
       await vi.waitFor(() => expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_GAVE_UP", owner: "akash1owner" })), {
         timeout: 5000
@@ -409,7 +409,7 @@ describe(StreamLifecycleManagerService.name, () => {
       expect(incidents.openIncident).toHaveBeenCalledWith("akash1owner");
     });
 
-    it("logs STREAM_RECONNECTING only once for a long-dead provider", async () => {
+    it("logs STREAM_RECONNECTING only once for a provider with an open incident", async () => {
       const streamFactory = mock<ProviderStreamFactory>();
       streamFactory.disposeProvider.mockResolvedValue();
       streamFactory.openStatusStream.mockImplementation(() => throwingStream(new Error("connection lost")));
@@ -422,7 +422,7 @@ describe(StreamLifecycleManagerService.name, () => {
       expect(countReconnects()).toBe(1);
     });
 
-    it("uses the full retry budget for a recently-updated offline provider", async () => {
+    it("uses the reduced retry budget even for a provider that just went offline", async () => {
       const streamFactory = mock<ProviderStreamFactory>();
       streamFactory.disposeProvider.mockResolvedValue();
       streamFactory.openStatusStream.mockImplementation(() => throwingStream(new Error("connection lost")));
@@ -431,10 +431,22 @@ describe(StreamLifecycleManagerService.name, () => {
       manager.start(createProvider({ offlineSince: new Date(Date.now() - 100) }));
 
       await vi.waitFor(() => expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_GAVE_UP" })), { timeout: 5000 });
-      expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(6);
+      expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(2);
     });
 
-    it("recovers a long-dead provider when its single retry succeeds", async () => {
+    it("uses the full retry budget for a healthy provider with no open incident", async () => {
+      const streamFactory = mock<ProviderStreamFactory>();
+      streamFactory.disposeProvider.mockResolvedValue();
+      streamFactory.openStatusStream.mockImplementation(() => throwingStream(new Error("connection lost")));
+      const { manager, logger } = setup({ streamFactory });
+
+      manager.start(createProvider({ offlineSince: null }));
+
+      await vi.waitFor(() => expect(logger.error).toHaveBeenCalledWith(expect.objectContaining({ event: "STREAM_GAVE_UP" })), { timeout: 5000 });
+      expect(streamFactory.openStatusStream).toHaveBeenCalledTimes(5);
+    });
+
+    it("recovers a provider with an open incident when its single retry succeeds", async () => {
       let attempt = 0;
       const streamFactory = mock<ProviderStreamFactory>();
       streamFactory.disposeProvider.mockResolvedValue();
@@ -621,7 +633,6 @@ describe(StreamLifecycleManagerService.name, () => {
     streams?: Record<string, AsyncIterable<ClusterState> | "hang">;
     streamFactory?: MockProxy<ProviderStreamFactory>;
     throttleMs?: number;
-    deadProviderThresholdMs?: number;
   }) {
     const streamFactory = input?.streamFactory ?? mock<ProviderStreamFactory>();
     streamFactory.disposeProvider.mockResolvedValue();
@@ -642,7 +653,7 @@ describe(StreamLifecycleManagerService.name, () => {
       STREAM_RECONNECT_MAX_DELAY_MS: 50,
       STREAM_FIRST_MESSAGE_TIMEOUT_MS: 80,
       STREAM_UPDATE_THROTTLE_MS: input?.throttleMs ?? 0,
-      DEAD_PROVIDER_UPDATED_THRESHOLD_MS: input?.deadProviderThresholdMs ?? 1000
+      DEAD_PROVIDER_UPDATED_THRESHOLD_MS: 1000
     });
 
     if (!input?.streamFactory) {

--- a/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
+++ b/apps/provider-inventory/src/services/stream-lifecycle-manager/stream-lifecycle-manager.service.ts
@@ -64,7 +64,7 @@ export class StreamLifecycleManagerService {
     this.#config = config;
     this.#logger = loggerFactory({ context: "StreamLifecycleManager" });
     this.#healthyProviderRetryStreamPolicy = retry(handleAll, {
-      maxAttempts: 5,
+      maxAttempts: 4,
       backoff: new ExponentialBackoff({
         initialDelay: this.#config.STREAM_RECONNECT_INITIAL_DELAY_MS,
         maxDelay: this.#config.STREAM_RECONNECT_MAX_DELAY_MS
@@ -159,9 +159,7 @@ export class StreamLifecycleManagerService {
   async #runStream(provider: ChainProviderWithOfflineSince, signal: AbortSignal, onFirstAttemptSettled: () => void): Promise<void> {
     const onSettleAttempt = once(onFirstAttemptSettled);
     try {
-      const isPotentiallyDeadProvider =
-        provider.offlineSince && Date.now() - provider.offlineSince.getTime() > this.#config.DEAD_PROVIDER_UPDATED_THRESHOLD_MS / 2;
-      const retryPolicy = isPotentiallyDeadProvider ? this.#potentiallyDeadProviderRetryStreamPolicy : this.#healthyProviderRetryStreamPolicy;
+      const retryPolicy = provider.offlineSince ? this.#potentiallyDeadProviderRetryStreamPolicy : this.#healthyProviderRetryStreamPolicy;
       await retryPolicy.execute(ctx => {
         if (signal.aborted) return;
         if (ctx.attempt > 0) {


### PR DESCRIPTION
## Why

ref CON-571

## What

1. reduces maxAttempts to 4, to have total attempts equal 5
2. retry provider with open incident only once (1 request + 1 retry)

Apparently, establishing TLS connection requires CPU and this is where providers-sync app spends most of its event loop time


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider reconnection behavior by adjusting retry limits for healthy and offline providers.
  * Providers that have recently gone offline now use a more conservative retry approach, reducing unnecessary reconnect attempts.
  * Discovery logging now includes the current number of connected providers for better visibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->