### PR TITLE
feat(deployment): add GPU, presets, commands and env vars configure cards

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.spec.tsx
@@ -8,13 +8,29 @@ import { MockComponents } from "@tests/unit/mocks";
 describe(AdditionalSection.name, () => {
   it("renders each additional row for the selected service", () => {
     const ImageRuntimeCard = vi.fn(() => null);
+    const EnvironmentVariablesCard = vi.fn(() => null);
+    const CommandsCard = vi.fn(() => null);
 
-    setup({ serviceIndex: 2, dependencies: { ImageRuntimeCard } });
+    setup({ serviceIndex: 2, dependencies: { ImageRuntimeCard, EnvironmentVariablesCard, CommandsCard } });
 
     expect(ImageRuntimeCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
+    expect(EnvironmentVariablesCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
+    expect(CommandsCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
   });
 
-  function setup(input: { serviceIndex?: number; dependencies?: Partial<typeof DEPENDENCIES> }) {
-    render(<AdditionalSection serviceIndex={input.serviceIndex ?? 0} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />);
+  it("forwards the locked state to every additional card", () => {
+    const ImageRuntimeCard = vi.fn(() => null);
+    const EnvironmentVariablesCard = vi.fn(() => null);
+    const CommandsCard = vi.fn(() => null);
+
+    setup({ locked: true, dependencies: { ImageRuntimeCard, EnvironmentVariablesCard, CommandsCard } });
+
+    expect(ImageRuntimeCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(EnvironmentVariablesCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(CommandsCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+  });
+
+  function setup(input: { serviceIndex?: number; locked?: boolean; dependencies?: Partial<typeof DEPENDENCIES> }) {
+    render(<AdditionalSection serviceIndex={input.serviceIndex ?? 0} locked={input.locked} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />);
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.tsx
@@ -1,8 +1,10 @@
 import type { FC } from "react";
 
+import { CommandsCard } from "../CommandsCard/CommandsCard";
+import { EnvironmentVariablesCard } from "../EnvironmentVariablesCard/EnvironmentVariablesCard";
 import { ImageRuntimeCard } from "../ImageRuntimeCard/ImageRuntimeCard";
 
-export const DEPENDENCIES = { ImageRuntimeCard };
+export const DEPENDENCIES = { ImageRuntimeCard, EnvironmentVariablesCard, CommandsCard };
 
 type Props = {
   serviceIndex: number;
@@ -22,6 +24,10 @@ export const AdditionalSection: FC<Props> = ({ serviceIndex, locked = false, dep
       <p className="font-mono text-xs uppercase text-muted-foreground">Additional</p>
       <div className="flex flex-col gap-4">
         <d.ImageRuntimeCard serviceIndex={serviceIndex} locked={locked} />
+
+        <d.EnvironmentVariablesCard serviceIndex={serviceIndex} locked={locked} />
+
+        <d.CommandsCard serviceIndex={serviceIndex} locked={locked} />
       </div>
     </div>
   );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/CommandsCard/CommandsCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/CommandsCard/CommandsCard.spec.tsx
@@ -1,0 +1,88 @@
+import type { PropsWithChildren } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { CommandsCard, DEPENDENCIES } from "./CommandsCard";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(CommandsCard.name, () => {
+  it("opens the modal when the card is clicked", async () => {
+    const { openCard } = setup({ command: "bash -c", arg: "echo hi" });
+
+    await openCard();
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByLabelText("Command")).toHaveValue("bash -c");
+    expect(screen.getByLabelText("Arguments")).toHaveValue("echo hi");
+  });
+
+  it("commits the command and arguments on Save", async () => {
+    const { getValues, openCard } = setup({});
+
+    await openCard();
+    await userEvent.type(screen.getByLabelText("Command"), "sh");
+    await userEvent.type(screen.getByLabelText("Arguments"), "apt-get update");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(getValues().services[0].command?.command).toBe("sh");
+    expect(getValues().services[0].command?.arg).toBe("apt-get update");
+  });
+
+  it("reverts changes and closes the modal on Cancel", async () => {
+    const { getValues, openCard } = setup({ command: "bash -c" });
+
+    await openCard();
+    await userEvent.type(screen.getByLabelText("Command"), " changed");
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(getValues().services[0].command?.command).toBe("bash -c");
+  });
+
+  it("preserves newlines in the command", async () => {
+    const { getValues, openCard } = setup({});
+
+    await openCard();
+    await userEvent.type(screen.getByLabelText("Command"), "sh{Enter}-c");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(getValues().services[0].command?.command).toBe("sh\n-c");
+  });
+
+  it("opens for viewing but disables the inputs and Save while locked", async () => {
+    const { openCard } = setup({ command: "bash -c", arg: "echo hi", locked: true });
+
+    await openCard();
+
+    expect(screen.getByLabelText("Command")).toBeDisabled();
+    expect(screen.getByLabelText("Arguments")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  function setup(input: { command?: string; arg?: string; locked?: boolean }) {
+    const values = defaultServiceWithPlacement({ command: { command: input.command ?? "", arg: input.arg ?? "" } });
+
+    let getValues: () => SdlBuilderFormValuesType = () => values;
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values, mode: "onChange" });
+      getValues = form.getValues;
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    render(
+      <Wrapper>
+        <CommandsCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES }} />
+      </Wrapper>
+    );
+
+    return {
+      getValues: () => getValues(),
+      openCard: () => userEvent.click(screen.getByText("Commands"))
+    };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/CommandsCard/CommandsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/CommandsCard/CommandsCard.tsx
@@ -1,0 +1,142 @@
+"use client";
+import { type FC, useCallback, useState } from "react";
+import { useController, useFormContext } from "react-hook-form";
+import {
+  Button,
+  CollapsibleCard,
+  DialogV2,
+  DialogV2Body,
+  DialogV2Content,
+  DialogV2Description,
+  DialogV2Footer,
+  DialogV2Header,
+  DialogV2Title,
+  Field,
+  FieldContent,
+  FieldLabel,
+  Textarea
+} from "@akashnetwork/ui/components";
+import { ChevronRightIcon, SaveIcon, TerminalIcon } from "lucide-react";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { commandsTooltip } from "../cardTooltips";
+
+export const DEPENDENCIES = { CollapsibleCard, DialogV2, DialogV2Content, DialogV2Header, DialogV2Title, DialogV2Description, DialogV2Body, DialogV2Footer };
+
+type Props = {
+  serviceIndex: number;
+  /** While the pane is locked the dialog still opens for viewing but its inputs and Save are disabled. */
+  locked?: boolean;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/**
+ * "Commands" card. Edits `services.${serviceIndex}.command.{command,arg}` on the
+ * shared deployment model — the container's CMD/ENTRYPOINT override. The command
+ * textarea holds one argv token per line (the SDL generator tokenizes by line);
+ * leaving it blank keeps the image's default. Arguments are emitted as the SDL
+ * `args` list only when a command is set.
+ *
+ * The card is non-collapsible: its header summarizes the current command (or notes the
+ * image default) and clicking it opens a Dialog for editing. Changes are committed on
+ * Save and reverted on Cancel.
+ */
+export const CommandsCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+  const { control, getValues, setValue } = useFormContext<SdlBuilderFormValuesType>();
+  const command = useController({ control, name: `services.${serviceIndex}.command.command` });
+  const arg = useController({ control, name: `services.${serviceIndex}.command.arg` });
+  const [open, setOpen] = useState(false);
+  const [snapshot, setSnapshot] = useState<{ command: string; arg: string } | null>(null);
+
+  const openModal = useCallback(() => {
+    setSnapshot({
+      command: getValues(`services.${serviceIndex}.command.command`) ?? "",
+      arg: getValues(`services.${serviceIndex}.command.arg`) ?? ""
+    });
+    setOpen(true);
+  }, [getValues, serviceIndex]);
+
+  const handleCancel = useCallback(() => {
+    if (snapshot) {
+      setValue(`services.${serviceIndex}.command.command`, snapshot.command, { shouldDirty: true });
+      setValue(`services.${serviceIndex}.command.arg`, snapshot.arg, { shouldDirty: true });
+    }
+    setOpen(false);
+  }, [setValue, snapshot, serviceIndex]);
+
+  const handleSave = useCallback(() => {
+    setOpen(false);
+  }, []);
+
+  return (
+    <>
+      <d.CollapsibleCard
+        title="Commands"
+        icon={<TerminalIcon className="h-4 w-4" />}
+        infoTooltip={commandsTooltip}
+        summary={<ChevronRightIcon />}
+        onHeaderClick={openModal}
+      />
+
+      <d.DialogV2
+        open={open}
+        onOpenChange={isOpen => {
+          if (!isOpen) handleCancel();
+        }}
+      >
+        <d.DialogV2Content className="max-w-lg" aria-describedby="commands-description">
+          <d.DialogV2Header>
+            <d.DialogV2Title>Edit commands</d.DialogV2Title>
+            <d.DialogV2Description id="commands-description">
+              Override the container's default CMD/ENTRYPOINT. Leave Command blank to keep the image's default.
+            </d.DialogV2Description>
+          </d.DialogV2Header>
+
+          <d.DialogV2Body className="flex flex-col gap-4">
+            <fieldset disabled={locked} className="contents">
+              <Field className="gap-2">
+                <FieldLabel htmlFor={`command-${serviceIndex}`}>Command</FieldLabel>
+                <FieldContent>
+                  <Textarea
+                    id={`command-${serviceIndex}`}
+                    aria-label="Command"
+                    rows={4}
+                    placeholder={"One token per line. Example:\nsh\n-c"}
+                    value={command.field.value ?? ""}
+                    onChange={event => command.field.onChange(event.target.value)}
+                    spellCheck={false}
+                  />
+                </FieldContent>
+              </Field>
+
+              <Field className="gap-2">
+                <FieldLabel htmlFor={`command-arg-${serviceIndex}`}>Arguments</FieldLabel>
+                <FieldContent>
+                  <Textarea
+                    id={`command-arg-${serviceIndex}`}
+                    aria-label="Arguments"
+                    rows={4}
+                    placeholder="Example: apt-get update; apt-get install -y --no-install-recommends -- ssh;"
+                    value={arg.field.value ?? ""}
+                    onChange={event => arg.field.onChange(event.target.value)}
+                    spellCheck={false}
+                  />
+                </FieldContent>
+              </Field>
+            </fieldset>
+          </d.DialogV2Body>
+
+          <d.DialogV2Footer className="flex items-center">
+            <Button type="button" variant="ghost" onClick={handleCancel}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleSave} disabled={locked}>
+              Save
+              <SaveIcon className="ml-2 size-4" />
+            </Button>
+          </d.DialogV2Footer>
+        </d.DialogV2Content>
+      </d.DialogV2>
+    </>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.spec.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { defaultPlacement, defaultService } from "@src/utils/sdl/data";
 import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
-import { HardwareSection } from "./HardwareSection/HardwareSection";
+import { DEPENDENCIES as HARDWARE_DEPENDENCIES, HardwareSection } from "./HardwareSection/HardwareSection";
 import { ConfigurationPane, DEPENDENCIES } from "./ConfigurationPane";
 
 import { render, screen } from "@testing-library/react";
@@ -72,7 +72,12 @@ describe(ConfigurationPane.name, () => {
       }
     });
     const values: SdlBuilderFormValuesType = { placements: [placement], services: [serviceA, serviceB], endpoints: [] };
-    const dependencies = { ...DEPENDENCIES, HardwareSection, AdditionalSection: () => null };
+
+    /** GpuCard fetches GPU models via React Query; stub it so this pane test stays provider-free and asserts only the Memory/Storage values. */
+    const HardwareSectionWithStubbedGpu: typeof HardwareSection = props => (
+      <HardwareSection {...props} dependencies={{ ...HARDWARE_DEPENDENCIES, GpuCard: () => null }} />
+    );
+    const dependencies = { ...DEPENDENCIES, HardwareSection: HardwareSectionWithStubbedGpu, AdditionalSection: () => null };
 
     const Tree = ({ selectedServiceId }: { selectedServiceId: string }) => {
       const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.spec.tsx
@@ -1,0 +1,260 @@
+import type { PropsWithChildren } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import { FormProvider, useForm, useFormContext, useFormState } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { describe, expect, it } from "vitest";
+
+import type { EnvironmentVariableType, SdlBuilderFormValuesType } from "@src/types";
+import { SdlBuilderFormValuesSchema } from "@src/types/sdlBuilder/sdlBuilder";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { DEPENDENCIES, EnvironmentVariablesCard } from "./EnvironmentVariablesCard";
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(EnvironmentVariablesCard.name, () => {
+  it("opens the modal when the card is clicked", async () => {
+    const { openCard } = setup({ env: [] });
+
+    await openCard();
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Environment variables")).toBeInTheDocument();
+  });
+
+  it("shows an empty key/value row in the modal when opened with no variables", async () => {
+    const { openCard } = setup({ env: [] });
+
+    await openCard();
+
+    expect(screen.getByLabelText("Environment variable 1 key")).toBeInTheDocument();
+    expect(screen.getByLabelText("Environment variable 1 value")).toBeInTheDocument();
+  });
+
+  it("shows existing variables in the modal", async () => {
+    const { openCard } = setup({ env: [{ key: "FOO", value: "bar" }] });
+
+    await openCard();
+
+    expect(screen.getByLabelText("Environment variable 1 key")).toHaveValue("FOO");
+    expect(screen.getByLabelText("Environment variable 1 value")).toHaveValue("bar");
+  });
+
+  it("appends a new empty row when Add variable is clicked inside the modal", async () => {
+    const { openCard } = setup({ env: [{ key: "FOO", value: "bar" }] });
+
+    await openCard();
+    await userEvent.click(screen.getByRole("button", { name: "Add variable" }));
+
+    expect(screen.getByLabelText("Environment variable 2 key")).toBeInTheDocument();
+  });
+
+  it("updates the footer variable count live as rows are added and removed, before saving", async () => {
+    const { openCard } = setup({ env: [{ key: "FOO", value: "bar" }] });
+
+    await openCard();
+    expect(screen.getByText("1 variable")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Add variable" }));
+    expect(screen.getByText("2 variables")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove environment variable 2" }));
+    expect(screen.getByText("1 variable")).toBeInTheDocument();
+  });
+
+  it("commits changes and closes the modal on Save", async () => {
+    const { getValues, openCard } = setup({ env: [] });
+
+    await openCard();
+
+    const keyInput = screen.getByLabelText("Environment variable 1 key");
+    await userEvent.clear(keyInput);
+    await userEvent.type(keyInput, "BAZ");
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(getValues().services[0].env?.[0]?.key).toBe("BAZ");
+  });
+
+  it("reverts changes and closes the modal on Cancel", async () => {
+    const { getValues, openCard } = setup({ env: [{ key: "FOO", value: "bar" }] });
+
+    await openCard();
+
+    const keyInput = screen.getByLabelText("Environment variable 1 key");
+    await userEvent.clear(keyInput);
+    await userEvent.type(keyInput, "CHANGED");
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(getValues().services[0].env?.[0]?.key).toBe("FOO");
+  });
+
+  it("keeps validation errors on the rest of the form when saving an env variable", async () => {
+    const { trigger, openCard } = setup({ env: [], image: "" });
+    await trigger();
+    await waitFor(() => expect(screen.getByTestId("image-error")).not.toBeEmptyDOMElement());
+
+    await openCard();
+    await userEvent.type(screen.getByLabelText("Environment variable 1 key"), "BAZ");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(screen.getByTestId("image-error")).not.toBeEmptyDOMElement();
+  });
+
+  it("keeps validation errors on the rest of the form when cancelling the env modal", async () => {
+    const { trigger, openCard } = setup({ env: [{ key: "FOO", value: "bar" }], image: "" });
+    await trigger();
+    await waitFor(() => expect(screen.getByTestId("image-error")).not.toBeEmptyDOMElement());
+
+    await openCard();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(screen.getByTestId("image-error")).not.toBeEmptyDOMElement();
+  });
+
+  it("removes a variable when its remove control is clicked", async () => {
+    const { getValues, openCard } = setup({
+      env: [
+        { key: "FOO", value: "bar" },
+        { key: "BAZ", value: "qux" }
+      ]
+    });
+
+    await openCard();
+    await userEvent.click(screen.getByRole("button", { name: "Remove environment variable 1" }));
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(getValues().services[0].env).toEqual([expect.objectContaining({ key: "BAZ", value: "qux" })]);
+  });
+
+  it("shows the trash icon even when only one variable is in the list", async () => {
+    const { openCard } = setup({ env: [{ key: "FOO", value: "bar" }] });
+
+    await openCard();
+
+    expect(screen.getByRole("button", { name: "Remove environment variable 1" })).toBeInTheDocument();
+  });
+
+  it("replaces the last variable with an empty row when removed so the modal stays usable", async () => {
+    const { openCard } = setup({ env: [{ key: "FOO", value: "bar" }] });
+
+    await openCard();
+    await userEvent.click(screen.getByRole("button", { name: "Remove environment variable 1" }));
+
+    expect(screen.getByLabelText("Environment variable 1 key")).toHaveValue("");
+  });
+
+  it("does not render SSH_PUBKEY as a row in the modal", async () => {
+    const { openCard } = setup({
+      env: [
+        { id: "SSH_PUBKEY", key: "SSH_PUBKEY", value: "abc123" },
+        { key: "FOO", value: "bar" }
+      ]
+    });
+
+    await openCard();
+
+    expect(screen.getByLabelText("Environment variable 1 key")).toHaveValue("FOO");
+    expect(screen.queryByDisplayValue("SSH_PUBKEY")).not.toBeInTheDocument();
+  });
+
+  it("shows an error on the key input and disables Save when a reserved key is entered", async () => {
+    const { openCard } = setup({ env: [] });
+
+    await openCard();
+    await userEvent.type(screen.getByLabelText("Environment variable 1 key"), "SSH_PUBKEY");
+
+    expect(await screen.findByText(/"SSH_PUBKEY" is a reserved variable name/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("re-enables Save once a reserved key is corrected", async () => {
+    const { openCard } = setup({ env: [] });
+
+    await openCard();
+    const keyInput = screen.getByLabelText("Environment variable 1 key");
+    await userEvent.type(keyInput, "SSH_PUBKEY");
+    await userEvent.clear(keyInput);
+    await userEvent.type(keyInput, "VALID_KEY");
+
+    expect(screen.queryByText(/"SSH_PUBKEY" is a reserved variable name/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+  });
+
+  it("does not flag the managed SSH_PUBKEY entry as reserved", async () => {
+    const { openCard } = setup({
+      env: [
+        { id: "SSH_PUBKEY", key: "SSH_PUBKEY", value: "abc123" },
+        { key: "FOO", value: "bar" }
+      ]
+    });
+
+    await openCard();
+
+    expect(screen.queryByText(/"SSH_PUBKEY" is a reserved variable name/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+  });
+
+  it("preserves the managed SSH_PUBKEY entry when saving the modal", async () => {
+    const { getValues, openCard } = setup({
+      env: [
+        { id: "SSH_PUBKEY", key: "SSH_PUBKEY", value: "abc123" },
+        { key: "FOO", value: "bar" }
+      ]
+    });
+
+    await openCard();
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(getValues().services[0].env).toContainEqual(expect.objectContaining({ id: "SSH_PUBKEY", key: "SSH_PUBKEY", value: "abc123" }));
+  });
+
+  it("opens for viewing but disables the inputs, Add and Save while locked", async () => {
+    const { openCard } = setup({ env: [{ key: "FOO", value: "bar" }], locked: true });
+
+    await openCard();
+
+    expect(screen.getByLabelText("Environment variable 1 key")).toBeDisabled();
+    expect(screen.getByLabelText("Environment variable 1 value")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Add variable" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  function setup(input: { env?: Array<Partial<EnvironmentVariableType>>; image?: string; locked?: boolean }) {
+    const env = input.env?.map(e => ({ key: "", value: "", isSecret: false, ...e })) ?? [];
+
+    const values = defaultServiceWithPlacement({ env, ...(input.image !== undefined ? { image: input.image } : {}) });
+
+    let form: UseFormReturn<SdlBuilderFormValuesType> | undefined;
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      form = useForm<SdlBuilderFormValuesType>({ defaultValues: values, mode: "onChange", resolver: zodResolver(SdlBuilderFormValuesSchema) });
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    render(
+      <Wrapper>
+        <EnvironmentVariablesCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES }} />
+        <ImageErrorProbe serviceIndex={0} />
+      </Wrapper>
+    );
+
+    return {
+      getValues: () => (form as UseFormReturn<SdlBuilderFormValuesType>).getValues(),
+      trigger: () => (form as UseFormReturn<SdlBuilderFormValuesType>).trigger(),
+      openCard: () => userEvent.click(screen.getByText(/^Environment Variables/))
+    };
+  }
+});
+
+/** Surfaces a service's image validation error in the DOM so tests can assert it survives env edits. */
+function ImageErrorProbe({ serviceIndex }: { serviceIndex: number }) {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const { errors } = useFormState({ control, name: `services.${serviceIndex}.image` });
+  const message = errors.services?.[serviceIndex]?.image?.message;
+  return <div data-testid="image-error">{message ?? ""}</div>;
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.tsx
@@ -1,0 +1,222 @@
+"use client";
+import { type FC, useCallback, useEffect, useState } from "react";
+import { useController, useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import {
+  Button,
+  CollapsibleCard,
+  DialogV2,
+  DialogV2Body,
+  DialogV2Content,
+  DialogV2Description,
+  DialogV2Footer,
+  DialogV2Header,
+  DialogV2Title,
+  Input
+} from "@akashnetwork/ui/components";
+import { ChevronRightIcon, KeyRoundIcon, PlusIcon, SaveIcon, TrashIcon } from "lucide-react";
+import { nanoid } from "nanoid";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { RESERVED_ENV_KEYS as RESERVED_ENV_KEY_LIST } from "@src/types/sdlBuilder/sdlBuilder";
+
+export const DEPENDENCIES = { CollapsibleCard, DialogV2, DialogV2Content, DialogV2Header, DialogV2Title, DialogV2Description, DialogV2Body, DialogV2Footer };
+
+const RESERVED_ENV_KEYS = new Set<string>(RESERVED_ENV_KEY_LIST);
+
+type Props = {
+  serviceIndex: number;
+  /** While the pane is locked the dialog still opens for viewing but its inputs, Add/Remove and Save are disabled. */
+  locked?: boolean;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/**
+ * "Environment Variables" card. The card is non-collapsible: clicking its header opens
+ * a Dialog where the user edits key/value pairs. Changes are committed on Save; cancelled on Close.
+ * The header shows the count of user-set variables (reserved keys like SSH_PUBKEY are excluded).
+ */
+export const EnvironmentVariablesCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+  const { control, getValues, reset, trigger, formState } = useFormContext<SdlBuilderFormValuesType>();
+  const hasEnvErrors = !!formState.errors.services?.[serviceIndex]?.env;
+  const env = useWatch({ control, name: `services.${serviceIndex}.env` });
+  const visibleCount = (env ?? []).filter(field => !RESERVED_ENV_KEYS.has(field.key)).length;
+  const [open, setOpen] = useState(false);
+  const [snapshot, setSnapshot] = useState<SdlBuilderFormValuesType | null>(null);
+
+  const openModal = useCallback(() => {
+    setSnapshot(structuredClone(getValues()));
+    setOpen(true);
+  }, [getValues]);
+
+  const handleCancel = useCallback(() => {
+    if (snapshot) {
+      reset(snapshot, { keepErrors: true });
+      void trigger(`services.${serviceIndex}.env`);
+    }
+    setOpen(false);
+  }, [reset, trigger, snapshot, serviceIndex]);
+
+  const handleSave = useCallback(() => {
+    const current = getValues();
+    const env = current.services[serviceIndex].env ?? [];
+    current.services[serviceIndex].env = env.filter(e => e.key.trim() !== "" && !(RESERVED_ENV_KEYS.has(e.key) && e.id !== e.key));
+    reset(current, { keepDirty: true, keepErrors: true });
+    void trigger(`services.${serviceIndex}.env`);
+    setOpen(false);
+  }, [getValues, reset, trigger, serviceIndex]);
+
+  return (
+    <>
+      <d.CollapsibleCard
+        title="Environment Variables"
+        icon={<KeyRoundIcon className="h-4 w-4" />}
+        summary={
+          <div className="flex items-center gap-1">
+            <span className="text-sm text-muted-foreground">{visibleCount}</span>
+            <ChevronRightIcon className="size-4" />
+          </div>
+        }
+        onHeaderClick={openModal}
+      />
+
+      <d.DialogV2
+        open={open}
+        onOpenChange={isOpen => {
+          if (!isOpen) handleCancel();
+        }}
+      >
+        <d.DialogV2Content className="max-w-lg" aria-describedby="env-vars-description">
+          <d.DialogV2Header>
+            <d.DialogV2Title>Environment variables</d.DialogV2Title>
+            <d.DialogV2Description id="env-vars-description">
+              Key/value pairs exposed to the container at runtime. Add as many as you need before saving.
+            </d.DialogV2Description>
+          </d.DialogV2Header>
+
+          <d.DialogV2Body>
+            <fieldset disabled={locked} className="contents">
+              <EnvironmentVariablesList serviceIndex={serviceIndex} locked={locked} />
+            </fieldset>
+          </d.DialogV2Body>
+
+          <d.DialogV2Footer className="flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">
+              {visibleCount} variable{visibleCount > 1 ? "s" : ""}
+            </p>
+            <div className="flex items-center gap-2">
+              <Button type="button" variant="ghost" onClick={handleCancel}>
+                Cancel
+              </Button>
+              <Button type="button" onClick={handleSave} disabled={hasEnvErrors || locked}>
+                Save
+                <SaveIcon className="ml-2 size-4" />
+              </Button>
+            </div>
+          </d.DialogV2Footer>
+        </d.DialogV2Content>
+      </d.DialogV2>
+    </>
+  );
+};
+
+type EnvironmentVariablesListProps = {
+  serviceIndex: number;
+  /** While locked the list is view-only: the seed-an-empty-row effect is skipped so opening the dialog can't mutate the form. */
+  locked?: boolean;
+};
+
+const EnvironmentVariablesList: FC<EnvironmentVariablesListProps> = ({ serviceIndex, locked = false }) => {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const { fields, append, remove } = useFieldArray({ control, name: `services.${serviceIndex}.env`, keyName: "fieldId" });
+
+  const visibleFields = fields.filter(f => !RESERVED_ENV_KEYS.has(f.key));
+
+  useEffect(() => {
+    if (visibleFields.length === 0 && !locked) {
+      append({ id: nanoid(), key: "", value: "", isSecret: false }, { shouldFocus: false });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const add = useCallback(() => {
+    append({ id: nanoid(), key: "", value: "", isSecret: false });
+  }, [append]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-2">
+        {visibleFields.map((field, visibleIndex) => (
+          <EnvironmentVariableFields
+            key={field.fieldId}
+            serviceIndex={serviceIndex}
+            envIndex={fields.indexOf(field)}
+            visibleIndex={visibleIndex}
+            onRemove={() => {
+              const arrayIndex = fields.indexOf(field);
+              remove(arrayIndex);
+              if (visibleFields.length === 1) {
+                append({ id: nanoid(), key: "", value: "", isSecret: false }, { shouldFocus: false });
+              }
+            }}
+          />
+        ))}
+      </div>
+
+      <div>
+        <Button size="sm" type="button" variant="ghost" onClick={add} className="text-muted-foreground hover:text-foreground">
+          <PlusIcon className="mr-1 h-4 w-4" />
+          Add variable
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+type EnvironmentVariableFieldsProps = {
+  serviceIndex: number;
+  envIndex: number;
+  visibleIndex: number;
+  onRemove: () => void;
+};
+
+const EnvironmentVariableFields: FC<EnvironmentVariableFieldsProps> = ({ serviceIndex, envIndex, visibleIndex, onRemove }) => {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const basePath = `services.${serviceIndex}.env.${envIndex}` as const;
+
+  const key = useController({ control, name: `${basePath}.key` });
+  const value = useController({ control, name: `${basePath}.value` });
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex items-start gap-2">
+        <Input
+          aria-label={`Environment variable ${visibleIndex + 1} key`}
+          placeholder="KEY"
+          value={key.field.value ?? ""}
+          onChange={key.field.onChange}
+          inputClassName="h-9"
+          className="flex-1"
+        />
+        <Input
+          aria-label={`Environment variable ${visibleIndex + 1} value`}
+          placeholder="value"
+          value={value.field.value ?? ""}
+          onChange={value.field.onChange}
+          inputClassName="h-9"
+          className="flex-1"
+        />
+        <Button
+          size="icon"
+          type="button"
+          variant="ghost"
+          className="h-9 w-9 shrink-0"
+          aria-label={`Remove environment variable ${visibleIndex + 1}`}
+          onClick={onRemove}
+        >
+          <TrashIcon className="h-4 w-4" />
+        </Button>
+      </div>
+      {key.fieldState.error && <p className="pl-1 text-xs text-destructive">{key.fieldState.error.message}</p>}
+    </div>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.spec.tsx
@@ -1,0 +1,266 @@
+import type { PropsWithChildren } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import type { GpuVendor } from "@src/types/gpu";
+import { validationConfig } from "@src/utils/akash/units";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { DEPENDENCIES, GpuCard } from "./GpuCard";
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const GPU_VENDORS: GpuVendor[] = [
+  {
+    name: "nvidia",
+    models: [
+      { name: "a100", memory: ["40Gi", "80Gi"], interface: ["pcie", "sxm"] },
+      { name: "t4", memory: ["16Gi"], interface: ["pcie"] }
+    ]
+  },
+  { name: "amd", models: [{ name: "mi300", memory: ["192Gi"], interface: ["pcie"] }] }
+];
+
+describe(GpuCard.name, () => {
+  it("hides the body while GPU is disabled", () => {
+    setup({ hasGpu: false });
+
+    expect(screen.getByRole("switch", { name: "Enable GPU" })).not.toBeChecked();
+    expect(screen.queryByLabelText("GPU vendor")).not.toBeInTheDocument();
+  });
+
+  it("enables hasGpu and defaults the count to one when toggled on", async () => {
+    const { getValues, user } = setup({ hasGpu: false, gpu: 0 });
+
+    await user.click(screen.getByRole("switch", { name: "Enable GPU" }));
+
+    expect(getValues().services[0].profile.hasGpu).toBe(true);
+    expect(getValues().services[0].profile.gpu).toBe(1);
+    expect(screen.getByLabelText("GPU vendor")).toBeInTheDocument();
+  });
+
+  it("disables hasGpu and resets the count to zero when toggled off", async () => {
+    const { getValues, user } = setup({ hasGpu: true, gpu: 2 });
+
+    await user.click(screen.getByRole("switch", { name: "Enable GPU" }));
+
+    expect(getValues().services[0].profile.hasGpu).toBe(false);
+    expect(getValues().services[0].profile.gpu).toBe(0);
+  });
+
+  it("increments the GPU count", async () => {
+    const { getValues, user } = setup({ hasGpu: true, gpu: 1 });
+
+    await user.click(screen.getByRole("button", { name: "Increase GPU count" }));
+
+    expect(getValues().services[0].profile.gpu).toBe(2);
+  });
+
+  it("associates GPU count errors with the quantity selector", () => {
+    setup({ hasGpu: true, gpuError: "GPU count is too high." });
+
+    const error = screen.getByText("GPU count is too high.");
+    expect(screen.getByLabelText("GPU count")).toHaveAttribute("aria-describedby", error.id);
+  });
+
+  it("removes a non-first collection", async () => {
+    const { getValues, user } = setup({
+      hasGpu: true,
+      gpuModels: [
+        { vendor: "nvidia", name: "a100", memory: "40Gi", interface: "pcie" },
+        { vendor: "amd", name: "mi300", memory: "192Gi", interface: "pcie" }
+      ]
+    });
+
+    await user.click(screen.getByRole("button", { name: "Remove GPU 2" }));
+
+    const gpuModels = getValues().services[0].profile.gpuModels;
+    expect(gpuModels).toHaveLength(1);
+    expect(gpuModels?.[0]).toMatchObject({ vendor: "nvidia", name: "a100" });
+  });
+
+  it("renders each collection's selects bound to its own entry", () => {
+    setup({
+      hasGpu: true,
+      gpuModels: [
+        { vendor: "nvidia", name: "a100", memory: "40Gi", interface: "pcie" },
+        { vendor: "amd", name: "mi300", memory: "192Gi", interface: "pcie" }
+      ]
+    });
+
+    const first = screen.getByRole("group", { name: "GPU 1" });
+    const second = screen.getByRole("group", { name: "GPU 2" });
+    expect(within(first).getByRole("combobox", { name: "GPU model" })).toHaveTextContent("a100");
+    expect(within(second).getByRole("combobox", { name: "GPU model" })).toHaveTextContent("mi300");
+  });
+
+  it("disables Add GPU once the collection count reaches the max", () => {
+    setup({ hasGpu: true, gpuModels: makeGpuModels(validationConfig.maxGpuAmount), dependencies: { GpuModelFields: StubGpuModelFields } });
+
+    expect(screen.getByRole("button", { name: "Add GPU" })).toBeDisabled();
+  });
+
+  it("writes the picked model and preselects its sole memory and interface", async () => {
+    const { getValues, user } = setup({ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "", memory: "", interface: "" }] });
+
+    await user.click(screen.getByRole("combobox", { name: "GPU model" }));
+    await user.click(await screen.findByRole("option", { name: "t4" }));
+
+    expect(getValues().services[0].profile.gpuModels?.[0]).toMatchObject({ vendor: "nvidia", name: "t4", memory: "16Gi", interface: "pcie" });
+  });
+
+  it("does not preselect memory or interface when the model offers several options", async () => {
+    const { getValues, user } = setup({ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "", memory: "", interface: "" }] });
+
+    await user.click(screen.getByRole("combobox", { name: "GPU model" }));
+    await user.click(await screen.findByRole("option", { name: "a100" }));
+
+    expect(getValues().services[0].profile.gpuModels?.[0]).toMatchObject({ memory: "", interface: "" });
+  });
+
+  it("resets model, memory, and interface when the vendor changes", async () => {
+    const { getValues, user } = setup({ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "a100", memory: "40Gi", interface: "pcie" }] });
+
+    await user.click(screen.getByRole("combobox", { name: "GPU vendor" }));
+    await user.click(await screen.findByRole("option", { name: "amd" }));
+
+    expect(getValues().services[0].profile.gpuModels?.[0]).toEqual({ vendor: "amd", name: "", memory: "", interface: "" });
+  });
+
+  it("clears the model along with memory and interface", async () => {
+    const { getValues, user } = setup({ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "a100", memory: "40Gi", interface: "pcie" }] });
+
+    await user.click(screen.getByRole("button", { name: "Clear GPU model" }));
+
+    expect(getValues().services[0].profile.gpuModels?.[0]).toMatchObject({ vendor: "nvidia", name: "", memory: "", interface: "" });
+  });
+
+  it("resets the model select's displayed value when the model is cleared", async () => {
+    const { user } = setup({ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "a100", memory: "40Gi", interface: "pcie" }] });
+
+    expect(screen.getByRole("combobox", { name: "GPU model" })).toHaveTextContent("a100");
+
+    await user.click(screen.getByRole("button", { name: "Clear GPU model" }));
+
+    expect(screen.getByRole("combobox", { name: "GPU model" })).not.toHaveTextContent("a100");
+  });
+
+  it("clears only the memory when the memory clear button is clicked", async () => {
+    const { getValues, user } = setup({ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "a100", memory: "40Gi", interface: "pcie" }] });
+
+    await user.click(screen.getByRole("button", { name: "Clear GPU memory" }));
+
+    expect(getValues().services[0].profile.gpuModels?.[0]).toMatchObject({ name: "a100", memory: "", interface: "pcie" });
+  });
+
+  it("clears only the interface when the interface clear button is clicked", async () => {
+    const { getValues, user } = setup({ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "a100", memory: "40Gi", interface: "pcie" }] });
+
+    await user.click(screen.getByRole("button", { name: "Clear GPU interface" }));
+
+    expect(getValues().services[0].profile.gpuModels?.[0]).toMatchObject({ name: "a100", memory: "40Gi", interface: "" });
+  });
+
+  it("does not offer clear buttons while the fields are empty", () => {
+    setup({ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "", memory: "", interface: "" }] });
+
+    expect(screen.queryByRole("button", { name: "Clear GPU model" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Clear GPU memory" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Clear GPU interface" })).not.toBeInTheDocument();
+  });
+
+  it("appends a GPU collection when Add GPU is clicked", async () => {
+    const { getValues, user } = setup({ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "", memory: "", interface: "" }] });
+
+    await user.click(screen.getByRole("button", { name: "Add GPU" }));
+
+    expect(await screen.findByRole("group", { name: "GPU 2" })).toBeInTheDocument();
+    expect(getValues().services[0].profile.gpuModels).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "Remove GPU 2" })).toBeInTheDocument();
+  });
+
+  it("does not offer a remove control for the first collection", () => {
+    setup({ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "", memory: "", interface: "" }] });
+
+    expect(screen.queryByRole("button", { name: "Remove GPU 1" })).not.toBeInTheDocument();
+  });
+
+  it("shows a loading affordance instead of the model selects while GPU models are loading", () => {
+    setup({ hasGpu: true, isLoading: true });
+
+    expect(screen.getByText("Loading GPU models...")).toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: "GPU model" })).not.toBeInTheDocument();
+  });
+
+  it("shows an error message instead of the model selects when GPU models fail to load", () => {
+    setup({ hasGpu: true, isError: true });
+
+    expect(screen.getByText(/failed to load gpu models/i)).toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: "GPU model" })).not.toBeInTheDocument();
+  });
+
+  it("disables the enable switch and every GPU input while locked", () => {
+    setup({ hasGpu: true, locked: true, gpuModels: [{ vendor: "nvidia", name: "a100", memory: "40Gi", interface: "pcie" }] });
+
+    expect(screen.getByRole("switch", { name: "Enable GPU" })).toBeDisabled();
+    expect(screen.getByLabelText("GPU count")).toBeDisabled();
+    expect(screen.getByRole("combobox", { name: "GPU vendor" })).toBeDisabled();
+    expect(screen.getByRole("combobox", { name: "GPU model" })).toBeDisabled();
+  });
+
+  const StubGpuModelFields: typeof DEPENDENCIES.GpuModelFields = ({ gpuIndex }) => <div role="group" aria-label={`GPU ${gpuIndex + 1}`} />;
+
+  function makeGpuModels(count: number): SdlBuilderFormValuesType["services"][number]["profile"]["gpuModels"] {
+    return Array.from({ length: count }, () => ({ vendor: "nvidia", name: "", memory: "", interface: "" }));
+  }
+
+  function setup(input: {
+    gpu?: number;
+    hasGpu?: boolean;
+    gpuModels?: SdlBuilderFormValuesType["services"][number]["profile"]["gpuModels"];
+    gpuError?: string;
+    isLoading?: boolean;
+    isError?: boolean;
+    locked?: boolean;
+    dependencies?: Partial<typeof DEPENDENCIES>;
+  }) {
+    const values = defaultServiceWithPlacement({
+      profile: {
+        cpu: 0.5,
+        gpu: input.gpu ?? (input.hasGpu ? 1 : 0),
+        gpuModels: input.gpuModels ?? [{ vendor: "nvidia", name: "", memory: "", interface: "" }],
+        hasGpu: input.hasGpu ?? false,
+        ram: 256,
+        ramUnit: "Mi",
+        storage: [{ size: 1, unit: "Gi", isPersistent: false, type: "beta2" }]
+      }
+    });
+
+    const gpuModelsResult = mock<ReturnType<typeof DEPENDENCIES.useGpuModels>>({
+      data: input.isLoading || input.isError ? undefined : GPU_VENDORS,
+      isLoading: input.isLoading ?? false,
+      isError: input.isError ?? false
+    } as Partial<ReturnType<typeof DEPENDENCIES.useGpuModels>>);
+    const useGpuModels: typeof DEPENDENCIES.useGpuModels = () => gpuModelsResult;
+    const useFieldError: typeof DEPENDENCIES.useFieldError = () => ({ error: input.gpuError });
+
+    let getValues: () => SdlBuilderFormValuesType = () => values;
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values, mode: "onChange" });
+      getValues = form.getValues;
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    render(
+      <Wrapper>
+        <GpuCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES, useGpuModels, useFieldError, ...input.dependencies }} />
+      </Wrapper>
+    );
+
+    const user = userEvent.setup();
+
+    return { user, getValues: () => getValues() };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
@@ -1,0 +1,346 @@
+import type { FC } from "react";
+import { useCallback, useId, useMemo } from "react";
+import { useController, useFieldArray, useFormContext } from "react-hook-form";
+import {
+  Button,
+  CollapsibleCard,
+  Field,
+  FieldContent,
+  FieldError,
+  FieldLabel,
+  QuantityStepper,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Spinner,
+  useFieldError
+} from "@akashnetwork/ui/components";
+import { GpuIcon, PlusIcon, TrashIcon, XIcon } from "lucide-react";
+
+import { useGpuModels } from "@src/queries/useGpuQuery";
+import type { SdlBuilderFormValuesType } from "@src/types";
+import type { GpuVendor } from "@src/types/gpu";
+import { gpuVendors as fallbackVendors } from "@src/utils/akash/gpu";
+import { validationConfig } from "@src/utils/akash/units";
+import { gpuTooltip } from "../cardTooltips";
+import { SELECT_TRUNCATE_VALUE } from "../selectStyles";
+
+export const DEPENDENCIES = { CollapsibleCard, useGpuModels, useFieldError, GpuModelFields };
+
+type Props = {
+  serviceIndex: number;
+  /** While the pane is locked the enable switch and every GPU input are disabled so the configured GPU stays viewable but read-only. */
+  locked?: boolean;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/** The defaults applied to a freshly added GPU collection. */
+const newGpuModel = { vendor: "nvidia", name: "", memory: "", interface: "" };
+
+/**
+ * Hardware "GPU" card. A header switch toggles `profile.hasGpu` (the SDL emits a
+ * GPU block only while enabled); enabling defaults the count to at least one and
+ * keeps at least one GPU collection. The body holds a count stepper followed by
+ * one collection per `profile.gpuModels` entry — vendor, model, memory and
+ * interface selects — plus an "Add GPU" button. Each collection after the first
+ * can be removed.
+ */
+export const GpuCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+  const { control, setValue, getValues } = useFormContext<SdlBuilderFormValuesType>();
+  const { data: gpuModels, isLoading: isLoadingModels, isError: isModelsError } = d.useGpuModels();
+
+  const hasGpu = useController({ control, name: `services.${serviceIndex}.profile.hasGpu` });
+
+  const { fields, append, remove } = useFieldArray({ control, name: `services.${serviceIndex}.profile.gpuModels`, keyName: "id" });
+
+  const toggleGpu = useCallback(
+    (checked: boolean) => {
+      hasGpu.field.onChange(checked);
+      if (checked) {
+        if (getValues(`services.${serviceIndex}.profile.gpu`) === 0) {
+          setValue(`services.${serviceIndex}.profile.gpu`, 1, { shouldValidate: true, shouldDirty: true });
+        }
+        if (fields.length === 0) {
+          append({ ...newGpuModel }, { shouldFocus: false });
+        }
+      } else {
+        setValue(`services.${serviceIndex}.profile.gpu`, 0, { shouldValidate: true, shouldDirty: true });
+      }
+    },
+    [hasGpu.field, getValues, setValue, serviceIndex, fields.length, append]
+  );
+
+  const hasReachedGpuLimit = fields.length >= validationConfig.maxGpuAmount;
+  const addGpuModel = useCallback(() => {
+    if (fields.length >= validationConfig.maxGpuAmount) return;
+    append({ ...newGpuModel }, { shouldFocus: false });
+  }, [append, fields.length]);
+
+  return (
+    <d.CollapsibleCard
+      title="GPU"
+      icon={<GpuIcon className="h-4 w-4" />}
+      infoTooltip={gpuTooltip}
+      isToggled={!!hasGpu.field.value}
+      onToggle={toggleGpu}
+      toggleAriaLabel="Enable GPU"
+      toggleDisabled={locked}
+    >
+      {hasGpu.field.value && (
+        <fieldset disabled={locked} className="flex flex-col gap-4 border-0 p-0">
+          <GpuCountField serviceIndex={serviceIndex} dependencies={d} />
+
+          {fields.map((field, index) => (
+            <d.GpuModelFields
+              key={field.id}
+              serviceIndex={serviceIndex}
+              gpuIndex={index}
+              gpuVendors={gpuModels}
+              isLoading={isLoadingModels}
+              isError={isModelsError}
+              onRemove={index === 0 ? undefined : () => remove(index)}
+            />
+          ))}
+
+          <div className="flex justify-end">
+            <button
+              type="button"
+              aria-label="Add GPU"
+              onClick={addGpuModel}
+              disabled={hasReachedGpuLimit}
+              className="flex w-full items-center justify-center rounded-md py-1.5 text-muted-foreground hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50 dark:hover:bg-black"
+            >
+              <PlusIcon className="h-4 w-4" />
+            </button>
+          </div>
+        </fieldset>
+      )}
+    </d.CollapsibleCard>
+  );
+};
+
+const GpuCountField: FC<Required<Omit<Props, "locked">>> = ({ serviceIndex, dependencies: d }) => {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const { error: gpuError } = d.useFieldError(`services.${serviceIndex}.profile.gpu`);
+  const errorId = useId();
+  const gpu = useController({ control, name: `services.${serviceIndex}.profile.gpu` });
+
+  return (
+    <Field className="gap-2">
+      <FieldLabel>Count</FieldLabel>
+      <FieldContent>
+        <QuantityStepper
+          label="GPU count"
+          className="self-start"
+          value={gpu.field.value ?? 0}
+          min={1}
+          max={validationConfig.maxGpuAmount}
+          aria-describedby={gpuError ? errorId : undefined}
+          onChange={gpu.field.onChange}
+        />
+        <FieldError id={errorId}>{gpuError}</FieldError>
+      </FieldContent>
+    </Field>
+  );
+};
+
+type GpuModelFieldsProps = {
+  serviceIndex: number;
+  gpuIndex: number;
+  gpuVendors: GpuVendor[] | undefined;
+  isLoading?: boolean;
+  isError?: boolean;
+  onRemove?: () => void;
+};
+
+/**
+ * A single GPU collection: vendor, model, memory and interface selects. Picking
+ * a vendor resets the downstream selections, and picking a model preselects the
+ * memory/interface when the model offers only one option (mirroring the legacy
+ * GPU control). Memory and interface stay disabled until a model is picked.
+ *
+ * While the GPU model catalog is loading a spinner replaces the selects, and a
+ * failed fetch shows a short retryless message, so the model/memory/interface
+ * selects never sit permanently dead with no explanation (matching the legacy
+ * GPU control's "Loading GPU models…" affordance).
+ */
+function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError, onRemove }: GpuModelFieldsProps) {
+  const { control, setValue } = useFormContext<SdlBuilderFormValuesType>();
+  const basePath = `services.${serviceIndex}.profile.gpuModels.${gpuIndex}` as const;
+
+  const vendor = useController({ control, name: `${basePath}.vendor` });
+  const name = useController({ control, name: `${basePath}.name` });
+  const memory = useController({ control, name: `${basePath}.memory` });
+  const gpuInterface = useController({ control, name: `${basePath}.interface` });
+
+  const vendorOptions = useMemo(() => (gpuVendors ? gpuVendors.map(v => v.name) : fallbackVendors.map(v => v.value)), [gpuVendors]);
+  const models = useMemo(() => gpuVendors?.find(v => v.name === vendor.field.value)?.models ?? [], [gpuVendors, vendor.field.value]);
+  const selectedModel = useMemo(() => models.find(m => m.name === name.field.value), [models, name.field.value]);
+  const memorySizes = selectedModel?.memory ?? [];
+  const interfaces = selectedModel?.interface ?? [];
+
+  const selectGpuVendor = useCallback(
+    (value: string) => {
+      vendor.field.onChange(value);
+      setValue(`${basePath}.name`, "", { shouldValidate: true, shouldDirty: true });
+      setValue(`${basePath}.memory`, "", { shouldValidate: true, shouldDirty: true });
+      setValue(`${basePath}.interface`, "", { shouldValidate: true, shouldDirty: true });
+    },
+    [vendor.field, setValue, basePath]
+  );
+
+  const selectGpuModel = useCallback(
+    (value: string) => {
+      const picked = models.find(m => m.name === value);
+      name.field.onChange(value);
+      setValue(`${basePath}.memory`, onlyOption(picked?.memory), { shouldValidate: true, shouldDirty: true });
+      setValue(`${basePath}.interface`, onlyOption(picked?.interface), { shouldValidate: true, shouldDirty: true });
+    },
+    [models, name.field, setValue, basePath]
+  );
+
+  const clearModel = useCallback(() => {
+    name.field.onChange("");
+    setValue(`${basePath}.memory`, "", { shouldValidate: true, shouldDirty: true });
+    setValue(`${basePath}.interface`, "", { shouldValidate: true, shouldDirty: true });
+  }, [name.field, setValue, basePath]);
+
+  return (
+    <div role="group" aria-label={`GPU ${gpuIndex + 1}`} className="flex flex-col gap-3 rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
+      <div className="flex items-center justify-between">
+        <span className="text-xs font-medium uppercase text-muted-foreground">GPU {gpuIndex + 1}</span>
+        {onRemove && (
+          <Button size="icon" type="button" variant="ghost" className="h-6 w-6" aria-label={`Remove GPU ${gpuIndex + 1}`} onClick={onRemove}>
+            <TrashIcon className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      <Field className="gap-2">
+        <FieldLabel>Vendor</FieldLabel>
+        <FieldContent>
+          <Select value={vendor.field.value || ""} onValueChange={selectGpuVendor}>
+            <SelectTrigger aria-label="GPU vendor" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
+              <SelectValue placeholder="Select" />
+            </SelectTrigger>
+            <SelectContent>
+              {vendorOptions.map(option => (
+                <SelectItem key={option} value={option}>
+                  {option}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </FieldContent>
+      </Field>
+
+      {isLoading ? (
+        <div className="flex items-center gap-2 py-1">
+          <Spinner size="small" />
+          <span className="text-sm text-muted-foreground">Loading GPU models...</span>
+        </div>
+      ) : isError ? (
+        <p className="py-1 text-sm text-destructive">Failed to load GPU models. You can still deploy without specifying a model.</p>
+      ) : (
+        <>
+          <Field className="gap-2">
+            <FieldLabel>Model</FieldLabel>
+            <FieldContent>
+              <ClearableSelect clearLabel="Clear GPU model" onClear={name.field.value ? clearModel : undefined}>
+                <Select value={name.field.value || ""} onValueChange={selectGpuModel} disabled={models.length === 0}>
+                  <SelectTrigger aria-label="GPU model" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
+                    <SelectValue placeholder="Select" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {models.map(model => (
+                      <SelectItem key={model.name} value={model.name}>
+                        {model.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </ClearableSelect>
+            </FieldContent>
+          </Field>
+
+          <Field className="gap-2">
+            <FieldLabel>Memory</FieldLabel>
+            <FieldContent>
+              <ClearableSelect clearLabel="Clear GPU memory" onClear={memory.field.value ? () => memory.field.onChange("") : undefined}>
+                <Select value={memory.field.value || ""} onValueChange={memory.field.onChange} disabled={!selectedModel}>
+                  <SelectTrigger aria-label="GPU memory" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
+                    <SelectValue placeholder="Select" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {memorySizes.map(size => (
+                      <SelectItem key={size} value={size}>
+                        {size}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </ClearableSelect>
+            </FieldContent>
+          </Field>
+
+          <Field className="gap-2">
+            <FieldLabel>Interface</FieldLabel>
+            <FieldContent>
+              <ClearableSelect clearLabel="Clear GPU interface" onClear={gpuInterface.field.value ? () => gpuInterface.field.onChange("") : undefined}>
+                <Select value={gpuInterface.field.value || ""} onValueChange={gpuInterface.field.onChange} disabled={!selectedModel}>
+                  <SelectTrigger aria-label="GPU interface" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
+                    <SelectValue placeholder="Select" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {interfaces.map(option => (
+                      <SelectItem key={option} value={option}>
+                        {option}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </ClearableSelect>
+            </FieldContent>
+          </Field>
+        </>
+      )}
+    </div>
+  );
+}
+
+type ClearableSelectProps = {
+  /** When set, a clear button is overlaid on the trigger (before the chevron). */
+  onClear?: () => void;
+  clearLabel: string;
+  children: React.ReactNode;
+};
+
+/**
+ * Overlays a clear button on a Select's trigger without nesting a button inside
+ * it (which would be invalid markup and break the combobox). The button sits
+ * absolutely to the right, before the chevron, and suppresses `pointer-down` so
+ * clicking it doesn't open the Select (Radix opens the trigger on pointer-down).
+ */
+const ClearableSelect: FC<ClearableSelectProps> = ({ onClear, clearLabel, children }) => (
+  <div className="relative">
+    {children}
+    {onClear && (
+      <button
+        type="button"
+        aria-label={clearLabel}
+        className="absolute right-8 top-1/2 flex h-4 w-4 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground hover:text-foreground"
+        onPointerDown={event => event.preventDefault()}
+        onClick={onClear}
+      >
+        <XIcon className="h-3.5 w-3.5" />
+      </button>
+    )}
+  </div>
+);
+
+/** Returns the single available option (so it can be preselected), otherwise an empty value. */
+function onlyOption(options: string[] | undefined): string {
+  return options?.length === 1 ? options[0] : "";
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
@@ -7,18 +7,38 @@ import { MockComponents } from "@tests/unit/mocks";
 
 describe(HardwareSection.name, () => {
   it("renders each hardware row for the selected service", () => {
+    const PresetsCard = vi.fn(() => null);
+    const GpuCard = vi.fn(() => null);
     const ComputeResourcesCard = vi.fn(() => null);
     const PersistentStorageCard = vi.fn(() => null);
     const RamStorageCard = vi.fn(() => null);
 
-    setup({ serviceIndex: 2, dependencies: { ComputeResourcesCard, PersistentStorageCard, RamStorageCard } });
+    setup({ serviceIndex: 2, dependencies: { PresetsCard, GpuCard, ComputeResourcesCard, PersistentStorageCard, RamStorageCard } });
 
+    expect(PresetsCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
+    expect(GpuCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
     expect(ComputeResourcesCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
     expect(PersistentStorageCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
     expect(RamStorageCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
   });
 
-  function setup(input: { serviceIndex?: number; dependencies?: Partial<typeof DEPENDENCIES> }) {
-    render(<HardwareSection serviceIndex={input.serviceIndex ?? 0} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />);
+  it("forwards the locked state to every hardware card", () => {
+    const PresetsCard = vi.fn(() => null);
+    const GpuCard = vi.fn(() => null);
+    const ComputeResourcesCard = vi.fn(() => null);
+    const PersistentStorageCard = vi.fn(() => null);
+    const RamStorageCard = vi.fn(() => null);
+
+    setup({ locked: true, dependencies: { PresetsCard, GpuCard, ComputeResourcesCard, PersistentStorageCard, RamStorageCard } });
+
+    expect(PresetsCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(GpuCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(ComputeResourcesCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(PersistentStorageCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(RamStorageCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+  });
+
+  function setup(input: { serviceIndex?: number; locked?: boolean; dependencies?: Partial<typeof DEPENDENCIES> }) {
+    render(<HardwareSection serviceIndex={input.serviceIndex ?? 0} locked={input.locked} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />);
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
@@ -1,11 +1,13 @@
 import type { FC } from "react";
 import { CollapsibleCard } from "@akashnetwork/ui/components";
-import { CpuIcon } from "lucide-react";
+import { CpuIcon, PackageOpenIcon } from "lucide-react";
 
 import { useRevalidateUniqueness } from "../../DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness";
-import { computeResourcesTooltip } from "../cardTooltips";
+import { computeResourcesTooltip, presetsTooltip } from "../cardTooltips";
 import { ComputeResourcesCard } from "../ComputeResourcesCard/ComputeResourcesCard";
+import { GpuCard } from "../GpuCard/GpuCard";
 import { PersistentStorageCard } from "../PersistentStorageCard/PersistentStorageCard";
+import { PresetsCard } from "../PresetsCard/PresetsCard";
 import { RamStorageCard } from "../RamStorageCard/RamStorageCard";
 
 type StorageVolume = { name?: string; mount?: string };
@@ -21,6 +23,8 @@ export const storageUniquenessKey = (storage: StorageVolume) => `${storage.name 
 
 export const DEPENDENCIES = {
   CollapsibleCard,
+  PresetsCard,
+  GpuCard,
   ComputeResourcesCard,
   RamStorageCard,
   PersistentStorageCard,
@@ -36,10 +40,10 @@ type Props = {
 
 /**
  * The "HARDWARE" section of the Configuration pane for the selected service:
- * CPU (with memory & ephemeral storage), RAM-backed storage and Persistent
- * Storage cards. Each card edits `services.${serviceIndex}.profile.*` on the
- * shared deployment model. The RAM and Persistent Storage cards own their own
- * card shell because they carry a header switch.
+ * Presets, GPU, CPU (with memory & storage) and Persistent Storage cards. Each
+ * card edits `services.${serviceIndex}.profile.*` on the shared deployment
+ * model. The GPU and Persistent Storage cards own their own card shell because
+ * they carry a header switch.
  *
  * Persistent and RAM volumes share `profile.storage` and must each have a unique
  * name and mount; re-validating the whole array on any name or mount change keeps
@@ -53,6 +57,12 @@ export const HardwareSection: FC<Props> = ({ serviceIndex, locked = false, depen
     <div className="flex flex-col gap-2 px-4">
       <p className="font-mono text-xs uppercase text-muted-foreground">Hardware</p>
       <div className="flex flex-col gap-4">
+        <d.CollapsibleCard title="Presets" icon={<PackageOpenIcon className="h-4 w-4" />} infoTooltip={presetsTooltip}>
+          <d.PresetsCard serviceIndex={serviceIndex} locked={locked} />
+        </d.CollapsibleCard>
+
+        <d.GpuCard serviceIndex={serviceIndex} locked={locked} />
+
         <d.CollapsibleCard title="Compute Resources" icon={<CpuIcon className="h-4 w-4" />} infoTooltip={computeResourcesTooltip}>
           <d.ComputeResourcesCard serviceIndex={serviceIndex} locked={locked} />
         </d.CollapsibleCard>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/PresetsCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/PresetsCard.spec.tsx
@@ -1,0 +1,132 @@
+import type { PropsWithChildren } from "react";
+import { FormProvider, useForm, type UseFormSetValue } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import type { HardwarePreset } from "./hardwarePresets";
+import { DEPENDENCIES, PresetsCard } from "./PresetsCard";
+
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const PRESETS: HardwarePreset[] = [
+  { id: "small", label: "Small preset", group: "compute", cpu: 2, ram: 4, ramUnit: "Gi", storage: 20, storageUnit: "Gi" },
+  { id: "gpu", label: "GPU preset", group: "gpu", cpu: 4, ram: 16, ramUnit: "Gi", storage: 100, storageUnit: "Gi", gpu: 2, gpuVendor: "nvidia", gpuModel: "t4" }
+];
+
+describe(PresetsCard.name, () => {
+  it("applies CPU, memory, and storage from the picked preset", async () => {
+    const { getValues } = setup({});
+
+    await pickPreset("Small preset");
+
+    const profile = getValues().services[0].profile;
+    expect(profile.cpu).toBe(2);
+    expect(profile.ram).toBe(4);
+    expect(profile.ramUnit).toBe("Gi");
+    expect(profile.storage[0]).toMatchObject({ size: 20, unit: "Gi" });
+  });
+
+  it("enables GPU when the preset includes one", async () => {
+    const { getValues } = setup({});
+
+    await pickPreset("GPU preset");
+
+    const profile = getValues().services[0].profile;
+    expect(profile.gpu).toBe(2);
+    expect(profile.hasGpu).toBe(true);
+    expect(profile.gpuModels).toEqual([{ vendor: "nvidia", name: "t4" }]);
+  });
+
+  it("leaves GPU disabled for a non-GPU preset", async () => {
+    const { getValues } = setup({});
+
+    await pickPreset("Small preset");
+
+    expect(getValues().services[0].profile.hasGpu).toBe(false);
+    expect(getValues().services[0].profile.gpu).toBe(0);
+  });
+
+  it("clears stale GPU models when switching to a non-GPU preset", async () => {
+    const { getValues } = setup({});
+
+    await pickPreset("GPU preset");
+    await pickPreset("Small preset");
+
+    expect(getValues().services[0].profile.gpuModels).toEqual([]);
+  });
+
+  it("re-applies the same preset after manual edits", async () => {
+    const { getValues, setValue } = setup({});
+
+    await pickPreset("Small preset");
+    act(() => setValue(`services.${0}.profile.cpu`, 9));
+    await pickPreset("Small preset");
+
+    expect(getValues().services[0].profile.cpu).toBe(2);
+  });
+
+  it("does not modify persistent storage entries", async () => {
+    const persistentStorage = { size: 10, unit: "Gi", isPersistent: true, type: "beta3", name: "data", mount: "/mnt/data", isReadOnly: false };
+    const { getValues } = setup({
+      storage: [{ size: 1, unit: "Gi", isPersistent: false, type: "beta2" }, persistentStorage]
+    });
+
+    await pickPreset("Small preset");
+
+    expect(getValues().services[0].profile.storage[1]).toEqual(persistentStorage);
+  });
+
+  it("reflects the picked preset in the select trigger", async () => {
+    setup({});
+
+    await pickPreset("Small preset");
+
+    expect(screen.getByRole("combobox", { name: "Preset" })).toHaveTextContent("Small preset");
+  });
+
+  it("falls back to the placeholder once the resources no longer match a preset", async () => {
+    const { setValue } = setup({});
+
+    await pickPreset("Small preset");
+    act(() => setValue(`services.${0}.profile.cpu`, 9));
+
+    expect(screen.getByRole("combobox", { name: "Preset" })).toHaveTextContent("Choose a starting point");
+  });
+
+  it("disables the preset select while locked", () => {
+    setup({ locked: true });
+
+    expect(screen.getByRole("combobox", { name: "Preset" })).toBeDisabled();
+  });
+
+  async function pickPreset(name: string) {
+    await userEvent.click(screen.getByRole("combobox", { name: "Preset" }));
+    await userEvent.click(await screen.findByRole("option", { name: new RegExp(name) }));
+  }
+
+  function setup(input: { storage?: SdlBuilderFormValuesType["services"][number]["profile"]["storage"]; locked?: boolean }) {
+    const values = defaultServiceWithPlacement();
+    if (input.storage) {
+      values.services[0].profile.storage = input.storage;
+    }
+
+    let getValues: () => SdlBuilderFormValuesType = () => values;
+    let setValue!: UseFormSetValue<SdlBuilderFormValuesType>;
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values, mode: "onChange" });
+      getValues = form.getValues;
+      setValue = form.setValue;
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    render(
+      <Wrapper>
+        <PresetsCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES, hardwarePresets: PRESETS }} />
+      </Wrapper>
+    );
+
+    return { getValues: () => getValues(), setValue };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/PresetsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/PresetsCard.tsx
@@ -1,0 +1,82 @@
+import type { FC } from "react";
+import { Fragment, useCallback, useMemo } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
+import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from "@akashnetwork/ui/components";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { SELECT_TRUNCATE_VALUE } from "../selectStyles";
+import type { HardwarePreset, HardwarePresetGroup } from "./hardwarePresets";
+import { applyPreset, detectPreset, formatPresetSpecs, HARDWARE_PRESET_GROUP_LABELS, HARDWARE_PRESET_GROUP_ORDER, hardwarePresets } from "./hardwarePresets";
+
+export const DEPENDENCIES = { hardwarePresets };
+
+type Props = {
+  serviceIndex: number;
+  /** While the pane is locked the preset select is disabled so the active preset stays viewable but can't be re-applied. */
+  locked?: boolean;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/**
+ * Hardware "Presets" card body: a select that, on pick, overwrites the selected
+ * service's compute values (CPU, memory, ephemeral storage, and optionally GPU)
+ * from a {@link HardwarePreset}. A preset isn't stored in the model as a separate
+ * field — its values live on `profile.*` — so the select's value is derived from
+ * the current resources via {@link detectPreset}: it shows the matching preset
+ * when the resources equal one and falls back to the placeholder once they're
+ * edited into a custom configuration.
+ *
+ * Options are grouped into labelled "Compute" and "GPU" sections, each option
+ * showing its name on the left and a spec summary on the right.
+ */
+export const PresetsCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+  const { control, setValue } = useFormContext<SdlBuilderFormValuesType>();
+  const profile = useWatch({ control, name: `services.${serviceIndex}.profile` });
+  const selectedPresetId = useMemo(() => detectPreset(d.hardwarePresets, profile ?? {})?.id ?? "", [d.hardwarePresets, profile]);
+
+  const applySelectedPreset = useCallback(
+    (id: string) => {
+      const preset = d.hardwarePresets.find(candidate => candidate.id === id);
+      if (!preset) {
+        return;
+      }
+      applyPreset(setValue, serviceIndex, preset);
+    },
+    [d.hardwarePresets, setValue, serviceIndex]
+  );
+
+  const groups = HARDWARE_PRESET_GROUP_ORDER.map(group => ({
+    group,
+    presets: d.hardwarePresets.filter(preset => preset.group === group)
+  })).filter(({ presets }) => presets.length > 0);
+
+  return (
+    <Select value={selectedPresetId} onValueChange={applySelectedPreset} disabled={locked}>
+      <SelectTrigger aria-label="Preset" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
+        <SelectValue placeholder="Choose a starting point..." />
+      </SelectTrigger>
+      <SelectContent className="min-w-[18rem]">
+        {groups.map(({ group, presets }, index) => (
+          <Fragment key={group}>
+            {index > 0 && <SelectSeparator />}
+            <PresetGroup group={group} presets={presets} />
+          </Fragment>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};
+
+const PresetGroup: FC<{ group: HardwarePresetGroup; presets: HardwarePreset[] }> = ({ group, presets }) => (
+  <SelectGroup>
+    <SelectLabel className="px-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">{HARDWARE_PRESET_GROUP_LABELS[group]}</SelectLabel>
+    {presets.map(preset => (
+      <SelectItem key={preset.id} value={preset.id} className="[&>span:last-child]:flex [&>span:last-child]:w-full">
+        <span className="flex w-full items-center justify-between gap-6">
+          <span>{preset.label}</span>
+          <span className="font-mono text-xs text-muted-foreground">{formatPresetSpecs(preset)}</span>
+        </span>
+      </SelectItem>
+    ))}
+  </SelectGroup>
+);

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/hardwarePresets.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/hardwarePresets.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import type { DetectableProfile, HardwarePreset } from "./hardwarePresets";
+import { detectPreset } from "./hardwarePresets";
+
+describe(detectPreset.name, () => {
+  const compute: HardwarePreset = { id: "medium", label: "medium", group: "compute", cpu: 4, ram: 16, ramUnit: "Gi", storage: 50, storageUnit: "Gi" };
+  const gpu: HardwarePreset = {
+    id: "gpu-t4",
+    label: "T4",
+    group: "gpu",
+    cpu: 4,
+    ram: 16,
+    ramUnit: "Gi",
+    storage: 100,
+    storageUnit: "Gi",
+    gpu: 1,
+    gpuVendor: "nvidia",
+    gpuModel: "t4"
+  };
+  const presets = [compute, gpu];
+
+  it("detects a compute preset when cpu, memory and ephemeral storage match", () => {
+    const profile: DetectableProfile = { cpu: 4, ram: 16, ramUnit: "Gi", storage: [{ size: 50, unit: "Gi" }], hasGpu: false };
+
+    expect(detectPreset(presets, profile)?.id).toBe("medium");
+  });
+
+  it("returns undefined when a compute value diverges from every preset", () => {
+    const profile: DetectableProfile = { cpu: 9, ram: 16, ramUnit: "Gi", storage: [{ size: 50, unit: "Gi" }], hasGpu: false };
+
+    expect(detectPreset(presets, profile)).toBeUndefined();
+  });
+
+  it("does not match a compute preset when the GPU is enabled", () => {
+    const profile: DetectableProfile = { cpu: 4, ram: 16, ramUnit: "Gi", storage: [{ size: 50, unit: "Gi" }], hasGpu: true, gpu: 1 };
+
+    expect(detectPreset(presets, profile)).toBeUndefined();
+  });
+
+  it("detects a GPU preset when the vendor, model and count also match", () => {
+    const profile: DetectableProfile = {
+      cpu: 4,
+      ram: 16,
+      ramUnit: "Gi",
+      storage: [{ size: 100, unit: "Gi" }],
+      hasGpu: true,
+      gpu: 1,
+      gpuModels: [{ vendor: "nvidia", name: "t4" }]
+    };
+
+    expect(detectPreset(presets, profile)?.id).toBe("gpu-t4");
+  });
+
+  it("does not match a GPU preset when the model differs", () => {
+    const profile: DetectableProfile = {
+      cpu: 4,
+      ram: 16,
+      ramUnit: "Gi",
+      storage: [{ size: 100, unit: "Gi" }],
+      hasGpu: true,
+      gpu: 1,
+      gpuModels: [{ vendor: "nvidia", name: "a100" }]
+    };
+
+    expect(detectPreset(presets, profile)).toBeUndefined();
+  });
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/hardwarePresets.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/hardwarePresets.ts
@@ -1,0 +1,151 @@
+import type { UseFormSetValue } from "react-hook-form";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+
+/**
+ * Predefined hardware profiles offered in the Configuration pane's "Presets"
+ * card. Picking a preset overwrites the selected service's compute values
+ * (CPU, memory, ephemeral storage, and optionally GPU). The values map directly
+ * to the `profile.*` fields of the SDL builder model, so units use the same
+ * suffixes as {@link memoryUnits} / {@link storageUnits}.
+ *
+ * Presets are split into {@link HardwarePresetGroup}s ("Compute" and "GPU") that
+ * render as labelled sections in the dropdown.
+ */
+export type HardwarePresetGroup = "compute" | "gpu";
+
+export interface HardwarePreset {
+  id: string;
+  /** Display name shown on the left of the option (e.g. "small", "H100"). */
+  label: string;
+  group: HardwarePresetGroup;
+  cpu: number;
+  ram: number;
+  ramUnit: string;
+  storage: number;
+  storageUnit: string;
+  /** GPU units; `0` (or omitted) means the preset has no GPU. */
+  gpu?: number;
+  /** GPU vendor applied to `profile.gpuModels[0]` when `gpu` > 0. */
+  gpuVendor?: string;
+  /** GPU model name applied to `profile.gpuModels[0]` when `gpu` > 0. */
+  gpuModel?: string;
+}
+
+export const hardwarePresets: HardwarePreset[] = [
+  { id: "small", label: "small", group: "compute", cpu: 1, ram: 2, ramUnit: "Gi", storage: 10, storageUnit: "Gi" },
+  { id: "medium", label: "medium", group: "compute", cpu: 4, ram: 16, ramUnit: "Gi", storage: 50, storageUnit: "Gi" },
+  { id: "large", label: "large", group: "compute", cpu: 16, ram: 64, ramUnit: "Gi", storage: 200, storageUnit: "Gi" },
+  { id: "gpu-t4", label: "T4", group: "gpu", cpu: 4, ram: 16, ramUnit: "Gi", storage: 100, storageUnit: "Gi", gpu: 1, gpuVendor: "nvidia", gpuModel: "t4" },
+  {
+    id: "gpu-a100",
+    label: "A100",
+    group: "gpu",
+    cpu: 8,
+    ram: 64,
+    ramUnit: "Gi",
+    storage: 200,
+    storageUnit: "Gi",
+    gpu: 1,
+    gpuVendor: "nvidia",
+    gpuModel: "a100"
+  },
+  {
+    id: "gpu-h100",
+    label: "H100",
+    group: "gpu",
+    cpu: 16,
+    ram: 128,
+    ramUnit: "Gi",
+    storage: 400,
+    storageUnit: "Gi",
+    gpu: 1,
+    gpuVendor: "nvidia",
+    gpuModel: "h100"
+  }
+];
+
+/** Section headings shown above each group in the dropdown. */
+export const HARDWARE_PRESET_GROUP_LABELS: Record<HardwarePresetGroup, string> = {
+  compute: "Compute",
+  gpu: "GPU"
+};
+
+/** The order groups appear in the dropdown. */
+export const HARDWARE_PRESET_GROUP_ORDER: HardwarePresetGroup[] = ["compute", "gpu"];
+
+/**
+ * Builds the right-aligned spec summary for a preset, e.g. "1 vCPU · 2 GiB" or
+ * "1× T4" appended for GPU presets.
+ */
+export function formatPresetSpecs(preset: HardwarePreset): string {
+  const parts = [`${preset.cpu} vCPU`, `${preset.ram} ${preset.ramUnit === "Gi" ? "GiB" : preset.ramUnit}`];
+  if (preset.gpu && preset.gpu > 0 && preset.gpuModel) {
+    parts.push(`${preset.gpu}× ${preset.gpuModel.toUpperCase()}`);
+  }
+  return parts.join(" · ");
+}
+
+/** The compute/GPU fields of a service profile that {@link detectPreset} compares against a preset. */
+export type DetectableProfile = {
+  cpu?: number | null;
+  ram?: number | null;
+  ramUnit?: string;
+  storage?: Array<{ size?: number | null; unit?: string }>;
+  hasGpu?: boolean;
+  gpu?: number;
+  gpuModels?: Array<{ vendor?: string; name?: string }> | null;
+};
+
+/**
+ * Returns the preset whose values equal the service's current compute resources,
+ * or `undefined` when they match none (a custom configuration). This is the
+ * inverse of applying a preset, so the Presets select can reflect the active
+ * preset instead of always resetting to its placeholder after each pick.
+ */
+export function detectPreset(presets: HardwarePreset[], profile: DetectableProfile): HardwarePreset | undefined {
+  return presets.find(preset => presetMatchesProfile(preset, profile));
+}
+
+/** Whether the profile's compute (and GPU, when the preset defines one) equals the preset's values. */
+function presetMatchesProfile(preset: HardwarePreset, profile: DetectableProfile): boolean {
+  const root = profile.storage?.[0];
+  const computeMatches =
+    profile.cpu === preset.cpu &&
+    profile.ram === preset.ram &&
+    profile.ramUnit === preset.ramUnit &&
+    root?.size === preset.storage &&
+    root?.unit === preset.storageUnit;
+
+  if (!computeMatches) {
+    return false;
+  }
+
+  if (!preset.gpu) {
+    return !profile.hasGpu;
+  }
+
+  const model = profile.gpuModels?.[0];
+  return !!profile.hasGpu && profile.gpu === preset.gpu && model?.vendor === (preset.gpuVendor ?? "nvidia") && model?.name === (preset.gpuModel ?? "");
+}
+
+/** Overwrites the service's compute profile with the preset's values — the inverse of {@link detectPreset}. */
+export function applyPreset(setValue: UseFormSetValue<SdlBuilderFormValuesType>, serviceIndex: number, preset: HardwarePreset) {
+  const options = { shouldValidate: true, shouldDirty: true } as const;
+
+  setValue(`services.${serviceIndex}.profile.cpu`, preset.cpu, options);
+  setValue(`services.${serviceIndex}.profile.ram`, preset.ram, options);
+  setValue(`services.${serviceIndex}.profile.ramUnit`, preset.ramUnit, options);
+  setValue(`services.${serviceIndex}.profile.storage.0.size`, preset.storage, options);
+  setValue(`services.${serviceIndex}.profile.storage.0.unit`, preset.storageUnit, options);
+
+  const gpu = preset.gpu ?? 0;
+  setValue(`services.${serviceIndex}.profile.gpu`, gpu, options);
+  setValue(`services.${serviceIndex}.profile.hasGpu`, gpu > 0, options);
+
+  if (gpu > 0) {
+    setValue(`services.${serviceIndex}.profile.gpuModels`, [{ vendor: preset.gpuVendor ?? "nvidia", name: preset.gpuModel ?? "" }], options);
+  } else {
+    setValue(`services.${serviceIndex}.profile.gpuModels`, [], options);
+  }
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/cardTooltips.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/cardTooltips.tsx
@@ -6,6 +6,29 @@
  * so stating them here would only risk drifting out of sync.
  */
 
+export const presetsTooltip = (
+  <>
+    Apply a starting point for this service's compute resources.
+    <br />
+    <br />
+    Picking a preset overwrites the CPU, memory, storage and GPU values below. You can fine-tune them afterwards.
+  </>
+);
+
+export const gpuTooltip = (
+  <>
+    The amount of GPUs required for this workload.
+    <br />
+    <br />
+    You can also specify the GPU vendor and model you want specifically. If you don't specify any model, providers with any GPU model will bid on your workload.
+    <br />
+    <br />
+    <a href="https://akash.network/docs/developers/deployment/akash-sdl/advanced-features/#gpu-configuration" target="_blank" rel="noopener">
+      View official documentation
+    </a>
+  </>
+);
+
 export const computeResourcesTooltip = (
   <>
     The compute resources required for this workload.
@@ -52,6 +75,20 @@ export const imageRuntimeTooltip = (
     <br />
     <br />
     <a href="https://akash.network/docs/developers/deployment/akash-sdl/advanced-features/#environment-variables" target="_blank" rel="noopener">
+      View official documentation
+    </a>
+  </>
+);
+
+export const commandsTooltip = (
+  <>
+    Custom command used when executing container.
+    <br />
+    <br />
+    An example and popular use case is to run a bash script to install packages or run specific commands.
+    <br />
+    <br />
+    <a href="https://akash.network/docs/developers/deployment/akash-sdl/advanced-features/#command-and-args-override" target="_blank" rel="noopener">
       View official documentation
     </a>
   </>

--- a/packages/ui/components/dialog-v2.tsx
+++ b/packages/ui/components/dialog-v2.tsx
@@ -1,0 +1,148 @@
+"use client";
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "../utils";
+
+/**
+ * Dialog v2 — a structured modal layout that matches the design system:
+ * a header with a bottom border, a scrollable body, and a footer with a top
+ * border whose actions are right-aligned. The close (X) button lives in the
+ * top-right of the content, aligned with the header.
+ *
+ * Composed from the same Radix primitives as the original {@link ./dialog}, so
+ * `open`/`onOpenChange` and accessibility behave identically. Prefer this when
+ * you want the bordered header/footer chrome from the screenshots; reach for the
+ * original `dialog` for borderless, centered modals.
+ *
+ * @example
+ * <DialogV2 open={open} onOpenChange={setOpen}>
+ *   <DialogV2Content className="max-w-lg">
+ *     <DialogV2Header>
+ *       <DialogV2Title>Title</DialogV2Title>
+ *       <DialogV2Description>Description</DialogV2Description>
+ *     </DialogV2Header>
+ *     <DialogV2Body>{children}</DialogV2Body>
+ *     <DialogV2Footer>
+ *       <Button variant="ghost" onClick={onCancel}>Cancel</Button>
+ *       <Button onClick={onConfirm}>Confirm</Button>
+ *     </DialogV2Footer>
+ *   </DialogV2Content>
+ * </DialogV2>
+ */
+const DialogV2 = DialogPrimitive.Root;
+
+const DialogV2Trigger = DialogPrimitive.Trigger;
+
+const DialogV2Portal = DialogPrimitive.Portal;
+
+const DialogV2Close = DialogPrimitive.Close;
+
+const DialogV2Overlay = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Overlay>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Overlay
+      ref={ref}
+      className={cn(
+        "bg-background/20 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[750] backdrop-blur-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+DialogV2Overlay.displayName = "DialogV2Overlay";
+
+/**
+ * The modal panel. Lays its children out as a column so a {@link DialogV2Header},
+ * {@link DialogV2Body} and {@link DialogV2Footer} stack with the header/footer
+ * pinned and the body scrolling. Has no internal padding of its own — each
+ * section owns its padding so the header/footer borders run edge to edge.
+ */
+const DialogV2Content = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    hideCloseButton?: boolean;
+  }
+>(({ className, children, hideCloseButton, ...props }, ref) => (
+  <DialogV2Portal>
+    <DialogV2Overlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "bg-popover data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] fixed left-[50%] top-[50%] z-[751] flex max-h-[85vh] w-full max-w-lg translate-x-[-50%] translate-y-[-50%] flex-col overflow-hidden border shadow-lg duration-200 sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+
+      {!hideCloseButton && (
+        <DialogPrimitive.Close className="ring-offset-background data-[state=open]:bg-accent data-[state=open]:text-muted-foreground focus:ring-ring absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:pointer-events-none">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
+    </DialogPrimitive.Content>
+  </DialogV2Portal>
+));
+DialogV2Content.displayName = "DialogV2Content";
+
+/**
+ * The header section: stacks the title and description and draws the bottom
+ * border that separates the header from the body. Reserves right padding so the
+ * text never collides with the close button.
+ */
+const DialogV2Header = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex shrink-0 flex-col space-y-1.5 border-b px-6 py-4 pr-12 text-left", className)} {...props} />
+);
+DialogV2Header.displayName = "DialogV2Header";
+
+/**
+ * The scrollable body section. Holds the main dialog content and grows to fill
+ * the space between the header and footer, scrolling when the content overflows.
+ */
+const DialogV2Body = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex-1 overflow-y-auto px-6 py-4", className)} {...props} />
+);
+DialogV2Body.displayName = "DialogV2Body";
+
+/**
+ * The footer section: draws the top border and right-aligns its actions
+ * (primary action last). On narrow viewports the buttons stack with the primary
+ * action on top.
+ */
+const DialogV2Footer = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("bg-muted flex shrink-0 flex-col-reverse justify-end gap-2 border-t px-6 py-4 sm:flex-row sm:items-center sm:space-x-2", className)}
+    {...props}
+  />
+);
+DialogV2Footer.displayName = "DialogV2Footer";
+
+const DialogV2Title = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Title>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Title ref={ref} className={cn("text-lg font-semibold leading-none tracking-tight", className)} {...props} />
+  )
+);
+DialogV2Title.displayName = "DialogV2Title";
+
+const DialogV2Description = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => <DialogPrimitive.Description ref={ref} className={cn("text-muted-foreground text-sm", className)} {...props} />);
+DialogV2Description.displayName = "DialogV2Description";
+
+export {
+  DialogV2,
+  DialogV2Portal,
+  DialogV2Overlay,
+  DialogV2Close,
+  DialogV2Trigger,
+  DialogV2Content,
+  DialogV2Header,
+  DialogV2Body,
+  DialogV2Footer,
+  DialogV2Title,
+  DialogV2Description
+};

--- a/packages/ui/components/index.tsx
+++ b/packages/ui/components/index.tsx
@@ -10,6 +10,7 @@ export * from "./collapsible";
 export * from "./collapsible-card";
 export * from "./command";
 export * from "./dialog";
+export * from "./dialog-v2";
 export * from "./multiple-selector";
 export * from "./drawer";
 export * from "./dropdown-menu";


### PR DESCRIPTION
### Why

Part of CON-411, closes CON-419. Completes the Configuration pane. After this PR its content matches the original
`feat/deployment-configure-pane-inputs` branch.

### What

- **GPU card** — enable toggle, count, and vendor/model/memory/interface selection.
- **Presets card** — applies a starting point for CPU/memory/storage/GPU.
- **Commands card** and **Environment Variables card** — both backed by the new `dialog-v2` modal;
  env vars guard the reserved `SSH_PUBKEY` key.
- Wires GPU + Presets into the Hardware section and Commands + Env vars into the Additional
  section.
- Tests for every added card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hardware **Presets** (compute + GPU) and a dedicated **GPU** configuration card.
  * Extended the runtime **Additional** area with **Environment Variables** and **Commands** cards.
  * Introduced **DialogV2** for modern modal editing and added related **Presets/GPU/Commands** tooltips.
* **Bug Fixes**
  * Implemented consistent **locked** mode across cards (controls disabled, view-only editing).
  * Improved modal Cancel/Save behavior, reserved environment-key handling, and command newline preservation.
* **Tests**
  * Expanded UI coverage for presets, GPU, environment variables, commands, and configuration-pane wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->