### PR TITLE
test: finish jest to vitest migration in api tests

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -118,7 +118,6 @@
     "@types/blocked-at": "^1.0.4",
     "@types/http-assert": "^1.5.5",
     "@types/http-errors": "^2.0.4",
-    "@types/jest": "^29.5.12",
     "@types/js-yaml": "^4.0.9",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/lodash": "^4.17.0",

--- a/apps/api/src/address/services/address/address.service.spec.ts
+++ b/apps/api/src/address/services/address/address.service.spec.ts
@@ -1,5 +1,6 @@
 import type { CosmosHttpService } from "@akashnetwork/http-sdk/src/cosmos/cosmos-http.service";
 import { AxiosError } from "axios";
+import { describe, expect, it } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 

--- a/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.spec.ts
@@ -1,5 +1,5 @@
 import type { DeploymentHttpService } from "@akashnetwork/http-sdk";
-import { describe, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { UserWalletRepository } from "@src/billing/repositories";

--- a/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.spec.ts
+++ b/apps/api/src/app/services/enable-deployment-alert/enable-deployment-alert.handler.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { EnableDeploymentAlertCommand } from "@src/billing/commands/enable-deployment-alert.command";
@@ -28,7 +29,7 @@ describe(EnableDeploymentAlertHandler.name, () => {
 
   function setup(params?: { notificationService?: Partial<NotificationService>; logger?: Partial<LoggerService> }) {
     const notificationService = mock<NotificationService>({
-      autoEnableDeploymentAlert: jest.fn().mockResolvedValue(undefined),
+      autoEnableDeploymentAlert: vi.fn().mockResolvedValue(undefined),
       ...params?.notificationService
     });
     const logger = mock<LoggerService>({

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
@@ -1,4 +1,5 @@
 import { addHours } from "date-fns";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { TrialDeploymentLeaseCreated } from "@src/billing/events/trial-deployment-lease-created";
@@ -17,7 +18,7 @@ import { createUserWallet } from "@test/seeders/user-wallet.seeder";
 describe(TrialDeploymentLeaseCreatedHandler.name, () => {
   it("logs a warning when wallet is not found", async () => {
     const { handler, userWalletRepository, jobQueueService, logger } = setup({
-      findWalletById: jest.fn().mockResolvedValue(null)
+      findWalletById: vi.fn().mockResolvedValue(null)
     });
 
     const payload: EventPayload<TrialDeploymentLeaseCreated> = {
@@ -49,7 +50,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
     });
 
     const { handler, userWalletRepository, jobQueueService, logger } = setup({
-      findWalletById: jest.fn().mockResolvedValue(wallet)
+      findWalletById: vi.fn().mockResolvedValue(wallet)
     });
 
     const payload: EventPayload<TrialDeploymentLeaseCreated> = {
@@ -86,7 +87,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
     const trialDeploymentLifetimeInHours = 24;
 
     const { handler, userWalletRepository, jobQueueService, billingConfig } = setup({
-      findWalletById: jest.fn().mockResolvedValue(wallet)
+      findWalletById: vi.fn().mockResolvedValue(wallet)
     });
 
     const payload: EventPayload<TrialDeploymentLeaseCreated> = {
@@ -140,7 +141,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
     });
 
     const { handler, jobQueueService, logger } = setup({
-      findWalletById: jest.fn().mockResolvedValue(wallet)
+      findWalletById: vi.fn().mockResolvedValue(wallet)
     });
 
     const payload: EventPayload<TrialDeploymentLeaseCreated> = {
@@ -173,7 +174,7 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
     });
 
     const { handler, jobQueueService } = setup({
-      findWalletById: jest.fn().mockResolvedValue(wallet)
+      findWalletById: vi.fn().mockResolvedValue(wallet)
     });
 
     const payload: EventPayload<TrialDeploymentLeaseCreated> = {
@@ -209,14 +210,14 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
   }) {
     const mocks = {
       userWalletRepository: mock<UserWalletRepository>({
-        findById: input?.findWalletById ?? jest.fn()
+        findById: input?.findWalletById ?? vi.fn()
       }),
       logger: mock<LoggerService>(),
       jobQueueService: mock<JobQueueService>({
-        enqueue: input?.enqueueJob ?? jest.fn().mockResolvedValue(undefined)
+        enqueue: input?.enqueueJob ?? vi.fn().mockResolvedValue(undefined)
       }),
       billingConfig: mock<BillingConfigService>({
-        get: jest.fn().mockReturnValue(input?.trialDeploymentLifetimeInHours ?? 24)
+        get: vi.fn().mockReturnValue(input?.trialDeploymentLifetimeInHours ?? 24)
       })
     };
 

--- a/apps/api/src/app/services/trial-started/trial-started.handler.spec.ts
+++ b/apps/api/src/app/services/trial-started/trial-started.handler.spec.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { addDays, subDays } from "date-fns";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
@@ -18,7 +19,7 @@ describe(TrialStartedHandler.name, () => {
   describe("handle", () => {
     it("returns early when user is not found", async () => {
       const { handler, userRepository, notificationService, jobQueueManager, logger } = setup({
-        findUserById: jest.fn().mockResolvedValue(null)
+        findUserById: vi.fn().mockResolvedValue(null)
       });
 
       await handler.handle({ userId: "non-existent-user", version: 1 });
@@ -38,7 +39,7 @@ describe(TrialStartedHandler.name, () => {
       });
 
       const { handler, userRepository, notificationService, jobQueueManager, logger } = setup({
-        findUserById: jest.fn().mockResolvedValue(user),
+        findUserById: vi.fn().mockResolvedValue(user),
         trialExpirationDays: 30
       });
 
@@ -64,7 +65,7 @@ describe(TrialStartedHandler.name, () => {
       const deploymentLifetimeInHours = faker.number.int({ min: 1, max: 24 });
 
       const { handler, userRepository, notificationService, jobQueueManager, logger } = setup({
-        findUserById: jest.fn().mockResolvedValue(user),
+        findUserById: vi.fn().mockResolvedValue(user),
         trialExpirationDays: 30,
         initialCredits,
         deploymentLifetimeInHours
@@ -104,7 +105,7 @@ describe(TrialStartedHandler.name, () => {
       const trialEndsAt = addDays(user.createdAt!, trialDays);
 
       const { handler, jobQueueManager, paymentLink } = setup({
-        findUserById: jest.fn().mockResolvedValue(user),
+        findUserById: vi.fn().mockResolvedValue(user),
         trialExpirationDays: trialDays
       });
 
@@ -180,7 +181,7 @@ describe(TrialStartedHandler.name, () => {
       const trialEndsAt = addDays(user.createdAt!, trialDays);
 
       const { handler, jobQueueManager } = setup({
-        findUserById: jest.fn().mockResolvedValue(user),
+        findUserById: vi.fn().mockResolvedValue(user),
         trialExpirationDays: trialDays
       });
 
@@ -216,13 +217,13 @@ describe(TrialStartedHandler.name, () => {
     const paymentLink = "https://console.akash.network/billing?openPayment=true";
     const mocks = {
       notificationService: mock<NotificationService>({
-        createNotification: input?.createNotification ?? jest.fn().mockResolvedValue(undefined)
+        createNotification: input?.createNotification ?? vi.fn().mockResolvedValue(undefined)
       }),
       jobQueueManager: mock<JobQueueService>({
-        enqueue: input?.enqueueJob ?? jest.fn().mockResolvedValue(undefined)
+        enqueue: input?.enqueueJob ?? vi.fn().mockResolvedValue(undefined)
       }),
       userRepository: mock<UserRepository>({
-        findById: input?.findUserById ?? jest.fn()
+        findById: input?.findUserById ?? vi.fn()
       }),
       logger: mock<LoggerService>(),
       coreConfig: mockConfig<BillingConfigService>({

--- a/apps/api/src/auth/controllers/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/controllers/auth/auth.controller.spec.ts
@@ -1,5 +1,6 @@
 import { ResponseError } from "auth0";
 import { container as rootContainer } from "tsyringe";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { AuthService } from "@src/auth/services/auth.service";

--- a/apps/api/src/auth/services/api-key/api-key-auth.service.spec.ts
+++ b/apps/api/src/auth/services/api-key/api-key-auth.service.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { mock, type MockProxy } from "vitest-mock-extended";
 
 import type { ApiKeyRepository } from "@src/auth/repositories/api-key/api-key.repository";

--- a/apps/api/src/auth/services/api-key/api-key-generator.service.spec.ts
+++ b/apps/api/src/auth/services/api-key/api-key-generator.service.spec.ts
@@ -1,4 +1,5 @@
 import { container } from "tsyringe";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mock, type MockProxy } from "vitest-mock-extended";
 
 import { ApiKeyGeneratorService } from "@src/auth/services/api-key/api-key-generator.service";
@@ -15,7 +16,7 @@ describe("ApiKeyGeneratorService", () => {
 
   beforeEach(() => {
     originalEnv = process.env.NODE_ENV;
-    config = mock<CoreConfigService>({ get: jest.fn() });
+    config = mock<CoreConfigService>({ get: vi.fn() });
     config.get.mockReturnValue("test");
     service = new ApiKeyGeneratorService(config);
   });

--- a/apps/api/src/auth/services/auth0/auth0.service.spec.ts
+++ b/apps/api/src/auth/services/auth0/auth0.service.spec.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import type { GetUsers200ResponseOneOfInner, ManagementClient } from "auth0";
 import type { Mock } from "vitest";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { Auth0Service } from "./auth0.service";

--- a/apps/api/src/auth/services/email-verification-code/email-verification-code.service.spec.ts
+++ b/apps/api/src/auth/services/email-verification-code/email-verification-code.service.spec.ts
@@ -2,6 +2,7 @@ import "@test/mocks/logger-service.mock";
 
 import { faker } from "@faker-js/faker";
 import { createHash } from "crypto";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type {

--- a/apps/api/src/bid/http-schemas/bid.schema.spec.ts
+++ b/apps/api/src/bid/http-schemas/bid.schema.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import { BidResponseSchema } from "./bid.schema";
 
 import { createBid } from "@test/seeders/bid.seeder";

--- a/apps/api/src/bid/services/bid/bid.service.spec.ts
+++ b/apps/api/src/bid/services/bid/bid.service.spec.ts
@@ -1,6 +1,7 @@
 import type { Provider } from "@akashnetwork/database/dbSchemas/akash";
 import type { BidHttpService } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { AuthService } from "@src/auth/services/auth.service";
@@ -26,7 +27,7 @@ describe(BidService.name, () => {
 
       authService.ability = {} as unknown as AuthService["ability"];
       userWalletRepository.accessibleBy.mockReturnValue({
-        findFirst: jest.fn().mockResolvedValue(userWallet)
+        findFirst: vi.fn().mockResolvedValue(userWallet)
       } as unknown as ReturnType<UserWalletRepository["accessibleBy"]>);
       bidHttpService.list.mockResolvedValue(mockBids);
 
@@ -48,7 +49,7 @@ describe(BidService.name, () => {
 
       authService.ability = {} as unknown as AuthService["ability"];
       userWalletRepository.accessibleBy.mockReturnValue({
-        findFirst: jest.fn().mockResolvedValue(userWallet)
+        findFirst: vi.fn().mockResolvedValue(userWallet)
       } as unknown as ReturnType<UserWalletRepository["accessibleBy"]>);
       bidHttpService.list.mockResolvedValue([blockedBid, allowedBid]);
 
@@ -69,7 +70,7 @@ describe(BidService.name, () => {
 
       authService.ability = {} as unknown as AuthService["ability"];
       userWalletRepository.accessibleBy.mockReturnValue({
-        findFirst: jest.fn().mockResolvedValue(userWallet)
+        findFirst: vi.fn().mockResolvedValue(userWallet)
       } as unknown as ReturnType<UserWalletRepository["accessibleBy"]>);
       bidHttpService.list.mockResolvedValue([blockedBid]);
 
@@ -101,7 +102,7 @@ describe(BidService.name, () => {
 
       authService.ability = {} as unknown as AuthService["ability"];
       userWalletRepository.accessibleBy.mockReturnValue({
-        findFirst: jest.fn().mockResolvedValue(userWallet)
+        findFirst: vi.fn().mockResolvedValue(userWallet)
       } as unknown as ReturnType<UserWalletRepository["accessibleBy"]>);
       bidHttpService.list.mockResolvedValue(mockBids);
       providerRepository.getProvidersByAddressesWithAttributes.mockResolvedValue([auditedProvider1, auditedProvider2, unauditedProvider]);
@@ -139,7 +140,7 @@ describe(BidService.name, () => {
 
       authService.ability = {} as unknown as AuthService["ability"];
       userWalletRepository.accessibleBy.mockReturnValue({
-        findFirst: jest.fn().mockResolvedValue(userWallet)
+        findFirst: vi.fn().mockResolvedValue(userWallet)
       } as unknown as ReturnType<UserWalletRepository["accessibleBy"]>);
       bidHttpService.list.mockResolvedValue(mockBids);
       providerRepository.getProvidersByAddressesWithAttributes.mockResolvedValue([unauditedProvider1, unauditedProvider2]);
@@ -154,7 +155,7 @@ describe(BidService.name, () => {
 
       authService.ability = {} as unknown as AuthService["ability"];
       userWalletRepository.accessibleBy.mockReturnValue({
-        findFirst: jest.fn().mockResolvedValue(null)
+        findFirst: vi.fn().mockResolvedValue(null)
       } as unknown as ReturnType<UserWalletRepository["accessibleBy"]>);
 
       await expect(service.list("123456")).rejects.toMatchObject({
@@ -173,7 +174,7 @@ describe(BidService.name, () => {
 
       authService.ability = {} as unknown as AuthService["ability"];
       userWalletRepository.accessibleBy.mockReturnValue({
-        findFirst: jest.fn().mockResolvedValue(userWallet)
+        findFirst: vi.fn().mockResolvedValue(userWallet)
       } as unknown as ReturnType<UserWalletRepository["accessibleBy"]>);
       bidHttpService.list.mockResolvedValue([]);
 

--- a/apps/api/src/billing/controllers/master-wallet-mint/master-wallet-mint.controller.spec.ts
+++ b/apps/api/src/billing/controllers/master-wallet-mint/master-wallet-mint.controller.spec.ts
@@ -1,4 +1,5 @@
 import { Ok } from "ts-results";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { MasterWalletMintService } from "@src/billing/services/master-wallet-mint/master-wallet-mint.service";

--- a/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
+++ b/apps/api/src/billing/controllers/stripe/stripe.controller.spec.ts
@@ -1,6 +1,7 @@
 import { faker } from "@faker-js/faker";
 import type Stripe from "stripe";
 import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { AuthService } from "@src/auth/services/auth.service";

--- a/apps/api/src/billing/controllers/wallet-settings/wallet-settings.controller.spec.ts
+++ b/apps/api/src/billing/controllers/wallet-settings/wallet-settings.controller.spec.ts
@@ -1,4 +1,5 @@
 import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { AuthService } from "@src/auth/services/auth.service";

--- a/apps/api/src/billing/controllers/wallet/wallet.controller.spec.ts
+++ b/apps/api/src/billing/controllers/wallet/wallet.controller.spec.ts
@@ -2,6 +2,7 @@ import type { MongoAbility } from "@casl/ability";
 import { createMongoAbility } from "@casl/ability";
 import { faker } from "@faker-js/faker";
 import { container as rootContainer } from "tsyringe";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { AuthService } from "@src/auth/services/auth.service";
@@ -117,7 +118,7 @@ describe("WalletController", () => {
     startTrialResult?: Awaited<ReturnType<WalletInitializerService["startTrial"]>>;
     startTrialError?: Error;
   }) {
-    const startTrial = jest.fn();
+    const startTrial = vi.fn();
     if (input?.startTrialError) {
       startTrial.mockRejectedValue(input.startTrialError);
     } else if (input?.startTrialResult) {
@@ -134,18 +135,18 @@ describe("WalletController", () => {
       useValue: mock<WalletInitializerService>({ startTrial })
     });
     rootContainer.register(BillingConfigService, {
-      useValue: mock<BillingConfigService>({ get: jest.fn().mockReturnValue("uakt") })
+      useValue: mock<BillingConfigService>({ get: vi.fn().mockReturnValue("uakt") })
     });
     rootContainer.register(ManagedSignerService, { useValue: mock<ManagedSignerService>() });
     rootContainer.register(RefillService, { useValue: mock<RefillService>() });
     rootContainer.register(WalletReaderService, {
-      useValue: mock<WalletReaderService>({ getWallets: jest.fn().mockResolvedValue(input?.wallets ?? []) })
+      useValue: mock<WalletReaderService>({ getWallets: vi.fn().mockResolvedValue(input?.wallets ?? []) })
     });
     rootContainer.register(BalancesService, { useValue: mock<BalancesService>() });
     rootContainer.register(UserWalletRepository, { useValue: mock<UserWalletRepository>() });
     rootContainer.register(TrialValidationService, {
       useValue: mock<TrialValidationService>({
-        getTopUpMinAmountUsd: jest.fn(wallet => (wallet?.isTrialing ? 100 : 20))
+        getTopUpMinAmountUsd: vi.fn(wallet => (wallet?.isTrialing ? 100 : 20))
       })
     });
 

--- a/apps/api/src/billing/http-schemas/stripe.schema.spec.ts
+++ b/apps/api/src/billing/http-schemas/stripe.schema.spec.ts
@@ -1,4 +1,5 @@
 import { secondsInDay } from "date-fns/constants";
+import { describe, expect, it } from "vitest";
 
 import { CustomerTransactionsCsvExportQuerySchema, CustomerTransactionsQuerySchema, PaymentMethodSchema } from "./stripe.schema";
 

--- a/apps/api/src/billing/lib/batch-signing-client/batch-signing-client.service.spec.ts
+++ b/apps/api/src/billing/lib/batch-signing-client/batch-signing-client.service.spec.ts
@@ -6,6 +6,7 @@ import { Registry } from "@cosmjs/proto-signing";
 import type { Account, DeliverTxResponse, SigningStargateClient } from "@cosmjs/stargate";
 import type { IndexedTx } from "@cosmjs/stargate/build/stargateclient";
 import { faker } from "@faker-js/faker";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { createAkashAddress } from "../../../../test/seeders";
@@ -223,7 +224,7 @@ describe(BatchSigningClientService.name, () => {
 
   function setup(testData: TransactionTestData[]) {
     const wallet = mock<Wallet>({
-      getFirstAddress: jest.fn(() => Promise.resolve(createAkashAddress()))
+      getFirstAddress: vi.fn(() => Promise.resolve(createAkashAddress()))
     });
 
     const billingConfigService = mockConfigService<BillingConfigService>({
@@ -236,8 +237,8 @@ describe(BatchSigningClientService.name, () => {
     const registry = new Registry();
 
     const client = mock<SigningStargateClient>({
-      getChainId: jest.fn(async () => "test-chain"),
-      getAccount: jest.fn(async (address: string) => ({ accountNumber: 0, sequence: 1, address }) as Account)
+      getChainId: vi.fn(async () => "test-chain"),
+      getAccount: vi.fn(async (address: string) => ({ accountNumber: 0, sequence: 1, address }) as Account)
     });
 
     testData.forEach((data, index) => {
@@ -263,7 +264,7 @@ describe(BatchSigningClientService.name, () => {
       }
     });
 
-    const createClientWithSigner = jest.fn(() => client);
+    const createClientWithSigner = vi.fn(() => client);
 
     const service = new BatchSigningClientService(billingConfigService, wallet, registry, createClientWithSigner);
 

--- a/apps/api/src/billing/lib/signing-stargate-client-factory/signing-stargate-client.factory.spec.ts
+++ b/apps/api/src/billing/lib/signing-stargate-client-factory/signing-stargate-client.factory.spec.ts
@@ -2,6 +2,7 @@ import type { SigningStargateClient } from "@cosmjs/stargate";
 import type { HttpClient } from "@cosmjs/tendermint-rpc";
 import type { Comet38Client } from "@cosmjs/tendermint-rpc";
 import { faker } from "@faker-js/faker";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { Wallet } from "../wallet/wallet";

--- a/apps/api/src/billing/repositories/usage/usage.repository.integration.ts
+++ b/apps/api/src/billing/repositories/usage/usage.repository.integration.ts
@@ -3,6 +3,8 @@ import type { Block, Day } from "@akashnetwork/database/dbSchemas/base";
 import type { CreationAttributes } from "sequelize";
 import { Op } from "sequelize";
 import { container } from "tsyringe";
+import type { Mock } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { UserWalletRepository } from "@src/billing/repositories/user-wallet/user-wallet.repository";
 import type { TxManagerService } from "@src/billing/services/tx-manager/tx-manager.service";
@@ -276,12 +278,12 @@ describe(UsageRepository.name, () => {
       const startDate = "2023-01-01";
       const endDate = "2023-01-01";
 
-      (userWalletRepository.findOneByAddress as jest.Mock).mockResolvedValue({
+      (userWalletRepository.findOneByAddress as Mock).mockResolvedValue({
         id: 1,
         address: testAddress,
         createdAt: new Date("2024-11-01")
       });
-      (txManagerService.getDerivedWalletAddress as jest.Mock).mockResolvedValue(oldAddress);
+      (txManagerService.getDerivedWalletAddress as Mock).mockResolvedValue(oldAddress);
 
       await createTestDay({
         date: new Date("2023-01-01"),
@@ -324,7 +326,7 @@ describe(UsageRepository.name, () => {
       const startDate = "2023-01-01";
       const endDate = "2023-01-01";
 
-      (userWalletRepository.findOneByAddress as jest.Mock).mockResolvedValue({
+      (userWalletRepository.findOneByAddress as Mock).mockResolvedValue({
         id: 1,
         address: testAddress,
         createdAt: new Date("2025-12-01")
@@ -416,11 +418,11 @@ describe(UsageRepository.name, () => {
 
   function setup() {
     const userWalletRepository = {
-      findOneByAddress: jest.fn().mockResolvedValue(undefined)
+      findOneByAddress: vi.fn().mockResolvedValue(undefined)
     } as unknown as UserWalletRepository;
 
     const txManagerService = {
-      getDerivedWalletAddress: jest.fn().mockResolvedValue("")
+      getDerivedWalletAddress: vi.fn().mockResolvedValue("")
     } as unknown as TxManagerService;
 
     const usageRepository = new UsageRepository(container.resolve(CHAIN_DB), userWalletRepository, txManagerService);

--- a/apps/api/src/billing/services/balances/balances.service.spec.ts
+++ b/apps/api/src/billing/services/balances/balances.service.spec.ts
@@ -1,5 +1,5 @@
 import type { AuthzHttpService, DeploymentHttpService } from "@akashnetwork/http-sdk";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingConfig } from "@src/billing/providers";

--- a/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
+++ b/apps/api/src/billing/services/chain-error/chain-error.service.spec.ts
@@ -3,6 +3,7 @@ import type { EncodeObject } from "@cosmjs/proto-signing";
 import { AxiosError, AxiosHeaders } from "axios";
 import { BadGateway, BadRequest, PaymentRequired, ServiceUnavailable } from "http-errors";
 import type { Mock } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 

--- a/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
+++ b/apps/api/src/billing/services/managed-signer/managed-signer.service.spec.ts
@@ -5,7 +5,7 @@ import type { LeaseHttpService } from "@akashnetwork/http-sdk";
 import type { MongoAbility } from "@casl/ability";
 import { createMongoAbility } from "@casl/ability";
 import type { EncodeObject, Registry } from "@cosmjs/proto-signing";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { AuthService } from "@src/auth/services/auth.service";
@@ -46,7 +46,7 @@ describe(ManagedSignerService.name, () => {
 
     it("throws 404 error when userWallet is not found", async () => {
       const { service, userWalletRepository, authService } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(null)
+        findOneByUserId: vi.fn().mockResolvedValue(null)
       });
 
       await expect(service.executeDerivedDecodedTxByUserId("user-123", [])).rejects.toThrow("UserWallet Not Found");
@@ -59,9 +59,9 @@ describe(ManagedSignerService.name, () => {
       const user = createUser({ userId: "user-123" });
       const wallet = createUserWallet({ userId: "user-123", feeAllowance: 0 });
       const { service } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
-        retrieveAndCalcFeeLimit: jest.fn().mockResolvedValue(0)
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        retrieveAndCalcFeeLimit: vi.fn().mockResolvedValue(0)
       });
 
       await expect(service.executeDerivedDecodedTxByUserId("user-123", [])).rejects.toThrow("Not enough funds to cover the transaction fee");
@@ -80,9 +80,9 @@ describe(ManagedSignerService.name, () => {
       };
 
       const { service } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
-        retrieveDeploymentLimit: jest.fn().mockResolvedValue(0)
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        retrieveDeploymentLimit: vi.fn().mockResolvedValue(0)
       });
 
       await expect(service.executeDerivedDecodedTxByUserId("user-123", [deploymentMessage])).rejects.toThrow("Not enough funds to cover the deployment costs");
@@ -107,15 +107,15 @@ describe(ManagedSignerService.name, () => {
       ];
 
       const { service, anonymousValidateService } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
         enabledFeatures: [],
-        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({
           code: 0,
           hash: "tx-hash",
           rawLog: "success"
         }),
-        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined)
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined)
       });
 
       await service.executeDerivedDecodedTxByUserId("user-123", messages);
@@ -149,10 +149,10 @@ describe(ManagedSignerService.name, () => {
       };
 
       const { service, txManagerService, balancesService } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
-        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue(txResult),
-        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined)
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue(txResult),
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined)
       });
 
       const result = await service.executeDerivedDecodedTxByUserId("user-123", messages);
@@ -188,18 +188,18 @@ describe(ManagedSignerService.name, () => {
         })
       };
 
-      const hasLeases = jest.fn();
+      const hasLeases = vi.fn();
       const { service, domainEvents } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
         enabledFeatures: [],
-        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({
           code: 0,
           hash: "tx-hash",
           rawLog: "success"
         }),
-        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined),
-        publish: jest.fn().mockResolvedValue(undefined),
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        publish: vi.fn().mockResolvedValue(undefined),
         hasLeases
       });
 
@@ -242,15 +242,15 @@ describe(ManagedSignerService.name, () => {
       };
 
       const { service, domainEvents, balancesService, walletReloadJobService, chainErrorService } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
-        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({
           code: 17,
           hash: "tx-hash",
           rawLog: "deployment exists"
         }),
-        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined),
-        transformChainError: jest.fn().mockResolvedValue(new Error("Deployment with provided dseq and owner already exists"))
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        transformChainError: vi.fn().mockResolvedValue(new Error("Deployment with provided dseq and owner already exists"))
       });
 
       await expect(service.executeDerivedDecodedTxByUserId("user-123", [deploymentMessage])).rejects.toThrow("Deployment with provided dseq");
@@ -281,10 +281,10 @@ describe(ManagedSignerService.name, () => {
       const chainError = new Error("Chain test error");
 
       const { service, chainErrorService } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
-        signAndBroadcastWithDerivedWallet: jest.fn().mockRejectedValue(chainError),
-        transformChainError: jest.fn().mockResolvedValue(new Error("App error"))
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockRejectedValue(chainError),
+        transformChainError: vi.fn().mockResolvedValue(new Error("App error"))
       });
 
       await expect(service.executeDerivedDecodedTxByUserId("user-123", messages)).rejects.toThrow("App error");
@@ -307,14 +307,14 @@ describe(ManagedSignerService.name, () => {
       ];
 
       const { service, userRepository } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(wallet),
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
         currentUser,
-        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({
           code: 0,
           hash: "tx-hash",
           rawLog: "success"
         }),
-        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined)
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined)
       });
 
       await service.executeDerivedDecodedTxByUserId("user-123", messages);
@@ -343,15 +343,15 @@ describe(ManagedSignerService.name, () => {
       ];
 
       const { service, anonymousValidateService } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
-        validateLeaseProvidersAuditors: jest.fn().mockResolvedValue(undefined),
-        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        validateLeaseProvidersAuditors: vi.fn().mockResolvedValue(undefined),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({
           code: 0,
           hash: "tx-hash",
           rawLog: "success"
         }),
-        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined)
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined)
       });
 
       await service.executeDerivedDecodedTxByUserId("user-123", messages);
@@ -380,15 +380,15 @@ describe(ManagedSignerService.name, () => {
       ];
 
       const { service, anonymousValidateService } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
-        validateLeaseProvidersAuditors: jest.fn().mockResolvedValue(undefined),
-        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        validateLeaseProvidersAuditors: vi.fn().mockResolvedValue(undefined),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({
           code: 0,
           hash: "tx-hash",
           rawLog: "success"
         }),
-        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined)
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined)
       });
 
       await service.executeDerivedDecodedTxByUserId("user-123", messages);
@@ -411,15 +411,15 @@ describe(ManagedSignerService.name, () => {
       };
 
       const { service, walletReloadJobService } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
-        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({
           code: 0,
           hash: "tx-hash",
           rawLog: "success"
         }),
-        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined),
-        decode: jest.fn().mockReturnValue({ id: { dseq: "123", owner: wallet.address } })
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        decode: vi.fn().mockReturnValue({ id: { dseq: "123", owner: wallet.address } })
       });
 
       await service.executeDerivedEncodedTxByUserId("user-123", [deploymentMessage]);
@@ -439,15 +439,15 @@ describe(ManagedSignerService.name, () => {
       };
 
       const { service, walletReloadJobService } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
-        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({
           code: 0,
           hash: "tx-hash",
           rawLog: "success"
         }),
-        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined),
-        decode: jest.fn().mockReturnValue({ owner: wallet.address, amount: "1000" })
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        decode: vi.fn().mockReturnValue({ owner: wallet.address, amount: "1000" })
       });
 
       await service.executeDerivedEncodedTxByUserId("user-123", [depositMessage]);
@@ -468,15 +468,15 @@ describe(ManagedSignerService.name, () => {
       };
 
       const { service, walletReloadJobService } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
-        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({
           code: 0,
           hash: "tx-hash",
           rawLog: "success"
         }),
-        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined),
-        decode: jest.fn().mockReturnValue({ bidId: { dseq: "123" } })
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined),
+        decode: vi.fn().mockReturnValue({ bidId: { dseq: "123" } })
       });
 
       await service.executeDerivedEncodedTxByUserId("user-123", [leaseMessage]);
@@ -492,7 +492,7 @@ describe(ManagedSignerService.name, () => {
       };
 
       const { service, logger } = setup({
-        decode: jest.fn().mockImplementation(() => {
+        decode: vi.fn().mockImplementation(() => {
           throw decodeError;
         })
       });
@@ -519,7 +519,7 @@ describe(ManagedSignerService.name, () => {
       const txResult = { code: 0, hash: "tx-hash", rawLog: "success" };
 
       const { service, txManagerService } = setup({
-        signAndBroadcastWithFundingWallet: jest.fn().mockResolvedValue(txResult)
+        signAndBroadcastWithFundingWallet: vi.fn().mockResolvedValue(txResult)
       });
 
       const result = await service.executeFundingTx(messages);
@@ -533,8 +533,8 @@ describe(ManagedSignerService.name, () => {
       const chainError = new Error("Chain funding error");
 
       const { service, chainErrorService } = setup({
-        signAndBroadcastWithFundingWallet: jest.fn().mockRejectedValue(chainError),
-        transformChainError: jest.fn().mockResolvedValue(new Error("Funding app error"))
+        signAndBroadcastWithFundingWallet: vi.fn().mockRejectedValue(chainError),
+        transformChainError: vi.fn().mockResolvedValue(new Error("Funding app error"))
       });
 
       await expect(service.executeFundingTx(messages)).rejects.toThrow("Funding app error");
@@ -549,14 +549,14 @@ describe(ManagedSignerService.name, () => {
       const messages: EncodeObject[] = [{ typeUrl: MsgCreateLease.$type, value: MsgCreateLease.fromPartial({ bidId: { dseq: 123 } }) }];
 
       const { service } = setup({
-        findOneByUserId: jest.fn().mockResolvedValue(wallet),
-        findById: jest.fn().mockResolvedValue(user),
-        signAndBroadcastWithDerivedWallet: jest.fn().mockResolvedValue({
+        findOneByUserId: vi.fn().mockResolvedValue(wallet),
+        findById: vi.fn().mockResolvedValue(user),
+        signAndBroadcastWithDerivedWallet: vi.fn().mockResolvedValue({
           code: 0,
           hash: "",
           rawLog: "empty hash"
         }),
-        refreshUserWalletLimits: jest.fn().mockResolvedValue(undefined)
+        refreshUserWalletLimits: vi.fn().mockResolvedValue(undefined)
       });
 
       const result = await service.executeDerivedDecodedTxByUserId("user-123", messages);
@@ -584,40 +584,40 @@ describe(ManagedSignerService.name, () => {
   }) {
     const mocks = {
       userWalletRepository: mock<UserWalletRepository>({
-        accessibleBy: jest.fn().mockReturnThis(),
-        findOneByUserId: input?.findOneByUserId ?? jest.fn()
+        accessibleBy: vi.fn().mockReturnThis(),
+        findOneByUserId: input?.findOneByUserId ?? vi.fn()
       }),
       userRepository: mock<UserRepository>({
-        findById: input?.findById ?? jest.fn()
+        findById: input?.findById ?? vi.fn()
       }),
       balancesService: mock<BalancesService>({
-        refreshUserWalletLimits: input?.refreshUserWalletLimits ?? jest.fn(),
-        retrieveAndCalcFeeLimit: input?.retrieveAndCalcFeeLimit ?? jest.fn().mockResolvedValue(1000000),
-        retrieveDeploymentLimit: input?.retrieveDeploymentLimit ?? jest.fn().mockResolvedValue(5000000)
+        refreshUserWalletLimits: input?.refreshUserWalletLimits ?? vi.fn(),
+        retrieveAndCalcFeeLimit: input?.retrieveAndCalcFeeLimit ?? vi.fn().mockResolvedValue(1000000),
+        retrieveDeploymentLimit: input?.retrieveDeploymentLimit ?? vi.fn().mockResolvedValue(5000000)
       }),
       authService: mock<AuthService>({
         currentUser: input?.currentUser ?? createUser({ userId: "current-user" }),
         ability: createMongoAbility<MongoAbility>()
       }),
       chainErrorService: mock<ChainErrorService>({
-        toAppError: input?.transformChainError ?? jest.fn(async e => e)
+        toAppError: input?.transformChainError ?? vi.fn(async e => e)
       }),
       anonymousValidateService: mock<TrialValidationService>({
-        validateLeaseProvidersAuditors: input?.validateLeaseProvidersAuditors ?? jest.fn()
+        validateLeaseProvidersAuditors: input?.validateLeaseProvidersAuditors ?? vi.fn()
       }),
       txManagerService: mock<TxManagerService>({
-        signAndBroadcastWithDerivedWallet: input?.signAndBroadcastWithDerivedWallet ?? jest.fn(),
-        signAndBroadcastWithFundingWallet: input?.signAndBroadcastWithFundingWallet ?? jest.fn(),
-        getFundingWalletAddress: jest.fn().mockResolvedValue(createAkashAddress())
+        signAndBroadcastWithDerivedWallet: input?.signAndBroadcastWithDerivedWallet ?? vi.fn(),
+        signAndBroadcastWithFundingWallet: input?.signAndBroadcastWithFundingWallet ?? vi.fn(),
+        getFundingWalletAddress: vi.fn().mockResolvedValue(createAkashAddress())
       }),
       domainEvents: mock<DomainEventsService>({
-        publish: input?.publish ?? jest.fn()
+        publish: input?.publish ?? vi.fn()
       }),
       leaseHttpService: mock<LeaseHttpService>({
-        hasLeases: input?.hasLeases ?? jest.fn(async () => false)
+        hasLeases: input?.hasLeases ?? vi.fn(async () => false)
       }),
       walletReloadJobService: mock<WalletReloadJobService>({
-        scheduleImmediate: jest.fn()
+        scheduleImmediate: vi.fn()
       }),
       billingConfigService: mockConfigService<BillingConfigService>({
         FEE_ALLOWANCE_REFILL_AMOUNT: 1000000,
@@ -625,16 +625,16 @@ describe(ManagedSignerService.name, () => {
         TRIAL_ALLOWANCE_EXPIRATION_DAYS: 30
       }),
       managedUserWalletService: mock<ManagedUserWalletService>({
-        refillWalletFees: jest.fn()
+        refillWalletFees: vi.fn()
       }),
       logger: mock<LoggerService>({
-        setContext: jest.fn(),
-        error: jest.fn()
+        setContext: vi.fn(),
+        error: vi.fn()
       })
     };
 
     const registryMock = mock<Registry>({
-      decode: input?.decode ?? jest.fn()
+      decode: input?.decode ?? vi.fn()
     });
 
     const service = new ManagedSignerService(

--- a/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.spec.ts
+++ b/apps/api/src/billing/services/managed-user-wallet/managed-user-wallet.service.spec.ts
@@ -3,6 +3,7 @@ import type { EncodeObject } from "@cosmjs/proto-signing";
 import { faker } from "@faker-js/faker";
 import addDays from "date-fns/addDays";
 import subDays from "date-fns/subDays";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingConfig } from "@src/billing/providers";

--- a/apps/api/src/billing/services/master-wallet-mint/master-wallet-mint.service.spec.ts
+++ b/apps/api/src/billing/services/master-wallet-mint/master-wallet-mint.service.spec.ts
@@ -1,6 +1,7 @@
 import { MsgMintACT } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import type { BmeHttpService } from "@akashnetwork/http-sdk";
 import { Ok } from "ts-results";
+import { describe, expect, it } from "vitest";
 import { mock, mockDeep } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";

--- a/apps/api/src/billing/services/refill/refill.service.spec.ts
+++ b/apps/api/src/billing/services/refill/refill.service.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingConfig } from "@src/billing/providers";

--- a/apps/api/src/billing/services/remaining-credits/remaining-credits.service.spec.ts
+++ b/apps/api/src/billing/services/remaining-credits/remaining-credits.service.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { UserWalletRepository } from "@src/billing/repositories";
@@ -16,8 +17,8 @@ describe(RemainingCreditsService.name, () => {
 
     const userWallet = createUserWallet();
     const { service, userWalletRepository, balanceService } = setup({
-      findOneByUserId: jest.fn().mockResolvedValue(userWallet),
-      retrieveDeploymentLimit: jest.fn().mockResolvedValue(remainingCreditsInUusdc)
+      findOneByUserId: vi.fn().mockResolvedValue(userWallet),
+      retrieveDeploymentLimit: vi.fn().mockResolvedValue(remainingCreditsInUusdc)
     });
 
     const result = await service.resolve(user);
@@ -31,7 +32,7 @@ describe(RemainingCreditsService.name, () => {
     const user = createUser();
 
     const { service, userWalletRepository, logger } = setup({
-      findOneByUserId: jest.fn().mockResolvedValue(null)
+      findOneByUserId: vi.fn().mockResolvedValue(null)
     });
 
     await expect(service.resolve(user)).rejects.toThrow("User wallet not found");
@@ -48,7 +49,7 @@ describe(RemainingCreditsService.name, () => {
 
     const userWallet = createUserWallet({ address: null });
     const { service, userWalletRepository, logger } = setup({
-      findOneByUserId: jest.fn().mockResolvedValue(userWallet)
+      findOneByUserId: vi.fn().mockResolvedValue(userWallet)
     });
 
     await expect(service.resolve(user)).rejects.toThrow("User wallet not found");
@@ -63,10 +64,10 @@ describe(RemainingCreditsService.name, () => {
   function setup(input?: { findOneByUserId?: UserWalletRepository["findOneByUserId"]; retrieveDeploymentLimit?: BalancesService["retrieveDeploymentLimit"] }) {
     const mocks = {
       userWalletRepository: mock<UserWalletRepository>({
-        findOneByUserId: input?.findOneByUserId ?? jest.fn()
+        findOneByUserId: input?.findOneByUserId ?? vi.fn()
       }),
       balanceService: mock<BalancesService>({
-        retrieveDeploymentLimit: input?.retrieveDeploymentLimit ?? jest.fn()
+        retrieveDeploymentLimit: input?.retrieveDeploymentLimit ?? vi.fn()
       }),
       logger: mock<LoggerService>()
     };

--- a/apps/api/src/billing/services/rpc-message-service/rpc-message.service.spec.ts
+++ b/apps/api/src/billing/services/rpc-message-service/rpc-message.service.spec.ts
@@ -1,4 +1,5 @@
 import { DeploymentReclamation, MsgMintACT } from "@akashnetwork/chain-sdk/private-types/akash.v1";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";

--- a/apps/api/src/billing/services/stripe-error/stripe-error.service.spec.ts
+++ b/apps/api/src/billing/services/stripe-error/stripe-error.service.spec.ts
@@ -1,4 +1,5 @@
 import type Stripe from "stripe";
+import { describe, expect, it } from "vitest";
 
 import { StripeErrorService } from "./stripe-error.service";
 

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
@@ -1,4 +1,6 @@
 import type Stripe from "stripe";
+import type { Mock } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { PaymentMethodRepository, StripeTransactionOutput, StripeTransactionRepository } from "@src/billing/repositories";
@@ -25,7 +27,7 @@ describe(StripeWebhookService.name, () => {
       stripeTransactionRepository.findOneByAndLock.mockResolvedValue(internalTransaction);
       stripeTransactionRepository.updateById.mockResolvedValue(undefined);
       refillService.topUpWallet.mockResolvedValue();
-      (stripeService.charges.retrieve as jest.Mock).mockResolvedValue({
+      (stripeService.charges.retrieve as Mock).mockResolvedValue({
         id: chargeId,
         payment_method_details: { card: { brand: "visa", last4: "4242" } },
         receipt_url: "https://receipt.url"
@@ -179,7 +181,7 @@ describe(StripeWebhookService.name, () => {
       stripeTransactionRepository.findOneByAndLock.mockResolvedValue(internalTransaction);
       stripeTransactionRepository.updateById.mockResolvedValue(undefined);
       refillService.topUpWallet.mockResolvedValue();
-      (stripeService.charges.retrieve as jest.Mock).mockResolvedValue({
+      (stripeService.charges.retrieve as Mock).mockResolvedValue({
         id: chargeId,
         payment_method_details: { card: { brand: "mastercard", last4: "5555" } },
         receipt_url: "https://receipt.stripe.com/inv"
@@ -786,7 +788,7 @@ describe(StripeWebhookService.name, () => {
 
     // Mock Stripe charges API
     stripeService.charges = {
-      retrieve: jest.fn()
+      retrieve: vi.fn()
     } as unknown as Stripe.ChargesResource;
 
     const service = new StripeWebhookService(stripeService, refillService, billingConfig, userRepository, paymentMethodRepository, stripeTransactionRepository);

--- a/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
+++ b/apps/api/src/billing/services/trial-validation/trial-validation.service.spec.ts
@@ -2,6 +2,7 @@ import { MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash
 import { MsgCreateLease } from "@akashnetwork/chain-sdk/private-types/akash.v1beta5";
 import type { BidHttpService } from "@akashnetwork/http-sdk";
 import type { EncodeObject } from "@cosmjs/proto-signing";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";

--- a/apps/api/src/billing/services/tx-manager/tx-manager.service.spec.ts
+++ b/apps/api/src/billing/services/tx-manager/tx-manager.service.spec.ts
@@ -1,5 +1,6 @@
 import type { EncodeObject } from "@cosmjs/proto-signing";
 import type { IndexedTx } from "@cosmjs/stargate/build/stargateclient";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { SignAndBroadcastOptions } from "@src/billing/lib/batch-signing-client/batch-signing-client.service";
@@ -89,14 +90,14 @@ describe(TxManagerService.name, () => {
     externalDerivedResult?: IndexedTx;
   }) {
     const fundingWallet = mock<Wallet>({
-      getFirstAddress: jest.fn().mockResolvedValue(input?.fundingWalletAddress ?? createAkashAddress())
+      getFirstAddress: vi.fn().mockResolvedValue(input?.fundingWalletAddress ?? createAkashAddress())
     });
 
     const derivedWallet = mock<Wallet>({
-      getFirstAddress: jest.fn().mockResolvedValue(input?.derivedWalletAddress ?? createAkashAddress())
+      getFirstAddress: vi.fn().mockResolvedValue(input?.derivedWalletAddress ?? createAkashAddress())
     });
 
-    const walletFactory = jest.fn().mockReturnValue(derivedWallet);
+    const walletFactory = vi.fn().mockReturnValue(derivedWallet);
 
     const walletResources = {
       v1: {
@@ -111,10 +112,10 @@ describe(TxManagerService.name, () => {
 
     const logger = mock<LoggerService>();
     const externalSignerHttpSdkService = mock<ExternalSignerHttpSdkService>({
-      signAndBroadcastWithFundingWallet: jest
+      signAndBroadcastWithFundingWallet: vi
         .fn()
         .mockResolvedValue(input?.externalFundingResult ?? mock<IndexedTx>({ code: 0, hash: "default-hash", rawLog: "success" })),
-      signAndBroadcastWithDerivedWallet: jest
+      signAndBroadcastWithDerivedWallet: vi
         .fn()
         .mockResolvedValue(input?.externalDerivedResult ?? mock<IndexedTx>({ code: 0, hash: "default-hash", rawLog: "success" }))
     });

--- a/apps/api/src/billing/services/usage/usage.service.spec.ts
+++ b/apps/api/src/billing/services/usage/usage.service.spec.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { addDays, format } from "date-fns";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { BillingUsageRawResult, UsageRepository } from "@src/billing/repositories/usage/usage.repository";
@@ -228,11 +229,11 @@ describe(UsageService.name, () => {
     ];
 
     const usageRepository = mock<UsageRepository>({
-      getHistory: jest.fn().mockResolvedValue(mockUsageData)
+      getHistory: vi.fn().mockResolvedValue(mockUsageData)
     });
 
     const deploymentRepository = mock<DeploymentRepository>({
-      countActiveByOwner: jest.fn().mockResolvedValue(totalDeployments)
+      countActiveByOwner: vi.fn().mockResolvedValue(totalDeployments)
     });
 
     const service = new UsageService(usageRepository, deploymentRepository);

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check-instrumentation.service.spec.ts
@@ -1,5 +1,3 @@
-import { vi } from "vitest";
-
 const mockLogger = vi.hoisted(() => ({
   info: vi.fn(),
   error: vi.fn(),
@@ -13,6 +11,7 @@ vi.mock("@akashnetwork/logging/otel", () => ({
 
 import { faker } from "@faker-js/faker";
 import type { Counter, Histogram } from "@opentelemetry/api";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { MetricsService } from "@src/core";

--- a/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
+++ b/apps/api/src/billing/services/wallet-balance-reload-check/wallet-balance-reload-check.handler.spec.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { addMilliseconds, millisecondsInHour } from "date-fns";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";
@@ -373,18 +374,18 @@ describe(WalletBalanceReloadCheckHandler.name, () => {
 
     const walletSettingRepository = mock<WalletSettingRepository>();
     const balancesService = mock<BalancesService>({
-      ensure2floatingDigits: jest.fn().mockImplementation((amount: number) => amount)
+      ensure2floatingDigits: vi.fn().mockImplementation((amount: number) => amount)
     });
     const walletReloadJobService = mock<WalletReloadJobService>();
     const drainingDeploymentService = mock<DrainingDeploymentService>();
     const stripeService = mock<StripeService>();
     const instrumentationService = mock<WalletBalanceReloadCheckInstrumentationService>({
-      recordJobExecution: jest.fn(),
-      recordReloadTriggered: jest.fn(),
-      recordReloadSkipped: jest.fn(),
-      recordReloadFailed: jest.fn(),
-      recordValidationError: jest.fn(),
-      recordSchedulingError: jest.fn()
+      recordJobExecution: vi.fn(),
+      recordReloadTriggered: vi.fn(),
+      recordReloadSkipped: vi.fn(),
+      recordReloadFailed: vi.fn(),
+      recordValidationError: vi.fn(),
+      recordSchedulingError: vi.fn()
     });
 
     const balance = input?.balance ?? 50.0;

--- a/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-initializer/wallet-initializer.service.spec.ts
@@ -1,6 +1,7 @@
 import { Registry } from "@cosmjs/proto-signing";
 import { faker } from "@faker-js/faker";
 import { container } from "tsyringe";
+import { describe, expect, it, vi } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 
@@ -77,8 +78,8 @@ describe(WalletInitializerService.name, () => {
         const di = setup({
           user,
           hasPaymentMethods: true,
-          getOrCreateWallet: jest.fn().mockResolvedValue({ wallet: newWallet, isNew: true }),
-          updateWalletById: jest.fn().mockResolvedValue(newWallet)
+          getOrCreateWallet: vi.fn().mockResolvedValue({ wallet: newWallet, isNew: true }),
+          updateWalletById: vi.fn().mockResolvedValue(newWallet)
         });
         const managedUserWalletService = di.resolve(ManagedUserWalletService) as MockProxy<ManagedUserWalletService>;
         managedUserWalletService.createAndAuthorizeTrialSpending.mockResolvedValue(createChainWallet());
@@ -98,8 +99,8 @@ describe(WalletInitializerService.name, () => {
           user,
           consoleOnboardingRedesign: true,
           hasPaymentMethods: false,
-          getOrCreateWallet: jest.fn().mockResolvedValue({ wallet: newWallet, isNew: true }),
-          updateWalletById: jest.fn().mockResolvedValue(newWallet)
+          getOrCreateWallet: vi.fn().mockResolvedValue({ wallet: newWallet, isNew: true }),
+          updateWalletById: vi.fn().mockResolvedValue(newWallet)
         });
         const managedUserWalletService = di.resolve(ManagedUserWalletService) as MockProxy<ManagedUserWalletService>;
         managedUserWalletService.createAndAuthorizeTrialSpending.mockResolvedValue(createChainWallet());
@@ -124,8 +125,8 @@ describe(WalletInitializerService.name, () => {
         const di = setup({
           user,
           consoleOnboardingRedesign: true,
-          getOrCreateWallet: jest.fn().mockResolvedValue({ wallet: newWallet, isNew: true }),
-          updateWalletById: jest.fn().mockResolvedValue(newWallet)
+          getOrCreateWallet: vi.fn().mockResolvedValue({ wallet: newWallet, isNew: true }),
+          updateWalletById: vi.fn().mockResolvedValue(newWallet)
         });
         const managedUserWalletService = di.resolve(ManagedUserWalletService) as MockProxy<ManagedUserWalletService>;
         managedUserWalletService.createAndAuthorizeTrialSpending.mockResolvedValue(createChainWallet());
@@ -141,8 +142,8 @@ describe(WalletInitializerService.name, () => {
       const userId = "test-user-id";
       const newWallet = createUserWallet({ userId });
       const chainWallet = createChainWallet();
-      const getOrCreateWallet = jest.fn().mockImplementation(async () => ({ wallet: newWallet, isNew: true }));
-      const updateWalletById = jest.fn().mockImplementation(async () => newWallet);
+      const getOrCreateWallet = vi.fn().mockImplementation(async () => ({ wallet: newWallet, isNew: true }));
+      const updateWalletById = vi.fn().mockImplementation(async () => newWallet);
 
       const di = setup({
         getOrCreateWallet,
@@ -169,7 +170,7 @@ describe(WalletInitializerService.name, () => {
     it("does not authorizes trial spending for existing wallet", async () => {
       const userId = "test-user-id";
       const existingWallet = createUserWallet({ userId });
-      const getOrCreateWallet = jest.fn().mockResolvedValue({ wallet: existingWallet, isNew: false });
+      const getOrCreateWallet = vi.fn().mockResolvedValue({ wallet: existingWallet, isNew: false });
 
       const di = setup({
         getOrCreateWallet
@@ -185,8 +186,8 @@ describe(WalletInitializerService.name, () => {
     it("throws an error when cannot authorize trial spending and deletes user wallet", async () => {
       const userId = "test-user-id";
       const newWallet = createUserWallet({ userId });
-      const getOrCreateWallet = jest.fn().mockImplementation(async () => ({ wallet: newWallet, isNew: true }));
-      const deleteWalletById = jest.fn().mockImplementation(async () => null);
+      const getOrCreateWallet = vi.fn().mockImplementation(async () => ({ wallet: newWallet, isNew: true }));
+      const deleteWalletById = vi.fn().mockImplementation(async () => null);
 
       const di = setup({
         getOrCreateWallet,
@@ -205,8 +206,8 @@ describe(WalletInitializerService.name, () => {
       const userId = "test-user-id";
       const newWallet = createUserWallet({ userId });
       const chainWallet = createChainWallet();
-      const getOrCreateWallet = jest.fn().mockImplementation(async () => ({ wallet: newWallet, isNew: true }));
-      const updateWalletById = jest.fn().mockImplementation(async () => newWallet);
+      const getOrCreateWallet = vi.fn().mockImplementation(async () => ({ wallet: newWallet, isNew: true }));
+      const updateWalletById = vi.fn().mockImplementation(async () => newWallet);
 
       const di = setup({
         userId,
@@ -243,7 +244,7 @@ describe(WalletInitializerService.name, () => {
       mock<UserWalletRepository>({
         getOrCreate: input?.getOrCreateWallet,
         updateById: input?.updateWalletById,
-        deleteById: input?.deleteWalletById ?? jest.fn(),
+        deleteById: input?.deleteWalletById ?? vi.fn(),
         accessibleBy() {
           return this as unknown as UserWalletRepository;
         },
@@ -264,7 +265,7 @@ describe(WalletInitializerService.name, () => {
     di.registerInstance(
       ProviderJwtTokenService,
       mock<ProviderJwtTokenService>({
-        generateJwtToken: jest.fn().mockResolvedValue("mock-jwt-token")
+        generateJwtToken: vi.fn().mockResolvedValue("mock-jwt-token")
       })
     );
     di.registerInstance(ManagedSignerService, mock<ManagedSignerService>());
@@ -272,7 +273,7 @@ describe(WalletInitializerService.name, () => {
     di.registerInstance(
       FeatureFlagsService,
       mock<FeatureFlagsService>({
-        isEnabled: jest.fn(flag => {
+        isEnabled: vi.fn(flag => {
           if (flag === FeatureFlags.CONSOLE_ONBOARDING_REDESIGN) return input?.consoleOnboardingRedesign ?? false;
           return true;
         })
@@ -282,12 +283,12 @@ describe(WalletInitializerService.name, () => {
       StripeService,
       mock<StripeService>({
         isProduction: input?.isProduction ?? false,
-        getPaymentMethods: jest.fn(async () => {
+        getPaymentMethods: vi.fn(async () => {
           if (!input?.hasPaymentMethods) return [];
           return [{ ...generatePaymentMethod(), validated: true, isDefault: false }];
         }),
-        hasDuplicateTrialAccount: jest.fn().mockResolvedValue(input?.hasDuplicateTrialAccount ?? false),
-        validatePaymentMethodForTrial: jest
+        hasDuplicateTrialAccount: vi.fn().mockResolvedValue(input?.hasDuplicateTrialAccount ?? false),
+        validatePaymentMethodForTrial: vi
           .fn()
           .mockResolvedValue(
             input?.requires3DS
@@ -296,11 +297,11 @@ describe(WalletInitializerService.name, () => {
           )
       })
     );
-    di.registerInstance(StripeErrorService, mock<StripeErrorService>({ isKnownError: jest.fn().mockReturnValue(false) }));
+    di.registerInstance(StripeErrorService, mock<StripeErrorService>({ isKnownError: vi.fn().mockReturnValue(false) }));
     di.registerInstance(
       UserRepository,
       mock<UserRepository>({
-        findTrialUsersByFingerprint: jest.fn().mockResolvedValue(input?.hasDuplicateFingerprint ? [{ id: faker.string.uuid() }] : [])
+        findTrialUsersByFingerprint: vi.fn().mockResolvedValue(input?.hasDuplicateFingerprint ? [{ id: faker.string.uuid() }] : [])
       })
     );
 

--- a/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
+++ b/apps/api/src/billing/services/wallet-reload-job/wallet-reload-job.service.spec.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { WalletBalanceReloadCheck } from "@src/billing/events/wallet-balance-reload-check";

--- a/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
+++ b/apps/api/src/billing/services/wallet-settings/wallet-settings.service.integration.ts
@@ -1,6 +1,7 @@
 import { createMongoAbility } from "@casl/ability";
 import { faker } from "@faker-js/faker";
 import { PostgresError } from "postgres";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { AuthService } from "@src/auth/services/auth.service";
@@ -181,7 +182,7 @@ describe(WalletSettingService.name, () => {
     userRepository.findById.mockResolvedValue(userWithStripe);
     const paymentMethod = { ...generatePaymentMethod(), validated: true };
     const stripeService = mock<StripeService>({
-      getDefaultPaymentMethod: jest.fn().mockResolvedValue(paymentMethod as PaymentMethod)
+      getDefaultPaymentMethod: vi.fn().mockResolvedValue(paymentMethod as PaymentMethod)
     });
     const walletSetting = generateWalletSetting({ userId: user.id });
     walletSettingRepository.findByUserId.mockResolvedValue(walletSetting);
@@ -192,7 +193,7 @@ describe(WalletSettingService.name, () => {
     });
     const jobId = faker.string.uuid();
     const walletReloadJobService = mock<WalletReloadJobService>({
-      scheduleForWalletSetting: jest.fn().mockResolvedValue(jobId)
+      scheduleForWalletSetting: vi.fn().mockResolvedValue(jobId)
     });
     const service = new WalletSettingService(walletSettingRepository, userWalletRepository, userRepository, stripeService, authService, walletReloadJobService);
 

--- a/apps/api/src/caching/helpers.spec.ts
+++ b/apps/api/src/caching/helpers.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it, vi } from "vitest";
+
 import { cacheEngine, cacheResponse, Memoize, memoizeAsync } from "./helpers";
 
 describe("Memoize Function", () => {
@@ -10,7 +12,7 @@ describe("Memoize Function", () => {
 
       cacheEngine.storeInCache("test-key", cachedObject);
 
-      const refreshRequest = jest.fn().mockResolvedValue({ new: "data" });
+      const refreshRequest = vi.fn().mockResolvedValue({ new: "data" });
 
       const result = await cacheResponse(120, "test-key", refreshRequest);
 
@@ -27,7 +29,7 @@ describe("Memoize Function", () => {
 
       cacheEngine.storeInCache("test-key", cachedObject);
 
-      const refreshRequest = jest.fn().mockResolvedValue({ new: "data" });
+      const refreshRequest = vi.fn().mockResolvedValue({ new: "data" });
 
       const result = await cacheResponse(120, "test-key", refreshRequest);
 
@@ -51,7 +53,7 @@ describe("Memoize Function", () => {
 
       cacheEngine.storeInCache("test-key", cachedObject);
 
-      const refreshRequest = jest.fn().mockResolvedValue({ new: "data" });
+      const refreshRequest = vi.fn().mockResolvedValue({ new: "data" });
 
       // Make multiple concurrent calls
       const promises = [
@@ -70,7 +72,7 @@ describe("Memoize Function", () => {
       setup();
 
       const newData = { fresh: "data" };
-      const refreshRequest = jest.fn().mockResolvedValue(newData);
+      const refreshRequest = vi.fn().mockResolvedValue(newData);
 
       const result = await cacheResponse(120, "test-key", refreshRequest);
 
@@ -91,7 +93,7 @@ describe("Memoize Function", () => {
 
       cacheEngine.storeInCache("test-key", cachedObject);
 
-      const refreshRequest = jest.fn().mockRejectedValue(new Error("Background refresh failed"));
+      const refreshRequest = vi.fn().mockRejectedValue(new Error("Background refresh failed"));
 
       const result = await cacheResponse(120, "test-key", refreshRequest);
 
@@ -110,7 +112,7 @@ describe("Memoize Function", () => {
       setup();
 
       const error = new Error("Request failed");
-      const refreshRequest = jest.fn().mockRejectedValue(error);
+      const refreshRequest = vi.fn().mockRejectedValue(error);
 
       await expect(cacheResponse(120, "test-key", refreshRequest)).rejects.toThrow("Request failed");
     });
@@ -124,7 +126,7 @@ describe("Memoize Function", () => {
 
       cacheEngine.storeInCache("test-key", cachedObject);
 
-      const refreshRequest = jest.fn().mockResolvedValue(undefined);
+      const refreshRequest = vi.fn().mockResolvedValue(undefined);
 
       const result = await cacheResponse(120, "test-key", refreshRequest);
 
@@ -146,7 +148,7 @@ describe("Memoize Function", () => {
       let resolveRequest: (value: any) => void;
       let requestCount = 0;
 
-      const refreshRequest = jest.fn().mockImplementation(() => {
+      const refreshRequest = vi.fn().mockImplementation(() => {
         requestCount++;
         return new Promise(resolve => {
           resolveRequest = resolve;
@@ -247,7 +249,7 @@ describe("Memoize Function", () => {
 
   describe(memoizeAsync.name, () => {
     it("should cache successful results and return the same promise", async () => {
-      const fn = jest.fn().mockResolvedValue("result");
+      const fn = vi.fn().mockResolvedValue("result");
       const memoized = memoizeAsync(fn);
 
       const result1 = await memoized();
@@ -264,7 +266,7 @@ describe("Memoize Function", () => {
         resolvePromise = resolve;
       });
 
-      const fn = jest.fn().mockReturnValue(promise);
+      const fn = vi.fn().mockReturnValue(promise);
       const memoized = memoizeAsync(fn);
 
       const call1 = memoized();
@@ -282,7 +284,7 @@ describe("Memoize Function", () => {
 
     it("should not cache rejected promises", async () => {
       const error = new Error("Test error");
-      const fn = jest.fn().mockRejectedValue(error);
+      const fn = vi.fn().mockRejectedValue(error);
       const memoized = memoizeAsync(fn);
 
       await expect(memoized()).rejects.toThrow("Test error");
@@ -293,7 +295,7 @@ describe("Memoize Function", () => {
 
     it("should make new requests after a rejection", async () => {
       const error = new Error("Test error");
-      const fn = jest.fn().mockRejectedValueOnce(error).mockResolvedValue("success");
+      const fn = vi.fn().mockRejectedValueOnce(error).mockResolvedValue("success");
       const memoized = memoizeAsync(fn);
 
       await expect(memoized()).rejects.toThrow("Test error");
@@ -304,7 +306,7 @@ describe("Memoize Function", () => {
     });
 
     it("should cache results for different arguments separately", async () => {
-      const fn = jest.fn((arg: string) => Promise.resolve(`result-${arg}`));
+      const fn = vi.fn((arg: string) => Promise.resolve(`result-${arg}`));
       const memoized = memoizeAsync(fn as unknown as (...args: unknown[]) => Promise<unknown>) as (arg: string) => Promise<string>;
 
       const result1 = await memoized("a");
@@ -318,7 +320,7 @@ describe("Memoize Function", () => {
     });
 
     it("should handle complex arguments correctly", async () => {
-      const fn = jest.fn((arg1: string, arg2: number) => Promise.resolve(`${arg1}-${arg2}`));
+      const fn = vi.fn((arg1: string, arg2: number) => Promise.resolve(`${arg1}-${arg2}`));
       const memoized = memoizeAsync(fn as unknown as (...args: unknown[]) => Promise<unknown>) as (arg1: string, arg2: number) => Promise<string>;
 
       const result1 = await memoized("test", 123);
@@ -333,7 +335,7 @@ describe("Memoize Function", () => {
 
     it("should handle concurrent calls with rejection correctly", async () => {
       const error = new Error("Concurrent error");
-      const fn = jest.fn().mockRejectedValue(error);
+      const fn = vi.fn().mockRejectedValue(error);
       const memoized = memoizeAsync(fn);
 
       const call1 = memoized();
@@ -346,7 +348,7 @@ describe("Memoize Function", () => {
     });
 
     it("should return cached result immediately on subsequent calls", async () => {
-      const fn = jest.fn().mockResolvedValue("cached");
+      const fn = vi.fn().mockResolvedValue("cached");
       const memoized = memoizeAsync(fn);
 
       await memoized();
@@ -368,7 +370,7 @@ describe("Memoize Function", () => {
   });
 
   function setup() {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
     cacheEngine.clearAllKeyInCache();
   }
 });

--- a/apps/api/src/caching/memoryCacheEngine.spec.ts
+++ b/apps/api/src/caching/memoryCacheEngine.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import MemoryCacheEngine from "./memoryCacheEngine";
 
 describe(MemoryCacheEngine.name, () => {

--- a/apps/api/src/chain/services/block-http/block-http.service.spec.ts
+++ b/apps/api/src/chain/services/block-http/block-http.service.spec.ts
@@ -2,6 +2,7 @@ import "@test/mocks/logger-service.mock";
 
 import type { BlockHttpService as BlockHttpServiceCommon } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { BlockHttpService } from "./block-http.service";

--- a/apps/api/src/core/lib/create-route/create-route.spec.ts
+++ b/apps/api/src/core/lib/create-route/create-route.spec.ts
@@ -2,7 +2,7 @@ import type { Context, Next } from "hono";
 import type { MiddlewareHandler } from "hono";
 import { container } from "tsyringe";
 import type { Mock } from "vitest";
-import { vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { AuthService } from "../../../auth/services/auth.service";

--- a/apps/api/src/core/lib/disposable-registry/disposable-registry.spec.ts
+++ b/apps/api/src/core/lib/disposable-registry/disposable-registry.spec.ts
@@ -1,4 +1,5 @@
 import { container } from "tsyringe";
+import { describe, expect, it, vi } from "vitest";
 
 import { DisposableRegistry } from "./disposable-registry";
 
@@ -6,8 +7,8 @@ describe(DisposableRegistry.name, () => {
   describe("registerFromFactory", () => {
     it("should resolve registry from container and call instance method", () => {
       const registry = setup();
-      const instanceMethodSpy = jest.spyOn(registry, "registerFromFactory");
-      const factory = jest.fn().mockReturnValue({});
+      const instanceMethodSpy = vi.spyOn(registry, "registerFromFactory");
+      const factory = vi.fn().mockReturnValue({});
 
       DisposableRegistry.registerFromFactory(factory);
 
@@ -19,8 +20,8 @@ describe(DisposableRegistry.name, () => {
   describe("prototype.registerFromFactory", () => {
     it("should return wrapped factory that calls original factory and returns its value", () => {
       const registry = setup();
-      const disposable = { dispose: jest.fn() };
-      const factory = jest.fn().mockReturnValue(disposable);
+      const disposable = { dispose: vi.fn() };
+      const factory = vi.fn().mockReturnValue(disposable);
 
       const wrappedFactory = registry.registerFromFactory(factory);
       const result = wrappedFactory(container);
@@ -31,7 +32,7 @@ describe(DisposableRegistry.name, () => {
 
     it("should return wrapped factory that handles null values", () => {
       const registry = setup();
-      const factory = jest.fn().mockReturnValue(null);
+      const factory = vi.fn().mockReturnValue(null);
 
       const wrappedFactory = registry.registerFromFactory(factory);
       const result = wrappedFactory(container);
@@ -42,7 +43,7 @@ describe(DisposableRegistry.name, () => {
 
     it("should return wrapped factory that handles undefined values", () => {
       const registry = setup();
-      const factory = jest.fn().mockReturnValue(undefined);
+      const factory = vi.fn().mockReturnValue(undefined);
 
       const wrappedFactory = registry.registerFromFactory(factory);
       const result = wrappedFactory(container);
@@ -53,7 +54,7 @@ describe(DisposableRegistry.name, () => {
 
     it("should return wrapped factory that handles primitive values", () => {
       const registry = setup();
-      const factory = jest.fn().mockReturnValue("string");
+      const factory = vi.fn().mockReturnValue("string");
 
       const wrappedFactory = registry.registerFromFactory(factory);
       const result = wrappedFactory(container);
@@ -65,7 +66,7 @@ describe(DisposableRegistry.name, () => {
     it("should return wrapped factory that handles values with dispose property that is not a function", () => {
       const registry = setup();
       const valueWithDispose = { dispose: "not a function" };
-      const factory = jest.fn().mockReturnValue(valueWithDispose);
+      const factory = vi.fn().mockReturnValue(valueWithDispose);
 
       const wrappedFactory = registry.registerFromFactory(factory);
       const result = wrappedFactory(container);
@@ -83,9 +84,9 @@ describe(DisposableRegistry.name, () => {
 
     it("should dispose registered disposable values", async () => {
       const registry = setup();
-      const dispose = jest.fn().mockResolvedValue(undefined);
+      const dispose = vi.fn().mockResolvedValue(undefined);
       const disposable = { dispose };
-      const factory = jest.fn().mockReturnValue(disposable);
+      const factory = vi.fn().mockReturnValue(disposable);
 
       registry.registerFromFactory(factory)(container);
 
@@ -96,17 +97,17 @@ describe(DisposableRegistry.name, () => {
 
     it("should dispose multiple disposables", async () => {
       const registry = setup();
-      const dispose1 = jest.fn().mockResolvedValue(undefined);
-      const dispose2 = jest.fn();
-      const dispose3 = jest.fn().mockResolvedValue(undefined);
+      const dispose1 = vi.fn().mockResolvedValue(undefined);
+      const dispose2 = vi.fn();
+      const dispose3 = vi.fn().mockResolvedValue(undefined);
 
       const disposable1 = { dispose: dispose1 };
       const disposable2 = { dispose: dispose2 };
       const disposable3 = { dispose: dispose3 };
 
-      const factory1 = jest.fn().mockReturnValue(disposable1);
-      const factory2 = jest.fn().mockReturnValue(disposable2);
-      const factory3 = jest.fn().mockReturnValue(disposable3);
+      const factory1 = vi.fn().mockReturnValue(disposable1);
+      const factory2 = vi.fn().mockReturnValue(disposable2);
+      const factory3 = vi.fn().mockReturnValue(disposable3);
 
       registry.registerFromFactory(factory1)(container);
       registry.registerFromFactory(factory2)(container);
@@ -123,17 +124,17 @@ describe(DisposableRegistry.name, () => {
       const registry = setup();
       const error1 = new Error("Error 1");
       const error3 = new Error("Error 3");
-      const dispose1 = jest.fn().mockRejectedValue(error1);
-      const dispose2 = jest.fn().mockResolvedValue(undefined);
-      const dispose3 = jest.fn().mockRejectedValue(error3);
+      const dispose1 = vi.fn().mockRejectedValue(error1);
+      const dispose2 = vi.fn().mockResolvedValue(undefined);
+      const dispose3 = vi.fn().mockRejectedValue(error3);
 
       const disposable1 = { dispose: dispose1 };
       const disposable2 = { dispose: dispose2 };
       const disposable3 = { dispose: dispose3 };
 
-      const factory1 = jest.fn().mockReturnValue(disposable1);
-      const factory2 = jest.fn().mockReturnValue(disposable2);
-      const factory3 = jest.fn().mockReturnValue(disposable3);
+      const factory1 = vi.fn().mockReturnValue(disposable1);
+      const factory2 = vi.fn().mockReturnValue(disposable2);
+      const factory3 = vi.fn().mockReturnValue(disposable3);
 
       registry.registerFromFactory(factory1)(container);
       registry.registerFromFactory(factory2)(container);
@@ -148,14 +149,14 @@ describe(DisposableRegistry.name, () => {
 
     it("should be idempotent and not dispose twice when called multiple times", async () => {
       const registry = setup();
-      const dispose1 = jest.fn().mockResolvedValue(undefined);
-      const dispose2 = jest.fn().mockResolvedValue(undefined);
+      const dispose1 = vi.fn().mockResolvedValue(undefined);
+      const dispose2 = vi.fn().mockResolvedValue(undefined);
 
       const disposable1 = { dispose: dispose1 };
       const disposable2 = { dispose: dispose2 };
 
-      const factory1 = jest.fn().mockReturnValue(disposable1);
-      const factory2 = jest.fn().mockReturnValue(disposable2);
+      const factory1 = vi.fn().mockReturnValue(disposable1);
+      const factory2 = vi.fn().mockReturnValue(disposable2);
 
       registry.registerFromFactory(factory1)(container);
       registry.registerFromFactory(factory2)(container);
@@ -170,7 +171,7 @@ describe(DisposableRegistry.name, () => {
 
   function setup() {
     const registry = new DisposableRegistry();
-    jest.spyOn(container, "resolve").mockReturnValue(registry);
+    vi.spyOn(container, "resolve").mockReturnValue(registry);
     return registry;
   }
 });

--- a/apps/api/src/core/services/analytics/analytics.service.spec.ts
+++ b/apps/api/src/core/services/analytics/analytics.service.spec.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { Amplitude } from "@src/core/providers/amplitude.provider";

--- a/apps/api/src/core/services/error/error.service.spec.ts
+++ b/apps/api/src/core/services/error/error.service.spec.ts
@@ -2,6 +2,7 @@ import "@test/mocks/logger-service.mock";
 
 import type { LoggerService } from "@akashnetwork/logging";
 import { faker } from "@faker-js/faker";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { ErrorService } from "./error.service";
@@ -10,7 +11,7 @@ describe(ErrorService.name, () => {
   it("should execute callback and return its result", async () => {
     const { service } = setup();
     const result = faker.lorem.sentence();
-    const cb = jest.fn().mockResolvedValue(result);
+    const cb = vi.fn().mockResolvedValue(result);
     const extraLog = { test: "test" };
 
     const actual = await service.execWithErrorHandler(extraLog, cb);
@@ -22,9 +23,9 @@ describe(ErrorService.name, () => {
   it("should handle errors and call onError handler", async () => {
     const { service, logger } = setup();
     const error = new Error("test");
-    const cb = jest.fn().mockRejectedValue(error);
+    const cb = vi.fn().mockRejectedValue(error);
     const extraLog = { test: "test" };
-    const onError = jest.fn();
+    const onError = vi.fn();
 
     const actual = await service.execWithErrorHandler(extraLog, cb, onError);
 
@@ -37,7 +38,7 @@ describe(ErrorService.name, () => {
   it("should handle errors without onError handler", async () => {
     const { service, logger } = setup();
     const error = new Error("test");
-    const cb = jest.fn().mockRejectedValue(error);
+    const cb = vi.fn().mockRejectedValue(error);
     const extraLog = { test: "test" };
 
     const actual = await service.execWithErrorHandler(extraLog, cb);

--- a/apps/api/src/core/services/feature-flags/feature-flags.service.spec.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.service.spec.ts
@@ -1,4 +1,5 @@
 import type { Unleash, UnleashConfig } from "unleash-client";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { ClientInfoContextVariables } from "@src/middlewares/clientInfoMiddleware";
@@ -15,7 +16,7 @@ describe(FeatureFlagsService.name, () => {
       UNLEASH_SERVER_API_URL: "http://localhost:4242/api",
       UNLEASH_SERVER_API_TOKEN: "default:development"
     } as const;
-    const createClient = jest.fn(() => createUnleashMockClient());
+    const createClient = vi.fn(() => createUnleashMockClient());
     await setup({
       config,
       createClient
@@ -30,7 +31,7 @@ describe(FeatureFlagsService.name, () => {
   });
 
   it("skips initialization if FEATURE_FLAGS_ENABLE_ALL is true", async () => {
-    const createClient = jest.fn(() => createUnleashMockClient());
+    const createClient = vi.fn(() => createUnleashMockClient());
     const service = await setup({
       config: { FEATURE_FLAGS_ENABLE_ALL: true },
       skipInitialization: true,
@@ -50,7 +51,7 @@ describe(FeatureFlagsService.name, () => {
 
   it("calls onChanged callback when feature flag is changed", async () => {
     const client = createUnleashMockClient({
-      isEnabledFeatureFlag: jest.fn(() => false)
+      isEnabledFeatureFlag: vi.fn(() => false)
     });
     const service = await setup({ createClient: () => client });
 
@@ -74,9 +75,9 @@ describe(FeatureFlagsService.name, () => {
   describe("isEnabled", () => {
     it("passes user and environment specific context to Unleash", async () => {
       const client = createUnleashMockClient({
-        isEnabledFeatureFlag: jest.fn(() => false)
+        isEnabledFeatureFlag: vi.fn(() => false)
       });
-      const createClient = jest.fn(() => client);
+      const createClient = vi.fn(() => client);
       const currentUser = { id: "123" };
       const config = {
         DEPLOYMENT_ENV: "development",
@@ -104,9 +105,9 @@ describe(FeatureFlagsService.name, () => {
 
     it("includes sessionId from Unleash cookie in context", async () => {
       const client = createUnleashMockClient({
-        isEnabledFeatureFlag: jest.fn(() => false)
+        isEnabledFeatureFlag: vi.fn(() => false)
       });
-      const createClient = jest.fn(() => client);
+      const createClient = vi.fn(() => client);
       const currentUser = { id: "123" };
       const config = {
         DEPLOYMENT_ENV: "development",
@@ -134,7 +135,7 @@ describe(FeatureFlagsService.name, () => {
     });
 
     it("returns false when feature flag is disabled", async () => {
-      const createClient = jest.fn(() =>
+      const createClient = vi.fn(() =>
         createUnleashMockClient({
           isEnabledFeatureFlag: () => false
         })
@@ -146,7 +147,7 @@ describe(FeatureFlagsService.name, () => {
     });
 
     it("return true when feature flag is enabled", async () => {
-      const createClient = jest.fn(() =>
+      const createClient = vi.fn(() =>
         createUnleashMockClient({
           isEnabledFeatureFlag: () => true
         })

--- a/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.spec.ts
+++ b/apps/api/src/core/services/hono-error-handler/hono-error-handler.service.spec.ts
@@ -1,5 +1,6 @@
 import { HTTPException } from "hono/http-exception";
 import createHttpError from "http-errors";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 import { z } from "zod";
 
@@ -112,7 +113,7 @@ describe(HonoErrorHandlerService.name, () => {
   function setup() {
     const service = new HonoErrorHandlerService();
     const mockContext = mock<AppContext>({
-      body: jest.fn(() => new Response())
+      body: vi.fn(() => new Response())
     });
 
     mockContext.json.mockImplementation(((data: unknown, options?: { status?: number }) => {

--- a/apps/api/src/core/services/shutdown-server/shutdown-server.spec.ts
+++ b/apps/api/src/core/services/shutdown-server/shutdown-server.spec.ts
@@ -1,7 +1,7 @@
 import type { Logger } from "@akashnetwork/logging";
 import type { ServerType } from "@hono/node-server";
 import type { Mock } from "vitest";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { shutdownServer } from "./shutdown-server";

--- a/apps/api/src/core/services/start-server/start-server.spec.ts
+++ b/apps/api/src/core/services/start-server/start-server.spec.ts
@@ -4,6 +4,7 @@ import EventEmitter from "events";
 import type { Hono } from "hono";
 import { setTimeout as delay } from "timers/promises";
 import type { DependencyContainer } from "tsyringe";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { AppInitializer } from "@src/core/providers/app-initializer";
@@ -31,7 +32,7 @@ describe("startServer", () => {
   });
 
   it("call beforeStart callback before running APP_INITIALIZERs", async () => {
-    const beforeStart = jest.fn().mockResolvedValue(undefined);
+    const beforeStart = vi.fn().mockResolvedValue(undefined);
     const { start, container } = setup({ beforeStart });
 
     await start();
@@ -40,10 +41,7 @@ describe("startServer", () => {
   });
 
   it("resolves all APP_INITIALIZER services and call their ON_APP_START methods", async () => {
-    const initializers: AppInitializer[] = [
-      { [ON_APP_START]: jest.fn().mockResolvedValue(undefined) },
-      { [ON_APP_START]: jest.fn().mockResolvedValue(undefined) }
-    ];
+    const initializers: AppInitializer[] = [{ [ON_APP_START]: vi.fn().mockResolvedValue(undefined) }, { [ON_APP_START]: vi.fn().mockResolvedValue(undefined) }];
     const { start, container } = setup({ initializers });
 
     await start();
@@ -56,7 +54,7 @@ describe("startServer", () => {
   it("registers shutdown handlers for process events", async () => {
     const { start, processEvents } = setup({});
 
-    jest.spyOn(processEvents, "on");
+    vi.spyOn(processEvents, "on");
     await start();
 
     expect(processEvents.on).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
@@ -78,7 +76,7 @@ describe("startServer", () => {
     const { start, container, processEvents } = setup();
 
     const server = await start();
-    const closeServer = jest.spyOn(server!, "close");
+    const closeServer = vi.spyOn(server!, "close");
     processEvents.emit("SIGTERM");
     await delay(10);
 
@@ -90,7 +88,7 @@ describe("startServer", () => {
     const { start, container, processEvents } = setup();
 
     const server = await start();
-    const closeServer = jest.spyOn(server!, "close");
+    const closeServer = vi.spyOn(server!, "close");
     processEvents.emit("SIGINT");
     await delay(10);
 
@@ -102,7 +100,7 @@ describe("startServer", () => {
     const { start, container, processEvents } = setup();
 
     const server = await start();
-    const closeServer = jest.spyOn(server!, "close");
+    const closeServer = vi.spyOn(server!, "close");
     processEvents.emit("exit");
     await delay(10);
 
@@ -114,7 +112,7 @@ describe("startServer", () => {
     const { start, container, processEvents } = setup();
 
     const server = await start();
-    const closeServer = jest.spyOn(server!, "close");
+    const closeServer = vi.spyOn(server!, "close");
     processEvents.emit("exit");
     processEvents.emit("SIGINT");
     processEvents.emit("SIGTERM");
@@ -144,7 +142,7 @@ describe("startServer", () => {
   });
 
   it("disposes container when `beforeStart` throws an error", async () => {
-    const { start, container } = setup({ beforeStart: jest.fn().mockRejectedValue(new Error("Failed to start server")) });
+    const { start, container } = setup({ beforeStart: vi.fn().mockRejectedValue(new Error("Failed to start server")) });
 
     await start();
     await delay(10);
@@ -153,7 +151,7 @@ describe("startServer", () => {
   });
 
   it("disposes container when `APP_INITIALIZER` throws an error", async () => {
-    const { start, container } = setup({ initializers: [{ [ON_APP_START]: jest.fn().mockRejectedValue(new Error("Failed to start server")) }] });
+    const { start, container } = setup({ initializers: [{ [ON_APP_START]: vi.fn().mockRejectedValue(new Error("Failed to start server")) }] });
 
     await start();
     await delay(10);
@@ -167,7 +165,7 @@ describe("startServer", () => {
     const logger = mock<LoggerService>();
     const processEvents = new EventEmitter();
     const container = mock<DependencyContainer>({
-      resolveAll: jest.fn().mockReturnValue(input?.initializers ?? [])
+      resolveAll: vi.fn().mockReturnValue(input?.initializers ?? [])
     });
 
     const options = {

--- a/apps/api/src/core/services/timer/timer.service.spec.ts
+++ b/apps/api/src/core/services/timer/timer.service.spec.ts
@@ -1,4 +1,4 @@
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { TimerService } from "./timer.service";
 

--- a/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.spec.ts
+++ b/apps/api/src/deployment/controllers/deployment/top-up-deployments.controller.spec.ts
@@ -1,5 +1,6 @@
 import "@test/mocks/logger-service.mock";
 
+import { describe, expect, it } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 

--- a/apps/api/src/deployment/lib/top-up-summarizer/top-up-summarizer.spec.ts
+++ b/apps/api/src/deployment/lib/top-up-summarizer/top-up-summarizer.spec.ts
@@ -1,6 +1,8 @@
 import "reflect-metadata";
 import "@test/mocks/logger-service.mock";
 
+import { beforeEach, describe, expect, it } from "vitest";
+
 import { TopUpSummarizer } from "./top-up-summarizer";
 
 import { createAkashAddress } from "@test/seeders";

--- a/apps/api/src/deployment/services/active-deployments-count/active-deployments-count.service.spec.ts
+++ b/apps/api/src/deployment/services/active-deployments-count/active-deployments-count.service.spec.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { UserWalletRepository } from "@src/billing/repositories";
@@ -16,8 +17,8 @@ describe(ActiveDeploymentsCountService.name, () => {
 
     const userWallet = createUserWallet();
     const { service, userWalletRepository, deploymentRepository } = setup({
-      findOneByUserId: jest.fn().mockResolvedValue(userWallet),
-      countActiveByOwner: jest.fn().mockResolvedValue(activeCount)
+      findOneByUserId: vi.fn().mockResolvedValue(userWallet),
+      countActiveByOwner: vi.fn().mockResolvedValue(activeCount)
     });
 
     const result = await service.resolve(user);
@@ -31,7 +32,7 @@ describe(ActiveDeploymentsCountService.name, () => {
     const user = createUser();
 
     const { service, userWalletRepository, logger } = setup({
-      findOneByUserId: jest.fn().mockResolvedValue(null)
+      findOneByUserId: vi.fn().mockResolvedValue(null)
     });
 
     await expect(service.resolve(user)).rejects.toThrow("User wallet not found");
@@ -48,7 +49,7 @@ describe(ActiveDeploymentsCountService.name, () => {
 
     const userWallet = createUserWallet({ address: null });
     const { service, userWalletRepository, logger } = setup({
-      findOneByUserId: jest.fn().mockResolvedValue(userWallet)
+      findOneByUserId: vi.fn().mockResolvedValue(userWallet)
     });
 
     await expect(service.resolve(user)).rejects.toThrow("User wallet not found");
@@ -63,10 +64,10 @@ describe(ActiveDeploymentsCountService.name, () => {
   function setup(input?: { findOneByUserId?: UserWalletRepository["findOneByUserId"]; countActiveByOwner?: DeploymentRepository["countActiveByOwner"] }) {
     const mocks = {
       userWalletRepository: mock<UserWalletRepository>({
-        findOneByUserId: input?.findOneByUserId ?? jest.fn()
+        findOneByUserId: input?.findOneByUserId ?? vi.fn()
       }),
       deploymentRepository: mock<DeploymentRepository>({
-        countActiveByOwner: input?.countActiveByOwner ?? jest.fn()
+        countActiveByOwner: input?.countActiveByOwner ?? vi.fn()
       }),
       logger: mock<LoggerService>()
     };

--- a/apps/api/src/deployment/services/blocked-gpu/blocked-gpu.service.spec.ts
+++ b/apps/api/src/deployment/services/blocked-gpu/blocked-gpu.service.spec.ts
@@ -1,5 +1,6 @@
 import type { SDLInput } from "@akashnetwork/chain-sdk";
 import { MsgCreateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { describe, expect, it } from "vitest";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { BlockedGpuService } from "./blocked-gpu.service";

--- a/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
+++ b/apps/api/src/deployment/services/cached-balance/cached-balance.service.spec.ts
@@ -1,5 +1,5 @@
 import type { Mocked } from "vitest";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { BalancesService } from "@src/billing/services/balances/balances.service";
 import { CachedBalanceService } from "./cached-balance.service";

--- a/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-reader/deployment-reader.service.spec.ts
@@ -2,6 +2,7 @@ import "@test/mocks/logger-service.mock";
 
 import type { DeploymentHttpService, LeaseHttpService } from "@akashnetwork/http-sdk";
 import { AxiosError } from "axios";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { WalletInitialized, WalletReaderService } from "@src/billing/services/wallet-reader/wallet-reader.service";
@@ -178,29 +179,29 @@ describe(DeploymentReaderService.name, () => {
 
     const mocks = {
       providerService: mock<ProviderService>({
-        getLeaseStatus: jest.fn().mockResolvedValue(null),
-        toProviderAuth: jest.fn().mockResolvedValue({ type: "jwt", token: "test" })
+        getLeaseStatus: vi.fn().mockResolvedValue(null),
+        toProviderAuth: vi.fn().mockResolvedValue({ type: "jwt", token: "test" })
       }),
       deploymentHttpService: mock<DeploymentHttpService>({
-        findByOwnerAndDseq: jest.fn().mockResolvedValue(defaultDeploymentInfo),
-        findAll: jest.fn().mockResolvedValue(defaultDeploymentList)
+        findByOwnerAndDseq: vi.fn().mockResolvedValue(defaultDeploymentInfo),
+        findAll: vi.fn().mockResolvedValue(defaultDeploymentList)
       }),
       fallbackDeploymentReaderService: mock<FallbackDeploymentReaderService>({
-        findByOwnerAndDseq: jest.fn().mockResolvedValue(input.fallbackDeploymentInfo ?? defaultDeploymentInfo),
-        findAll: jest.fn().mockResolvedValue(input.fallbackDeploymentList ?? defaultDeploymentList)
+        findByOwnerAndDseq: vi.fn().mockResolvedValue(input.fallbackDeploymentInfo ?? defaultDeploymentInfo),
+        findAll: vi.fn().mockResolvedValue(input.fallbackDeploymentList ?? defaultDeploymentList)
       }),
       leaseHttpService: mock<LeaseHttpService>({
-        list: jest.fn().mockResolvedValue({ leases: [], pagination: { next_key: null, total: "0" } })
+        list: vi.fn().mockResolvedValue({ leases: [], pagination: { next_key: null, total: "0" } })
       }),
       fallbackLeaseReaderService: mock<FallbackLeaseReaderService>({
-        list: jest.fn().mockResolvedValue({
+        list: vi.fn().mockResolvedValue({
           leases: input.fallbackLeases ?? [],
           pagination: { next_key: null, total: "0" }
         })
       }),
       messageService: mock<MessageService>(),
       walletReaderService: mock<WalletReaderService>({
-        getWalletByUserId: jest.fn().mockResolvedValue(wallet)
+        getWalletByUserId: vi.fn().mockResolvedValue(wallet)
       }),
       logger: mock<LoggerService>()
     };

--- a/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-setting/deployment-setting.service.spec.ts
@@ -2,6 +2,7 @@ import "@test/mocks/logger-service.mock";
 
 import { ForbiddenError } from "@casl/ability";
 import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { AuthService } from "@src/auth/services/auth.service";

--- a/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
+++ b/apps/api/src/deployment/services/deployment-writer/deployment-writer.service.spec.ts
@@ -1,6 +1,6 @@
 import { DeploymentReclamation, MsgAccountDeposit } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import { MsgCloseDeployment, MsgCreateDeployment, MsgUpdateDeployment } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
-import { vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock, type MockProxy } from "vitest-mock-extended";
 
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";

--- a/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment-rpc/draining-deployment-rpc.service.spec.ts
@@ -2,6 +2,7 @@ import "@test/mocks/logger-service.mock";
 
 import type { DeploymentHttpService, DeploymentListResponse, LeaseHttpService } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { LoggerService } from "@src/core";

--- a/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
+++ b/apps/api/src/deployment/services/draining-deployment/draining-deployment.service.spec.ts
@@ -4,6 +4,7 @@ import type { AnyAbility } from "@casl/ability";
 import { faker } from "@faker-js/faker";
 import { addWeeks } from "date-fns";
 import { groupBy } from "lodash";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { UserWalletRepository } from "@src/billing/repositories";
@@ -64,8 +65,7 @@ describe(DrainingDeploymentService.name, () => {
         }
       ];
 
-      jest
-        .spyOn(service, "findLeases")
+      vi.spyOn(service, "findLeases")
         .mockResolvedValueOnce(activeBatches[0])
         .mockResolvedValueOnce(closedBatch)
         .mockResolvedValueOnce([])
@@ -80,7 +80,7 @@ describe(DrainingDeploymentService.name, () => {
         })()
       );
 
-      const callback = jest.fn();
+      const callback = vi.fn();
       for await (const result of service.findDrainingDeploymentsByOwner()) {
         callback(result);
       }
@@ -194,7 +194,7 @@ describe(DrainingDeploymentService.name, () => {
       const { service, userWalletRepository, leaseRepository } = setup();
       userWalletRepository.findOneByUserId.mockResolvedValue(userWallet);
       leaseRepository.findOneByDseqAndOwner.mockResolvedValue(deployment);
-      jest.spyOn(service, "calculateTopUpAmount").mockResolvedValue(expectedTopUpAmount);
+      vi.spyOn(service, "calculateTopUpAmount").mockResolvedValue(expectedTopUpAmount);
 
       const amount = await service.calculateTopUpAmountForDseqAndUserId(dseq, userId);
 
@@ -393,8 +393,8 @@ describe(DrainingDeploymentService.name, () => {
 
   describe("calculateAllDeploymentCostUntilDate", () => {
     it("calculates total cost for deployments closing within target date", async () => {
-      jest.useFakeTimers();
-      jest.setSystemTime(new Date("2025-01-01T12:00:00.000Z"));
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2025-01-01T12:00:00.000Z"));
 
       try {
         const blockRate1 = 50;
@@ -419,7 +419,7 @@ describe(DrainingDeploymentService.name, () => {
         expect(result).toBe(expectedTotal);
         expect(leaseRepository.findManyByDseqAndOwner).toHaveBeenCalledWith(expectedTargetHeight, address, expect.any(Array));
       } finally {
-        jest.useRealTimers();
+        vi.useRealTimers();
       }
     });
 

--- a/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
+++ b/apps/api/src/deployment/services/sdl/sdl.service.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import type { BillingConfig } from "@src/billing/providers";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { BlockedGpuService } from "@src/deployment/services/blocked-gpu/blocked-gpu.service";

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments-instrumentation.service.spec.ts
@@ -2,6 +2,7 @@ import "@test/mocks/logger-service.mock";
 
 import { faker } from "@faker-js/faker";
 import type { Counter } from "@opentelemetry/api";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { LoggerService, MetricsService } from "@src/core";

--- a/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
+++ b/apps/api/src/deployment/services/top-up-managed-deployments/top-up-managed-deployments.service.spec.ts
@@ -3,6 +3,7 @@ import "@test/mocks/logger-service.mock";
 import { Scope, Source } from "@akashnetwork/chain-sdk/private-types/akash.v1";
 import type { IndexedTx } from "@cosmjs/stargate";
 import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { RpcMessageService } from "@src/billing/services";

--- a/apps/api/src/deployment/utils/blocked-gpu/blocked-gpu.spec.ts
+++ b/apps/api/src/deployment/utils/blocked-gpu/blocked-gpu.spec.ts
@@ -1,5 +1,6 @@
 import type { SDLInput } from "@akashnetwork/chain-sdk";
 import type { GroupSpec } from "@akashnetwork/chain-sdk/private-types/akash.v1beta4";
+import { describe, expect, it } from "vitest";
 
 import { extractRequestedGpusFromGroupSpecs, extractRequestedGpusFromSdl, findBlockedGpus, formatGpuLabel, toBlockedGpuSet } from "./blocked-gpu";
 

--- a/apps/api/src/gpu/services/gpu-price/gpu-price.service.spec.ts
+++ b/apps/api/src/gpu/services/gpu-price/gpu-price.service.spec.ts
@@ -5,6 +5,7 @@ import type { Day } from "@akashnetwork/database/dbSchemas/base";
 import { faker } from "@faker-js/faker";
 import { subDays } from "date-fns";
 import { container } from "tsyringe";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { Registry } from "@src/billing/providers/type-registry.provider";

--- a/apps/api/src/healthz/controllers/healthz/healthz.controller.spec.ts
+++ b/apps/api/src/healthz/controllers/healthz/healthz.controller.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 

--- a/apps/api/src/healthz/services/healthz/healthz.service.spec.ts
+++ b/apps/api/src/healthz/services/healthz/healthz.service.spec.ts
@@ -1,5 +1,6 @@
 import type { LoggerService } from "@akashnetwork/logging";
 import { millisecondsInMinute } from "date-fns";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { DbHealthcheck, JobQueueHealthcheck } from "@src/core";
@@ -106,7 +107,7 @@ describe(HealthzService.name, () => {
     });
 
     it("caches liveness results and retries after TTL expires", async () => {
-      jest.useFakeTimers();
+      vi.useFakeTimers();
       const { service, dbHealthcheck, jobQueueHealthcheck } = setup();
 
       // First call - both should be called
@@ -120,14 +121,14 @@ describe(HealthzService.name, () => {
       expect(jobQueueHealthcheck.ping).toHaveBeenCalledTimes(1);
 
       // Advance time beyond TTL
-      jest.advanceTimersByTime(millisecondsInMinute + 1);
+      vi.advanceTimersByTime(millisecondsInMinute + 1);
 
       // Call after TTL - should make new calls
       await service.getLivenessStatus();
       expect(dbHealthcheck.ping).toHaveBeenCalledTimes(2);
       expect(jobQueueHealthcheck.ping).toHaveBeenCalledTimes(2);
 
-      jest.useRealTimers();
+      vi.useRealTimers();
     });
 
     it("does not tolerate failure if has not succeeded at least once", async () => {
@@ -146,13 +147,13 @@ describe(HealthzService.name, () => {
     });
 
     it("tolerates failure for the 1st time and waits for the cache to expire until the next check", async () => {
-      jest.useFakeTimers();
+      vi.useFakeTimers();
       const { service, dbHealthcheck, jobQueueHealthcheck } = setup();
 
       await service.getLivenessStatus();
 
       // wait for TTL to expire
-      jest.advanceTimersByTime(millisecondsInMinute + 1);
+      vi.advanceTimersByTime(millisecondsInMinute + 1);
       dbHealthcheck.ping.mockRejectedValue(new Error("Postgres is not ready"));
 
       expect(await service.getLivenessStatus()).toEqual({
@@ -177,7 +178,7 @@ describe(HealthzService.name, () => {
       expect(jobQueueHealthcheck.ping).toHaveBeenCalledTimes(2);
 
       // wait for TTL to expire
-      jest.advanceTimersByTime(millisecondsInMinute + 1);
+      vi.advanceTimersByTime(millisecondsInMinute + 1);
 
       expect(await service.getLivenessStatus()).toEqual({
         status: "error",
@@ -189,14 +190,14 @@ describe(HealthzService.name, () => {
       expect(dbHealthcheck.ping).toHaveBeenCalledTimes(3);
       expect(jobQueueHealthcheck.ping).toHaveBeenCalledTimes(3);
 
-      jest.useRealTimers();
+      vi.useRealTimers();
     });
   });
 
   function setup() {
     const logger = mock<LoggerService>();
-    const dbHealthcheck = mock<DbHealthcheck>({ ping: jest.fn().mockResolvedValue(undefined) });
-    const jobQueueHealthcheck = mock<JobQueueHealthcheck>({ ping: jest.fn().mockResolvedValue(undefined) });
+    const dbHealthcheck = mock<DbHealthcheck>({ ping: vi.fn().mockResolvedValue(undefined) });
+    const jobQueueHealthcheck = mock<JobQueueHealthcheck>({ ping: vi.fn().mockResolvedValue(undefined) });
     const healthzService = new HealthzService(dbHealthcheck, jobQueueHealthcheck, logger);
 
     return {

--- a/apps/api/src/middlewares/contentTypeMiddleware/contentTypeMiddleware.spec.ts
+++ b/apps/api/src/middlewares/contentTypeMiddleware/contentTypeMiddleware.spec.ts
@@ -1,6 +1,6 @@
 import type { Context, Next } from "hono";
 import type { Mock } from "vitest";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { contentTypeMiddleware } from "./contentTypeMiddleware";

--- a/apps/api/src/notifications/routes/proxy/proxy.route.spec.ts
+++ b/apps/api/src/notifications/routes/proxy/proxy.route.spec.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { AuthService } from "@src/auth/services/auth.service";
@@ -71,7 +72,7 @@ describe("createProxy", () => {
 
     const authService = mock<AuthService>({
       currentUser: { id: userId },
-      throwUnlessCan: jest.fn().mockReturnValue(undefined)
+      throwUnlessCan: vi.fn().mockReturnValue(undefined)
     });
     const owner = createAkashAddress();
 
@@ -87,7 +88,7 @@ describe("createProxy", () => {
       NOTIFICATIONS_API_BASE_URL: "https://proxy.example"
     };
 
-    const fetchMock = jest.fn().mockResolvedValue(new Response(null, { status: method === "GET" ? 204 : 200 }));
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: method === "GET" ? 204 : 200 }));
 
     const handler = createProxy(authService, userWalletRepository, config, fetchMock);
 
@@ -100,7 +101,7 @@ describe("createProxy", () => {
         },
         text: async () => JSON.stringify(body)
       },
-      get: jest.fn().mockReturnValue(undefined)
+      get: vi.fn().mockReturnValue(undefined)
     } as unknown as AppContext;
 
     return {

--- a/apps/api/src/notifications/services/notification-data-resolver/notification-data-resolver.service.spec.ts
+++ b/apps/api/src/notifications/services/notification-data-resolver/notification-data-resolver.service.spec.ts
@@ -1,6 +1,6 @@
 import { faker } from "@faker-js/faker";
 import type { Mock } from "vitest";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { LoggerService } from "@src/core/providers/logging.provider";

--- a/apps/api/src/notifications/services/notification-handler/notification.handler.spec.ts
+++ b/apps/api/src/notifications/services/notification-handler/notification.handler.spec.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { LoggerService } from "@src/core/providers/logging.provider";
@@ -34,7 +35,7 @@ describe(NotificationHandler.name, () => {
 
   it("logs warning and returns early when user is not found", async () => {
     const { handler, userRepository, logger, notificationService } = setup({
-      findUserById: jest.fn().mockResolvedValue(null)
+      findUserById: vi.fn().mockResolvedValue(null)
     });
 
     await handler.handle({
@@ -62,7 +63,7 @@ describe(NotificationHandler.name, () => {
     });
 
     const { handler, userRepository, logger, notificationService } = setup({
-      findUserById: jest.fn().mockResolvedValue(user)
+      findUserById: vi.fn().mockResolvedValue(user)
     });
 
     await handler.handle({
@@ -91,7 +92,7 @@ describe(NotificationHandler.name, () => {
     });
 
     const { handler, userRepository, notificationService } = setup({
-      findUserById: jest.fn().mockResolvedValue(user)
+      findUserById: vi.fn().mockResolvedValue(user)
     });
 
     await handler.handle({
@@ -116,7 +117,7 @@ describe(NotificationHandler.name, () => {
     });
 
     const { handler, userRepository, notificationService } = setup({
-      findUserById: jest.fn().mockResolvedValue(user)
+      findUserById: vi.fn().mockResolvedValue(user)
     });
     const vars = {
       paymentLink: faker.internet.url()
@@ -141,7 +142,7 @@ describe(NotificationHandler.name, () => {
     });
 
     const { handler, userRepository, notificationService } = setup({
-      findUserById: jest.fn().mockResolvedValue(user)
+      findUserById: vi.fn().mockResolvedValue(user)
     });
 
     const initialCredits = faker.number.int({ min: 5_000_000, max: 10_000_000 });
@@ -170,7 +171,7 @@ describe(NotificationHandler.name, () => {
     const createdDate = new Date("2023-10-01T12:00:00Z");
     const currentDate = new Date("2023-10-15T12:00:00Z");
 
-    jest.useFakeTimers({ now: currentDate });
+    vi.useFakeTimers({ now: currentDate });
 
     const user = createUser({
       id: "user-123",
@@ -179,13 +180,13 @@ describe(NotificationHandler.name, () => {
       trial: true
     });
     const resolvedVars = { remainingCredits: faker.number.int({ min: 1000, max: 10000 }), activeDeployments: faker.number.int({ min: 0, max: 10 }) };
-    const resolveVars = jest.fn().mockImplementation(async (user, vars) => ({
+    const resolveVars = vi.fn().mockImplementation(async (user, vars) => ({
       ...vars,
       ...resolvedVars
     }));
 
     const { handler, userRepository, notificationService } = setup({
-      findUserById: jest.fn().mockResolvedValue(user),
+      findUserById: vi.fn().mockResolvedValue(user),
       resolveVars
     });
 
@@ -202,7 +203,7 @@ describe(NotificationHandler.name, () => {
     expect(userRepository.findById).toHaveBeenCalledWith(user.id);
     expect(notificationService.createNotification).toHaveBeenCalledWith(beforeTrialEndsNotification(user, { trialEndsAt, paymentLink, ...resolvedVars }));
 
-    jest.useRealTimers();
+    vi.useRealTimers();
   });
 
   it("creates afterTrialEnds notification", async () => {
@@ -213,7 +214,7 @@ describe(NotificationHandler.name, () => {
     });
 
     const { handler, userRepository, notificationService } = setup({
-      findUserById: jest.fn().mockResolvedValue(user)
+      findUserById: vi.fn().mockResolvedValue(user)
     });
 
     const vars = {
@@ -240,7 +241,7 @@ describe(NotificationHandler.name, () => {
     });
 
     const { handler, userRepository, notificationService } = setup({
-      findUserById: jest.fn().mockResolvedValue(user)
+      findUserById: vi.fn().mockResolvedValue(user)
     });
 
     const vars = {
@@ -271,7 +272,7 @@ describe(NotificationHandler.name, () => {
     });
 
     const { handler, userRepository, notificationService } = setup({
-      findUserById: jest.fn().mockResolvedValue(user)
+      findUserById: vi.fn().mockResolvedValue(user)
     });
 
     await handler.handle({
@@ -298,13 +299,13 @@ describe(NotificationHandler.name, () => {
   }) {
     const mocks = {
       notificationService: mock<NotificationService>({
-        createNotification: input?.createNotification ?? jest.fn().mockResolvedValue(undefined)
+        createNotification: input?.createNotification ?? vi.fn().mockResolvedValue(undefined)
       }),
       userRepository: mock<UserRepository>({
-        findById: input?.findUserById ?? jest.fn()
+        findById: input?.findUserById ?? vi.fn()
       }),
       notificationDataResolverService: mock<NotificationDataResolverService>({
-        resolve: input?.resolveVars ?? jest.fn().mockImplementation(async (user, vars) => vars)
+        resolve: input?.resolveVars ?? vi.fn().mockImplementation(async (user, vars) => vars)
       }),
       logger: mock<LoggerService>()
     };

--- a/apps/api/src/notifications/services/notification-templates/email-verification-code-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/email-verification-code-notification.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import { emailVerificationCodeNotification } from "./email-verification-code-notification";
 
 describe(emailVerificationCodeNotification.name, () => {

--- a/apps/api/src/pricing/services/pricing/pricing.service.spec.ts
+++ b/apps/api/src/pricing/services/pricing/pricing.service.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import type { PricingBody } from "@src/pricing/http-schemas/pricing.schema";
 import { PricingService } from "./pricing.service";
 

--- a/apps/api/src/provider/controllers/jwt-token/jwt-token.controller.spec.ts
+++ b/apps/api/src/provider/controllers/jwt-token/jwt-token.controller.spec.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker";
 import { Ok } from "ts-results";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { createUser } from "../../../../test/seeders/user.seeder";

--- a/apps/api/src/provider/services/provider-dashboard/provider-dashboard.service.integration.ts
+++ b/apps/api/src/provider/services/provider-dashboard/provider-dashboard.service.integration.ts
@@ -2,6 +2,7 @@ import type { Provider } from "@akashnetwork/database/dbSchemas/akash";
 import type { Block } from "@akashnetwork/database/dbSchemas/base";
 import { subDays } from "date-fns";
 import { container } from "tsyringe";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { CHAIN_DB } from "@src/chain";
 import { ProviderDashboardService } from "./provider-dashboard.service";

--- a/apps/api/src/provider/services/provider-deployments/provider-deployments.service.integration.ts
+++ b/apps/api/src/provider/services/provider-deployments/provider-deployments.service.integration.ts
@@ -3,6 +3,7 @@ import type { Block } from "@akashnetwork/database/dbSchemas/base";
 import { faker } from "@faker-js/faker";
 import type { CreationAttributes } from "sequelize";
 import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
 
 import { CHAIN_DB } from "@src/chain";
 import { ProviderDeploymentsService } from "./provider-deployments.service";

--- a/apps/api/src/provider/services/provider-jwt-token/provider-jwt-token.service.spec.ts
+++ b/apps/api/src/provider/services/provider-jwt-token/provider-jwt-token.service.spec.ts
@@ -1,6 +1,7 @@
 import type { JwtTokenManager, JwtTokenPayload } from "@akashnetwork/chain-sdk";
 import type { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import { faker } from "@faker-js/faker";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { Wallet } from "../../../billing/lib/wallet/wallet";

--- a/apps/api/src/provider/services/provider-regions/provider-regions.service.integration.ts
+++ b/apps/api/src/provider/services/provider-regions/provider-regions.service.integration.ts
@@ -4,6 +4,7 @@ import type { GitHubHttpService } from "@akashnetwork/http-sdk";
 import fs from "fs/promises";
 import path from "path";
 import { container } from "tsyringe";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { CHAIN_DB } from "@src/chain";
 import { ProviderAttributesSchemaService } from "../provider-attributes-schema/provider-attributes-schema.service";

--- a/apps/api/src/provider/services/provider-versions/provider-versions.service.integration.ts
+++ b/apps/api/src/provider/services/provider-versions/provider-versions.service.integration.ts
@@ -1,5 +1,6 @@
 import type { Provider } from "@akashnetwork/database/dbSchemas/akash";
 import { container } from "tsyringe";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { CHAIN_DB } from "@src/chain";
 import { PROVIDER_CONFIG } from "@src/provider/providers/config.provider";

--- a/apps/api/src/provider/services/provider/provider.service.spec.ts
+++ b/apps/api/src/provider/services/provider/provider.service.spec.ts
@@ -4,7 +4,7 @@ import type { ProviderAttributesSchema } from "@akashnetwork/http-sdk";
 import { faker } from "@faker-js/faker";
 import { AxiosError } from "axios";
 import { Ok } from "ts-results";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { cacheEngine } from "@src/caching/helpers";
@@ -514,7 +514,7 @@ describe(ProviderService.name, () => {
     const providerAttributesSchemaService = mock<ProviderAttributesSchemaService>();
     const auditorsService = mock<AuditorService>();
     const jwtTokenService = mock<ProviderJwtTokenService>({
-      generateJwtToken: jest.fn().mockResolvedValue(Ok("mock-jwt-token"))
+      generateJwtToken: vi.fn().mockResolvedValue(Ok("mock-jwt-token"))
     });
 
     const service = new ProviderService(providerProxyService, providerRepository, providerAttributesSchemaService, auditorsService, jwtTokenService);

--- a/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
+++ b/apps/api/src/template/services/github-archive/github-archive.service.spec.ts
@@ -1,5 +1,6 @@
 import { gzipSync } from "node:zlib";
 import tar from "tar";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { LoggerService } from "@src/core";
@@ -88,7 +89,7 @@ describe(GitHubArchiveService.name, () => {
     async function installArchive(files: Record<string, string>) {
       const tarGzBuffer = createTarGzBuffer(files);
 
-      jest.spyOn(globalThis, "fetch").mockResolvedValue(
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
         new Response(new Uint8Array(tarGzBuffer), {
           status: 200,
           headers: { "Content-Type": "application/gzip" }

--- a/apps/api/src/template/services/template-fetcher/template-fetcher.service.spec.ts
+++ b/apps/api/src/template/services/template-fetcher/template-fetcher.service.spec.ts
@@ -1,4 +1,5 @@
 import type { Octokit } from "@octokit/rest";
+import { describe, expect, it } from "vitest";
 import { mock, mockDeep } from "vitest-mock-extended";
 
 import type { LoggerService } from "@src/core";

--- a/apps/api/src/template/services/template-gallery/template-gallery.service.spec.ts
+++ b/apps/api/src/template/services/template-gallery/template-gallery.service.spec.ts
@@ -1,3 +1,4 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 import { z } from "zod";
 
@@ -340,7 +341,7 @@ describe(TemplateGalleryService.name, () => {
   function setup(input?: { getTagsConfig?: () => TemplateTagsConfig }) {
     const logger = mock<LoggerService>();
     const fsMock = mock<FileSystemApi>({
-      access: jest.fn(() => Promise.reject(new Error("File not found")))
+      access: vi.fn(() => Promise.reject(new Error("File not found")))
     });
     const dataFolderPath = "/data";
 
@@ -351,10 +352,10 @@ describe(TemplateGalleryService.name, () => {
     });
 
     const templateFetcher = mock<TemplateFetcherService>({
-      fetchLatestCommitSha: jest.fn(() => Promise.resolve("abc123")),
-      fetchAwesomeAkashTemplates: jest.fn(() => Promise.resolve([])),
-      fetchOmnibusTemplates: jest.fn(() => Promise.resolve([])),
-      clearArchiveCache: jest.fn()
+      fetchLatestCommitSha: vi.fn(() => Promise.resolve("abc123")),
+      fetchAwesomeAkashTemplates: vi.fn(() => Promise.resolve([])),
+      fetchOmnibusTemplates: vi.fn(() => Promise.resolve([])),
+      clearArchiveCache: vi.fn()
     });
 
     Object.assign(service, { templateFetcher });

--- a/apps/api/src/template/services/template-processor/template-processor.service.spec.ts
+++ b/apps/api/src/template/services/template-processor/template-processor.service.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import type { Category, TemplateSource } from "../../types/template";
 import { TemplateProcessorService } from "./template-processor.service";
 

--- a/apps/api/src/transaction/repositories/transaction/transaction.repository.integration.ts
+++ b/apps/api/src/transaction/repositories/transaction/transaction.repository.integration.ts
@@ -1,4 +1,5 @@
 import { container } from "tsyringe";
+import { describe, expect, it } from "vitest";
 
 import { TransactionRepository } from "./transaction.repository";
 

--- a/apps/api/src/user/services/user-templates/user-templates.service.spec.ts
+++ b/apps/api/src/user/services/user-templates/user-templates.service.spec.ts
@@ -1,4 +1,5 @@
 import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 

--- a/apps/api/src/user/services/user/user.service.integration.ts
+++ b/apps/api/src/user/services/user/user.service.integration.ts
@@ -1,7 +1,7 @@
 import { faker } from "@faker-js/faker";
 import type { GetUsers200ResponseOneOfInner } from "auth0";
 import { container } from "tsyringe";
-import { vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { Auth0Service } from "@src/auth/services/auth0/auth0.service";

--- a/apps/api/src/user/services/user/user.service.spec.ts
+++ b/apps/api/src/user/services/user/user.service.spec.ts
@@ -1,6 +1,7 @@
 import "@test/mocks/logger-service.mock";
 
 import { faker } from "@faker-js/faker";
+import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { Auth0Service } from "@src/auth/services/auth0/auth0.service";

--- a/apps/api/src/utils/array/array.spec.ts
+++ b/apps/api/src/utils/array/array.spec.ts
@@ -1,4 +1,5 @@
 import { setTimeout as wait } from "node:timers/promises";
+import { describe, expect, it, vi } from "vitest";
 
 import { createFilterUnique, forEachInChunks } from "./array";
 
@@ -22,7 +23,7 @@ describe("array helpers", () => {
   describe(forEachInChunks.name, () => {
     it("iterates over the array in chunks with specified time limit per chunk", async () => {
       const array = Array.from({ length: 100_000 }, (_, i) => i);
-      const anotherTask = jest.fn();
+      const anotherTask = vi.fn();
       let currentIndex = 0;
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/apps/api/src/utils/date/date.spec.ts
+++ b/apps/api/src/utils/date/date.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import { getPrettyTime, getTodayUTC, toUTC } from "./date";
 
 describe("date helpers", () => {

--- a/apps/api/test/functional/addresses.spec.ts
+++ b/apps/api/test/functional/addresses.spec.ts
@@ -3,6 +3,7 @@ import { AddressReference, Day, Transaction, Validator } from "@akashnetwork/dat
 import { faker } from "@faker-js/faker";
 import nock from "nock";
 import { container } from "tsyringe";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 
 import type { GetAddressTransactionsResponse } from "@src/address/http-schemas/address.schema";
 import { CORE_CONFIG } from "@src/core";
@@ -38,7 +39,7 @@ describe("Addresses API", () => {
   });
 
   afterAll(async () => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     nock.cleanAll();
   });
 

--- a/apps/api/test/functional/auditors.spec.ts
+++ b/apps/api/test/functional/auditors.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import type { AuditorListResponse } from "@src/provider/http-schemas/auditor.schema";
 import { app } from "@src/rest-app";
 

--- a/apps/api/test/functional/blocks.spec.ts
+++ b/apps/api/test/functional/blocks.spec.ts
@@ -1,5 +1,6 @@
 import type { AkashBlock } from "@akashnetwork/database/dbSchemas/akash";
 import { addMinutes, addSeconds, getUnixTime, subSeconds } from "date-fns";
+import { describe, expect, it } from "vitest";
 
 import { app, initDb } from "@src/rest-app";
 

--- a/apps/api/test/functional/dashboard-data.spec.ts
+++ b/apps/api/test/functional/dashboard-data.spec.ts
@@ -1,5 +1,6 @@
 import type { AkashBlock, Provider, ProviderSnapshot } from "@akashnetwork/database/dbSchemas/akash";
 import { subHours } from "date-fns";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { app, initDb } from "@src/rest-app";
 

--- a/apps/api/test/functional/deployment-fallback.spec.ts
+++ b/apps/api/test/functional/deployment-fallback.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import { app, initDb } from "@src/rest-app";
 import type { RestAkashDeploymentListResponse } from "@src/types/rest/akashDeploymentListResponse";
 import { deploymentVersion } from "@src/utils/constants";

--- a/apps/api/test/functional/deployment-info-fallback.spec.ts
+++ b/apps/api/test/functional/deployment-info-fallback.spec.ts
@@ -1,6 +1,7 @@
 import type { Deployment } from "@akashnetwork/database/dbSchemas/akash";
 import type { DeploymentGroup } from "@akashnetwork/database/dbSchemas/akash";
 import type { DeploymentGroupResource } from "@akashnetwork/database/dbSchemas/akash";
+import { describe, expect, it } from "vitest";
 
 import { app, initDb } from "@src/rest-app";
 import type { RestAkashDeploymentInfoResponse } from "@src/types/rest/akashDeploymentInfoResponse";

--- a/apps/api/test/functional/deployments.spec.ts
+++ b/apps/api/test/functional/deployments.spec.ts
@@ -5,6 +5,7 @@ import nock from "nock";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { container } from "tsyringe";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ApiKeyOutput } from "@src/auth/repositories/api-key/api-key.repository";
 import { ApiKeyAuthService } from "@src/auth/services/api-key/api-key-auth.service";
@@ -51,7 +52,7 @@ describe("Deployments API", () => {
     allWallets = [];
     currentHeight = faker.number.int({ min: 1000000, max: 10000000 });
 
-    jest.spyOn(userRepository, "findById").mockImplementation(async (id: string) => {
+    vi.spyOn(userRepository, "findById").mockImplementation(async (id: string) => {
       return Promise.resolve(
         knownUsers[id]
           ? {
@@ -63,13 +64,13 @@ describe("Deployments API", () => {
       );
     });
 
-    jest.spyOn(apiKeyAuthService, "getAndValidateApiKeyFromHeader").mockImplementation(async (key: string | undefined) => {
+    vi.spyOn(apiKeyAuthService, "getAndValidateApiKeyFromHeader").mockImplementation(async (key: string | undefined) => {
       return knownApiKeys[key!];
     });
 
-    jest.spyOn(blockHttpService, "getCurrentHeight").mockResolvedValue(currentHeight);
+    vi.spyOn(blockHttpService, "getCurrentHeight").mockResolvedValue(currentHeight);
 
-    jest.spyOn(userWalletRepository, "findOneBy").mockImplementation(async (query: Partial<UserWalletOutput> | undefined) => {
+    vi.spyOn(userWalletRepository, "findOneBy").mockImplementation(async (query: Partial<UserWalletOutput> | undefined) => {
       return Promise.resolve(allWallets.find(wallet => wallet.address === query?.address));
     });
 
@@ -85,27 +86,27 @@ describe("Deployments API", () => {
       }
     } as unknown as UserWalletRepository;
 
-    jest.spyOn(userWalletRepository, "accessibleBy").mockReturnValue(fakeWalletRepository);
+    vi.spyOn(userWalletRepository, "accessibleBy").mockReturnValue(fakeWalletRepository);
 
-    jest.spyOn(signerService, "executeDerivedDecodedTxByUserId").mockResolvedValue({
+    vi.spyOn(signerService, "executeDerivedDecodedTxByUserId").mockResolvedValue({
       code: 200,
       transactionHash: "fake-transaction-hash",
       hash: "fake-transaction-hash",
       rawLog: "fake-raw-log"
     });
 
-    jest.spyOn(providerService, "sendManifest").mockResolvedValue(true);
-    jest.spyOn(providerService, "getLeaseStatus").mockResolvedValue(createLeaseStatus());
+    vi.spyOn(providerService, "sendManifest").mockResolvedValue(true);
+    vi.spyOn(providerService, "getLeaseStatus").mockResolvedValue(createLeaseStatus());
   });
 
   afterEach(async () => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     nock.cleanAll();
   });
 
   afterAll(async () => {
     await container.dispose();
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     nock.cleanAll();
   });
 
@@ -573,7 +574,7 @@ describe("Deployments API", () => {
         rawLog: "success"
       };
 
-      jest.spyOn(signerService, "executeDecodedTxByUserWallet").mockResolvedValueOnce(mockTxResult);
+      vi.spyOn(signerService, "executeDecodedTxByUserWallet").mockResolvedValueOnce(mockTxResult);
 
       const response = await app.request(`/v1/deployments/${dseq}`, {
         method: "DELETE",
@@ -593,7 +594,7 @@ describe("Deployments API", () => {
       const { userApiKeySecret } = await mockUser();
       const dseq = "1234";
 
-      jest.spyOn(deploymentReaderService, "findByWalletAndDseq").mockRejectedValueOnce(new NotFound("Deployment not found"));
+      vi.spyOn(deploymentReaderService, "findByWalletAndDseq").mockRejectedValueOnce(new NotFound("Deployment not found"));
 
       const response = await app.request(`/v1/deployments/${dseq}`, {
         method: "DELETE",
@@ -680,7 +681,7 @@ describe("Deployments API", () => {
         rawLog: "success"
       };
 
-      jest.spyOn(signerService, "executeDerivedDecodedTxByUserId").mockResolvedValueOnce(mockTxResult);
+      vi.spyOn(signerService, "executeDerivedDecodedTxByUserId").mockResolvedValueOnce(mockTxResult);
 
       const response = await app.request(`/v1/deposit-deployment`, {
         method: "POST",
@@ -700,7 +701,7 @@ describe("Deployments API", () => {
       const { userApiKeySecret } = await mockUser();
       const dseq = "1234";
 
-      jest.spyOn(deploymentReaderService, "findByWalletAndDseq").mockRejectedValueOnce(new NotFound("Deployment not found"));
+      vi.spyOn(deploymentReaderService, "findByWalletAndDseq").mockRejectedValueOnce(new NotFound("Deployment not found"));
 
       const response = await app.request(`/v1/deposit-deployment`, {
         method: "POST",
@@ -776,7 +777,7 @@ describe("Deployments API", () => {
         rawLog: "success"
       };
 
-      jest.spyOn(signerService, "executeDerivedDecodedTxByUserId").mockResolvedValueOnce(mockTxResult);
+      vi.spyOn(signerService, "executeDerivedDecodedTxByUserId").mockResolvedValueOnce(mockTxResult);
 
       const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8");
 
@@ -803,7 +804,7 @@ describe("Deployments API", () => {
       const { userApiKeySecret } = await mockUser();
       const dseq = "1234";
 
-      jest.spyOn(deploymentReaderService, "findByWalletAndDseq").mockRejectedValueOnce(new NotFound("Deployment not found"));
+      vi.spyOn(deploymentReaderService, "findByWalletAndDseq").mockRejectedValueOnce(new NotFound("Deployment not found"));
 
       const yml = fs.readFileSync(path.resolve(__dirname, "../mocks/hello-world-sdl.yml"), "utf8");
 

--- a/apps/api/test/functional/docs.spec.ts
+++ b/apps/api/test/functional/docs.spec.ts
@@ -1,10 +1,12 @@
+import { describe, expect, it, vi } from "vitest";
+
 import { app } from "@src/rest-app";
 
 describe("API Docs", () => {
   describe("GET /v1/doc", () => {
     it(`returns docs with all routes expected`, async () => {
-      jest.useFakeTimers();
-      jest.setSystemTime(new Date("2025-07-03T12:00:00.000Z"));
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2025-07-03T12:00:00.000Z"));
 
       const response = await app.request(`/v1/doc?scope=console`);
 
@@ -12,7 +14,7 @@ describe("API Docs", () => {
       const data = await response.json();
       expect(data).toMatchSnapshot();
 
-      jest.useRealTimers();
+      vi.useRealTimers();
     });
   });
 });

--- a/apps/api/test/functional/gpu.spec.ts
+++ b/apps/api/test/functional/gpu.spec.ts
@@ -6,6 +6,7 @@ import type { ProviderSnapshot, ProviderSnapshotNode } from "@akashnetwork/datab
 import type { Day, Transaction } from "@akashnetwork/database/dbSchemas/base";
 import { faker } from "@faker-js/faker";
 import nock from "nock";
+import { afterAll, describe, expect, it } from "vitest";
 
 import type { ListGpuResponse } from "@src/gpu/http-schemas/gpu.schema";
 import { app, initDb } from "@src/rest-app";

--- a/apps/api/test/functional/graph-data.spec.ts
+++ b/apps/api/test/functional/graph-data.spec.ts
@@ -1,6 +1,7 @@
 import type { Provider, ProviderSnapshot } from "@akashnetwork/database/dbSchemas/akash";
 import { subDays } from "date-fns";
 import { container } from "tsyringe";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { AuthorizedGraphDataNames } from "@src/dashboard/services/stats/stats.types";
 import { app, initDb } from "@src/rest-app";

--- a/apps/api/test/functional/lease-fallback.spec.ts
+++ b/apps/api/test/functional/lease-fallback.spec.ts
@@ -1,4 +1,5 @@
 import { subDays } from "date-fns";
+import { describe, expect, it } from "vitest";
 
 import type { FallbackLeaseListResponse } from "@src/deployment/http-schemas/lease-rpc.schema";
 import { app, initDb } from "@src/rest-app";

--- a/apps/api/test/functional/leases-duration.spec.ts
+++ b/apps/api/test/functional/leases-duration.spec.ts
@@ -1,5 +1,6 @@
 import type { AkashBlock, Deployment, DeploymentGroup, Provider } from "@akashnetwork/database/dbSchemas/akash";
 import { faker } from "@faker-js/faker";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { app, initDb } from "@src/rest-app";
 

--- a/apps/api/test/functional/market-data.spec.ts
+++ b/apps/api/test/functional/market-data.spec.ts
@@ -1,5 +1,6 @@
 import nock from "nock";
 import { container } from "tsyringe";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { CORE_CONFIG } from "@src/core";
 import { app } from "@src/rest-app";

--- a/apps/api/test/functional/network-capacity.spec.ts
+++ b/apps/api/test/functional/network-capacity.spec.ts
@@ -1,6 +1,7 @@
 import type { Provider, ProviderSnapshot } from "@akashnetwork/database/dbSchemas/akash";
 import { subHours } from "date-fns";
 import { container } from "tsyringe";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { app, initDb } from "@src/rest-app";
 

--- a/apps/api/test/functional/proposals.spec.ts
+++ b/apps/api/test/functional/proposals.spec.ts
@@ -1,5 +1,6 @@
 import nock from "nock";
 import { container } from "tsyringe";
+import { afterAll, describe, expect, it } from "vitest";
 
 import { CORE_CONFIG } from "@src/core";
 import type { GetProposalByIdResponse, GetProposalListResponse } from "@src/proposal/http-schemas/proposal.schema";

--- a/apps/api/test/functional/provider-deployments.spec.ts
+++ b/apps/api/test/functional/provider-deployments.spec.ts
@@ -2,6 +2,7 @@ import type { Deployment, Provider } from "@akashnetwork/database/dbSchemas/akas
 import map from "lodash/map";
 import nock from "nock";
 import { container } from "tsyringe";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { cacheEngine } from "@src/caching/helpers";
 import { app, initDb } from "@src/rest-app";

--- a/apps/api/test/functional/provider-earnings.spec.ts
+++ b/apps/api/test/functional/provider-earnings.spec.ts
@@ -2,6 +2,7 @@ import type { Provider } from "@akashnetwork/database/dbSchemas/akash";
 import { subDays } from "date-fns";
 import nock from "nock";
 import { container } from "tsyringe";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import { cacheEngine } from "@src/caching/helpers";
 import type { ProviderEarningsResponse } from "@src/provider/http-schemas/provider-earnings.schema";

--- a/apps/api/test/functional/provider-graph-data.spec.ts
+++ b/apps/api/test/functional/provider-graph-data.spec.ts
@@ -1,6 +1,7 @@
 import type { Provider, ProviderSnapshot } from "@akashnetwork/database/dbSchemas/akash";
 import { subDays } from "date-fns";
 import { container } from "tsyringe";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 import { app, initDb } from "@src/rest-app";
 
@@ -246,8 +247,8 @@ describe("Provider Graph Data", () => {
       const testYesterday = subDays(today, 1);
 
       // Mock the current time to match the snapshot time
-      jest.useFakeTimers({ doNotFake: ["nextTick", "setImmediate"] });
-      jest.setSystemTime(today);
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval", "Date"] });
+      vi.setSystemTime(today);
 
       try {
         await createProviderSnapshot({
@@ -292,7 +293,7 @@ describe("Provider Graph Data", () => {
         expect(data.snapshots[data.snapshots.length - 1].date).toBe(formatUTCDate(testYesterday) + "T00:00:00.000Z");
       } finally {
         // Restore real timers
-        jest.useRealTimers();
+        vi.useRealTimers();
       }
     });
   });

--- a/apps/api/test/functional/providers.spec.ts
+++ b/apps/api/test/functional/providers.spec.ts
@@ -4,6 +4,7 @@ import subDays from "date-fns/subDays";
 import map from "lodash/map";
 import nock from "nock";
 import { container } from "tsyringe";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import { cacheEngine } from "@src/caching/helpers";
 import { AUDITOR, TRIAL_ATTRIBUTE } from "@src/deployment/config/provider.config";

--- a/apps/api/test/functional/templates.spec.ts
+++ b/apps/api/test/functional/templates.spec.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from "vitest";
+
 import { app, initDb } from "@src/rest-app";
 
 describe("Templates", () => {

--- a/apps/api/test/functional/usage.spec.ts
+++ b/apps/api/test/functional/usage.spec.ts
@@ -1,4 +1,5 @@
 import { subDays } from "date-fns";
+import { describe, expect, it } from "vitest";
 
 import type { UsageHistoryResponse, UsageHistoryStats } from "@src/billing/http-schemas/usage.schema";
 import { app, initDb } from "@src/rest-app";

--- a/apps/api/test/functional/validators.spec.ts
+++ b/apps/api/test/functional/validators.spec.ts
@@ -1,6 +1,7 @@
 import type { Validator } from "@akashnetwork/database/dbSchemas/base";
 import nock from "nock";
 import { container } from "tsyringe";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { CORE_CONFIG } from "@src/core";
 import { app, initDb } from "@src/rest-app";

--- a/apps/api/test/mocks/config-service.mock.ts
+++ b/apps/api/test/mocks/config-service.mock.ts
@@ -1,3 +1,4 @@
+import type { MockedFunction } from "vitest";
 import type { MockProxy } from "vitest-mock-extended";
 import { mock } from "vitest-mock-extended";
 import type { z } from "zod";
@@ -16,7 +17,7 @@ type ConfigOf<T> = EnvOf<T> & AppCfgOf<T>;
 export const mockConfigService = <T extends ConfigService<any, any>>(values: Partial<ConfigOf<T>> = {}): MockProxy<T> => {
   const svc = mock<T>();
 
-  (svc.get as unknown as jest.MockedFunction<(key: keyof ConfigOf<T>) => any>).mockImplementation(key => {
+  (svc.get as unknown as MockedFunction<(key: keyof ConfigOf<T>) => any>).mockImplementation(key => {
     if (key in values) return (values as ConfigOf<T>)[key];
     throw new Error(`Missing mock for config key "${String(key)}" in ${svc.constructor?.name ?? "ConfigService"}`);
   });

--- a/apps/api/test/services/mock-config.service.ts
+++ b/apps/api/test/services/mock-config.service.ts
@@ -1,3 +1,4 @@
+import type { MockedFunction } from "vitest";
 import { mock, type MockProxy } from "vitest-mock-extended";
 import type { z, ZodEffects, ZodObject, ZodRawShape } from "zod";
 
@@ -10,7 +11,7 @@ type ConfigOf<S> = S extends ConfigService<infer E extends EnvLike, infer C exte
 export function mockConfig<S extends ConfigService<EnvLike, Record<string, unknown>>>(config: Partial<ConfigOf<S>>): MockProxy<S> {
   const svc = mock<S>();
   type K = keyof ConfigOf<S>;
-  const getMock = svc.get as unknown as jest.MockedFunction<(key: K) => ConfigOf<S>[K]>;
+  const getMock = svc.get as unknown as MockedFunction<(key: K) => ConfigOf<S>[K]>;
   getMock.mockImplementation(key => config[key] as ConfigOf<S>[typeof key]);
 
   return svc;

--- a/apps/api/test/services/wallet-testing.service.ts
+++ b/apps/api/test/services/wallet-testing.service.ts
@@ -2,6 +2,7 @@ import { faker } from "@faker-js/faker";
 import type { Hono } from "hono";
 import { decode } from "jsonwebtoken";
 import { container } from "tsyringe";
+import { vi } from "vitest";
 
 import { AbilityService } from "@src/auth/services/ability/ability.service";
 import { AuthService } from "@src/auth/services/auth.service";
@@ -29,7 +30,7 @@ export class WalletTestingService<T extends Hono<any>> {
   }
 
   private async createWallet(user: UserOutput) {
-    jest.spyOn(container.resolve(DomainEventsService), "publish").mockResolvedValue(null);
+    vi.spyOn(container.resolve(DomainEventsService), "publish").mockResolvedValue(null);
 
     return container.resolve(ExecutionContextService).runWithContext(async () => {
       container.resolve(AuthService).currentUser = user;
@@ -115,7 +116,7 @@ export class WalletTestingService<T extends Hono<any>> {
 
     const decoded = decode(access_token) as { sub: string; email: string; nickname: string; email_verified: boolean };
 
-    jest.spyOn(container.resolve(NotificationService), "createDefaultChannel").mockResolvedValue(undefined);
+    vi.spyOn(container.resolve(NotificationService), "createDefaultChannel").mockResolvedValue(undefined);
     const userResponse = await this.app.request(`/v1/register-user`, {
       method: "POST",
       headers: new Headers({

--- a/apps/api/test/setup-functional-tests.ts
+++ b/apps/api/test/setup-functional-tests.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 
 import { container } from "tsyringe";
+import { afterAll, afterEach, beforeAll, beforeEach, expect } from "vitest";
 
 import { cacheEngine } from "@src/caching/helpers";
 import { RAW_APP_CONFIG } from "@src/core/providers/raw-app-config.provider";

--- a/apps/api/test/setup-integration-tests.ts
+++ b/apps/api/test/setup-integration-tests.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 
 import { container } from "tsyringe";
+import { afterAll, afterEach, beforeAll, beforeEach, expect } from "vitest";
 
 import { cacheEngine } from "@src/caching/helpers";
 import { TestDatabaseService } from "./services/test-database.service";

--- a/apps/api/test/setup-unit-tests.ts
+++ b/apps/api/test/setup-unit-tests.ts
@@ -1,6 +1,7 @@
 import "reflect-metadata";
 
 import { container } from "tsyringe";
+import { afterAll } from "vitest";
 
 afterAll(async () => {
   try {

--- a/apps/api/test/vitest-jest-compat.ts
+++ b/apps/api/test/vitest-jest-compat.ts
@@ -1,5 +1,0 @@
-import { vi } from "vitest";
-
-// temporary compat layer to reduce changes
-/** @deprecated Use Vitest APIs directly instead of Jest */
-globalThis.jest = vi as any;

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -31,7 +31,7 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    globals: true,
+    globals: false,
     outputFile: {
       junit: "junit.xml"
     },
@@ -62,7 +62,7 @@ export default defineConfig({
         test: {
           name: "unit",
           include: ["src/**/*.spec.ts"],
-          setupFiles: ["./test/vitest-jest-compat.ts", "./test/setup-unit-env.ts", "./test/setup-unit-tests.ts"]
+          setupFiles: ["./test/setup-unit-env.ts", "./test/setup-unit-tests.ts"]
         }
       },
       {
@@ -70,7 +70,7 @@ export default defineConfig({
         test: {
           name: "integration",
           include: ["src/**/*.integration.ts"],
-          setupFiles: ["./test/vitest-jest-compat.ts", "./test/setup-integration-env.ts", "./test/setup-integration-tests.ts"],
+          setupFiles: ["./test/setup-integration-env.ts", "./test/setup-integration-tests.ts"],
           testTimeout: 60_000,
           hookTimeout: 30_000
         }
@@ -80,7 +80,7 @@ export default defineConfig({
         test: {
           name: "functional",
           include: ["test/functional/**/*.spec.ts"],
-          setupFiles: ["./test/vitest-jest-compat.ts", "./test/setup-functional-env.ts", "./test/setup-functional-tests.ts"],
+          setupFiles: ["./test/setup-functional-env.ts", "./test/setup-functional-tests.ts"],
           testTimeout: 30_000,
           hookTimeout: 15_000,
           pool: "threads",
@@ -92,7 +92,7 @@ export default defineConfig({
         test: {
           name: "e2e",
           include: ["test/e2e/**/*.spec.ts"],
-          setupFiles: ["./test/vitest-jest-compat.ts", "./test/setup-e2e-env.ts"]
+          setupFiles: ["./test/setup-e2e-env.ts"]
         }
       }
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,6 @@
         "@types/blocked-at": "^1.0.4",
         "@types/http-assert": "^1.5.5",
         "@types/http-errors": "^2.0.4",
-        "@types/jest": "^29.5.12",
         "@types/js-yaml": "^4.0.9",
         "@types/jsonwebtoken": "^9.0.6",
         "@types/lodash": "^4.17.0",
@@ -21176,15 +21175,6 @@
         "@types/istanbul-lib-report": "*"
       }
     },
-    "node_modules/@types/jest": {
-      "version": "29.5.14",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "expect": "^29.0.0",
-        "pretty-format": "^29.0.0"
-      }
-    },
     "node_modules/@types/js-yaml": {
       "version": "4.0.9",
       "license": "MIT"
@@ -21337,7 +21327,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-8yQrvS6sMpSwIovhPOwfyNf2Wz6v/B62LFSVYQ85+Rq3tLsBIG7rP5geMxaijTUxSkrO6RzN/IRuIAADYQsleA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }


### PR DESCRIPTION
## Why

consistency and remove confusion

## What

Replace remaining jest APIs with vitest equivalents, add explicit vitest imports across api test files now that globals is set to false, and remove the vitest-jest-compat shim and the @types/jest dependency.
