### PR TITLE
fix(jwt): remove attestation from global managed-wallet token scope

### DIFF
--- a/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.spec.tsx
+++ b/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.spec.tsx
@@ -66,7 +66,7 @@ describe(useProviderJwt.name, () => {
         ttl: 1800, // 30 * 60
         leases: {
           access: "scoped",
-          scope: ["status", "shell", "events", "logs", "send-manifest", "get-manifest", "attestation"]
+          scope: ["status", "shell", "events", "logs", "send-manifest", "get-manifest"]
         }
       }
     });

--- a/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.ts
+++ b/apps/deploy-web/src/hooks/useProviderJwt/useProviderJwt.ts
@@ -62,7 +62,7 @@ export function useProviderJwt({ dependencies: d = DEPENDENCIES }: { dependencie
         ttl: 30 * 60,
         leases: {
           access: "scoped",
-          scope: ["status", "shell", "events", "logs", "send-manifest", "get-manifest", "attestation"]
+          scope: ["status", "shell", "events", "logs", "send-manifest", "get-manifest"]
         }
       }
     });


### PR DESCRIPTION
## Why

PR #3353 (CON-575 console rollout) added `"attestation"` to the **global** managed-wallet provider JWT scope unconditionally. Field and non-TEE providers validate the scope against an enum that does not include `"attestation"` and reject the **entire** JWT with "JWT has invalid claims". As a result manifest sends fail for **every** managed deployment (not just CC ones), the deployment never goes active, and the two real-deployment E2E specs time out at `validateLease()`:
- `apps/deploy-web/tests/ui/managed-wallet-deployment.spec.ts`
- `apps/deploy-web/tests/ui/managed-wallet-alerts.spec.ts`

The `attestation` scope is a distinct `ActionScope` value that only gates the provider `attestationQuote` endpoint (`/v1/lease/attestation/quote`); it is not needed to send a manifest, and nothing on the global token calls that endpoint. Deploying a CC (TEE) workload does not need it either, since sidecar injection rides the manifest `tee.attestation` flag (auto-set by chain-sdk `generateManifest`), not the JWT.

This reverts the global scope to the base set. The attestation scope moves to a per-provider granular token, requested only for confidential-compute attestation-evidence downloads, in #3359.

Ref CON-575

## What

Remove `"attestation"` from the global `access: "scoped"` token request in `useProviderJwt.ts` and update the corresponding spec expectation. No other behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced the permissions requested when generating access tokens, removing an unnecessary scope while keeping the rest of the token behavior unchanged.
  * Updated the related test expectation to match the new token request payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->