### PR TITLE
refactor(deployment): collapse attestation evidence reports by default

### DIFF
--- a/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.spec.tsx
@@ -24,13 +24,17 @@ describe(AttestationEvidenceModal.name, () => {
     expect(mutate).toHaveBeenCalled();
   });
 
-  it("renders the platform and CPU report on success", () => {
+  it("keeps each report row collapsed until it is expanded", async () => {
     setup({ quote: { report: "cpu-report-base64", tee_platform: "snp" } });
-    expect(screen.getByText("snp")).toBeInTheDocument();
+
+    expect(screen.queryByText("cpu-report-base64")).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /CPU/ }));
+
     expect(screen.getByText("cpu-report-base64")).toBeInTheDocument();
   });
 
-  it("lists one report per GPU for a cpu-gpu platform", () => {
+  it("lists one collapsible row per GPU with 1-based labels for a cpu-gpu platform", async () => {
     setup({
       quote: {
         report: "cpu-report",
@@ -41,16 +45,21 @@ describe(AttestationEvidenceModal.name, () => {
         ]
       }
     });
-    expect(screen.getByText("GPU reports (2)")).toBeInTheDocument();
-    expect(screen.getByText("GPU 0")).toBeInTheDocument();
-    expect(screen.getByText("GPU 1")).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: /GPU 1/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /GPU 2/ })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /GPU 1/ }));
+    await userEvent.click(screen.getByRole("button", { name: /GPU 2/ }));
+
+    // device_index 0 is labelled "GPU 1", so its report shows when that row is expanded.
     expect(screen.getByText("gpu-0-report")).toBeInTheDocument();
     expect(screen.getByText("gpu-1-report")).toBeInTheDocument();
   });
 
-  it("does not render a GPU section for a CPU-only platform", () => {
+  it("does not render any GPU rows for a CPU-only platform", () => {
     setup({ quote: { report: "cpu-report", tee_platform: "snp" } });
-    expect(screen.queryByText(/GPU reports/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /GPU/ })).not.toBeInTheDocument();
   });
 
   it("downloads the full bundle including the nonce and cert material as JSON when the download action is clicked", async () => {
@@ -110,9 +119,14 @@ describe(AttestationEvidenceModal.name, () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Validate" }));
 
-    // Per-report isolation: the CPU verdict stands even though the GPU report is unverifiable.
+    // Badges live in the always-visible row header, so they show without expanding.
     expect(await screen.findByText("Valid")).toBeInTheDocument();
     expect(screen.getByText("Unverifiable")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /CPU/ }));
+    await userEvent.click(screen.getByRole("button", { name: /GPU 1/ }));
+
+    // Per-report isolation: the CPU verdict detail stands even though the GPU report is unverifiable.
     expect(screen.getByText("Genuine AMD SEV-SNP hardware")).toBeInTheDocument();
     expect(screen.getByText("NVIDIA NRAS unreachable")).toBeInTheDocument();
   });
@@ -130,6 +144,9 @@ describe(AttestationEvidenceModal.name, () => {
     await userEvent.click(screen.getByRole("button", { name: "Validate" }));
 
     expect(await screen.findByText("Invalid")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /CPU/ }));
+
     expect(screen.getByText("signature did not verify")).toBeInTheDocument();
   });
 
