### PR TITLE
fix(deployment): extend deploy progress overlay to cover the configure header

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -168,24 +168,26 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, intent, depende
     <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col dark:bg-card">
       <d.NextSeo title="Configure your deployment" />
       <FormProvider {...form}>
-        <div className="px-6 pt-6">
-          <d.ConfigureDeploymentHeader flow={flow} sdl={liveSdl} onDeploy={() => setReviewOpen(true)} allPlacementsHaveBids={allPlacementsHaveBids} />
-        </div>
-        <div className="relative mt-6 flex min-h-0 flex-1">
-          <d.ConfigureDeploymentPanes
-            sdl={liveSdl}
-            previewSdl={previewSdl}
-            selectedServiceId={selectedServiceId}
-            selectedPlacementName={selectedPlacement.name}
-            selectedPlacementRegion={selectedPlacement.region}
-            selectedPlacementId={selectedPlacement.id}
-            onSelectService={setSelectedServiceId}
-            phase={flow.phase}
-            dseq={flow.dseq}
-            selections={flow.selections}
-            onSelectProvider={selectProviderAndAdvance}
-            onCancelAndEdit={flow.actions.cancelAndEdit}
-          />
+        <div className="relative flex min-h-0 flex-1 flex-col">
+          <div className="px-6 pt-6">
+            <d.ConfigureDeploymentHeader flow={flow} sdl={liveSdl} onDeploy={() => setReviewOpen(true)} allPlacementsHaveBids={allPlacementsHaveBids} />
+          </div>
+          <div className="relative mt-6 flex min-h-0 flex-1">
+            <d.ConfigureDeploymentPanes
+              sdl={liveSdl}
+              previewSdl={previewSdl}
+              selectedServiceId={selectedServiceId}
+              selectedPlacementName={selectedPlacement.name}
+              selectedPlacementRegion={selectedPlacement.region}
+              selectedPlacementId={selectedPlacement.id}
+              onSelectService={setSelectedServiceId}
+              phase={flow.phase}
+              dseq={flow.dseq}
+              selections={flow.selections}
+              onSelectProvider={selectProviderAndAdvance}
+              onCancelAndEdit={flow.actions.cancelAndEdit}
+            />
+          </div>
           {flow.phase === "deploying" && (
             <DeployProgressOverlay
               providerAddress={firstSelectedProviderAddress(flow.selections)}


### PR DESCRIPTION
## Why

The configure deploy-progress overlay was meant to be full-screen, but it covered only the panes —
leaving the configure header (title, deployment cost, Deploy CTA) visible and clickable while deploying.
That makes the deploying state look half-finished and lets users hit stale header controls mid-deploy.

Part of CON-425.

## What

A layout-only fix on the configure screen so the deploy-progress overlay covers the whole surface:

- The overlay was positioned `absolute inset-0` inside the panes' content wrapper — a sibling that sits
  below the header — so `inset-0` could only ever span the panes.
- Wrapped the header and panes in one shared `relative` container and moved `DeployProgressOverlay` to be
  its child. `inset-0` now spans the full configure surface (everything below the global account bar), so
  the opaque overlay covers and intercepts clicks on the header while deploying, and the progress panel's
  `pt-[80px]` measures from the true top of the surface — matching the onboarding deploy-progress layout
  the overlay was modeled on.
- The panes' own `relative` wrapper is preserved, so nothing inside the panes shifts.

No behavior change outside the deploying phase. No API/SDL changes, no breaking changes, no migrations.


## Testing

- This is a CSS/positioning occlusion change. It isn't meaningfully unit-testable — jsdom has no layout
  engine, and asserting the wrapper markup would be a brittle structure test — so it's verified visually
  via the deploying-phase walkthrough.
- Existing `ConfigureDeploymentForm` and `DeployProgressOverlay` unit specs still pass (no regression);
  lint and type-check are clean for the changed file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted the deployment configuration page layout for a cleaner, more consistent structure.
  * Updated the header and panes container spacing/behavior to improve alignment and page flow, without changing any visible form fields or actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->