### PR TITLE
feat(sdl): add reclamation window control to deployment pane

### DIFF
--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -1970,7 +1970,7 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "default": "2026-06-17",
+              "default": "2026-06-26",
               "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
               "example": "2024-01-31"
             },
@@ -2096,7 +2096,7 @@
             "schema": {
               "type": "string",
               "format": "date",
-              "default": "2026-06-17",
+              "default": "2026-06-26",
               "description": "End date (YYYY-MM-DD). Defaults to today by UTC 23:59:59",
               "example": "2024-01-31"
             },
@@ -16769,6 +16769,13 @@
                     "type": "string",
                     "description": "Client timezone, validated against supported Node.js Intl timezones",
                     "example": "America/Chicago"
+                  },
+                  "reclamationWindow": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "exclusiveMinimum": true,
+                    "description": "Optional reclamation window in seconds; if provided, only providers with a reclamationWindow greater than or equal to this value will be considered",
+                    "example": 3600
                   }
                 },
                 "required": [

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
@@ -6,9 +6,10 @@ import { InfoCircle, Plus, SidebarCollapse, SidebarExpand } from "iconoir-react"
 import { PaneLockBanner } from "../PaneLockBanner/PaneLockBanner";
 import { IpEndpointsSection } from "./IpEndpointsSection/IpEndpointsSection";
 import { PlacementCard } from "./PlacementCard/PlacementCard";
+import { ReclamationSection } from "./ReclamationSection/ReclamationSection";
 import { usePlacementManager } from "./usePlacementManager/usePlacementManager";
 
-export const DEPENDENCIES = { PlacementCard, usePlacementManager, IpEndpointsSection };
+export const DEPENDENCIES = { PlacementCard, usePlacementManager, IpEndpointsSection, ReclamationSection };
 
 type Props = {
   selectedServiceId: string;
@@ -54,6 +55,7 @@ export const DeploymentPane: FC<Props> = ({
       </header>
       {locked ? <PaneLockBanner onCancelAndEdit={onCancelAndEdit ?? noop} isClosing={isClosing} /> : null}
       <div className="flex-1 space-y-6 overflow-y-auto p-4">
+        <d.ReclamationSection locked={locked} />
         <div className="space-y-2">
           <div className="flex items-center gap-2 px-1 font-mono text-xs uppercase text-muted-foreground">
             Placement

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ReclamationSection/ReclamationSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ReclamationSection/ReclamationSection.spec.tsx
@@ -1,0 +1,91 @@
+import type { PropsWithChildren } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { TooltipProvider } from "@akashnetwork/ui/components";
+import { describe, expect, it } from "vitest";
+
+import type { ReclamationMinWindow, SdlBuilderFormValuesType } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { ReclamationSection } from "./ReclamationSection";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(ReclamationSection.name, () => {
+  it("renders the Reclamation label", () => {
+    setup();
+    expect(screen.getByText("Reclamation")).toBeInTheDocument();
+  });
+
+  it("defaults to Any when no reclamation window is set", () => {
+    setup();
+    expect(screen.getByRole("combobox", { name: "Reclamation" })).toHaveTextContent("Any");
+  });
+
+  it("reflects the existing reclamation window selection", () => {
+    setup({ reclamationMinWindow: "24h" });
+    expect(screen.getByRole("combobox", { name: "Reclamation" })).toHaveTextContent("1 day");
+  });
+
+  it.each([
+    { label: "1 hour", expected: "1h" },
+    { label: "4 hours", expected: "4h" },
+    { label: "1 day", expected: "24h" },
+    { label: "3 days", expected: "72h" }
+  ])("writes $expected to reclamationMinWindow when $label is picked", async ({ label, expected }) => {
+    const { getValues } = setup();
+
+    await userEvent.click(screen.getByRole("combobox", { name: "Reclamation" }));
+    await userEvent.click(await screen.findByRole("option", { name: label }));
+
+    expect(getValues().reclamationMinWindow).toBe(expected);
+  });
+
+  it("offers Any as a selectable option from the default state", async () => {
+    const { getValues } = setup();
+
+    await userEvent.click(screen.getByRole("combobox", { name: "Reclamation" }));
+    const anyOption = await screen.findByRole("option", { name: "Any" });
+    expect(anyOption).toBeEnabled();
+
+    await userEvent.click(anyOption);
+
+    expect(getValues().reclamationMinWindow).toBeUndefined();
+  });
+
+  it("clears reclamationMinWindow back to Any when Any is picked after a value", async () => {
+    const { getValues } = setup({ reclamationMinWindow: "24h" });
+
+    await userEvent.click(screen.getByRole("combobox", { name: "Reclamation" }));
+    await userEvent.click(await screen.findByRole("option", { name: "Any" }));
+
+    expect(getValues().reclamationMinWindow).toBeUndefined();
+  });
+
+  it("disables the control when the pane is locked", () => {
+    setup({ locked: true });
+    expect(screen.getByRole("combobox", { name: "Reclamation" })).toBeDisabled();
+  });
+
+  function setup(input: { reclamationMinWindow?: ReclamationMinWindow; locked?: boolean } = {}) {
+    const values: SdlBuilderFormValuesType = { ...defaultServiceWithPlacement(), reclamationMinWindow: input.reclamationMinWindow };
+
+    let getValues: () => SdlBuilderFormValuesType = () => values;
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values });
+      getValues = form.getValues;
+      return (
+        <TooltipProvider>
+          <FormProvider {...form}>{children}</FormProvider>
+        </TooltipProvider>
+      );
+    };
+
+    render(
+      <Wrapper>
+        <ReclamationSection locked={input.locked} />
+      </Wrapper>
+    );
+
+    return { getValues: () => getValues() };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ReclamationSection/ReclamationSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/ReclamationSection/ReclamationSection.tsx
@@ -1,0 +1,88 @@
+import type { FC } from "react";
+import { Controller, useFormContext } from "react-hook-form";
+import { CustomTooltip, Select, SelectContent, SelectGroup, SelectItem, SelectTrigger, SelectValue } from "@akashnetwork/ui/components";
+import { InfoCircle } from "iconoir-react";
+
+import type { ReclamationMinWindow, SdlBuilderFormValuesType } from "@src/types";
+
+/**
+ * Sentinel value for the selectable "Any" item. Radix forbids empty-string item values, so the
+ * "no requirement" choice needs a non-empty marker. It is intentionally distinct from the Select's
+ * cleared value (the empty string): keeping them different means "Any" is never the active value, so
+ * clicking it always fires `onValueChange` instead of being a no-op on the already-selected item.
+ */
+export const RECLAMATION_ANY_VALUE = "any";
+
+/**
+ * Dropdown options for the reclamation window. Each option carries a friendly `label` and the SDL
+ * duration `value` it maps to. "Any" is the default — it means the user has no requirement, so it is
+ * represented by the {@link RECLAMATION_ANY_VALUE} sentinel and omitted from the generated SDL.
+ */
+export const RECLAMATION_WINDOW_OPTIONS: ReadonlyArray<{ label: string; value: ReclamationMinWindow | typeof RECLAMATION_ANY_VALUE }> = [
+  { label: "Any", value: RECLAMATION_ANY_VALUE },
+  { label: "1 hour", value: "1h" },
+  { label: "4 hours", value: "4h" },
+  { label: "1 day", value: "24h" },
+  { label: "3 days", value: "72h" }
+];
+
+type Props = {
+  /** While the pane is locked the control is disabled so it can't be edited while quotes are active. */
+  locked?: boolean;
+};
+
+export const ReclamationSection: FC<Props> = ({ locked = false }) => {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+
+  return (
+    <fieldset disabled={locked} className="m-0 min-w-0 space-y-2 border-0 p-0">
+      <div className="flex items-center gap-2 px-1 font-mono text-xs uppercase text-muted-foreground">
+        Reclamation
+        <CustomTooltip
+          className="max-w-[260px] p-3 font-sans text-xs normal-case text-muted-foreground"
+          title={
+            <>
+              <strong>Minimum Reclamation Window</strong>
+              <br />
+              <br />
+              The minimum notice a provider must give before reclaiming your deployment, giving you time to migrate your workload.
+              <br />
+              <br />
+              Selecting a value narrows the pool of eligible providers — the larger the window, the fewer providers can satisfy it.
+              <br />
+              <br />
+              Choose <strong>Any</strong> if you have no requirement.
+            </>
+          }
+        >
+          <InfoCircle className="h-3.5 w-3.5" />
+        </CustomTooltip>
+      </div>
+
+      <Controller
+        control={control}
+        name="reclamationMinWindow"
+        render={({ field }) => (
+          <Select
+            disabled={locked}
+            value={field.value ?? ""}
+            onValueChange={value => field.onChange(value === RECLAMATION_ANY_VALUE ? undefined : (value as ReclamationMinWindow))}
+          >
+            <SelectTrigger aria-label="Reclamation" className="h-8 w-full text-xs">
+              <SelectValue placeholder="Any" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {RECLAMATION_WINDOW_OPTIONS.map(option => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        )}
+      />
+    </fieldset>
+  );
+};

--- a/apps/deploy-web/src/queries/useScreenedProviders.ts
+++ b/apps/deploy-web/src/queries/useScreenedProviders.ts
@@ -1,11 +1,11 @@
 import { useMemo } from "react";
 import { GroupSpec } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { generateManifest, type SDLInput, yaml } from "@akashnetwork/chain-sdk/web";
 import type { paths } from "@akashnetwork/console-api-types";
 import { keepPreviousData } from "@tanstack/react-query";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { usePacedValue } from "@src/hooks/usePacedValue/usePacedValue";
-import { DeploymentGroups } from "@src/utils/deploymentData/helpers";
 import { AUDITOR } from "@src/utils/deploymentData/v1beta3";
 
 type ScreeningRequest = NonNullable<paths["/v1/bid-screening"]["post"]["requestBody"]>["content"]["application/json"];
@@ -50,7 +50,8 @@ export function useScreenedProviders({ sdl, placementName, region, enabled = tru
   const { api } = useServices();
   const request = useMemo(() => {
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    return { ...(buildPlacementScreeningRequest(sdl, placementName) ?? buildCatalogScreeningRequest(region)), timezone };
+    const req = buildPlacementScreeningRequest(sdl, placementName) ?? buildCatalogScreeningRequest(region);
+    return { ...req, timezone };
   }, [sdl, placementName, region]);
   const pacedRequest = usePacedValue(request, { wait: SCREENING_DEBOUNCE_MS, maxWait: SCREENING_MAX_WAIT_MS });
   const query = api.v1.screenProviders.useQuery(pacedRequest, { enabled, placeholderData: keepPreviousData });
@@ -69,31 +70,35 @@ export function useScreenedProviders({ sdl, placementName, region, enabled = tru
  * from the placement and carry the `location-region` filter (and any other declared attribute). The proto
  * JSON encodes resource values as base64 integer strings, which the screening endpoint accepts.
  */
-export function buildPlacementScreeningRequest(sdl: string, placementName: string): ScreeningRequestBody | null {
-  if (!sdl) return null;
+export function buildPlacementScreeningRequest(rawSdl: string, placementName: string): ScreeningRequestBody | null {
+  if (!rawSdl) return null;
 
-  let groups: ReturnType<typeof DeploymentGroups>;
   try {
-    groups = DeploymentGroups(sdl);
+    // `yaml.raw` throws on malformed YAML (e.g. mid-edit), so the whole conversion is guarded: any
+    // parse/manifest failure returns null, letting the caller fall back to the full catalog.
+    const manifestResult = generateManifest(yaml.raw(rawSdl) as SDLInput);
+    if (!manifestResult.ok) return null;
+
+    const manifest = manifestResult.value;
+    const group = manifest.groupSpecs.find(candidate => candidate.name === placementName);
+    if (!group) return null;
+
+    const groupJson = GroupSpec.toJSON(group) as {
+      resources: ScreeningRequest["resources"];
+      requirements?: { attributes?: Array<{ key: string; value: string }> };
+    };
+
+    return {
+      requirements: {
+        signedBy: { allOf: [AUDITOR] },
+        attributes: groupJson.requirements?.attributes ?? []
+      },
+      resources: groupJson.resources,
+      reclamationWindow: manifest.reclamation?.minWindow?.seconds.toInt()
+    };
   } catch {
     return null;
   }
-
-  const group = groups.find(candidate => candidate.name === placementName);
-  if (!group) return null;
-
-  const groupJson = GroupSpec.toJSON(group) as {
-    resources: ScreeningRequest["resources"];
-    requirements?: { attributes?: Array<{ key: string; value: string }> };
-  };
-
-  return {
-    requirements: {
-      signedBy: { allOf: [AUDITOR] },
-      attributes: groupJson.requirements?.attributes ?? []
-    },
-    resources: groupJson.resources
-  };
 }
 
 /**

--- a/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
+++ b/apps/deploy-web/src/types/sdlBuilder/sdlBuilder.ts
@@ -452,11 +452,22 @@ const logProviderVars = z.discriminatedUnion("PROVIDER", [
   })
 ]);
 
+/**
+ * Allowed `reclamation.min_window` durations exposed by the builder. The user picks a friendly label
+ * (1hr / 4hrs / 1day / 3days) and "Any"; "Any" means no requirement and is represented as an absent
+ * field, so it is intentionally not part of this enum.
+ */
+export const RECLAMATION_MIN_WINDOW_VALUES = ["1h", "4h", "24h", "72h"] as const;
+export const ReclamationMinWindowSchema = z.enum(RECLAMATION_MIN_WINDOW_VALUES);
+export type ReclamationMinWindow = z.infer<typeof ReclamationMinWindowSchema>;
+
 export const SdlBuilderFormValuesSchema = z
   .object({
     placements: z.array(PlacementSchema).min(1, { message: "At least one placement is required." }),
     services: z.array(ServiceSchema).min(1, { message: "At least one service is required." }),
-    endpoints: z.array(EndpointSchema).optional().default([])
+    endpoints: z.array(EndpointSchema).optional().default([]),
+    // Optional deployment-level reclamation requirement; maps to `reclamation.min_window` in the SDL.
+    reclamationMinWindow: ReclamationMinWindowSchema.optional()
   })
   .merge(ImageList)
   .merge(SSHKey)

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
@@ -105,6 +105,22 @@ describe("sdlGenerator", () => {
       expect(parsed.endpoints).toEqual({ "endpoint-1": { kind: "ip" } });
     });
 
+    it("omits reclamation when reclamationMinWindow is unset", () => {
+      const result = generateSdl(buildFormValues(buildLogCollectorService({ title: "web", image: "nginx:latest" })));
+      const parsed = yaml.load(result) as { reclamation?: unknown };
+
+      expect(parsed.reclamation).toBeUndefined();
+    });
+
+    it.each([["1h"], ["4h"], ["24h"], ["72h"]] as const)("emits reclamation.min_window %s when reclamationMinWindow is set", minWindow => {
+      const formValues = buildFormValues(buildLogCollectorService({ title: "web", image: "nginx:latest" }));
+      formValues.reclamationMinWindow = minWindow;
+      const result = generateSdl(formValues);
+      const parsed = yaml.load(result) as { reclamation?: { min_window?: string } };
+
+      expect(parsed.reclamation).toEqual({ min_window: minWindow });
+    });
+
     function buildLogCollectorService(overrides?: Partial<ServiceType>): ServiceType {
       return {
         id: overrides?.title ? `${overrides.title}-id` : "web-log-collector",

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
@@ -18,6 +18,13 @@ export const buildCommand = (command: string): string[] => {
 
 export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
   const sdl: Record<string, any> = { version: "2.0", services: {}, profiles: { compute: {}, placement: {} }, deployment: {} };
+
+  // Optional deployment-level reclamation requirement. Omitted entirely when unset ("Any"), which
+  // signals the user has no minimum-window requirement.
+  if (formValues.reclamationMinWindow) {
+    sdl.reclamation = { min_window: formValues.reclamationMinWindow };
+  }
+
   const placementById = new Map<string, PlacementType>(formValues.placements.map(p => [p.id, p]));
 
   formValues.placements.forEach(placement => {

--- a/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
@@ -338,3 +338,62 @@ describe("importSimpleSdl endpoints", () => {
     expect(imported.endpoints?.map(endpoint => endpoint.name)).toEqual(["endpoint-1"]);
   });
 });
+
+const reclamationSdl = (minWindow: string) =>
+  [
+    "version: '2.0'",
+    "reclamation:",
+    `  min_window: ${minWindow}`,
+    "services:",
+    "  web:",
+    "    image: nginx:latest",
+    "    expose:",
+    "      - port: 80",
+    "        as: 80",
+    "        to:",
+    "          - global: true",
+    "profiles:",
+    "  compute:",
+    "    web:",
+    "      resources:",
+    "        cpu:",
+    "          units: 0.5",
+    "        memory:",
+    "          size: 512Mi",
+    "        storage:",
+    "          - size: 512Mi",
+    "  placement:",
+    "    dcloud:",
+    "      pricing:",
+    "        web:",
+    "          denom: uakt",
+    "          amount: 1000",
+    "deployment:",
+    "  web:",
+    "    dcloud:",
+    "      profile: web",
+    "      count: 1"
+  ].join("\n");
+
+describe("importSimpleSdl reclamation", () => {
+  it.each([["1h"], ["4h"], ["24h"], ["72h"]] as const)("imports reclamation.min_window %s into reclamationMinWindow", minWindow => {
+    expect(importSimpleSdl(reclamationSdl(minWindow)).reclamationMinWindow).toBe(minWindow);
+  });
+
+  it("leaves reclamationMinWindow undefined when there is no reclamation block", () => {
+    const yml = fs.readFileSync(path.resolve(__dirname, "../../../tests/mocks/two-services-sdl.yml"), "utf8");
+
+    expect(importSimpleSdl(yml).reclamationMinWindow).toBeUndefined();
+  });
+
+  it("ignores a reclamation window the builder cannot represent", () => {
+    expect(importSimpleSdl(reclamationSdl("30m")).reclamationMinWindow).toBeUndefined();
+  });
+
+  it.each([["1h"], ["24h"]] as const)("round-trips reclamation.min_window %s through import then regeneration", minWindow => {
+    const regenerated = generateSdl(importSimpleSdl(reclamationSdl(minWindow)));
+    const parsed = yaml.load(regenerated) as { reclamation?: { min_window?: string } };
+
+    expect(parsed.reclamation).toEqual({ min_window: minWindow });
+  });
+});

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -2,7 +2,7 @@ import yaml from "js-yaml";
 import { nanoid } from "nanoid";
 
 import type { EndpointType, ExposeType, PlacementAttributeType, PlacementType, ProfileGpuModelType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
-import { RESERVED_ENV_KEYS } from "@src/types/sdlBuilder/sdlBuilder";
+import { ReclamationMinWindowSchema, RESERVED_ENV_KEYS } from "@src/types/sdlBuilder/sdlBuilder";
 import { CustomValidationError } from "../deploymentData";
 import { capitalizeFirstLetter } from "../stringUtils";
 import { defaultHttpOptions } from "./data";
@@ -42,7 +42,12 @@ export const importSimpleSdl = (yamlStr: string, { placementPerService = false }
         ? Object.keys(yamlJson.endpoints).map(name => ({ id: nanoid(), name }))
         : [];
 
-    if (!yamlJson.services) return { placements, services, endpoints };
+    // Only round-trip a reclamation window the builder can represent in its dropdown; any other
+    // value falls back to "Any" (omitted) rather than producing an invalid form state.
+    const reclamationParse = ReclamationMinWindowSchema.safeParse(yamlJson.reclamation?.min_window);
+    const reclamationMinWindow = reclamationParse.success ? reclamationParse.data : undefined;
+
+    if (!yamlJson.services) return { placements, services, endpoints, reclamationMinWindow };
 
     Object.keys(yamlJson.services).forEach(svcName => {
       const svc = yamlJson.services[svcName];
@@ -179,7 +184,7 @@ export const importSimpleSdl = (yamlStr: string, { placementPerService = false }
       services.push(service as ServiceType);
     });
 
-    return { placements, services, endpoints };
+    return { placements, services, endpoints, reclamationMinWindow };
   } catch (error) {
     console.error(error);
     throw error;

--- a/packages/console-api-types/src/schema.d.ts
+++ b/packages/console-api-types/src/schema.d.ts
@@ -8670,6 +8670,11 @@ export interface operations {
            * @example America/Chicago
            */
           timezone: string;
+          /**
+           * @description Optional reclamation window in seconds; if provided, only providers with a reclamationWindow greater than or equal to this value will be considered
+           * @example 3600
+           */
+          reclamationWindow?: number;
         };
       };
     };


### PR DESCRIPTION
## Why

Closes CON-574

## What


https://github.com/user-attachments/assets/e07005b0-c32d-4a89-9965-52a308a1a809




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Minimum Reclamation Window” option to deployment configuration, with choices for Any, 1 hour, 4 hours, 1 day, and 3 days.
  * Deployment exports now include the reclamation setting when selected, and imports preserve it when supported.

* **Bug Fixes**
  * Unsupported reclamation values are now safely ignored instead of creating invalid form state.
  * Provider screening now respects the selected reclamation window when filtering results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->