### PR TITLE
fix: triggers auto charge job right after auto top up

### DIFF
--- a/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.ts
+++ b/apps/api/src/billing/repositories/wallet-settings/wallet-settings.repository.ts
@@ -36,13 +36,7 @@ export class WalletSettingRepository extends BaseRepository<Table, WalletSetting
   }
 
   async findByUserId(userId: WalletSettingOutput["userId"]): Promise<WalletSettingOutput | undefined> {
-    const walletSetting = await this.cursor.query.WalletSetting.findFirst({
-      where: this.whereAccessibleBy(eq(this.table.userId, userId))
-    });
-
-    if (!walletSetting) return undefined;
-
-    return this.toOutput(walletSetting);
+    return this.findOneBy({ userId });
   }
 
   async findInternalByUserIdWithRelations(userId: WalletSettingOutput["userId"]) {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -424,7 +424,7 @@ describe(ManagedSignerService.name, () => {
 
       await service.executeDerivedEncodedTxByUserId("user-123", [deploymentMessage]);
 
-      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith("user-123");
+      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith({ userId: "user-123" });
     });
 
     it("executes transaction and calls scheduleImmediate when transaction contains MsgAccountDeposit", async () => {
@@ -452,7 +452,7 @@ describe(ManagedSignerService.name, () => {
 
       await service.executeDerivedEncodedTxByUserId("user-123", [depositMessage]);
 
-      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith("user-123");
+      expect(walletReloadJobService.scheduleImmediate).toHaveBeenCalledWith({ userId: "user-123" });
     });
 
     it("executes transaction and does not call scheduleImmediate when transaction does not contain spending messages", async () => {

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.ts
@@ -165,7 +165,7 @@ export class ManagedSignerService {
     const hasSpendingTx = messages.some(message => SPENDING_TXS.some(msg => message.typeUrl.endsWith(msg.$type)));
 
     if (hasSpendingTx) {
-      await this.walletReloadJobService.scheduleImmediate(userId);
+      await this.walletReloadJobService.scheduleImmediate({ userId });
     }
   }
 

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
@@ -16,8 +16,9 @@ describe(WalletReloadJobService.name, () => {
       const userId = faker.string.uuid();
       walletSettingRepository.findByUserId.mockResolvedValue(undefined);
 
-      await service.scheduleImmediate(userId);
+      const result = await service.scheduleImmediate({ userId });
 
+      expect(result).toBe(false);
       expect(walletSettingRepository.findByUserId).toHaveBeenCalledWith(userId);
       expect(jobQueueService.enqueue).not.toHaveBeenCalled();
     });
@@ -28,8 +29,9 @@ describe(WalletReloadJobService.name, () => {
       const walletSetting = generateWalletSetting({ autoReloadEnabled: false });
       walletSettingRepository.findByUserId.mockResolvedValue(walletSetting);
 
-      await service.scheduleImmediate(userId);
+      const result = await service.scheduleImmediate({ userId });
 
+      expect(result).toBe(false);
       expect(walletSettingRepository.findByUserId).toHaveBeenCalledWith(userId);
       expect(jobQueueService.enqueue).not.toHaveBeenCalled();
     });
@@ -42,8 +44,9 @@ describe(WalletReloadJobService.name, () => {
       const jobId = faker.string.uuid();
       jobQueueService.enqueue.mockResolvedValue(jobId);
 
-      await service.scheduleImmediate(userId);
+      const result = await service.scheduleImmediate({ userId });
 
+      expect(result).toBe(true);
       expect(walletSettingRepository.findByUserId).toHaveBeenCalledWith(userId);
       expect(jobQueueService.enqueue).toHaveBeenCalledWith(
         expect.any(WalletBalanceReloadCheck),
@@ -51,6 +54,38 @@ describe(WalletReloadJobService.name, () => {
           singletonKey: `${WalletBalanceReloadCheck.name}.${walletSetting.userId}`
         })
       );
+    });
+
+    it("looks up the wallet setting by walletId when given a walletId", async () => {
+      const { service, walletSettingRepository, jobQueueService } = setup();
+      const walletId = faker.number.int({ min: 1, max: 1000000 });
+      const walletSetting = generateWalletSetting({ walletId, autoReloadEnabled: true });
+      walletSettingRepository.findOneBy.mockResolvedValue(walletSetting);
+      jobQueueService.enqueue.mockResolvedValue(faker.string.uuid());
+
+      const result = await service.scheduleImmediate({ walletId });
+
+      expect(result).toBe(true);
+      expect(walletSettingRepository.findOneBy).toHaveBeenCalledWith({ walletId });
+      expect(walletSettingRepository.findByUserId).not.toHaveBeenCalled();
+      expect(jobQueueService.enqueue).toHaveBeenCalledWith(
+        expect.any(WalletBalanceReloadCheck),
+        expect.objectContaining({
+          singletonKey: `${WalletBalanceReloadCheck.name}.${walletSetting.userId}`
+        })
+      );
+    });
+
+    it("returns false when no wallet setting is found by walletId", async () => {
+      const { service, walletSettingRepository, jobQueueService } = setup();
+      const walletId = faker.number.int({ min: 1, max: 1000000 });
+      walletSettingRepository.findOneBy.mockResolvedValue(undefined);
+
+      const result = await service.scheduleImmediate({ walletId });
+
+      expect(result).toBe(false);
+      expect(walletSettingRepository.findOneBy).toHaveBeenCalledWith({ walletId });
+      expect(jobQueueService.enqueue).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.ts
@@ -15,12 +15,18 @@ export class WalletReloadJobService {
     this.logger.setContext(WalletReloadJobService.name);
   }
 
-  async scheduleImmediate(userId: string): Promise<void> {
-    const walletSetting = await this.walletSettingRepository.findByUserId(userId);
+  async scheduleImmediate(input: WalletReloadImmediateInput): Promise<boolean> {
+    const walletSetting =
+      "userId" in input
+        ? await this.walletSettingRepository.findByUserId(input.userId)
+        : await this.walletSettingRepository.findOneBy({ walletId: input.walletId });
 
     if (walletSetting?.autoReloadEnabled) {
       await this.scheduleForWalletSetting(walletSetting);
+      return true;
     }
+
+    return false;
   }
 
   async scheduleForWalletSetting(
@@ -31,10 +37,15 @@ export class WalletReloadJobService {
       await this.cancelCreatedByUserId(walletSetting.userId);
     }
 
-    const createdJobId = await this.jobQueueService.enqueue(new WalletBalanceReloadCheck({ userId: walletSetting.userId }), {
-      singletonKey: `${WalletBalanceReloadCheck.name}.${walletSetting.userId}`,
-      ...(options?.startAfter && { startAfter: options.startAfter })
-    });
+    const createdJobId = await this.jobQueueService.enqueue(
+      new WalletBalanceReloadCheck({
+        userId: walletSetting.userId
+      }),
+      {
+        singletonKey: `${WalletBalanceReloadCheck.name}.${walletSetting.userId}`,
+        ...(options?.startAfter && { startAfter: options.startAfter })
+      }
+    );
 
     if (!createdJobId) {
       this.logger.error({
@@ -51,3 +62,5 @@ export class WalletReloadJobService {
     await this.jobQueueService.cancelCreatedBy({ name: WalletBalanceReloadCheck.name, singletonKey: `${WalletBalanceReloadCheck.name}.${userId}` });
   }
 }
+
+export type WalletReloadImmediateInput = { userId: string } | { walletId: number };

--- a/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
+++ b/apps/api/src/deployment/repositories/deployment-setting/deployment-setting.repository.ts
@@ -39,11 +39,16 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
     return new DeploymentSettingRepository(this.pg, this.table, this.txManager).withAbility(...abilityParams) as this;
   }
 
-  async *findAutoTopUpDeploymentsByOwnerIteratively(): AsyncGenerator<{ address: string; deploymentSettings: AutoTopUpDeployment[] }> {
+  async *findAutoTopUpDeploymentsByOwnerIteratively(): AsyncGenerator<{
+    address: string;
+    walletId: number;
+    deploymentSettings: AutoTopUpDeployment[];
+  }> {
     const baseClauses = [eq(this.table.autoTopUpEnabled, true), eq(this.table.closed, false)];
 
     const distinctOwnersQuery = this.pg
-      .selectDistinct({
+      .selectDistinctOn([UserWallets.address], {
+        walletId: UserWallets.id,
         address: UserWallets.address
       })
       .from(this.table)
@@ -54,15 +59,15 @@ export class DeploymentSettingRepository extends BaseRepository<Table, Deploymen
 
     const distinctOwners = await distinctOwnersQuery.where(and(...distinctClauses));
 
-    for (const { address } of distinctOwners) {
-      if (!address) {
+    for (const { address, walletId } of distinctOwners) {
+      if (!address || !walletId) {
         continue;
       }
 
       const deployments = await this.findAutoTopUpDeploymentsByOwner(address);
 
       if (deployments.length > 0) {
-        yield { address, deploymentSettings: deployments as AutoTopUpDeployment[] };
+        yield { address, walletId, deploymentSettings: deployments as AutoTopUpDeployment[] };
       }
     }
   }

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.ts
@@ -57,7 +57,7 @@ export class DeploymentSettingService {
     const result = await this.withEstimatedTopUpAmount(await this.deploymentSettingRepository.accessibleBy(this.authService.ability, "create").create(input));
 
     if (result.autoTopUpEnabled) {
-      await this.walletReloadJobService.scheduleImmediate(result.userId);
+      await this.walletReloadJobService.scheduleImmediate({ userId: result.userId });
     }
 
     return result;

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -75,7 +75,7 @@ describe(DrainingDeploymentService.name, () => {
       deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively.mockImplementation(() =>
         (async function* () {
           for (const [address, settings] of Object.entries(deploymentSettingsByAddress)) {
-            yield { address, deploymentSettings: settings };
+            yield { address, walletId: settings[0].walletId, deploymentSettings: settings };
           }
         })()
       );

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.ts
@@ -40,11 +40,11 @@ export class DrainingDeploymentService {
    *
    * @yields Object with owner address and array of draining deployments
    */
-  async *findDrainingDeploymentsByOwner(): AsyncGenerator<{ address: string; deployments: DrainingDeployment[] }> {
+  async *findDrainingDeploymentsByOwner(): AsyncGenerator<{ address: string; walletId: number; deployments: DrainingDeployment[] }> {
     const currentHeight = await this.blockHttpService.getCurrentHeight();
     const expectedClosureHeight = Math.floor(currentHeight + averageBlockCountInAnHour * this.config.get("AUTO_TOP_UP_LOOK_AHEAD_WINDOW_IN_H"));
 
-    for await (const { address, deploymentSettings } of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
+    for await (const { address, walletId, deploymentSettings } of this.deploymentSettingRepository.findAutoTopUpDeploymentsByOwnerIteratively()) {
       if (deploymentSettings.length === 0) {
         continue;
       }
@@ -82,7 +82,7 @@ export class DrainingDeploymentService {
         }
 
         if (active.length) {
-          yield { address, deployments: active };
+          yield { address, walletId, deployments: active };
         }
       }
     }

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -9,6 +9,7 @@ import { RpcMessageService } from "@src/billing/services";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import type { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import type { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import type { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
 import type { DrainingDeployment, DrainingDeploymentService } from "@src/deployment/services/draining-deployment/draining-deployment.service";
 import { mockConfigService } from "../../../../test/mocks/config-service.mock";
@@ -33,7 +34,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
 
   describe("topUpDeployments", () => {
     it("should top up draining deployments", async () => {
-      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, instrumentation } = setup();
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, instrumentation, walletReloadService } = setup();
       const deployments = createManyAutoTopUpDeployments(2);
       const desiredAmount = faker.number.int({ min: 3500000, max: 4000000 });
       const sufficientAmount = faker.number.int({ min: 1000000, max: 2000000 });
@@ -63,7 +64,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
           );
 
           for (const [address, items] of Object.entries(byAddress)) {
-            yield { address, deployments: items };
+            yield { address, walletId: items[0].walletId, deployments: items };
           }
         })()
       );
@@ -124,6 +125,9 @@ describe(TopUpManagedDeploymentsService.name, () => {
       });
 
       expect(instrumentation.finish).toHaveBeenCalledWith("success", CURRENT_BLOCK_HEIGHT);
+      deployments.forEach(deployment => {
+        expect(walletReloadService.scheduleImmediate).toHaveBeenCalledWith({ walletId: deployment.walletId });
+      });
     });
 
     it("should handle errors and continue processing", async () => {
@@ -153,7 +157,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
           );
 
           for (const [address, items] of Object.entries(byAddress)) {
-            yield { address, deployments: items };
+            yield { address, walletId: items[0].walletId, deployments: items };
           }
         })()
       );
@@ -168,7 +172,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     });
 
     it("should not execute transactions in dry run mode", async () => {
-      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService } = setup();
+      const { service, drainingDeploymentService, cachedBalanceService, managedSignerService, walletReloadService } = setup();
       const deployments = createManyAutoTopUpDeployments(2);
       const predictedClosedHeight = CURRENT_BLOCK_HEIGHT + 1500;
 
@@ -194,7 +198,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
           );
 
           for (const [address, items] of Object.entries(byAddress)) {
-            yield { address, deployments: items };
+            yield { address, walletId: items[0].walletId, deployments: items };
           }
         })()
       );
@@ -204,6 +208,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
       await service.topUpDeployments({ dryRun: true });
 
       expect(managedSignerService.executeDerivedTx).not.toHaveBeenCalled();
+      expect(walletReloadService.scheduleImmediate).not.toHaveBeenCalled();
     });
 
     it("should not execute transactions if no draining deployments", async () => {
@@ -246,7 +251,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
           );
 
           for (const [address, items] of Object.entries(byAddress)) {
-            yield { address, deployments: items };
+            yield { address, walletId: items[0].walletId, deployments: items };
           }
         })()
       );
@@ -313,7 +318,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
               dseq: deployment.dseq
             } as DrainingDeployment
           ];
-          yield { address: deployment.address, deployments: items };
+          yield { address: deployment.address, walletId: deployment.walletId, deployments: items };
         })()
       );
 
@@ -366,7 +371,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
           );
 
           for (const [address, items] of Object.entries(byAddress)) {
-            yield { address, deployments: items };
+            yield { address, walletId: items[0].walletId, deployments: items };
           }
         })()
       );
