### PR TITLE
fix(deployment): read device_index for GPU attestation report label

### DIFF
--- a/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.spec.tsx
@@ -26,12 +26,14 @@ describe(AttestationEvidenceModal.name, () => {
         report: "cpu-report",
         tee_platform: "snp-gpu",
         gpu_reports: [
-          { index: 0, report: "gpu-0-report" },
-          { index: 1, report: "gpu-1-report" }
+          { device_index: 0, report: "gpu-0-report" },
+          { device_index: 1, report: "gpu-1-report" }
         ]
       }
     });
     expect(screen.getByText("GPU reports (2)")).toBeInTheDocument();
+    expect(screen.getByText("GPU 0")).toBeInTheDocument();
+    expect(screen.getByText("GPU 1")).toBeInTheDocument();
     expect(screen.getByText("gpu-0-report")).toBeInTheDocument();
     expect(screen.getByText("gpu-1-report")).toBeInTheDocument();
   });

--- a/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.tsx
+++ b/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.tsx
@@ -121,7 +121,7 @@ export function AttestationEvidenceModal({ provider, lease, onClose, dependencie
             <div className="space-y-2">
               <ReportLabel>GPU reports ({gpuReports.length})</ReportLabel>
               {gpuReports.map(gpu => (
-                <ReportBlock key={gpu.index} label={`GPU ${gpu.index}`} report={gpu.report} />
+                <ReportBlock key={gpu.device_index} label={`GPU ${gpu.device_index}`} report={gpu.report} />
               ))}
             </div>
           )}

--- a/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
+++ b/apps/deploy-web/src/services/provider-proxy/provider-proxy.service.spec.ts
@@ -1128,7 +1128,7 @@ describe(ProviderProxyService.name, () => {
 
   describe("fetchAttestationQuote", () => {
     it("posts a fresh 64-byte nonce to the attestation quote endpoint with jwt credentials", async () => {
-      const quote = { report: "cpu-report", tee_platform: "snp-gpu", gpu_reports: [{ index: 0, report: "gpu-0" }] };
+      const quote = { report: "cpu-report", tee_platform: "snp-gpu", gpu_reports: [{ device_index: 0, report: "gpu-0" }] };
       const httpClient = mock<HttpClient>({ post: vi.fn().mockResolvedValue({ data: quote }) } as unknown as HttpClient);
       const { service } = setup({ httpClient });
 

--- a/apps/deploy-web/src/utils/confidentialCompute.ts
+++ b/apps/deploy-web/src/utils/confidentialCompute.ts
@@ -197,7 +197,7 @@ export type TeePlatform = "snp" | "tdx" | "snp-gpu" | "tdx-gpu";
 
 export interface GpuAttestationReport {
   /** Device index of the GPU this report attests, used to disambiguate multiple GPUs. */
-  index: number;
+  device_index: number;
   /** Hardware-signed GPU attestation report, base64. */
   report: string;
 }


### PR DESCRIPTION
## Why

The "Attestation evidence" modal renders **"GPU undefined"** instead of **"GPU 0"** for confidential-compute (SNP-GPU) leases.

The provider's live quote endpoint returns each GPU report with a snake_case `device_index`, and the quote is forwarded to the UI as a pure passthrough (no snake→camel transform). `GpuAttestationReport` modelled the field as `index`, so the modal read `gpu.index` — `undefined` at runtime — and rendered "GPU undefined".

Tests didn't catch it: the mocks used the wrong field (`index`) and the modal spec asserted only the GPU count and the report text, never the per-GPU label.

Ref CON-540

## What

- Rename `GpuAttestationReport.index` → `device_index` to match the wire contract (consistent with the rest of `AttestationQuote`, which already mirrors the snake_case payload untransformed).
- Read `gpu.device_index` in `AttestationEvidenceModal`.
- Fix the test mocks (`AttestationEvidenceModal.spec.tsx`, `provider-proxy.service.spec.ts`) to use `device_index`, and add the `GPU 0` / `GPU 1` label assertions that would have caught this.

Note: the _downloaded_ JSON bundle was already correct — it passes `gpu_reports` through verbatim, so it already contained `device_index`. Only the on-screen label was affected.

**Before:** `GPU undefined` → **After:** `GPU 0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GPU attestation report display so GPU labels and report details render correctly using the updated GPU index field.
  * Kept the existing attestation evidence layout and download behavior unchanged.
  * Updated related validation to match the revised GPU report data shape, helping ensure attestation details continue to appear as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->