### PR TITLE
feat(deployment): merge screened providers with bids in the configure marketplace

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
@@ -125,7 +125,12 @@ describe(MarketplaceProvidersTable.name, () => {
     expect(screen.getByText("Cost")).toBeInTheDocument();
   });
 
-  it("drops the empty Select column when no offer is selectable, leaving only Provider, Region, and Uptime", () => {
+  it("shows the Cost column when the only bids have expired", () => {
+    setup({ providers: [closedOffer({ owner: "akash1c", hostUri: "https://c.example:8443" })] });
+    expect(screen.getByText("Cost")).toBeInTheDocument();
+  });
+
+  it("shows only Provider, Region, and Uptime while every offer is still searching", () => {
     setup({ providers: [searchingOffer({ owner: "akash1a" })] });
     expect(screen.getAllByRole("columnheader")).toHaveLength(3);
   });
@@ -145,6 +150,94 @@ describe(MarketplaceProvidersTable.name, () => {
   it("marks the selected offer's row and makes its button non-clickable", () => {
     setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" })], selectedBidId: "akash1a/1/1/1" });
     expect(screen.getByRole("button", { name: /selected/i })).toBeDisabled();
+  });
+
+  it("renders a non-bidding screened provider with a No bid indicator and no Select button", () => {
+    setup({
+      providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" }), unavailableOffer({ owner: "akash1b", hostUri: "https://b.example:8443" })]
+    });
+    expect(screen.getByText("No bid")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Select akash1b" })).not.toBeInTheDocument();
+  });
+
+  it("marks a provider whose bid expired with an Expired indicator", () => {
+    setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" }), closedOffer({ owner: "akash1c", hostUri: "https://c.example:8443" })] });
+    expect(screen.getByText("Expired")).toBeInTheDocument();
+  });
+
+  it("pins non-bidding rows below the bidding rows", () => {
+    setup({
+      providers: [
+        unavailableOffer({ owner: "akash1b", hostUri: "https://nobid.example:8443" }),
+        submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1", hostUri: "https://bidder.example:8443" })
+      ]
+    });
+    const rows = screen.getAllByRole("row");
+    expect(within(rows[1]).getByText("bidder.example")).toBeInTheDocument();
+    expect(within(rows[rows.length - 1]).getByText("nobid.example")).toBeInTheDocument();
+  });
+
+  it("keeps an expired bid in the bidding group above the divider, not selectable", () => {
+    setup({
+      providers: [
+        unavailableOffer({ owner: "akash1n", hostUri: "https://never.example:8443" }),
+        submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1", hostUri: "https://bidder.example:8443" }),
+        closedOffer({ owner: "akash1c", hostUri: "https://closed.example:8443" })
+      ]
+    });
+    const rowTexts = screen.getAllByRole("row").map(row => row.textContent ?? "");
+    const closedIndex = rowTexts.findIndex(text => text.includes("closed.example"));
+    const dividerIndex = rowTexts.findIndex(text => /didn't bid/i.test(text));
+    const neverIndex = rowTexts.findIndex(text => text.includes("never.example"));
+    expect(closedIndex).toBeGreaterThan(-1);
+    expect(closedIndex).toBeLessThan(dividerIndex);
+    expect(dividerIndex).toBeLessThan(neverIndex);
+    expect(screen.getByText("Expired")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Select closed.example" })).not.toBeInTheDocument();
+  });
+
+  it("sorts the bidding rows by cost when the Cost header is toggled ascending", async () => {
+    setup({
+      providers: [
+        submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1", hostUri: "https://pricey.example:8443", price: { amount: "5000", denom: "uakt" } }),
+        submittedOffer({ owner: "akash1b", bidId: "akash1b/1/1/1", hostUri: "https://cheap.example:8443", price: { amount: "1000", denom: "uakt" } })
+      ]
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Cost/ }));
+
+    const rows = screen.getAllByRole("row");
+    expect(within(rows[1]).getByText("cheap.example")).toBeInTheDocument();
+    expect(within(rows[2]).getByText("pricey.example")).toBeInTheDocument();
+  });
+
+  it("keeps bidding rows on top while sorting the non-bidding rows by the active column", async () => {
+    setup({
+      providers: [
+        unavailableOffer({ owner: "akash1m", hostUri: "https://mmm.example:8443" }),
+        submittedOffer({ owner: "akash1z", bidId: "akash1z/1/1/1", hostUri: "https://zzz.example:8443" }),
+        unavailableOffer({ owner: "akash1a", hostUri: "https://aaa.example:8443" })
+      ]
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Provider/ }));
+
+    const rowTexts = screen.getAllByRole("row").map(row => row.textContent ?? "");
+    const biddingIndex = rowTexts.findIndex(text => text.includes("zzz.example"));
+    const firstNoBidIndex = rowTexts.findIndex(text => text.includes("aaa.example"));
+    const secondNoBidIndex = rowTexts.findIndex(text => text.includes("mmm.example"));
+    expect(biddingIndex).toBeLessThan(firstNoBidIndex);
+    expect(firstNoBidIndex).toBeLessThan(secondNoBidIndex);
+  });
+
+  it("shows the didn't-bid divider when both bidding and non-bidding rows are present", () => {
+    setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" }), unavailableOffer({ owner: "akash1b" })] });
+    expect(screen.getByText(/didn't bid/i)).toBeInTheDocument();
+  });
+
+  it("omits the didn't-bid divider when only bidding rows are present", () => {
+    setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" })] });
+    expect(screen.queryByText(/didn't bid/i)).not.toBeInTheDocument();
   });
 
   /** A screened provider promoted to a (not-yet-bid) offer, so the display/sort tests keep using the realistic seeder without casting. */
@@ -167,6 +260,32 @@ describe(MarketplaceProvidersTable.name, () => {
   function searchingOffer(overrides: Partial<PlacementOffer>): PlacementOffer {
     return mock<PlacementOffer>({
       offerState: "searching",
+      bidId: undefined,
+      price: undefined,
+      organization: null,
+      hostUri: "",
+      location: null,
+      incidents: [],
+      ...overrides
+    });
+  }
+
+  function closedOffer(overrides: Partial<PlacementOffer>): PlacementOffer {
+    return mock<PlacementOffer>({
+      offerState: "closed",
+      bidId: undefined,
+      price: { amount: "100", denom: "uakt" },
+      organization: null,
+      hostUri: "",
+      location: null,
+      incidents: [],
+      ...overrides
+    });
+  }
+
+  function unavailableOffer(overrides: Partial<PlacementOffer>): PlacementOffer {
+    return mock<PlacementOffer>({
+      offerState: "unavailable",
       bidId: undefined,
       price: undefined,
       organization: null,

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
@@ -1,7 +1,8 @@
 import type { FC } from "react";
 import { useMemo, useState } from "react";
-import { Button, Spinner, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@akashnetwork/ui/components";
-import type { Column, SortingState } from "@tanstack/react-table";
+import { Badge, Button, Spinner, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
+import type { Column, Row, SortingState } from "@tanstack/react-table";
 import { createColumnHelper, flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
 import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react";
 
@@ -16,7 +17,7 @@ import { ProviderUptimeCell } from "./ProviderUptimeCell/ProviderUptimeCell";
 
 const columnHelper = createColumnHelper<PlacementOffer>();
 
-/** Shown when a provider has no region attribute. */
+/** Shown when a provider has no region attribute, and as the cost placeholder for a row with no price. */
 const NO_REGION = "—";
 
 /** Fallback uptime for a provider missing from the derived map; treated as fully healthy. */
@@ -35,13 +36,13 @@ export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading, isS
   const [sorting, setSorting] = useState<SortingState>([]);
 
   const uptimeByOwner = useProvidersUptime(providers);
-  /** Cost only makes sense once firm bids arrive; until then the marketplace lists screened candidates with no price. */
-  const hasBids = providers.some(provider => provider.offerState === "submitted");
-  /** The Select column is only useful when a visible offer can actually be picked; otherwise it's an empty trailing column. */
-  const hasSelectableOffers = providers.some(provider => provider.offerState === "submitted" && !!provider.bidId);
+  /** The status column and the "didn't bid" split appear once real bid outcomes exist; before that the marketplace lists screened candidates as `searching`. */
+  const isMerged = providers.some(provider => provider.offerState !== "searching");
+  /** Cost only makes sense once bids arrive: a submitted bid is priced and a closed/expired one keeps its last price, but a screened-only candidate has none. */
+  const showCost = providers.some(provider => !!provider.price);
   const columns = useMemo(
-    () => buildColumns(uptimeByOwner, { selectedBidId, onSelect, showCost: hasBids, showSelect: hasSelectableOffers }),
-    [uptimeByOwner, selectedBidId, onSelect, hasBids, hasSelectableOffers]
+    () => buildColumns(uptimeByOwner, { selectedBidId, onSelect, showCost, showStatus: isMerged }),
+    [uptimeByOwner, selectedBidId, onSelect, showCost, isMerged]
   );
 
   const table = useReactTable({
@@ -77,6 +78,16 @@ export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading, isS
     return <p className="p-4 text-sm text-muted-foreground">No providers found.</p>;
   }
 
+  const sortedRows = table.getRowModel().rows;
+  /**
+   * Sorting applies across the whole table, but screened providers that never bid are pinned into a group at
+   * the bottom: partitioning the already-sorted rows keeps the active column sort inside each group. Bidders
+   * and closed/expired bids stay together up top (they did bid); only never-bid providers drop below.
+   */
+  const biddableRows = sortedRows.filter(row => !isPinnedBelow(row.original.offerState));
+  const noBidRows = sortedRows.filter(row => isPinnedBelow(row.original.offerState));
+  const columnCount = table.getVisibleFlatColumns().length;
+
   return (
     <div className="overflow-hidden rounded-[14px] border shadow-sm">
       <Table>
@@ -92,20 +103,48 @@ export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading, isS
           ))}
         </TableHeader>
         <TableBody>
-          {table.getRowModel().rows.map(row => (
-            <TableRow key={row.id} className="h-[52px]">
-              {row.getVisibleCells().map(cell => (
-                <TableCell key={cell.id} className="py-2 pl-4 pr-2 text-sm font-medium text-foreground">
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </TableCell>
-              ))}
+          {biddableRows.map(row => (
+            <OfferRow key={row.id} row={row} />
+          ))}
+          {noBidRows.length > 0 && biddableRows.length > 0 && (
+            <TableRow key="didnt-bid-divider" className="hover:bg-transparent">
+              <TableCell colSpan={columnCount} className="h-8 bg-muted/30 py-1 pl-4 font-mono text-xs uppercase tracking-wide text-muted-foreground">
+                didn&apos;t bid
+              </TableCell>
             </TableRow>
+          )}
+          {noBidRows.map(row => (
+            <OfferRow key={row.id} row={row} />
           ))}
         </TableBody>
       </Table>
     </div>
   );
 };
+
+/** Only never-bid providers are pinned into the bottom group; a closed/expired bid stays up with the bidders (it did bid) — just muted and unselectable. */
+function isPinnedBelow(state: PlacementOffer["offerState"]): boolean {
+  return state === "unavailable";
+}
+
+/** Neither a closed/expired bid nor a never-bid provider can be picked, so both read muted with a status badge in place of a Select button. */
+function isNonSelectable(state: PlacementOffer["offerState"]): boolean {
+  return state === "closed" || state === "unavailable";
+}
+
+/** One marketplace row. Selectable rows read normally; closed/expired and never-bid rows are muted (which also greys their price). Cell content (price vs "—", Select vs status badge) comes from the column defs. */
+function OfferRow({ row }: { row: Row<PlacementOffer> }) {
+  const isDisabled = isNonSelectable(row.original.offerState);
+  return (
+    <TableRow className={cn("h-[52px]", isDisabled && "text-muted-foreground hover:bg-transparent")}>
+      {row.getVisibleCells().map(cell => (
+        <TableCell key={cell.id} className={cn("py-2 pl-4 pr-2 text-sm", !isDisabled && "font-medium text-foreground")}>
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </TableCell>
+      ))}
+    </TableRow>
+  );
+}
 
 /** Design-system column header: an uppercase mono label that toggles sort on click. */
 function SortableHeader({ column, title }: { column: Column<PlacementOffer, unknown>; title: string }) {
@@ -128,10 +167,10 @@ function SortableHeader({ column, title }: { column: Column<PlacementOffer, unkn
   );
 }
 
-/** Builds the table columns, closing over the per-provider uptime derived once in the component. */
+/** Builds the columns, closing over the per-provider uptime derived once in the component. Every column is an accessor so it sorts; the trailing status column is display-only. */
 function buildColumns(
   uptimeByOwner: Map<string, ProviderUptime>,
-  selection: { selectedBidId?: string; onSelect?: (bidId: string) => void; showCost: boolean; showSelect: boolean }
+  selection: { selectedBidId?: string; onSelect?: (bidId: string) => void; showCost: boolean; showStatus: boolean }
 ) {
   return [
     columnHelper.accessor(providerDisplayName, {
@@ -150,24 +189,26 @@ function buildColumns(
     }),
     ...(selection.showCost
       ? [
-          columnHelper.display({
+          columnHelper.accessor(provider => (provider.price ? Number(provider.price.amount) : 0), {
             id: "cost",
-            header: () => <span className="font-mono text-sm font-normal uppercase text-muted-foreground">Cost</span>,
+            header: ({ column }) => <SortableHeader column={column} title="Cost" />,
             cell: ({ row }) => {
               const { price } = row.original;
-              if (!price) return <span className="text-muted-foreground">—</span>;
+              if (!price) return <span className="text-muted-foreground">{NO_REGION}</span>;
               return <PricePerTimeUnit denom={price.denom} perBlockValue={udenomToDenom(price.amount, PRICE_DISPLAY_PRECISION)} showAsHourly abbreviated />;
             }
           })
         ]
       : []),
-    ...(selection.showSelect
+    ...(selection.showStatus
       ? [
           columnHelper.display({
-            id: "select",
+            id: "status",
             header: () => null,
             cell: ({ row }) => {
               const offer = row.original;
+              if (offer.offerState === "closed") return <Badge variant="secondary">Expired</Badge>;
+              if (offer.offerState === "unavailable") return <Badge variant="outline">No bid</Badge>;
               if (offer.offerState !== "submitted" || !offer.bidId) return null;
               const isSelected = offer.bidId === selection.selectedBidId;
               return (

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
@@ -216,6 +216,54 @@ describe(useDeploymentFlow.name, () => {
     );
   });
 
+  it("clears a placement's selection when its bid is no longer open", async () => {
+    const { result } = renderFlow({
+      intent: { dseq: "555" },
+      listBids: [
+        { bid: { state: "closed", price: { amount: "1", denom: "uakt" }, id: { provider: "akash1a", dseq: "555", gseq: 1, oseq: 3 } } },
+        { bid: { state: "open", price: { amount: "1", denom: "uakt" }, id: { provider: "akash1b", dseq: "555", gseq: 1, oseq: 3 } } }
+      ]
+    });
+
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+
+    await waitFor(() => expect(result.current.selections).toEqual({}));
+  });
+
+  it("prunes only the placement whose bid closed, keeping other open selections", async () => {
+    const { result } = renderFlow({
+      intent: { dseq: "555" },
+      listBids: [
+        { bid: { state: "closed", price: { amount: "1", denom: "uakt" }, id: { provider: "akash1a", dseq: "555", gseq: 1, oseq: 3 } } },
+        { bid: { state: "open", price: { amount: "1", denom: "uakt" }, id: { provider: "akash1b", dseq: "555", gseq: 2, oseq: 4 } } }
+      ]
+    });
+
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+    act(() => result.current.actions.selectProvider("placement-2", "akash1b/555/2/4"));
+
+    await waitFor(() => expect(result.current.selections).toEqual({ "placement-2": "akash1b/555/2/4" }));
+  });
+
+  it("keeps a selection whose bid is still open", () => {
+    const { result } = renderFlow({
+      intent: { dseq: "555" },
+      listBids: [{ bid: { state: "open", price: { amount: "1", denom: "uakt" }, id: { provider: "akash1a", dseq: "555", gseq: 1, oseq: 3 } } }]
+    });
+
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+
+    expect(result.current.selections).toEqual({ "placement-1": "akash1a/555/1/3" });
+  });
+
+  it("does not prune selections while no bids have loaded", () => {
+    const { result } = renderFlow({ intent: { dseq: "555" }, listBids: [] });
+
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+
+    expect(result.current.selections).toEqual({ "placement-1": "akash1a/555/1/3" });
+  });
+
   function setup(input: {
     intent?: { sdlStrategy: "default" | "edit"; bidStrategy: "auto" | "select"; dseq?: string; templateId?: string; draftId?: string };
     replace?: ReturnType<typeof vi.fn>;
@@ -227,6 +275,7 @@ describe(useDeploymentFlow.name, () => {
       useCreateDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useCreateDeployment>>({ mutate: (input.createMutate ?? vi.fn()) as never })) as never,
       useCloseDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useCloseDeployment>>({ mutate: (input.closeMutate ?? vi.fn()) as never })) as never,
       useCreateLease: (() => mock<ReturnType<typeof DEPENDENCIES.useCreateLease>>({ mutate: vi.fn() as never })) as never,
+      useListBids: (() => ({ data: { data: [] }, isLoading: false, isError: false })) as never,
       useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: (input.replace ?? vi.fn()) as never })) as never,
       manifestFromSdl: () => "manifest"
     };
@@ -239,6 +288,7 @@ describe(useDeploymentFlow.name, () => {
     createLease?: ReturnType<typeof mockMutation>;
     closeDeployment?: ReturnType<typeof mockMutation>;
     manifestFromSdl?: (sdl: string) => string | null;
+    listBids?: Array<{ bid: { state: string; price: { amount: string; denom: string }; id: { provider: string; dseq: string; gseq: number; oseq: number } } }>;
   }) {
     const intent: DeploymentIntent = { sdlStrategy: "edit", bidStrategy: "select", dseq: undefined, ...input?.intent };
     const router = mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: vi.fn(), push: vi.fn() });
@@ -246,6 +296,7 @@ describe(useDeploymentFlow.name, () => {
       useCreateDeployment: (() => input?.createDeployment ?? mockMutation()) as never,
       useCloseDeployment: (() => input?.closeDeployment ?? mockMutation()) as never,
       useCreateLease: (() => input?.createLease ?? mockMutation()) as never,
+      useListBids: (() => ({ data: { data: input?.listBids ?? [] }, isLoading: false, isError: false })) as never,
       useRouter: () => router,
       manifestFromSdl: input?.manifestFromSdl ?? (() => "DERIVED_MANIFEST")
     };

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -3,7 +3,8 @@ import { extractApiErrorMessage } from "@akashnetwork/openapi-sdk";
 import { useRouter } from "next/router";
 
 import { useServices } from "@src/context/ServicesProvider";
-import { parseBidId } from "@src/utils/bids/bidId";
+import { BID_POLL_INTERVAL, useListBids } from "@src/queries/useListBids";
+import { formatBidId, parseBidId } from "@src/utils/bids/bidId";
 import { ManifestYaml } from "@src/utils/deploymentData/helpers";
 import { UrlService } from "@src/utils/urlUtils";
 import type { BidStrategy, DeploymentIntent } from "./deploymentIntent";
@@ -61,7 +62,7 @@ function useCreateLease() {
   return useServices().api.v1.createLease.useMutation();
 }
 
-export const DEPENDENCIES = { useCreateDeployment, useCloseDeployment, useCreateLease, useRouter, manifestFromSdl };
+export const DEPENDENCIES = { useCreateDeployment, useCloseDeployment, useCreateLease, useListBids, useRouter, manifestFromSdl };
 
 /**
  * Controlled lifecycle state machine for the configure flow. Owns interaction state (phase, dseq,
@@ -87,12 +88,27 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
   const intentRef = useRef(intent);
   intentRef.current = intent;
 
+  const bidsQuery = dependencies.useListBids(dseq, { enabled: phase === "quoting", refetchInterval: BID_POLL_INTERVAL });
+
   const redirectTimerRef = useRef<ReturnType<typeof setTimeout>>();
   useEffect(function clearRedirectTimerOnUnmount() {
     return function cancelPendingRedirect() {
       if (redirectTimerRef.current) clearTimeout(redirectTimerRef.current);
     };
   }, []);
+
+  useEffect(
+    function pruneStaleSelections() {
+      const bids = bidsQuery.data?.data;
+      if (!bids || bids.length === 0) return;
+      const openBidIds = new Set(bids.filter(entry => entry.bid.state === "open").map(entry => formatBidId(entry.bid.id)));
+      setSelections(function dropClosedSelections(previous) {
+        const survivors = Object.entries(previous).filter(([, bidId]) => openBidIds.has(bidId));
+        return survivors.length === Object.keys(previous).length ? previous : Object.fromEntries(survivors);
+      });
+    },
+    [bidsQuery.data]
+  );
 
   const requestQuotes = useCallback(
     function requestQuotes(sdl: string) {

--- a/apps/deploy-web/src/queries/usePlacementOffers.spec.ts
+++ b/apps/deploy-web/src/queries/usePlacementOffers.spec.ts
@@ -74,14 +74,101 @@ describe(usePlacementOffers.name, () => {
     expect(useProviderList).toHaveBeenCalledWith(expect.objectContaining({ enabled: true }));
   });
 
-  it("drops the non-bidding screened candidates once bids arrive", () => {
+  it("keeps a non-bidding screened candidate as an unavailable offer once bids arrive", () => {
     const { result } = setup({
       phase: "quoting",
       dseq: "100",
-      screened: [polaris(), mock<ScreenedProvider>({ owner: "akash1bbb" })],
+      screened: [polaris(), mock<ScreenedProvider>({ owner: "akash1bbb", organization: "Beta", location: "eu-west" })],
+      bids: [{ bid: { state: "open", price: { amount: "1900", denom: "uakt" }, id: { provider: "akash1aaa", dseq: "100", gseq: 1, oseq: 1 } } }]
+    });
+    expect(result.current.offers).toEqual([
+      expect.objectContaining({ owner: "akash1aaa", offerState: "submitted" }),
+      expect.objectContaining({ owner: "akash1bbb", offerState: "unavailable", bidId: undefined, price: undefined })
+    ]);
+  });
+
+  it("marks a provider whose only bid is closed as a closed offer that keeps its last price", () => {
+    const { result } = setup({
+      phase: "quoting",
+      dseq: "100",
+      screened: [polaris()],
+      bids: [{ bid: { state: "closed", price: { amount: "1900", denom: "uakt" }, id: { provider: "akash1aaa", dseq: "100", gseq: 1, oseq: 1 } } }]
+    });
+    expect(result.current.offers).toEqual([
+      expect.objectContaining({ owner: "akash1aaa", offerState: "closed", bidId: undefined, price: { amount: "1900", denom: "uakt" } })
+    ]);
+  });
+
+  it("deduplicates a provider that appears twice in the screened list", () => {
+    const { result } = setup({
+      phase: "quoting",
+      dseq: "100",
+      screened: [polaris(), polaris()],
       bids: [{ bid: { state: "open", price: { amount: "1900", denom: "uakt" }, id: { provider: "akash1aaa", dseq: "100", gseq: 1, oseq: 1 } } }]
     });
     expect(result.current.offers).toEqual([expect.objectContaining({ owner: "akash1aaa", offerState: "submitted" })]);
+  });
+
+  it("prefers the open bid when a provider has both an open and a closed bid", () => {
+    const { result } = setup({
+      phase: "quoting",
+      dseq: "100",
+      screened: [polaris()],
+      bids: [
+        { bid: { state: "closed", price: { amount: "10", denom: "uakt" }, id: { provider: "akash1aaa", dseq: "100", gseq: 1, oseq: 1 } } },
+        { bid: { state: "open", price: { amount: "20", denom: "uakt" }, id: { provider: "akash1aaa", dseq: "100", gseq: 1, oseq: 2 } } }
+      ]
+    });
+    expect(result.current.offers).toEqual([
+      expect.objectContaining({ owner: "akash1aaa", offerState: "submitted", price: { amount: "20", denom: "uakt" }, bidId: "akash1aaa/100/1/2" })
+    ]);
+  });
+
+  it("prefers the open bid regardless of the order bids are returned in", () => {
+    const { result } = setup({
+      phase: "quoting",
+      dseq: "100",
+      screened: [polaris()],
+      bids: [
+        { bid: { state: "open", price: { amount: "20", denom: "uakt" }, id: { provider: "akash1aaa", dseq: "100", gseq: 1, oseq: 2 } } },
+        { bid: { state: "closed", price: { amount: "10", denom: "uakt" }, id: { provider: "akash1aaa", dseq: "100", gseq: 1, oseq: 1 } } }
+      ]
+    });
+    expect(result.current.offers).toEqual([
+      expect.objectContaining({ owner: "akash1aaa", offerState: "submitted", price: { amount: "20", denom: "uakt" }, bidId: "akash1aaa/100/1/2" })
+    ]);
+  });
+
+  it("includes a provider that bid without being screened", () => {
+    const { result } = setup({
+      phase: "quoting",
+      dseq: "100",
+      screened: [polaris()],
+      providerList: [{ owner: "akash1new", organization: "Newcomer", hostUri: "https://new.example:8443", locationRegion: "ap-south", isAudited: false }],
+      bids: [
+        { bid: { state: "open", price: { amount: "1900", denom: "uakt" }, id: { provider: "akash1aaa", dseq: "100", gseq: 1, oseq: 1 } } },
+        { bid: { state: "open", price: { amount: "2500", denom: "uakt" }, id: { provider: "akash1new", dseq: "100", gseq: 1, oseq: 1 } } }
+      ]
+    });
+    expect(result.current.offers).toEqual([
+      expect.objectContaining({ owner: "akash1aaa", offerState: "submitted" }),
+      expect.objectContaining({ owner: "akash1new", organization: "Newcomer", location: "ap-south", offerState: "submitted" })
+    ]);
+  });
+
+  it("reuses screened metadata for a bidder instead of the provider list", () => {
+    const { result } = setup({
+      phase: "quoting",
+      dseq: "100",
+      screened: [polaris()],
+      providerList: [
+        { owner: "akash1aaa", organization: "Stale Name", locationRegion: "wrong-region", hostUri: "https://stale.example:8443", isAudited: false }
+      ],
+      bids: [{ bid: { state: "open", price: { amount: "1900", denom: "uakt" }, id: { provider: "akash1aaa", dseq: "100", gseq: 1, oseq: 1 } } }]
+    });
+    expect(result.current.offers).toEqual([
+      expect.objectContaining({ owner: "akash1aaa", organization: "Polaris", location: "us-east", offerState: "submitted" })
+    ]);
   });
 
   it("surfaces a listBids failure while quoting", () => {

--- a/apps/deploy-web/src/queries/usePlacementOffers.ts
+++ b/apps/deploy-web/src/queries/usePlacementOffers.ts
@@ -8,7 +8,7 @@ import type { ApiProviderList } from "@src/types/provider";
 import { formatBidId } from "@src/utils/bids/bidId";
 import { getPlacementGseq } from "@src/utils/sdl/placementGseq";
 
-export type OfferState = "searching" | "submitted" | "unavailable";
+export type OfferState = "searching" | "submitted" | "closed" | "unavailable";
 
 /** A screened provider annotated with its on-chain bid status. Extends ScreenedProvider so the marketplace table keeps its existing columns/uptime/sorting. */
 export interface PlacementOffer extends ScreenedProvider {
@@ -16,6 +16,9 @@ export interface PlacementOffer extends ScreenedProvider {
   bidId?: string;
   price?: { amount: string; denom: string };
 }
+
+/** One deployment bid from listBids, derived from the query result so it can't drift from the SDK's bid shape (matches the sibling quote hooks). */
+type BidEntry = NonNullable<ReturnType<typeof useListBids>["data"]>["data"][number];
 
 interface UsePlacementOffersInput {
   phase: "configuring" | "creating" | "quoting" | "closing" | "deploying" | "error";
@@ -34,27 +37,22 @@ interface UsePlacementOffersResult {
 export const DEPENDENCIES = { useScreenedProviders, useListBids, useProviderList, getPlacementGseq };
 
 /**
- * The shared offers seam, read by both the marketplace pane and the lifecycle hook so they can never
- * disagree about which offers exist. It surfaces one source at a time, never a merge of the two:
+ * The shared offers seam, read by the marketplace pane so screening and bids can never disagree about which
+ * offers exist.
  *
- * - While screening (`configuring`/`creating`) it returns the screened providers as `searching` offers —
- *   the candidate pool for the current spec.
- * - Otherwise (`quoting`/`closing`/`error`) it returns the placement's open bids as `submitted` offers
- *   once any have arrived; until the first bid it keeps showing the screened candidates as `searching`,
- *   so the marketplace is never blank while bids are still coming in. Bids are shaped like a screened
- *   provider so the table renders them identically; the provider list supplies each bid's name
- *   (organization, else host), region and audited flag so a bid reads the same as a screened result.
+ * - While screening (`configuring`/`creating`) it returns the screened providers as `searching` offers.
+ * - Otherwise, until this placement's first bid arrives, it keeps showing the screened candidates as
+ *   `searching`, so the marketplace is never blank while bids are still coming in.
+ * - Once bids exist it returns a 1:1 merge of the screened pool with the bids, deduplicated by provider
+ *   address: an open bid is `submitted` (priced, selectable), a closed bid is `closed`, and a screened
+ *   provider that never bid is `unavailable`. A provider that bid without being screened is still included.
+ *   Screened metadata (name, region, audited flag, incident-derived uptime) is reused for any provider that
+ *   was screened; the provider list only fills in a bidder that was never screened.
  *
- * Once the deployment is locked (`creating`/`quoting`/`closing`) the spec is frozen, so screening is paused
- * (the CPU-heavy query stops re-running against an unchanging spec); the last screened set is kept as the
- * pre-bid fallback. `listBids` returns every bid for the deployment across all its groups, so bids are
- * scoped to this placement by its group sequence (`gseq`): only open bids whose `gseq` matches are kept,
- * so a provider that bid on a different placement's group is not surfaced here.
- *
- * `isLoading`/`isError` follow the source that's driving the view: the screened query normally, plus the
- * `listBids` query while quoting — so a failing or still-loading bids request surfaces instead of silently
- * sitting on stale offers. Bids loading only counts when there is nothing to show yet, so the screened
- * pre-bid fallback is never replaced by a spinner.
+ * Once the deployment is locked (`creating`/`quoting`/`closing`/`deploying`) screening is paused and the last
+ * screened set is kept (`keepPreviousData`) as both the pre-bid fallback and the metadata source. `listBids`
+ * returns every bid for the deployment across its groups, so bids are scoped to this placement by its group
+ * sequence (`gseq`).
  */
 export function usePlacementOffers(
   { phase, dseq, sdl, placementName, region }: UsePlacementOffersInput,
@@ -67,17 +65,25 @@ export function usePlacementOffers(
   const providerListQuery = dependencies.useProviderList({ enabled: !isScreening });
   const gseq = useMemo(() => dependencies.getPlacementGseq(sdl, placementName), [dependencies, sdl, placementName]);
   const providersByOwner = useMemo(() => new Map((providerListQuery.data ?? []).map(provider => [provider.owner, provider])), [providerListQuery.data]);
+  const screenedByOwner = useMemo(() => new Map(screened.providers.map(provider => [provider.owner, provider])), [screened.providers]);
 
   const offers = useMemo(
     function buildOffers(): PlacementOffer[] {
-      const openBids = isScreening
-        ? []
-        : (bidsQuery.data?.data ?? []).filter(entry => entry.bid.state === "open" && (gseq === undefined || entry.bid.id.gseq === gseq));
-      return openBids.length > 0
-        ? openBids.map(entry => toBidOffer(entry, providersByOwner.get(entry.bid.id.provider)))
-        : screened.providers.map(toSearchingOffer);
+      if (isScreening) return screened.providers.map(toSearchingOffer);
+
+      const placementBids = (bidsQuery.data?.data ?? []).filter(entry => gseq === undefined || entry.bid.id.gseq === gseq);
+      if (placementBids.length === 0) return screened.providers.map(toSearchingOffer);
+
+      const bidByOwner = pickBestBidPerOwner(placementBids);
+      return mergedOwners(screened.providers, bidByOwner).map(function toMergedOffer(owner): PlacementOffer {
+        const meta = screenedByOwner.get(owner) ?? providerListToOffer(owner, providersByOwner.get(owner));
+        const entry = bidByOwner.get(owner);
+        if (entry?.bid.state === "open") return { ...meta, offerState: "submitted", bidId: formatBidId(entry.bid.id), price: entry.bid.price };
+        if (entry) return { ...meta, offerState: "closed", bidId: undefined, price: entry.bid.price };
+        return { ...meta, offerState: "unavailable", bidId: undefined, price: undefined };
+      });
     },
-    [isScreening, screened.providers, bidsQuery.data, gseq, providersByOwner]
+    [isScreening, screened.providers, screenedByOwner, bidsQuery.data, gseq, providersByOwner]
   );
 
   const isQuoting = phase === "quoting";
@@ -88,32 +94,53 @@ export function usePlacementOffers(
   };
 }
 
-/** A screened provider as a not-yet-bid offer — the candidate pool shown while screening. */
+/** A screened provider as a not-yet-bid offer — shown while screening and before this placement's first bid. */
 function toSearchingOffer(provider: ScreenedProvider): PlacementOffer {
   return { ...provider, offerState: "searching", bidId: undefined, price: undefined };
 }
 
+/** The best bid per provider address: an open bid always wins over a closed one so a re-bidding provider stays selectable. */
+function pickBestBidPerOwner(entries: BidEntry[]): Map<string, BidEntry> {
+  const byOwner = new Map<string, BidEntry>();
+  for (const entry of entries) {
+    const existing = byOwner.get(entry.bid.id.provider);
+    if (!existing || (existing.bid.state !== "open" && entry.bid.state === "open")) byOwner.set(entry.bid.id.provider, entry);
+  }
+  return byOwner;
+}
+
+/** Screened owners first (deduped by address, first-seen order), then any bidder that was never screened, so the merge is a 1:1 superset of the screened pool with no repeated rows. */
+function mergedOwners(screened: ScreenedProvider[], bidByOwner: Map<string, BidEntry>): string[] {
+  const owners: string[] = [];
+  const seen = new Set<string>();
+  for (const provider of screened) {
+    if (!seen.has(provider.owner)) {
+      owners.push(provider.owner);
+      seen.add(provider.owner);
+    }
+  }
+  for (const owner of bidByOwner.keys()) {
+    if (!seen.has(owner)) {
+      owners.push(owner);
+      seen.add(owner);
+    }
+  }
+  return owners;
+}
+
 /**
- * An open bid as an offer, shaped like a screened provider so the marketplace table renders it the same
- * way. The bid carries only the provider address and price; the provider record (when loaded) supplies
- * the name (organization, else host), region and audited flag so a bid reads like a screened result.
- * Uptime is left to the table's neutral fallback — the provider record doesn't carry the per-day
- * incident history the screened uptime is derived from.
+ * A screened-provider-shaped record for a bidder that was never screened, so the table renders it identically.
+ * The provider list (when loaded) supplies the name (organization, else host), region and audited flag; uptime
+ * is left to the table's neutral fallback since the provider record carries no per-day incident history.
  */
-function toBidOffer(
-  entry: { bid: { id: { provider: string; dseq: string; gseq: number; oseq: number }; price: { amount: string; denom: string } } },
-  provider?: ApiProviderList
-): PlacementOffer {
+function providerListToOffer(owner: string, provider?: ApiProviderList): ScreenedProvider {
   return {
-    owner: entry.bid.id.provider,
+    owner,
     hostUri: provider?.hostUri ?? "",
     isAudited: provider?.isAudited ?? false,
     createdAt: "",
     location: provider?.locationRegion || null,
     organization: provider?.organization || null,
-    incidents: [],
-    offerState: "submitted",
-    bidId: formatBidId(entry.bid.id),
-    price: entry.bid.price
+    incidents: []
   };
 }


### PR DESCRIPTION
## Why

Bid screening returns a much larger provider set than actually bids — screening ≠ bidding, and providers can run internal/whitelist bid logic we can't replicate or see. After **Request quotes**, the marketplace collapsed from ~2–3 screens of providers down to only the ~10 that bid, with no explanation. Once users notice the list shrinking 3–4× every time, they start distrusting the screened list. The original design intent was a 1:1 list where screened-in providers that don't bid stay visible rather than silently disappearing.

Fixes CON-600

## What

After bids return, the marketplace is now a single unified list instead of replacing the screened set with bids:

- **Bidding providers** appear first, selectable and priced (existing behaviour).
- **Screened providers that didn't bid** stay in the list, pinned at the bottom, disabled, with a clear **"No bid"** indicator — so the row count stays roughly consistent before/after requesting quotes and nothing silently disappears.
- **Providers whose bid closed** are pinned in the disabled group with a distinct **"Bid closed"** indicator.
- Offers are **deduplicated by provider address** and **reuse the existing screened metadata** (name, region, uptime) instead of refetching it; a provider that bid without being screened is still shown.

Additional changes in this PR:

- **Sortable columns, including Cost** (previously the cost column couldn't be sorted). Sorting applies within both the biddable and disabled groups while the groups stay pinned — a disabled row never rises above a selectable one.
- **Stale-selection safeguard**: if a selected provider's bid is no longer open, that selection is cleared so a deploy can't target a dead bid.

Out of scope: showing *why* a provider didn't bid (private per-provider config we can't fetch), and the separate "the screened list is a loose estimate" messaging tooltip (tracked separately).

https://github.com/user-attachments/assets/7d1b8fa4-7388-48e0-bd16-4da9084e86f3




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marketplace table now shows an offer status (“Expired” for closed bids, “No bid” for unavailable providers) and a sortable Cost column. Biddable rows are prioritized and separated from non-biddable rows with a “didn’t bid” divider (shown only when both sections exist).
* **Bug Fixes**
  * During the quoting phase, bid/offer states stay in sync and selections tied to bids that close are automatically cleared.
* **Tests**
  * Expanded UI and hook test coverage for state mapping, row grouping/pinning, sorting behavior, divider visibility, and quoting-phase selection pruning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->