### PR TITLE
feat: adds tee control to new sdl configuration

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfidentialComputeCard/ConfidentialComputeCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfidentialComputeCard/ConfidentialComputeCard.spec.tsx
@@ -1,0 +1,144 @@
+import type { PropsWithChildren } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { ConfidentialComputeCard, DEPENDENCIES } from "./ConfidentialComputeCard";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(ConfidentialComputeCard.name, () => {
+  it("hides the body and leaves the switch off when no TEE is set", () => {
+    setup({});
+
+    expect(screen.getByRole("switch", { name: "Enable confidential compute" })).not.toBeChecked();
+    expect(screen.queryByRole("radiogroup", { name: "Confidential compute type" })).not.toBeInTheDocument();
+  });
+
+  it("sets the TEE to cpu and reveals the radios when toggled on", async () => {
+    const { getValues } = setup({});
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable confidential compute" }));
+
+    expect(getValues().services[0].params?.tee).toBe("cpu");
+    expect(screen.getByRole("radio", { name: "CPU" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "CPU-GPU" })).not.toBeChecked();
+  });
+
+  it("clears the TEE param when toggled off", async () => {
+    const { getValues } = setup({ tee: "cpu" });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable confidential compute" }));
+
+    expect(getValues().services[0].params?.tee).toBeUndefined();
+    expect(screen.queryByRole("radiogroup", { name: "Confidential compute type" })).not.toBeInTheDocument();
+  });
+
+  it("switches the TEE to cpu-gpu when that radio is chosen", async () => {
+    const { getValues } = setup({ tee: "cpu" });
+
+    await userEvent.click(screen.getByRole("radio", { name: "CPU-GPU" }));
+
+    expect(getValues().services[0].params?.tee).toBe("cpu-gpu");
+    expect(screen.getByRole("radio", { name: "CPU-GPU" })).toBeChecked();
+  });
+
+  it("reflects an initial cpu-gpu value", () => {
+    setup({ tee: "cpu-gpu" });
+
+    expect(screen.getByRole("switch", { name: "Enable confidential compute" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "CPU-GPU" })).toBeChecked();
+  });
+
+  it("enables GPU when cpu-gpu is chosen so the attested GPU is backed by resources", async () => {
+    const { getValues } = setup({ tee: "cpu", profile: { hasGpu: false, gpu: 0, gpuModels: [] } });
+
+    await userEvent.click(screen.getByRole("radio", { name: "CPU-GPU" }));
+
+    const profile = getValues().services[0].profile;
+    expect(profile.hasGpu).toBe(true);
+    expect(profile.gpu).toBeGreaterThanOrEqual(1);
+    expect((profile.gpuModels ?? []).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("preserves an already-configured GPU instead of resetting it when cpu-gpu is chosen", async () => {
+    const { getValues } = setup({ tee: "cpu", profile: { hasGpu: true, gpu: 4, gpuModels: [{ vendor: "nvidia", name: "h100" }] } });
+
+    await userEvent.click(screen.getByRole("radio", { name: "CPU-GPU" }));
+
+    const profile = getValues().services[0].profile;
+    expect(profile.gpu).toBe(4);
+    expect(profile.gpuModels).toEqual([{ vendor: "nvidia", name: "h100" }]);
+  });
+
+  it("leaves GPU untouched when cpu is chosen", async () => {
+    const { getValues } = setup({ tee: "cpu-gpu", profile: { hasGpu: true, gpu: 2, gpuModels: [{ vendor: "nvidia" }] } });
+
+    await userEvent.click(screen.getByRole("radio", { name: "CPU" }));
+
+    expect(getValues().services[0].profile.hasGpu).toBe(true);
+    expect(getValues().services[0].profile.gpu).toBe(2);
+  });
+
+  it("preserves other params when the TEE is toggled on and off", async () => {
+    const { getValues } = setup({ params: { permissions: { read: ["logs"] } } });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable confidential compute" }));
+    expect(getValues().services[0].params).toMatchObject({ permissions: { read: ["logs"] }, tee: "cpu" });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable confidential compute" }));
+    expect(getValues().services[0].params).toMatchObject({ permissions: { read: ["logs"] } });
+    expect(getValues().services[0].params?.tee).toBeUndefined();
+  });
+
+  it("drops the params object entirely when toggling off leaves nothing behind", async () => {
+    const { getValues } = setup({ tee: "cpu" });
+
+    await userEvent.click(screen.getByRole("switch", { name: "Enable confidential compute" }));
+
+    expect(getValues().services[0].params).toBeUndefined();
+  });
+
+  it("disables the switch and radios while the pane is locked", () => {
+    setup({ tee: "cpu", locked: true });
+
+    expect(screen.getByRole("switch", { name: "Enable confidential compute" })).toBeDisabled();
+    expect(screen.getByRole("radio", { name: "CPU" })).toBeDisabled();
+    expect(screen.getByRole("radio", { name: "CPU-GPU" })).toBeDisabled();
+  });
+
+  it("shows an off-state hint instead of radios when opened while off and locked", async () => {
+    setup({ locked: true });
+
+    await userEvent.click(screen.getByRole("button", { name: "Expand Confidential Compute" }));
+
+    expect(screen.getByText("Confidential compute is off.")).toBeInTheDocument();
+    expect(screen.queryByRole("radiogroup", { name: "Confidential compute type" })).not.toBeInTheDocument();
+  });
+
+  function setup(input: { tee?: "cpu" | "cpu-gpu"; params?: ServiceType["params"]; profile?: Partial<ServiceType["profile"]>; locked?: boolean }) {
+    const params = input.params ?? (input.tee ? { tee: input.tee } : undefined);
+    const base = defaultServiceWithPlacement({ params });
+    const values: SdlBuilderFormValuesType = {
+      ...base,
+      services: [{ ...base.services[0], profile: { ...base.services[0].profile, ...input.profile } }]
+    };
+
+    let getValues: () => SdlBuilderFormValuesType = () => values;
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values, mode: "onChange" });
+      getValues = form.getValues;
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    render(
+      <Wrapper>
+        <ConfidentialComputeCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES }} />
+      </Wrapper>
+    );
+
+    return { getValues: () => getValues() };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfidentialComputeCard/ConfidentialComputeCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfidentialComputeCard/ConfidentialComputeCard.tsx
@@ -1,0 +1,129 @@
+import type { FC } from "react";
+import { useCallback } from "react";
+import { useFormContext, useWatch } from "react-hook-form";
+import { CollapsibleCard, Label, RadioGroup, RadioGroupItem } from "@akashnetwork/ui/components";
+import { ShieldCheckIcon } from "lucide-react";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { defaultGpuModel } from "@src/utils/sdl/data";
+import { confidentialComputeTooltip } from "../cardTooltips";
+
+export const DEPENDENCIES = { CollapsibleCard, RadioGroup, RadioGroupItem, Label };
+
+type ServiceParams = NonNullable<SdlBuilderFormValuesType["services"][number]["params"]>;
+type TeeType = NonNullable<ServiceParams["tee"]>;
+
+const TEE_OPTIONS: { value: TeeType; label: string; description: string }[] = [
+  { value: "cpu", label: "CPU", description: "Run inside a CPU-only Trusted Execution Environment." },
+  { value: "cpu-gpu", label: "CPU-GPU", description: "Attest the GPU as well — this enables the GPU card for this service." }
+];
+
+/** TEE type a freshly enabled card defaults to. CPU is the least restrictive and needs no GPU resources. */
+const DEFAULT_TEE: TeeType = "cpu";
+
+type Props = {
+  serviceIndex: number;
+  locked?: boolean;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/**
+ * Hardware "Confidential Compute" card. A header switch toggles whether the
+ * service requests a Trusted Execution Environment, persisted as
+ * `services.${serviceIndex}.params.tee`. Enabling defaults to `cpu`; the body
+ * then offers a radio choice between `cpu` and `cpu-gpu`. Disabling clears `tee`
+ * while preserving any other `params` (e.g. log-collector `permissions`), and
+ * drops `params` entirely once nothing is left so the generated SDL stays clean.
+ *
+ * Picking `cpu-gpu` attests the GPU, so it enables the GPU card for this service
+ * (sets `profile.hasGpu`, a count of at least one, and a default GPU model) — the
+ * same state that card's own switch produces — so the attested GPU is backed by
+ * real GPU resources and the SDL stays valid. Cross-service TEE conflicts within a
+ * placement group are still caught by the SDL validator before requesting quotes.
+ *
+ * The body renders only while the card is open: an open, switched-off card is
+ * reachable only when the pane is locked, where the short off-state hint just
+ * tells the viewer no confidential compute is configured.
+ */
+export const ConfidentialComputeCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+  const { control, getValues, setValue } = useFormContext<SdlBuilderFormValuesType>();
+  const tee = useWatch({ control, name: `services.${serviceIndex}.params.tee` });
+  const isEnabled = tee === "cpu" || tee === "cpu-gpu";
+
+  /**
+   * Brings the GPU card to its enabled state — `profile.hasGpu` on, a count of at least one, and at least
+   * one GPU model — matching what the GPU card's own switch does. Only ever turns GPU on (never off), so a
+   * GPU the user configured independently, or one left over after switching back to `cpu`, is preserved.
+   */
+  const enableGpu = useCallback(() => {
+    const profile = `services.${serviceIndex}.profile` as const;
+    if (!getValues(`${profile}.hasGpu`)) {
+      setValue(`${profile}.hasGpu`, true, { shouldDirty: true });
+    }
+    if ((getValues(`${profile}.gpu`) ?? 0) < 1) {
+      setValue(`${profile}.gpu`, 1, { shouldValidate: true, shouldDirty: true });
+    }
+    if ((getValues(`${profile}.gpuModels`) ?? []).length === 0) {
+      setValue(`${profile}.gpuModels`, [{ ...defaultGpuModel }], { shouldDirty: true });
+    }
+  }, [getValues, serviceIndex, setValue]);
+
+  const setTee = useCallback(
+    (value: TeeType | undefined) => {
+      const params = getValues(`services.${serviceIndex}.params`);
+      const nextParams: ServiceParams = { ...params, tee: value };
+      if (!value) {
+        delete nextParams.tee;
+      }
+      const isEmpty = Object.values(nextParams).every(entry => entry === undefined);
+      setValue(`services.${serviceIndex}.params`, isEmpty ? undefined : nextParams, { shouldDirty: true });
+
+      if (value === "cpu-gpu") {
+        enableGpu();
+      }
+    },
+    [enableGpu, getValues, serviceIndex, setValue]
+  );
+
+  const toggleConfidentialCompute = useCallback(
+    (checked: boolean) => {
+      setTee(checked ? DEFAULT_TEE : undefined);
+    },
+    [setTee]
+  );
+
+  return (
+    <d.CollapsibleCard
+      title="Confidential Compute"
+      icon={<ShieldCheckIcon className="h-4 w-4" />}
+      infoTooltip={confidentialComputeTooltip}
+      isToggled={isEnabled}
+      onToggle={toggleConfidentialCompute}
+      toggleAriaLabel="Enable confidential compute"
+      toggleDisabled={locked}
+    >
+      {isEnabled ? (
+        <d.RadioGroup aria-label="Confidential compute type" value={tee} onValueChange={value => setTee(value as TeeType)} className="gap-3" disabled={locked}>
+          {TEE_OPTIONS.map(option => {
+            const id = `tee-${serviceIndex}-${option.value}`;
+            return (
+              <d.Label
+                key={option.value}
+                htmlFor={id}
+                className="flex items-start gap-3 rounded-md border border-zinc-200 p-3 font-normal dark:border-zinc-800"
+              >
+                <d.RadioGroupItem id={id} value={option.value} aria-label={option.label} disabled={locked} className="mt-0.5" />
+                <span className="flex flex-col gap-0.5">
+                  <span className="text-sm font-medium">{option.label}</span>
+                  <span className="text-xs text-muted-foreground">{option.description}</span>
+                </span>
+              </d.Label>
+            );
+          })}
+        </d.RadioGroup>
+      ) : (
+        <p className="text-sm text-muted-foreground">Confidential compute is off.</p>
+      )}
+    </d.CollapsibleCard>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
@@ -24,6 +24,7 @@ import type { SdlBuilderFormValuesType } from "@src/types";
 import type { GpuVendor } from "@src/types/gpu";
 import { gpuVendors as fallbackVendors } from "@src/utils/akash/gpu";
 import { validationConfig } from "@src/utils/akash/units";
+import { defaultGpuModel } from "@src/utils/sdl/data";
 import { gpuTooltip } from "../cardTooltips";
 import { SELECT_TRUNCATE_VALUE } from "../selectStyles";
 
@@ -35,9 +36,6 @@ type Props = {
   locked?: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
-
-/** The defaults applied to a freshly added GPU collection. */
-const newGpuModel = { vendor: "nvidia", name: "", memory: "", interface: "" };
 
 /**
  * Hardware "GPU" card. A header switch toggles `profile.hasGpu` (the SDL emits a
@@ -63,7 +61,7 @@ export const GpuCard: FC<Props> = ({ serviceIndex, locked = false, dependencies:
           setValue(`services.${serviceIndex}.profile.gpu`, 1, { shouldValidate: true, shouldDirty: true });
         }
         if (fields.length === 0) {
-          append({ ...newGpuModel }, { shouldFocus: false });
+          append({ ...defaultGpuModel }, { shouldFocus: false });
         }
       } else {
         setValue(`services.${serviceIndex}.profile.gpu`, 0, { shouldValidate: true, shouldDirty: true });
@@ -75,7 +73,7 @@ export const GpuCard: FC<Props> = ({ serviceIndex, locked = false, dependencies:
   const hasReachedGpuLimit = fields.length >= validationConfig.maxGpuAmount;
   const addGpuModel = useCallback(() => {
     if (fields.length >= validationConfig.maxGpuAmount) return;
-    append({ ...newGpuModel }, { shouldFocus: false });
+    append({ ...defaultGpuModel }, { shouldFocus: false });
   }, [append, fields.length]);
 
   return (

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
@@ -12,14 +12,16 @@ describe(HardwareSection.name, () => {
     const ComputeResourcesCard = vi.fn(() => null);
     const PersistentStorageCard = vi.fn(() => null);
     const RamStorageCard = vi.fn(() => null);
+    const ConfidentialComputeCard = vi.fn(() => null);
 
-    setup({ serviceIndex: 2, dependencies: { PresetsCard, GpuCard, ComputeResourcesCard, PersistentStorageCard, RamStorageCard } });
+    setup({ serviceIndex: 2, dependencies: { PresetsCard, GpuCard, ComputeResourcesCard, PersistentStorageCard, RamStorageCard, ConfidentialComputeCard } });
 
     expect(PresetsCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
     expect(GpuCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
     expect(ComputeResourcesCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
     expect(PersistentStorageCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
     expect(RamStorageCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
+    expect(ConfidentialComputeCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
   });
 
   it("forwards the locked state to every hardware card", () => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
@@ -5,6 +5,7 @@ import { CpuIcon, PackageOpenIcon } from "lucide-react";
 import { useRevalidateUniqueness } from "../../DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness";
 import { computeResourcesTooltip, presetsTooltip } from "../cardTooltips";
 import { ComputeResourcesCard } from "../ComputeResourcesCard/ComputeResourcesCard";
+import { ConfidentialComputeCard } from "../ConfidentialComputeCard/ConfidentialComputeCard";
 import { GpuCard } from "../GpuCard/GpuCard";
 import { PersistentStorageCard } from "../PersistentStorageCard/PersistentStorageCard";
 import { PresetsCard } from "../PresetsCard/PresetsCard";
@@ -28,6 +29,7 @@ export const DEPENDENCIES = {
   ComputeResourcesCard,
   RamStorageCard,
   PersistentStorageCard,
+  ConfidentialComputeCard,
   useRevalidateUniqueness
 };
 
@@ -66,6 +68,8 @@ export const HardwareSection: FC<Props> = ({ serviceIndex, locked = false, depen
         <d.CollapsibleCard title="Compute Resources" icon={<CpuIcon className="h-4 w-4" />} infoTooltip={computeResourcesTooltip}>
           <d.ComputeResourcesCard serviceIndex={serviceIndex} locked={locked} />
         </d.CollapsibleCard>
+
+        <d.ConfidentialComputeCard serviceIndex={serviceIndex} locked={locked} />
 
         <d.RamStorageCard serviceIndex={serviceIndex} locked={locked} />
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/cardTooltips.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/cardTooltips.tsx
@@ -66,6 +66,19 @@ export const persistentStorageTooltip = (
   </>
 );
 
+export const confidentialComputeTooltip = (
+  <>
+    Run this service inside a Trusted Execution Environment (TEE) so its memory stays encrypted and isolated from the provider.
+    <br />
+    <br />
+    Choose <strong>CPU</strong> for a CPU-only enclave, or <strong>CPU-GPU</strong> to additionally attest the GPU — which requires GPU resources on the
+    service.
+    <br />
+    <br />
+    All services in the same placement group must agree on their confidential compute type; conflicting types are rejected when the deployment is validated.
+  </>
+);
+
 export const imageRuntimeTooltip = (
   <>
     Docker image of the container.

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -103,7 +103,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, intent, depende
     [form]
   );
 
-  const flow = d.useDeploymentFlow({ intent, sdl: liveSdl });
+  const flow = d.useDeploymentFlow({ intent });
 
   return (
     <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col dark:bg-card">

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.spec.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { FormProvider, useForm } from "react-hook-form";
+import { Snackbar } from "@akashnetwork/ui/components";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -9,12 +10,35 @@ import { ConfigureDeploymentHeader } from "./ConfigureDeploymentHeader";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
+/** Stand-in for the SDL the header regenerates from the submitted form values. */
+const GENERATED_SDL = 'version: "2.0" # generated';
+
 describe(ConfigureDeploymentHeader.name, () => {
-  it("shows Request quotes while configuring and calls requestQuotes", async () => {
+  it("requests quotes with the SDL generated from the submitted form values, not a stale snapshot", async () => {
     const requestQuotes = vi.fn();
-    setup({ phase: "configuring", requestQuotes });
+    const { enqueueSnackbar } = setup({ phase: "configuring", requestQuotes });
+
     fireEvent.click(screen.getByRole("button", { name: /request quotes/i }));
-    await waitFor(() => expect(requestQuotes).toHaveBeenCalled());
+
+    await waitFor(() => expect(requestQuotes).toHaveBeenCalledWith(GENERATED_SDL));
+    expect(enqueueSnackbar).not.toHaveBeenCalled();
+  });
+
+  it("surfaces SDL validation errors and does not request quotes when the spec is invalid", async () => {
+    const requestQuotes = vi.fn();
+    const { enqueueSnackbar } = setup({
+      phase: "configuring",
+      requestQuotes,
+      validationErrors: ["/services/web/params/tee: missing required property 'gpu'"]
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /request quotes/i }));
+
+    await waitFor(() => expect(enqueueSnackbar).toHaveBeenCalledTimes(1));
+    expect(requestQuotes).not.toHaveBeenCalled();
+
+    render(enqueueSnackbar.mock.calls[0][0] as ReactNode);
+    expect(screen.getByText("/services/web/params/tee: missing required property 'gpu'")).toBeInTheDocument();
   });
 
   it("shows a disabled Requesting CTA while creating", () => {
@@ -40,17 +64,25 @@ describe(ConfigureDeploymentHeader.name, () => {
     expect(screen.getByRole("button", { name: /request quotes/i })).toBeInTheDocument();
   });
 
-  function setup(input: { phase: DeploymentFlow["phase"]; requestQuotes?: () => void }) {
+  function setup(input: { phase: DeploymentFlow["phase"]; requestQuotes?: (sdl: string) => void; validationErrors?: string[] }) {
     const flow = mock<DeploymentFlow>({
       phase: input.phase,
       actions: mock<DeploymentFlow["actions"]>({ requestQuotes: input.requestQuotes ?? vi.fn() })
     });
-    const dependencies: typeof DEPENDENCIES = { useDeploymentResourceSummary: (() => "1 vCPU") as never };
-    return render(
+    const enqueueSnackbar = vi.fn();
+    const dependencies: typeof DEPENDENCIES = {
+      useDeploymentResourceSummary: (() => "1 vCPU") as never,
+      useSnackbar: () => mock<ReturnType<(typeof DEPENDENCIES)["useSnackbar"]>>({ enqueueSnackbar }),
+      Snackbar,
+      generateSdl: () => GENERATED_SDL,
+      validateGeneratedSdl: () => input.validationErrors ?? []
+    };
+    render(
       <Wrapper>
         <ConfigureDeploymentHeader flow={flow} dependencies={dependencies} />
       </Wrapper>
     );
+    return { enqueueSnackbar };
   }
 
   function Wrapper({ children }: { children: ReactNode }) {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
@@ -1,25 +1,57 @@
 import type { FC } from "react";
 import { useFormContext } from "react-hook-form";
-import { Button } from "@akashnetwork/ui/components";
+import { Button, Snackbar } from "@akashnetwork/ui/components";
 import { Send } from "iconoir-react";
 import { LoaderCircle } from "lucide-react";
+import { useSnackbar } from "notistack";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
+import { generateSdl } from "@src/utils/sdl/sdlGenerator";
+import { validateGeneratedSdl } from "@src/utils/sdl/validateGeneratedSdl";
 import { useDeploymentResourceSummary } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
 import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
 
-export const DEPENDENCIES = { useDeploymentResourceSummary };
+export const DEPENDENCIES = { useDeploymentResourceSummary, useSnackbar, Snackbar, generateSdl, validateGeneratedSdl };
 
 type Props = { flow: DeploymentFlow; dependencies?: typeof DEPENDENCIES };
 
 export const ConfigureDeploymentHeader: FC<Props> = ({ flow, dependencies: d = DEPENDENCIES }) => {
   const deploymentSummary = d.useDeploymentResourceSummary();
   const { handleSubmit } = useFormContext<SdlBuilderFormValuesType>();
+  const { enqueueSnackbar } = d.useSnackbar();
 
   const isEditable = flow.phase === "configuring" || flow.phase === "error";
 
-  /** Request quotes validates the form first; only a valid spec proceeds to create the deployment. */
-  const onRequestQuotes = handleSubmit(() => flow.actions.requestQuotes());
+  /**
+   * Request quotes runs the zod form validation first, then regenerates the SDL from the values
+   * `handleSubmit` just accepted — not a prop snapshot, which lags behind in-flight edits — and runs the
+   * chain-sdk SDL validator on it. That validator catches semantic rules the form can't, such as a `cpu-gpu`
+   * confidential-compute service missing GPU resources or conflicting TEE types across a placement group.
+   * Either failure surfaces the errors to the user; otherwise the same freshly generated SDL is what gets
+   * submitted, so validation and creation can never disagree about which spec they acted on.
+   */
+  const onRequestQuotes = handleSubmit(values => {
+    const sdl = d.generateSdl(values);
+    const errors = d.validateGeneratedSdl(sdl);
+    if (errors.length > 0) {
+      enqueueSnackbar(
+        <d.Snackbar
+          title="Your deployment can't be submitted yet"
+          subTitle={
+            <ul className="list-disc pl-4">
+              {errors.map(error => (
+                <li key={error}>{error}</li>
+              ))}
+            </ul>
+          }
+          iconVariant="error"
+        />,
+        { variant: "error" }
+      );
+      return;
+    }
+    flow.actions.requestQuotes(sdl);
+  });
 
   return (
     <header className="flex flex-row items-center justify-between gap-3 md:items-end">

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
@@ -23,7 +23,7 @@ describe(useDeploymentFlow.name, () => {
     const createMutate = vi.fn((_args, { onSuccess }) => onSuccess({ data: { dseq: "999", manifest: "m" } }));
     const { result } = setup({ replace, createMutate });
 
-    act(() => result.current.actions.requestQuotes());
+    act(() => result.current.actions.requestQuotes("sdl-content"));
 
     await waitFor(() => expect(result.current.phase).toBe("quoting"));
     expect(result.current.dseq).toBe("999");
@@ -34,7 +34,7 @@ describe(useDeploymentFlow.name, () => {
   it("surfaces a retryable error when create fails", async () => {
     const createMutate = vi.fn((_args, { onError }) => onError(new Error("boom")));
     const { result } = setup({ createMutate });
-    act(() => result.current.actions.requestQuotes());
+    act(() => result.current.actions.requestQuotes("sdl-content"));
     await waitFor(() => expect(result.current.phase).toBe("error"));
   });
 
@@ -71,14 +71,13 @@ describe(useDeploymentFlow.name, () => {
     const createMutate = vi.fn((_args, { onSuccess }) => onSuccess({ data: { dseq: "999", manifest: "m" } }));
     const { result } = setup({ replace, createMutate, intent: { sdlStrategy: "edit", bidStrategy: "select", draftId: "draft-1" } });
 
-    act(() => result.current.actions.requestQuotes());
+    act(() => result.current.actions.requestQuotes("sdl-content"));
 
     await waitFor(() => expect(replace).toHaveBeenCalledWith(expect.stringContaining("draftId=draft-1"), undefined, { shallow: true }));
   });
 
   function setup(input: {
     intent?: { sdlStrategy: "default" | "edit"; bidStrategy: "auto" | "select"; dseq?: string; templateId?: string; draftId?: string };
-    sdl?: string;
     replace?: ReturnType<typeof vi.fn>;
     createMutate?: ReturnType<typeof vi.fn>;
     closeMutate?: ReturnType<typeof vi.fn>;
@@ -89,7 +88,7 @@ describe(useDeploymentFlow.name, () => {
       useCloseDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useCloseDeployment>>({ mutate: (input.closeMutate ?? vi.fn()) as never })) as never,
       useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: (input.replace ?? vi.fn()) as never })) as never
     };
-    return renderHook(() => useDeploymentFlow({ intent, sdl: input.sdl ?? "sdl-content" }, dependencies));
+    return renderHook(() => useDeploymentFlow({ intent }, dependencies));
   }
 });
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -16,7 +16,9 @@ export interface DeploymentFlowState {
 }
 
 export interface DeploymentFlowActions {
-  requestQuotes: () => void;
+  /** Creates the deployment from the given SDL. The caller passes the SDL generated from the just-submitted
+   * form values so the request can never lag behind an in-flight edit. */
+  requestQuotes: (sdl: string) => void;
   cancelAndEdit: () => void;
   setBidStrategy: (strategy: BidStrategy) => void;
   refreshQuotes: () => void;
@@ -27,7 +29,6 @@ export type DeploymentFlow = DeploymentFlowState & { actions: DeploymentFlowActi
 
 interface UseDeploymentFlowInput {
   intent: DeploymentIntent;
-  sdl: string;
 }
 
 /** Default escrow deposit in USD (ACT maps 1:1 to USD). Matches `DEFAULT_DEPOSIT_USD` in the phased flow so a trial grant covers it. */
@@ -49,7 +50,7 @@ export const DEPENDENCIES = { useCreateDeployment, useCloseDeployment, useRouter
  * lives in react-query via `usePlacementOffers`. Resumes in `quoting` when the URL already carries
  * a dseq, so a reload picks up live bids rather than restarting.
  */
-export function useDeploymentFlow({ intent, sdl }: UseDeploymentFlowInput, dependencies: typeof DEPENDENCIES = DEPENDENCIES): DeploymentFlow {
+export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependencies: typeof DEPENDENCIES = DEPENDENCIES): DeploymentFlow {
   const router = dependencies.useRouter();
   const createDeployment = dependencies.useCreateDeployment();
   const closeDeployment = dependencies.useCloseDeployment();
@@ -63,7 +64,7 @@ export function useDeploymentFlow({ intent, sdl }: UseDeploymentFlowInput, depen
   intentRef.current = intent;
 
   const requestQuotes = useCallback(
-    function requestQuotes() {
+    function requestQuotes(sdl: string) {
       setPhase("creating");
       setError(undefined);
       createDeployment.mutate(
@@ -81,7 +82,7 @@ export function useDeploymentFlow({ intent, sdl }: UseDeploymentFlowInput, depen
         }
       );
     },
-    [createDeployment, router, sdl, bidStrategy]
+    [createDeployment, router, bidStrategy]
   );
 
   const cancelAndEdit = useCallback(

--- a/apps/deploy-web/src/components/sdl/LogCollectorControl/LogCollectorControl.tsx
+++ b/apps/deploy-web/src/components/sdl/LogCollectorControl/LogCollectorControl.tsx
@@ -206,7 +206,7 @@ export const LogCollectorControl: FC<Props> = ({ serviceIndex, dependencies: d =
 };
 
 export function isLogCollectorService(service: ServiceType): boolean {
-  return service.title.endsWith("-log-collector") && service.image === LOG_COLLECTOR_IMAGE;
+  return !!service.title?.endsWith("-log-collector") && service.image === LOG_COLLECTOR_IMAGE;
 }
 
 export function findOwnLogCollectorServiceIndex(service: ServiceType, services: ServiceType[]): number {

--- a/apps/deploy-web/src/components/sdl/SDLEditor/getMonacoErrorMarkers.ts
+++ b/apps/deploy-web/src/components/sdl/SDLEditor/getMonacoErrorMarkers.ts
@@ -2,10 +2,12 @@ import type { ValidationError as SchemaValidationError } from "@akashnetwork/cha
 import type { editor, MarkerSeverity } from "monaco-editor";
 import type { Document, ParsedNode } from "yaml";
 
+import { formatSdlValidationError } from "@src/utils/sdl/validateGeneratedSdl";
+
 export function getMonacoErrorMarkers(errors: SchemaValidationError[], doc: Document.Parsed, yamlText: string): editor.IMarkerData[] {
   return errors.map(error => {
     const node = findNodeAtPath(doc, error.instancePath);
-    const message = formatErrorMessage(error);
+    const message = formatSdlValidationError(error);
 
     let startPos = { line: 1, column: 1 };
     let endPos = { line: 1, column: 1 };
@@ -26,25 +28,6 @@ export function getMonacoErrorMarkers(errors: SchemaValidationError[], doc: Docu
       endColumn: endPos.column
     };
   });
-}
-
-function formatErrorMessage(error: SchemaValidationError): string {
-  const path = error.instancePath || "(root)";
-  const baseMessage = error.message || "Validation error";
-
-  if (error.keyword === "required" && error.params && "missingProperty" in error.params) {
-    return `${path}: missing required property '${error.params.missingProperty}'`;
-  }
-
-  if (error.keyword === "additionalProperties" && error.params && "additionalProperty" in error.params) {
-    return `${path}: unknown property '${error.params.additionalProperty}'`;
-  }
-
-  if (error.keyword === "type" && error.params && "type" in error.params) {
-    return `${path}: ${baseMessage} (expected ${error.params.type})`;
-  }
-
-  return `${path}: ${baseMessage}`;
 }
 
 function offsetToLineColumn(text: string, offset: number): { line: number; column: number } {

--- a/apps/deploy-web/src/utils/sdl/data.ts
+++ b/apps/deploy-web/src/utils/sdl/data.ts
@@ -129,6 +129,9 @@ export const defaultRamStorage = {
   isReadOnly: false
 };
 
+/** The defaults applied to a freshly added GPU collection (vendor preset, model left for the user to pick). */
+export const defaultGpuModel = { vendor: "nvidia", name: "", memory: "", interface: "" };
+
 export const SSH_VM_IMAGES = {
   "Ubuntu 24.04": "ghcr.io/akash-network/ubuntu-2404-ssh:2",
   "CentOS Stream 9": "ghcr.io/akash-network/centos-stream9-ssh:2",

--- a/apps/deploy-web/src/utils/sdl/validateGeneratedSdl.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/validateGeneratedSdl.spec.ts
@@ -1,0 +1,65 @@
+import type { ValidationError } from "@akashnetwork/chain-sdk/web";
+import { describe, expect, it } from "vitest";
+
+import { defaultServiceWithPlacement } from "./data";
+import { generateSdl } from "./sdlGenerator";
+import { formatSdlValidationError, validateGeneratedSdl } from "./validateGeneratedSdl";
+
+describe(validateGeneratedSdl.name, () => {
+  it("returns no errors for a valid SDL", () => {
+    const sdl = generateSdl(defaultServiceWithPlacement({ image: "nginx:latest" }));
+
+    expect(validateGeneratedSdl(sdl)).toEqual([]);
+  });
+
+  it("reports a cpu-gpu service that declares no GPU resources", () => {
+    const sdl = generateSdl(defaultServiceWithPlacement({ image: "nginx:latest", params: { tee: "cpu-gpu" } }));
+
+    expect(validateGeneratedSdl(sdl).some(error => error.includes("/params/tee") && /gpu/i.test(error))).toBe(true);
+  });
+
+  it("accepts a cpu TEE service without GPU resources", () => {
+    const sdl = generateSdl(defaultServiceWithPlacement({ image: "nginx:latest", params: { tee: "cpu" } }));
+
+    expect(validateGeneratedSdl(sdl)).toEqual([]);
+  });
+
+  it("returns no errors when the input does not parse into an object", () => {
+    expect(validateGeneratedSdl("::: not valid yaml :::")).toEqual([]);
+    expect(validateGeneratedSdl("just a string")).toEqual([]);
+  });
+});
+
+describe(formatSdlValidationError.name, () => {
+  it("formats a missing required property", () => {
+    const message = formatSdlValidationError(error({ keyword: "required", instancePath: "/services/web", params: { missingProperty: "image" } }));
+
+    expect(message).toBe("/services/web: missing required property 'image'");
+  });
+
+  it("formats an unknown property", () => {
+    const message = formatSdlValidationError(
+      error({ keyword: "additionalProperties", instancePath: "/services/web/params", params: { additionalProperty: "foo" } })
+    );
+
+    expect(message).toBe("/services/web/params: unknown property 'foo'");
+  });
+
+  it("formats a type mismatch", () => {
+    const message = formatSdlValidationError(
+      error({ keyword: "type", instancePath: "/services/web/params/tee", params: { type: "string" }, message: "must be string" })
+    );
+
+    expect(message).toBe("/services/web/params/tee: must be string (expected string)");
+  });
+
+  it("falls back to (root) and the raw message when there is no instance path", () => {
+    const message = formatSdlValidationError(error({ keyword: "enum", instancePath: "", params: {}, message: "must be equal to one of the allowed values" }));
+
+    expect(message).toBe("(root): must be equal to one of the allowed values");
+  });
+
+  function error(overrides: Partial<ValidationError>): ValidationError {
+    return { schemaPath: "", instancePath: "", keyword: "", params: {}, message: "", ...overrides };
+  }
+});

--- a/apps/deploy-web/src/utils/sdl/validateGeneratedSdl.ts
+++ b/apps/deploy-web/src/utils/sdl/validateGeneratedSdl.ts
@@ -1,0 +1,55 @@
+import type { SDLInput, ValidationError } from "@akashnetwork/chain-sdk/web";
+import { validateSDL } from "@akashnetwork/chain-sdk/web";
+import yaml from "js-yaml";
+
+/**
+ * Runs the chain-sdk SDL validator over a generated SDL YAML string and returns
+ * human-readable error messages (empty when the SDL is valid). This is the same
+ * validation the SDL editor surfaces as inline markers, lifted out so the
+ * builder flow can gate "Request quotes" on it too.
+ *
+ * `validateSDL` enforces semantic rules the zod form schema can't, most notably
+ * the TEE rules: a `cpu-gpu` service must declare GPU resources, and the `tee`
+ * value must be one of the allowed types. A YAML that doesn't parse into an
+ * object yields no errors here — the generator only ever emits valid YAML, and
+ * structural form problems are already caught by the zod schema.
+ */
+export function validateGeneratedSdl(sdl: string): string[] {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(sdl);
+  } catch {
+    return [];
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    return [];
+  }
+
+  const errors = validateSDL(parsed as SDLInput);
+  return (errors ?? []).map(formatSdlValidationError);
+}
+
+/**
+ * Formats a single chain-sdk validation error into a readable line, prefixed
+ * with the offending instance path. Shared with the SDL editor's Monaco markers
+ * so both surfaces phrase the same error identically.
+ */
+export function formatSdlValidationError(error: ValidationError): string {
+  const path = error.instancePath || "(root)";
+  const baseMessage = error.message || "Validation error";
+
+  if (error.keyword === "required" && error.params && "missingProperty" in error.params) {
+    return `${path}: missing required property '${error.params.missingProperty}'`;
+  }
+
+  if (error.keyword === "additionalProperties" && error.params && "additionalProperty" in error.params) {
+    return `${path}: unknown property '${error.params.additionalProperty}'`;
+  }
+
+  if (error.keyword === "type" && error.params && "type" in error.params) {
+    return `${path}: ${baseMessage} (expected ${error.params.type})`;
+  }
+
+  return `${path}: ${baseMessage}`;
+}

--- a/packages/docker/.env.sandbox.docker-compose-dev
+++ b/packages/docker/.env.sandbox.docker-compose-dev
@@ -6,7 +6,7 @@ POSTGRES_DB_URI=postgres://postgres:password@db:5432/console-users
 DB_HOST=db
 NOTIFICATIONS_API_BASE_URL=http://notifications:3000
 TX_SIGNER_BASE_URL=http://tx-signer:3000
-PROVIDER_INVENTORY_BASE_URL=http://provider-inventory:3000
+PROVIDER_INVENTORY_API_URL=http://provider-inventory:3000
 
 # Deploy Web
 API_BASE_URL=http://api:3000


### PR DESCRIPTION
## Why

closes CON-573

## What

https://github.com/user-attachments/assets/878ffdb7-3fcc-474a-b2f4-7291d30b6178





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Confidential Compute hardware option to configure CPU vs CPU-GPU, including guidance via tooltip and proper locked-state behavior.
  * Deployment headers now validate generated configuration (SDL) before requesting quotes, surfacing validation errors in a snackbar.
* **Bug Fixes**
  * Prevented a potential crash when log collector service titles are missing.
  * Improved Monaco SDL validation marker messages for consistent, user-friendly formatting.
* **Tests**
  * Added/expanded coverage for Confidential Compute behavior, SDL validation, quote-request error handling, and related flow updates.
* **Chores**
  * Updated sandbox provider inventory environment variable naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->