### PR TITLE
feat(deployment): add provider selection, review and deploy to configure flow

### DIFF
--- a/apps/deploy-web/playwright.config.ts
+++ b/apps/deploy-web/playwright.config.ts
@@ -8,6 +8,10 @@ dotenv.config({ path: path.resolve(__dirname, "env/.env.test.local") });
 dotenv.config({ path: path.resolve(__dirname, "env/.env.test") });
 
 const slowMo = Number(process.env.PW_SLOW_MO) || 0;
+/** Capture a high-quality, Mac-sized video of the run. Opt-in via PW_RECORD=1, or implied when slow-mo is on. */
+const isRecording = process.env.PW_RECORD === "1" || slowMo > 0;
+/** ~16" MacBook Pro logical viewport (16:10). Use { width: 1512, height: 945 } for a 14"/15" feel. */
+const RECORDING_VIEWPORT = { width: 1728, height: 1080 };
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -42,7 +46,8 @@ export default defineConfig({
       use: {
         ...devices["Desktop Chrome"],
         channel: "chromium", // https://github.com/microsoft/playwright/issues/33566
-        userAgent: getUserAgent()
+        userAgent: getUserAgent(),
+        ...(isRecording ? { viewport: RECORDING_VIEWPORT, deviceScaleFactor: 2, video: { mode: "on" as const, size: RECORDING_VIEWPORT } } : {})
       }
     }
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -2,11 +2,11 @@ import { useFormContext, useWatch } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { SdlBuilderFormValuesType } from "@src/types";
+import type { PlacementType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { defaultService } from "@src/utils/sdl/data";
 import { usePlacementManager } from "../DeploymentPane/usePlacementManager/usePlacementManager";
 import type { DEPENDENCIES } from "./ConfigureDeploymentForm";
-import { ConfigureDeploymentForm } from "./ConfigureDeploymentForm";
+import { ConfigureDeploymentForm, firstBidReadyServiceId, nextUndoneServiceId } from "./ConfigureDeploymentForm";
 
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -221,7 +221,9 @@ describe(ConfigureDeploymentForm.name, () => {
       useConfigureDraft: useConfigureDraft as never,
       useDeploymentFlow: (() => mock<ReturnType<typeof DEPENDENCIES.useDeploymentFlow>>({ phase: "configuring", dseq: null, bidStrategy: "select" })) as never,
       useSnackbar: () => mock<ReturnType<typeof DEPENDENCIES.useSnackbar>>({ enqueueSnackbar }),
-      Snackbar: Snackbar as never
+      Snackbar: Snackbar as never,
+      ReviewAndDeployModal: () => null,
+      usePlacementsWithBids: () => new Set<string>()
     };
 
     render(
@@ -233,6 +235,54 @@ describe(ConfigureDeploymentForm.name, () => {
     );
 
     return { ConfigureDeploymentPanes, enqueueSnackbar, save };
+  }
+});
+
+describe(nextUndoneServiceId.name, () => {
+  it("falls back to the first undone placement's service when none have bids yet", () => {
+    const placements = [placement("p1"), placement("p2")];
+    const services = [service("s1", "p1"), service("s2", "p2")];
+    expect(nextUndoneServiceId(placements, services, { p1: "bid" }, new Set())).toBe("s2");
+  });
+
+  it("prefers the first undone placement that already has bids", () => {
+    const placements = [placement("p1"), placement("p2"), placement("p3")];
+    const services = [service("s1", "p1"), service("s2", "p2"), service("s3", "p3")];
+    expect(nextUndoneServiceId(placements, services, { p1: "bid" }, new Set(["p3"]))).toBe("s3");
+  });
+
+  it("returns null once every placement has a selection", () => {
+    const placements = [placement("p1"), placement("p2")];
+    const services = [service("s1", "p1"), service("s2", "p2")];
+    expect(nextUndoneServiceId(placements, services, { p1: "b1", p2: "b2" }, new Set(["p1", "p2"]))).toBeNull();
+  });
+
+  function placement(id: string): PlacementType {
+    return mock<PlacementType>({ id });
+  }
+  function service(id: string, placementId: string): ServiceType {
+    return mock<ServiceType>({ id, placementId, title: id });
+  }
+});
+
+describe(firstBidReadyServiceId.name, () => {
+  it("returns the first unselected placement that has bids", () => {
+    const placements = [placement("p1"), placement("p2")];
+    const services = [service("s1", "p1"), service("s2", "p2")];
+    expect(firstBidReadyServiceId(placements, services, {}, new Set(["p2"]))).toBe("s2");
+  });
+
+  it("returns null when no unselected placement has bids", () => {
+    const placements = [placement("p1")];
+    const services = [service("s1", "p1")];
+    expect(firstBidReadyServiceId(placements, services, {}, new Set())).toBeNull();
+  });
+
+  function placement(id: string): PlacementType {
+    return mock<PlacementType>({ id });
+  }
+  function service(id: string, placementId: string): ServiceType {
+    return mock<ServiceType>({ id, placementId, title: id });
   }
 });
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 import type { FC } from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FormProvider, useForm, useWatch } from "react-hook-form";
 import { Snackbar } from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -9,14 +9,18 @@ import { useSnackbar } from "notistack";
 
 import Layout from "@src/components/layout/Layout";
 import { isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
+import { usePlacementsWithBids } from "@src/queries/usePlacementsWithBids";
 import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { SdlBuilderFormValuesSchema } from "@src/types";
+import { parseBidId } from "@src/utils/bids/bidId";
 import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
 import { generateSdl } from "@src/utils/sdl/sdlGenerator";
 import { importSimpleSdl } from "@src/utils/sdl/sdlImport";
 import { applyImportedSshState } from "@src/utils/sdl/sshKey";
 import { ConfigureDeploymentHeader } from "../ConfigureDeploymentHeader/ConfigureDeploymentHeader";
 import { ConfigureDeploymentPanes } from "../ConfigureDeploymentPanes/ConfigureDeploymentPanes";
+import { DeployProgressOverlay } from "../DeployProgressOverlay/DeployProgressOverlay";
+import { ReviewAndDeployModal } from "../ReviewAndDeployModal/ReviewAndDeployModal";
 import { useConfigureDraft } from "../useConfigureDraft/useConfigureDraft";
 import type { DeploymentIntent } from "../useDeploymentFlow/deploymentIntent";
 import { useDeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
@@ -26,8 +30,10 @@ export const DEPENDENCIES = {
   NextSeo,
   ConfigureDeploymentHeader,
   ConfigureDeploymentPanes,
+  ReviewAndDeployModal,
   useConfigureDraft,
   useDeploymentFlow,
+  usePlacementsWithBids,
   useSnackbar,
   Snackbar
 };
@@ -104,27 +110,100 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, intent, depende
   );
 
   const flow = d.useDeploymentFlow({ intent });
+  const placementsWithBids = d.usePlacementsWithBids({ enabled: flow.phase === "quoting", dseq: flow.dseq, sdl: liveSdl, placements });
+  const [isReviewOpen, setReviewOpen] = useState(false);
+  const allPlacementsHaveBids = placements.length > 0 && placements.every(placement => placementsWithBids.has(placement.id));
+  const lastToastedDeployError = useRef(flow.deployError);
+  const hasAutoFocusedFirstBids = useRef(false);
+
+  useEffect(
+    function toastDeployFailure() {
+      if (flow.deployError && flow.deployError !== lastToastedDeployError.current) {
+        enqueueSnackbar(
+          <d.Snackbar
+            title="Couldn't deploy"
+            subTitle={flow.deployError.message ?? "Something went wrong while deploying. Please try again."}
+            iconVariant="error"
+          />,
+          { variant: "error" }
+        );
+      }
+      lastToastedDeployError.current = flow.deployError;
+    },
+    [flow.deployError, enqueueSnackbar, d]
+  );
+
+  useEffect(
+    function focusFirstBidReadyPlacement() {
+      if (flow.phase !== "quoting") {
+        hasAutoFocusedFirstBids.current = false;
+        return;
+      }
+      if (hasAutoFocusedFirstBids.current || placementsWithBids.size === 0) return;
+      hasAutoFocusedFirstBids.current = true;
+      const activePlacementId = selectedPlacement.id;
+      if (placementsWithBids.has(activePlacementId) || flow.selections[activePlacementId]) return;
+      const targetServiceId = firstBidReadyServiceId(placements, services, flow.selections, placementsWithBids);
+      if (targetServiceId) setSelectedServiceId(targetServiceId);
+    },
+    [flow.phase, flow.selections, placementsWithBids, selectedPlacement.id, placements, services]
+  );
+
+  /**
+   * Records the provider chosen for a placement, then advances: focuses the next placement still missing a
+   * selection, or — when that was the last one — opens the review modal so the user confirms without hunting
+   * for the Deploy button.
+   */
+  function selectProviderAndAdvance(placementId: string, bidId: string) {
+    flow.actions.selectProvider(placementId, bidId);
+    const nextServiceId = nextUndoneServiceId(placements, services, { ...flow.selections, [placementId]: bidId }, placementsWithBids);
+    if (nextServiceId) {
+      setSelectedServiceId(nextServiceId);
+    } else {
+      setReviewOpen(true);
+    }
+  }
 
   return (
     <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col dark:bg-card">
       <d.NextSeo title="Configure your deployment" />
       <FormProvider {...form}>
         <div className="px-6 pt-6">
-          <d.ConfigureDeploymentHeader flow={flow} />
+          <d.ConfigureDeploymentHeader flow={flow} onDeploy={() => setReviewOpen(true)} allPlacementsHaveBids={allPlacementsHaveBids} />
         </div>
-        <div className="mt-6 flex min-h-0 flex-1">
+        <div className="relative mt-6 flex min-h-0 flex-1">
           <d.ConfigureDeploymentPanes
             sdl={liveSdl}
             previewSdl={previewSdl}
             selectedServiceId={selectedServiceId}
             selectedPlacementName={selectedPlacement.name}
             selectedPlacementRegion={selectedPlacement.region}
+            selectedPlacementId={selectedPlacement.id}
             onSelectService={setSelectedServiceId}
             phase={flow.phase}
             dseq={flow.dseq}
+            selections={flow.selections}
+            onSelectProvider={selectProviderAndAdvance}
             onCancelAndEdit={flow.actions.cancelAndEdit}
           />
+          {flow.phase === "deploying" && (
+            <DeployProgressOverlay
+              providerAddress={firstSelectedProviderAddress(flow.selections)}
+              activePhase={flow.deploySucceeded ? "success" : "preparing"}
+            />
+          )}
         </div>
+        <d.ReviewAndDeployModal
+          open={isReviewOpen}
+          dseq={flow.dseq}
+          placements={placements}
+          selections={flow.selections}
+          onBack={() => setReviewOpen(false)}
+          onConfirm={() => {
+            setReviewOpen(false);
+            flow.actions.deploy(liveSdl);
+          }}
+        />
       </FormProvider>
     </d.Layout>
   );
@@ -220,4 +299,53 @@ function nextSelectedServiceId(values: SdlBuilderFormValuesType, previous: strin
   }
   const visible = services.find(candidate => candidate && !isLogCollectorService(candidate as ServiceType)) ?? services[0];
   return visible.id;
+}
+
+/** The provider chosen for the first placement, focused on the deploy-progress globe while deploying. */
+function firstSelectedProviderAddress(selections: Record<string, string>): string | null {
+  const first = Object.values(selections)[0];
+  return first ? parseBidId(first).provider : null;
+}
+
+/** The first unselected placement that already has bids, as its first service id — used to focus where the first bids land. */
+export function firstBidReadyServiceId(
+  placements: SdlBuilderFormValuesType["placements"],
+  services: SdlBuilderFormValuesType["services"],
+  selections: Record<string, string>,
+  placementsWithBids: Set<string>
+): string | null {
+  return serviceIdOfPlacement(
+    services,
+    placements.find(placement => !selections[placement.id] && placementsWithBids.has(placement.id))
+  );
+}
+
+/**
+ * After a provider is chosen, the service to focus next: the first unselected placement that already has bids,
+ * else the first unselected placement at all (so focus still advances while its bids are pending). Null when
+ * every placement is selected — the cue to open the review modal.
+ */
+export function nextUndoneServiceId(
+  placements: SdlBuilderFormValuesType["placements"],
+  services: SdlBuilderFormValuesType["services"],
+  selections: Record<string, string>,
+  placementsWithBids: Set<string>
+): string | null {
+  return (
+    firstBidReadyServiceId(placements, services, selections, placementsWithBids) ??
+    serviceIdOfPlacement(
+      services,
+      placements.find(placement => !selections[placement.id])
+    )
+  );
+}
+
+/** The first non-log-collector service of a placement (or null), used to make that placement the active one. */
+function serviceIdOfPlacement(
+  services: SdlBuilderFormValuesType["services"],
+  placement: SdlBuilderFormValuesType["placements"][number] | undefined
+): string | null {
+  if (!placement) return null;
+  const service = services.find(candidate => candidate.placementId === placement.id && !isLogCollectorService(candidate));
+  return service?.id ?? null;
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.spec.tsx
@@ -4,11 +4,12 @@ import { Snackbar } from "@akashnetwork/ui/components";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
-import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
+import type { DeploymentFlow, DeploymentFlowActions } from "../useDeploymentFlow/useDeploymentFlow";
 import type { DEPENDENCIES } from "./ConfigureDeploymentHeader";
 import { ConfigureDeploymentHeader } from "./ConfigureDeploymentHeader";
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 /** Stand-in for the SDL the header regenerates from the submitted form values. */
 const GENERATED_SDL = 'version: "2.0" # generated';
@@ -49,9 +50,9 @@ describe(ConfigureDeploymentHeader.name, () => {
     expect(screen.queryByRole("button", { name: /request quotes/i })).not.toBeInTheDocument();
   });
 
-  it("keeps the Requesting CTA while quoting", () => {
-    setup({ phase: "quoting" });
-    expect(screen.getByRole("button", { name: /requesting/i })).toBeInTheDocument();
+  it("shows Request quotes while configuring", () => {
+    setup({ phase: "configuring" });
+    expect(screen.getByRole("button", { name: /request quotes/i })).toBeInTheDocument();
   });
 
   it("keeps the Requesting CTA while closing", () => {
@@ -64,11 +65,59 @@ describe(ConfigureDeploymentHeader.name, () => {
     expect(screen.getByRole("button", { name: /request quotes/i })).toBeInTheDocument();
   });
 
-  function setup(input: { phase: DeploymentFlow["phase"]; requestQuotes?: (sdl: string) => void; validationErrors?: string[] }) {
+  it("keeps the Requesting CTA while quoting until the first bid arrives", () => {
+    setup({ phase: "quoting", allPlacementsHaveBids: false, placements: [{ id: "p1" }], selections: {} });
+    expect(screen.getByRole("button", { name: /requesting/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Deploy" })).not.toBeInTheDocument();
+  });
+
+  it("shows Deploy disabled until every placement has a selection", () => {
+    setup({ phase: "quoting", allPlacementsHaveBids: true, placements: [{ id: "p1" }, { id: "p2" }], selections: { p1: "akash1a/1/1/1" } });
+    expect(screen.getByRole("button", { name: "Deploy" })).toBeDisabled();
+  });
+
+  it("enables Deploy when all placements are selected and calls onDeploy", async () => {
+    const onDeploy = vi.fn();
+    setup({ phase: "quoting", allPlacementsHaveBids: true, placements: [{ id: "p1" }], selections: { p1: "akash1a/1/1/1" }, onDeploy });
+    const deploy = screen.getByRole("button", { name: "Deploy" });
+    expect(deploy).toBeEnabled();
+    await userEvent.click(deploy);
+    expect(onDeploy).toHaveBeenCalled();
+  });
+
+  it("shows Retry instead of Deploy after a failed deploy and re-fires the deploy request", async () => {
+    const deploy = vi.fn();
+    setup({
+      phase: "quoting",
+      allPlacementsHaveBids: true,
+      placements: [{ id: "p1" }],
+      selections: { p1: "akash1a/1/1/1" },
+      deployError: { message: "boom" },
+      deploy
+    });
+    expect(screen.queryByRole("button", { name: "Deploy" })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(deploy).toHaveBeenCalled();
+  });
+
+  function setup(input: {
+    phase: DeploymentFlow["phase"];
+    requestQuotes?: (sdl: string) => void;
+    validationErrors?: string[];
+    placements?: { id: string }[];
+    selections?: Record<string, string>;
+    onDeploy?: () => void;
+    allPlacementsHaveBids?: boolean;
+    deployError?: { message?: string };
+    deploy?: () => void;
+  }) {
     const flow = mock<DeploymentFlow>({
       phase: input.phase,
-      actions: mock<DeploymentFlow["actions"]>({ requestQuotes: input.requestQuotes ?? vi.fn() })
+      dseq: null,
+      deployError: input.deployError,
+      actions: mock<DeploymentFlowActions>({ requestQuotes: input.requestQuotes ?? vi.fn(), deploy: input.deploy ?? vi.fn() })
     });
+    flow.selections = input.selections ?? {};
     const enqueueSnackbar = vi.fn();
     const dependencies: typeof DEPENDENCIES = {
       useDeploymentResourceSummary: (() => "1 vCPU") as never,
@@ -78,15 +127,20 @@ describe(ConfigureDeploymentHeader.name, () => {
       validateGeneratedSdl: () => input.validationErrors ?? []
     };
     render(
-      <Wrapper>
-        <ConfigureDeploymentHeader flow={flow} dependencies={dependencies} />
+      <Wrapper placements={input.placements}>
+        <ConfigureDeploymentHeader
+          flow={flow}
+          onDeploy={input.onDeploy ?? vi.fn()}
+          allPlacementsHaveBids={input.allPlacementsHaveBids ?? false}
+          dependencies={dependencies}
+        />
       </Wrapper>
     );
     return { enqueueSnackbar };
   }
 
-  function Wrapper({ children }: { children: ReactNode }) {
-    const form = useForm();
+  function Wrapper({ children, placements }: { children: ReactNode; placements?: { id: string }[] }) {
+    const form = useForm({ defaultValues: { placements: placements ?? [] } });
     return <FormProvider {...form}>{children}</FormProvider>;
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
@@ -1,5 +1,5 @@
 import type { FC } from "react";
-import { useFormContext } from "react-hook-form";
+import { useFormContext, useWatch } from "react-hook-form";
 import { Button, Snackbar } from "@akashnetwork/ui/components";
 import { Send } from "iconoir-react";
 import { LoaderCircle } from "lucide-react";
@@ -13,14 +13,20 @@ import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
 
 export const DEPENDENCIES = { useDeploymentResourceSummary, useSnackbar, Snackbar, generateSdl, validateGeneratedSdl };
 
-type Props = { flow: DeploymentFlow; dependencies?: typeof DEPENDENCIES };
+type Props = { flow: DeploymentFlow; onDeploy: () => void; allPlacementsHaveBids: boolean; dependencies?: typeof DEPENDENCIES };
 
-export const ConfigureDeploymentHeader: FC<Props> = ({ flow, dependencies: d = DEPENDENCIES }) => {
+export const ConfigureDeploymentHeader: FC<Props> = ({ flow, onDeploy, allPlacementsHaveBids, dependencies: d = DEPENDENCIES }) => {
   const deploymentSummary = d.useDeploymentResourceSummary();
-  const { handleSubmit } = useFormContext<SdlBuilderFormValuesType>();
+  const { control, handleSubmit, getValues } = useFormContext<SdlBuilderFormValuesType>();
   const { enqueueSnackbar } = d.useSnackbar();
+  const placements = useWatch({ control, name: "placements" });
 
   const isEditable = flow.phase === "configuring" || flow.phase === "error";
+  /** Deploy only takes over from the loading CTA once every placement has bids; until then quoting still reads as "Requesting…". */
+  const showDeployCta = flow.phase === "quoting" && allPlacementsHaveBids;
+  const allPlacementsSelected = placements.length > 0 && placements.every(placement => !!flow.selections[placement.id]);
+  /** A failed deploy returns to quoting with the error set; the CTA then re-fires the same request rather than re-opening review. */
+  const hasDeployError = !!flow.deployError;
 
   /**
    * Request quotes runs the zod form validation first, then regenerates the SDL from the values
@@ -70,6 +76,16 @@ export const ConfigureDeploymentHeader: FC<Props> = ({ flow, dependencies: d = D
           <Button type="button" onClick={onRequestQuotes} className="h-9 shrink-0 px-3 md:h-10 md:px-8">
             <Send className="h-4 w-4 md:hidden" aria-label="Request quotes" />
             <span className="hidden md:inline">Request quotes</span>
+          </Button>
+        ) : showDeployCta ? (
+          <Button
+            type="button"
+            disabled={!allPlacementsSelected}
+            onClick={hasDeployError ? () => flow.actions.deploy(d.generateSdl(getValues())) : onDeploy}
+            aria-label={hasDeployError ? "Retry" : "Deploy"}
+            className="h-9 shrink-0 px-3 md:h-10 md:px-8"
+          >
+            {hasDeployError ? "Retry" : "Deploy"}
           </Button>
         ) : (
           <Button type="button" disabled aria-label="Requesting" className="h-9 shrink-0 gap-2 px-3 md:h-10 md:px-8">

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
@@ -1,6 +1,7 @@
 import { createStore, Provider as JotaiStoreProvider } from "jotai";
 import { describe, expect, it, vi } from "vitest";
 
+import type { DeploymentFlowPhase } from "../useDeploymentFlow/useDeploymentFlow";
 import type { DEPENDENCIES } from "./ConfigureDeploymentPanes";
 import { ConfigureDeploymentPanes } from "./ConfigureDeploymentPanes";
 
@@ -142,9 +143,12 @@ describe("ConfigureDeploymentPanes", () => {
       selectedServiceId?: string;
       selectedPlacementName?: string;
       selectedPlacementRegion?: string;
+      selectedPlacementId?: string;
       onSelectService?: (serviceId: string) => void;
-      phase?: "configuring" | "creating" | "quoting" | "closing" | "error";
+      phase?: DeploymentFlowPhase;
       dseq?: string | null;
+      selections?: Record<string, string>;
+      onSelectProvider?: (placementId: string, bidId: string) => void;
       onCancelAndEdit?: () => void;
     } = {}
   ) {
@@ -177,9 +181,12 @@ describe("ConfigureDeploymentPanes", () => {
           selectedServiceId={input.selectedServiceId ?? ""}
           selectedPlacementName={input.selectedPlacementName ?? "dcloud"}
           selectedPlacementRegion={input.selectedPlacementRegion}
+          selectedPlacementId={input.selectedPlacementId ?? ""}
           onSelectService={input.onSelectService ?? vi.fn()}
           phase={input.phase ?? "configuring"}
           dseq={input.dseq ?? null}
+          selections={input.selections ?? {}}
+          onSelectProvider={input.onSelectProvider ?? vi.fn()}
           onCancelAndEdit={input.onCancelAndEdit ?? vi.fn()}
           dependencies={dependencies}
         />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
@@ -21,9 +21,12 @@ type Props = {
   selectedServiceId: string;
   selectedPlacementName: string;
   selectedPlacementRegion?: string;
+  selectedPlacementId: string;
   onSelectService: (serviceId: string) => void;
   phase: DeploymentFlowPhase;
   dseq: string | null;
+  selections: Record<string, string>;
+  onSelectProvider: (placementId: string, bidId: string) => void;
   onCancelAndEdit: () => void;
   dependencies?: typeof DEPENDENCIES;
 };
@@ -34,16 +37,19 @@ export const ConfigureDeploymentPanes: FC<Props> = ({
   selectedServiceId,
   selectedPlacementName,
   selectedPlacementRegion,
+  selectedPlacementId,
   onSelectService,
   phase,
   dseq,
+  selections,
+  onSelectProvider,
   onCancelAndEdit,
   dependencies: d = DEPENDENCIES
 }) => {
   const [activePane, setActivePane] = useState<ActivePane>("deployment");
   const [isSdlPreviewOpen, setIsSdlPreviewOpen] = useAtom(sdlStore.sdlPreviewOpen);
   const isSdlPreviewEnabled = d.useFlag("ui_sdl_preview_panel");
-  const isLocked = phase === "creating" || phase === "quoting" || phase === "closing";
+  const isLocked = phase === "creating" || phase === "quoting" || phase === "closing" || phase === "deploying";
   const isClosing = phase === "closing";
 
   return (
@@ -57,6 +63,11 @@ export const ConfigureDeploymentPanes: FC<Props> = ({
               locked={isLocked}
               isClosing={isClosing}
               onCancelAndEdit={onCancelAndEdit}
+              phase={phase}
+              selections={selections}
+              selectedPlacementId={selectedPlacementId}
+              sdl={sdl}
+              dseq={dseq}
             />
           </div>
           <div className={cn("min-h-0 md:block", { hidden: activePane !== "configuration" })}>
@@ -64,7 +75,16 @@ export const ConfigureDeploymentPanes: FC<Props> = ({
           </div>
         </div>
         <div className={cn("min-h-0 md:block md:border-l md:border-zinc-300 md:dark:border-zinc-700", { hidden: activePane !== "marketplace" })}>
-          <d.MarketplacePane sdl={sdl} placementName={selectedPlacementName} region={selectedPlacementRegion} phase={phase} dseq={dseq} />
+          <d.MarketplacePane
+            sdl={sdl}
+            placementName={selectedPlacementName}
+            region={selectedPlacementRegion}
+            phase={phase}
+            dseq={dseq}
+            selectedPlacementId={selectedPlacementId}
+            selectedBidId={selections[selectedPlacementId]}
+            onSelectProvider={onSelectProvider}
+          />
         </div>
         {isSdlPreviewEnabled && (
           <d.SdlPreviewPane sdl={previewSdl} isOpen={isSdlPreviewOpen} onOpen={() => setIsSdlPreviewOpen(true)} onClose={() => setIsSdlPreviewOpen(false)} />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/DeployProgressOverlay.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/DeployProgressOverlay.spec.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { DEPENDENCIES, DeployProgressOverlay } from "./DeployProgressOverlay";
+
+import { render, screen } from "@testing-library/react";
+
+describe(DeployProgressOverlay.name, () => {
+  it("renders the progress panel while deploying", () => {
+    setup();
+    expect(screen.getByText(/preparing deployment/i)).toBeInTheDocument();
+  });
+
+  it("completes the final phase once the deploy has succeeded", () => {
+    setup({ activePhase: "success" });
+    expect(screen.getByText(/deployment prepared/i)).toBeInTheDocument();
+  });
+
+  function setup(input: { activePhase?: "preparing" | "success" } = {}) {
+    const ProvidersGlobe: typeof DEPENDENCIES.ProvidersGlobe = () => null;
+    render(<DeployProgressOverlay activePhase={input.activePhase} dependencies={{ ...DEPENDENCIES, ProvidersGlobe }} />);
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/DeployProgressOverlay.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/DeployProgressOverlay.tsx
@@ -1,0 +1,34 @@
+import type { FC } from "react";
+
+import { PhasedDeploymentProgress } from "@src/components/deployments/PhasedDeploymentProgress/PhasedDeploymentProgress";
+import { ProvidersGlobe } from "./ProvidersGlobe";
+import { type DeployActivePhase, useConfigureDeployProgress } from "./useConfigureDeployProgress";
+
+export const DEPENDENCIES = { PhasedDeploymentProgress, ProvidersGlobe, useConfigureDeployProgress };
+
+interface Props {
+  /** Provider chosen for the deployment; the globe narrows to and focuses on it. */
+  providerAddress?: string | null;
+  /** The deploy's current active step, from `useDeploymentFlow`: the lease ("preparing"), then "success" once it lands. */
+  activePhase?: DeployActivePhase;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+/**
+ * Full-screen overlay shown during the `deploying` phase: the reused CON-315 progress panel (creating +
+ * matching pre-completed, since the deployment already exists and the provider is chosen) over the provider
+ * globe. The "choose my provider" CTA is intentionally omitted — the provider was already selected here.
+ * Deploy failures unmount this overlay (the flow returns to quoting) and surface a toast, so no error panel
+ * is rendered here; a `"success"` active phase completes the panel and is held briefly before the flow redirects.
+ */
+export const DeployProgressOverlay: FC<Props> = ({ providerAddress, activePhase = "preparing", dependencies: d = DEPENDENCIES }) => {
+  const { state, progressPercent, phases } = d.useConfigureDeployProgress(activePhase);
+  return (
+    <div className="absolute inset-0 z-20 flex flex-col items-center overflow-hidden bg-white dark:bg-background">
+      <div className="w-[632px] max-w-full px-[20px] pt-[80px]">
+        <d.PhasedDeploymentProgress state={state} templateName="your deployment" progressPercent={progressPercent} phases={phases} />
+      </div>
+      <d.ProvidersGlobe focusedProviderAddress={providerAddress} />
+    </div>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/ProvidersGlobe.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/ProvidersGlobe.spec.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { ApiProviderList } from "@src/types/provider";
+import type { DEPENDENCIES } from "./ProvidersGlobe";
+import { ProvidersGlobe } from "./ProvidersGlobe";
+
+import { render } from "@testing-library/react";
+
+describe(ProvidersGlobe.name, () => {
+  it("shows a marker for every online provider when none is focused", () => {
+    const { globe } = setup({
+      providers: [
+        provider({ owner: "p1", name: "One", ipLat: "10", ipLon: "20", isOnline: true }),
+        provider({ owner: "p2", name: "Two", ipLat: "30", ipLon: "40", isOnline: false })
+      ]
+    });
+    expect(globe.mock.calls[0][0].markers).toEqual([{ id: "p1", label: "One", lat: 10, lng: 20 }]);
+    expect(globe.mock.calls[0][0].focusedMarker).toBeNull();
+  });
+
+  it("narrows to the focused provider and focuses the camera on it", () => {
+    const { globe } = setup({
+      focusedProviderAddress: "p2",
+      providers: [
+        provider({ owner: "p1", name: "One", ipLat: "10", ipLon: "20", isOnline: true }),
+        provider({ owner: "p2", name: "Two", ipLat: "30", ipLon: "40", isOnline: true })
+      ]
+    });
+    expect(globe.mock.calls[0][0].markers).toEqual([{ id: "p2", label: "Two", lat: 30, lng: 40 }]);
+    expect(globe.mock.calls[0][0].focusedMarker).toEqual({ lat: 30, lng: 40 });
+  });
+
+  function provider(overrides: Partial<ApiProviderList>) {
+    return mock<ApiProviderList>(overrides);
+  }
+
+  function setup(input: { providers: ApiProviderList[]; focusedProviderAddress?: string }) {
+    const globe = vi.fn<typeof DEPENDENCIES.Globe>(() => <div />);
+    const dependencies: typeof DEPENDENCIES = {
+      useProviderList: () => mock<ReturnType<typeof DEPENDENCIES.useProviderList>>({ data: input.providers }),
+      useTheme: () => "light",
+      Globe: globe
+    };
+    render(<ProvidersGlobe focusedProviderAddress={input.focusedProviderAddress} dependencies={dependencies} />);
+    return { globe };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/ProvidersGlobe.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/ProvidersGlobe.tsx
@@ -1,0 +1,91 @@
+"use client";
+import type { FC } from "react";
+import { useMemo } from "react";
+
+import type { GlobeMarker } from "@src/components/globe/Globe/Globe";
+import { Globe } from "@src/components/globe/Globe/Globe";
+import useCookieTheme from "@src/hooks/useTheme";
+import { useProviderList } from "@src/queries/useProvidersQuery";
+import type { ApiProviderList } from "@src/types/provider";
+
+/** Lifts a focused marker toward the top of the visible cap of the oversized globe (negative = up from sphere center). */
+const GLOBE_FOCUS_BIAS_Y = -0.75;
+/** Horizontal offset of a focused marker from the camera meridian; 0 rests it on the centerline. */
+const GLOBE_FOCUS_BIAS_X = 0;
+/** Marker dot radius (fraction of sphere radius); small because the globe is rendered oversized and clipped to a top cap. */
+const GLOBE_MARKER_SIZE = 0.01;
+/** Square diameter that always overshoots the viewport so the sphere fills the visible cap on any aspect ratio. */
+const GLOBE_CONTAINER_SIZE = "min(220vh, 120vw)";
+
+export const DEPENDENCIES = { useProviderList, useTheme: useCookieTheme, Globe };
+
+interface Props {
+  /** When set, the globe shows only this provider's marker and focuses the camera on it; otherwise it shows every online provider. */
+  focusedProviderAddress?: string | null;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+/**
+ * The provider globe behind the deploy-progress panel: every online provider while matching, narrowing to
+ * the chosen provider once one is selected. The configure flow is the home for the deploy-progress surface;
+ * onboarding's quick-deploy renders the same globe and will fold into this when it redirects here.
+ * TODO(onboarding-merge): the globe constants, cobe options and marker mapping here are duplicated from
+ * PhasedDeploymentContainer; consolidate into one shared globe when that fold-in happens.
+ */
+export const ProvidersGlobe: FC<Props> = ({ focusedProviderAddress, dependencies: d = DEPENDENCIES }) => {
+  const documentTheme = d.useTheme();
+  const { data: providers } = d.useProviderList();
+
+  const cobeOptions = useMemo(() => {
+    const glowColor: [number, number, number] = documentTheme === "dark" ? [0.05, 0.05, 0.05] : [1, 1, 1];
+    return { mapSamples: 32000, dark: 1, diffuse: 0, mapBrightness: documentTheme === "dark" ? 3 : 1, glowColor };
+  }, [documentTheme]);
+
+  const focused = useMemo(
+    () => (focusedProviderAddress && providers ? providers.find(provider => provider.owner === focusedProviderAddress) ?? null : null),
+    [focusedProviderAddress, providers]
+  );
+
+  const focusedMarker = useMemo(() => {
+    if (!focused) return null;
+    const lat = parseFloat(focused.ipLat);
+    const lng = parseFloat(focused.ipLon);
+    return Number.isFinite(lat) && Number.isFinite(lng) ? { lat, lng } : null;
+  }, [focused]);
+
+  const markers = useMemo<GlobeMarker[]>(() => {
+    if (!providers) return [];
+    if (focused) {
+      const marker = providerToMarker(focused);
+      return marker ? [marker] : [];
+    }
+    return providers
+      .filter(provider => provider.isOnline)
+      .map(providerToMarker)
+      .filter((marker): marker is GlobeMarker => marker !== null);
+  }, [providers, focused]);
+
+  return (
+    <div aria-hidden className="relative w-full flex-1 overflow-hidden">
+      <div className="absolute left-1/2 top-0 -translate-x-1/2 lg:top-[-50px]" style={{ width: GLOBE_CONTAINER_SIZE, height: GLOBE_CONTAINER_SIZE }}>
+        <d.Globe
+          markers={markers}
+          focusedMarker={focusedMarker}
+          focusScreenBiasY={GLOBE_FOCUS_BIAS_Y}
+          focusScreenBiasX={GLOBE_FOCUS_BIAS_X}
+          markerSize={GLOBE_MARKER_SIZE}
+          surfaceTheme="dark"
+          cobeOptions={cobeOptions}
+        />
+      </div>
+    </div>
+  );
+};
+
+/** A provider as a globe marker, or null when it has no usable coordinates. */
+function providerToMarker(provider: ApiProviderList): GlobeMarker | null {
+  const lat = parseFloat(provider.ipLat);
+  const lng = parseFloat(provider.ipLon);
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null;
+  return { id: provider.owner, label: provider.name ?? provider.hostUri, lat, lng };
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/useConfigureDeployProgress.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/useConfigureDeployProgress.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { useConfigureDeployProgress } from "./useConfigureDeployProgress";
+
+import { renderHook } from "@testing-library/react";
+
+describe("useConfigureDeployProgress", () => {
+  it("marks creating+matching completed and preparing active while the lease is in flight", () => {
+    const { result } = renderHook(() => useConfigureDeployProgress("preparing"));
+    expect(result.current.state).toEqual({ kind: "preparing" });
+    expect(result.current.phases.map(p => p.status)).toEqual(["completed", "completed", "active"]);
+  });
+
+  it("completes every phase and fills the bar once the lease has succeeded", () => {
+    const { result } = renderHook(() => useConfigureDeployProgress("success"));
+    expect(result.current.state).toEqual({ kind: "success" });
+    expect(result.current.phases.map(p => p.status)).toEqual(["completed", "completed", "completed"]);
+    expect(result.current.progressPercent).toBe(100);
+  });
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/useConfigureDeployProgress.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/useConfigureDeployProgress.ts
@@ -1,0 +1,54 @@
+import { usePhasedProgressBar } from "@src/hooks/useGradualProgress/usePhasedProgressBar";
+
+type DeployPhaseId = "creating" | "matching" | "preparing";
+/** The active step the configure deploy can be on while the overlay is up: the lease ("preparing"), then "success" once it lands. Create + match already happened before the overlay mounted, so they only ever read as completed. */
+export type DeployActivePhase = "preparing" | "success";
+type Phase = { id: DeployPhaseId; label: string; status: "pending" | "active" | "completed" };
+type State = { kind: DeployActivePhase };
+
+const PHASE_ORDER: ReadonlyArray<DeployPhaseId> = ["creating", "matching", "preparing"];
+
+/**
+ * Where each phase ends on the bar (0–100); mirrors the 3-phase checkpoint layout.
+ * TODO(onboarding-merge): these phase shapes/markers/time-constants/labels mirror `usePhasedDeploymentFlow`;
+ * consolidate into a shared module when onboarding's quick-deploy folds into the configure flow.
+ */
+const MARKERS: ReadonlyArray<number> = PHASE_ORDER.map((_, i) => ((i + 1) / PHASE_ORDER.length) * 100);
+
+/** Per-phase easing time constants in ms — creating is quick; preparing is the active lease step. */
+const TIME_CONSTANTS: ReadonlyArray<number> = [3000, 12000, 6000];
+
+const PHASE_LABELS: Record<DeployPhaseId, { active: string; completed: string }> = {
+  creating: { active: "Creating deployment", completed: "Deployment created" },
+  matching: { active: "Matching providers", completed: "Providers matched" },
+  preparing: { active: "Preparing deployment", completed: "Deployment prepared" }
+};
+
+/**
+ * Renders the reused PhasedDeploymentProgress for the configure flow as a pure function of the deploy's
+ * current active step, passed down from `useDeploymentFlow`. The overlay only mounts during `deploying`, by
+ * which point the deployment is created and the provider chosen — so the active step is the lease
+ * ("preparing"), and the earlier phases read as completed because they precede it. On "success" every phase
+ * is completed and the bar fills to 100% so the deploy visibly finishes before the redirect. Deploy failures
+ * unmount the overlay and surface a toast, so there is no error state here.
+ */
+export function useConfigureDeployProgress(activePhase: DeployActivePhase): {
+  state: State;
+  progressPercent: number;
+  phases: [Phase, Phase, Phase];
+} {
+  const succeeded = activePhase === "success";
+  const activeIndex = succeeded ? PHASE_ORDER.length : PHASE_ORDER.indexOf(activePhase);
+  const animatedPercent = usePhasedProgressBar({ markers: MARKERS, activeIndex, timeConstants: TIME_CONSTANTS, resetKey: 0 });
+
+  const phases = PHASE_ORDER.map(function toPhase(id, index): Phase {
+    const status = succeeded || index < activeIndex ? "completed" : index === activeIndex ? "active" : "pending";
+    return { id, label: status === "completed" ? PHASE_LABELS[id].completed : PHASE_LABELS[id].active, status };
+  }) as [Phase, Phase, Phase];
+
+  return {
+    state: { kind: activePhase },
+    progressPercent: succeeded ? 100 : animatedPercent,
+    phases
+  };
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.spec.tsx
@@ -8,7 +8,7 @@ import { mock } from "vitest-mock-extended";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { defaultPlacement, defaultService, defaultServiceWithPlacement } from "@src/utils/sdl/data";
 import { DEPENDENCIES as PLACEMENT_CARD_DEPENDENCIES, PlacementCard } from "./PlacementCard/PlacementCard";
-import { DEPENDENCIES, DeploymentPane } from "./DeploymentPane";
+import { DEPENDENCIES, DeploymentPane, placementSelectionState } from "./DeploymentPane";
 
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -121,7 +121,12 @@ describe("DeploymentPane", () => {
           onSelectService={input.onSelectService ?? vi.fn()}
           locked={input.locked}
           onCancelAndEdit={input.onCancelAndEdit}
-          dependencies={MockComponents(DEPENDENCIES, { usePlacementManager, ...input.dependencies })}
+          phase="configuring"
+          selections={{}}
+          selectedPlacementId=""
+          sdl=""
+          dseq={null}
+          dependencies={MockComponents(DEPENDENCIES, { usePlacementManager, usePlacementsWithBids: () => new Set<string>(), ...input.dependencies })}
         />
       </TooltipProvider>
     );
@@ -165,10 +170,47 @@ describe("DeploymentPane placement management", () => {
 
     render(
       <Wrapper>
-        <DeploymentPane selectedServiceId="" onSelectService={vi.fn()} dependencies={{ ...DEPENDENCIES, PlacementCard: PlacementCardWithStubbedRegion }} />
+        <DeploymentPane
+          selectedServiceId=""
+          onSelectService={vi.fn()}
+          phase="configuring"
+          selections={{}}
+          selectedPlacementId=""
+          sdl=""
+          dseq={null}
+          dependencies={{ ...DEPENDENCIES, PlacementCard: PlacementCardWithStubbedRegion, usePlacementsWithBids: () => new Set<string>() }}
+        />
       </Wrapper>
     );
 
     return { getForm: () => form };
   }
+});
+
+describe(placementSelectionState.name, () => {
+  it("is idle while configuring, and while closing or errored even with a selection", () => {
+    expect(placementSelectionState({ phase: "configuring", placementId: "p1", selectedPlacementId: "p1", selections: {}, hasBids: true })).toBe("idle");
+    expect(placementSelectionState({ phase: "closing", placementId: "p1", selectedPlacementId: "p1", selections: { p1: "bid" }, hasBids: true })).toBe("idle");
+    expect(placementSelectionState({ phase: "error", placementId: "p1", selectedPlacementId: "p1", selections: { p1: "bid" }, hasBids: true })).toBe("idle");
+  });
+
+  it("is awaiting from the creating phase, so there's no badge-less gap after Request quotes", () => {
+    expect(placementSelectionState({ phase: "creating", placementId: "p1", selectedPlacementId: "p1", selections: {}, hasBids: false })).toBe("awaiting");
+  });
+
+  it("is awaiting while the placement has no bids yet", () => {
+    expect(placementSelectionState({ phase: "quoting", placementId: "p1", selectedPlacementId: "p1", selections: {}, hasBids: false })).toBe("awaiting");
+  });
+
+  it("is selecting for the focused placement once its bids arrive", () => {
+    expect(placementSelectionState({ phase: "quoting", placementId: "p1", selectedPlacementId: "p1", selections: {}, hasBids: true })).toBe("selecting");
+  });
+
+  it("is idle for a non-focused placement that has bids but no selection", () => {
+    expect(placementSelectionState({ phase: "quoting", placementId: "p1", selectedPlacementId: "p2", selections: {}, hasBids: true })).toBe("idle");
+  });
+
+  it("is done once the placement has a selection, regardless of bids", () => {
+    expect(placementSelectionState({ phase: "quoting", placementId: "p1", selectedPlacementId: "p2", selections: { p1: "bid" }, hasBids: false })).toBe("done");
+  });
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
@@ -3,13 +3,16 @@ import { useState } from "react";
 import { Button, CustomTooltip } from "@akashnetwork/ui/components";
 import { InfoCircle, Plus, SidebarCollapse, SidebarExpand } from "iconoir-react";
 
+import { usePlacementsWithBids } from "@src/queries/usePlacementsWithBids";
 import { PaneLockBanner } from "../PaneLockBanner/PaneLockBanner";
+import type { DeploymentFlowPhase } from "../useDeploymentFlow/useDeploymentFlow";
 import { IpEndpointsSection } from "./IpEndpointsSection/IpEndpointsSection";
 import { PlacementCard } from "./PlacementCard/PlacementCard";
+import type { PlacementSelectionState } from "./PlacementSelectionBadge/PlacementSelectionBadge";
 import { ReclamationSection } from "./ReclamationSection/ReclamationSection";
 import { usePlacementManager } from "./usePlacementManager/usePlacementManager";
 
-export const DEPENDENCIES = { PlacementCard, usePlacementManager, IpEndpointsSection, ReclamationSection };
+export const DEPENDENCIES = { PlacementCard, usePlacementManager, usePlacementsWithBids, IpEndpointsSection, ReclamationSection };
 
 type Props = {
   selectedServiceId: string;
@@ -18,6 +21,11 @@ type Props = {
   locked?: boolean;
   isClosing?: boolean;
   onCancelAndEdit?: () => void;
+  phase: DeploymentFlowPhase;
+  selections: Record<string, string>;
+  selectedPlacementId: string;
+  sdl: string;
+  dseq: string | null;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -27,10 +35,16 @@ export const DeploymentPane: FC<Props> = ({
   locked = false,
   isClosing = false,
   onCancelAndEdit,
+  phase,
+  selections,
+  selectedPlacementId,
+  sdl,
+  dseq,
   dependencies: d = DEPENDENCIES
 }) => {
   const [minimized, setMinimized] = useState(false);
   const manager = d.usePlacementManager();
+  const placementsWithBids = d.usePlacementsWithBids({ enabled: phase === "quoting", dseq, sdl, placements: manager.placements });
   const toggle = () => setMinimized(prev => !prev);
 
   if (minimized) {
@@ -77,6 +91,13 @@ export const DeploymentPane: FC<Props> = ({
                 canRemove={manager.canRemovePlacement && !locked}
                 canRemoveService={manager.canRemoveService && !locked}
                 locked={locked}
+                selectionState={placementSelectionState({
+                  phase,
+                  placementId: placement.id as string,
+                  selectedPlacementId,
+                  selections,
+                  hasBids: placementsWithBids.has(placement.id as string)
+                })}
                 onSelectService={onSelectService}
                 onAddService={() => onSelectService(manager.addService(placement.id))}
                 onRemoveService={manager.removeService}
@@ -103,3 +124,23 @@ export const DeploymentPane: FC<Props> = ({
 
 /** Fallback when the pane is locked without a cancel handler (defensive; the parent always supplies one while locked). */
 function noop() {}
+
+/**
+ * Derives the selection badge state for a single placement chip. Badges run from the moment quotes are
+ * requested through deploy (creating/quoting/deploying) — to the user, "creating" is already a waiting-for-
+ * quotes state, so there's no badge-less gap after Request quotes: WAITING until the placement's bids arrive,
+ * SELECTING when it's the focused placement with its bids in, DONE once a provider is chosen. Idle otherwise
+ * (configuring, closing, error).
+ */
+export function placementSelectionState(args: {
+  phase: DeploymentFlowPhase;
+  placementId: string;
+  selectedPlacementId: string;
+  selections: Record<string, string>;
+  hasBids: boolean;
+}): PlacementSelectionState {
+  if (args.phase !== "creating" && args.phase !== "quoting" && args.phase !== "deploying") return "idle";
+  if (args.selections[args.placementId]) return "done";
+  if (!args.hasBids) return "awaiting";
+  return args.placementId === args.selectedPlacementId ? "selecting" : "idle";
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.spec.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { defaultPlacement, defaultService } from "@src/utils/sdl/data";
 import type { ConfigStatus } from "../ConfigStatusIcon/ConfigStatusIcon";
+import type { PlacementSelectionState } from "../PlacementSelectionBadge/PlacementSelectionBadge";
 import { DEPENDENCIES, PlacementCard } from "./PlacementCard";
 
 import { render, screen } from "@testing-library/react";
@@ -112,12 +113,18 @@ describe("PlacementCard", () => {
     expect(RegionSelect.mock.calls[0][0]).toEqual(expect.objectContaining({ disabled: true }));
   });
 
+  it("shows the DONE badge when the placement has a selection", () => {
+    setup({ serviceTitles: ["web"], selectionState: "done" });
+    expect(screen.getByText("DONE")).toBeInTheDocument();
+  });
+
   function setup(input: {
     serviceTitles: string[];
     canRemove?: boolean;
     status?: ConfigStatus;
     error?: string;
     locked?: boolean;
+    selectionState?: PlacementSelectionState;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const placement = defaultPlacement({ name: "placement-1" });
@@ -145,6 +152,7 @@ describe("PlacementCard", () => {
           canRemove={input.canRemove ?? true}
           canRemoveService={true}
           locked={input.locked}
+          selectionState={input.selectionState}
           onSelectService={onSelectService}
           onAddService={onAddService}
           onRemoveService={onRemoveService}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementCard/PlacementCard.tsx
@@ -7,6 +7,8 @@ import { Plus, Trash } from "iconoir-react";
 import { RegionSelect } from "@src/components/sdl/RegionSelect/RegionSelect";
 import type { PlacementType } from "@src/types";
 import { ConfigStatusIcon } from "../ConfigStatusIcon/ConfigStatusIcon";
+import type { PlacementSelectionState } from "../PlacementSelectionBadge/PlacementSelectionBadge";
+import { PlacementSelectionBadge } from "../PlacementSelectionBadge/PlacementSelectionBadge";
 import { ServiceRow } from "../ServiceRow/ServiceRow";
 import type { IndexedService } from "../usePlacementManager/usePlacementManager";
 import { usePlacementStatus } from "../usePlacementStatus/usePlacementStatus";
@@ -22,6 +24,7 @@ type Props = {
   canRemoveService: boolean;
   /** While locked the card stays selectable, but the SDL-mutating controls (name, region, add service) are disabled. */
   locked?: boolean;
+  selectionState?: PlacementSelectionState;
   onSelectService: (serviceId: string) => void;
   onAddService: () => void;
   onRemoveService: (serviceId: string) => void;
@@ -37,6 +40,7 @@ export const PlacementCard: FC<Props> = ({
   canRemove,
   canRemoveService,
   locked = false,
+  selectionState = "idle",
   onSelectService,
   onAddService,
   onRemoveService,
@@ -68,8 +72,11 @@ export const PlacementCard: FC<Props> = ({
     <div
       onClick={selectPlacement}
       className={cn("cursor-pointer rounded-lg border p-2", {
-        "border-foreground ring-[3px] ring-blue-500/25": isSelected,
-        "border-zinc-300 dark:border-zinc-700": !isSelected
+        "border-green-500/60 bg-green-50 dark:border-green-500/40 dark:bg-green-950/30": selectionState === "done",
+        "ring-[3px] ring-blue-500/20": selectionState === "done" && isSelected,
+        "border-blue-500 ring-[3px] ring-blue-500/20": selectionState === "selecting",
+        "border-foreground ring-[3px] ring-blue-500/25": selectionState === "idle" && isSelected,
+        "border-zinc-300 dark:border-zinc-700": selectionState === "idle" && !isSelected
       })}
     >
       <div className="flex flex-col gap-1 px-1 pb-2">
@@ -78,6 +85,7 @@ export const PlacementCard: FC<Props> = ({
           <fieldset disabled={locked} className="m-0 min-w-0 flex-1 border-0 p-0 disabled:pointer-events-none">
             <d.InlineEditInput name={`placements.${placementIndex}.name`} label="Placement name" suppressErrorMessage errorMessageId={errorId} />
           </fieldset>
+          <PlacementSelectionBadge state={selectionState} />
           {canRemove && (
             <button type="button" aria-label="Remove placement" onClick={removePlacement} className="shrink-0 text-muted-foreground hover:text-foreground">
               <Trash className="h-3.5 w-3.5" />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementSelectionBadge/PlacementSelectionBadge.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementSelectionBadge/PlacementSelectionBadge.spec.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { PlacementSelectionBadge } from "./PlacementSelectionBadge";
+
+import { render, screen } from "@testing-library/react";
+
+describe(PlacementSelectionBadge.name, () => {
+  it("renders DONE when the placement is selected", () => {
+    render(<PlacementSelectionBadge state="done" />);
+    expect(screen.getByText("DONE")).toBeInTheDocument();
+  });
+  it("renders SELECTING when active without a selection", () => {
+    render(<PlacementSelectionBadge state="selecting" />);
+    expect(screen.getByText("SELECTING")).toBeInTheDocument();
+  });
+  it("renders WAITING while the placement is awaiting bids", () => {
+    render(<PlacementSelectionBadge state="awaiting" />);
+    expect(screen.getByText("WAITING")).toBeInTheDocument();
+  });
+  it("renders nothing when idle", () => {
+    const { container } = render(<PlacementSelectionBadge state="idle" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementSelectionBadge/PlacementSelectionBadge.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/PlacementSelectionBadge/PlacementSelectionBadge.tsx
@@ -1,0 +1,28 @@
+import type { FC } from "react";
+import { Badge } from "@akashnetwork/ui/components";
+
+export type PlacementSelectionState = "idle" | "awaiting" | "selecting" | "done";
+
+/** Per-placement selection marker shown while picking providers: muted WAITING until its bids arrive, dark SELECTING for the active one with bids, green DONE once a provider is chosen. Sits at the right edge of the placement header; the green status check is rendered separately to its left. */
+export const PlacementSelectionBadge: FC<{ state: PlacementSelectionState }> = ({ state }) => {
+  if (state === "done") {
+    return (
+      <Badge className="shrink-0 rounded-md bg-green-600 px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-white hover:bg-green-600">DONE</Badge>
+    );
+  }
+  if (state === "selecting") {
+    return (
+      <Badge className="shrink-0 rounded-md bg-foreground px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-background hover:bg-foreground">
+        SELECTING
+      </Badge>
+    );
+  }
+  if (state === "awaiting") {
+    return (
+      <Badge className="shrink-0 rounded-md bg-muted px-2 py-0.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:bg-muted">
+        WAITING
+      </Badge>
+    );
+  }
+  return null;
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
@@ -6,6 +6,7 @@ import type { DEPENDENCIES } from "./MarketplacePane";
 import { MarketplacePane } from "./MarketplacePane";
 
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { buildScreenedProvider } from "@tests/seeders/screenedProvider";
 
 describe(MarketplacePane.name, () => {
@@ -60,6 +61,13 @@ describe(MarketplacePane.name, () => {
     );
   });
 
+  it("passes the active placement's selection and an onSelect bound to that placement to the table", async () => {
+    const onSelectProvider = vi.fn();
+    const { user } = setup({ selectedPlacementId: "placement-1", selectedBidId: "akash1a/1/1/1", onSelectProvider });
+    await user.click(screen.getByRole("button", { name: "selected" }));
+    expect(onSelectProvider).toHaveBeenCalledWith("placement-1", "NEW");
+  });
+
   function buildOffer(overrides: Partial<PlacementOffer> = {}): PlacementOffer {
     return { ...buildScreenedProvider(), offerState: "searching", ...overrides };
   }
@@ -76,6 +84,9 @@ describe(MarketplacePane.name, () => {
       isLoading?: boolean;
       isError?: boolean;
       isSearchActive?: boolean;
+      selectedPlacementId?: string;
+      selectedBidId?: string;
+      onSelectProvider?: (placementId: string, bidId: string) => void;
     } = {}
   ) {
     const usePlacementOffers = vi.fn(() => ({
@@ -90,13 +101,18 @@ describe(MarketplacePane.name, () => {
       filteredProviders: input.filteredProviders ?? offers,
       isSearchActive: input.isSearchActive ?? false
     }));
-    const MarketplaceProvidersTable = vi.fn(() => <div data-testid="marketplace-table-mock" />);
+    const MarketplaceProvidersTable = vi.fn(({ selectedBidId, onSelect }: Parameters<typeof DEPENDENCIES.MarketplaceProvidersTable>[0]) => (
+      <button type="button" onClick={() => onSelect?.("NEW")}>
+        {selectedBidId ? "selected" : "select"}
+      </button>
+    ));
     const dependencies: typeof DEPENDENCIES = {
       usePlacementOffers: usePlacementOffers as never,
       useProviderSearch: useProviderSearch as never,
       MarketplaceProvidersTable: MarketplaceProvidersTable as never,
       ProviderSearchInput
     };
+    const user = userEvent.setup();
 
     render(
       <MarketplacePane
@@ -105,9 +121,12 @@ describe(MarketplacePane.name, () => {
         region={input.region}
         phase={input.phase ?? "configuring"}
         dseq={input.dseq ?? null}
+        selectedPlacementId={input.selectedPlacementId ?? "placement-1"}
+        selectedBidId={input.selectedBidId}
+        onSelectProvider={input.onSelectProvider ?? vi.fn()}
         dependencies={dependencies}
       />
     );
-    return { usePlacementOffers, useProviderSearch, MarketplaceProvidersTable };
+    return { usePlacementOffers, useProviderSearch, MarketplaceProvidersTable, user };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
@@ -14,10 +14,23 @@ interface Props {
   region?: string;
   phase: DeploymentFlowPhase;
   dseq: string | null;
+  selectedPlacementId: string;
+  selectedBidId?: string;
+  onSelectProvider: (placementId: string, bidId: string) => void;
   dependencies?: typeof DEPENDENCIES;
 }
 
-export const MarketplacePane: FC<Props> = ({ sdl, placementName, region, phase, dseq, dependencies: d = DEPENDENCIES }) => {
+export const MarketplacePane: FC<Props> = ({
+  sdl,
+  placementName,
+  region,
+  phase,
+  dseq,
+  selectedPlacementId,
+  selectedBidId,
+  onSelectProvider,
+  dependencies: d = DEPENDENCIES
+}) => {
   const { offers, isLoading, isError } = d.usePlacementOffers({ phase, dseq: dseq ?? undefined, sdl, placementName, region });
   const { query, setQuery, clear, filteredProviders, isSearchActive } = d.useProviderSearch(offers);
   const hasFailedWithoutData = isError && offers.length === 0;
@@ -39,7 +52,14 @@ export const MarketplacePane: FC<Props> = ({ sdl, placementName, region, phase, 
             Failed to load providers. Please try again.
           </p>
         ) : (
-          <d.MarketplaceProvidersTable providers={filteredProviders} isLoading={isLoading} isSearchActive={isSearchActive} onClearSearch={clear} />
+          <d.MarketplaceProvidersTable
+            providers={filteredProviders}
+            isLoading={isLoading}
+            isSearchActive={isSearchActive}
+            onClearSearch={clear}
+            selectedBidId={selectedBidId}
+            onSelect={bidId => onSelectProvider(selectedPlacementId, bidId)}
+          />
         )}
       </div>
     </section>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
@@ -2,20 +2,22 @@ import { IntlProvider } from "react-intl";
 import { TooltipProvider } from "@akashnetwork/ui/components";
 import { format, subDays } from "date-fns";
 import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
 
-import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
+import type { PlacementOffer } from "@src/queries/usePlacementOffers";
 import { MarketplaceProvidersTable } from "./MarketplaceProvidersTable";
 
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { buildScreenedProvider } from "@tests/seeders/screenedProvider";
+import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
 
-describe("MarketplaceProvidersTable", () => {
+describe(MarketplaceProvidersTable.name, () => {
   it("renders a row per provider showing host and region", () => {
     setup({
       providers: [
-        buildScreenedProvider({ hostUri: "https://a.example:8443", location: "us-west" }),
-        buildScreenedProvider({ hostUri: "https://b.example:8443", location: "eu-central" })
+        buildOffer({ hostUri: "https://a.example:8443", location: "us-west" }),
+        buildOffer({ hostUri: "https://b.example:8443", location: "eu-central" })
       ]
     });
 
@@ -26,14 +28,14 @@ describe("MarketplaceProvidersTable", () => {
   });
 
   it("renders an em dash when region is null", () => {
-    setup({ providers: [buildScreenedProvider({ hostUri: "https://a.example:8443", location: null })] });
+    setup({ providers: [buildOffer({ hostUri: "https://a.example:8443", location: null })] });
 
-    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
   });
 
   it("sorts rows by provider host when the Provider header is toggled ascending", async () => {
     setup({
-      providers: [buildScreenedProvider({ hostUri: "https://zeta.example:8443" }), buildScreenedProvider({ hostUri: "https://alpha.example:8443" })]
+      providers: [buildOffer({ hostUri: "https://zeta.example:8443" }), buildOffer({ hostUri: "https://alpha.example:8443" })]
     });
 
     await userEvent.click(screen.getByRole("button", { name: /Provider/ }));
@@ -45,7 +47,7 @@ describe("MarketplaceProvidersTable", () => {
 
   it("sorts by the displayed hostname regardless of scheme or port", async () => {
     setup({
-      providers: [buildScreenedProvider({ hostUri: "http://zeta.example:80" }), buildScreenedProvider({ hostUri: "https://alpha.example:8443" })]
+      providers: [buildOffer({ hostUri: "http://zeta.example:80" }), buildOffer({ hostUri: "https://alpha.example:8443" })]
     });
 
     await userEvent.click(screen.getByRole("button", { name: /Provider/ }));
@@ -57,12 +59,12 @@ describe("MarketplaceProvidersTable", () => {
 
   it("sorts rows by derived uptime when the Uptime header is toggled ascending", async () => {
     const recentDay = format(subDays(new Date(), 2), "yyyy-MM-dd");
-    const downProvider = buildScreenedProvider({
+    const downProvider = buildOffer({
       owner: "akash1down",
       hostUri: "https://down.example:8443",
       incidents: [{ date: recentDay, hasOpenIncident: false, incidentCount: 1, downtimeSeconds: 24 * 60 * 60 }]
     });
-    const upProvider = buildScreenedProvider({ owner: "akash1up", hostUri: "https://up.example:8443", incidents: [] });
+    const upProvider = buildOffer({ owner: "akash1up", hostUri: "https://up.example:8443", incidents: [] });
     setup({ providers: [upProvider, downProvider] });
 
     await userEvent.click(screen.getByRole("button", { name: /Uptime/ }));
@@ -73,19 +75,19 @@ describe("MarketplaceProvidersTable", () => {
   });
 
   it("displays the organization name when present", () => {
-    setup({ providers: [buildScreenedProvider({ organization: "Polaris Compute", hostUri: "https://a.example:8443" })] });
+    setup({ providers: [buildOffer({ organization: "Polaris Compute", hostUri: "https://a.example:8443" })] });
 
     expect(screen.getByText("Polaris Compute")).toBeInTheDocument();
   });
 
   it("falls back to the host name when organization is absent", () => {
-    setup({ providers: [buildScreenedProvider({ organization: null, hostUri: "https://a.example:8443" })] });
+    setup({ providers: [buildOffer({ organization: null, hostUri: "https://a.example:8443" })] });
 
     expect(screen.getByText("a.example")).toBeInTheDocument();
   });
 
   it("falls back to the provider address when it has no host or organization (bid-sourced offer)", () => {
-    setup({ providers: [buildScreenedProvider({ organization: null, hostUri: "", owner: "akash1bidder" })] });
+    setup({ providers: [buildOffer({ organization: null, hostUri: "", owner: "akash1bidder" })] });
 
     expect(screen.getByText("akash1bidder")).toBeInTheDocument();
   });
@@ -113,18 +115,87 @@ describe("MarketplaceProvidersTable", () => {
     expect(screen.queryByRole("button", { name: /clear search/i })).not.toBeInTheDocument();
   });
 
-  function setup(input: { providers: ScreenedProvider[]; isLoading?: boolean; isSearchActive?: boolean; onClearSearch?: () => void }) {
-    return render(
-      <IntlProvider locale="en">
-        <TooltipProvider>
-          <MarketplaceProvidersTable
-            providers={input.providers}
-            isLoading={input.isLoading}
-            isSearchActive={input.isSearchActive}
-            onClearSearch={input.onClearSearch}
-          />
-        </TooltipProvider>
-      </IntlProvider>
+  it("hides the Cost column until a bid is received", () => {
+    setup({ providers: [searchingOffer({ owner: "akash1a" })] });
+    expect(screen.queryByText("Cost")).not.toBeInTheDocument();
+  });
+
+  it("shows the Cost column once a bid is submitted", () => {
+    setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" })] });
+    expect(screen.getByText("Cost")).toBeInTheDocument();
+  });
+
+  it("drops the empty Select column when no offer is selectable, leaving only Provider, Region, and Uptime", () => {
+    setup({ providers: [searchingOffer({ owner: "akash1a" })] });
+    expect(screen.getAllByRole("columnheader")).toHaveLength(3);
+  });
+
+  it("enables Select only for submitted offers", () => {
+    setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" }), searchingOffer({ owner: "akash1b" })] });
+    expect(screen.getByRole("button", { name: "Select akash1a" })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: "Select akash1b" })).not.toBeInTheDocument();
+  });
+
+  it("calls onSelect with the offer's bid id when Select is clicked", async () => {
+    const { onSelect, user } = setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" })] });
+    await user.click(screen.getByRole("button", { name: "Select akash1a" }));
+    expect(onSelect).toHaveBeenCalledWith("akash1a/1/1/1");
+  });
+
+  it("marks the selected offer's row and makes its button non-clickable", () => {
+    setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" })], selectedBidId: "akash1a/1/1/1" });
+    expect(screen.getByRole("button", { name: /selected/i })).toBeDisabled();
+  });
+
+  /** A screened provider promoted to a (not-yet-bid) offer, so the display/sort tests keep using the realistic seeder without casting. */
+  function buildOffer(overrides?: Parameters<typeof buildScreenedProvider>[0]): PlacementOffer {
+    return { ...buildScreenedProvider(overrides), offerState: "searching" };
+  }
+
+  function submittedOffer(overrides: Partial<PlacementOffer>): PlacementOffer {
+    return mock<PlacementOffer>({
+      offerState: "submitted",
+      price: { amount: "100", denom: "uakt" },
+      organization: null,
+      hostUri: "",
+      location: null,
+      incidents: [],
+      ...overrides
+    });
+  }
+
+  function searchingOffer(overrides: Partial<PlacementOffer>): PlacementOffer {
+    return mock<PlacementOffer>({
+      offerState: "searching",
+      bidId: undefined,
+      price: undefined,
+      organization: null,
+      hostUri: "",
+      location: null,
+      incidents: [],
+      ...overrides
+    });
+  }
+
+  function setup(input: { providers: PlacementOffer[]; isLoading?: boolean; isSearchActive?: boolean; onClearSearch?: () => void; selectedBidId?: string }) {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <TestContainerProvider>
+        <IntlProvider locale="en">
+          <TooltipProvider>
+            <MarketplaceProvidersTable
+              providers={input.providers}
+              isLoading={input.isLoading}
+              isSearchActive={input.isSearchActive}
+              onClearSearch={input.onClearSearch}
+              selectedBidId={input.selectedBidId}
+              onSelect={onSelect}
+            />
+          </TooltipProvider>
+        </IntlProvider>
+      </TestContainerProvider>
     );
+    return { onSelect, user };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
@@ -5,14 +5,16 @@ import type { Column, SortingState } from "@tanstack/react-table";
 import { createColumnHelper, flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
 import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react";
 
+import { PricePerTimeUnit } from "@src/components/shared/PricePerTimeUnit";
 import { ShortenedValue } from "@src/components/shared/ShortenedValue";
-import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
-import { getProviderNameFromUri } from "@src/utils/providerUtils";
+import type { PlacementOffer } from "@src/queries/usePlacementOffers";
+import { PRICE_DISPLAY_PRECISION, udenomToDenom } from "@src/utils/mathHelpers";
+import { providerDisplayName } from "@src/utils/providerUtils";
 import type { ProviderUptime } from "./ProviderUptimeCell/deriveProviderUptime";
 import { useProvidersUptime } from "./ProviderUptimeCell/deriveProviderUptime";
 import { ProviderUptimeCell } from "./ProviderUptimeCell/ProviderUptimeCell";
 
-const columnHelper = createColumnHelper<ScreenedProvider>();
+const columnHelper = createColumnHelper<PlacementOffer>();
 
 /** Shown when a provider has no region attribute. */
 const NO_REGION = "—";
@@ -21,17 +23,26 @@ const NO_REGION = "—";
 const HEALTHY_UPTIME: ProviderUptime = { percent: 1, buckets: [] };
 
 interface Props {
-  providers: ScreenedProvider[];
+  providers: PlacementOffer[];
   isLoading?: boolean;
   isSearchActive?: boolean;
   onClearSearch?: () => void;
+  selectedBidId?: string;
+  onSelect?: (bidId: string) => void;
 }
 
-export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading, isSearchActive, onClearSearch }) => {
+export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading, isSearchActive, onClearSearch, selectedBidId, onSelect }) => {
   const [sorting, setSorting] = useState<SortingState>([]);
 
   const uptimeByOwner = useProvidersUptime(providers);
-  const columns = useMemo(() => buildColumns(uptimeByOwner), [uptimeByOwner]);
+  /** Cost only makes sense once firm bids arrive; until then the marketplace lists screened candidates with no price. */
+  const hasBids = providers.some(provider => provider.offerState === "submitted");
+  /** The Select column is only useful when a visible offer can actually be picked; otherwise it's an empty trailing column. */
+  const hasSelectableOffers = providers.some(provider => provider.offerState === "submitted" && !!provider.bidId);
+  const columns = useMemo(
+    () => buildColumns(uptimeByOwner, { selectedBidId, onSelect, showCost: hasBids, showSelect: hasSelectableOffers }),
+    [uptimeByOwner, selectedBidId, onSelect, hasBids, hasSelectableOffers]
+  );
 
   const table = useReactTable({
     data: providers,
@@ -97,7 +108,7 @@ export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading, isS
 };
 
 /** Design-system column header: an uppercase mono label that toggles sort on click. */
-function SortableHeader({ column, title }: { column: Column<ScreenedProvider, unknown>; title: string }) {
+function SortableHeader({ column, title }: { column: Column<PlacementOffer, unknown>; title: string }) {
   const sorted = column.getIsSorted();
   return (
     <button
@@ -117,21 +128,13 @@ function SortableHeader({ column, title }: { column: Column<ScreenedProvider, un
   );
 }
 
-/**
- * Display name for a provider: its organization, else the host parsed from its URI, else its on-chain
- * address. The address fallback covers bid-sourced offers, which carry no screened host/organization —
- * `getProviderNameFromUri` would throw on their empty `hostUri`.
- */
-function providerLabel(provider: ScreenedProvider): string {
-  const organization = provider.organization?.trim();
-  if (organization) return organization;
-  return provider.hostUri ? getProviderNameFromUri(provider.hostUri) : provider.owner;
-}
-
 /** Builds the table columns, closing over the per-provider uptime derived once in the component. */
-function buildColumns(uptimeByOwner: Map<string, ProviderUptime>) {
+function buildColumns(
+  uptimeByOwner: Map<string, ProviderUptime>,
+  selection: { selectedBidId?: string; onSelect?: (bidId: string) => void; showCost: boolean; showSelect: boolean }
+) {
   return [
-    columnHelper.accessor(providerLabel, {
+    columnHelper.accessor(providerDisplayName, {
       id: "hostUri",
       header: ({ column }) => <SortableHeader column={column} title="Provider" />,
       cell: info => <ShortenedValue value={info.getValue()} maxLength={40} headLength={14} />
@@ -144,6 +147,44 @@ function buildColumns(uptimeByOwner: Map<string, ProviderUptime>) {
       id: "uptime",
       header: ({ column }) => <SortableHeader column={column} title="Uptime (7D)" />,
       cell: info => <ProviderUptimeCell uptime={uptimeByOwner.get(info.row.original.owner) ?? HEALTHY_UPTIME} />
-    })
+    }),
+    ...(selection.showCost
+      ? [
+          columnHelper.display({
+            id: "cost",
+            header: () => <span className="font-mono text-sm font-normal uppercase text-muted-foreground">Cost</span>,
+            cell: ({ row }) => {
+              const { price } = row.original;
+              if (!price) return <span className="text-muted-foreground">—</span>;
+              return <PricePerTimeUnit denom={price.denom} perBlockValue={udenomToDenom(price.amount, PRICE_DISPLAY_PRECISION)} showAsHourly abbreviated />;
+            }
+          })
+        ]
+      : []),
+    ...(selection.showSelect
+      ? [
+          columnHelper.display({
+            id: "select",
+            header: () => null,
+            cell: ({ row }) => {
+              const offer = row.original;
+              if (offer.offerState !== "submitted" || !offer.bidId) return null;
+              const isSelected = offer.bidId === selection.selectedBidId;
+              return (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={isSelected ? "default" : "outline"}
+                  disabled={isSelected}
+                  aria-label={isSelected ? `Selected ${providerDisplayName(offer)}` : `Select ${providerDisplayName(offer)}`}
+                  onClick={() => selection.onSelect?.(offer.bidId!)}
+                >
+                  {isSelected ? "Selected" : "Select"}
+                </Button>
+              );
+            }
+          })
+        ]
+      : [])
   ];
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/useProviderSearch/useProviderSearch.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/useProviderSearch/useProviderSearch.ts
@@ -5,11 +5,11 @@ import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
 /** Delay before a typed query is applied; clearing bypasses it. Matches the SDL-sync precedent. */
 const SEARCH_DEBOUNCE_MS = 300;
 
-interface UseProviderSearchResult {
+interface UseProviderSearchResult<T extends ScreenedProvider> {
   query: string;
   setQuery: (value: string) => void;
   clear: () => void;
-  filteredProviders: ScreenedProvider[];
+  filteredProviders: T[];
   isSearchActive: boolean;
 }
 
@@ -17,7 +17,7 @@ interface UseProviderSearchResult {
  * Presentation-only narrowing of the screened list by organization name and host URI. The typed
  * query is debounced; an empty query applies immediately so clearing snaps the full list back.
  */
-export function useProviderSearch(providers: ScreenedProvider[]): UseProviderSearchResult {
+export function useProviderSearch<T extends ScreenedProvider>(providers: T[]): UseProviderSearchResult<T> {
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.spec.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { PlacementType } from "@src/types";
+import type { DEPENDENCIES } from "./ReviewAndDeployModal";
+import { ReviewAndDeployModal } from "./ReviewAndDeployModal";
+import type { ReviewRow } from "./useReviewRows";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe(ReviewAndDeployModal.name, () => {
+  it("lists one row per selected placement with provider and price", () => {
+    setup({
+      rows: [{ placementId: "p1", placementName: "placement-1", region: "Any region", providerName: "Dune Networks", price: { amount: "100", denom: "uakt" } }]
+    });
+    expect(screen.getByText("placement-1 · Any region")).toBeInTheDocument();
+    expect(screen.getByText("Dune Networks")).toBeInTheDocument();
+    expect(screen.getAllByTestId("price")).toHaveLength(2);
+  });
+
+  it("confirms with onConfirm", async () => {
+    const onConfirm = vi.fn();
+    setup({ onConfirm });
+    await userEvent.click(screen.getByRole("button", { name: /confirm and deploy/i }));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it("goes back with onBack", async () => {
+    const onBack = vi.fn();
+    setup({ onBack });
+    await userEvent.click(screen.getByRole("button", { name: /back to marketplace/i }));
+    expect(onBack).toHaveBeenCalled();
+  });
+
+  it("disables Confirm and deploy when a selected placement is no longer priced", () => {
+    setup({
+      rows: [
+        { placementId: "p1", placementName: "placement-1", providerName: "Dune Networks", price: { amount: "100", denom: "uakt" } },
+        { placementId: "p2", placementName: "placement-2", providerName: "Polaris", price: undefined }
+      ],
+      pricedCount: 1,
+      totalCount: 2
+    });
+    expect(screen.getByRole("button", { name: /confirm and deploy/i })).toBeDisabled();
+  });
+
+  function setup(input: { rows?: ReviewRow[]; pricedCount?: number; totalCount?: number; onConfirm?: () => void; onBack?: () => void }) {
+    const rows = input.rows ?? [
+      { placementId: "p1", placementName: "placement-1", region: "Any region", providerName: "Dune Networks", price: { amount: "100", denom: "uakt" } }
+    ];
+    const useReviewRows: typeof DEPENDENCIES.useReviewRows = () => ({
+      rows,
+      pricedCount: input.pricedCount ?? rows.filter(row => row.price).length,
+      totalCount: input.totalCount ?? rows.length
+    });
+    const PricePerTimeUnit: typeof DEPENDENCIES.PricePerTimeUnit = () => <span data-testid="price" />;
+    render(
+      <ReviewAndDeployModal
+        open
+        dseq="55"
+        placements={[mock<PlacementType>({ id: "p1", name: "placement-1", region: "Any region" })]}
+        selections={{ p1: "akash1a/55/1/2" }}
+        onConfirm={input.onConfirm ?? vi.fn()}
+        onBack={input.onBack ?? vi.fn()}
+        dependencies={{ useReviewRows, PricePerTimeUnit }}
+      />
+    );
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.tsx
@@ -1,0 +1,117 @@
+"use client";
+import type { ComponentProps, FC } from "react";
+import {
+  Button,
+  DialogV2,
+  DialogV2Body,
+  DialogV2Content,
+  DialogV2Description,
+  DialogV2Footer,
+  DialogV2Header,
+  DialogV2Title
+} from "@akashnetwork/ui/components";
+import { ArrowRight, Rocket } from "iconoir-react";
+
+import { PricePerTimeUnit } from "@src/components/shared/PricePerTimeUnit";
+import type { PlacementType } from "@src/types";
+import { PRICE_DISPLAY_PRECISION, udenomToDenom } from "@src/utils/mathHelpers";
+import type { ReviewRow } from "./useReviewRows";
+import { useReviewRows } from "./useReviewRows";
+
+export const DEPENDENCIES = { useReviewRows, PricePerTimeUnit };
+
+interface Props {
+  open: boolean;
+  dseq: string | null;
+  placements: PlacementType[];
+  selections: Record<string, string>;
+  onConfirm: () => void;
+  onBack: () => void;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+/**
+ * Built on DialogV2 (the bordered header/body/footer chrome) so it reads as a sibling of the
+ * other configure-flow modals (LogsCard, ExposePortsCard, …) rather than a one-off.
+ */
+export const ReviewAndDeployModal: FC<Props> = ({ open, dseq, placements, selections, onConfirm, onBack, dependencies: d = DEPENDENCIES }) => {
+  const { rows, pricedCount, totalCount } = d.useReviewRows({ dseq, placements, selections });
+  /** Only deployable once every placement is selected and still has a live (priced) bid — a closed/stale bid leaves a row unpriced and would fail at create-lease. */
+  const canConfirm = totalCount > 0 && rows.length === totalCount && pricedCount === totalCount;
+
+  return (
+    <DialogV2 open={open} onOpenChange={isOpen => (!isOpen ? onBack() : undefined)}>
+      <DialogV2Content className="max-w-2xl">
+        <DialogV2Header>
+          <DialogV2Title>Review and deploy</DialogV2Title>
+          <DialogV2Description>Review your provider selections for each placement before deploying.</DialogV2Description>
+        </DialogV2Header>
+
+        <DialogV2Body className="space-y-4">
+          <ul className="divide-y">
+            {rows.map((row, index) => (
+              <li key={row.placementId} className="flex items-center gap-4 py-4 first:pt-0">
+                <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-xs text-muted-foreground">{index + 1}</span>
+                <div className="min-w-0 flex-1">
+                  <p className="font-mono text-xs uppercase tracking-wide text-muted-foreground">Placement</p>
+                  <p className="truncate text-sm">{row.region ? `${row.placementName} · ${row.region}` : row.placementName}</p>
+                </div>
+                <ArrowRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <div className="min-w-0 flex-1">
+                  <p className="font-mono text-xs uppercase tracking-wide text-muted-foreground">Provider</p>
+                  <p className="truncate text-sm">{row.providerName}</p>
+                </div>
+                <div className="shrink-0 text-right">
+                  <p className="font-mono text-xs uppercase tracking-wide text-muted-foreground">Price</p>
+                  {row.price ? (
+                    <d.PricePerTimeUnit
+                      denom={row.price.denom}
+                      perBlockValue={udenomToDenom(row.price.amount, PRICE_DISPLAY_PRECISION)}
+                      showAsHourly
+                      abbreviated
+                    />
+                  ) : (
+                    <span>—</span>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+
+          <div className="flex items-center justify-between rounded-lg border bg-muted p-4">
+            <div>
+              <p className="font-mono text-xs uppercase tracking-wide text-muted-foreground">Total deployment cost</p>
+              <p className="text-xs text-muted-foreground">
+                {pricedCount} of {totalCount} {totalCount === 1 ? "placement" : "placements"} priced
+              </p>
+            </div>
+            <TotalPrice rows={rows} PricePerTimeUnit={d.PricePerTimeUnit} />
+          </div>
+        </DialogV2Body>
+
+        <DialogV2Footer>
+          <Button variant="ghost" onClick={onBack}>
+            Back to marketplace
+          </Button>
+          <Button onClick={onConfirm} className="gap-2" disabled={!canConfirm}>
+            Confirm and deploy
+            <Rocket className="h-4 w-4" />
+          </Button>
+        </DialogV2Footer>
+      </DialogV2Content>
+    </DialogV2>
+  );
+};
+
+/**
+ * Sums the selected offers' per-block prices and renders the hourly USD total through the shared price
+ * component. Assumes a single denom across placements (one deployment shares a deposit denom), so it labels
+ * the sum with the first priced row's denom; mixed denoms are not expected in this flow.
+ */
+function TotalPrice({ rows, PricePerTimeUnit: Price }: { rows: ReviewRow[]; PricePerTimeUnit: FC<ComponentProps<typeof PricePerTimeUnit>> }) {
+  const priced = rows.filter((r): r is ReviewRow & { price: { amount: string; denom: string } } => !!r.price);
+  if (priced.length === 0) return <span className="text-2xl font-bold">—</span>;
+  const denom = priced[0].price.denom;
+  const perBlockTotal = priced.reduce((sum, r) => sum + udenomToDenom(r.price.amount, PRICE_DISPLAY_PRECISION), 0);
+  return <Price denom={denom} perBlockValue={perBlockTotal} showAsHourly abbreviated className="text-2xl font-bold" />;
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useReviewRows.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useReviewRows.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { PlacementType } from "@src/types";
+import type { DEPENDENCIES } from "./useReviewRows";
+import { useReviewRows } from "./useReviewRows";
+
+import { renderHook } from "@testing-library/react";
+
+type BidEntry = NonNullable<ReturnType<typeof DEPENDENCIES.useListBids>["data"]>["data"][number];
+type ProviderEntry = NonNullable<ReturnType<typeof DEPENDENCIES.useProviderList>["data"]>[number];
+
+describe("useReviewRows", () => {
+  it("builds a row per selected placement with provider name and price", () => {
+    const { result } = setup({
+      placements: [mock<PlacementType>({ id: "p1", name: "placement-1", region: "us-west" })],
+      selections: { p1: "akash1a/55/1/2" },
+      bids: [mock<BidEntry>({ bid: { id: { provider: "akash1a", dseq: "55", gseq: 1, oseq: 2 }, price: { amount: "100", denom: "uakt" }, state: "open" } })],
+      providers: [mock<ProviderEntry>({ owner: "akash1a", organization: "Dune Networks", hostUri: "" })]
+    });
+    expect(result.current.rows).toEqual([
+      expect.objectContaining({
+        placementName: "placement-1",
+        region: "us-west",
+        providerName: "Dune Networks",
+        price: expect.objectContaining({ amount: "100", denom: "uakt" })
+      })
+    ]);
+  });
+
+  it("omits placements without a selection and counts priced rows", () => {
+    const { result } = setup({
+      placements: [mock<PlacementType>({ id: "p1", name: "placement-1" }), mock<PlacementType>({ id: "p2", name: "placement-2" })],
+      selections: { p1: "akash1a/55/1/2" },
+      bids: [mock<BidEntry>({ bid: { id: { provider: "akash1a", dseq: "55", gseq: 1, oseq: 2 }, price: { amount: "100", denom: "uakt" }, state: "open" } })],
+      providers: [mock<ProviderEntry>({ owner: "akash1a", organization: "Dune", hostUri: "" })]
+    });
+    expect(result.current.rows).toHaveLength(1);
+    expect(result.current.pricedCount).toBe(1);
+    expect(result.current.totalCount).toBe(2);
+  });
+
+  function setup(input: { placements: PlacementType[]; selections: Record<string, string>; bids: BidEntry[]; providers: ProviderEntry[] }) {
+    const dependencies: typeof DEPENDENCIES = {
+      useListBids: () => mock<ReturnType<typeof DEPENDENCIES.useListBids>>({ data: { data: input.bids } }),
+      useProviderList: () => mock<ReturnType<typeof DEPENDENCIES.useProviderList>>({ data: input.providers })
+    };
+    return renderHook(() => useReviewRows({ dseq: "55", placements: input.placements, selections: input.selections }, dependencies));
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useReviewRows.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/useReviewRows.ts
@@ -1,0 +1,67 @@
+import { useMemo } from "react";
+
+import { useListBids } from "@src/queries/useListBids";
+import { useProviderList } from "@src/queries/useProvidersQuery";
+import type { PlacementType } from "@src/types";
+import { type BidId, parseBidId } from "@src/utils/bids/bidId";
+import { providerDisplayName } from "@src/utils/providerUtils";
+
+export interface ReviewRow {
+  placementId: string;
+  placementName: string;
+  region?: string;
+  providerName: string;
+  price?: { amount: string; denom: string };
+}
+
+export const DEPENDENCIES = { useListBids, useProviderList };
+
+interface Input {
+  dseq: string | null;
+  placements: PlacementType[];
+  selections: Record<string, string>;
+}
+
+/** Joins the per-placement selection (a bid id) to its live bid (price) and provider record (name) to drive the review modal. */
+export function useReviewRows({ dseq, placements, selections }: Input, dependencies: typeof DEPENDENCIES = DEPENDENCIES) {
+  const bidsQuery = dependencies.useListBids(dseq);
+  const providerListQuery = dependencies.useProviderList({ enabled: true });
+
+  return useMemo(() => {
+    const bids = bidsQuery.data?.data ?? [];
+    const providersByOwner = new Map((providerListQuery.data ?? []).map(p => [p.owner, p]));
+
+    const rows: ReviewRow[] = placements
+      .filter(placement => selections[placement.id])
+      .map(placement => {
+        const bidId = selections[placement.id];
+        const parsed = parseBidId(bidId);
+        const match = findOpenBidForSelection(bids, parsed);
+        const provider = providersByOwner.get(parsed.provider);
+        return {
+          placementId: placement.id,
+          placementName: placement.name,
+          region: placement.region || undefined,
+          providerName: provider ? providerDisplayName(provider) : parsed.provider,
+          price: match?.bid.price
+        };
+      });
+
+    return { rows, pricedCount: rows.filter(r => !!r.price).length, totalCount: placements.length };
+  }, [bidsQuery.data, providerListQuery.data, placements, selections]);
+}
+
+/** A `listBids` result entry. */
+type BidEntry = NonNullable<ReturnType<typeof useListBids>["data"]>["data"][number];
+
+/**
+ * The open (selectable) live bid matching a selection — matched on provider plus group/order sequence and
+ * open state. `dseq` is intentionally not compared: the bids are already scoped to one deployment by the
+ * dseq-keyed `listBids` query.
+ */
+function findOpenBidForSelection(bids: BidEntry[], selected: BidId): BidEntry | undefined {
+  return bids.find(
+    entry =>
+      entry.bid.state === "open" && entry.bid.id.provider === selected.provider && entry.bid.id.gseq === selected.gseq && entry.bid.id.oseq === selected.oseq
+  );
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { DeploymentIntent } from "./deploymentIntent";
 import type { DEPENDENCIES } from "./useDeploymentFlow";
 import { buildConfigureUrl, useDeploymentFlow } from "./useDeploymentFlow";
 
@@ -76,6 +77,145 @@ describe(useDeploymentFlow.name, () => {
     await waitFor(() => expect(replace).toHaveBeenCalledWith(expect.stringContaining("draftId=draft-1"), undefined, { shallow: true }));
   });
 
+  it("records a provider selection per placement", () => {
+    const { result } = renderFlow();
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/1/1/1"));
+    act(() => result.current.actions.selectProvider("placement-2", "akash1b/1/2/1"));
+    expect(result.current.selections).toEqual({ "placement-1": "akash1a/1/1/1", "placement-2": "akash1b/1/2/1" });
+  });
+
+  it("replaces a placement's selection when picked again", () => {
+    const { result } = renderFlow();
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/1/1/1"));
+    act(() => result.current.actions.selectProvider("placement-1", "akash1c/1/1/2"));
+    expect(result.current.selections).toEqual({ "placement-1": "akash1c/1/1/2" });
+  });
+
+  it("clears a single placement's selection without touching the others", () => {
+    const { result } = renderFlow();
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/1/1/1"));
+    act(() => result.current.actions.selectProvider("placement-2", "akash1b/1/2/1"));
+    act(() => result.current.actions.clearSelection("placement-1"));
+    expect(result.current.selections).toEqual({ "placement-2": "akash1b/1/2/1" });
+  });
+
+  it("deploy creates leases from the current selections and the captured manifest", async () => {
+    const createDeployment = mockMutation();
+    createDeployment.mutate.mockImplementation((_input, opts) => opts.onSuccess({ data: { dseq: "555", manifest: "MANIFEST_JSON" } }));
+    const createLease = mockMutation();
+    const { result } = renderFlow({ createDeployment, createLease });
+
+    act(() => result.current.actions.requestQuotes("sdl"));
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+    act(() => result.current.actions.deploy("sdl"));
+
+    expect(result.current.phase).toBe("deploying");
+    expect(createLease.mutate).toHaveBeenCalledWith(
+      { manifest: "MANIFEST_JSON", leases: [{ dseq: "555", gseq: 1, oseq: 3, provider: "akash1a" }] },
+      expect.anything()
+    );
+  });
+
+  it("marks the deploy succeeded, then redirects to the deployment detail after a brief dwell", () => {
+    vi.useFakeTimers();
+    try {
+      const createDeployment = mockMutation();
+      createDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({ data: { dseq: "555", manifest: "M" } }));
+      const createLease = mockMutation();
+      createLease.mutate.mockImplementation((_i, o) => o.onSuccess());
+      const { result, router } = renderFlow({ createDeployment, createLease });
+
+      act(() => result.current.actions.requestQuotes("sdl"));
+      act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+      act(() => result.current.actions.deploy("sdl"));
+
+      expect(result.current.deploySucceeded).toBe(true);
+      expect(router.push).not.toHaveBeenCalled();
+
+      act(() => vi.runAllTimers());
+      expect(router.push).toHaveBeenCalledWith("/deployments/555");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("returns to quoting and surfaces a retryable deploy error when the lease request fails", () => {
+    const createDeployment = mockMutation();
+    createDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({ data: { dseq: "555", manifest: "M" } }));
+    const createLease = mockMutation();
+    createLease.mutate.mockImplementation((_i, o) => o.onError(new Error("boom")));
+    const { result } = renderFlow({ createDeployment, createLease });
+
+    act(() => result.current.actions.requestQuotes("sdl"));
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+    act(() => result.current.actions.deploy("sdl"));
+
+    expect(result.current.phase).toBe("quoting");
+    expect(result.current.deployError).toBeDefined();
+  });
+
+  it("retry re-fires the same lease request after a failure", () => {
+    const createDeployment = mockMutation();
+    createDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({ data: { dseq: "555", manifest: "M" } }));
+    const createLease = mockMutation();
+    createLease.mutate.mockImplementation((_i, o) => o.onError(new Error("boom")));
+    const { result } = renderFlow({ createDeployment, createLease });
+
+    act(() => result.current.actions.requestQuotes("sdl"));
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+    act(() => result.current.actions.deploy("sdl"));
+    act(() => result.current.actions.deploy("sdl"));
+
+    expect(createLease.mutate).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears a prior deploy error when a new provider is selected", () => {
+    const createDeployment = mockMutation();
+    createDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({ data: { dseq: "555", manifest: "M" } }));
+    const createLease = mockMutation();
+    createLease.mutate.mockImplementation((_i, o) => o.onError(new Error("boom")));
+    const { result } = renderFlow({ createDeployment, createLease });
+
+    act(() => result.current.actions.requestQuotes("sdl"));
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+    act(() => result.current.actions.deploy("sdl"));
+    expect(result.current.deployError).toBeDefined();
+
+    act(() => result.current.actions.selectProvider("placement-1", "akash1b/555/1/3"));
+    expect(result.current.deployError).toBeUndefined();
+  });
+
+  it("clears selections when the deployment is closed so a re-quote cannot reuse stale bids", () => {
+    const closeDeployment = mockMutation();
+    closeDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({}));
+    const { result } = renderFlow({ closeDeployment, intent: { dseq: "555" } });
+
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+    expect(result.current.selections).toEqual({ "placement-1": "akash1a/555/1/3" });
+
+    act(() => result.current.actions.cancelAndEdit());
+
+    expect(result.current.phase).toBe("configuring");
+    expect(result.current.selections).toEqual({});
+  });
+
+  it("derives the manifest from the sdl when deploying after a reload that resumed straight into quoting", () => {
+    const createLease = mockMutation();
+    const manifestFromSdl = vi.fn(() => "DERIVED_MANIFEST");
+    const { result } = renderFlow({ createLease, manifestFromSdl, intent: { dseq: "555" } });
+
+    expect(result.current.phase).toBe("quoting");
+
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+    act(() => result.current.actions.deploy("SDL_CONTENT"));
+
+    expect(manifestFromSdl).toHaveBeenCalledWith("SDL_CONTENT");
+    expect(createLease.mutate).toHaveBeenCalledWith(
+      { manifest: "DERIVED_MANIFEST", leases: [{ dseq: "555", gseq: 1, oseq: 3, provider: "akash1a" }] },
+      expect.anything()
+    );
+  });
+
   function setup(input: {
     intent?: { sdlStrategy: "default" | "edit"; bidStrategy: "auto" | "select"; dseq?: string; templateId?: string; draftId?: string };
     replace?: ReturnType<typeof vi.fn>;
@@ -86,9 +226,35 @@ describe(useDeploymentFlow.name, () => {
     const dependencies: typeof DEPENDENCIES = {
       useCreateDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useCreateDeployment>>({ mutate: (input.createMutate ?? vi.fn()) as never })) as never,
       useCloseDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useCloseDeployment>>({ mutate: (input.closeMutate ?? vi.fn()) as never })) as never,
-      useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: (input.replace ?? vi.fn()) as never })) as never
+      useCreateLease: (() => mock<ReturnType<typeof DEPENDENCIES.useCreateLease>>({ mutate: vi.fn() as never })) as never,
+      useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: (input.replace ?? vi.fn()) as never })) as never,
+      manifestFromSdl: () => "manifest"
     };
     return renderHook(() => useDeploymentFlow({ intent }, dependencies));
+  }
+
+  function renderFlow(input?: {
+    intent?: Partial<DeploymentIntent>;
+    createDeployment?: ReturnType<typeof mockMutation>;
+    createLease?: ReturnType<typeof mockMutation>;
+    closeDeployment?: ReturnType<typeof mockMutation>;
+    manifestFromSdl?: (sdl: string) => string | null;
+  }) {
+    const intent: DeploymentIntent = { sdlStrategy: "edit", bidStrategy: "select", dseq: undefined, ...input?.intent };
+    const router = mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: vi.fn(), push: vi.fn() });
+    const dependencies: typeof DEPENDENCIES = {
+      useCreateDeployment: (() => input?.createDeployment ?? mockMutation()) as never,
+      useCloseDeployment: (() => input?.closeDeployment ?? mockMutation()) as never,
+      useCreateLease: (() => input?.createLease ?? mockMutation()) as never,
+      useRouter: () => router,
+      manifestFromSdl: input?.manifestFromSdl ?? (() => "DERIVED_MANIFEST")
+    };
+    const utils = renderHook(() => useDeploymentFlow({ intent }, dependencies));
+    return { ...utils, router };
+  }
+
+  function mockMutation() {
+    return mock<{ mutate: ReturnType<typeof vi.fn> }>({ mutate: vi.fn() });
   }
 });
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -1,17 +1,24 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { extractApiErrorMessage } from "@akashnetwork/openapi-sdk";
 import { useRouter } from "next/router";
 
 import { useServices } from "@src/context/ServicesProvider";
+import { parseBidId } from "@src/utils/bids/bidId";
+import { ManifestYaml } from "@src/utils/deploymentData/helpers";
 import { UrlService } from "@src/utils/urlUtils";
 import type { BidStrategy, DeploymentIntent } from "./deploymentIntent";
 
-export type DeploymentFlowPhase = "configuring" | "creating" | "quoting" | "closing" | "error";
+export type DeploymentFlowPhase = "configuring" | "creating" | "quoting" | "closing" | "deploying" | "error";
 
 export interface DeploymentFlowState {
   phase: DeploymentFlowPhase;
   dseq: string | null;
   bidStrategy: BidStrategy;
+  /** Provider chosen per placement, keyed by placement id; value is the offer's bid id (provider/dseq/gseq/oseq). Sibling state, not a form field. */
+  selections: Record<string, string>;
+  /** True once the lease is created; the deploy overlay completes its progress before the brief redirect to the deployment. */
+  deploySucceeded: boolean;
+  deployError?: { message?: string };
   error?: { message?: string };
 }
 
@@ -23,6 +30,11 @@ export interface DeploymentFlowActions {
   setBidStrategy: (strategy: BidStrategy) => void;
   refreshQuotes: () => void;
   retry: () => void;
+  selectProvider: (placementId: string, bidId: string) => void;
+  clearSelection: (placementId: string) => void;
+  /** Creates the lease(s) and sends the manifest. The caller passes the current SDL so the manifest can be
+   * rederived when it wasn't captured in this session (e.g. after a reload that resumed straight into quoting). */
+  deploy: (sdl: string) => void;
 }
 
 export type DeploymentFlow = DeploymentFlowState & { actions: DeploymentFlowActions };
@@ -34,6 +46,9 @@ interface UseDeploymentFlowInput {
 /** Default escrow deposit in USD (ACT maps 1:1 to USD). Matches `DEFAULT_DEPOSIT_USD` in the phased flow so a trial grant covers it. */
 const DEFAULT_DEPOSIT = 0.5;
 
+/** Hold after a successful lease so the deploy overlay's progress bar can fill to 100% and its final step turn green before redirecting. */
+const DEPLOY_SUCCESS_DWELL_MS = 1200;
+
 function useCreateDeployment() {
   return useServices().api.v1.createDeployment.useMutation();
 }
@@ -42,7 +57,11 @@ function useCloseDeployment() {
   return useServices().api.v1.closeDeployment.useMutation();
 }
 
-export const DEPENDENCIES = { useCreateDeployment, useCloseDeployment, useRouter };
+function useCreateLease() {
+  return useServices().api.v1.createLease.useMutation();
+}
+
+export const DEPENDENCIES = { useCreateDeployment, useCloseDeployment, useCreateLease, useRouter, manifestFromSdl };
 
 /**
  * Controlled lifecycle state machine for the configure flow. Owns interaction state (phase, dseq,
@@ -54,14 +73,26 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
   const router = dependencies.useRouter();
   const createDeployment = dependencies.useCreateDeployment();
   const closeDeployment = dependencies.useCloseDeployment();
+  const createLease = dependencies.useCreateLease();
 
   const [phase, setPhase] = useState<DeploymentFlowPhase>(intent.dseq ? "quoting" : "configuring");
   const [dseq, setDseq] = useState<string | null>(intent.dseq ?? null);
   const [bidStrategy, setBidStrategyState] = useState<BidStrategy>(intent.bidStrategy);
   const [error, setError] = useState<{ message?: string } | undefined>(undefined);
+  const [selections, setSelections] = useState<Record<string, string>>({});
+  const [manifest, setManifest] = useState<string | null>(null);
+  const [deployError, setDeployError] = useState<{ message?: string } | undefined>(undefined);
+  const [deploySucceeded, setDeploySucceeded] = useState(false);
 
   const intentRef = useRef(intent);
   intentRef.current = intent;
+
+  const redirectTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  useEffect(function clearRedirectTimerOnUnmount() {
+    return function cancelPendingRedirect() {
+      if (redirectTimerRef.current) clearTimeout(redirectTimerRef.current);
+    };
+  }, []);
 
   const requestQuotes = useCallback(
     function requestQuotes(sdl: string) {
@@ -72,6 +103,10 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
         {
           onSuccess: function onCreated(result: { data: { dseq: string; manifest: string } }) {
             setDseq(result.data.dseq);
+            setManifest(result.data.manifest);
+            setSelections({});
+            setDeployError(undefined);
+            setDeploySucceeded(false);
             setPhase("quoting");
             router.replace(buildConfigureUrl(intentRef.current, result.data.dseq, bidStrategy), undefined, { shallow: true });
           },
@@ -98,6 +133,10 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
         {
           onSuccess: function onClosed() {
             setDseq(null);
+            setSelections({});
+            setManifest(null);
+            setDeployError(undefined);
+            setDeploySucceeded(false);
             setPhase("configuring");
             router.replace(buildConfigureUrl(intentRef.current, undefined, bidStrategy), undefined, { shallow: true });
           },
@@ -131,7 +170,80 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
     [dseq]
   );
 
-  return { phase, dseq, bidStrategy, error, actions: { requestQuotes, cancelAndEdit, setBidStrategy, refreshQuotes, retry } };
+  const selectProvider = useCallback(function selectProvider(placementId: string, bidId: string) {
+    setDeployError(undefined);
+    setSelections(previous => ({ ...previous, [placementId]: bidId }));
+  }, []);
+
+  const clearSelection = useCallback(function clearSelection(placementId: string) {
+    setSelections(function omitPlacement(previous) {
+      const next = { ...previous };
+      delete next[placementId];
+      return next;
+    });
+  }, []);
+
+  /**
+   * Creates the lease(s) and sends the manifest(s) via the combined create-lease request. The manifest
+   * captured at create time is used when present; on a reload that resumed straight into `quoting` it was
+   * never captured, so it is rederived from the passed SDL (identical to the server's create-deployment
+   * manifest, both being `manifestToSortedJSON` of the SDL's groups) rather than leaving deploy a no-op.
+   * On failure it drops back to `quoting` so the progress overlay unmounts and the user is returned to where
+   * they took off; `deployError` is set to drive the error toast and the header's Retry CTA. Retry re-fires
+   * this same request with the current selections — provider re-selection after a lease exists is out of
+   * scope here (a partial-failure-aware, idempotent retry is tracked separately).
+   */
+  const deploy = useCallback(
+    function deploy(sdl: string) {
+      const effectiveManifest = manifest ?? dependencies.manifestFromSdl(sdl);
+      if (!dseq || !effectiveManifest) return;
+      const leases = Object.values(selections).map(parseBidId);
+      if (leases.length === 0) return;
+      setDeployError(undefined);
+      setDeploySucceeded(false);
+      setPhase("deploying");
+      createLease.mutate(
+        { manifest: effectiveManifest, leases },
+        {
+          onSuccess: function onDeployed() {
+            setDeploySucceeded(true);
+            redirectTimerRef.current = setTimeout(function redirectToDeployment() {
+              router.push(UrlService.deploymentDetails(dseq));
+            }, DEPLOY_SUCCESS_DWELL_MS);
+          },
+          onError: function onDeployFailed(cause: unknown) {
+            setDeployError({ message: extractApiErrorMessage(cause) ?? undefined });
+            setPhase("quoting");
+          }
+        }
+      );
+    },
+    [createLease, dseq, manifest, selections, router, dependencies]
+  );
+
+  return {
+    phase,
+    dseq,
+    bidStrategy,
+    selections,
+    deploySucceeded,
+    deployError,
+    error,
+    actions: { requestQuotes, cancelAndEdit, setBidStrategy, refreshQuotes, retry, selectProvider, clearSelection, deploy }
+  };
+}
+
+/**
+ * The provider manifest for an SDL, or null when the SDL can't be built (e.g. invalid/mid-edit). Matches the
+ * server's create-deployment manifest (both are `manifestToSortedJSON` of the SDL's groups), so a session that
+ * lost the captured manifest — a reload resumed straight into quoting — can still deploy from the restored SDL.
+ */
+function manifestFromSdl(sdl: string): string | null {
+  try {
+    return ManifestYaml(sdl);
+  } catch {
+    return null;
+  }
 }
 
 /** Builds the canonical configure URL preserving templateId/sdl-strategy/draftId and the current dseq + bid-strategy. */

--- a/apps/deploy-web/src/components/deployments/PhasedDeploymentProgress/PhasedDeploymentProgress.tsx
+++ b/apps/deploy-web/src/components/deployments/PhasedDeploymentProgress/PhasedDeploymentProgress.tsx
@@ -140,14 +140,16 @@ function DeployProgressPanel({ templateName, progressPercent, phases, onChoosePr
         </div>
       </div>
 
-      <div className="flex w-full flex-col items-start gap-3 rounded-xl border border-border p-4 sm:flex-row sm:items-center">
-        <p className="flex-1 text-sm leading-5 text-muted-foreground">Want to choose the provider yourself?</p>
+      {onChooseProvider && (
+        <div className="flex w-full flex-col items-start gap-3 rounded-xl border border-border p-4 sm:flex-row sm:items-center">
+          <p className="flex-1 text-sm leading-5 text-muted-foreground">Want to choose the provider yourself?</p>
 
-        <Button variant="outline" size="sm" className="w-full gap-2 px-3 text-xs sm:w-auto" onClick={onChooseProvider}>
-          <span>Choose my provider</span>
-          <ArrowRight className="h-4 w-4" />
-        </Button>
-      </div>
+          <Button variant="outline" size="sm" className="w-full gap-2 px-3 text-xs sm:w-auto" onClick={onChooseProvider}>
+            <span>Choose my provider</span>
+            <ArrowRight className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/deploy-web/src/components/shared/PricePerTimeUnit.tsx
+++ b/apps/deploy-web/src/components/shared/PricePerTimeUnit.tsx
@@ -11,20 +11,22 @@ interface IProps {
   className?: string;
   children?: ReactNode;
   showAsHourly?: boolean;
+  /** Render the unit abbreviated and tight ("$1.23/hr") instead of spelled out ("$1.23 / hour"). */
+  abbreviated?: boolean;
 }
 
-export const PricePerTimeUnit: React.FunctionComponent<IProps> = ({ perBlockValue, denom, className, showAsHourly = false, ...rest }) => {
+export const PricePerTimeUnit: React.FunctionComponent<IProps> = ({ perBlockValue, denom, className, showAsHourly = false, abbreviated = false, ...rest }) => {
   const hourlyValue = perBlockValue * (60 / averageBlockTime) * 60;
   const monthlyValue = hourlyValue * 24 * averageDaysInMonth;
   const value = showAsHourly ? hourlyValue : monthlyValue;
-  const timeUnit = showAsHourly ? "hour" : "month";
+  const unitLabel = showAsHourly ? (abbreviated ? "hr" : "hour") : "month";
 
   return (
     <span className={className} {...rest}>
       <strong>
         <PriceValue value={value} denom={denom} />
-      </strong>{" "}
-      / {timeUnit}
+      </strong>
+      {abbreviated ? `/${unitLabel}` : ` / ${unitLabel}`}
     </span>
   );
 };

--- a/apps/deploy-web/src/queries/useListBids.ts
+++ b/apps/deploy-web/src/queries/useListBids.ts
@@ -1,0 +1,14 @@
+import { useServices } from "@src/context/ServicesProvider";
+
+/** Poll cadence for live bids while quoting; callers that don't poll omit it. */
+export const BID_POLL_INTERVAL = 2000;
+
+/**
+ * `listBids` for a deployment, keyed on its dseq. Disabled until a dseq exists (and when `enabled` is false),
+ * so every caller shares one react-query cache entry rather than re-declaring the query. Wrapped so consumers
+ * can inject it via their own DEPENDENCIES for unit tests.
+ */
+export function useListBids(dseq: string | null | undefined, options?: { enabled?: boolean; refetchInterval?: number }) {
+  const { api } = useServices();
+  return api.v1.listBids.useQuery({ dseq: dseq ?? "" }, { enabled: (options?.enabled ?? true) && !!dseq, refetchInterval: options?.refetchInterval });
+}

--- a/apps/deploy-web/src/queries/usePlacementOffers.ts
+++ b/apps/deploy-web/src/queries/usePlacementOffers.ts
@@ -1,11 +1,12 @@
 import { useMemo } from "react";
 
-import { useServices } from "@src/context/ServicesProvider";
+import { BID_POLL_INTERVAL, useListBids } from "@src/queries/useListBids";
 import { useProviderList } from "@src/queries/useProvidersQuery";
 import type { ScreenedProvider } from "@src/queries/useScreenedProviders";
 import { useScreenedProviders } from "@src/queries/useScreenedProviders";
 import type { ApiProviderList } from "@src/types/provider";
-import { DeploymentGroups } from "@src/utils/deploymentData/helpers";
+import { formatBidId } from "@src/utils/bids/bidId";
+import { getPlacementGseq } from "@src/utils/sdl/placementGseq";
 
 export type OfferState = "searching" | "submitted" | "unavailable";
 
@@ -17,7 +18,7 @@ export interface PlacementOffer extends ScreenedProvider {
 }
 
 interface UsePlacementOffersInput {
-  phase: "configuring" | "creating" | "quoting" | "closing" | "error";
+  phase: "configuring" | "creating" | "quoting" | "closing" | "deploying" | "error";
   dseq?: string;
   sdl: string;
   placementName: string;
@@ -28,37 +29,6 @@ interface UsePlacementOffersResult {
   offers: PlacementOffer[];
   isLoading: boolean;
   isError: boolean;
-}
-
-/** Poll cadence for live bids while quoting; matches the existing phased flow. */
-const BID_POLL_INTERVAL = 2000;
-
-/** `listBids` bound to a dseq, enabled only while quoting. Wrapped in DEPENDENCIES so the selector is unit-testable. */
-function useListBids(dseq: string | undefined, enabled: boolean) {
-  const { api } = useServices();
-  return api.v1.listBids.useQuery({ dseq: dseq ?? "" }, { enabled: enabled && !!dseq, refetchInterval: BID_POLL_INTERVAL });
-}
-
-/**
- * Resolves a placement's on-chain group sequence (gseq) from the SDL. The chain numbers groups in the order
- * they are submitted in the create-deployment message, which is the order `DeploymentGroups` returns them
- * (both derive from chain-sdk's `buildManifest`), so the gseq is the 1-based index of the group whose name
- * matches the placement. Returns undefined when the SDL is absent/invalid (e.g. mid-edit) or the placement
- * isn't in it, so the caller skips gseq filtering rather than hiding every bid. Wrapped in DEPENDENCIES so the
- * selector is unit-testable without parsing a real SDL.
- */
-function getPlacementGseq(sdl: string, placementName: string): number | undefined {
-  if (!sdl) return undefined;
-
-  let groups: ReturnType<typeof DeploymentGroups>;
-  try {
-    groups = DeploymentGroups(sdl);
-  } catch {
-    return undefined;
-  }
-
-  const index = groups.findIndex(group => group.name === placementName);
-  return index === -1 ? undefined : index + 1;
 }
 
 export const DEPENDENCIES = { useScreenedProviders, useListBids, useProviderList, getPlacementGseq };
@@ -90,10 +60,10 @@ export function usePlacementOffers(
   { phase, dseq, sdl, placementName, region }: UsePlacementOffersInput,
   dependencies: typeof DEPENDENCIES = DEPENDENCIES
 ): UsePlacementOffersResult {
-  const isLocked = phase === "creating" || phase === "quoting" || phase === "closing";
+  const isLocked = phase === "creating" || phase === "quoting" || phase === "closing" || phase === "deploying";
   const isScreening = phase === "configuring" || phase === "creating";
   const screened = dependencies.useScreenedProviders({ sdl, placementName, region, enabled: !isLocked });
-  const bidsQuery = dependencies.useListBids(dseq, phase === "quoting");
+  const bidsQuery = dependencies.useListBids(dseq, { enabled: phase === "quoting", refetchInterval: BID_POLL_INTERVAL });
   const providerListQuery = dependencies.useProviderList({ enabled: !isScreening });
   const gseq = useMemo(() => dependencies.getPlacementGseq(sdl, placementName), [dependencies, sdl, placementName]);
   const providersByOwner = useMemo(() => new Map((providerListQuery.data ?? []).map(provider => [provider.owner, provider])), [providerListQuery.data]);
@@ -143,12 +113,7 @@ function toBidOffer(
     organization: provider?.organization || null,
     incidents: [],
     offerState: "submitted",
-    bidId: toBidId(entry.bid.id),
+    bidId: formatBidId(entry.bid.id),
     price: entry.bid.price
   };
-}
-
-/** Stable identifier for a bid across renders, built from its on-chain composite key. */
-function toBidId(id: { provider: string; dseq: string; gseq: number; oseq: number }): string {
-  return `${id.provider}/${id.dseq}/${id.gseq}/${id.oseq}`;
 }

--- a/apps/deploy-web/src/queries/usePlacementsWithBids.spec.ts
+++ b/apps/deploy-web/src/queries/usePlacementsWithBids.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DEPENDENCIES } from "./usePlacementsWithBids";
+import { usePlacementsWithBids } from "./usePlacementsWithBids";
+
+import { renderHook } from "@testing-library/react";
+
+describe("usePlacementsWithBids", () => {
+  it("includes only placements whose group has an open bid", () => {
+    const { result } = setup({
+      gseqByName: { "placement-1": 1, "placement-2": 2 },
+      placements: [
+        { id: "p1", name: "placement-1" },
+        { id: "p2", name: "placement-2" }
+      ],
+      bids: [{ gseq: 1, state: "open" }]
+    });
+    expect(result.current.has("p1")).toBe(true);
+    expect(result.current.has("p2")).toBe(false);
+  });
+
+  it("ignores closed bids", () => {
+    const { result } = setup({
+      gseqByName: { "placement-1": 1 },
+      placements: [{ id: "p1", name: "placement-1" }],
+      bids: [{ gseq: 1, state: "closed" }]
+    });
+    expect(result.current.has("p1")).toBe(false);
+  });
+
+  it("is empty before any bid arrives", () => {
+    const { result } = setup({ gseqByName: { "placement-1": 1 }, placements: [{ id: "p1", name: "placement-1" }], bids: [] });
+    expect(result.current.size).toBe(0);
+  });
+
+  it("includes a placement with an unresolved gseq when any open bid exists, matching usePlacementOffers", () => {
+    const { result } = setup({ gseqByName: {}, placements: [{ id: "p1", name: "placement-1" }], bids: [{ gseq: 7, state: "open" }] });
+    expect(result.current.has("p1")).toBe(true);
+  });
+
+  function setup(input: { gseqByName: Record<string, number>; placements: { id: string; name: string }[]; bids: { gseq: number; state: string }[] }) {
+    const dependencies: typeof DEPENDENCIES = {
+      useListBids: () =>
+        mock<ReturnType<typeof DEPENDENCIES.useListBids>>({ data: { data: input.bids.map(bid => ({ bid: { id: { gseq: bid.gseq }, state: bid.state } })) } }),
+      getPlacementGseq: (_sdl, name) => input.gseqByName[name]
+    };
+    return renderHook(() => usePlacementsWithBids({ enabled: true, dseq: "55", sdl: "sdl", placements: input.placements }, dependencies));
+  }
+});

--- a/apps/deploy-web/src/queries/usePlacementsWithBids.ts
+++ b/apps/deploy-web/src/queries/usePlacementsWithBids.ts
@@ -1,0 +1,56 @@
+import { useMemo } from "react";
+
+import { BID_POLL_INTERVAL, useListBids } from "@src/queries/useListBids";
+import { getPlacementGseq } from "@src/utils/sdl/placementGseq";
+
+export const DEPENDENCIES = { useListBids, getPlacementGseq };
+
+interface Input {
+  /** Whether to query bids — the caller enables this while the marketplace is live (quoting). */
+  enabled: boolean;
+  dseq: string | null;
+  sdl: string;
+  placements: ReadonlyArray<{ id?: string; name: string }>;
+}
+
+/**
+ * The set of placement ids that currently have at least one open (selectable) bid. Bids arrive per group and
+ * independently, so this lets the UI tell apart a placement that's ready to choose from one still searching —
+ * rather than treating the whole deployment as "quoting" the moment any one group gets a bid. Reuses the same
+ * `listBids` query as the marketplace, so react-query serves both from one request.
+ */
+export function usePlacementsWithBids({ enabled, dseq, sdl, placements }: Input, dependencies: typeof DEPENDENCIES = DEPENDENCIES): Set<string> {
+  const bidsQuery = dependencies.useListBids(dseq, { enabled, refetchInterval: BID_POLL_INTERVAL });
+  const bids = bidsQuery.data?.data;
+
+  return useMemo(
+    function buildPlacementsWithBids() {
+      const openBids = (bids ?? []).filter(entry => entry.bid.state === "open");
+      if (openBids.length === 0) return new Set<string>();
+      return placementIdsWithOpenBids(placements, openBids, sdl, dependencies.getPlacementGseq);
+    },
+    [bids, placements, sdl, dependencies]
+  );
+}
+
+/**
+ * Placement ids whose on-chain group (gseq, resolved from the SDL) matches at least one of the open bids.
+ * When the gseq can't be resolved (absent/invalid SDL, or the placement isn't in it), it falls back to
+ * "has bids if any open bid exists" — the same fallback as `usePlacementOffers`, so the readiness state
+ * and the marketplace offers never disagree for that placement. Called only with a non-empty `openBids`.
+ */
+function placementIdsWithOpenBids(
+  placements: Input["placements"],
+  openBids: ReadonlyArray<{ bid: { id: { gseq: number } } }>,
+  sdl: string,
+  getPlacementGseq: typeof DEPENDENCIES.getPlacementGseq
+): Set<string> {
+  const withBids = new Set<string>();
+  for (const placement of placements) {
+    if (!placement.id) continue;
+    const gseq = getPlacementGseq(sdl, placement.name);
+    const hasOpenBid = gseq === undefined || openBids.some(entry => entry.bid.id.gseq === gseq);
+    if (hasOpenBid) withBids.add(placement.id);
+  }
+  return withBids;
+}

--- a/apps/deploy-web/src/utils/bids/bidId.spec.ts
+++ b/apps/deploy-web/src/utils/bids/bidId.spec.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { formatBidId, parseBidId } from "./bidId";
+
+describe("bidId", () => {
+  it("formats a bid id from its on-chain composite key", () => {
+    expect(formatBidId({ provider: "akash1prov", dseq: "123", gseq: 1, oseq: 2 })).toBe("akash1prov/123/1/2");
+  });
+
+  it("parses a formatted bid id back into its composite key with numeric gseq/oseq", () => {
+    expect(parseBidId("akash1prov/123/1/2")).toEqual({ provider: "akash1prov", dseq: "123", gseq: 1, oseq: 2 });
+  });
+
+  it("round-trips", () => {
+    const id = { provider: "akash1xyz", dseq: "999", gseq: 3, oseq: 4 };
+    expect(parseBidId(formatBidId(id))).toEqual(id);
+  });
+});

--- a/apps/deploy-web/src/utils/bids/bidId.ts
+++ b/apps/deploy-web/src/utils/bids/bidId.ts
@@ -1,0 +1,18 @@
+/** A bid's on-chain composite key. `dseq` stays a string (chain ids overflow JS numbers); gseq/oseq are small ints. */
+export interface BidId {
+  provider: string;
+  dseq: string;
+  gseq: number;
+  oseq: number;
+}
+
+/** Stable string identifier for a bid, used as the selection key and for React keys. */
+export function formatBidId(id: BidId): string {
+  return `${id.provider}/${id.dseq}/${id.gseq}/${id.oseq}`;
+}
+
+/** Inverse of {@link formatBidId}. Restores numeric gseq/oseq so the value can feed `createLease`. */
+export function parseBidId(value: string): BidId {
+  const [provider, dseq, gseq, oseq] = value.split("/");
+  return { provider, dseq, gseq: Number(gseq), oseq: Number(oseq) };
+}

--- a/apps/deploy-web/src/utils/mathHelpers.ts
+++ b/apps/deploy-web/src/utils/mathHelpers.ts
@@ -25,6 +25,9 @@ export function udenomToDenom(_amount: string | number, precision = 6, decimals:
   return roundDecimal(amount / decimals, precision);
 }
 
+/** Decimal precision for rendering marketplace/review prices (overrides `udenomToDenom`'s default of 6). */
+export const PRICE_DISPLAY_PRECISION = 10;
+
 /**
  * @deprecated don't use JS floating point number to represent a denom amount.
  * use the string representation instead and use `Decimal` from `@cosmjs/math` to do manipulation on amounts.

--- a/apps/deploy-web/src/utils/providerUtils.spec.ts
+++ b/apps/deploy-web/src/utils/providerUtils.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { providerDisplayName } from "./providerUtils";
+
+describe(providerDisplayName.name, () => {
+  it("prefers the organization when present", () => {
+    expect(providerDisplayName({ organization: "Dune Networks", hostUri: "https://provider.example:8443", owner: "akash1a" })).toBe("Dune Networks");
+  });
+
+  it("falls back to the host name when there is no organization", () => {
+    expect(providerDisplayName({ organization: null, hostUri: "https://provider.example:8443", owner: "akash1a" })).toBe("provider.example");
+  });
+
+  it("falls back to the owner address when there is no organization or host", () => {
+    expect(providerDisplayName({ organization: null, hostUri: "", owner: "akash1a" })).toBe("akash1a");
+  });
+
+  it("falls back to the owner address when the host uri is malformed rather than throwing", () => {
+    expect(providerDisplayName({ organization: null, hostUri: "not a url", owner: "akash1a" })).toBe("akash1a");
+  });
+
+  it("falls back to the owner address when the host uri is whitespace only", () => {
+    expect(providerDisplayName({ organization: null, hostUri: "   ", owner: "akash1a" })).toBe("akash1a");
+  });
+});

--- a/apps/deploy-web/src/utils/providerUtils.ts
+++ b/apps/deploy-web/src/utils/providerUtils.ts
@@ -76,3 +76,22 @@ export const getProviderNameFromUri = (uri: string) => {
   const name = new URL(uri).hostname;
   return name;
 };
+
+/**
+ * Display name for a provider: its organization, else the host parsed from its URI, else its on-chain
+ * address. The address fallback covers bid-sourced offers, which carry no screened host/organization —
+ * `getProviderNameFromUri` would throw on their empty `hostUri`.
+ */
+export const providerDisplayName = (provider: { organization?: string | null; hostUri?: string | null; owner: string }): string => {
+  const organization = provider.organization?.trim();
+  if (organization) return organization;
+
+  const hostUri = provider.hostUri?.trim();
+  if (!hostUri) return provider.owner;
+
+  try {
+    return getProviderNameFromUri(hostUri);
+  } catch {
+    return provider.owner;
+  }
+};

--- a/apps/deploy-web/src/utils/sdl/placementGseq.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/placementGseq.spec.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { generateSdl } from "@src/utils/sdl/sdlGenerator";
+import { getPlacementGseq } from "./placementGseq";
+
+describe(getPlacementGseq.name, () => {
+  it("resolves a placement's 1-based group sequence from the SDL", () => {
+    const { sdl, placementName } = sdlWithSinglePlacement();
+    expect(getPlacementGseq(sdl, placementName)).toBe(1);
+  });
+
+  it("returns undefined when the placement is not in the SDL", () => {
+    const { sdl } = sdlWithSinglePlacement();
+    expect(getPlacementGseq(sdl, "missing-placement")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty SDL", () => {
+    expect(getPlacementGseq("", "dcloud")).toBeUndefined();
+  });
+
+  it("returns undefined when the SDL can't be parsed", () => {
+    expect(getPlacementGseq('version: "2.0"\nservices: [', "dcloud")).toBeUndefined();
+  });
+
+  function sdlWithSinglePlacement() {
+    const values = defaultServiceWithPlacement({ image: "nginx:latest" });
+    return { sdl: generateSdl(values), placementName: values.placements[0].name };
+  }
+});

--- a/apps/deploy-web/src/utils/sdl/placementGseq.ts
+++ b/apps/deploy-web/src/utils/sdl/placementGseq.ts
@@ -1,0 +1,22 @@
+import { DeploymentGroups } from "@src/utils/deploymentData/helpers";
+
+/**
+ * Resolves a placement's on-chain group sequence (gseq) from the SDL. The chain numbers groups in the order
+ * they are submitted in the create-deployment message, which is the order `DeploymentGroups` returns them
+ * (both derive from chain-sdk's `buildManifest`), so the gseq is the 1-based index of the group whose name
+ * matches the placement. Returns undefined when the SDL is absent/invalid (e.g. mid-edit) or the placement
+ * isn't in it, so callers skip gseq filtering rather than hiding every bid.
+ */
+export function getPlacementGseq(sdl: string, placementName: string): number | undefined {
+  if (!sdl) return undefined;
+
+  let groups: ReturnType<typeof DeploymentGroups>;
+  try {
+    groups = DeploymentGroups(sdl);
+  } catch {
+    return undefined;
+  }
+
+  const index = groups.findIndex(group => group.name === placementName);
+  return index === -1 ? undefined : index + 1;
+}

--- a/apps/deploy-web/tests/ui/configure-deployment-flow.spec.ts
+++ b/apps/deploy-web/tests/ui/configure-deployment-flow.spec.ts
@@ -40,6 +40,38 @@ test.describe("Configure deployment — request quotes flow", () => {
       await expect(configure.requestQuotesButton()).toBeVisible();
     });
   });
+
+  test("selects a provider, reviews, and deploys", async ({ page }) => {
+    test.setTimeout(5 * 60 * 1000);
+
+    const configure = new ConfigureDeploymentPage(page);
+    let dseq: string | undefined;
+
+    await test.step("request quotes to create the deployment and surface bids", async () => {
+      await configure.goto();
+      await configure.fillImageName("nginx:latest");
+      await configure.requestQuotes();
+
+      await page.waitForURL(/\/new-deployment\/configure\/\d+/, { timeout: 90_000 });
+      dseq = new URL(page.url()).pathname.match(/\/new-deployment\/configure\/(\d+)/)?.[1];
+      expect(dseq).toBeTruthy();
+      await expect(configure.marketplaceHeading()).toBeVisible({ timeout: 30_000 });
+    });
+
+    await test.step("selecting the only placement's provider auto-opens the review", async () => {
+      // waits for the first submitted bid's Select button, then picks it
+      await configure.selectFirstAvailableProvider();
+
+      // the last selection completes every placement, so the review modal opens on its own
+      await expect(configure.reviewDialog()).toBeVisible({ timeout: 30_000 });
+      await expect(configure.reviewDialog().getByText(/total deployment cost/i)).toBeVisible();
+    });
+
+    await test.step("confirming creates the lease and redirects to the deployment created in this run", async () => {
+      await configure.confirmAndDeploy();
+      await page.waitForURL(new RegExp(`/deployments/${dseq}(?:[/?]|$)`), { timeout: 180_000 });
+    });
+  });
 });
 
 test.describe("Configure deployment — draft persistence", () => {

--- a/apps/deploy-web/tests/ui/pages/ConfigureDeploymentPage.ts
+++ b/apps/deploy-web/tests/ui/pages/ConfigureDeploymentPage.ts
@@ -60,4 +60,23 @@ export class ConfigureDeploymentPage {
   marketplaceHeading() {
     return this.page.getByRole("heading", { name: /Compute Marketplace/i });
   }
+
+  /** The marketplace pane region — used to scope provider rows away from the deployment pane's "Select service-N" buttons. */
+  marketplace() {
+    return this.page.getByRole("region", { name: /Compute Marketplace/i });
+  }
+
+  /** Waits for the first submitted bid's Select button in the marketplace, then picks it. */
+  async selectFirstAvailableProvider() {
+    const select = this.marketplace().getByRole("button", { name: /^Select / }).first();
+    await select.click({ timeout: 90_000 });
+  }
+
+  reviewDialog() {
+    return this.page.getByRole("dialog");
+  }
+
+  async confirmAndDeploy() {
+    await this.reviewDialog().getByRole("button", { name: /confirm and deploy/i }).click();
+  }
 }


### PR DESCRIPTION
## Why

After requesting quotes, users need to choose a provider for each placement and confirm exactly what
they're about to deploy — provider and price per placement, plus the total — before committing. The
configure flow had the marketplace and quotes but no way to select, review, and deploy. This adds that
final stretch on the managed-wallet path.

Closes CON-425.
Part of CON-589 (partial-failure-aware idempotent lease retry — follow-up that hardens the deploy step).
Related to CON-473 (auto-select reuses this review surface).

## What

The selection → review → deploy flow on the configure screen:

- **Per-placement selection.** Once bids arrive, the marketplace shows a Cost column and a Select button
  per submitted offer; one provider can be selected per placement. Placement cards show a SELECTING marker
  for the active placement and DONE once chosen.
- **Auto-advance.** Selecting a provider focuses the next placement still missing a selection; selecting the
  last one opens the **Review and deploy** modal automatically. The header's Deploy CTA also opens it and is
  enabled only when every placement has a selection.
- **Review modal.** One row per placement (placement → provider → price) with the hourly USD total, then
  Confirm and deploy.
- **Deploy.** Confirming creates the lease(s) and sends the manifest(s) via the managed-wallet path, showing
  a full-screen progress overlay (the reused CON-315 progress panel over a providers globe) and redirecting
  to the deployment on success.
- **Deploy failure.** The overlay is dismissed, the user is returned to the live marketplace with their
  selections intact, an error toast is shown, and the CTA becomes **Retry** (re-fires the same request).
  Note: re-firing after a lease already exists is made fully safe by CON-589 (server-side idempotent lease
  creation); until that lands, retry reliably recovers the lease-not-created case.

Supporting changes: a bid-id format/parse utility, a placement → group-sequence (gseq) resolver, a
"placements with bids" query and a shared `listBids` hook (one cached request across the marketplace,
selection state, and review), a shared provider-display-name helper, and an abbreviated form of the shared
price component.

**Tests.** Unit/component specs across the flow (selection, review rows, deploy lifecycle incl. retry,
progress, globe), plus an end-to-end test covering select → review → deploy.

No breaking changes. No migrations.

[video.webm](https://github.com/user-attachments/assets/b485e9f0-30ec-4822-8464-096b590fefe6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a “Review and Deploy” modal that validates selections and shows per-placement pricing plus a total deployment cost.
  * Introduced a full-screen deployment progress overlay with phase-based status and a focused providers globe.
  * Enhanced marketplace/placement selection UX with “SELECTING”, “DONE”, and “WAITING” badges, and improved navigation to the next needed placement.

* **Bug Fixes**
  * Improved quoting → deploy flow with deploy/ retry CTA when bids are ready, deploy error deduplication, and safer focus/selection progression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->