### PR TITLE
refactor: replaces drizzle insert with INSERT SELECT and 1 bind param

### DIFF
--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.integration.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.integration.ts
@@ -138,6 +138,43 @@ describe(ProviderInventoryRepository.name, () => {
       const rows = await db.select().from(providerInventory);
       expect(rows).toEqual([]);
     });
+
+    it("returns the owners of inserted and changed providers", async () => {
+      const { repository, db } = setup();
+      await seed(db, { owner: "akash1changed", hostUri: "https://old:8443" });
+
+      const result = await repository.bulkUpsertProviders([
+        createProvider({ owner: "akash1new", hostUri: "https://new:8443" }),
+        createProvider({ owner: "akash1changed", hostUri: "https://updated:8443" })
+      ]);
+
+      expect(new Set(result.map(r => r.owner))).toEqual(new Set(["akash1new", "akash1changed"]));
+    });
+
+    it("does not return owners whose values are unchanged", async () => {
+      // DiscoveryScheduler's dead-provider detection treats an owner absent from the returned set as
+      // "not updated this tick", so unchanged rows must be omitted from RETURNING.
+      const { repository, db } = setup();
+      await seed(db, {
+        owner: "akash1same",
+        hostUri: "https://h:8443",
+        selfAttributes: [{ key: "region", value: "us-east" }],
+        signedAttributes: [{ key: "tier", value: "gold", auditor: "aud-1" }],
+        auditedBy: ["aud-1"]
+      });
+
+      const result = await repository.bulkUpsertProviders([
+        createProvider({
+          owner: "akash1same",
+          hostUri: "https://h:8443",
+          selfAttributes: [{ key: "region", value: "us-east" }],
+          signedAttributes: [{ key: "tier", value: "gold", auditor: "aud-1" }],
+          auditedBy: ["aud-1"]
+        })
+      ]);
+
+      expect(result).toEqual([]);
+    });
   });
 
   describe("streamOnlineProviders", () => {

--- a/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
+++ b/apps/provider-inventory/src/repositories/provider-inventory/provider-inventory.repository.ts
@@ -1,9 +1,10 @@
 import type { InferSelectModel } from "drizzle-orm";
-import { and, eq, gt, inArray, isNull, lt, or, sql as rawSql } from "drizzle-orm";
-import { singleton } from "tsyringe";
+import { and, eq, getTableName, gt, inArray, isNull, lt, or, sql as rawSql } from "drizzle-orm";
+import { inject, singleton } from "tsyringe";
 
 import { paginate } from "@src/lib/generators/paginate/paginate";
 import { providerInventory } from "@src/model-schemas/provider-inventory/provider-inventory.schema";
+import { type Database, PG_CLIENT } from "@src/providers/postgres.provider";
 import type { ChainProvider } from "@src/types/chain-provider";
 import { ClusterState } from "@src/types/inventory";
 import { DbDriver } from "../db-driver/db-driver";
@@ -12,13 +13,16 @@ import { mapToStoredClusterState } from "./stored-cluster-state-mapper/stored-cl
 export type ProviderInventory = InferSelectModel<typeof providerInventory>;
 
 const DEFAULT_ONLINE_STREAM_BATCH_SIZE = 500;
+const TABLE = getTableName(providerInventory);
 
 @singleton()
 export class ProviderInventoryRepository {
   readonly #driver: DbDriver;
+  readonly #sql: Database;
 
-  constructor(dbDriver: DbDriver) {
+  constructor(dbDriver: DbDriver, @inject(PG_CLIENT) sql: Database) {
     this.#driver = dbDriver;
+    this.#sql = sql;
   }
 
   async *streamOnlineProviders(options?: { batchSize?: number }): AsyncGenerator<Pick<ProviderInventory, "owner" | "hostUri">> {
@@ -106,39 +110,42 @@ export class ProviderInventoryRepository {
   async bulkUpsertProviders(providers: ChainProvider[]): Promise<Pick<ProviderInventory, "owner">[]> {
     if (providers.length === 0) return [];
 
-    const NOW_SQL = rawSql`now()`;
-    const rows = providers.map(provider => {
-      return {
-        owner: provider.owner,
-        hostUri: provider.hostUri,
-        selfAttributes: provider.selfAttributes,
-        signedAttributes: provider.signedAttributes,
-        auditedBy: provider.auditedBy.toSorted(),
-        updatedAt: NOW_SQL
-      };
-    });
+    const sql = this.#sql;
+    const c = providerInventory;
+    const payload = providers.map(provider => ({
+      [c.owner.name]: provider.owner,
+      [c.hostUri.name]: provider.hostUri,
+      [c.selfAttributes.name]: provider.selfAttributes,
+      [c.signedAttributes.name]: provider.signedAttributes,
+      [c.auditedBy.name]: provider.auditedBy.toSorted()
+    }));
 
-    const conflictColumns = [providerInventory.hostUri, providerInventory.selfAttributes, providerInventory.signedAttributes, providerInventory.auditedBy];
-    const hasChanges = rawSql.join(
-      conflictColumns.map(column => rawSql`${column} IS DISTINCT FROM excluded.${rawSql.raw(column.name)}`),
-      rawSql` OR `
-    );
+    // 2-3x faster than using drizzle-orm's insert().onConflict().doUpdate() for bulk upsert
+    const rows = await sql<Array<Pick<ProviderInventory, "owner">>>`
+      INSERT INTO ${sql(TABLE)} (
+        ${sql(c.owner.name)}, ${sql(c.hostUri.name)}, ${sql(c.selfAttributes.name)}, ${sql(c.signedAttributes.name)}, ${sql(c.auditedBy.name)}, ${sql(c.updatedAt.name)}
+      )
+      SELECT ${sql(c.owner.name)}, ${sql(c.hostUri.name)}, ${sql(c.selfAttributes.name)}, ${sql(c.signedAttributes.name)}, ${sql(c.auditedBy.name)}, now()
+      FROM jsonb_to_recordset(${sql.json(payload as Parameters<typeof sql.json>[0])}::jsonb) AS x(
+        ${sql(c.owner.name)} text,
+        ${sql(c.hostUri.name)} text,
+        ${sql(c.selfAttributes.name)} jsonb,
+        ${sql(c.signedAttributes.name)} jsonb,
+        ${sql(c.auditedBy.name)} text[]
+      )
+      ON CONFLICT (${sql(c.owner.name)}) DO UPDATE SET
+        ${sql(c.hostUri.name)} = excluded.${sql(c.hostUri.name)},
+        ${sql(c.selfAttributes.name)} = excluded.${sql(c.selfAttributes.name)},
+        ${sql(c.signedAttributes.name)} = excluded.${sql(c.signedAttributes.name)},
+        ${sql(c.auditedBy.name)} = excluded.${sql(c.auditedBy.name)},
+        ${sql(c.updatedAt.name)} = now()
+      WHERE ${sql(TABLE)}.${sql(c.hostUri.name)} IS DISTINCT FROM excluded.${sql(c.hostUri.name)}
+        OR ${sql(TABLE)}.${sql(c.selfAttributes.name)} IS DISTINCT FROM excluded.${sql(c.selfAttributes.name)}
+        OR ${sql(TABLE)}.${sql(c.signedAttributes.name)} IS DISTINCT FROM excluded.${sql(c.signedAttributes.name)}
+        OR ${sql(TABLE)}.${sql(c.auditedBy.name)} IS DISTINCT FROM excluded.${sql(c.auditedBy.name)}
+      RETURNING ${sql(c.owner.name)}
+    `;
 
-    return this.#driver
-      .getDb()
-      .insert(providerInventory)
-      .values(rows)
-      .onConflictDoUpdate({
-        target: providerInventory.owner,
-        set: {
-          hostUri: rawSql.raw(`excluded.${providerInventory.hostUri.name}`),
-          selfAttributes: rawSql.raw(`excluded.${providerInventory.selfAttributes.name}`),
-          signedAttributes: rawSql.raw(`excluded.${providerInventory.signedAttributes.name}`),
-          auditedBy: rawSql.raw(`excluded.${providerInventory.auditedBy.name}`),
-          updatedAt: NOW_SQL
-        },
-        setWhere: hasChanges
-      })
-      .returning({ owner: providerInventory.owner });
+    return rows.map(row => ({ owner: row.owner }));
   }
 }


### PR DESCRIPTION
## Why

ref CON-571

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider inventory updates so only newly inserted or actually changed providers are reported as updated.
  * Unchanged provider records are now correctly excluded from update results.

* **Tests**
  * Added integration coverage for bulk provider updates to verify returned owners for changed records and omission of unchanged ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->