### PR TITLE
feat(sdl): auto-match confidential compute deployments to capable providers

### DIFF
--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.spec.ts
@@ -64,6 +64,46 @@ describe("sdlGenerator", () => {
       expect(parsedAny.profiles.placement["dcloud"].attributes?.["location-region"]).toBeUndefined();
     });
 
+    it.each([["cpu"], ["cpu-gpu"]] as const)("injects the tee/type placement requirement from a service's params.tee (%s)", tee => {
+      const result = generateSdl(buildFormValues(buildLogCollectorService({ title: "web", image: "nginx:latest", params: { tee } })));
+      const parsed = yaml.load(result) as { profiles: { placement: Record<string, { attributes?: Record<string, string> }> } };
+
+      expect(parsed.profiles.placement["dcloud"].attributes).toMatchObject({ "tee/type": tee });
+    });
+
+    it("does not inject a tee/type placement requirement when no service requests confidential compute", () => {
+      const result = generateSdl(buildFormValues(buildLogCollectorService({ title: "web", image: "nginx:latest" })));
+      const parsed = yaml.load(result) as { profiles: { placement: Record<string, { attributes?: Record<string, string> }> } };
+
+      expect(parsed.profiles.placement["dcloud"].attributes?.["tee/type"]).toBeUndefined();
+    });
+
+    it("merges the tee/type requirement alongside location-region and other declared attributes", () => {
+      const formValues = buildFormValues(buildLogCollectorService({ title: "web", image: "nginx:latest", params: { tee: "cpu-gpu" } }));
+      formValues.placements[0].region = "us-west";
+      formValues.placements[0].attributes = [{ id: "a-1", key: "organization", value: "akash" }];
+      const result = generateSdl(formValues);
+      const parsed = yaml.load(result) as { profiles: { placement: Record<string, { attributes?: Record<string, string> }> } };
+
+      expect(parsed.profiles.placement["dcloud"].attributes).toEqual({
+        organization: "akash",
+        "location-region": "us-west",
+        "tee/type": "cpu-gpu"
+      });
+    });
+
+    it("emits a single tee/type requirement when multiple services share a placement and TEE type", () => {
+      const result = generateSdl(
+        buildFormValues(
+          buildLogCollectorService({ title: "web", image: "nginx:latest", params: { tee: "cpu" } }),
+          buildLogCollectorService({ title: "api", image: "nginx:latest", params: { tee: "cpu" } })
+        )
+      );
+      const parsed = yaml.load(result) as { profiles: { placement: Record<string, { attributes?: Record<string, string> }> } };
+
+      expect(parsed.profiles.placement["dcloud"].attributes).toEqual({ "tee/type": "cpu" });
+    });
+
     it("throws when a service references a placementId that does not exist", () => {
       const formValues = {
         placements: [{ id: "p-1", name: "dcloud" }],

--- a/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlGenerator.ts
@@ -2,6 +2,8 @@ import yaml from "js-yaml";
 
 import { isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
 import type { ExposeType, PlacementType, ProfileGpuModelType, SdlBuilderFormValuesType } from "@src/types";
+import type { TeeType } from "@src/utils/confidentialCompute";
+import { TEE_TYPE_ATTRIBUTE_KEY } from "@src/utils/confidentialCompute";
 import { defaultHttpOptions } from "./data";
 
 /**
@@ -26,6 +28,14 @@ export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
   }
 
   const placementById = new Map<string, PlacementType>(formValues.placements.map(p => [p.id, p]));
+
+  // Derive each placement's Confidential Compute type from its services' `params.tee`. The TEE choice is
+  // per-service, but the provider-matching requirement is per-placement/group; CON-449 guarantees all
+  // services sharing a placement use the same TEE type (or none), so a single value per placement is safe.
+  const teeTypeByPlacementId = new Map<string, TeeType>();
+  formValues.services.forEach(service => {
+    if (service.params?.tee) teeTypeByPlacementId.set(service.placementId, service.params.tee);
+  });
 
   formValues.placements.forEach(placement => {
     sdl.profiles.placement[placement.name] = { pricing: {} };
@@ -52,6 +62,17 @@ export const generateSdl = (formValues: SdlBuilderFormValuesType) => {
       sdl.profiles.placement[placement.name].attributes = {
         ...(sdl.profiles.placement[placement.name].attributes || {}),
         "location-region": placement.region.toLowerCase()
+      };
+    }
+
+    // Auto-managed provider-matching requirement derived from the placement's TEE type, so only
+    // TEE-capable providers bid/match. Stripped back out on import so it never becomes a hand-editable
+    // attribute and can never duplicate on re-export.
+    const teeType = teeTypeByPlacementId.get(placement.id);
+    if (teeType) {
+      sdl.profiles.placement[placement.name].attributes = {
+        ...(sdl.profiles.placement[placement.name].attributes || {}),
+        [TEE_TYPE_ATTRIBUTE_KEY]: teeType
       };
     }
   });

--- a/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.spec.ts
@@ -208,6 +208,14 @@ describe("sdlImport", () => {
 
       expect(services[0].params).toBeUndefined();
     });
+
+    it("drops the auto-managed tee/type placement requirement so it is not a hand-editable attribute", () => {
+      const { placements } = importSimpleSdl(teeSdlWithPlacementRequirement("cpu"));
+
+      expect(placements[0].attributes?.some(a => a.key === "tee/type")).toBe(false);
+      // Genuinely declared attributes still import.
+      expect(placements[0].attributes?.some(a => a.key === "organization")).toBe(true);
+    });
   });
 
   describe("SDL roundtrip", () => {
@@ -216,6 +224,21 @@ describe("sdlImport", () => {
       const parsed = yaml.load(regenerated) as { services: Record<string, { params?: { tee?: string } }> };
 
       expect(parsed.services.web.params?.tee).toBe("cpu");
+    });
+
+    it.each([["cpu"], ["cpu-gpu"]] as const)("re-derives a single tee/type placement requirement from params.tee on regenerate (%s)", tee => {
+      const regenerated = generateSdl(importSimpleSdl(teeSdl(tee)));
+      const parsed = yaml.load(regenerated) as { profiles: { placement: Record<string, { attributes?: Record<string, string> }> } };
+
+      expect(parsed.profiles.placement["dcloud"].attributes).toEqual({ "tee/type": tee });
+    });
+
+    it("does not duplicate the tee/type requirement when re-importing an SDL that already declares it", () => {
+      const regenerated = generateSdl(importSimpleSdl(teeSdlWithPlacementRequirement("cpu")));
+      const parsed = yaml.load(regenerated) as { profiles: { placement: Record<string, { attributes?: Record<string, string> }> } };
+
+      // Exactly one tee/type, alongside the genuinely declared attribute — no duplicate/conflicting entry.
+      expect(parsed.profiles.placement["dcloud"].attributes).toEqual({ organization: "akash", "tee/type": "cpu" });
     });
 
     it("imports an SDL, regenerates it, and produces semantically equal output", () => {
@@ -317,6 +340,47 @@ const teeSdl = (tee: "cpu" | "cpu-gpu") =>
     "          - size: 512Mi",
     "  placement:",
     "    dcloud:",
+    "      pricing:",
+    "        web:",
+    "          denom: uakt",
+    "          amount: 1000",
+    "deployment:",
+    "  web:",
+    "    dcloud:",
+    "      profile: web",
+    "      count: 1"
+  ].join("\n");
+
+// Mirrors an SDL that already carries the auto-managed matching requirement on the placement (as an
+// exported/round-tripped deployment would), alongside a genuinely declared attribute.
+const teeSdlWithPlacementRequirement = (tee: "cpu" | "cpu-gpu") =>
+  [
+    "version: '2.1'",
+    "services:",
+    "  web:",
+    "    image: nginx:latest",
+    "    expose:",
+    "      - port: 80",
+    "        as: 80",
+    "        to:",
+    "          - global: true",
+    "    params:",
+    `      tee: ${tee}`,
+    "profiles:",
+    "  compute:",
+    "    web:",
+    "      resources:",
+    "        cpu:",
+    "          units: 0.5",
+    "        memory:",
+    "          size: 512Mi",
+    "        storage:",
+    "          - size: 512Mi",
+    "  placement:",
+    "    dcloud:",
+    "      attributes:",
+    "        organization: akash",
+    `        tee/type: ${tee}`,
     "      pricing:",
     "        web:",
     "          denom: uakt",

--- a/apps/deploy-web/src/utils/sdl/sdlImport.ts
+++ b/apps/deploy-web/src/utils/sdl/sdlImport.ts
@@ -3,6 +3,7 @@ import { nanoid } from "nanoid";
 
 import type { EndpointType, ExposeType, PlacementAttributeType, PlacementType, ProfileGpuModelType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { ReclamationMinWindowSchema, RESERVED_ENV_KEYS } from "@src/types/sdlBuilder/sdlBuilder";
+import { TEE_TYPE_ATTRIBUTE_KEY } from "@src/utils/confidentialCompute";
 import { CustomValidationError } from "../deploymentData";
 import { capitalizeFirstLetter } from "../stringUtils";
 import { defaultHttpOptions } from "./data";
@@ -240,6 +241,11 @@ function hydratePlacement(id: string, name: string, profile: any): PlacementType
   for (const [key, value] of Object.entries(rawAttributes)) {
     if (key === "location-region") {
       region = value;
+      continue;
+    }
+    // Auto-managed provider-matching requirement re-derived from services' `params.tee` on export; drop
+    // it here so it never surfaces as a hand-editable attribute or duplicates on the next round-trip.
+    if (key === TEE_TYPE_ATTRIBUTE_KEY) {
       continue;
     }
     attributes.push({ id: nanoid(), key, value });


### PR DESCRIPTION
## Why

Part of CON-543.

When a tenant enables Confidential Compute (TEE) on a deployment, it must only ever be offered to providers that can actually run it. Today the per-service `params.tee` choice only lands in the provider manifest (`TEEParams`) — it never becomes an on-chain group placement requirement, so **any** provider can bid on a confidential workload and a won bid can't be honored as confidential.

`@akashnetwork/chain-sdk`'s `generateManifest` builds `group_spec.requirements.attributes` exclusively from `profiles.placement.<name>.attributes`; it does not derive anything from `params.tee`. So the builder must inject the matching requirement itself.

## What

Auto-manage a `tee/type` provider-matching requirement derived from the tenant's TEE choice, fully round-tripped and hidden from the manual attribute editor.

- **Export** (`sdlGenerator.ts`): derive each placement's TEE type from its services' `params.tee` (CON-449 guarantees one shared type per placement) and merge `tee/type: cpu | cpu-gpu` into the placement attributes — mirroring the existing `location-region` handling.
- **Import** (`sdlImport.ts`): drop `tee/type` in `hydratePlacement` (same lift as `location-region`) so it never populates the hand-editable attribute list and can't duplicate on re-export. The value is re-derived from `params.tee` (which already round-trips) on every export.

Single injection point covers both consumers: once `tee/type` is on the group spec, on-chain bidding and the marketplace bid-screening request (`buildPlacementScreeningRequest`) both pick it up automatically. Non-TEE deployments are unchanged.

**Acceptance criteria**
- [x] Enabling Confidential Compute auto-restricts the deployment to capable providers, no manual action.
- [x] CPU and CPU+GPU deployments round-trip (import → edit → re-export) losslessly, ending with exactly one requirement, no duplicates.
- [x] Re-importing an SDL that already carries the requirement does not add a second/conflicting one.
- [x] The requirement is not exposed in the manual attribute editor and cannot be hand-edited.
- [ ] Consistent in managed Console **and Console Air** — this repo covers managed Console; Console Air is a separate repo (`akash-network/console-air`) with its own copy of these utils, so the same pattern must be mirrored there as a follow-up.

**Verification**
- New unit tests in `sdlGenerator.spec.ts` / `sdlImport.spec.ts` cover injection (cpu/cpu-gpu), no-injection when off, merge with region + other attributes, single attribute for multi-service placements, import-drop, and no-duplication on re-import. Full affected SDL suite: 75 passing.
- Confirmed end-to-end against the real `generateManifest`: a generated TEE SDL yields `group requirements.attributes: [{"key":"tee/type","value":"cpu-gpu"}]`.

**Note (to confirm with provider/AEP-83):** matching key is `tee/type` with value `cpu`/`cpu-gpu` — the contract the console read side (`confidentialCompute.ts`) already uses. Only the constant changes if the provider expects a different key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SDL generation now automatically adds the required confidential compute placement attribute when a service requests a TEE type.
  * Import and export flows now preserve this placement requirement without exposing it as a manually editable field.

* **Bug Fixes**
  * Prevented duplicate TEE placement requirements when multiple services share the same placement.
  * Improved round-tripping so existing placement attributes remain intact while derived TEE requirements are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->