### PR TITLE
feat(deployment): show deployment cost in the configure header

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -169,7 +169,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, intent, depende
       <d.NextSeo title="Configure your deployment" />
       <FormProvider {...form}>
         <div className="px-6 pt-6">
-          <d.ConfigureDeploymentHeader flow={flow} onDeploy={() => setReviewOpen(true)} allPlacementsHaveBids={allPlacementsHaveBids} />
+          <d.ConfigureDeploymentHeader flow={flow} sdl={liveSdl} onDeploy={() => setReviewOpen(true)} allPlacementsHaveBids={allPlacementsHaveBids} />
         </div>
         <div className="relative mt-6 flex min-h-0 flex-1">
           <d.ConfigureDeploymentPanes

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.spec.tsx
@@ -4,6 +4,7 @@ import { Snackbar } from "@akashnetwork/ui/components";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import type { DeploymentCost } from "../useDeploymentCost/useDeploymentCost";
 import type { DeploymentFlow, DeploymentFlowActions } from "../useDeploymentFlow/useDeploymentFlow";
 import type { DEPENDENCIES } from "./ConfigureDeploymentHeader";
 import { ConfigureDeploymentHeader } from "./ConfigureDeploymentHeader";
@@ -100,6 +101,35 @@ describe(ConfigureDeploymentHeader.name, () => {
     expect(deploy).toHaveBeenCalled();
   });
 
