### PR TITLE
feat(deployment): download attestation evidence for confidential compute leases

### DIFF
--- a/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.spec.tsx
@@ -1,3 +1,4 @@
+import type { Mock } from "vitest";
 import { describe, expect, it, vi } from "vitest";
 
 import type { AttestationQuote } from "@src/utils/confidentialCompute";
@@ -14,14 +15,14 @@ describe(AttestationEvidenceModal.name, () => {
   });
 
   it("renders the platform and CPU report on success", () => {
-    setup({ data: { report: "cpu-report-base64", tee_platform: "snp" } });
+    setup({ quote: { report: "cpu-report-base64", tee_platform: "snp" } });
     expect(screen.getByText("snp")).toBeInTheDocument();
     expect(screen.getByText("cpu-report-base64")).toBeInTheDocument();
   });
 
   it("lists one report per GPU for a cpu-gpu platform", () => {
     setup({
-      data: {
+      quote: {
         report: "cpu-report",
         tee_platform: "snp-gpu",
         gpu_reports: [
@@ -36,16 +37,18 @@ describe(AttestationEvidenceModal.name, () => {
   });
 
   it("does not render a GPU section for a CPU-only platform", () => {
-    setup({ data: { report: "cpu-report", tee_platform: "snp" } });
+    setup({ quote: { report: "cpu-report", tee_platform: "snp" } });
     expect(screen.queryByText(/GPU reports/)).not.toBeInTheDocument();
   });
 
-  it("downloads the full bundle as JSON when the download action is clicked", async () => {
-    const { saveFile } = setup({ data: { report: "cpu-report", tee_platform: "snp" } });
+  it("downloads the full bundle including the nonce as JSON when the download action is clicked", async () => {
+    const { saveFile } = setup({ nonce: "nonce-base64", quote: { report: "cpu-report", tee_platform: "snp" } });
 
     await userEvent.click(screen.getByRole("button", { name: "Download JSON" }));
 
     expect(saveFile).toHaveBeenCalledWith(expect.any(Blob), "attestation-123-1-2.json");
+    const [blob] = (saveFile as Mock).mock.calls[0];
+    expect(JSON.parse(await blob.text())).toMatchObject({ nonce: "nonce-base64", report: "cpu-report", tee_platform: "snp" });
   });
 
   it("shows an error and offers a retry when the fetch fails", () => {
@@ -54,12 +57,12 @@ describe(AttestationEvidenceModal.name, () => {
     expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
   });
 
-  function setup(input: { data?: AttestationQuote; error?: Error }) {
+  function setup(input: { nonce?: string; quote?: AttestationQuote; error?: Error }) {
     const mutate = vi.fn();
     const saveFile = vi.fn();
+    const data = input.quote ? { nonce: input.nonce ?? "nonce-base64", quote: input.quote } : undefined;
     const useAttestationQuoteMutation = vi.fn(
-      () =>
-        ({ mutate, data: input.data, error: input.error ?? null, isPending: false }) as unknown as ReturnType<typeof DEPENDENCIES.useAttestationQuoteMutation>
+      () => ({ mutate, data, error: input.error ?? null, isPending: false }) as unknown as ReturnType<typeof DEPENDENCIES.useAttestationQuoteMutation>
     );
 
     render(

--- a/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.spec.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { AttestationQuote } from "@src/utils/confidentialCompute";
+import type { DEPENDENCIES } from "./AttestationEvidenceModal";
+import { AttestationEvidenceModal } from "./AttestationEvidenceModal";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(AttestationEvidenceModal.name, () => {
+  it("fetches the evidence when opened", () => {
+    const { mutate } = setup({});
+    expect(mutate).toHaveBeenCalled();
+  });
+
+  it("renders the platform and CPU report on success", () => {
+    setup({ data: { report: "cpu-report-base64", tee_platform: "snp" } });
+    expect(screen.getByText("snp")).toBeInTheDocument();
+    expect(screen.getByText("cpu-report-base64")).toBeInTheDocument();
+  });
+
+  it("lists one report per GPU for a cpu-gpu platform", () => {
+    setup({
+      data: {
+        report: "cpu-report",
+        tee_platform: "snp-gpu",
+        gpu_reports: [
+          { index: 0, report: "gpu-0-report" },
+          { index: 1, report: "gpu-1-report" }
+        ]
+      }
+    });
+    expect(screen.getByText("GPU reports (2)")).toBeInTheDocument();
+    expect(screen.getByText("gpu-0-report")).toBeInTheDocument();
+    expect(screen.getByText("gpu-1-report")).toBeInTheDocument();
+  });
+
+  it("does not render a GPU section for a CPU-only platform", () => {
+    setup({ data: { report: "cpu-report", tee_platform: "snp" } });
+    expect(screen.queryByText(/GPU reports/)).not.toBeInTheDocument();
+  });
+
+  it("downloads the full bundle as JSON when the download action is clicked", async () => {
+    const { saveFile } = setup({ data: { report: "cpu-report", tee_platform: "snp" } });
+
+    await userEvent.click(screen.getByRole("button", { name: "Download JSON" }));
+
+    expect(saveFile).toHaveBeenCalledWith(expect.any(Blob), "attestation-123-1-2.json");
+  });
+
+  it("shows an error and offers a retry when the fetch fails", () => {
+    setup({ error: new Error("provider unreachable") });
+    expect(screen.getByText(/provider unreachable/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+  });
+
+  function setup(input: { data?: AttestationQuote; error?: Error }) {
+    const mutate = vi.fn();
+    const saveFile = vi.fn();
+    const useAttestationQuoteMutation = vi.fn(
+      () =>
+        ({ mutate, data: input.data, error: input.error ?? null, isPending: false }) as unknown as ReturnType<typeof DEPENDENCIES.useAttestationQuoteMutation>
+    );
+
+    render(
+      <AttestationEvidenceModal
+        provider={{ owner: "akash1provider", hostUri: "https://provider.test" }}
+        lease={{ dseq: "123", gseq: 1, oseq: 2 }}
+        onClose={vi.fn()}
+        dependencies={{ useAttestationQuoteMutation, saveFile }}
+      />
+    );
+
+    return { mutate, saveFile };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.tsx
+++ b/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.tsx
@@ -1,0 +1,125 @@
+"use client";
+import { useEffect } from "react";
+import { Alert, Popup, Spinner } from "@akashnetwork/ui/components";
+import saveFileInBrowser from "file-saver";
+
+import { useAttestationQuoteMutation } from "@src/queries/useAttestationQuoteMutation";
+import type { ProviderIdentity } from "@src/services/provider-proxy/provider-proxy.service";
+import type { LeaseDto } from "@src/types/deployment";
+import type { AttestationQuote } from "@src/utils/confidentialCompute";
+
+export const DEPENDENCIES = {
+  useAttestationQuoteMutation,
+  saveFile: saveFileInBrowser as (data: Blob, filename?: string) => void
+};
+
+type Props = {
+  provider: ProviderIdentity | undefined | null;
+  lease: Pick<LeaseDto, "dseq" | "gseq" | "oseq">;
+  onClose: () => void;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+function ReportBlock({ label, report }: { label: string; report: string }) {
+  return (
+    <div className="space-y-1">
+      <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-all rounded-md border bg-muted/40 p-2 font-mono text-xs">{report}</pre>
+    </div>
+  );
+}
+
+function buildBundle(lease: Pick<LeaseDto, "dseq" | "gseq" | "oseq">, quote: AttestationQuote) {
+  return {
+    lease: { dseq: lease.dseq, gseq: lease.gseq, oseq: lease.oseq },
+    tee_platform: quote.tee_platform,
+    report: quote.report,
+    gpu_reports: quote.gpu_reports ?? []
+  };
+}
+
+export function AttestationEvidenceModal({ provider, lease, onClose, dependencies: d = DEPENDENCIES }: Props) {
+  const { mutate, data, error, isPending } = d.useAttestationQuoteMutation({
+    provider,
+    dseq: lease.dseq,
+    gseq: lease.gseq,
+    oseq: lease.oseq
+  });
+
+  useEffect(() => {
+    mutate();
+  }, [mutate]);
+
+  const onDownload = () => {
+    if (!data) return;
+    const filename = `attestation-${lease.dseq}-${lease.gseq}-${lease.oseq}.json`;
+    d.saveFile(new Blob([JSON.stringify(buildBundle(lease, data), null, 2)], { type: "application/json" }), filename);
+  };
+
+  const gpuReports = data?.gpu_reports ?? [];
+
+  return (
+    <Popup
+      fullWidth
+      open
+      variant="custom"
+      title="Attestation evidence"
+      actions={[
+        {
+          label: "Close",
+          color: "primary",
+          variant: "text",
+          side: "left",
+          onClick: onClose
+        },
+        {
+          label: error ? "Retry" : "Download JSON",
+          color: "secondary",
+          variant: "default",
+          side: "right",
+          disabled: isPending || (!data && !error),
+          onClick: error ? () => mutate() : onDownload
+        }
+      ]}
+      onClose={onClose}
+      maxWidth="sm"
+    >
+      <p className="text-xs text-muted-foreground">
+        Hardware-signed evidence fetched from the provider for this lease, bound to a fresh challenge. Download it to verify the workload independently against
+        the hardware vendor.
+      </p>
+
+      {isPending && (
+        <div className="flex items-center justify-center py-8">
+          <Spinner size="large" />
+        </div>
+      )}
+
+      {!isPending && error && (
+        <Alert variant="destructive" className="my-2">
+          <p className="text-xs">Failed to fetch attestation evidence: {error.message}</p>
+        </Alert>
+      )}
+
+      {!isPending && data && (
+        <div className="mt-3 space-y-3">
+          <div className="flex items-center justify-between gap-4 text-sm">
+            <span className="text-muted-foreground">Platform</span>
+            <span className="font-medium uppercase">{data.tee_platform}</span>
+          </div>
+
+          <ReportBlock label="CPU report" report={data.report} />
+
+          {gpuReports.length > 0 && (
+            <div className="space-y-2">
+              <p className="text-xs font-medium text-muted-foreground">GPU reports ({gpuReports.length})</p>
+              {gpuReports.map(gpu => (
+                <ReportBlock key={gpu.index} label={`GPU ${gpu.index}`} report={gpu.report} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </Popup>
+  );
+}

--- a/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.tsx
+++ b/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.tsx
@@ -1,4 +1,5 @@
 "use client";
+import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { Alert, Popup, Spinner } from "@akashnetwork/ui/components";
 import saveFileInBrowser from "file-saver";
@@ -20,10 +21,14 @@ type Props = {
   dependencies?: typeof DEPENDENCIES;
 };
 
+function ReportLabel({ children }: { children: ReactNode }) {
+  return <p className="text-xs font-medium text-muted-foreground">{children}</p>;
+}
+
 function ReportBlock({ label, report }: { label: string; report: string }) {
   return (
     <div className="space-y-1">
-      <p className="text-xs font-medium text-muted-foreground">{label}</p>
+      <ReportLabel>{label}</ReportLabel>
       <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-all rounded-md border bg-muted/40 p-2 font-mono text-xs">{report}</pre>
     </div>
   );
@@ -112,7 +117,7 @@ export function AttestationEvidenceModal({ provider, lease, onClose, dependencie
 
           {gpuReports.length > 0 && (
             <div className="space-y-2">
-              <p className="text-xs font-medium text-muted-foreground">GPU reports ({gpuReports.length})</p>
+              <ReportLabel>GPU reports ({gpuReports.length})</ReportLabel>
               {gpuReports.map(gpu => (
                 <ReportBlock key={gpu.index} label={`GPU ${gpu.index}`} report={gpu.report} />
               ))}

--- a/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.tsx
+++ b/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.tsx
@@ -7,7 +7,7 @@ import saveFileInBrowser from "file-saver";
 import { useAttestationQuoteMutation } from "@src/queries/useAttestationQuoteMutation";
 import type { ProviderIdentity } from "@src/services/provider-proxy/provider-proxy.service";
 import type { LeaseDto } from "@src/types/deployment";
-import type { AttestationQuote } from "@src/utils/confidentialCompute";
+import type { AttestationEvidence } from "@src/utils/confidentialCompute";
 
 export const DEPENDENCIES = {
   useAttestationQuoteMutation,
@@ -34,12 +34,13 @@ function ReportBlock({ label, report }: { label: string; report: string }) {
   );
 }
 
-function buildBundle(lease: Pick<LeaseDto, "dseq" | "gseq" | "oseq">, quote: AttestationQuote) {
+function buildBundle(lease: Pick<LeaseDto, "dseq" | "gseq" | "oseq">, evidence: AttestationEvidence) {
   return {
     lease: { dseq: lease.dseq, gseq: lease.gseq, oseq: lease.oseq },
-    tee_platform: quote.tee_platform,
-    report: quote.report,
-    gpu_reports: quote.gpu_reports ?? []
+    nonce: evidence.nonce,
+    tee_platform: evidence.quote.tee_platform,
+    report: evidence.quote.report,
+    gpu_reports: evidence.quote.gpu_reports ?? []
   };
 }
 
@@ -61,7 +62,8 @@ export function AttestationEvidenceModal({ provider, lease, onClose, dependencie
     d.saveFile(new Blob([JSON.stringify(buildBundle(lease, data), null, 2)], { type: "application/json" }), filename);
   };
 
-  const gpuReports = data?.gpu_reports ?? [];
+  const quote = data?.quote;
+  const gpuReports = quote?.gpu_reports ?? [];
 
   return (
     <Popup
@@ -106,14 +108,14 @@ export function AttestationEvidenceModal({ provider, lease, onClose, dependencie
         </Alert>
       )}
 
-      {!isPending && data && (
+      {!isPending && quote && (
         <div className="mt-3 space-y-3">
           <div className="flex items-center justify-between gap-4 text-sm">
             <span className="text-muted-foreground">Platform</span>
-            <span className="font-medium uppercase">{data.tee_platform}</span>
+            <span className="font-medium uppercase">{quote.tee_platform}</span>
           </div>
 
-          <ReportBlock label="CPU report" report={data.report} />
+          <ReportBlock label="CPU report" report={quote.report} />
 
           {gpuReports.length > 0 && (
             <div className="space-y-2">

--- a/apps/deploy-web/src/components/deployments/DownloadAttestationEvidence.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DownloadAttestationEvidence.spec.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentGroup, LeaseDto } from "@src/types/deployment";
+import { TEE_TYPE_ATTRIBUTE_KEY } from "@src/utils/confidentialCompute";
+import { DEPENDENCIES, DownloadAttestationEvidence } from "./DownloadAttestationEvidence";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MockComponents } from "@tests/unit/mocks";
+
+const TEE_GROUP = mock<DeploymentGroup>({
+  group_spec: { requirements: { attributes: [{ key: TEE_TYPE_ATTRIBUTE_KEY, value: "cpu-gpu" }] } }
+} as unknown as DeploymentGroup);
+
+describe(DownloadAttestationEvidence.name, () => {
+  it("renders the trigger when the flag is on, the lease is live and a TEE type is declared", () => {
+    setup({ flagEnabled: true, state: "active", group: TEE_GROUP });
+    expect(screen.getByRole("button", { name: /Attestation evidence/ })).toBeInTheDocument();
+  });
+
+  it("renders nothing when the feature flag is off", () => {
+    setup({ flagEnabled: false, state: "active", group: TEE_GROUP });
+    expect(screen.queryByRole("button", { name: /Attestation evidence/ })).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when the lease is not live", () => {
+    setup({ flagEnabled: true, state: "closed", group: TEE_GROUP });
+    expect(screen.queryByRole("button", { name: /Attestation evidence/ })).not.toBeInTheDocument();
+  });
+
+  it("renders nothing for a non-Confidential-Compute lease", () => {
+    setup({ flagEnabled: true, state: "active", group: undefined });
+    expect(screen.queryByRole("button", { name: /Attestation evidence/ })).not.toBeInTheDocument();
+  });
+
+  it("opens the evidence modal when the trigger is clicked", async () => {
+    const { AttestationEvidenceModal } = setup({ flagEnabled: true, state: "active", group: TEE_GROUP });
+
+    expect(AttestationEvidenceModal).not.toHaveBeenCalled();
+    await userEvent.click(screen.getByRole("button", { name: /Attestation evidence/ }));
+
+    expect(AttestationEvidenceModal).toHaveBeenCalled();
+  });
+
+  function setup(input: { flagEnabled: boolean; state: LeaseDto["state"]; group?: DeploymentGroup }) {
+    const useFlag = vi.fn(() => input.flagEnabled);
+    const AttestationEvidenceModal = vi.fn(() => <div>modal</div>);
+    const lease = mock<LeaseDto>({ state: input.state, group: input.group, dseq: "123", gseq: 1, oseq: 2 });
+
+    render(
+      <DownloadAttestationEvidence
+        lease={lease}
+        provider={{ owner: "akash1provider", hostUri: "https://provider.test" }}
+        dependencies={MockComponents(DEPENDENCIES, { useFlag, AttestationEvidenceModal })}
+      />
+    );
+
+    return { useFlag, AttestationEvidenceModal };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/DownloadAttestationEvidence.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DownloadAttestationEvidence.spec.tsx
@@ -14,28 +14,23 @@ const TEE_GROUP = mock<DeploymentGroup>({
 } as unknown as DeploymentGroup);
 
 describe(DownloadAttestationEvidence.name, () => {
-  it("renders the trigger when the flag is on, the lease is live and a TEE type is declared", () => {
-    setup({ flagEnabled: true, state: "active", group: TEE_GROUP });
+  it("renders the trigger when the lease is live and a TEE type is declared", () => {
+    setup({ state: "active", group: TEE_GROUP });
     expect(screen.getByRole("button", { name: /Attestation evidence/ })).toBeInTheDocument();
   });
 
-  it("renders nothing when the feature flag is off", () => {
-    setup({ flagEnabled: false, state: "active", group: TEE_GROUP });
-    expect(screen.queryByRole("button", { name: /Attestation evidence/ })).not.toBeInTheDocument();
-  });
-
   it("renders nothing when the lease is not live", () => {
-    setup({ flagEnabled: true, state: "closed", group: TEE_GROUP });
+    setup({ state: "closed", group: TEE_GROUP });
     expect(screen.queryByRole("button", { name: /Attestation evidence/ })).not.toBeInTheDocument();
   });
 
   it("renders nothing for a non-Confidential-Compute lease", () => {
-    setup({ flagEnabled: true, state: "active", group: undefined });
+    setup({ state: "active", group: undefined });
     expect(screen.queryByRole("button", { name: /Attestation evidence/ })).not.toBeInTheDocument();
   });
 
   it("opens the evidence modal when the trigger is clicked", async () => {
-    const { AttestationEvidenceModal } = setup({ flagEnabled: true, state: "active", group: TEE_GROUP });
+    const { AttestationEvidenceModal } = setup({ state: "active", group: TEE_GROUP });
 
     expect(AttestationEvidenceModal).not.toHaveBeenCalled();
     await userEvent.click(screen.getByRole("button", { name: /Attestation evidence/ }));
@@ -43,8 +38,7 @@ describe(DownloadAttestationEvidence.name, () => {
     expect(AttestationEvidenceModal).toHaveBeenCalled();
   });
 
-  function setup(input: { flagEnabled: boolean; state: LeaseDto["state"]; group?: DeploymentGroup }) {
-    const useFlag = vi.fn(() => input.flagEnabled);
+  function setup(input: { state: LeaseDto["state"]; group?: DeploymentGroup }) {
     const AttestationEvidenceModal = vi.fn(() => <div>modal</div>);
     const lease = mock<LeaseDto>({ state: input.state, group: input.group, dseq: "123", gseq: 1, oseq: 2 });
 
@@ -52,10 +46,10 @@ describe(DownloadAttestationEvidence.name, () => {
       <DownloadAttestationEvidence
         lease={lease}
         provider={{ owner: "akash1provider", hostUri: "https://provider.test" }}
-        dependencies={MockComponents(DEPENDENCIES, { useFlag, AttestationEvidenceModal })}
+        dependencies={MockComponents(DEPENDENCIES, { AttestationEvidenceModal })}
       />
     );
 
-    return { useFlag, AttestationEvidenceModal };
+    return { AttestationEvidenceModal };
   }
 });

--- a/apps/deploy-web/src/components/deployments/DownloadAttestationEvidence.tsx
+++ b/apps/deploy-web/src/components/deployments/DownloadAttestationEvidence.tsx
@@ -1,0 +1,45 @@
+"use client";
+import { useState } from "react";
+import { Button } from "@akashnetwork/ui/components";
+import { ShieldCheck } from "lucide-react";
+
+import { useFlag } from "@src/hooks/useFlag";
+import type { ProviderIdentity } from "@src/services/provider-proxy/provider-proxy.service";
+import type { LeaseDto } from "@src/types/deployment";
+import { getGroupTeeType } from "@src/utils/confidentialCompute";
+import { isLeaseLive } from "@src/utils/reclamationUtils";
+import { AttestationEvidenceModal } from "./AttestationEvidenceModal";
+
+export const DEPENDENCIES = {
+  useFlag,
+  AttestationEvidenceModal
+};
+
+type Props = {
+  lease: LeaseDto;
+  provider: ProviderIdentity | undefined | null;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/**
+ * Surfaces the attestation-evidence download for a running Confidential Compute lease. Renders nothing
+ * unless the feature flag is on, the lease is live, and the lease's on-chain group declares a TEE type —
+ * so the option never appears for non-Confidential-Compute deployments (CON-540).
+ */
+export function DownloadAttestationEvidence({ lease, provider, dependencies: d = DEPENDENCIES }: Props) {
+  const isEnabled = d.useFlag("ui_confidential_compute");
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (!isEnabled || !isLeaseLive(lease) || !getGroupTeeType(lease.group)) return null;
+
+  return (
+    <>
+      <Button variant="outline" size="sm" onClick={() => setIsOpen(true)}>
+        <ShieldCheck className="mr-2 h-4 w-4" />
+        Attestation evidence
+      </Button>
+
+      {isOpen && <d.AttestationEvidenceModal provider={provider} lease={lease} onClose={() => setIsOpen(false)} />}
+    </>
+  );
+}

--- a/apps/deploy-web/src/components/deployments/DownloadAttestationEvidence.tsx
+++ b/apps/deploy-web/src/components/deployments/DownloadAttestationEvidence.tsx
@@ -23,14 +23,14 @@ type Props = {
 
 /**
  * Surfaces the attestation-evidence download for a running Confidential Compute lease. Renders nothing
- * unless the feature flag is on, the lease is live, and the lease's on-chain group declares a TEE type —
- * so the option never appears for non-Confidential-Compute deployments (CON-540).
+ * unless the feature flag is on, the lease is live, a provider is resolved, and the lease's on-chain group
+ * declares a TEE type — so the option never appears for non-Confidential-Compute deployments (CON-540).
  */
 export function DownloadAttestationEvidence({ lease, provider, dependencies: d = DEPENDENCIES }: Props) {
   const isEnabled = d.useFlag("ui_confidential_compute");
   const [isOpen, setIsOpen] = useState(false);
 
-  if (!isEnabled || !isLeaseLive(lease) || !getGroupTeeType(lease.group)) return null;
+  if (!isEnabled || !isLeaseLive(lease) || !provider || !getGroupTeeType(lease.group)) return null;
 
   return (
     <>

--- a/apps/deploy-web/src/components/deployments/DownloadAttestationEvidence.tsx
+++ b/apps/deploy-web/src/components/deployments/DownloadAttestationEvidence.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 import { Button } from "@akashnetwork/ui/components";
 import { ShieldCheck } from "lucide-react";
 
-import { useFlag } from "@src/hooks/useFlag";
 import type { ProviderIdentity } from "@src/services/provider-proxy/provider-proxy.service";
 import type { LeaseDto } from "@src/types/deployment";
 import { getGroupTeeType } from "@src/utils/confidentialCompute";
@@ -11,7 +10,6 @@ import { isLeaseLive } from "@src/utils/reclamationUtils";
 import { AttestationEvidenceModal } from "./AttestationEvidenceModal";
 
 export const DEPENDENCIES = {
-  useFlag,
   AttestationEvidenceModal
 };
 
@@ -23,14 +21,13 @@ type Props = {
 
 /**
  * Surfaces the attestation-evidence download for a running Confidential Compute lease. Renders nothing
- * unless the feature flag is on, the lease is live, a provider is resolved, and the lease's on-chain group
- * declares a TEE type — so the option never appears for non-Confidential-Compute deployments (CON-540).
+ * unless the lease is live, a provider is resolved, and the lease's on-chain group declares a TEE type
+ * — so the option never appears for non-Confidential-Compute deployments (CON-540).
  */
 export function DownloadAttestationEvidence({ lease, provider, dependencies: d = DEPENDENCIES }: Props) {
-  const isEnabled = d.useFlag("ui_confidential_compute");
   const [isOpen, setIsOpen] = useState(false);
 
-  if (!isEnabled || !isLeaseLive(lease) || !provider || !getGroupTeeType(lease.group)) return null;
+  if (!isLeaseLive(lease) || !provider || !getGroupTeeType(lease.group)) return null;
 
   return (
     <>

--- a/apps/deploy-web/src/components/deployments/LeaseRow.tsx
+++ b/apps/deploy-web/src/components/deployments/LeaseRow.tsx
@@ -37,6 +37,7 @@ import { ManifestErrorSnackbar } from "../shared/ManifestErrorSnackbar/ManifestE
 import { ProviderName } from "../shared/ProviderName";
 import { ReclamationCard } from "./ReclamationCard/ReclamationCard";
 import { ConfidentialComputeResources } from "./ConfidentialComputeResources";
+import { DownloadAttestationEvidence } from "./DownloadAttestationEvidence";
 
 type Props = {
   index: number;
@@ -213,6 +214,7 @@ export const LeaseRow = React.forwardRef<AcceptRefType, Props>(
             </div>
 
             <ConfidentialComputeResources carveouts={teeCarveouts} />
+            <DownloadAttestationEvidence lease={lease} provider={provider} />
             <LabelValueOld
               label="Price:"
               value={

--- a/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.spec.tsx
+++ b/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.spec.tsx
@@ -99,6 +99,69 @@ describe(useProviderJwt.name, () => {
     expect(consoleApiHttpClient.post).not.toHaveBeenCalled();
   });
 
+  it("generates a per-provider granular token without persisting it", async () => {
+    const token = genFakeToken();
+    const userId = "user-1";
+    const consoleApiHttpClient = mock<HttpClient>({
+      post: vi.fn().mockResolvedValue({ data: { data: { token } } })
+    } as unknown as HttpClient);
+    const storedWalletsService = mock<StoredWalletsService>({
+      getStorageManagedWallet: vi.fn().mockReturnValue(undefined),
+      updateStorageManagedWallet: vi.fn()
+    });
+
+    const { result } = setup({
+      services: { consoleApiHttpClient: () => consoleApiHttpClient, storedWalletsService: () => storedWalletsService },
+      user: { id: userId },
+      wallet: { isWalletConnected: true }
+    });
+
+    const returned = await result.current.generateScopedProviderToken({ provider: "akash1provider", scope: ["attestation"] });
+
+    expect(returned).toBe(token);
+    expect(consoleApiHttpClient.post).toHaveBeenCalledWith("/v1/create-jwt-token", {
+      data: {
+        ttl: 1800, // 30 * 60
+        leases: {
+          access: "granular",
+          permissions: [{ provider: "akash1provider", access: "scoped", scope: ["attestation"] }]
+        }
+      }
+    });
+    // ephemeral: the shared global token (storage + atom) must not be touched
+    expect(storedWalletsService.updateStorageManagedWallet).not.toHaveBeenCalled();
+    expect(result.current.accessToken).toBeNull();
+  });
+
+  it("throws when generating a scoped provider token while wallet is disconnected", async () => {
+    const consoleApiHttpClient = mock<HttpClient>({ post: vi.fn() } as unknown as HttpClient);
+
+    const { result } = setup({
+      services: { consoleApiHttpClient: () => consoleApiHttpClient },
+      wallet: { isWalletConnected: false }
+    });
+
+    await expect(result.current.generateScopedProviderToken({ provider: "akash1provider", scope: ["attestation"] })).rejects.toThrow(
+      /wallet is not connected/i
+    );
+    expect(consoleApiHttpClient.post).not.toHaveBeenCalled();
+  });
+
+  it("throws when generating a scoped provider token without an authenticated user", async () => {
+    const consoleApiHttpClient = mock<HttpClient>({ post: vi.fn() } as unknown as HttpClient);
+
+    const { result } = setup({
+      services: { consoleApiHttpClient: () => consoleApiHttpClient },
+      wallet: { isWalletConnected: true },
+      user: null
+    });
+
+    await expect(result.current.generateScopedProviderToken({ provider: "akash1provider", scope: ["attestation"] })).rejects.toThrow(
+      /user is not authenticated/i
+    );
+    expect(consoleApiHttpClient.post).not.toHaveBeenCalled();
+  });
+
   it("detects expired token correctly", () => {
     const pastTime = Math.floor(Date.now() / 1000) - 100;
     const { result } = setup({ initialToken: genFakeToken({ exp: pastTime }) });

--- a/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.spec.tsx
+++ b/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.spec.tsx
@@ -66,7 +66,7 @@ describe(useProviderJwt.name, () => {
         ttl: 1800, // 30 * 60
         leases: {
           access: "scoped",
-          scope: ["status", "shell", "events", "logs", "send-manifest", "get-manifest", "attestation"]
+          scope: ["status", "shell", "events", "logs", "send-manifest", "get-manifest"]
         }
       }
     });

--- a/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.ts
+++ b/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.ts
@@ -62,7 +62,7 @@ export function useProviderJwt({ dependencies: d = DEPENDENCIES }: { dependencie
         ttl: 30 * 60,
         leases: {
           access: "scoped",
-          scope: ["status", "shell", "events", "logs", "send-manifest", "get-manifest", "attestation"]
+          scope: ["status", "shell", "events", "logs", "send-manifest", "get-manifest"]
         }
       }
     });

--- a/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.ts
+++ b/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.ts
@@ -73,6 +73,32 @@ export function useProviderJwt({ dependencies: d = DEPENDENCIES }: { dependencie
     return token;
   }, [isWalletConnected, userId, consoleApiHttpClient, storedWalletsService, setAccessToken]);
 
+  const generateScopedProviderToken = useCallback(
+    async ({ provider, scope }: { provider: string; scope: readonly string[] }): Promise<string> => {
+      if (!isWalletConnected) {
+        throw new Error("Cannot generate JWT: wallet is not connected");
+      }
+      if (!userId) {
+        throw new Error("Cannot generate JWT: user is not authenticated");
+      }
+
+      const response = await consoleApiHttpClient.post<{ data: { token: string } }>("/v1/create-jwt-token", {
+        data: {
+          ttl: 30 * 60,
+          leases: {
+            access: "granular",
+            permissions: [{ provider, access: "scoped", scope }]
+          }
+        }
+      });
+
+      // Intentionally not persisted to JWT_TOKEN_ATOM / managed-wallet storage: this is an ephemeral,
+      // single-provider token (e.g. for the attestation-quote endpoint), not the shared global token.
+      return response.data.data.token;
+    },
+    [isWalletConnected, userId, consoleApiHttpClient]
+  );
+
   return useMemo(
     () => ({
       get isTokenExpired() {
@@ -80,9 +106,10 @@ export function useProviderJwt({ dependencies: d = DEPENDENCIES }: { dependencie
       },
       accessToken,
       generateToken,
+      generateScopedProviderToken,
       isHydrated
     }),
-    [accessToken, generateToken, isHydrated]
+    [accessToken, generateToken, generateScopedProviderToken, isHydrated]
   );
 }
 
@@ -90,5 +117,6 @@ export interface UseProviderJwtResult {
   isTokenExpired: boolean;
   accessToken: string | null;
   generateToken: () => Promise<string>;
+  generateScopedProviderToken: (params: { provider: string; scope: readonly string[] }) => Promise<string>;
   isHydrated: boolean;
 }

--- a/apps/deploy-web/src/queries/useAttestationQuoteMutation.spec.ts
+++ b/apps/deploy-web/src/queries/useAttestationQuoteMutation.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
+import type { ProviderProxyService } from "@src/services/provider-proxy/provider-proxy.service";
+import type { AttestationQuote } from "@src/utils/confidentialCompute";
+import { DEPENDENCIES, useAttestationQuoteMutation } from "./useAttestationQuoteMutation";
+
+import { setupQuery } from "@tests/unit/query-client";
+
+describe(useAttestationQuoteMutation.name, () => {
+  it("fetches the attestation quote for the lease and exposes the data", async () => {
+    const quote: AttestationQuote = { report: "cpu-report", tee_platform: "snp" };
+    const { result, providerProxy } = setup({ quote });
+
+    result.current.mutate();
+
+    await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(quote);
+    expect(providerProxy.fetchAttestationQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: { owner: "akash1provider", hostUri: "https://provider.test" }, dseq: "123", gseq: 1, oseq: 2 })
+    );
+  });
+
+  it("surfaces the error when the provider call fails", async () => {
+    const { result } = setup({ rejection: new Error("provider unreachable") });
+
+    result.current.mutate();
+
+    await vi.waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe("provider unreachable");
+  });
+
+  function setup(input: { quote?: AttestationQuote; rejection?: Error }) {
+    const providerProxy = mock<ProviderProxyService>({
+      fetchAttestationQuote: vi.fn(input.rejection ? () => Promise.reject(input.rejection) : () => Promise.resolve(input.quote!))
+    });
+    const ensureToken = vi.fn().mockResolvedValue("jwt-token");
+    const useProviderCredentialsMock: typeof useProviderCredentials = () => mock<ReturnType<typeof useProviderCredentials>>({ ensureToken });
+
+    const { result } = setupQuery(
+      () =>
+        useAttestationQuoteMutation(
+          { provider: { owner: "akash1provider", hostUri: "https://provider.test" }, dseq: "123", gseq: 1, oseq: 2 },
+          { ...DEPENDENCIES, useProviderCredentials: useProviderCredentialsMock }
+        ),
+      { services: { providerProxy: () => providerProxy } }
+    );
+
+    return { result, providerProxy, ensureToken };
+  }
+});

--- a/apps/deploy-web/src/queries/useAttestationQuoteMutation.spec.ts
+++ b/apps/deploy-web/src/queries/useAttestationQuoteMutation.spec.ts
@@ -9,14 +9,13 @@ import { DEPENDENCIES, useAttestationQuoteMutation } from "./useAttestationQuote
 import { setupQuery } from "@tests/unit/query-client";
 
 describe(useAttestationQuoteMutation.name, () => {
-  it("fetches the attestation quote for the lease and exposes the data", async () => {
-    const quote: AttestationQuote = { report: "cpu-report", tee_platform: "snp" };
-    const { result, providerProxy } = setup({ quote });
+  it("fetches the attestation evidence for the lease and exposes the data", async () => {
+    const { result, providerProxy, evidence } = setup({ nonce: "nonce-base64", quote: { report: "cpu-report", tee_platform: "snp" } });
 
     result.current.mutate();
 
     await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual(quote);
+    expect(result.current.data).toEqual(evidence);
     expect(providerProxy.fetchAttestationQuote).toHaveBeenCalledWith(
       expect.objectContaining({ provider: { owner: "akash1provider", hostUri: "https://provider.test" }, dseq: "123", gseq: 1, oseq: 2 })
     );
@@ -42,9 +41,10 @@ describe(useAttestationQuoteMutation.name, () => {
     expect(result.current.error?.message).toBe("provider unreachable");
   });
 
-  function setup(input: { quote?: AttestationQuote; rejection?: Error }) {
+  function setup(input: { quote?: AttestationQuote; nonce?: string; rejection?: Error }) {
+    const evidence = input.quote ? { nonce: input.nonce ?? "nonce-base64", quote: input.quote } : undefined;
     const providerProxy = mock<ProviderProxyService>({
-      fetchAttestationQuote: vi.fn(input.rejection ? () => Promise.reject(input.rejection) : () => Promise.resolve(input.quote!))
+      fetchAttestationQuote: vi.fn(input.rejection ? () => Promise.reject(input.rejection) : () => Promise.resolve(evidence!))
     });
     const generateScopedProviderToken = vi.fn().mockResolvedValue("attestation-jwt");
     const useProviderJwtMock: typeof useProviderJwt = () => mock<ReturnType<typeof useProviderJwt>>({ generateScopedProviderToken });
@@ -58,6 +58,6 @@ describe(useAttestationQuoteMutation.name, () => {
       { services: { providerProxy: () => providerProxy } }
     );
 
-    return { result, providerProxy, generateScopedProviderToken };
+    return { result, providerProxy, generateScopedProviderToken, evidence };
   }
 });

--- a/apps/deploy-web/src/queries/useAttestationQuoteMutation.spec.ts
+++ b/apps/deploy-web/src/queries/useAttestationQuoteMutation.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
+import type { useProviderJwt } from "@src/hooks/useProviderJwt/useProviderJwt";
 import type { ProviderProxyService } from "@src/services/provider-proxy/provider-proxy.service";
 import type { AttestationQuote } from "@src/utils/confidentialCompute";
 import { DEPENDENCIES, useAttestationQuoteMutation } from "./useAttestationQuoteMutation";
@@ -22,6 +22,17 @@ describe(useAttestationQuoteMutation.name, () => {
     );
   });
 
+  it("authorizes the provider call with a per-provider attestation-scoped token", async () => {
+    const { result, providerProxy, generateScopedProviderToken } = setup({ quote: { report: "cpu-report", tee_platform: "snp" } });
+
+    result.current.mutate();
+
+    await vi.waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const { ensureToken } = providerProxy.fetchAttestationQuote.mock.calls[0][0];
+    await expect(ensureToken()).resolves.toBe("attestation-jwt");
+    expect(generateScopedProviderToken).toHaveBeenCalledWith({ provider: "akash1provider", scope: ["attestation"] });
+  });
+
   it("surfaces the error when the provider call fails", async () => {
     const { result } = setup({ rejection: new Error("provider unreachable") });
 
@@ -35,18 +46,18 @@ describe(useAttestationQuoteMutation.name, () => {
     const providerProxy = mock<ProviderProxyService>({
       fetchAttestationQuote: vi.fn(input.rejection ? () => Promise.reject(input.rejection) : () => Promise.resolve(input.quote!))
     });
-    const ensureToken = vi.fn().mockResolvedValue("jwt-token");
-    const useProviderCredentialsMock: typeof useProviderCredentials = () => mock<ReturnType<typeof useProviderCredentials>>({ ensureToken });
+    const generateScopedProviderToken = vi.fn().mockResolvedValue("attestation-jwt");
+    const useProviderJwtMock: typeof useProviderJwt = () => mock<ReturnType<typeof useProviderJwt>>({ generateScopedProviderToken });
 
     const { result } = setupQuery(
       () =>
         useAttestationQuoteMutation(
           { provider: { owner: "akash1provider", hostUri: "https://provider.test" }, dseq: "123", gseq: 1, oseq: 2 },
-          { ...DEPENDENCIES, useProviderCredentials: useProviderCredentialsMock }
+          { ...DEPENDENCIES, useProviderJwt: useProviderJwtMock }
         ),
       { services: { providerProxy: () => providerProxy } }
     );
 
-    return { result, providerProxy, ensureToken };
+    return { result, providerProxy, generateScopedProviderToken };
   }
 });

--- a/apps/deploy-web/src/queries/useAttestationQuoteMutation.ts
+++ b/apps/deploy-web/src/queries/useAttestationQuoteMutation.ts
@@ -1,0 +1,41 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { useServices } from "@src/context/ServicesProvider";
+import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
+import type { ProviderIdentity } from "@src/services/provider-proxy/provider-proxy.service";
+import type { AttestationQuote } from "@src/utils/confidentialCompute";
+
+export const DEPENDENCIES = {
+  useServices,
+  useProviderCredentials
+};
+
+/**
+ * Fetches the lease's attestation evidence on demand. Modeled as a mutation rather than a query because a
+ * fresh nonce is generated per request (CON-540): the evidence must be re-fetched, never served from cache.
+ */
+export function useAttestationQuoteMutation(
+  params: {
+    provider: ProviderIdentity | undefined | null;
+    dseq: string;
+    gseq: number;
+    oseq: number;
+  },
+  dependencies: typeof DEPENDENCIES = DEPENDENCIES
+) {
+  const { providerProxy } = dependencies.useServices();
+  const { ensureToken } = dependencies.useProviderCredentials();
+
+  return useMutation<AttestationQuote, Error>({
+    mutationFn: () => {
+      if (!params.provider) throw new Error("Provider is not available for this lease.");
+      return providerProxy.fetchAttestationQuote({
+        provider: params.provider,
+        dseq: params.dseq,
+        gseq: params.gseq,
+        oseq: params.oseq,
+        ensureToken
+      });
+    }
+  });
+}

--- a/apps/deploy-web/src/queries/useAttestationQuoteMutation.ts
+++ b/apps/deploy-web/src/queries/useAttestationQuoteMutation.ts
@@ -1,18 +1,22 @@
 import { useMutation } from "@tanstack/react-query";
 
 import { useServices } from "@src/context/ServicesProvider";
-import { useProviderCredentials } from "@src/hooks/useProviderCredentials/useProviderCredentials";
+import { useProviderJwt } from "@src/hooks/useProviderJwt/useProviderJwt";
 import type { ProviderIdentity } from "@src/services/provider-proxy/provider-proxy.service";
 import type { AttestationQuote } from "@src/utils/confidentialCompute";
 
 export const DEPENDENCIES = {
   useServices,
-  useProviderCredentials
+  useProviderJwt
 };
 
 /**
  * Fetches the lease's attestation evidence on demand. Modeled as a mutation rather than a query because a
  * fresh nonce is generated per request (CON-540): the evidence must be re-fetched, never served from cache.
+ *
+ * The provider attestationQuote endpoint requires the `attestation` JWT scope, which is NOT on the shared
+ * global token. We mint an ephemeral, single-provider granular token carrying only `attestation` for the
+ * target provider, since only TEE-capable providers accept that scope (non-TEE providers reject it).
  */
 export function useAttestationQuoteMutation(
   params: {
@@ -24,17 +28,18 @@ export function useAttestationQuoteMutation(
   dependencies: typeof DEPENDENCIES = DEPENDENCIES
 ) {
   const { providerProxy } = dependencies.useServices();
-  const { ensureToken } = dependencies.useProviderCredentials();
+  const { generateScopedProviderToken } = dependencies.useProviderJwt();
 
   return useMutation<AttestationQuote, Error>({
     mutationFn: () => {
-      if (!params.provider) throw new Error("Provider is not available for this lease.");
+      const provider = params.provider;
+      if (!provider) throw new Error("Provider is not available for this lease.");
       return providerProxy.fetchAttestationQuote({
-        provider: params.provider,
+        provider,
         dseq: params.dseq,
         gseq: params.gseq,
         oseq: params.oseq,
-        ensureToken
+        ensureToken: () => generateScopedProviderToken({ provider: provider.owner, scope: ["attestation"] })
       });
     }
   });

--- a/apps/deploy-web/src/queries/useAttestationQuoteMutation.ts
+++ b/apps/deploy-web/src/queries/useAttestationQuoteMutation.ts
@@ -3,7 +3,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useServices } from "@src/context/ServicesProvider";
 import { useProviderJwt } from "@src/hooks/useProviderJwt/useProviderJwt";
 import type { ProviderIdentity } from "@src/services/provider-proxy/provider-proxy.service";
-import type { AttestationQuote } from "@src/utils/confidentialCompute";
+import type { AttestationEvidence } from "@src/utils/confidentialCompute";
 
 export const DEPENDENCIES = {
   useServices,
@@ -30,7 +30,7 @@ export function useAttestationQuoteMutation(
   const { providerProxy } = dependencies.useServices();
   const { generateScopedProviderToken } = dependencies.useProviderJwt();
 
-  return useMutation<AttestationQuote, Error>({
+  return useMutation<AttestationEvidence, Error>({
     mutationFn: () => {
       const provider = params.provider;
       if (!provider) throw new Error("Provider is not available for this lease.");

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
@@ -1140,8 +1140,7 @@ describe(ProviderProxyService.name, () => {
         ensureToken: () => Promise.resolve("jwt-token")
       });
 
-      expect(result).toEqual(quote);
-      const [, payload] = (httpClient.post as Mock).mock.calls[0];
+      const [, payload, requestConfig] = (httpClient.post as Mock).mock.calls[0];
       expect(payload.method).toBe("POST");
       expect(payload.url).toBe("https://provider.test/lease/123/1/2/attestation/quote");
       expect(payload.auth).toEqual({ type: "jwt", token: "jwt-token" });
@@ -1149,6 +1148,10 @@ describe(ProviderProxyService.name, () => {
       const body = JSON.parse(payload.body);
       expect(body.bind_tls).toBe(false);
       expect(fromBase64(body.nonce)).toHaveLength(64);
+
+      expect(result.quote).toEqual(quote);
+      expect(result.nonce).toBe(body.nonce);
+      expect(requestConfig.timeout).toBe(60_000);
     });
   });
 

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
@@ -5,6 +5,7 @@ import type { LoggerService } from "@akashnetwork/logging";
 import { afterEach, describe, expect, it, type Mock, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { fromBase64 } from "@src/utils/encoding";
 import type { K8sEventMessage, LogEntryMessage, ProviderCredentials } from "./provider-proxy.service";
 import { ProviderProxyService, WS_ERRORS } from "./provider-proxy.service";
 
@@ -1122,6 +1123,32 @@ describe(ProviderProxyService.name, () => {
       await vi.advanceTimersByTimeAsync(10_000);
 
       expect(createWebSocket).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("fetchAttestationQuote", () => {
+    it("posts a fresh 64-byte nonce to the attestation quote endpoint with jwt credentials", async () => {
+      const quote = { report: "cpu-report", tee_platform: "snp-gpu", gpu_reports: [{ index: 0, report: "gpu-0" }] };
+      const httpClient = mock<HttpClient>({ post: vi.fn().mockResolvedValue({ data: quote }) } as unknown as HttpClient);
+      const { service } = setup({ httpClient });
+
+      const result = await service.fetchAttestationQuote({
+        provider: { owner: "akash1provider", hostUri: "https://provider.test" },
+        dseq: "123",
+        gseq: 1,
+        oseq: 2,
+        ensureToken: () => Promise.resolve("jwt-token")
+      });
+
+      expect(result).toEqual(quote);
+      const [, payload] = (httpClient.post as Mock).mock.calls[0];
+      expect(payload.method).toBe("POST");
+      expect(payload.url).toBe("https://provider.test/lease/123/1/2/attestation/quote");
+      expect(payload.auth).toEqual({ type: "jwt", token: "jwt-token" });
+
+      const body = JSON.parse(payload.body);
+      expect(body.bind_tls).toBe(false);
+      expect(fromBase64(body.nonce)).toHaveLength(64);
     });
   });
 

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
@@ -6,7 +6,7 @@ import saveFileInBrowser from "file-saver";
 
 import { WebsocketSession } from "@src/lib/websocket/WebsocketSession";
 import type { ApiProviderList } from "@src/types/provider";
-import type { AttestationQuote } from "@src/utils/confidentialCompute";
+import type { AttestationEvidence, AttestationQuote } from "@src/utils/confidentialCompute";
 import { generateAttestationNonce } from "@src/utils/confidentialCompute";
 import { toBase64 } from "@src/utils/encoding";
 import { wait } from "@src/utils/timer";
@@ -46,9 +46,12 @@ export class ProviderProxyService {
     );
   }
 
+  static readonly ATTESTATION_QUOTE_TIMEOUT = 60_000;
+
   /**
    * Fetches the lease's attestation evidence (AEP-83 §5). A fresh 64-byte nonce is generated per call so the
-   * returned hardware-signed evidence is bound to this specific request. Authenticated with the lease JWT
+   * returned hardware-signed evidence is bound to this specific request, and the nonce is returned alongside the
+   * quote so callers can persist the freshness challenge with the evidence. Authenticated with the lease JWT
    * (the managed-wallet token carries the `attestation` scope) through the provider proxy.
    */
   async fetchAttestationQuote(input: {
@@ -57,15 +60,16 @@ export class ProviderProxyService {
     gseq: number;
     oseq: number;
     ensureToken: () => Promise<string>;
-  }): Promise<AttestationQuote> {
+  }): Promise<AttestationEvidence> {
     const nonce = generateAttestationNonce();
     const response = await this.request<AttestationQuote>(`/lease/${input.dseq}/${input.gseq}/${input.oseq}/attestation/quote`, {
       method: "POST",
       body: JSON.stringify({ nonce, bind_tls: false }),
       credentials: { type: "jwt", value: await input.ensureToken() },
-      providerIdentity: input.provider
+      providerIdentity: input.provider,
+      timeout: ProviderProxyService.ATTESTATION_QUOTE_TIMEOUT
     });
-    return response.data;
+    return { nonce, quote: response.data };
   }
 
   async sendManifest(providerInfo: ApiProviderList | undefined | null, manifest: Manifest, options: SendManifestToProviderOptions) {

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.ts
@@ -6,6 +6,8 @@ import saveFileInBrowser from "file-saver";
 
 import { WebsocketSession } from "@src/lib/websocket/WebsocketSession";
 import type { ApiProviderList } from "@src/types/provider";
+import type { AttestationQuote } from "@src/utils/confidentialCompute";
+import { generateAttestationNonce } from "@src/utils/confidentialCompute";
 import { toBase64 } from "@src/utils/encoding";
 import { wait } from "@src/utils/timer";
 import { formatK8sEvent, formatLogMessage } from "./logFormatters";
@@ -42,6 +44,28 @@ export class ProviderProxyService {
       },
       { timeout }
     );
+  }
+
+  /**
+   * Fetches the lease's attestation evidence (AEP-83 §5). A fresh 64-byte nonce is generated per call so the
+   * returned hardware-signed evidence is bound to this specific request. Authenticated with the lease JWT
+   * (the managed-wallet token carries the `attestation` scope) through the provider proxy.
+   */
+  async fetchAttestationQuote(input: {
+    provider: ProviderIdentity;
+    dseq: string;
+    gseq: number;
+    oseq: number;
+    ensureToken: () => Promise<string>;
+  }): Promise<AttestationQuote> {
+    const nonce = generateAttestationNonce();
+    const response = await this.request<AttestationQuote>(`/lease/${input.dseq}/${input.gseq}/${input.oseq}/attestation/quote`, {
+      method: "POST",
+      body: JSON.stringify({ nonce, bind_tls: false }),
+      credentials: { type: "jwt", value: await input.ensureToken() },
+      providerIdentity: input.provider
+    });
+    return response.data;
   }
 
   async sendManifest(providerInfo: ApiProviderList | undefined | null, manifest: Manifest, options: SendManifestToProviderOptions) {

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -12,4 +12,5 @@ export type FeatureFlag =
   | "console_onboarding_redesign"
   | "bid_screening"
   | "ui_sdl_preview_panel"
-  | "ui_build_and_deploy";
+  | "ui_build_and_deploy"
+  | "ui_confidential_compute";

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -12,5 +12,4 @@ export type FeatureFlag =
   | "console_onboarding_redesign"
   | "bid_screening"
   | "ui_sdl_preview_panel"
-  | "ui_build_and_deploy"
-  | "ui_confidential_compute";
+  | "ui_build_and_deploy";

--- a/apps/deploy-web/src/utils/confidentialCompute.spec.ts
+++ b/apps/deploy-web/src/utils/confidentialCompute.spec.ts
@@ -2,9 +2,12 @@ import type { QueryInput as DeepPartial } from "@akashnetwork/chain-sdk";
 import { describe, expect, it } from "vitest";
 
 import type { DeploymentGroup } from "@src/types/deployment";
+import { fromBase64 } from "@src/utils/encoding";
 import {
+  ATTESTATION_NONCE_BYTES,
   computeSidecarCarveout,
   formatTeeTypeLabel,
+  generateAttestationNonce,
   getDeclaredTeeTypes,
   getGroupTeeType,
   getTeeResourceCarveouts,
@@ -284,5 +287,16 @@ describe(formatTeeTypeLabel.name, () => {
   it("renders friendly labels for each TEE type", () => {
     expect(formatTeeTypeLabel("cpu")).toBe("CPU");
     expect(formatTeeTypeLabel("cpu-gpu")).toBe("CPU + GPU");
+  });
+});
+
+describe(generateAttestationNonce.name, () => {
+  it("produces a base64 value decoding to exactly 64 bytes", () => {
+    const nonce = generateAttestationNonce();
+    expect(fromBase64(nonce)).toHaveLength(ATTESTATION_NONCE_BYTES);
+  });
+
+  it("produces a distinct value on each call", () => {
+    expect(generateAttestationNonce()).not.toEqual(generateAttestationNonce());
   });
 });

--- a/apps/deploy-web/src/utils/confidentialCompute.ts
+++ b/apps/deploy-web/src/utils/confidentialCompute.ts
@@ -190,8 +190,8 @@ export function formatTeeTypeLabel(teeType: TeeType): string {
 
 /**
  * Attestation evidence (AEP-83 §5). The provider gateway forwards the tenant nonce to the attestation
- * sidecar and returns the hardware-signed evidence unchanged. The exact field names are provider-controlled,
- * so consumers should treat every field as potentially absent and never throw on a malformed payload.
+ * sidecar and returns the hardware-signed evidence unchanged: a CPU report and platform for every quote,
+ * plus one report per GPU on GPU-backed platforms.
  */
 export type TeePlatform = "snp" | "tdx" | "snp-gpu" | "tdx-gpu";
 

--- a/apps/deploy-web/src/utils/confidentialCompute.ts
+++ b/apps/deploy-web/src/utils/confidentialCompute.ts
@@ -1,4 +1,5 @@
 import type { DeploymentGroup } from "@src/types/deployment";
+import { toBase64 } from "@src/utils/encoding";
 
 /**
  * Confidential Compute (TEE) helpers for the deployment detail view.
@@ -185,4 +186,39 @@ export function omitAttestationSidecar<T extends LeaseStatusLike>(leaseStatus: T
 /** Human-readable label for a TEE type (bare "cpu" reads oddly as a TEE indicator). */
 export function formatTeeTypeLabel(teeType: TeeType): string {
   return teeType === "cpu-gpu" ? "CPU + GPU" : "CPU";
+}
+
+/**
+ * Attestation evidence (AEP-83 §5). The provider gateway forwards the tenant nonce to the attestation
+ * sidecar and returns the hardware-signed evidence unchanged. The exact field names are provider-controlled,
+ * so consumers should treat every field as potentially absent and never throw on a malformed payload.
+ */
+export type TeePlatform = "snp" | "tdx" | "snp-gpu" | "tdx-gpu";
+
+export interface GpuAttestationReport {
+  /** Device index of the GPU this report attests, used to disambiguate multiple GPUs. */
+  index: number;
+  /** Hardware-signed GPU attestation report, base64. */
+  report: string;
+}
+
+export interface AttestationQuote {
+  /** CPU attestation report (one per quote), base64. */
+  report: string;
+  tee_platform: TeePlatform;
+  /** Per-GPU attestation reports; absent/empty for CPU-only platforms. */
+  gpu_reports?: GpuAttestationReport[];
+}
+
+/** The attestation nonce must decode to exactly this many bytes (AEP-83 §5). */
+export const ATTESTATION_NONCE_BYTES = 64;
+
+/**
+ * Generates a fresh per-request attestation challenge: 64 cryptographically random bytes, base64-encoded.
+ * A new value on every call binds the returned evidence to that specific request (CON-540 acceptance criteria).
+ */
+export function generateAttestationNonce(): string {
+  const bytes = new Uint8Array(ATTESTATION_NONCE_BYTES);
+  crypto.getRandomValues(bytes);
+  return toBase64(bytes);
 }

--- a/apps/deploy-web/src/utils/confidentialCompute.ts
+++ b/apps/deploy-web/src/utils/confidentialCompute.ts
@@ -210,6 +210,16 @@ export interface AttestationQuote {
   gpu_reports?: GpuAttestationReport[];
 }
 
+/**
+ * The attestation evidence as fetched for a single request: the per-request {@link nonce} that was sent as the
+ * freshness challenge plus the hardware-signed {@link quote} it produced. The nonce must travel with the quote so a
+ * verifier can confirm the evidence is bound to this specific request (AEP-83 §5).
+ */
+export interface AttestationEvidence {
+  nonce: string;
+  quote: AttestationQuote;
+}
+
 /** The attestation nonce must decode to exactly this many bytes (AEP-83 §5). */
 export const ATTESTATION_NONCE_BYTES = 64;
 


### PR DESCRIPTION
## Why

Tenants running a Confidential Compute (TEE) workload need to obtain the hardware-signed attestation evidence for their running lease so they can independently confirm the workload is genuinely running inside a Trusted Execution Environment.

Part of CON-540

> **Auth note for reviewers:** CON-540's spec note says the attestation endpoint requires mTLS with the lease owner's key. This PR intentionally uses the **JWT provider-proxy path** instead: deploy-web's mTLS/certificate flows were removed in #3217, and the live CC provider was confirmed to return quotes over the JWT/API-key path. The mTLS note reads as spec-derived/outdated. The hardware-vendor validation + per-report verdict display is the separate follow-up CON-552.
>
> **Token model — stacked on #3360.** The `attestation` scope is **not** on the shared global managed-wallet token. It was briefly added there (CON-575) but that broke manifest sends on every non-TEE provider (they reject the unknown scope), so #3360 reverts it. This PR instead mints an **ephemeral, single-provider granular token** carrying only `attestation` (`useProviderJwt.generateScopedProviderToken`) at download time, scoped to the CC lease's provider. Only TEE-capable providers accept the scope, and the trigger is already gated to CC leases, so the scoped token is only ever sent where the provider accepts it. **Base this PR on #3360; merge #3360 first.**

## What

From the deployment detail view of a **running** Confidential Compute lease (and only when behind the new `ui_confidential_compute` flag, and the on-chain group declares a `tee/type`), the tenant can fetch and download the attestation evidence:

- **`POST /lease/{dseq}/{gseq}/{oseq}/attestation/quote`** via the existing JWT provider-proxy path — front-end only, no API/provider-proxy/backend change.
- A **fresh 64-byte nonce** is generated per request (`{ nonce, bind_tls: false }`) so the evidence is bound to that request.
- A preview modal shows the platform, the single **CPU report**, and a list of **per-GPU reports** (with device indices), making the CPU-vs-per-GPU split explicit. A **Download JSON** action saves the full bundle.
- The trigger renders nothing for non-Confidential-Compute deployments, when the lease is not live, or when the flag is off.

### Changes
- `ui_confidential_compute` added to the `FeatureFlag` union.
- `generateAttestationNonce()` + `AttestationQuote`/`TeePlatform` types in `confidentialCompute.ts`.
- `ProviderProxyService.fetchAttestationQuote()`.
- `useAttestationQuoteMutation` (mutation, not query — evidence is never cached); mints a per-provider `attestation`-scoped token via `useProviderJwt.generateScopedProviderToken` instead of using the global token.
- `useProviderJwt.generateScopedProviderToken` — ephemeral, single-provider granular token (`access: "granular"`, not persisted to the JWT atom / managed-wallet storage).
- `AttestationEvidenceModal` + `DownloadAttestationEvidence`, wired into `LeaseRow`.

Tests cover the nonce util, the service request shape, the mutation hook, and both components (76 passing across the affected files).

### Follow-ups / notes
- The `AttestationQuote` shape (esp. `gpu_reports[].index`/`.report`) is from AEP-83 §5 and should be confirmed against the live CC provider (`pro6000.hou`, `snp-gpu`) before merge.
- The Unleash flag `ui_confidential_compute` must be registered server-side; it defaults off. Use `NEXT_PUBLIC_UNLEASH_ENABLE_ALL` for local testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an attestation evidence action for eligible live leases.
  * Users can view attestation details, including CPU and GPU report information where available.
  * Users can download the evidence as a JSON file.

* **Bug Fixes**
  * Added clearer loading, error, and retry handling when attestation evidence cannot be fetched.
  * The attestation action now only appears when it is relevant to the lease state and platform.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
