### PR TITLE
fix(deployment): skip lease creation when a lease already exists

### DIFF
--- a/apps/api/src/deployment/services/lease/lease.service.spec.ts
+++ b/apps/api/src/deployment/services/lease/lease.service.spec.ts
@@ -1,0 +1,121 @@
+import type { LeaseHttpService } from "@akashnetwork/http-sdk";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ManagedSignerService, RpcMessageService } from "@src/billing/services";
+import type { WalletInitialized, WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
+import type { GetDeploymentResponse } from "@src/deployment/http-schemas/deployment.schema";
+import type { DeploymentReaderService } from "@src/deployment/services/deployment-reader/deployment-reader.service";
+import type { ProviderService } from "@src/provider/services/provider/provider.service";
+import { LeaseService } from "./lease.service";
+
+import { createAkashAddress } from "@test/seeders/akash-address.seeder";
+import { createLeaseApiResponse } from "@test/seeders/lease-api-response.seeder";
+import { createUserWallet } from "@test/seeders/user-wallet.seeder";
+
+const MANIFEST = '{"version":"v2","groups":[]}';
+
+describe(LeaseService.name, () => {
+  describe("createLeasesAndSendManifest", () => {
+    it("creates the lease and sends the manifest when no lease exists on-chain", async () => {
+      const { service, leaseHttpService, signerService, rpcMessageService, providerService, wallet, deployment } = setup();
+      const lease = { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() };
+
+      const result = await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST, userId: wallet.userId });
+
+      expect(leaseHttpService.list).toHaveBeenCalledWith({ owner: wallet.address, dseq: lease.dseq });
+      expect(rpcMessageService.getCreateLeaseMsg).toHaveBeenCalledWith({
+        owner: wallet.address,
+        dseq: lease.dseq,
+        gseq: lease.gseq,
+        oseq: lease.oseq,
+        provider: lease.provider
+      });
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
+      expect(providerService.sendManifest).toHaveBeenCalledTimes(1);
+      expect(result).toBe(deployment);
+    });
+
+    it("skips lease creation but still sends the manifest when an active lease already exists", async () => {
+      const { service, leaseHttpService, signerService, rpcMessageService, providerService, wallet, deployment } = setup();
+      const lease = { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() };
+      leaseHttpService.list.mockResolvedValue({
+        leases: [createLeaseApiResponse({ owner: wallet.address, dseq: lease.dseq, state: "active" })],
+        pagination: { next_key: null, total: "1" }
+      });
+
+      const result = await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST, userId: wallet.userId });
+
+      expect(rpcMessageService.getCreateLeaseMsg).not.toHaveBeenCalled();
+      expect(signerService.executeDerivedDecodedTxByUserId).not.toHaveBeenCalled();
+      expect(providerService.sendManifest).toHaveBeenCalledTimes(1);
+      expect(result).toBe(deployment);
+    });
+
+    it("recreates the lease when only a closed lease exists for the deployment", async () => {
+      const { service, leaseHttpService, signerService, wallet } = setup();
+      const lease = { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() };
+      leaseHttpService.list.mockResolvedValue({
+        leases: [createLeaseApiResponse({ owner: wallet.address, dseq: lease.dseq, state: "closed" })],
+        pagination: { next_key: null, total: "1" }
+      });
+
+      await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST, userId: wallet.userId });
+
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
+    });
+
+    it("creates every placement lease in a single transaction when none exist", async () => {
+      const { service, signerService, rpcMessageService, providerService, wallet } = setup();
+      const leases = [
+        { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() },
+        { dseq: "100", gseq: 2, oseq: 1, provider: createAkashAddress() }
+      ];
+
+      await service.createLeasesAndSendManifest({ leases, manifest: MANIFEST, userId: wallet.userId });
+
+      expect(rpcMessageService.getCreateLeaseMsg).toHaveBeenCalledTimes(2);
+      expect(signerService.executeDerivedDecodedTxByUserId).toHaveBeenCalledTimes(1);
+      const [, messages] = signerService.executeDerivedDecodedTxByUserId.mock.calls[0];
+      expect(messages).toHaveLength(2);
+      expect(providerService.sendManifest).toHaveBeenCalledTimes(2);
+    });
+
+    it("sends the manifest to the provider with generated auth", async () => {
+      const { service, providerService, wallet } = setup();
+      const lease = { dseq: "100", gseq: 1, oseq: 1, provider: createAkashAddress() };
+
+      await service.createLeasesAndSendManifest({ leases: [lease], manifest: MANIFEST, userId: wallet.userId });
+
+      expect(providerService.toProviderAuth).toHaveBeenCalledWith({ walletId: wallet.id, provider: lease.provider });
+      expect(providerService.sendManifest).toHaveBeenCalledWith({
+        provider: lease.provider,
+        dseq: lease.dseq,
+        manifest: MANIFEST,
+        auth: { type: "jwt", token: "jwt-token" }
+      });
+    });
+  });
+
+  function setup(input: { wallet?: WalletInitialized } = {}) {
+    const wallet = input.wallet ?? (createUserWallet() as WalletInitialized);
+
+    const signerService = mock<ManagedSignerService>();
+    const rpcMessageService = mock<RpcMessageService>();
+    const providerService = mock<ProviderService>();
+    const deploymentReaderService = mock<DeploymentReaderService>();
+    const walletReaderService = mock<WalletReaderService>();
+    const leaseHttpService = mock<LeaseHttpService>();
+
+    const deployment = mock<GetDeploymentResponse["data"]>();
+
+    walletReaderService.getWalletByUserId.mockResolvedValue(wallet);
+    leaseHttpService.list.mockResolvedValue({ leases: [], pagination: { next_key: null, total: "0" } });
+    providerService.toProviderAuth.mockResolvedValue({ type: "jwt", token: "jwt-token" });
+    deploymentReaderService.findByWalletAndDseq.mockResolvedValue(deployment);
+
+    const service = new LeaseService(signerService, rpcMessageService, providerService, deploymentReaderService, walletReaderService, leaseHttpService);
+
+    return { service, signerService, rpcMessageService, providerService, deploymentReaderService, walletReaderService, leaseHttpService, wallet, deployment };
+  }
+});

