### PR TITLE
feat(deployment): add type-ahead search to the region filter

### DIFF
--- a/apps/deploy-web/src/components/sdl/RegionSelect/RegionSelect.spec.tsx
+++ b/apps/deploy-web/src/components/sdl/RegionSelect/RegionSelect.spec.tsx
@@ -4,36 +4,83 @@ import { describe, expect, it } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
+import type { ApiProviderRegion } from "@src/types/provider";
 import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
 import type { DEPENDENCIES } from "./RegionSelect";
-import { RegionSelect } from "./RegionSelect";
+import { filterRegions, RegionSelect } from "./RegionSelect";
 
-import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const REGIONS: ApiProviderRegion[] = [
+  { key: "eu-west", description: "Western Europe. Countries (FR, LU, BE, NL, GB, IE)", providers: [] },
+  { key: "eu-central", description: "Central Europe. Countries (SI, HU, SK, PL, CZ, AT, CH, DE)", providers: [] },
+  { key: "na-us-west", description: "North America United States of America West. States: (CA, OR, WA)", providers: [] }
+];
 
 describe("RegionSelect", () => {
-  it("writes the picked region to the placement", async () => {
-    const { getValues } = setup({ regions: [{ key: "us-west", description: "US West", providers: [] }] });
-
-    await userEvent.click(screen.getByRole("combobox", { name: "Region" }));
-    await userEvent.click(await screen.findByRole("option", { name: "us-west" }));
-
-    expect(getValues().placements[0].region).toBe("us-west");
-  });
-
-  it("clears the region when Any region is picked", async () => {
-    const { getValues } = setup({
-      regions: [{ key: "us-west", description: "US West", providers: [] }],
-      region: "us-west"
+  describe("filterRegions", () => {
+    it("returns all regions for an empty or whitespace query", () => {
+      expect(filterRegions(REGIONS, "")).toEqual(REGIONS);
+      expect(filterRegions(REGIONS, "   ")).toEqual(REGIONS);
     });
 
-    await userEvent.click(screen.getByRole("combobox", { name: "Region" }));
-    await userEvent.click(await screen.findByRole("option", { name: "Any region" }));
+    it("matches case-insensitive substrings of the visible key", () => {
+      expect(filterRegions(REGIONS, "EU")).toEqual([REGIONS[0], REGIONS[1]]);
+    });
 
-    expect(getValues().placements[0].region).toBeUndefined();
+    it("ignores text that only appears in the hidden description", () => {
+      expect(filterRegions(REGIONS, "europe")).toEqual([]);
+      expect(filterRegions(REGIONS, "america")).toEqual([]);
+    });
   });
 
-  function setup(input: { regions: Array<{ key: string; description: string; providers: string[] }>; region?: string }) {
+  it("writes the picked region, reflects it in the trigger, and resets the search", async () => {
+    const { getValues } = setup({ regions: REGIONS });
+    const trigger = screen.getByRole("button", { name: "Region" });
+
+    fireEvent.click(trigger);
+    fireEvent.change(await screen.findByRole("combobox", { name: "Search regions" }), { target: { value: "na" } });
+    fireEvent.click(await screen.findByRole("option", { name: "na-us-west" }));
+
+    expect(getValues().placements[0].region).toBe("na-us-west");
+    expect(trigger).toHaveTextContent("na-us-west");
+
+    fireEvent.click(trigger);
+    expect(await screen.findByRole("combobox", { name: "Search regions" })).toHaveValue("");
+  });
+
+  it("clears the region and shows Any region in the trigger when Any region is picked", async () => {
+    const { getValues } = setup({ regions: REGIONS, region: "eu-west" });
+    const trigger = screen.getByRole("button", { name: "Region" });
+
+    fireEvent.click(trigger);
+    fireEvent.click(await screen.findByRole("option", { name: "Any region" }));
+
+    expect(getValues().placements[0].region).toBeFalsy();
+    expect(trigger).toHaveTextContent("Any region");
+  });
+
+  it("filters by the visible key, ignores description text, keeps Any region, and restores on clear", async () => {
+    setup({ regions: REGIONS });
+
+    fireEvent.click(screen.getByRole("button", { name: "Region" }));
+    const input = await screen.findByRole("combobox", { name: "Search regions" });
+
+    fireEvent.change(input, { target: { value: "eu" } });
+    expect(screen.getByRole("option", { name: "eu-west" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "eu-central" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "na-us-west" })).not.toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "europe" } });
+    expect(screen.getByText("No regions found.")).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "eu-west" })).not.toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Any region" })).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: "" } });
+    expect(screen.getByRole("option", { name: "na-us-west" })).toBeInTheDocument();
+  });
+
+  function setup(input: { regions: ApiProviderRegion[]; region?: string }) {
     const values = defaultServiceWithPlacement();
     values.placements[0].region = input.region;
     const useProviderRegions: typeof DEPENDENCIES.useProviderRegions = () => mock<ReturnType<typeof DEPENDENCIES.useProviderRegions>>({ data: input.regions });

--- a/apps/deploy-web/src/components/sdl/RegionSelect/RegionSelect.tsx
+++ b/apps/deploy-web/src/components/sdl/RegionSelect/RegionSelect.tsx
@@ -1,15 +1,14 @@
 import type { FC } from "react";
+import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@akashnetwork/ui/components";
-import { MapPin } from "iconoir-react";
+import { Button, Command, CommandInput, CommandItem, CommandList, Popover, PopoverContent, PopoverTrigger } from "@akashnetwork/ui/components";
+import { MapPin, NavArrowDown } from "iconoir-react";
 
 import { useProviderRegions } from "@src/queries/useProvidersQuery";
 import type { SdlBuilderFormValuesType } from "@src/types";
+import type { ApiProviderRegion } from "@src/types/provider";
 
 export const DEPENDENCIES = { useProviderRegions };
-
-/** Sentinel item value: radix Select forbids empty-string values, so "no region" needs a marker. */
-const ANY_REGION_VALUE = "any";
 
 type Props = {
   placementIndex: number;
@@ -21,33 +20,78 @@ type Props = {
 export const RegionSelect: FC<Props> = ({ placementIndex, disabled, dependencies: d = DEPENDENCIES }) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const { data: regions } = d.useProviderRegions();
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const filteredRegions = filterRegions(regions ?? [], search);
+
+  function closeAndResetSearch(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setSearch("");
+    }
+  }
 
   return (
     <Controller
       control={control}
       name={`placements.${placementIndex}.region`}
       render={({ field }) => (
-        <Select
-          disabled={disabled}
-          value={field.value || ANY_REGION_VALUE}
-          onValueChange={value => field.onChange(value === ANY_REGION_VALUE ? undefined : value)}
-        >
-          <SelectTrigger aria-label="Region" className="h-8 w-full text-xs">
-            <div className="flex min-w-0 items-center gap-1.5 truncate">
-              <MapPin aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-              <SelectValue />
-            </div>
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={ANY_REGION_VALUE}>Any region</SelectItem>
-            {(regions ?? []).map(region => (
-              <SelectItem key={region.key} value={region.key}>
-                {region.key}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <Popover open={open} onOpenChange={closeAndResetSearch}>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              aria-label="Region"
+              disabled={disabled}
+              className="h-8 w-full justify-between gap-1.5 px-3 text-xs font-normal"
+            >
+              <span className="flex min-w-0 items-center gap-1.5">
+                <MapPin aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span className="truncate">{field.value || "Any region"}</span>
+              </span>
+              <NavArrowDown aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
+            <Command label="Search regions" shouldFilter={false}>
+              <CommandInput value={search} onValueChange={setSearch} placeholder="Search regions..." />
+              <CommandList>
+                <CommandItem
+                  value="any"
+                  onSelect={function selectAnyRegion() {
+                    field.onChange("");
+                    closeAndResetSearch(false);
+                  }}
+                >
+                  Any region
+                </CommandItem>
+                {filteredRegions.map(region => (
+                  <CommandItem
+                    key={region.key}
+                    value={region.key}
+                    onSelect={function selectRegion() {
+                      field.onChange(region.key);
+                      closeAndResetSearch(false);
+                    }}
+                  >
+                    {region.key}
+                  </CommandItem>
+                ))}
+                {search && filteredRegions.length === 0 && <p className="py-6 text-center text-sm text-muted-foreground">No regions found.</p>}
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
       )}
     />
   );
 };
+
+/** Case-insensitive substring match over each region's visible key only; an empty/whitespace query returns every region. */
+export function filterRegions(regions: ApiProviderRegion[], query: string): ApiProviderRegion[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return regions;
+  }
+  return regions.filter(region => region.key.toLowerCase().includes(normalized));
+}

--- a/packages/ui/components/command.tsx
+++ b/packages/ui/components/command.tsx
@@ -88,7 +88,7 @@ const CommandItem = React.forwardRef<React.ElementRef<typeof CommandPrimitive.It
     <CommandPrimitive.Item
       ref={ref}
       className={cn(
-        "aria-selected:bg-accent aria-selected:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "aria-selected:bg-accent aria-selected:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
         className
       )}
       {...props}


### PR DESCRIPTION
## Why

The region filter on the configure marketplace was scroll-and-click only. With ~38 regions,
finding one meant scrolling the whole list. During the Console Onboarding Sync, Cheng asked to be
able to type (e.g. "eu") and have the list narrow down.

Fixes CON-601.

## What

Turns the region picker into a searchable combobox and fixes the interaction issues surfaced while
building it.

- **Type-ahead combobox.** Replaced the region `Select` with a `Popover` + cmdk `Command` combobox
  (`RegionSelect`). A search input above the list filters regions in real time. The form binding
  (`placements.${i}.region`), the `disabled` handling, and the trigger's look (MapPin + selected
  slug) are unchanged, so nothing downstream (marketplace screening, SDL generation) changes.

- **Filter matches the visible key only.** Matching is a case-insensitive substring over the region
  key shown in the list. I first also matched the hidden human description, but that surfaced regions
  whose visible label didn't contain the query — e.g. searching "south" returned `sa-north` / `sa-west`
  / `sa-brazil` because their descriptions start with "South America…", which reads as "why are these
  in the list?". Matching only what the user sees removes that surprise.

- **"Any region" is always available.** It's a persistent reset item at the top of the list (it was
  previously hidden while searching, which left no way back to it once you'd typed). Selecting it
  clears the region to `""` rather than `undefined`: React Hook Form does not re-render the
  `Controller` when a field is set to `undefined`, so the trigger kept showing the previous region.
  `""` is still treated as "no region" by both `sdlGenerator` (`!!region && region !== "any"`) and
  `useScreenedProviders` (falsy region → no `location-region` constraint).

- **Shared cmdk fix (`packages/ui/components/command.tsx`).** cmdk 1.0 renders `data-disabled="false"`
  on every enabled item, but `CommandItem` used the presence selector `data-[disabled]:pointer-events-none`
  / `data-[disabled]:opacity-50`, which matched `"false"` and put `pointer-events: none` on every item —
  so mouse clicks were blocked (keyboard selection still worked) on **all** cmdk comboboxes. Switched to
  `data-[disabled=true]:`, matching upstream shadcn's cmdk-1.0 fix. The Radix-based `select.tsx` /
  `dropdown-menu.tsx` use the same pattern but are unaffected, because Radix only emits `data-disabled`
  when an item is actually disabled.

No API/SDL changes, no breaking changes, no migrations.

## Testing

- **Unit (`RegionSelect.spec.tsx`):** `filterRegions` (empty query → all, case-insensitive key match,
  ignores description-only text) plus component behavior — picks a region and reflects it in the trigger
  while resetting the search, clears via "Any region" and shows "Any region" in the trigger, and
  filters / shows the empty state / restores the full list on clear while keeping "Any region" visible.
- **Verified in-browser** for the two aspects jsdom can't cover: the `pointer-events` CSS fix (no layout/
  CSS engine in jsdom) and end-to-end mouse selection.
- lint and type-check clean for the changed files.


<img width="239" height="327" alt="image" src="https://github.com/user-attachments/assets/fbe0c41b-499b-4433-b651-4acf22c1a00c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Region selection now uses a searchable picker, making it easier to find and choose a region.
  * “Any region” is always available as a quick default option.

* **Bug Fixes**
  * Search results now match region names more reliably and ignore unrelated description text.
  * The selection field now clears correctly when “Any region” is chosen.
  * Disabled command items now display and behave more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->