### PR TITLE
feat(deployment): add expose ports and logs configure cards

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.spec.tsx
@@ -10,24 +10,32 @@ describe(AdditionalSection.name, () => {
     const ImageRuntimeCard = vi.fn(() => null);
     const EnvironmentVariablesCard = vi.fn(() => null);
     const CommandsCard = vi.fn(() => null);
+    const ExposePortsCard = vi.fn(() => null);
+    const LogsCard = vi.fn(() => null);
 
-    setup({ serviceIndex: 2, dependencies: { ImageRuntimeCard, EnvironmentVariablesCard, CommandsCard } });
+    setup({ serviceIndex: 2, dependencies: { ImageRuntimeCard, EnvironmentVariablesCard, CommandsCard, ExposePortsCard, LogsCard } });
 
     expect(ImageRuntimeCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
     expect(EnvironmentVariablesCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
     expect(CommandsCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
+    expect(ExposePortsCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
+    expect(LogsCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
   });
 
   it("forwards the locked state to every additional card", () => {
     const ImageRuntimeCard = vi.fn(() => null);
     const EnvironmentVariablesCard = vi.fn(() => null);
     const CommandsCard = vi.fn(() => null);
+    const ExposePortsCard = vi.fn(() => null);
+    const LogsCard = vi.fn(() => null);
 
-    setup({ locked: true, dependencies: { ImageRuntimeCard, EnvironmentVariablesCard, CommandsCard } });
+    setup({ locked: true, dependencies: { ImageRuntimeCard, EnvironmentVariablesCard, CommandsCard, ExposePortsCard, LogsCard } });
 
     expect(ImageRuntimeCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
     expect(EnvironmentVariablesCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
     expect(CommandsCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(ExposePortsCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(LogsCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
   });
 
   function setup(input: { serviceIndex?: number; locked?: boolean; dependencies?: Partial<typeof DEPENDENCIES> }) {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.tsx
@@ -2,9 +2,11 @@ import type { FC } from "react";
 
 import { CommandsCard } from "../CommandsCard/CommandsCard";
 import { EnvironmentVariablesCard } from "../EnvironmentVariablesCard/EnvironmentVariablesCard";
+import { ExposePortsCard } from "../ExposePortsCard/ExposePortsCard";
 import { ImageRuntimeCard } from "../ImageRuntimeCard/ImageRuntimeCard";
+import { LogsCard } from "../LogsCard/LogsCard";
 
-export const DEPENDENCIES = { ImageRuntimeCard, EnvironmentVariablesCard, CommandsCard };
+export const DEPENDENCIES = { ImageRuntimeCard, EnvironmentVariablesCard, CommandsCard, ExposePortsCard, LogsCard };
 
 type Props = {
   serviceIndex: number;
@@ -28,6 +30,10 @@ export const AdditionalSection: FC<Props> = ({ serviceIndex, locked = false, dep
         <d.EnvironmentVariablesCard serviceIndex={serviceIndex} locked={locked} />
 
         <d.CommandsCard serviceIndex={serviceIndex} locked={locked} />
+
+        <d.ExposePortsCard serviceIndex={serviceIndex} locked={locked} />
+
+        <d.LogsCard serviceIndex={serviceIndex} locked={locked} />
       </div>
     </div>
   );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.spec.tsx
@@ -1,0 +1,514 @@
+import type { PropsWithChildren } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import { FormProvider, useForm, useFormContext, useFormState } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { describe, expect, it } from "vitest";
+
+import type { ExposeType, SdlBuilderFormValuesType } from "@src/types";
+import { SdlBuilderFormValuesSchema } from "@src/types/sdlBuilder/sdlBuilder";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import {
+  DEPENDENCIES,
+  ExposePortsCard,
+  hostnamesToInput,
+  inputToHostnames,
+  INTERNAL_ROUTING,
+  PUBLIC_ROUTING,
+  routingToModel,
+  routingValueOf
+} from "./ExposePortsCard";
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(ExposePortsCard.name, () => {
+  it("opens the modal when the card is clicked", async () => {
+    const { openCard } = setup({});
+
+    await openCard();
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Exposed ports")).toBeInTheDocument();
+  });
+
+  it("opens for viewing but disables the inputs and Save while locked", async () => {
+    const { openCard } = setup({ expose: [{ port: 8080, as: 443 }], locked: true });
+
+    await openCard();
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByLabelText("Port 1 container port")).toBeDisabled();
+    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+  });
+
+  it("highlights the card after submit when an exposed port is invalid", async () => {
+    const { submit } = setup({ expose: [{ port: 0 }] });
+
+    await submit();
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /Expose Ports/ })).toHaveClass("border-destructive"));
+  });
+
+  it("does not highlight the card before the form is submitted", async () => {
+    const { trigger } = setup({ expose: [{ port: 0 }] });
+
+    await trigger();
+
+    expect(screen.getByRole("button", { name: /Expose Ports/ })).not.toHaveClass("border-destructive");
+  });
+
+  it("does not surface errors when the modal is closed before submitting", async () => {
+    const { openCard, getErrors } = setup({ expose: [{ port: 0 }] });
+
+    await openCard();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByRole("button", { name: /Expose Ports/ })).not.toHaveClass("border-destructive");
+    expect(getErrors().services).toBeUndefined();
+  });
+
+  it("shows the existing port mapping in the modal", async () => {
+    const { openCard } = setup({ expose: [{ port: 8080, as: 443, proto: "tcp" }] });
+
+    await openCard();
+
+    expect(screen.getByLabelText("Port 1 container port")).toHaveValue(8080);
+    expect(screen.getByLabelText("Port 1 exposed as")).toHaveValue(443);
+  });
+
+  it("shows the port count in the card header summary", () => {
+    setup({
+      expose: [
+        { port: 80, as: 80 },
+        { port: 443, as: 443 }
+      ]
+    });
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("appends a new port row when Add another port is clicked", async () => {
+    const { openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+    await openCard();
+    await userEvent.click(screen.getByRole("button", { name: "Add another port" }));
+
+    expect(screen.getByLabelText("Port 2 container port")).toBeInTheDocument();
+  });
+
+  it("updates the footer port count live as rows are added and removed, before saving", async () => {
+    const { openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+    await openCard();
+    expect(screen.getByText("1 port")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Add another port" }));
+    expect(screen.getByText("2 ports")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove port 2" }));
+    expect(screen.getByText("1 port")).toBeInTheDocument();
+  });
+
+  it("does not render a remove control when only one port is in the list", async () => {
+    const { openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+    await openCard();
+
+    expect(screen.queryByRole("button", { name: "Remove port 1" })).not.toBeInTheDocument();
+  });
+
+  it("commits changes and closes the modal on Save", async () => {
+    const { getValues, openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+    await openCard();
+    setPort("Port 1 container port", "3000");
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(getValues().services[0].expose[0].port).toBe(3000);
+  });
+
+  it("reverts changes and closes the modal on Cancel", async () => {
+    const { getValues, openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+    await openCard();
+    setPort("Port 1 container port", "3000");
+
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(getValues().services[0].expose[0].port).toBe(80);
+  });
+
+  it("removes a port when its remove control is clicked and saved", async () => {
+    const { getValues, openCard } = setup({
+      expose: [
+        { port: 80, as: 80 },
+        { port: 443, as: 443 }
+      ]
+    });
+
+    await openCard();
+    await userEvent.click(screen.getByRole("button", { name: "Remove port 1" }));
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(getValues().services[0].expose).toEqual([expect.objectContaining({ port: 443, as: 443 })]);
+  });
+
+  it("hides the accept hostnames input when the port is internal", async () => {
+    const { openCard } = setup({ expose: [{ port: 80, as: 80, global: false }] });
+
+    await openCard();
+
+    expect(screen.queryByLabelText("Port 1 accept hostnames")).not.toBeInTheDocument();
+  });
+
+  it("shows the accept hostnames input when the port is externally reachable", async () => {
+    const { openCard } = setup({ expose: [{ port: 80, as: 80, global: true }] });
+
+    await openCard();
+
+    expect(screen.getByLabelText("Port 1 accept hostnames")).toBeInTheDocument();
+  });
+
+  it("treats a port bound to an IP endpoint as externally reachable and round-trips the binding", async () => {
+    const { getValues, openCard } = setup({
+      expose: [{ port: 80, as: 80, global: true, ipName: "endpoint-1" }],
+      endpoints: [{ id: "ep-1", name: "endpoint-1" }]
+    });
+
+    await openCard();
+    expect(screen.getByLabelText("Port 1 accept hostnames")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(getValues().services[0].expose[0].ipName).toBe("endpoint-1");
+    expect(getValues().services[0].expose[0].global).toBe(true);
+  });
+
+  it("seeds the accept hostnames input from the existing accept list", async () => {
+    const { openCard } = setup({ expose: [{ port: 80, as: 80, global: true, accept: [{ value: "example.com" }, { value: "api.example.com" }] }] });
+
+    await openCard();
+
+    expect(screen.getByLabelText("Port 1 accept hostnames")).toHaveValue("example.com, api.example.com");
+  });
+
+  it("stores comma-separated hostnames as the accept list", async () => {
+    const { getValues, openCard } = setup({ expose: [{ port: 80, as: 80, global: true }] });
+
+    await openCard();
+    await userEvent.type(screen.getByLabelText("Port 1 accept hostnames"), "example.com, api.example.com");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(getValues().services[0].expose[0].accept).toEqual([
+      expect.objectContaining({ value: "example.com" }),
+      expect.objectContaining({ value: "api.example.com" })
+    ]);
+  });
+
+  it("surfaces an inline error when a port is out of range", async () => {
+    const { openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+    await openCard();
+    setPort("Port 1 container port", "70000");
+
+    expect(await screen.findByText("Port number must be at most 65535.")).toBeInTheDocument();
+  });
+
+  it("keeps validation errors on the rest of the form when saving", async () => {
+    const { trigger, openCard } = setup({ expose: [{ port: 80, as: 80 }], image: "" });
+    await trigger();
+    await waitFor(() => expect(screen.getByTestId("image-error")).not.toBeEmptyDOMElement());
+
+    await openCard();
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(screen.getByTestId("image-error")).not.toBeEmptyDOMElement();
+  });
+
+  describe("To targets", () => {
+    it("does not show the To section when there are no other services", async () => {
+      const { openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+      await openCard();
+
+      expect(screen.queryByLabelText("Port 1 to targets")).not.toBeInTheDocument();
+    });
+
+    it("shows other services as To targets whenever other services exist, independent of log forwarding", async () => {
+      const { openCard } = setup({ expose: [{ port: 80, as: 80 }], extraServiceTitles: ["service-2"] });
+
+      await openCard();
+
+      expect(screen.getByLabelText("Port 1 to targets")).toBeInTheDocument();
+      expect(screen.getByLabelText("service-2")).toBeInTheDocument();
+    });
+
+    it("does not list the current service as a target", async () => {
+      const { openCard } = setup({ expose: [{ port: 80, as: 80 }], extraServiceTitles: ["service-2"] });
+
+      await openCard();
+
+      expect(screen.queryByLabelText("service-1")).not.toBeInTheDocument();
+    });
+
+    it("stores a checked target in the expose to list on Save", async () => {
+      const { getValues, openCard } = setup({ expose: [{ port: 80, as: 80 }], extraServiceTitles: ["service-2"] });
+
+      await openCard();
+      await userEvent.click(screen.getByLabelText("service-2"));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      expect(getValues().services[0].expose[0].to).toEqual([expect.objectContaining({ value: "service-2" })]);
+    });
+  });
+
+  describe("HTTP options", () => {
+    it("hides the HTTP options fields until custom options are enabled", async () => {
+      const { openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+      await openCard();
+
+      expect(screen.queryByLabelText("Max body size")).not.toBeInTheDocument();
+    });
+
+    it("leaves httpOptions absent and the port valid when custom options stay off across Save", async () => {
+      const { getValues, trigger, openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+      await openCard();
+      await userEvent.click(screen.getByRole("button", { name: "Add another port" }));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+      await trigger();
+
+      await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+      expect(screen.getByTestId("expose-error")).toBeEmptyDOMElement();
+      expect(getValues().services[0].expose[0].httpOptions).toBeUndefined();
+    });
+
+    it("seeds the full httpOptions default object when custom options are enabled", async () => {
+      const { getValues, openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+      await openCard();
+      await userEvent.click(screen.getByLabelText("Custom HTTP options"));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      const httpOptions = getValues().services[0].expose[0].httpOptions;
+      expect(httpOptions).toEqual({
+        maxBodySize: 1048576,
+        readTimeout: 60000,
+        sendTimeout: 60000,
+        nextTries: 3,
+        nextTimeout: 60000,
+        nextCases: ["error", "timeout"]
+      });
+    });
+
+    it("reveals and seeds the HTTP options fields when custom options are enabled", async () => {
+      const { openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+      await openCard();
+      await userEvent.click(screen.getByLabelText("Custom HTTP options"));
+
+      expect(screen.getByLabelText("Max body size")).toHaveValue(1048576);
+      expect(screen.getByLabelText("Read timeout")).toHaveValue(60000);
+    });
+
+    it("persists custom HTTP options on Save", async () => {
+      const { getValues, openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+      await openCard();
+      await userEvent.click(screen.getByLabelText("Custom HTTP options"));
+      fireEvent.change(screen.getByLabelText("Max body size"), { target: { value: "2000" } });
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      expect(getValues().services[0].expose[0].hasCustomHttpOptions).toBe(true);
+      expect(getValues().services[0].expose[0].httpOptions?.maxBodySize).toBe(2000);
+    });
+
+    it("toggles a next case on Save", async () => {
+      const { getValues, openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+      await openCard();
+      await userEvent.click(screen.getByLabelText("Custom HTTP options"));
+      await userEvent.click(screen.getByLabelText("503"));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      expect(getValues().services[0].expose[0].httpOptions?.nextCases).toContain("503");
+    });
+
+    it("clears httpOptions when custom options are enabled and then turned back off", async () => {
+      const { getValues, openCard } = setup({ expose: [{ port: 80, as: 80 }] });
+
+      await openCard();
+      await userEvent.click(screen.getByLabelText("Custom HTTP options"));
+      await userEvent.click(screen.getByLabelText("Custom HTTP options"));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      expect(getValues().services[0].expose[0].hasCustomHttpOptions).toBe(false);
+      expect(getValues().services[0].expose[0].httpOptions).toBeUndefined();
+    });
+
+    it("hides the accept hostnames and custom HTTP options for a TCP port", async () => {
+      const { openCard } = setup({ expose: [{ port: 80, as: 80, proto: "tcp" }] });
+
+      await openCard();
+
+      expect(screen.queryByLabelText("Port 1 accept hostnames")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Custom HTTP options")).not.toBeInTheDocument();
+    });
+
+    it("clears accept hostnames and httpOptions when a configured HTTP port switches to TCP", async () => {
+      const { getValues, openCard } = setup({ expose: [{ port: 80, as: 80, proto: "http" }] });
+
+      await openCard();
+      fireEvent.change(screen.getByLabelText("Port 1 accept hostnames"), { target: { value: "example.com" } });
+      await userEvent.click(screen.getByLabelText("Custom HTTP options"));
+      await userEvent.click(screen.getByLabelText("tcp"));
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      const saved = getValues().services[0].expose[0];
+      expect(saved.proto).toBe("tcp");
+      expect(saved.accept).toEqual([]);
+      expect(saved.hasCustomHttpOptions).toBe(false);
+      expect(saved.httpOptions).toBeUndefined();
+    });
+  });
+
+  describe("routingValueOf", () => {
+    it("returns public for a global port with no IP name", () => {
+      expect(routingValueOf({ global: true, ipName: "" })).toBe(PUBLIC_ROUTING);
+    });
+
+    it("returns internal for a non-global port", () => {
+      expect(routingValueOf({ global: false, ipName: "" })).toBe(INTERNAL_ROUTING);
+    });
+
+    it("returns the IP endpoint name when one is bound", () => {
+      expect(routingValueOf({ global: true, ipName: "endpoint-1" })).toBe("endpoint-1");
+    });
+  });
+
+  describe("routingToModel", () => {
+    it("maps public to a global port with no IP name", () => {
+      expect(routingToModel(PUBLIC_ROUTING)).toEqual({ global: true, ipName: "" });
+    });
+
+    it("maps internal to a non-global port with no IP name", () => {
+      expect(routingToModel(INTERNAL_ROUTING)).toEqual({ global: false, ipName: "" });
+    });
+
+    it("binds any other value to that named IP endpoint", () => {
+      expect(routingToModel("endpoint-1")).toEqual({ global: true, ipName: "endpoint-1" });
+    });
+  });
+
+  describe("hostnamesToInput", () => {
+    it("joins the accept list into a comma-separated string", () => {
+      expect(hostnamesToInput([{ value: "example.com" }, { value: "api.example.com" }])).toBe("example.com, api.example.com");
+    });
+
+    it("returns an empty string for an empty or missing accept list", () => {
+      expect(hostnamesToInput([])).toBe("");
+      expect(hostnamesToInput(undefined)).toBe("");
+    });
+  });
+
+  describe("inputToHostnames", () => {
+    it("splits on commas and drops blank entries", () => {
+      expect(inputToHostnames("example.com, , api.example.com,")).toEqual([
+        expect.objectContaining({ value: "example.com" }),
+        expect.objectContaining({ value: "api.example.com" })
+      ]);
+    });
+
+    it("returns an empty list for a blank string", () => {
+      expect(inputToHostnames("   ")).toEqual([]);
+    });
+  });
+
+  function setup(
+    input: {
+      expose?: Array<Partial<ExposeType>>;
+      image?: string;
+      extraServiceTitles?: string[];
+      withLogForwarding?: boolean;
+      endpoints?: Array<{ id: string; name: string }>;
+      locked?: boolean;
+    } = {}
+  ) {
+    const values = defaultServiceWithPlacement(input.image !== undefined ? { image: input.image } : undefined);
+    if (input.expose) {
+      values.services[0].expose = input.expose.map(e => ({ port: 80, as: 80, proto: "http", global: true, to: [], accept: [], ipName: "", ...e }));
+    }
+
+    if (input.endpoints) {
+      values.endpoints = input.endpoints;
+    }
+
+    const parent = values.services[0];
+    (input.extraServiceTitles ?? []).forEach((title, index) => {
+      values.services.push({ ...parent, id: `service-${index + 2}`, title, expose: [] });
+    });
+
+    if (input.withLogForwarding) {
+      values.services.push({
+        ...parent,
+        id: `${parent.id}-log-collector`,
+        title: `${parent.title}-log-collector`,
+        image: "ghcr.io/akash-network/log-collector:2.25.0",
+        expose: [],
+        env: [{ key: "PROVIDER", value: "DATADOG" }]
+      });
+    }
+
+    let form: UseFormReturn<SdlBuilderFormValuesType> | undefined;
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      form = useForm<SdlBuilderFormValuesType>({ defaultValues: values, mode: "onChange", resolver: zodResolver(SdlBuilderFormValuesSchema) });
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    render(
+      <Wrapper>
+        <ExposePortsCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES }} />
+        <ImageErrorProbe serviceIndex={0} />
+        <ExposeErrorProbe serviceIndex={0} />
+      </Wrapper>
+    );
+
+    return {
+      getValues: () => (form as UseFormReturn<SdlBuilderFormValuesType>).getValues(),
+      getErrors: () => (form as UseFormReturn<SdlBuilderFormValuesType>).formState.errors,
+      trigger: () => (form as UseFormReturn<SdlBuilderFormValuesType>).trigger(),
+      submit: () => (form as UseFormReturn<SdlBuilderFormValuesType>).handleSubmit(() => undefined)(),
+      openCard: () => userEvent.click(screen.getByText(/^Expose Ports/))
+    };
+  }
+});
+
+/**
+ * Sets a number input's value. `userEvent` can't reliably overwrite a controlled
+ * `type="number"` input in jsdom (clear/select-all/backspace all leave stale
+ * digits), so the change is fired directly with the full replacement value.
+ */
+function setPort(label: string, value: string) {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } });
+}
+
+/** Surfaces a service's image validation error in the DOM so tests can assert it survives expose edits. */
+function ImageErrorProbe({ serviceIndex }: { serviceIndex: number }) {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const { errors } = useFormState({ control, name: `services.${serviceIndex}.image` });
+  const message = errors.services?.[serviceIndex]?.image?.message;
+  return <div data-testid="image-error">{message ?? ""}</div>;
+}
+
+/** Surfaces whether a service's expose array has any validation errors, so tests can assert the form stays valid. */
+function ExposeErrorProbe({ serviceIndex }: { serviceIndex: number }) {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const { errors } = useFormState({ control, name: `services.${serviceIndex}.expose` });
+  const exposeErrors = errors.services?.[serviceIndex]?.expose;
+  return <div data-testid="expose-error">{exposeErrors ? JSON.stringify(exposeErrors) : ""}</div>;
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
@@ -1,0 +1,604 @@
+"use client";
+import { type FC, useCallback, useId, useMemo, useState } from "react";
+import { useController, useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import {
+  Button,
+  CheckboxWithLabel,
+  CollapsibleCard,
+  DialogV2,
+  DialogV2Body,
+  DialogV2Content,
+  DialogV2Description,
+  DialogV2Footer,
+  DialogV2Header,
+  DialogV2Title,
+  Field,
+  FieldContent,
+  FieldError,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Separator,
+  ToggleGroup,
+  ToggleGroupItem
+} from "@akashnetwork/ui/components";
+import { ChevronRightIcon, GlobeIcon, PlusIcon, SaveIcon, XIcon } from "lucide-react";
+import { nanoid } from "nanoid";
+
+import type { ExposeType, SdlBuilderFormValuesType } from "@src/types";
+import { defaultHttpOptions, nextCases as nextCaseOptions, protoTypes } from "@src/utils/sdl/data";
+import { exposePortsTooltip } from "../cardTooltips";
+
+export const DEPENDENCIES = { CollapsibleCard, DialogV2, DialogV2Content, DialogV2Header, DialogV2Title, DialogV2Description, DialogV2Body, DialogV2Footer };
+
+type Props = {
+  serviceIndex: number;
+  /** While the pane is locked the dialog still opens for viewing but its inputs and Save are disabled. */
+  locked?: boolean;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/** Routing values stored as the `global`/`ipName` pair on the model. */
+export const PUBLIC_ROUTING = "public" as const;
+export const INTERNAL_ROUTING = "internal" as const;
+
+/** The `global`/`ipName` subset of an expose entry that routing derives from and writes back. */
+export type RoutingModel = Pick<ExposeType, "global" | "ipName">;
+
+/**
+ * Collapses the model's `global`/`ipName` pair into the single routing value the
+ * dropdown shows: a non-empty `ipName` selects that IP endpoint, otherwise the
+ * port is "public" when global and "internal" when not.
+ */
+export const routingValueOf = ({ global, ipName }: RoutingModel): string => {
+  if (ipName) return ipName;
+  return global ? PUBLIC_ROUTING : INTERNAL_ROUTING;
+};
+
+/**
+ * Maps a routing dropdown value back onto the model's `global`/`ipName` pair:
+ * "public" is globally reachable with no IP name, "internal" is neither, and any
+ * other value binds the port to that named (publicly routable) IP endpoint.
+ */
+export const routingToModel = (value: string): RoutingModel => {
+  if (value === PUBLIC_ROUTING) return { global: true, ipName: "" };
+  if (value === INTERNAL_ROUTING) return { global: false, ipName: "" };
+  return { global: true, ipName: value };
+};
+
+/** Serializes the accept-hostname list into the comma-separated value the input shows. */
+export const hostnamesToInput = (accept: ExposeType["accept"]): string => (accept ?? []).map(entry => entry.value).join(", ");
+
+/** Parses the comma-separated hostnames input into the model's `accept` list, dropping blanks. */
+export const inputToHostnames = (value: string): NonNullable<ExposeType["accept"]> =>
+  value
+    .split(",")
+    .map(token => token.trim())
+    .filter(Boolean)
+    .map(token => ({ id: nanoid(), value: token }));
+
+/**
+ * "Expose Ports" card. The card is non-collapsible: clicking its header opens a
+ * Dialog where the user maps container ports to externally reachable ports on the
+ * shared deployment model (`services.${serviceIndex}.expose`). Each row edits a
+ * port mapping — container port, exposed-as port, protocol (the SDL supports
+ * http/tcp), routing and accepted hostnames.
+ *
+ * Routing is a derived control over the model's `global`/`ipName` pair: "Public"
+ * is `global: true` with no IP name, "Internal" is `global: false`, and each
+ * declared IP endpoint is `global: true` bound to that endpoint's name. Accepted
+ * hostnames (the `accept` array) and the custom `httpOptions` are HTTP-only: they
+ * surface only while the protocol is `http` (and `accept` only when not internal),
+ * and switching a port to `tcp` clears their backing values so the SDL never carries
+ * HTTP-only config onto a non-HTTP expose.
+ *
+ * Changes are committed on Save and reverted on Cancel. The header shows the count
+ * of mapped ports.
+ */
+export const ExposePortsCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+  const { control, getValues, reset, trigger, formState } = useFormContext<SdlBuilderFormValuesType>();
+  const expose = useWatch({ control, name: `services.${serviceIndex}.expose` });
+  const portCount = (expose ?? []).length;
+  const { isSubmitted } = formState;
+  /**
+   * Expose errors live on per-port fields inside the (closed) modal, so surface them on the card
+   * itself. Both this and the card's own Save/Cancel re-validation are deferred until after the first
+   * submit (`isSubmitted`), matching the form's `onSubmit` mode — otherwise closing the modal would
+   * light up the card and its fields before the user ever submits.
+   */
+  const hasErrors = isSubmitted && !!formState.errors.services?.[serviceIndex]?.expose;
+  const [open, setOpen] = useState(false);
+  const [snapshot, setSnapshot] = useState<SdlBuilderFormValuesType | null>(null);
+
+  const openModal = useCallback(() => {
+    setSnapshot(structuredClone(getValues()));
+    setOpen(true);
+  }, [getValues]);
+
+  const handleCancel = useCallback(() => {
+    if (snapshot) {
+      reset(snapshot, { keepErrors: true });
+      if (isSubmitted) void trigger(`services.${serviceIndex}.expose`);
+    }
+    setOpen(false);
+  }, [reset, trigger, snapshot, serviceIndex, isSubmitted]);
+
+  const handleSave = useCallback(() => {
+    reset(getValues(), { keepDirty: true, keepErrors: true });
+    if (isSubmitted) void trigger(`services.${serviceIndex}.expose`);
+    setOpen(false);
+  }, [getValues, reset, trigger, serviceIndex, isSubmitted]);
+
+  return (
+    <>
+      <d.CollapsibleCard
+        title="Expose Ports"
+        icon={<GlobeIcon className="h-4 w-4" />}
+        infoTooltip={exposePortsTooltip}
+        className={hasErrors ? "border-destructive dark:border-destructive" : undefined}
+        summary={
+          <div className="flex items-center gap-1">
+            <span className="text-sm text-muted-foreground">{portCount}</span>
+            <ChevronRightIcon className="size-4" />
+          </div>
+        }
+        onHeaderClick={openModal}
+      />
+
+      <d.DialogV2
+        open={open}
+        onOpenChange={isOpen => {
+          if (!isOpen) handleCancel();
+        }}
+      >
+        <d.DialogV2Content className="max-w-lg" aria-describedby="expose-ports-description">
+          <d.DialogV2Header>
+            <d.DialogV2Title>Exposed ports</d.DialogV2Title>
+            <d.DialogV2Description id="expose-ports-description">
+              Map container ports to external ports. TCP/HTTP. Add as many as you need before saving.
+            </d.DialogV2Description>
+          </d.DialogV2Header>
+
+          <d.DialogV2Body>
+            <fieldset disabled={locked} className="contents">
+              <ExposePortsList serviceIndex={serviceIndex} />
+            </fieldset>
+          </d.DialogV2Body>
+
+          <d.DialogV2Footer className="flex items-center justify-between">
+            <p className="text-sm text-muted-foreground">
+              {portCount} port{portCount === 1 ? "" : "s"}
+            </p>
+            <div className="flex items-center gap-2">
+              <Button type="button" variant="ghost" onClick={handleCancel}>
+                Cancel
+              </Button>
+              <Button type="button" onClick={handleSave} disabled={locked}>
+                Save
+                <SaveIcon className="ml-2 size-4" />
+              </Button>
+            </div>
+          </d.DialogV2Footer>
+        </d.DialogV2Content>
+      </d.DialogV2>
+    </>
+  );
+};
+
+/** A fresh port mapping seeded with the single-port HTTP defaults. */
+const newExpose = (): Partial<ExposeType> => ({ id: nanoid(), port: 80, as: 80, proto: "http", global: true, to: [], accept: [], ipName: "" });
+
+/** Parses a numeric input value, returning `undefined` for blank/non-numeric input so the field can show empty. */
+const parsePort = (value: string): number | undefined => {
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+/**
+ * Returns focus to the Select trigger when a nested dropdown closes so the dialog's
+ * focus scope keeps ownership; without it the nested Radix focus scopes can fight
+ * over focus restoration when the dropdown closes inside the modal.
+ */
+const keepFocusInDialog = (event: Event) => event.preventDefault();
+
+type ExposePortsListProps = {
+  serviceIndex: number;
+};
+
+const ExposePortsList: FC<ExposePortsListProps> = ({ serviceIndex }) => {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const { fields, append, remove } = useFieldArray({ control, name: `services.${serviceIndex}.expose`, keyName: "fieldId" });
+
+  const add = useCallback(() => {
+    append(newExpose() as ExposeType);
+  }, [append]);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {fields.map((field, exposeIndex) => (
+        <ExposePortFields
+          key={field.fieldId}
+          serviceIndex={serviceIndex}
+          exposeIndex={exposeIndex}
+          onRemove={fields.length > 1 ? () => remove(exposeIndex) : undefined}
+        />
+      ))}
+
+      <Button type="button" variant="outline" onClick={add} className="w-full border-dashed text-muted-foreground hover:text-foreground">
+        <PlusIcon className="mr-2 size-4" />
+        Add another port
+      </Button>
+    </div>
+  );
+};
+
+type ExposePortFieldsProps = {
+  serviceIndex: number;
+  exposeIndex: number;
+  onRemove?: () => void;
+};
+
+const ExposePortFields: FC<ExposePortFieldsProps> = ({ serviceIndex, exposeIndex, onRemove }) => {
+  const { control, setValue } = useFormContext<SdlBuilderFormValuesType>();
+  const basePath = `services.${serviceIndex}.expose.${exposeIndex}` as const;
+  const endpoints = useWatch({ control, name: "endpoints" }) ?? [];
+  const watchedServices = useWatch({ control, name: "services" });
+  const services = useMemo(() => watchedServices ?? [], [watchedServices]);
+  const fieldId = useId();
+
+  const port = useController({ control, name: `${basePath}.port` });
+  const as = useController({ control, name: `${basePath}.as` });
+  const proto = useController({ control, name: `${basePath}.proto` });
+  const global = useController({ control, name: `${basePath}.global` });
+  const ipName = useController({ control, name: `${basePath}.ipName` });
+  const accept = useController({ control, name: `${basePath}.accept` });
+  const to = useController({ control, name: `${basePath}.to` });
+
+  const routingValue = useMemo(() => routingValueOf({ global: global.field.value, ipName: ipName.field.value }), [global.field.value, ipName.field.value]);
+
+  const isInternal = routingValue === INTERNAL_ROUTING;
+  const isHttp = (proto.field.value ?? "http") === "http";
+
+  const currentService = services[serviceIndex];
+  const otherServices = useMemo(
+    () => (services as SdlBuilderFormValuesType["services"]).filter(service => service.id !== currentService?.id),
+    [services, currentService?.id]
+  );
+
+  const selectedTargets = useMemo(() => new Set((to.field.value ?? []).map(entry => entry.value)), [to.field.value]);
+
+  const toggleTarget = useCallback(
+    (title: string, checked: boolean) => {
+      const next = (to.field.value ?? []).filter(entry => entry.value !== title);
+      if (checked) next.push({ id: nanoid(), value: title });
+      to.field.onChange(next);
+    },
+    [to.field]
+  );
+
+  const changeRouting = useCallback(
+    (value: string) => {
+      const next = routingToModel(value);
+      global.field.onChange(next.global);
+      ipName.field.onChange(next.ipName);
+    },
+    [global.field, ipName.field]
+  );
+
+  const hostnamesValue = useMemo(() => hostnamesToInput(accept.field.value), [accept.field.value]);
+
+  const changeHostnames = useCallback(
+    (value: string) => {
+      accept.field.onChange(inputToHostnames(value));
+    },
+    [accept.field]
+  );
+
+  /**
+   * `accept` hostnames and `httpOptions` are HTTP-only — switching a port to a non-HTTP
+   * protocol hides those controls, so clear their backing values too (and reset the custom
+   * HTTP options toggle) to keep the model from carrying HTTP-only config onto a TCP expose.
+   */
+  const changeProto = useCallback(
+    (value: string) => {
+      if (!value) return;
+      proto.field.onChange(value);
+      if (value !== "http") {
+        accept.field.onChange([]);
+        setValue(`${basePath}.hasCustomHttpOptions`, false, { shouldDirty: true });
+        setValue(`${basePath}.httpOptions`, undefined, { shouldDirty: true });
+      }
+    },
+    [proto.field, accept.field, setValue, basePath]
+  );
+
+  return (
+    <div role="group" aria-label={`Port ${exposeIndex + 1}`} className="flex flex-col gap-3 rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
+      <div className="flex items-start gap-2">
+        <Field className="flex-1 gap-2">
+          <FieldLabel htmlFor={`${fieldId}-port`}>Container port</FieldLabel>
+          <FieldContent>
+            <Input
+              id={`${fieldId}-port`}
+              aria-label={`Port ${exposeIndex + 1} container port`}
+              type="number"
+              min={1}
+              max={65535}
+              value={port.field.value ?? ""}
+              onChange={event => port.field.onChange(parsePort(event.target.value))}
+              error={!!port.fieldState.error}
+              inputClassName="h-9"
+            />
+            <FieldError>{port.fieldState.error?.message}</FieldError>
+          </FieldContent>
+        </Field>
+
+        <Field className="flex-1 gap-2">
+          <FieldLabel htmlFor={`${fieldId}-as`}>Exposed as</FieldLabel>
+          <FieldContent>
+            <Input
+              id={`${fieldId}-as`}
+              aria-label={`Port ${exposeIndex + 1} exposed as`}
+              type="number"
+              min={1}
+              max={65535}
+              value={as.field.value ?? ""}
+              onChange={event => as.field.onChange(parsePort(event.target.value))}
+              error={!!as.fieldState.error}
+              inputClassName="h-9"
+            />
+            <FieldError>{as.fieldState.error?.message}</FieldError>
+          </FieldContent>
+        </Field>
+
+        {onRemove && (
+          <Button size="icon" type="button" variant="ghost" className="mt-6 h-9 w-9 shrink-0" aria-label={`Remove port ${exposeIndex + 1}`} onClick={onRemove}>
+            <XIcon className="h-4 w-4" />
+          </Button>
+        )}
+      </div>
+
+      <div className="flex items-start gap-2">
+        <Field className="flex-1 gap-2">
+          <FieldLabel>Protocol</FieldLabel>
+          <FieldContent>
+            <ToggleGroup
+              type="single"
+              variant="outline"
+              value={proto.field.value ?? "http"}
+              onValueChange={changeProto}
+              className="h-9 justify-start gap-0 rounded-md border"
+              aria-label={`Port ${exposeIndex + 1} protocol`}
+            >
+              {protoTypes.map(option => (
+                <ToggleGroupItem
+                  key={option.id}
+                  value={option.name}
+                  aria-label={option.name}
+                  className="h-full flex-1 rounded-none border-0 uppercase first:rounded-l-md last:rounded-r-md"
+                >
+                  {option.name}
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
+          </FieldContent>
+        </Field>
+
+        <Field className="flex-1 gap-2">
+          <FieldLabel>Routing</FieldLabel>
+          <FieldContent>
+            <Select value={routingValue} onValueChange={changeRouting}>
+              <SelectTrigger aria-label={`Port ${exposeIndex + 1} routing`} className="h-9">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent onCloseAutoFocus={keepFocusInDialog}>
+                <SelectItem value={PUBLIC_ROUTING}>Public (any IP)</SelectItem>
+                <SelectItem value={INTERNAL_ROUTING}>Internal</SelectItem>
+                {endpoints.map(endpoint => (
+                  <SelectItem key={endpoint.id} value={endpoint.name}>
+                    IP endpoint: {endpoint.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </FieldContent>
+        </Field>
+      </div>
+
+      {isHttp && !isInternal && (
+        <Field className="gap-2">
+          <FieldLabel htmlFor={`${fieldId}-hostnames`}>Accept hostnames</FieldLabel>
+          <FieldContent>
+            <Input
+              id={`${fieldId}-hostnames`}
+              aria-label={`Port ${exposeIndex + 1} accept hostnames`}
+              placeholder="example.com, api.example.com"
+              defaultValue={hostnamesValue}
+              onChange={event => changeHostnames(event.target.value)}
+              inputClassName="h-9"
+            />
+          </FieldContent>
+        </Field>
+      )}
+
+      {otherServices.length > 0 && (
+        <Field className="gap-2">
+          <FieldLabel>To</FieldLabel>
+          <FieldContent>
+            <div role="group" aria-label={`Port ${exposeIndex + 1} to targets`} className="flex flex-col gap-2">
+              {otherServices.map(service => (
+                <CheckboxWithLabel
+                  key={service.id}
+                  checked={selectedTargets.has(service.title)}
+                  onCheckedChange={state => toggleTarget(service.title, state === "indeterminate" ? false : state)}
+                  label={service.title}
+                />
+              ))}
+            </div>
+          </FieldContent>
+        </Field>
+      )}
+
+      {isHttp && (
+        <>
+          <Separator className="my-2" />
+
+          <HttpOptionsFields serviceIndex={serviceIndex} exposeIndex={exposeIndex} />
+        </>
+      )}
+    </div>
+  );
+};
+
+type HttpOptionsFieldsProps = {
+  serviceIndex: number;
+  exposeIndex: number;
+};
+
+/** Numeric HTTP option fields rendered when custom options are enabled, with their seeded default. */
+const HTTP_OPTION_FIELDS = [
+  { key: "maxBodySize", label: "Max body size", default: defaultHttpOptions.maxBodySize },
+  { key: "readTimeout", label: "Read timeout", default: defaultHttpOptions.readTimeout },
+  { key: "sendTimeout", label: "Send timeout", default: defaultHttpOptions.sendTimeout },
+  { key: "nextTries", label: "Next tries", default: defaultHttpOptions.nextTries },
+  { key: "nextTimeout", label: "Next timeout", default: defaultHttpOptions.nextTimeout }
+] as const;
+
+/** The full `httpOptions` object the schema requires, seeded from the shared defaults. */
+const fullHttpOptions = (): NonNullable<ExposeType["httpOptions"]> => ({
+  maxBodySize: defaultHttpOptions.maxBodySize,
+  readTimeout: defaultHttpOptions.readTimeout,
+  sendTimeout: defaultHttpOptions.sendTimeout,
+  nextTries: defaultHttpOptions.nextTries,
+  nextTimeout: defaultHttpOptions.nextTimeout,
+  nextCases: [...defaultHttpOptions.nextCases]
+});
+
+/**
+ * Per-port HTTP options. A checkbox toggles `hasCustomHttpOptions`; while on, the
+ * SDL `http_options` block is emitted with the values below (max body size, the
+ * proxy timeouts/retries and the retry "next cases").
+ *
+ * `httpOptions` must be present in full or absent entirely — the schema marks the
+ * whole object optional but requires all six fields once it exists. So enabling
+ * seeds the complete default object (unless the port already carries one) and the
+ * `nextCases`/numeric controllers mount only while enabled; writing only some of
+ * them would leave the port silently invalid.
+ */
+const HttpOptionsFields: FC<HttpOptionsFieldsProps> = ({ serviceIndex, exposeIndex }) => {
+  const { control, getValues, setValue } = useFormContext<SdlBuilderFormValuesType>();
+  const basePath = `services.${serviceIndex}.expose.${exposeIndex}` as const;
+  const hasCustomHttpOptions = useController({ control, name: `${basePath}.hasCustomHttpOptions` });
+
+  const toggleCustomOptions = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        if (!getValues(`${basePath}.httpOptions`)) {
+          setValue(`${basePath}.httpOptions`, fullHttpOptions(), { shouldDirty: true });
+        }
+      } else {
+        setValue(`${basePath}.httpOptions`, undefined, { shouldDirty: true });
+      }
+      hasCustomHttpOptions.field.onChange(checked);
+    },
+    [hasCustomHttpOptions.field, getValues, setValue, basePath]
+  );
+
+  return (
+    <div className="flex flex-col gap-3">
+      <CheckboxWithLabel
+        checked={!!hasCustomHttpOptions.field.value}
+        onCheckedChange={state => toggleCustomOptions(state === "indeterminate" ? false : state)}
+        label="Custom HTTP options"
+      />
+
+      {hasCustomHttpOptions.field.value && (
+        <div
+          role="group"
+          aria-label={`Port ${exposeIndex + 1} HTTP options`}
+          className="flex flex-col gap-3 rounded-md border border-zinc-200 p-3 dark:border-zinc-800"
+        >
+          {HTTP_OPTION_FIELDS.map(option => (
+            <HttpOptionNumberField key={option.key} basePath={basePath} optionKey={option.key} label={option.label} defaultValue={option.default} />
+          ))}
+
+          <NextCasesField basePath={basePath} />
+        </div>
+      )}
+    </div>
+  );
+};
+
+type NextCasesFieldProps = {
+  basePath: `services.${number}.expose.${number}`;
+};
+
+/** Retry "next cases" checkbox group, mounted only while custom HTTP options are enabled. */
+const NextCasesField: FC<NextCasesFieldProps> = ({ basePath }) => {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const nextCasesField = useController({ control, name: `${basePath}.httpOptions.nextCases`, defaultValue: [...defaultHttpOptions.nextCases] });
+
+  const selectedCases = new Set(nextCasesField.field.value ?? []);
+  const toggleCase = useCallback(
+    (value: string, checked: boolean) => {
+      const next = (nextCasesField.field.value ?? []).filter(entry => entry !== value);
+      if (checked) next.push(value);
+      nextCasesField.field.onChange(next);
+    },
+    [nextCasesField.field]
+  );
+
+  return (
+    <Field className="gap-2">
+      <FieldLabel>Next cases</FieldLabel>
+      <FieldContent>
+        <div className="flex flex-wrap gap-x-4 gap-y-2">
+          {nextCaseOptions.map(option => (
+            <CheckboxWithLabel
+              key={option.value}
+              checked={selectedCases.has(option.value)}
+              onCheckedChange={state => toggleCase(option.value, state === "indeterminate" ? false : state)}
+              label={option.label}
+            />
+          ))}
+        </div>
+      </FieldContent>
+    </Field>
+  );
+};
+
+type HttpOptionNumberFieldProps = {
+  basePath: `services.${number}.expose.${number}`;
+  optionKey: (typeof HTTP_OPTION_FIELDS)[number]["key"];
+  label: string;
+  defaultValue: number;
+};
+
+const HttpOptionNumberField: FC<HttpOptionNumberFieldProps> = ({ basePath, optionKey, label, defaultValue }) => {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const field = useController({ control, name: `${basePath}.httpOptions.${optionKey}`, defaultValue });
+  const id = useId();
+
+  return (
+    <Field className="gap-2">
+      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+      <FieldContent>
+        <Input
+          id={id}
+          aria-label={label}
+          type="number"
+          min={0}
+          value={field.field.value ?? ""}
+          onChange={event => field.field.onChange(parsePort(event.target.value))}
+          error={!!field.fieldState.error}
+          inputClassName="h-9"
+        />
+        <FieldError>{field.fieldState.error?.message}</FieldError>
+      </FieldContent>
+    </Field>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/LogsCard/LogsCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/LogsCard/LogsCard.spec.tsx
@@ -1,0 +1,302 @@
+import type { PropsWithChildren } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import { FormProvider, useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
+import { LOG_COLLECTOR_IMAGE } from "@src/config/log-collector.config";
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { SdlBuilderFormValuesSchema } from "@src/types/sdlBuilder/sdlBuilder";
+import { kvArrayToObject } from "@src/utils/keyValue/keyValue";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { DEPENDENCIES, LogsCard } from "./LogsCard";
+
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(LogsCard.name, () => {
+  it("shows the switch off and no provider in the header summary when log forwarding is disabled", () => {
+    setup();
+
+    expect(screen.getByRole("switch", { name: "Enable log forwarding" })).not.toBeChecked();
+    expect(screen.queryByText("Datadog")).not.toBeInTheDocument();
+  });
+
+  it("shows the switch on and the provider in the header summary when log forwarding is already enabled", () => {
+    setup({ withLogForwarding: true });
+
+    expect(screen.getByRole("switch", { name: "Enable log forwarding" })).toBeChecked();
+    expect(screen.getByText("Datadog")).toBeInTheDocument();
+  });
+
+  it("shows the switch on for a restored collector whose id was reassigned on import", () => {
+    setup({ withLogForwarding: true, collectorId: "imported-random-id" });
+
+    expect(screen.getByRole("switch", { name: "Enable log forwarding" })).toBeChecked();
+  });
+
+  it("highlights the card after submit when the collector's Datadog config is invalid", async () => {
+    const { submit, container } = setup({ withLogForwarding: true, invalidProviderConfig: true });
+
+    await submit();
+
+    await waitFor(() => expect(container.querySelector(".border-destructive")).not.toBeNull());
+  });
+
+  it("does not highlight the card before the form is submitted", async () => {
+    const { trigger, container } = setup({ withLogForwarding: true, invalidProviderConfig: true });
+
+    await trigger();
+
+    expect(container.querySelector(".border-destructive")).toBeNull();
+  });
+
+  it("does not surface errors when the modal is closed before submitting", async () => {
+    const { toggleSwitch, container, getErrors } = setup();
+
+    await toggleSwitch();
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(container.querySelector(".border-destructive")).toBeNull();
+    expect(getErrors().services).toBeUndefined();
+  });
+
+  it("adds the collector and opens the modal when the switch is turned on", async () => {
+    const { getValues, toggleSwitch } = setup();
+
+    await toggleSwitch();
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(getValues().services.some(isLogCollectorService)).toBe(true);
+  });
+
+  it("adds the collector and opens the modal when a disabled card's header is clicked", async () => {
+    const { getValues, openViaHeader } = setup();
+
+    await openViaHeader();
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(getValues().services.some(isLogCollectorService)).toBe(true);
+  });
+
+  it("opens the modal for editing when an enabled card's header is clicked", async () => {
+    const { openViaHeader } = setup({ withLogForwarding: true });
+
+    await openViaHeader();
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByLabelText("Datadog regional URL")).toBeInTheDocument();
+  });
+
+  it("removes the collector without opening the modal when the switch is turned off", async () => {
+    const { getValues, toggleSwitch } = setup({ withLogForwarding: true });
+
+    await toggleSwitch();
+
+    expect(getValues().services.some(isLogCollectorService)).toBe(false);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("reveals the Datadog fields and collector resources in the modal", async () => {
+    const { toggleSwitch } = setup();
+
+    await toggleSwitch();
+
+    expect(screen.getByLabelText("Datadog regional URL")).toBeInTheDocument();
+    expect(screen.getByLabelText("Datadog API key")).toBeInTheDocument();
+    expect(screen.getByLabelText("CPU Count")).toBeInTheDocument();
+  });
+
+  it("keeps the collector on Save after enabling", async () => {
+    const { getValues, toggleSwitch } = setup();
+
+    await toggleSwitch();
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    const collector = getValues().services.find(isLogCollectorService);
+    expect(collector?.title).toBe("service-1-log-collector");
+  });
+
+  it("removes the just-added collector on Cancel after enabling", async () => {
+    const { getValues, toggleSwitch } = setup();
+
+    await toggleSwitch();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(getValues().services.some(isLogCollectorService)).toBe(false);
+  });
+
+  describe("analytics", () => {
+    it("tracks log_collector_enabled when a fresh enable is saved", async () => {
+      const { analyticsService, toggleSwitch } = setup();
+
+      await toggleSwitch();
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      expect(analyticsService.track).toHaveBeenCalledWith("log_collector_enabled", { category: "deployments" });
+    });
+
+    it("tracks log_collector_disabled when forwarding is turned off", async () => {
+      const { analyticsService, toggleSwitch } = setup({ withLogForwarding: true });
+
+      await toggleSwitch();
+
+      expect(analyticsService.track).toHaveBeenCalledWith("log_collector_disabled", { category: "deployments" });
+    });
+
+    it("does not track enabled when a fresh enable is cancelled", async () => {
+      const { analyticsService, toggleSwitch } = setup();
+
+      await toggleSwitch();
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+      expect(analyticsService.track).not.toHaveBeenCalledWith("log_collector_enabled", expect.anything());
+    });
+
+    it("does not track enabled when an already-enabled card is edited and saved", async () => {
+      const { analyticsService, openViaHeader } = setup({ withLogForwarding: true });
+
+      await openViaHeader();
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      expect(analyticsService.track).not.toHaveBeenCalledWith("log_collector_enabled", expect.anything());
+    });
+  });
+
+  it("stores the Datadog provider settings on the collector service's env", async () => {
+    const { getValues, toggleSwitch } = setup();
+
+    await toggleSwitch();
+    await userEvent.type(screen.getByLabelText("Datadog regional URL"), "datadoghq.eu");
+    await userEvent.type(screen.getByLabelText("Datadog API key"), "secret-key");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    const collector = getValues().services.find(isLogCollectorService);
+    const env = kvArrayToObject(collector?.env ?? []);
+    expect(env.DD_SITE).toBe("datadoghq.eu");
+    expect(env.DD_API_KEY).toBe("secret-key");
+  });
+
+  it("edits the collector's compute profile through the resource controls", async () => {
+    const { getValues, openViaHeader } = setup({ withLogForwarding: true });
+
+    await openViaHeader();
+    const cpu = screen.getByLabelText("CPU Count");
+    await userEvent.clear(cpu);
+    await userEvent.type(cpu, "2");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    const collector = getValues().services.find(isLogCollectorService);
+    expect(collector?.profile.cpu).toBe(2);
+  });
+
+  it("reverts edits to the previous version on Cancel when editing an enabled card", async () => {
+    const { getValues, openViaHeader } = setup({ withLogForwarding: true });
+
+    await openViaHeader();
+    const url = screen.getByLabelText("Datadog regional URL");
+    await userEvent.clear(url);
+    await userEvent.type(url, "datadoghq.eu");
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    const collector = getValues().services.find(isLogCollectorService);
+    expect(collector).toBeDefined();
+    expect(kvArrayToObject(collector?.env ?? []).DD_SITE).toBe("datadoghq.com");
+  });
+
+  it("disables the switch and opens an enabled card read-only while locked", async () => {
+    const { openViaHeader } = setup({ withLogForwarding: true, locked: true });
+
+    expect(screen.getByRole("switch", { name: "Enable log forwarding" })).toBeDisabled();
+
+    await openViaHeader();
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByLabelText("Datadog regional URL")).toBeDisabled();
+    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+  });
+
+  describe("when the parent service is renamed outside the modal", () => {
+    it("keeps a single collector paired and re-syncs its title", async () => {
+      const { getValues, renameParent } = setup({ withLogForwarding: true });
+
+      act(() => renameParent("api"));
+
+      await waitFor(() => {
+        const collectors = getValues().services.filter(isLogCollectorService);
+        expect(collectors).toHaveLength(1);
+        expect(collectors[0].title).toBe("api-log-collector");
+      });
+    });
+
+    it("re-points the collector's POD_LABEL_SELECTOR at the renamed parent", async () => {
+      const { getValues, renameParent } = setup({ withLogForwarding: true });
+
+      act(() => renameParent("api"));
+
+      await waitFor(() => {
+        const collector = getValues().services.find(isLogCollectorService);
+        const env = kvArrayToObject(collector?.env ?? []);
+        expect(env.POD_LABEL_SELECTOR).toBe("akash.network/manifest-service=api");
+      });
+    });
+
+    it("still reports log forwarding as enabled in the header summary after a rename", async () => {
+      const { renameParent } = setup({ withLogForwarding: true });
+
+      act(() => renameParent("api"));
+
+      await waitFor(() => expect(screen.getByText("Datadog")).toBeInTheDocument());
+    });
+  });
+
+  function setup(input: { withLogForwarding?: boolean; locked?: boolean; collectorId?: string; invalidProviderConfig?: boolean } = {}) {
+    const values = defaultServiceWithPlacement();
+    if (input.withLogForwarding) {
+      const parent = values.services[0];
+      parent.image = "nginx:latest";
+      values.services.push({
+        ...parent,
+        id: input.collectorId ?? `${parent.id}-log-collector`,
+        title: `${parent.title}-log-collector`,
+        image: LOG_COLLECTOR_IMAGE,
+        expose: [],
+        env: [
+          { key: "PROVIDER", value: "DATADOG" },
+          { key: "DD_API_KEY", value: input.invalidProviderConfig ? "" : "existing" },
+          { key: "DD_SITE", value: input.invalidProviderConfig ? "" : "datadoghq.com" }
+        ]
+      });
+    }
+
+    const analyticsService = mock<ReturnType<typeof DEPENDENCIES.useServices>["analyticsService"]>();
+    const useServices: typeof DEPENDENCIES.useServices = () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ analyticsService });
+
+    let form: UseFormReturn<SdlBuilderFormValuesType> | undefined;
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      form = useForm<SdlBuilderFormValuesType>({ defaultValues: values, mode: "onChange", resolver: zodResolver(SdlBuilderFormValuesSchema) });
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    const { container } = render(
+      <Wrapper>
+        <LogsCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES, useServices }} />
+      </Wrapper>
+    );
+
+    return {
+      container,
+      analyticsService,
+      getValues: () => (form as UseFormReturn<SdlBuilderFormValuesType>).getValues(),
+      getErrors: () => (form as UseFormReturn<SdlBuilderFormValuesType>).formState.errors,
+      trigger: () => (form as UseFormReturn<SdlBuilderFormValuesType>).trigger(),
+      submit: () => (form as UseFormReturn<SdlBuilderFormValuesType>).handleSubmit(() => undefined)(),
+      renameParent: (title: string) =>
+        (form as UseFormReturn<SdlBuilderFormValuesType>).setValue("services.0.title", title, { shouldDirty: true, shouldTouch: true }),
+      toggleSwitch: () => userEvent.click(screen.getByRole("switch", { name: "Enable log forwarding" })),
+      openViaHeader: () => userEvent.click(screen.getByText(/^Logs/))
+    };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/LogsCard/LogsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/LogsCard/LogsCard.tsx
@@ -1,0 +1,372 @@
+"use client";
+import { type FC, useCallback, useMemo, useState } from "react";
+import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
+import {
+  Button,
+  CollapsibleCard,
+  DialogV2,
+  DialogV2Body,
+  DialogV2Content,
+  DialogV2Description,
+  DialogV2Footer,
+  DialogV2Header,
+  DialogV2Title,
+  Field,
+  FieldContent,
+  FieldLabel,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@akashnetwork/ui/components";
+import { SaveIcon, ScrollTextIcon } from "lucide-react";
+
+import { datadogEnvSchema } from "@src/components/sdl/DatadogEnvConfig/DatadogEnvConfig";
+import {
+  findOwnLogCollectorServiceIndex,
+  generateLogCollectorService,
+  toLogCollectorTitle,
+  toPodLabelSelector
+} from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
+import { useServices } from "@src/context/ServicesProvider";
+import { useSdlEnv } from "@src/hooks/useSdlEnv/useSdlEnv";
+import { useThrottledEffect } from "@src/hooks/useThrottledEffect/useThrottledEffect";
+import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
+import { kvArrayToObject, objectToKvArray } from "@src/utils/keyValue/keyValue";
+import { logsTooltip } from "../cardTooltips";
+import { ComputeResourcesCard } from "../ComputeResourcesCard/ComputeResourcesCard";
+
+export const DEPENDENCIES = {
+  CollapsibleCard,
+  DialogV2,
+  DialogV2Content,
+  DialogV2Header,
+  DialogV2Title,
+  DialogV2Description,
+  DialogV2Body,
+  DialogV2Footer,
+  ComputeResourcesCard,
+  useSdlEnv,
+  useServices
+};
+
+type Props = {
+  serviceIndex: number;
+  /** While the pane is locked the dialog still opens for viewing but its inputs and Save are disabled. */
+  locked?: boolean;
+  dependencies?: typeof DEPENDENCIES;
+};
+
+/**
+ * "Logs" card. A header switch enables/disables log forwarding for the selected
+ * service; the settings live in a modal. Like the legacy {@link LogCollectorControl},
+ * enabling appends a separate `-log-collector` sibling service to `services[]`
+ * (Datadog provider, seeded default resources) that ships the parent service's logs;
+ * the sibling's title/placement/pricing are kept in sync with the parent.
+ *
+ * Trigger behavior:
+ * - Off → flip the switch (or click the header): the collector is added straight away
+ *   and the modal opens. **Cancel** removes it again (back to off); **Save** keeps it.
+ * - On → flip the switch: the collector is removed (no modal).
+ * - On → click the header: the modal opens to edit; **Save** applies, **Cancel** reverts
+ *   to the values captured when it opened.
+ *
+ * Only Datadog is supported as a provider; its Regional URL (`DD_SITE`) and API key
+ * (`DD_API_KEY`) are edited in the modal and stored on the sibling service's env. The
+ * collector's CPU/memory/storage are editable through the shared {@link ComputeResourcesCard}.
+ */
+export const LogsCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+  const { control, getValues, setValue, reset, trigger, formState } = useFormContext<SdlBuilderFormValuesType>();
+  const { analyticsService } = d.useServices();
+  const { append, remove } = useFieldArray({ control, name: "services", keyName: "fieldId" });
+  const services = useWatch({ control, name: "services" }) ?? [];
+  const targetService = services[serviceIndex];
+  const collectorIndex = useMemo(
+    () => (targetService ? findOwnLogCollectorServiceIndex(targetService, services as SdlBuilderFormValuesType["services"]) : -1),
+    [services, targetService]
+  );
+  const isEnabled = collectorIndex !== -1;
+  const { isSubmitted } = formState;
+  /**
+   * The collector service is hidden (no tab, modal closed), so surface its validation errors on this
+   * card. Both this and the card's own Save/Cancel re-validation are deferred until after the first
+   * submit (`isSubmitted`), matching the form's `onSubmit` mode — otherwise closing the modal would
+   * light up the card and its fields before the user ever submits.
+   */
+  const hasCollectorErrors = isSubmitted && collectorIndex !== -1 && !!formState.errors.services?.[collectorIndex];
+
+  const [open, setOpen] = useState(false);
+  const [snapshot, setSnapshot] = useState<SdlBuilderFormValuesType | null>(null);
+
+  /**
+   * Appends the collector sibling if it isn't there yet. Uses the field array's
+   * `append` (not a raw `setValue`) so the live SDL preview, which is driven by a
+   * `form.watch` subscription, is notified of the structural change.
+   */
+  const addCollector = useCallback(() => {
+    const current = getValues();
+    const target = current.services[serviceIndex];
+    if (findOwnLogCollectorServiceIndex(target, current.services) === -1) {
+      append(generateLogCollectorService(target));
+    }
+  }, [getValues, append, serviceIndex]);
+
+  /** Removes the collector sibling if present, via the field array so the SDL preview updates. */
+  const removeCollector = useCallback(() => {
+    const current = getValues();
+    const existingIndex = findOwnLogCollectorServiceIndex(current.services[serviceIndex], current.services);
+    if (existingIndex !== -1) {
+      remove(existingIndex);
+    }
+  }, [getValues, remove, serviceIndex]);
+
+  /** Snapshots the form, enables forwarding, and opens the settings modal. */
+  const enableAndOpen = useCallback(() => {
+    setSnapshot(structuredClone(getValues()));
+    addCollector();
+    setOpen(true);
+  }, [getValues, addCollector]);
+
+  /** Snapshots the form and opens the settings modal for an already-enabled card. */
+  const openForEdit = useCallback(() => {
+    setSnapshot(structuredClone(getValues()));
+    setOpen(true);
+  }, [getValues]);
+
+  /**
+   * Header switch: enabling (from off) adds the collector and opens the modal so it
+   * can be configured immediately; disabling (from on) just removes it, no modal.
+   */
+  const handleToggle = useCallback(
+    (checked: boolean) => {
+      if (checked) {
+        enableAndOpen();
+      } else {
+        removeCollector();
+        analyticsService.track("log_collector_disabled", { category: "deployments" });
+      }
+    },
+    [enableAndOpen, removeCollector, analyticsService]
+  );
+
+  /**
+   * Header click (title/chevron): an enabled card opens for editing; a disabled card
+   * enables and opens (same as flipping the switch). While locked nothing is mutated —
+   * an enabled card still opens read-only and a disabled one stays put.
+   */
+  const handleHeaderClick = useCallback(() => {
+    if (isEnabled) {
+      openForEdit();
+    } else if (!locked) {
+      enableAndOpen();
+    }
+  }, [isEnabled, locked, openForEdit, enableAndOpen]);
+
+  const handleCancel = useCallback(() => {
+    if (snapshot) {
+      reset(snapshot, { keepErrors: true });
+      if (isSubmitted) void trigger("services");
+    }
+    setOpen(false);
+  }, [reset, trigger, snapshot, isSubmitted]);
+
+  /**
+   * Re-derives the collector's parent-coupled fields (title, placement, pricing and
+   * the `POD_LABEL_SELECTOR` env that targets the parent's pods) from the current
+   * parent and writes back only what changed. Returns whether anything was written.
+   */
+  const syncCollectorToParent = useCallback((): boolean => {
+    const current = getValues();
+    const target = current.services[serviceIndex];
+    if (!target) return false;
+    const existingIndex = findOwnLogCollectorServiceIndex(target, current.services);
+    if (existingIndex === -1) return false;
+    return syncCollectorService({ services: current.services, parent: target, collectorIndex: existingIndex, setValue });
+  }, [getValues, setValue, serviceIndex]);
+
+  useThrottledEffect(() => {
+    syncCollectorToParent();
+  }, [targetService?.title, targetService?.placementId, targetService?.pricing?.amount, targetService?.pricing?.denom, collectorIndex, syncCollectorToParent]);
+
+  const handleSave = useCallback(() => {
+    const enabledThisSession = !!snapshot && findOwnLogCollectorServiceIndex(snapshot.services[serviceIndex], snapshot.services) === -1;
+
+    syncCollectorToParent();
+
+    reset(getValues(), { keepDirty: true, keepErrors: true });
+    if (isSubmitted) void trigger("services");
+    setOpen(false);
+
+    if (enabledThisSession) {
+      analyticsService.track("log_collector_enabled", { category: "deployments" });
+    }
+  }, [getValues, reset, trigger, syncCollectorToParent, snapshot, serviceIndex, analyticsService, isSubmitted]);
+
+  return (
+    <>
+      <d.CollapsibleCard
+        title="Logs"
+        icon={<ScrollTextIcon className="h-4 w-4" />}
+        infoTooltip={logsTooltip}
+        isToggled={isEnabled}
+        onToggle={handleToggle}
+        toggleAriaLabel="Enable log forwarding"
+        toggleDisabled={locked}
+        className={hasCollectorErrors ? "border-destructive dark:border-destructive" : undefined}
+        summary={isEnabled ? <span className="text-sm text-muted-foreground">Datadog</span> : undefined}
+        onHeaderClick={handleHeaderClick}
+      />
+
+      <d.DialogV2
+        open={open}
+        onOpenChange={isOpen => {
+          if (!isOpen) handleCancel();
+        }}
+      >
+        <d.DialogV2Content className="max-w-lg" aria-describedby="logs-description">
+          <d.DialogV2Header>
+            <d.DialogV2Title>Log forwarding</d.DialogV2Title>
+            <d.DialogV2Description id="logs-description">
+              Forward this service's logs to a third-party monitoring provider. A separate collector service is added to your deployment.
+            </d.DialogV2Description>
+          </d.DialogV2Header>
+
+          <d.DialogV2Body className="flex flex-col gap-4">
+            <fieldset disabled={locked} className="contents">
+              {collectorIndex !== -1 && (
+                <>
+                  <DatadogFields serviceIndex={collectorIndex} dependencies={d} />
+
+                  <div className="flex flex-col gap-3 rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
+                    <div>
+                      <p className="text-sm font-medium">Resources</p>
+                      <p className="text-sm text-muted-foreground">The collector runs as a separate service alongside your deployment.</p>
+                    </div>
+                    <d.ComputeResourcesCard serviceIndex={collectorIndex} locked={locked} />
+                  </div>
+                </>
+              )}
+            </fieldset>
+          </d.DialogV2Body>
+
+          <d.DialogV2Footer className="flex items-center justify-end">
+            <Button type="button" variant="ghost" onClick={handleCancel}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleSave} disabled={locked}>
+              Save
+              <SaveIcon className="ml-2 h-4 w-4" />
+            </Button>
+          </d.DialogV2Footer>
+        </d.DialogV2Content>
+      </d.DialogV2>
+    </>
+  );
+};
+
+type SyncCollectorServiceInput = {
+  services: SdlBuilderFormValuesType["services"];
+  parent: ServiceType;
+  collectorIndex: number;
+  setValue: ReturnType<typeof useFormContext<SdlBuilderFormValuesType>>["setValue"];
+};
+
+/**
+ * Writes the collector at `collectorIndex` back into form state with its
+ * parent-derived fields refreshed: title, placement, pricing and the
+ * `POD_LABEL_SELECTOR` env entry (which targets the parent's pods by title). Only
+ * fields that actually changed are written; returns whether anything was written.
+ */
+function syncCollectorService({ services, parent, collectorIndex, setValue }: SyncCollectorServiceInput): boolean {
+  const collector = services[collectorIndex];
+  if (!collector) return false;
+
+  let changed = false;
+
+  const nextTitle = toLogCollectorTitle(parent);
+  if (collector.title !== nextTitle) {
+    setValue(`services.${collectorIndex}.title`, nextTitle, { shouldDirty: true });
+    changed = true;
+  }
+
+  if (collector.placementId !== parent.placementId) {
+    setValue(`services.${collectorIndex}.placementId`, parent.placementId, { shouldDirty: true });
+    changed = true;
+  }
+
+  if (collector.pricing.amount !== parent.pricing.amount || collector.pricing.denom !== parent.pricing.denom) {
+    setValue(`services.${collectorIndex}.pricing`, parent.pricing, { shouldDirty: true });
+    changed = true;
+  }
+
+  const nextSelector = toPodLabelSelector(parent);
+  const env = kvArrayToObject(collector.env ?? []);
+  if (env.POD_LABEL_SELECTOR !== nextSelector) {
+    setValue(`services.${collectorIndex}.env`, objectToKvArray({ ...env, POD_LABEL_SELECTOR: nextSelector }), { shouldDirty: true });
+    changed = true;
+  }
+
+  return changed;
+}
+
+type DatadogFieldsProps = {
+  serviceIndex: number;
+  dependencies: typeof DEPENDENCIES;
+};
+
+const DatadogFields: FC<DatadogFieldsProps> = ({ serviceIndex, dependencies: d }) => {
+  const env = d.useSdlEnv({ serviceIndex, schema: datadogEnvSchema });
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
+      <Field className="gap-2">
+        <FieldLabel htmlFor={`logs-provider-${serviceIndex}`}>Provider</FieldLabel>
+        <FieldContent>
+          <Select value="DATADOG" disabled>
+            <SelectTrigger id={`logs-provider-${serviceIndex}`} aria-label="Log provider" className="h-9">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="DATADOG">Datadog</SelectItem>
+            </SelectContent>
+          </Select>
+        </FieldContent>
+      </Field>
+
+      <Field className="gap-2">
+        <FieldLabel htmlFor={`logs-dd-site-${serviceIndex}`}>Regional URL</FieldLabel>
+        <FieldContent>
+          <Input
+            id={`logs-dd-site-${serviceIndex}`}
+            aria-label="Datadog regional URL"
+            placeholder="e.g. datadoghq.eu"
+            value={env.values.DD_SITE ?? ""}
+            onChange={event => env.setValue("DD_SITE", event.target.value)}
+            error={!!env.errors.DD_SITE}
+            inputClassName="h-9"
+          />
+          {env.errors.DD_SITE && <p className="text-sm text-destructive">{env.errors.DD_SITE}</p>}
+        </FieldContent>
+      </Field>
+
+      <Field className="gap-2">
+        <FieldLabel htmlFor={`logs-dd-api-key-${serviceIndex}`}>Provider API key</FieldLabel>
+        <FieldContent>
+          <Input
+            id={`logs-dd-api-key-${serviceIndex}`}
+            aria-label="Datadog API key"
+            type="password"
+            placeholder="Paste the API key from your provider"
+            value={env.values.DD_API_KEY ?? ""}
+            onChange={event => env.setValue("DD_API_KEY", event.target.value)}
+            error={!!env.errors.DD_API_KEY}
+            inputClassName="h-9"
+          />
+          {env.errors.DD_API_KEY && <p className="text-sm text-destructive">{env.errors.DD_API_KEY}</p>}
+        </FieldContent>
+      </Field>
+    </div>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/cardTooltips.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/cardTooltips.tsx
@@ -106,3 +106,32 @@ export const commandsTooltip = (
     </a>
   </>
 );
+
+export const exposePortsTooltip = (
+  <>
+    Map a container port to an externally reachable port and choose how it is routed.
+    <br />
+    <br />
+    Public routing accepts connections from any IP; internal routing keeps the port reachable only from other services in the deployment. Accepted hostnames
+    apply to HTTP traffic and only when the port isn&apos;t internal.
+    <br />
+    <br />
+    <a href="https://akash.network/docs/developers/deployment/akash-sdl/syntax-reference/#expose" target="_blank" rel="noopener">
+      View official documentation
+    </a>
+  </>
+);
+
+export const logsTooltip = (
+  <>
+    Forward this service's logs to a third-party monitoring provider.
+    <br />
+    <br />
+    Enabling log forwarding adds a separate collector service to your deployment that ships the primary service's logs (currently to Datadog).
+    <br />
+    <br />
+    <a href="https://akash.network/docs/developers/deployment/akash-sdl/advanced-features/#log-forwarding" target="_blank" rel="noopener">
+      View official documentation
+    </a>
+  </>
+);

--- a/apps/deploy-web/src/components/sdl/LogCollectorControl/LogCollectorControl.tsx
+++ b/apps/deploy-web/src/components/sdl/LogCollectorControl/LogCollectorControl.tsx
@@ -101,9 +101,9 @@ export const LogCollectorControl: FC<Props> = ({ serviceIndex, dependencies: d =
   );
 
   useThrottledEffect(() => {
-    const nextTitle = `akash.network/manifest-service=${targetService.title}`;
-    if (env.values.POD_LABEL_SELECTOR !== nextTitle) {
-      env.setValue("POD_LABEL_SELECTOR", nextTitle);
+    const nextSelector = toPodLabelSelector(targetService);
+    if (env.values.POD_LABEL_SELECTOR !== nextSelector) {
+      env.setValue("POD_LABEL_SELECTOR", nextSelector);
     }
   }, [env, targetService.title]);
 
@@ -209,11 +209,24 @@ export function isLogCollectorService(service: ServiceType): boolean {
   return !!service.title?.endsWith("-log-collector") && service.image === LOG_COLLECTOR_IMAGE;
 }
 
+/**
+ * Locates the log-collector paired with `service`. Matches first on the stable id
+ * (`<service.id>-log-collector`): the parent title is editable, so an id pairing
+ * survives renames where a title pairing would orphan the collector. As a fallback
+ * it matches a real collector (by image) whose title is `<service.title>-log-collector`,
+ * which covers collectors loaded from an imported SDL — import assigns fresh ids, so
+ * the deterministic id no longer matches but the title pairing still holds.
+ */
 export function findOwnLogCollectorServiceIndex(service: ServiceType, services: ServiceType[]): number {
-  return services.findIndex(s => s.title === toLogCollectorTitle(service));
+  return services.findIndex(s => s.id === toLogCollectorId(service) || (isLogCollectorService(s) && s.title === toLogCollectorTitle(service)));
 }
 
-function generateLogCollectorService<T extends ServiceType>(
+/** Builds the `POD_LABEL_SELECTOR` env value that points the collector at the parent service's pods. */
+export function toPodLabelSelector(service: ServiceType): string {
+  return `akash.network/manifest-service=${service.title}`;
+}
+
+export function generateLogCollectorService<T extends ServiceType>(
   targetService: T
 ): Pick<T, "placementId" | "pricing"> & Omit<ServiceType, "placementId" | "pricing"> {
   return {
@@ -224,7 +237,7 @@ function generateLogCollectorService<T extends ServiceType>(
     pricing: targetService.pricing,
     env: [
       { key: "PROVIDER", value: "DATADOG" },
-      { key: "POD_LABEL_SELECTOR", value: `akash.network/manifest-service=${targetService.title}` },
+      { key: "POD_LABEL_SELECTOR", value: toPodLabelSelector(targetService) },
       { key: "DD_API_KEY", value: "" },
       { key: "DD_SITE", value: "" }
     ],
@@ -247,10 +260,10 @@ function generateLogCollectorService<T extends ServiceType>(
   };
 }
 
-function toLogCollectorTitle(service: ServiceType): string {
+export function toLogCollectorTitle(service: ServiceType): string {
   return `${service.title}-log-collector`;
 }
 
-function toLogCollectorId(service: ServiceType): string {
+export function toLogCollectorId(service: ServiceType): string {
   return `${service.id}-log-collector`;
 }

--- a/apps/deploy-web/src/utils/sdl/formArrayHelpers.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/formArrayHelpers.spec.ts
@@ -47,8 +47,29 @@ describe("serviceRemovalIndexes", () => {
   });
 
   it("includes the paired log collector index sorted descending", () => {
-    const web = buildSDLService({ title: "web" });
-    const collector = buildSDLService({ title: `${web.title}-log-collector`, image: LOG_COLLECTOR_IMAGE });
+    const web = buildSDLService({ id: "web-id", title: "web" });
+    const collector = buildSDLService({ id: `${web.id}-log-collector`, title: `${web.title}-log-collector`, image: LOG_COLLECTOR_IMAGE });
+    const services = [web, collector];
+
+    const indexes = serviceRemovalIndexes(services, 0);
+
+    expect(indexes).toEqual([1, 0]);
+  });
+
+  it("still pairs the collector after the parent is renamed, since pairing is by id not title", () => {
+    const web = buildSDLService({ id: "web-id", title: "web" });
+    const collector = buildSDLService({ id: `${web.id}-log-collector`, title: "web-log-collector", image: LOG_COLLECTOR_IMAGE });
+    const renamed = { ...web, title: "api" };
+    const services = [renamed, collector];
+
+    const indexes = serviceRemovalIndexes(services, 0);
+
+    expect(indexes).toEqual([1, 0]);
+  });
+
+  it("pairs an imported collector by title when its id was reassigned on import", () => {
+    const web = buildSDLService({ id: "web-id", title: "web" });
+    const collector = buildSDLService({ id: "imported-random-id", title: `${web.title}-log-collector`, image: LOG_COLLECTOR_IMAGE });
     const services = [web, collector];
 
     const indexes = serviceRemovalIndexes(services, 0);

--- a/packages/ui/components/collapsible-card.spec.tsx
+++ b/packages/ui/components/collapsible-card.spec.tsx
@@ -271,6 +271,54 @@ describe(CollapsibleCard.name, () => {
 
       expect(onHeaderClick).not.toHaveBeenCalled();
     });
+
+    it("renders an enable switch when isToggled is provided", () => {
+      setup({ onHeaderClick: vi.fn(), isToggled: false, toggleAriaLabel: "Enable GPU" });
+
+      expect(screen.getByRole("switch", { name: "Enable GPU" })).not.toBeChecked();
+    });
+
+    it("fires onToggle from the header switch without firing onHeaderClick", async () => {
+      const onToggle = vi.fn();
+      const onHeaderClick = vi.fn();
+      setup({ onHeaderClick, onToggle, isToggled: false, toggleAriaLabel: "Enable GPU" });
+
+      await userEvent.click(screen.getByRole("switch", { name: "Enable GPU" }));
+
+      expect(onToggle).toHaveBeenCalledWith(true);
+      expect(onHeaderClick).not.toHaveBeenCalled();
+    });
+
+    it("fires onHeaderClick when the title is clicked without toggling", async () => {
+      const onToggle = vi.fn();
+      const onHeaderClick = vi.fn();
+      setup({ onHeaderClick, onToggle, isToggled: true, toggleAriaLabel: "Enable GPU" });
+
+      await userEvent.click(screen.getByText("GPU"));
+
+      expect(onHeaderClick).toHaveBeenCalledTimes(1);
+      expect(onToggle).not.toHaveBeenCalled();
+    });
+
+    it("disables the enable switch while toggleDisabled", async () => {
+      const onToggle = vi.fn();
+      setup({ onHeaderClick: vi.fn(), onToggle, isToggled: true, toggleAriaLabel: "Enable GPU", toggleDisabled: true });
+
+      expect(screen.getByRole("switch", { name: "Enable GPU" })).toBeDisabled();
+      await userEvent.click(screen.getByRole("switch", { name: "Enable GPU" }));
+      expect(onToggle).not.toHaveBeenCalled();
+    });
+
+    it("fires onHeaderClick from the chevron without toggling", async () => {
+      const onToggle = vi.fn();
+      const onHeaderClick = vi.fn();
+      setup({ onHeaderClick, onToggle, isToggled: true, toggleAriaLabel: "Enable GPU" });
+
+      await userEvent.click(screen.getByRole("button", { name: "Open settings" }));
+
+      expect(onHeaderClick).toHaveBeenCalledTimes(1);
+      expect(onToggle).not.toHaveBeenCalled();
+    });
   });
 
   function setup(input: {

--- a/packages/ui/components/collapsible-card.tsx
+++ b/packages/ui/components/collapsible-card.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import { useEffect, useRef, useState } from "react";
 import { InfoCircle } from "iconoir-react";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronRight, ChevronUp } from "lucide-react";
 
 import { cn } from "../utils";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "./collapsible";
@@ -74,8 +74,21 @@ export interface CollapsibleCardProps {
  */
 const CollapsibleCard = React.forwardRef<HTMLDivElement, CollapsibleCardProps>(({ onHeaderClick, ...props }, ref) => {
   if (onHeaderClick) {
-    const { title, icon, infoTooltip, summary, className } = props;
-    return <ActionCard title={title} icon={icon} infoTooltip={infoTooltip} summary={summary} onHeaderClick={onHeaderClick} className={className} />;
+    const { title, icon, infoTooltip, summary, className, isToggled, onToggle, toggleAriaLabel, toggleDisabled } = props;
+    return (
+      <ActionCard
+        title={title}
+        icon={icon}
+        infoTooltip={infoTooltip}
+        summary={summary}
+        onHeaderClick={onHeaderClick}
+        className={className}
+        isToggled={isToggled}
+        onToggle={onToggle}
+        toggleAriaLabel={toggleAriaLabel}
+        toggleDisabled={toggleDisabled}
+      />
+    );
   }
 
   return <CollapsibleCardBody ref={ref} {...props} />;
@@ -176,31 +189,63 @@ const CollapsibleCardBody = React.forwardRef<HTMLDivElement, Omit<CollapsibleCar
 CollapsibleCardBody.displayName = "CollapsibleCardBody";
 
 /**
- * Non-collapsible variant: the whole header row is a button that fires
- * `onHeaderClick` (e.g. to open a modal). No chevron, no body. The optional
- * info tooltip stops event propagation, so opening it doesn't fire the handler.
+ * Non-collapsible variant: the header row fires `onHeaderClick` (e.g. to open a
+ * modal) instead of expanding a body. The optional info tooltip stops event
+ * propagation, so opening it doesn't fire the handler.
+ *
+ * Pass `isToggled`/`onToggle` to add a header enable switch (same control the
+ * collapsible variant uses). The switch sits as a sibling of the clickable
+ * region, so it toggles independently without firing `onHeaderClick`.
  */
-const ActionCard: React.FC<Pick<CollapsibleCardProps, "title" | "icon" | "infoTooltip" | "summary" | "className"> & { onHeaderClick: () => void }> = ({
-  title,
-  icon,
-  infoTooltip,
-  summary,
-  onHeaderClick,
-  className
-}) => (
-  <button
-    type="button"
-    onClick={onHeaderClick}
-    className={cn(
-      "bg-card focus-visible:ring-ring flex h-12 w-full items-center gap-2 rounded-lg border border-zinc-300 px-4 text-left outline-none focus-visible:ring-1 dark:border-zinc-700",
-      className
-    )}
-  >
-    <CardIcon icon={icon} />
-    <CardTitle title={title} infoTooltip={infoTooltip} />
-    {summary && <CardSummary summary={summary} />}
-  </button>
-);
+const ActionCard: React.FC<
+  Pick<CollapsibleCardProps, "title" | "icon" | "infoTooltip" | "summary" | "className" | "isToggled" | "onToggle" | "toggleAriaLabel" | "toggleDisabled"> & {
+    onHeaderClick: () => void;
+  }
+> = ({ title, icon, infoTooltip, summary, onHeaderClick, className, isToggled, onToggle, toggleAriaLabel, toggleDisabled = false }) => {
+  const content = (
+    <>
+      <CardIcon icon={icon} />
+      <CardTitle title={title} infoTooltip={infoTooltip} />
+      {summary && <CardSummary summary={summary} />}
+    </>
+  );
+
+  if (isToggled === undefined) {
+    return (
+      <button
+        type="button"
+        onClick={onHeaderClick}
+        className={cn(
+          "bg-card focus-visible:ring-ring flex h-12 w-full items-center gap-2 rounded-lg border border-zinc-300 px-4 text-left outline-none focus-visible:ring-1 dark:border-zinc-700",
+          className
+        )}
+      >
+        {content}
+      </button>
+    );
+  }
+
+  return (
+    <div className={cn("bg-card flex h-12 w-full items-center gap-2 rounded-lg border border-zinc-300 px-4 dark:border-zinc-700", className)}>
+      <button
+        type="button"
+        onClick={onHeaderClick}
+        className="focus-visible:ring-ring flex min-w-0 flex-1 items-center gap-2 self-stretch rounded text-left outline-none focus-visible:ring-1"
+      >
+        {content}
+      </button>
+      <Switch size="sm" aria-label={toggleAriaLabel} checked={isToggled} onCheckedChange={onToggle} disabled={toggleDisabled} />
+      <button
+        type="button"
+        onClick={onHeaderClick}
+        aria-label="Open settings"
+        className="text-foreground focus-visible:ring-ring flex h-6 w-6 shrink-0 items-center justify-center rounded outline-none focus-visible:ring-1"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </button>
+    </div>
+  );
+};
 
 const CardIcon: React.FC<{ icon: React.ReactNode }> = ({ icon }) => (
   <span className="text-foreground flex h-4 w-4 shrink-0 items-center justify-center" aria-hidden>


### PR DESCRIPTION
## Why

Adds the **Exposed Ports** and **Logs** configuration cards to the new Configure‑deployment flow, completing parity with the legacy SDL builder for **ports, IP endpoints, and log forwarding**. These are the last of the per‑service "Additional" cards needed for the new flow to fully replace the legacy expose/endpoint/log‑collector controls.

Closes CON-420
Closes CON-472

## What

Two new cards in the Configuration pane's **Additional** section, plus a small shared‑component extension and the wiring they need. Both edit the shared `services.${i}` model and round‑trip through the existing `sdlGenerator`/`sdlImport`, so SDL output matches the legacy builder.

### Expose Ports card
- Non‑collapsible action card opening a modal to edit `services.${i}.expose`.
- Per‑port: **container port / exposed‑as** (1–65535), **protocol** (HTTP/TCP), **routing** (Public / Internal / a declared IP endpoint), **accept hostnames** (shown when not Internal), service‑to‑service **"To" targets**, and **custom HTTP options** (max body size, read/send timeout, next tries/timeout, next cases).
- Add/remove port rows (keeps ≥1); snapshot‑based **Save commits / Cancel reverts**.

### Logs card
- Header **enable switch** (storage‑card style) + chevron; settings live in a modal.
  - Off → flip switch *or* click header: adds the `-log-collector` sibling service immediately and opens the modal — **Cancel** removes it, **Save** keeps it.
  - On → flip switch: removes the collector (no modal). On → click header: opens to edit (Save applies / Cancel reverts).
- Datadog provider config (`DD_SITE`, `DD_API_KEY`) on the collector's env; collector CPU/memory/storage via the shared Compute Resources card.
- Collector stays in sync with its parent (title, placement, pricing, `POD_LABEL_SELECTOR`); paired by **stable id with a title fallback** so the pairing survives both parent renames and SDL import (which reassigns ids). Collector add/remove uses `useFieldArray` so the live SDL preview updates.
- Restores the legacy **`log_collector_enabled` / `log_collector_disabled` analytics** events (fired on committed enable / disable).

### Visible validation state (both cards)
The card's editable fields live inside a closed modal, and the collector is hidden from the service tabs — so a validation error there previously made "Request quotes" fail silently. Both cards now **highlight (destructive border)** when their (possibly hidden) fields are invalid. The highlight and the cards' own re‑validation are gated on `formState.isSubmitted`, so nothing lights up until the user actually submits — matching the form's `onSubmit` mode.

### Shared component
- Extended `CollapsibleCard`'s action‑card variant to optionally render a header toggle (same switch the collapsible variant uses); backward‑compatible (existing action cards pass no toggle).

### Supporting changes
- `LogCollectorControl`: exported the collector helpers the Logs card reuses, added `toPodLabelSelector`, and switched pairing to id‑or‑title.
- `cardTooltips`: added the Expose Ports and Logs help copy.

## Testing

- Unit specs for both cards (incl. toggle/modal behavior, snapshot Save/Cancel, collector sync, analytics, and submit‑gated error highlight), the `CollapsibleCard` toggle variant, and `formArrayHelpers` collector pairing.
- Playwright walkthrough (`tests/ui/ports-logs-walkthrough.spec.ts`) covering both flows end‑to‑end.
- `npm run test:unit`, `npm run lint -- --quiet`, `npx tsc --noEmit` pass for the touched files.

<!-- Frontend change — add a short screen capture of the two cards (enable/disable, modal, error highlight) before merging. -->

## Notes for reviewers

- A legacy‑vs‑new parity audit (ports / IP endpoints / logs) found the new flow at parity or a superset; the one regression found — dropped log‑forwarding analytics — is restored here. One pre‑existing follow‑up left out of scope: referential integrity between a port's `ipName` and the declared endpoint list (orphan refs after import or endpoint deletion).

https://github.com/user-attachments/assets/acc7928d-b457-4e93-90d5-a0150e62d0e9



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Expose Ports” configuration card for port mappings, routing/hostnames, and advanced HTTP options.
  * Added “Logs” configuration card for enabling log forwarding and configuring log collection.
  * Added Expose Ports and Logs tooltips with links to official documentation.
* **Bug Fixes**
  * Improved log-collector pairing so it stays correctly linked across renames and imported SDL cases.
* **UX Improvements**
  * Enhanced card header behavior to support combined header-click and enable-switch interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->