--- a/apps/api/src/deployment/services/lease/lease.service.ts
+++ b/apps/api/src/deployment/services/lease/lease.service.ts
@@ -1,3 +1,4 @@
+import { LeaseHttpService } from "@akashnetwork/http-sdk";
 import { Trace } from "@akashnetwork/instrumentation";
 import { singleton } from "tsyringe";
 
@@ -15,24 +16,30 @@ export class LeaseService {
     private readonly rpcMessageService: RpcMessageService,
     private readonly providerService: ProviderService,
     private readonly deploymentReaderService: DeploymentReaderService,
-    private readonly walletReaderService: WalletReaderService
+    private readonly walletReaderService: WalletReaderService,
+    private readonly leaseHttpService: LeaseHttpService
   ) {}
 
   @Trace()
   public async createLeasesAndSendManifest({ leases, manifest, userId }: CreateLeaseRequest & { userId: string }): Promise<GetDeploymentResponse["data"]> {
     const wallet = await this.walletReaderService.getWalletByUserId(userId);
+    const dseq = leases[0].dseq;
 
-    const leaseMessages = leases.map(lease =>
-      this.rpcMessageService.getCreateLeaseMsg({
-        owner: wallet.address!,
-        dseq: lease.dseq,
-        gseq: lease.gseq,
-        oseq: lease.oseq,
-        provider: lease.provider
-      })
-    );
+    // Leases for all groups are created in one tx, so one existing lease means all exist:
+    // skip creation when already on-chain to keep retries idempotent.
+    if (!(await this.#hasActiveLease(wallet.address!, dseq))) {
+      const leaseMessages = leases.map(lease =>
+        this.rpcMessageService.getCreateLeaseMsg({
+          owner: wallet.address!,
+          dseq: lease.dseq,
+          gseq: lease.gseq,
+          oseq: lease.oseq,
+          provider: lease.provider
+        })
+      );
 
-    await this.signerService.executeDerivedDecodedTxByUserId(wallet.userId, leaseMessages);
+      await this.signerService.executeDerivedDecodedTxByUserId(wallet.userId, leaseMessages);
+    }
 
     for (const lease of leases) {
       const commonParams = {
@@ -46,6 +53,11 @@ export class LeaseService {
       });
     }
 
-    return await this.deploymentReaderService.findByWalletAndDseq(wallet, leases[0].dseq);
+    return await this.deploymentReaderService.findByWalletAndDseq(wallet, dseq);
+  }
+
+  async #hasActiveLease(owner: string, dseq: string): Promise<boolean> {
+    const { leases } = await this.leaseHttpService.list({ owner, dseq });
+    return leases.some(({ lease }) => lease.state !== "closed");
   }
 }


### PR DESCRIPTION
## Why

Confirming a deployment via `POST /v1/leases` creates the lease(s) and delivers the manifest(s) in one step. When it failed partway (lease created on-chain, manifest delivery failed), retrying re-broadcast `MsgCreateLease`, which the chain rejected, leaving no safe way to recover without closing the deployment. With the managed API this blocked any retry in web.

Closes CON-589

## What

Made `LeaseService.createLeasesAndSendManifest` idempotent. Before broadcasting, it checks on-chain lease state and skips lease creation when the deployment already has a non-closed lease, then re-delivers the manifest (idempotent `PUT`). Leases for all groups are created in a single atomic tx, so a single existing lease means every lease exists.

- Retry after a lease exists delivers the manifest with no duplicate lease and no extra charge
- Retry before any lease exists still does the full create + deliver
- Retry after full success is a safe no-op
- First-creation side effects (alerts/notifications) fire once, since they are tied to the skipped broadcast
- Added `lease.service.spec.ts` (5 cases)

No special race handling: a concurrent duplicate `createLease` is rejected on-chain with the already-mapped "bid not open" error. Response shape and the frontend are unchanged; the inline Retry CTA is tracked separately in CON-425.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made lease creation idempotent by checking for an existing active lease before submitting create-lease actions.
  * Improved recovery by recreating leases when only closed leases are present.
  * Continued sending the deployment manifest to each provider even when lease creation is skipped or bundled.
* **Tests**
  * Added a Vitest suite covering active vs. closed lease scenarios, transaction bundling behavior, manifest dispatch, and provider auth token shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->