+  it("shows a dash for the cost before any bids arrive", () => {
+    setup({ phase: "quoting", cost: null });
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.queryByTestId("price")).not.toBeInTheDocument();
+    expect(screen.queryByText("/hr")).not.toBeInTheDocument();
+  });
+
+  it("shows a single hourly price when the cost bounds are equal", () => {
+    setup({ phase: "quoting", cost: { minPerBlock: 5, maxPerBlock: 5, denom: "uakt" } });
+    expect(screen.getAllByTestId("price")).toHaveLength(1);
+    expect(screen.getByText("/hr")).toBeInTheDocument();
+  });
+
+  it("shows a min–max range when the cost bounds differ", () => {
+    setup({ phase: "quoting", cost: { minPerBlock: 5, maxPerBlock: 8, denom: "uakt" } });
+    expect(screen.getAllByTestId("price")).toHaveLength(2);
+    expect(screen.getByText("/hr")).toBeInTheDocument();
+  });
+
+  it("passes the sdl and current selections through to the cost hook", () => {
+    const { useDeploymentCost } = setup({
+      phase: "quoting",
+      sdl: "the-sdl",
+      selections: { p1: "akash1a/1/1/1" },
+      placements: [{ id: "p1" }]
+    });
+    expect(useDeploymentCost).toHaveBeenCalledWith(expect.objectContaining({ sdl: "the-sdl", selections: { p1: "akash1a/1/1/1" } }));
+  });
+
   function setup(input: {
     phase: DeploymentFlow["phase"];
     requestQuotes?: (sdl: string) => void;
@@ -110,6 +140,8 @@ describe(ConfigureDeploymentHeader.name, () => {
     allPlacementsHaveBids?: boolean;
     deployError?: { message?: string };
     deploy?: () => void;
+    cost?: DeploymentCost | null;
+    sdl?: string;
   }) {
     const flow = mock<DeploymentFlow>({
       phase: input.phase,
@@ -119,24 +151,28 @@ describe(ConfigureDeploymentHeader.name, () => {
     });
     flow.selections = input.selections ?? {};
     const enqueueSnackbar = vi.fn();
+    const useDeploymentCost = vi.fn(() => input.cost ?? null);
     const dependencies: typeof DEPENDENCIES = {
       useDeploymentResourceSummary: (() => "1 vCPU") as never,
       useSnackbar: () => mock<ReturnType<(typeof DEPENDENCIES)["useSnackbar"]>>({ enqueueSnackbar }),
       Snackbar,
       generateSdl: () => GENERATED_SDL,
-      validateGeneratedSdl: () => input.validationErrors ?? []
+      validateGeneratedSdl: () => input.validationErrors ?? [],
+      useDeploymentCost: useDeploymentCost as typeof DEPENDENCIES.useDeploymentCost,
+      PriceValue: ({ value }) => <span data-testid="price">{String(value)}</span>
     };
     render(
       <Wrapper placements={input.placements}>
         <ConfigureDeploymentHeader
           flow={flow}
+          sdl={input.sdl ?? ""}
           onDeploy={input.onDeploy ?? vi.fn()}
           allPlacementsHaveBids={input.allPlacementsHaveBids ?? false}
           dependencies={dependencies}
         />
       </Wrapper>
     );
-    return { enqueueSnackbar };
+    return { enqueueSnackbar, useDeploymentCost };
   }
 
   function Wrapper({ children, placements }: { children: ReactNode; placements?: { id: string }[] }) {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
@@ -1,25 +1,30 @@
-import type { FC } from "react";
+import type { FC, ReactNode } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { Button, Snackbar } from "@akashnetwork/ui/components";
 import { Send } from "iconoir-react";
 import { LoaderCircle } from "lucide-react";
 import { useSnackbar } from "notistack";
 
+import { PriceValue } from "@src/components/shared/PriceValue";
 import type { SdlBuilderFormValuesType } from "@src/types";
+import { perBlockToHourly } from "@src/utils/priceUtils";
 import { generateSdl } from "@src/utils/sdl/sdlGenerator";
 import { validateGeneratedSdl } from "@src/utils/sdl/validateGeneratedSdl";
 import { useDeploymentResourceSummary } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
+import type { DeploymentCost } from "../useDeploymentCost/useDeploymentCost";
+import { useDeploymentCost } from "../useDeploymentCost/useDeploymentCost";
 import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
 
-export const DEPENDENCIES = { useDeploymentResourceSummary, useSnackbar, Snackbar, generateSdl, validateGeneratedSdl };
+export const DEPENDENCIES = { useDeploymentResourceSummary, useSnackbar, Snackbar, generateSdl, validateGeneratedSdl, useDeploymentCost, PriceValue };
 
-type Props = { flow: DeploymentFlow; onDeploy: () => void; allPlacementsHaveBids: boolean; dependencies?: typeof DEPENDENCIES };
+type Props = { flow: DeploymentFlow; sdl: string; onDeploy: () => void; allPlacementsHaveBids: boolean; dependencies?: typeof DEPENDENCIES };
 
-export const ConfigureDeploymentHeader: FC<Props> = ({ flow, onDeploy, allPlacementsHaveBids, dependencies: d = DEPENDENCIES }) => {
+export const ConfigureDeploymentHeader: FC<Props> = ({ flow, sdl, onDeploy, allPlacementsHaveBids, dependencies: d = DEPENDENCIES }) => {
   const deploymentSummary = d.useDeploymentResourceSummary();
   const { control, handleSubmit, getValues } = useFormContext<SdlBuilderFormValuesType>();
   const { enqueueSnackbar } = d.useSnackbar();
   const placements = useWatch({ control, name: "placements" });
+  const cost = d.useDeploymentCost({ dseq: flow.dseq, sdl, placements, selections: flow.selections });
 
   const isEditable = flow.phase === "configuring" || flow.phase === "error";
   /** Deploy only takes over from the loading CTA once every placement has bids; until then quoting still reads as "Requesting…". */
@@ -71,7 +76,7 @@ export const ConfigureDeploymentHeader: FC<Props> = ({ flow, onDeploy, allPlacem
       <div className="flex shrink-0 items-center gap-3 md:gap-6">
         <DeploymentSummaryBlock label="Your deployment" value={deploymentSummary} />
         <div className="hidden h-12 w-px self-stretch bg-border md:block" aria-hidden="true" />
-        <DeploymentSummaryBlock label="Cost" value="—" suffix="/hr" />
+        <DeploymentSummaryBlock label="Deployment cost" value={<CostValue cost={cost} PriceValue={d.PriceValue} />} suffix={cost ? "/hr" : undefined} />
         {isEditable ? (
           <Button type="button" onClick={onRequestQuotes} className="h-9 shrink-0 px-3 md:h-10 md:px-8">
             <Send className="h-4 w-4 md:hidden" aria-label="Request quotes" />
@@ -100,7 +105,7 @@ export const ConfigureDeploymentHeader: FC<Props> = ({ flow, onDeploy, allPlacem
 
 interface DeploymentSummaryBlockProps {
   label: string;
-  value: string;
+  value: ReactNode;
   suffix?: string;
 }
 
@@ -113,5 +118,24 @@ function DeploymentSummaryBlock({ label, value, suffix }: DeploymentSummaryBlock
         {suffix ? <span className="font-mono text-xs text-muted-foreground md:text-base">{suffix}</span> : null}
       </div>
     </div>
+  );
+}
+
+interface CostValueProps {
+  cost: DeploymentCost | null;
+  PriceValue: typeof DEPENDENCIES.PriceValue;
+}
+
+/** The header cost value: a dash before bids, a single hourly USD price when the bounds are equal, otherwise a min–max range. */
+function CostValue({ cost, PriceValue }: CostValueProps) {
+  if (!cost) return <>—</>;
+  if (cost.minPerBlock === cost.maxPerBlock) {
+    return <PriceValue denom={cost.denom} value={perBlockToHourly(cost.minPerBlock)} />;
+  }
+  return (
+    <>
+      <PriceValue denom={cost.denom} value={perBlockToHourly(cost.minPerBlock)} /> -{" "}
+      <PriceValue denom={cost.denom} value={perBlockToHourly(cost.maxPerBlock)} />
+    </>
   );
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentCost/useDeploymentCost.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentCost/useDeploymentCost.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DEPENDENCIES } from "./useDeploymentCost";
+import { useDeploymentCost } from "./useDeploymentCost";
+
+import { renderHook } from "@testing-library/react";
+
+type BidEntry = NonNullable<ReturnType<typeof DEPENDENCIES.useListBids>["data"]>["data"][number];
+
+/** A `listBids` entry; `amount` of "1000000" is 1.0 per block at PRICE_DISPLAY_PRECISION. */
+function bidEntry(input: { provider: string; gseq: number; oseq: number; amount: string; denom?: string; state?: string }): BidEntry {
+  return mock<BidEntry>({
+    bid: {
+      id: { provider: input.provider, dseq: "55", gseq: input.gseq, oseq: input.oseq },
+      price: { amount: input.amount, denom: input.denom ?? "uakt" },
+      state: input.state ?? "open"
+    }
+  });
+}
+
+describe("useDeploymentCost", () => {
+  it("returns null before any open bid exists", () => {
+    const { result } = setup({ placements: [{ id: "p1", name: "placement-1" }], bids: [] });
+    expect(result.current).toBeNull();
+  });
+
+  it("returns null when the only bids are not open", () => {
+    const { result } = setup({
+      placements: [{ id: "p1", name: "placement-1" }],
+      bids: [bidEntry({ provider: "a", gseq: 1, oseq: 1, amount: "1000000", state: "closed" })]
+    });
+    expect(result.current).toBeNull();
+  });
+
+  it("ranges over an unselected placement's open bids (cheapest..priciest)", () => {
+    const { result } = setup({
+      placements: [{ id: "p1", name: "placement-1" }],
+      bids: [
+        bidEntry({ provider: "a", gseq: 1, oseq: 1, amount: "1000000" }),
+        bidEntry({ provider: "b", gseq: 1, oseq: 1, amount: "3000000" })
+      ]
+    });
+    expect(result.current).toEqual({ minPerBlock: 1, maxPerBlock: 3, denom: "uakt" });
+  });
+
+  it("ignores non-open bids when computing the range", () => {
+    const { result } = setup({
+      placements: [{ id: "p1", name: "placement-1" }],
+      bids: [
+        bidEntry({ provider: "a", gseq: 1, oseq: 1, amount: "2000000" }),
+        bidEntry({ provider: "b", gseq: 1, oseq: 1, amount: "9000000", state: "closed" })
+      ]
+    });
+    expect(result.current).toEqual({ minPerBlock: 2, maxPerBlock: 2, denom: "uakt" });
+  });
+
+  it("fixes a placement's contribution to its selected bid, ignoring other bids", () => {
+    const { result } = setup({
+      placements: [{ id: "p1", name: "placement-1" }],
+      selections: { p1: "b/55/1/1" },
+      bids: [
+        bidEntry({ provider: "a", gseq: 1, oseq: 1, amount: "1000000" }),
+        bidEntry({ provider: "b", gseq: 1, oseq: 1, amount: "3000000" })
+      ]
+    });
+    expect(result.current).toEqual({ minPerBlock: 3, maxPerBlock: 3, denom: "uakt" });
+  });
+
+  it("falls back to the open range when the selected bid is no longer open", () => {
+    const { result } = setup({
+      placements: [{ id: "p1", name: "placement-1" }],
+      selections: { p1: "b/55/1/1" },
+      bids: [
+        bidEntry({ provider: "a", gseq: 1, oseq: 1, amount: "2000000" }),
+        bidEntry({ provider: "b", gseq: 1, oseq: 1, amount: "5000000", state: "closed" })
+      ]
+    });
+    expect(result.current).toEqual({ minPerBlock: 2, maxPerBlock: 2, denom: "uakt" });
+  });
+
+  it("sums a fixed selected placement with an unselected ranged placement", () => {
+    const { result } = setup({
+      placements: [
+        { id: "p1", name: "placement-1" },
+        { id: "p2", name: "placement-2" }
+      ],
+      selections: { p1: "a/55/1/1" },
+      gseqByName: { "placement-1": 1, "placement-2": 2 },
+      bids: [
+        bidEntry({ provider: "a", gseq: 1, oseq: 1, amount: "1000000" }),
+        bidEntry({ provider: "c", gseq: 2, oseq: 1, amount: "2000000" }),
+        bidEntry({ provider: "d", gseq: 2, oseq: 1, amount: "5000000" })
+      ]
+    });
+    expect(result.current).toEqual({ minPerBlock: 3, maxPerBlock: 6, denom: "uakt" });
+  });
+
+  it("treats a placement with no bids yet as a 0/0 contribution (progressive total)", () => {
+    const { result } = setup({
+      placements: [
+        { id: "p1", name: "placement-1" },
+        { id: "p2", name: "placement-2" }
+      ],
+      gseqByName: { "placement-1": 1, "placement-2": 2 },
+      bids: [bidEntry({ provider: "a", gseq: 1, oseq: 1, amount: "4000000" })]
+    });
+    expect(result.current).toEqual({ minPerBlock: 4, maxPerBlock: 4, denom: "uakt" });
+  });
+
+  function setup(input: {
+    placements: Array<{ id?: string; name: string }>;
+    selections?: Record<string, string>;
+    bids: BidEntry[];
+    gseqByName?: Record<string, number | undefined>;
+  }) {
+    const dependencies: typeof DEPENDENCIES = {
+      useListBids: () => mock<ReturnType<typeof DEPENDENCIES.useListBids>>({ data: { data: input.bids } }),
+      getPlacementGseq: (_sdl: string, name: string) => (input.gseqByName ? input.gseqByName[name] : 1)
+    };
+    return renderHook(() =>
+      useDeploymentCost({ dseq: "55", sdl: "sdl", placements: input.placements, selections: input.selections ?? {} }, dependencies)
+    );
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentCost/useDeploymentCost.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentCost/useDeploymentCost.ts
@@ -1,0 +1,96 @@
+import { useMemo } from "react";
+
+import { useListBids } from "@src/queries/useListBids";
+import { parseBidId } from "@src/utils/bids/bidId";
+import { PRICE_DISPLAY_PRECISION, udenomToDenom } from "@src/utils/mathHelpers";
+import { getPlacementGseq } from "@src/utils/sdl/placementGseq";
+
+export const DEPENDENCIES = { useListBids, getPlacementGseq };
+
+interface Input {
+  dseq: string | null;
+  sdl: string;
+  placements: ReadonlyArray<{ id?: string; name: string }>;
+  selections: Record<string, string>;
+}
+
+export interface DeploymentCost {
+  /** Summed cheapest per-block price across placements, in denom units. */
+  minPerBlock: number;
+  /** Summed priciest per-block price across placements, in denom units. */
+  maxPerBlock: number;
+  denom: string;
+}
+
+/** A `listBids` result entry. */
+type BidEntry = NonNullable<ReturnType<typeof useListBids>["data"]>["data"][number];
+
+/**
+ * The running deployment cost as a per-block `[min, max]` total across placements, or `null` until the first
+ * open bid exists. Each placement contributes its selected bid's price (fixed to both bounds) when one is
+ * chosen, otherwise the `[cheapest, priciest]` of its open bids, otherwise `[0, 0]` while it has no bids — so
+ * the total grows as bids arrive and collapses to a single value once every placement is selected. Reuses the
+ * shared `listBids` cache (no extra poll) and the same `gseq` bucketing as `usePlacementsWithBids`, so cost,
+ * readiness, and the marketplace never disagree about which bids belong to a placement. The total assumes a
+ * single denom per deployment (chain-guaranteed), labelling it with the first open bid's denom like the review
+ * modal's total.
+ */
+export function useDeploymentCost(
+  { dseq, sdl, placements, selections }: Input,
+  dependencies: typeof DEPENDENCIES = DEPENDENCIES
+): DeploymentCost | null {
+  const bidsQuery = dependencies.useListBids(dseq);
+  const bids = bidsQuery.data?.data;
+
+  return useMemo(
+    function buildDeploymentCost(): DeploymentCost | null {
+      const openBids = (bids ?? []).filter(entry => entry.bid.state === "open");
+      if (openBids.length === 0) return null;
+
+      let minPerBlock = 0;
+      let maxPerBlock = 0;
+      for (const placement of placements) {
+        const [min, max] = placementBounds(placement, openBids, sdl, selections, dependencies.getPlacementGseq);
+        minPerBlock += min;
+        maxPerBlock += max;
+      }
+      return { minPerBlock, maxPerBlock, denom: openBids[0].bid.price.denom };
+    },
+    [bids, placements, sdl, selections, dependencies]
+  );
+}
+
+/**
+ * One placement's per-block `[min, max]`: its selected bid (fixed) when chosen and still open, otherwise its
+ * open-bid range, otherwise `[0, 0]`. Bids are bucketed by the placement's `gseq`; when the gseq can't be
+ * resolved it falls back to all open bids — the same fallback as `usePlacementsWithBids`, safe here because the
+ * spec is frozen and valid while quoting, so every placement's gseq resolves whenever bids exist and the
+ * fallback can't double-count across placements in practice. A selection whose bid has since closed degrades
+ * to the open range.
+ */
+function placementBounds(
+  placement: { id?: string; name: string },
+  openBids: BidEntry[],
+  sdl: string,
+  selections: Record<string, string>,
+  getPlacementGseq: typeof DEPENDENCIES.getPlacementGseq
+): [number, number] {
+  const gseq = getPlacementGseq(sdl, placement.name);
+  const placementBids = openBids.filter(entry => gseq === undefined || entry.bid.id.gseq === gseq);
+  if (placementBids.length === 0) return [0, 0];
+
+  const selectedBidId = placement.id ? selections[placement.id] : undefined;
+  if (selectedBidId) {
+    const selected = parseBidId(selectedBidId);
+    const match = placementBids.find(
+      entry => entry.bid.id.provider === selected.provider && entry.bid.id.gseq === selected.gseq && entry.bid.id.oseq === selected.oseq
+    );
+    if (match) {
+      const price = udenomToDenom(match.bid.price.amount, PRICE_DISPLAY_PRECISION);
+      return [price, price];
+    }
+  }
+
+  const prices = placementBids.map(entry => udenomToDenom(entry.bid.price.amount, PRICE_DISPLAY_PRECISION));
+  return [Math.min(...prices), Math.max(...prices)];
+}

--- a/apps/deploy-web/src/components/shared/PricePerTimeUnit.tsx
+++ b/apps/deploy-web/src/components/shared/PricePerTimeUnit.tsx
@@ -2,7 +2,7 @@
 import type { ReactNode } from "react";
 
 import { averageDaysInMonth } from "@src/utils/dateUtils";
-import { averageBlockTime } from "@src/utils/priceUtils";
+import { perBlockToHourly } from "@src/utils/priceUtils";
 import { PriceValue } from "./PriceValue";
 
 interface IProps {
@@ -16,7 +16,7 @@ interface IProps {
 }
 
 export const PricePerTimeUnit: React.FunctionComponent<IProps> = ({ perBlockValue, denom, className, showAsHourly = false, abbreviated = false, ...rest }) => {
-  const hourlyValue = perBlockValue * (60 / averageBlockTime) * 60;
+  const hourlyValue = perBlockToHourly(perBlockValue);
   const monthlyValue = hourlyValue * 24 * averageDaysInMonth;
   const value = showAsHourly ? hourlyValue : monthlyValue;
   const unitLabel = showAsHourly ? (abbreviated ? "hr" : "hour") : "month";

--- a/apps/deploy-web/src/utils/priceUtils.spec.ts
+++ b/apps/deploy-web/src/utils/priceUtils.spec.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { averageBlockTime, perBlockToHourly } from "./priceUtils";
+
+describe("perBlockToHourly", () => {
+  it("converts a per-block price into its hourly equivalent (3600 / blockTime blocks per hour)", () => {
+    expect(perBlockToHourly(1)).toBeCloseTo(3600 / averageBlockTime, 6);
+    expect(perBlockToHourly(0)).toBe(0);
+  });
+});

--- a/apps/deploy-web/src/utils/priceUtils.ts
+++ b/apps/deploy-web/src/utils/priceUtils.ts
@@ -9,6 +9,11 @@ import { denomToUdenom, udenomToDenom } from "./mathHelpers";
 
 export const averageBlockTime = 6.098;
 
+/** Converts a per-block price to its hourly rate. Block time is in seconds, so there are `3600 / averageBlockTime` blocks per hour. */
+export function perBlockToHourly(perBlockValue: number): number {
+  return perBlockValue * (60 / averageBlockTime) * 60;
+}
+
 export const getUsdcDenom = (networkId?: NetworkId): string => {
   return USDC_IBC_DENOMS[networkId ?? (networkStore.selectedNetworkId as keyof typeof USDC_IBC_DENOMS)] as string;
 };


### PR DESCRIPTION
## Why

Once quotes arrive, users need to see what the deployment will cost in USD, right in the configure
header. This adds the header deployment-cost figure, derived from the current bid prices. No price is
shown before bids exist.

Closes CON-522.

## What

The configure-flow header now shows a live **Deployment cost** derived from the on-chain bids:

- **Per-placement range.** Each placement contributes a cost bound: its selected bid's price (fixed to
  both bounds) once a provider is chosen, otherwise the cheapest–priciest range over its open bids, and
  `0` until it has any bid. The header sums these into a `min – max` total, collapses it to a single value
  when the bounds match (e.g. once every placement is selected), and shows `—` until the first bid arrives.
- **No extra fetch.** A new `useDeploymentCost` hook reads the same shared, dseq-keyed `listBids` query the
  marketplace already polls — React Query dedupes by key, so it's a passive reader with no added request or
  polling.
- **Reuses the price stack.** `PricePerTimeUnit`'s per-block→hourly factor is extracted into a shared
  `perBlockToHourly` helper; USD formatting goes through the existing `PriceValue` (ACT maps 1:1 to USD).

No countdown — it was removed from the Figma design, so it's out of scope here.

## Testing

- `useDeploymentCost`: range over an unselected placement's open bids, fixed contribution for a selected
  bid, multi-placement sum (fixed + ranged), `0` contribution for a not-yet-bid placement, `null` before
  any open bid, closed-bid filtering, and fallback to the open range when a selected bid is no longer open.
- `ConfigureDeploymentHeader`: single value when bounds match, `min – max` range when they differ, `—`
  before bids, and that `sdl`/`selections` are threaded into the cost hook.
- `perBlockToHourly`: per-block → hourly conversion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a live deployment cost section to the deployment configuration header, using the current SDL to compute hourly pricing.
  * Shows an hourly value as a single price, a min–max range, or a dash when cost data is unavailable.
* **Bug Fixes**
  * Improved deployment cost calculation to correctly account for selected placements and open bids.
  * Standardized per-block to hourly price conversion across the app.
* **Tests**
  * Added unit tests for the deployment cost hook and for per-block hourly conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->