### PR TITLE
chore(repo): ignore .claude/worktrees directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Worktrees
 .worktrees
+.claude/worktrees
 
 # Logs
 logs


### PR DESCRIPTION
## Why

The Claude Code harness creates git worktrees under `.claude/worktrees/`. These were showing up as untracked changes and could be accidentally committed. The existing `.worktrees` ignore rule doesn't cover this path.

## What

- Add `.claude/worktrees` to `.gitignore`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to exclude a new local worktree directory from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->