@@ -422,7 +427,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
           );
 
           for (const [address, items] of Object.entries(byAddress)) {
-            yield { address, deployments: items };
+            yield { address, walletId: items[0].walletId, deployments: items };
           }
         })()
       );
@@ -444,6 +449,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         (async function* () {
           yield {
             address: deployment.address,
+            walletId: deployment.walletId,
             deployments: [
               {
                 ...deployment,
@@ -476,6 +482,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         (async function* () {
           yield {
             address: deployment.address,
+            walletId: deployment.walletId,
             deployments: [
               {
                 ...deployment,
@@ -509,6 +516,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
         (async function* () {
           yield {
             address: deployment.address,
+            walletId: deployment.walletId,
             deployments: [
               {
                 ...deployment,
@@ -550,6 +558,7 @@ describe(TopUpManagedDeploymentsService.name, () => {
     const chainErrorService = mock<ChainErrorService>();
     chainErrorService.isMasterWalletInsufficientFundsError.mockResolvedValue(false);
     const instrumentation = mock<TopUpManagedDeploymentsInstrumentationService>();
+    const walletReloadService = mock<WalletReloadJobService>();
 
     const service = new TopUpManagedDeploymentsService(
       managedSignerService,
@@ -559,7 +568,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
       cachedBalanceService,
       blockHttpService,
       chainErrorService,
-      instrumentation
+      instrumentation,
+      walletReloadService
     );
 
     return {
@@ -571,7 +581,8 @@ describe(TopUpManagedDeploymentsService.name, () => {
       cachedBalanceService,
       blockHttpService,
       chainErrorService,
-      instrumentation
+      instrumentation,
+      walletReloadService
     };
   }
 });

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.ts
@@ -6,6 +6,7 @@ import { DepositDeploymentMsgOptions, RpcMessageService } from "@src/billing/ser
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { ChainErrorService } from "@src/billing/services/chain-error/chain-error.service";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
+import { WalletReloadJobService } from "@src/billing/services/wallet-reload-job/wallet-reload-job.service";
 import { BlockHttpService } from "@src/chain/services/block-http/block-http.service";
 import type { DryRunOptions } from "@src/core/types/console";
 import { DrainingDeployment } from "@src/deployment/services/draining-deployment/draining-deployment.service";
@@ -29,7 +30,8 @@ export class TopUpManagedDeploymentsService {
     private readonly cachedBalanceService: CachedBalanceService,
     private readonly blockHttpService: BlockHttpService,
     private readonly chainErrorService: ChainErrorService,
-    private readonly instrumentation: TopUpManagedDeploymentsInstrumentationService
+    private readonly instrumentation: TopUpManagedDeploymentsInstrumentationService,
+    private readonly walletReloadService: WalletReloadJobService
   ) {}
 
   async topUpDeployments(options: DryRunOptions): Promise<Result<void, unknown[]>> {
@@ -37,11 +39,14 @@ export class TopUpManagedDeploymentsService {
     const errors: unknown[] = [];
 
     try {
-      for await (const { address, deployments } of this.drainingDeploymentService.findDrainingDeploymentsByOwner()) {
+      for await (const { address, walletId, deployments } of this.drainingDeploymentService.findDrainingDeploymentsByOwner()) {
         try {
           const messageInputs = await this.collectMessages(deployments);
           if (messageInputs.length) {
             await this.topUpForOwner(address, messageInputs, options);
+            if (!options.dryRun) {
+              await this.walletReloadService.scheduleImmediate({ walletId });
+            }
           } else {
             this.instrumentation.recordSkipped({
               owner: address,


### PR DESCRIPTION
## Why

Ref CON-512

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wallet reloads can now be scheduled using either a user or a wallet reference.
  * Auto top-up and deployment draining now carry wallet context, enabling more precise follow-up actions.

* **Bug Fixes**
  * Immediate wallet reloads now return a clear success/failure result.
  * Reload scheduling and top-up flows now behave consistently when wallet-based settings are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->