@@ -142,9 +159,11 @@ describe(AttestationEvidenceModal.name, () => {
     await userEvent.click(screen.getByRole("button", { name: "Validate" }));
 
     expect(await screen.findByText(/validation service unavailable/)).toBeInTheDocument();
-    // The raw report still renders, so the rest of the view is intact.
-    expect(screen.getByText("cpu-report")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Validate" })).toBeEnabled();
+
+    // The raw report still renders once its row is expanded, so the rest of the view is intact.
+    await userEvent.click(screen.getByRole("button", { name: /CPU/ }));
+    expect(screen.getByText("cpu-report")).toBeInTheDocument();
   });
 
   function setup(input: { nonce?: string; quote?: AttestationQuote; error?: Error; validationResponse?: ValidationResult; validationError?: Error }) {

--- a/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.tsx
+++ b/apps/deploy-web/src/components/deployments/AttestationEvidenceModal.tsx
@@ -1,9 +1,10 @@
 "use client";
-import type { ReactNode } from "react";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import type { paths } from "@akashnetwork/console-api-types";
-import { Alert, Badge, Popup, Spinner } from "@akashnetwork/ui/components";
+import { Alert, Badge, Button, Collapsible, CollapsibleContent, CollapsibleTrigger, Popup, Spinner } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
 import saveFileInBrowser from "file-saver";
+import { NavArrowDown } from "iconoir-react";
 
 import { useServices } from "@src/context/ServicesProvider";
 import { useAttestationQuoteMutation } from "@src/queries/useAttestationQuoteMutation";
@@ -39,20 +40,29 @@ function VerdictBadge({ verdict }: { verdict: AttestationReportVerdict }) {
   return <Badge variant={variant}>{label}</Badge>;
 }
 
-function ReportLabel({ children }: { children: ReactNode }) {
-  return <p className="text-xs font-medium text-muted-foreground">{children}</p>;
-}
+function ReportRow({ label, report, verdict }: { label: string; report: string; verdict?: AttestationReportVerdict }) {
+  // Each row owns its collapsed state so the raw base64 report stays hidden until the user
+  // opts in; rows expand independently rather than accordion-style.
+  const [open, setOpen] = useState(false);
 
-function ReportBlock({ label, report, verdict }: { label: string; report: string; verdict?: AttestationReportVerdict }) {
   return (
-    <div className="space-y-1">
-      <div className="flex items-center justify-between gap-2">
-        <ReportLabel>{label}</ReportLabel>
-        {verdict && <VerdictBadge verdict={verdict} />}
-      </div>
-      <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-all rounded-md border bg-muted/40 p-2 font-mono text-xs">{report}</pre>
-      {verdict?.detail && <p className="text-xs text-muted-foreground">{verdict.detail}</p>}
-    </div>
+    <Collapsible open={open} onOpenChange={setOpen} className="rounded-md border">
+      <CollapsibleTrigger asChild>
+        <Button type="button" variant="ghost" className="flex h-auto w-full items-center justify-between gap-2 p-3 normal-case">
+          <span className="flex items-center gap-2">
+            <NavArrowDown fontSize="1rem" className={cn("transition-transform duration-100", { "rotate-180": open })} />
+            <span className="text-sm font-medium">{label}</span>
+          </span>
+          {verdict && <VerdictBadge verdict={verdict} />}
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="space-y-2 border-t p-3">
+          <pre className="max-h-32 overflow-auto whitespace-pre-wrap break-all rounded-md border bg-muted/40 p-2 font-mono text-xs">{report}</pre>
+          {verdict?.detail && <p className="text-xs text-muted-foreground">{verdict.detail}</p>}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
   );
 }
 
@@ -162,11 +172,6 @@ export function AttestationEvidenceModal({ provider, lease, onClose, dependencie
 
       {!isPending && quote && (
         <div className="mt-3 space-y-3">
-          <div className="flex items-center justify-between gap-4 text-sm">
-            <span className="text-muted-foreground">Platform</span>
-            <span className="font-medium uppercase">{quote.tee_platform}</span>
-          </div>
-
           {validation.isPending && (
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               <Spinner size="small" />
@@ -180,16 +185,12 @@ export function AttestationEvidenceModal({ provider, lease, onClose, dependencie
             </Alert>
           )}
 
-          <ReportBlock label="CPU report" report={quote.report} verdict={cpuVerdict} />
-
-          {gpuReports.length > 0 && (
-            <div className="space-y-2">
-              <ReportLabel>GPU reports ({gpuReports.length})</ReportLabel>
-              {gpuReports.map(gpu => (
-                <ReportBlock key={gpu.device_index} label={`GPU ${gpu.device_index}`} report={gpu.report} verdict={gpuVerdictByIndex.get(gpu.device_index)} />
-              ))}
-            </div>
-          )}
+          <div className="space-y-2">
+            <ReportRow label="CPU" report={quote.report} verdict={cpuVerdict} />
+            {gpuReports.map(gpu => (
+              <ReportRow key={gpu.device_index} label={`GPU ${gpu.device_index + 1}`} report={gpu.report} verdict={gpuVerdictByIndex.get(gpu.device_index)} />
+            ))}
+          </div>
         </div>
       )}
     </Popup>


### PR DESCRIPTION
## Why

The attestation evidence modal rendered every CPU/GPU report fully expanded, so a multi-GPU lease dumped several large base64 blobs at once and pushed the verdict badges and actions below the fold. Collapsing each report by default keeps the modal scannable while leaving the raw evidence one click away.

Replicates console-air #40. Part of CON-552.

## What

- Each CPU/GPU report is now a collapsible row, collapsed by default. The verdict badge stays in the always-visible row header; the raw base64 report and verdict detail are revealed on expand.
- Removed the standalone "Platform" row and the "GPU reports (N)" heading.
- GPU rows are labelled 1-based ("GPU 1", "GPU 2") while still keyed on the 0-based `device_index`.
- Updated the modal spec to drive the new collapse/expand interaction; the validation flow stays on the generated Console API client.

Stacked on top of #3365.