### PR TITLE
feat(bid): explain resource reclamation in bid-list tooltip

### DIFF
--- a/apps/deploy-web/src/components/new-deployment/BidRow/BidRow.tsx
+++ b/apps/deploy-web/src/components/new-deployment/BidRow/BidRow.tsx
@@ -154,7 +154,19 @@ export const BidRow: React.FunctionComponent<Props> = ({
           </div>
         </div>
         {reclamationWindowLabel && (
-          <c.CustomTooltip title={<>This provider offers a reclamation window of {reclamationWindowLabel} before reclaiming the lease.</>}>
+          <c.CustomTooltip
+            title={
+              <>
+                Resource reclamation gives you a grace period before this provider can terminate your lease. If the provider initiates reclamation, your
+                workload keeps running (and being paid for) for {reclamationWindowLabel}, giving you time to migrate to another provider.
+                <br />
+                <br />
+                <a href="https://akash.network/docs/developers/deployment/akash-sdl/advanced-features/#resource-reclamation" target="_blank" rel="noopener">
+                  Learn more
+                </a>
+              </>
+            }
+          >
             <c.Badge variant="secondary" className="mt-1 inline-flex items-center gap-1 px-1.5 py-0 text-xs font-normal">
               <c.ShieldCheck className="text-xs" />
               <span>Reclamation: {reclamationWindowLabel}</span>


### PR DESCRIPTION
## Why

Users seeing the `Reclamation: 1 day` badge in the bid list don't know what reclamation means (raised in Slack: "what does reclamation mean?"). The badge already had a tooltip, but it only restated the window length without explaining the feature.

## What

Rewrote the reclamation badge tooltip copy in the bid list to explain the grace-period behavior (when a provider initiates reclamation, the workload keeps running and being paid for through the window, giving the tenant time to migrate) and added a "Learn more" link to the official Akash docs.

Copy-only change to the existing tooltip's `title` — badge text, icon, and the window derivation are unchanged.

Tooltip now reads:
> Resource reclamation gives you a grace period before this provider can terminate your lease. If the provider initiates reclamation, your workload keeps running (and being paid for) for 1 day, giving you time to migrate to another provider.
>
> Learn more →


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the reclamation-window tooltip with clearer guidance on grace-period behavior.
  * Added a “Learn more” link for easier access to additional information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->