### PR TITLE
feat(deployment): support pasting env vars in dotenv format

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.spec.tsx
@@ -225,6 +225,116 @@ describe(EnvironmentVariablesCard.name, () => {
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
   });
 
+  describe("pasting dotenv content into a key field", () => {
+    it("creates a row per pasted KEY=value line and drops the empty row pasted into", async () => {
+      const { openCard } = setup({ env: [] });
+
+      await openCard();
+      await pasteIntoKey(1, "KEY1=value1\nKEY2=value2");
+
+      expect(keyValues()).toEqual(["KEY1", "KEY2"]);
+      expect(valueValues()).toEqual(["value1", "value2"]);
+    });
+
+    it("leaves the focused key untouched when the pasted text has no equals sign", async () => {
+      const { openCard } = setup({ env: [] });
+
+      await openCard();
+      await pasteIntoKey(1, "KEY1");
+
+      expect(keyValues()).toEqual(["KEY1"]);
+      expect(valueValues()).toEqual([""]);
+    });
+
+    it("skips reserved keys when pasting", async () => {
+      const { openCard } = setup({ env: [] });
+
+      await openCard();
+      await pasteIntoKey(1, "SSH_PUBKEY=abc123\nFOO=bar");
+
+      expect(keyValues()).toEqual(["FOO"]);
+      expect(valueValues()).toEqual(["bar"]);
+    });
+
+    it("does not leak the raw text into the key field when every pasted line is a reserved key", async () => {
+      const { openCard } = setup({ env: [] });
+
+      await openCard();
+      await pasteIntoKey(1, "SSH_PUBKEY=abc123");
+
+      expect(keyValues()).toEqual([""]);
+      expect(valueValues()).toEqual([""]);
+    });
+
+    it("updates an existing variable's value in place when its key is pasted again", async () => {
+      const { openCard } = setup({ env: [{ key: "KEY1", value: "value1" }] });
+
+      await openCard();
+      await pasteIntoKey(1, "KEY1=new_value\nKEY2=value2");
+
+      expect(keyValues()).toEqual(["KEY1", "KEY2"]);
+      expect(valueValues()).toEqual(["new_value", "value2"]);
+    });
+
+    it("keeps a non-empty focused key and appends the pasted rows below it", async () => {
+      const { openCard } = setup({ env: [{ key: "KEY1", value: "key1" }] });
+
+      await openCard();
+      await pasteIntoKey(1, "KEY2=key2\nKEY3=key3");
+
+      expect(keyValues()).toEqual(["KEY1", "KEY2", "KEY3"]);
+      expect(valueValues()).toEqual(["key1", "key2", "key3"]);
+    });
+
+    it("appends to previously pasted variables when pasting into a newly added row", async () => {
+      const { openCard } = setup({ env: [] });
+
+      await openCard();
+      await pasteIntoKey(1, "KEY1=value1\nKEY2=value2");
+      await userEvent.click(screen.getByRole("button", { name: "Add variable" }));
+      await pasteIntoKey(3, "KEY3=value3");
+
+      expect(keyValues()).toEqual(["KEY1", "KEY2", "KEY3"]);
+      expect(valueValues()).toEqual(["value1", "value2", "value3"]);
+    });
+
+    it("preserves a manually typed variable when pasting into another row", async () => {
+      const { openCard } = setup({ env: [] });
+
+      await openCard();
+      await userEvent.type(screen.getByLabelText("Environment variable 1 key"), "TYPED");
+      await userEvent.type(screen.getByLabelText("Environment variable 1 value"), "typed_value");
+      await userEvent.click(screen.getByRole("button", { name: "Add variable" }));
+      await pasteIntoKey(2, "PASTED=pasted_value");
+
+      expect(keyValues()).toEqual(["TYPED", "PASTED"]);
+      expect(valueValues()).toEqual(["typed_value", "pasted_value"]);
+    });
+
+    it("splits only on the first equals sign so values may contain equals signs", async () => {
+      const { openCard } = setup({ env: [] });
+
+      await openCard();
+      await pasteIntoKey(1, "URL=postgres://user:pass@host/db?ssl=true");
+
+      expect(keyValues()).toEqual(["URL"]);
+      expect(valueValues()).toEqual(["postgres://user:pass@host/db?ssl=true"]);
+    });
+
+    async function pasteIntoKey(visibleIndex: number, text: string) {
+      await userEvent.click(screen.getByLabelText(`Environment variable ${visibleIndex} key`));
+      await userEvent.paste(text);
+    }
+
+    function keyValues() {
+      return screen.getAllByLabelText<HTMLInputElement>(/^Environment variable \d+ key$/).map(el => el.value);
+    }
+
+    function valueValues() {
+      return screen.getAllByLabelText<HTMLInputElement>(/^Environment variable \d+ value$/).map(el => el.value);
+    }
+  });
+
   function setup(input: { env?: Array<Partial<EnvironmentVariableType>>; image?: string; locked?: boolean }) {
     const env = input.env?.map(e => ({ key: "", value: "", isSecret: false, ...e })) ?? [];
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { type FC, useCallback, useEffect, useState } from "react";
+import { type ClipboardEvent, type FC, useCallback, useEffect, useState } from "react";
 import { useController, useFieldArray, useFormContext, useWatch } from "react-hook-form";
 import {
   Button,
@@ -126,8 +126,8 @@ type EnvironmentVariablesListProps = {
 };
 
 const EnvironmentVariablesList: FC<EnvironmentVariablesListProps> = ({ serviceIndex, locked = false }) => {
-  const { control } = useFormContext<SdlBuilderFormValuesType>();
-  const { fields, append, remove } = useFieldArray({ control, name: `services.${serviceIndex}.env`, keyName: "fieldId" });
+  const { control, getValues } = useFormContext<SdlBuilderFormValuesType>();
+  const { fields, append, remove, replace } = useFieldArray({ control, name: `services.${serviceIndex}.env`, keyName: "fieldId" });
 
   const visibleFields = fields.filter(f => !RESERVED_ENV_KEYS.has(f.key));
 
@@ -142,6 +142,46 @@ const EnvironmentVariablesList: FC<EnvironmentVariablesListProps> = ({ serviceIn
     append({ id: nanoid(), key: "", value: "", isSecret: false });
   }, [append]);
 
+  /**
+   * Merges pasted `KEY=value` lines into the variables read live from the form: new keys are appended,
+   * existing keys (including ones just typed or added) are updated in place, and the empty row pasted
+   * into is dropped. Reading the live values is what makes a later paste append rather than overwrite.
+   */
+  const insertPastedEnvVars = useCallback(
+    (event: ClipboardEvent<HTMLInputElement>, focusedEnvIndex: number) => {
+      const pastedText = event.clipboardData.getData("text")?.trim();
+      if (!pastedText || !pastedText.includes("=")) return;
+
+      event.preventDefault();
+
+      const nextEnv = [...(getValues(`services.${serviceIndex}.env`) ?? [])];
+      let didUpdate = false;
+      pastedText.split("\n").forEach(line => {
+        const equalsIndex = line.indexOf("=");
+        if (equalsIndex === -1) return;
+
+        const key = line.slice(0, equalsIndex).trim();
+        const value = line.slice(equalsIndex + 1).trim();
+        if (!key || RESERVED_ENV_KEYS.has(key)) return;
+        didUpdate = true;
+
+        const existingEnvIndex = nextEnv.findIndex(env => env.key === key);
+        if (existingEnvIndex === -1) {
+          nextEnv.push({ id: nanoid(), key, value, isSecret: false });
+        } else {
+          nextEnv[existingEnvIndex] = { ...nextEnv[existingEnvIndex], value };
+        }
+      });
+
+      if (!didUpdate) return;
+      if (!nextEnv[focusedEnvIndex]?.key.trim()) {
+        nextEnv.splice(focusedEnvIndex, 1);
+      }
+      replace(nextEnv);
+    },
+    [getValues, replace, serviceIndex]
+  );
+
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-col gap-2">
@@ -151,6 +191,7 @@ const EnvironmentVariablesList: FC<EnvironmentVariablesListProps> = ({ serviceIn
             serviceIndex={serviceIndex}
             envIndex={fields.indexOf(field)}
             visibleIndex={visibleIndex}
+            onPasteKey={insertPastedEnvVars}
             onRemove={() => {
               const arrayIndex = fields.indexOf(field);
               remove(arrayIndex);
@@ -177,9 +218,11 @@ type EnvironmentVariableFieldsProps = {
   envIndex: number;
   visibleIndex: number;
   onRemove: () => void;
+  /** Parses pasted `KEY=value` lines into rows; `envIndex` is the row pasted into so an empty one can be dropped. */
+  onPasteKey: (event: ClipboardEvent<HTMLInputElement>, envIndex: number) => void;
 };
 
-const EnvironmentVariableFields: FC<EnvironmentVariableFieldsProps> = ({ serviceIndex, envIndex, visibleIndex, onRemove }) => {
+const EnvironmentVariableFields: FC<EnvironmentVariableFieldsProps> = ({ serviceIndex, envIndex, visibleIndex, onRemove, onPasteKey }) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const basePath = `services.${serviceIndex}.env.${envIndex}` as const;
 
@@ -194,6 +237,7 @@ const EnvironmentVariableFields: FC<EnvironmentVariableFieldsProps> = ({ service
           placeholder="KEY"
           value={key.field.value ?? ""}
           onChange={key.field.onChange}
+          onPaste={event => onPasteKey(event, envIndex)}
           inputClassName="h-9"
           className="flex-1"
         />


### PR DESCRIPTION
## Why

The legacy SDL builder lets users bulk-insert environment variables by pasting a block of
`KEY=value` lines (dotenv format) into a key field. The redesigned **Environment Variables**
configure card had no equivalent, so users had to add and fill every variable one row at a time.
This brings the bulk-paste capability to the new card.

Closes CON-419

## What

Pasting multi-line `KEY=value` text into any environment variable **key** field now parses every
line into rows — same trigger as the legacy builder, no new UI.

- Splits each line on the **first** `=`, so values may themselves contain `=`.
- Trims keys and values; skips blank lines, lines without `=`, and reserved keys (`SSH_PUBKEY`).
- New keys are appended; an existing key updates its value in place; the empty row pasted into is
  dropped. Pasting text with no `=` falls through to a normal paste.

**Difference from legacy (intentional):** the merge reads the **live** form values rather than the
`useFieldArray` snapshot, so a second paste — after typing or adding more rows — appends to what's
already there instead of overwriting it. Within a single paste, duplicate keys collapse to last-wins
(one row) rather than producing duplicate rows, because the new schema flags duplicate keys as errors.

Tests: 8 behavior specs added to `EnvironmentVariablesCard.spec.tsx` (26 passing in the file),
covering multi-line parsing, no-`=` passthrough, reserved-key skipping, update-in-place,
non-empty-focused-row append, first-`=` splitting, and the two append-not-override regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pasting multiple `KEY=value` lines into environment variable rows, merging into existing keys or appending new rows based on the current focused row.

* **Bug Fixes**
  * Clipboard parsing now skips reserved environment keys, ignores invalid/empty clipboard content, and splits only on the first `=` to preserve values containing additional `=` characters.
  * If the focused row becomes empty after the merge, it’s removed.

* **Tests**
  * Added coverage for bulk paste, updates vs new rows, reserved-key skipping, and first-`=` value parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->