### PR TITLE
fix(deployment): persist SDL and reset state after deploying in the configure flow

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.spec.tsx
@@ -106,6 +106,7 @@ describe(ConfigureDeployment.name, () => {
       Layout: vi.fn(({ children }) => <div data-testid="layout-mock">{children}</div>) as never,
       NextSeo: vi.fn(() => null) as never,
       ConfigureDeploymentForm: ConfigureDeploymentForm as never,
+      RedirectIfLeased: vi.fn(({ children }) => <>{children}</>) as never,
       usePublicTemplate: usePublicTemplate as never,
       useConfigureDraft: useConfigureDraft as never,
       useSearchParams: () => params as unknown as ReadonlyURLSearchParams,

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.tsx
@@ -12,6 +12,7 @@ import { usePublicTemplate } from "@src/queries/useTemplateQuery";
 import sdlStore from "@src/store/sdlStore";
 import { hardcodedTemplates } from "@src/utils/templates";
 import { ConfigureDeploymentForm } from "../ConfigureDeploymentForm/ConfigureDeploymentForm";
+import { RedirectIfLeased } from "../RedirectIfLeased/RedirectIfLeased";
 import { useConfigureDraft } from "../useConfigureDraft/useConfigureDraft";
 import type { DeploymentIntent } from "../useDeploymentFlow/deploymentIntent";
 import { parseDeploymentIntent } from "../useDeploymentFlow/deploymentIntent";
@@ -20,6 +21,7 @@ export const DEPENDENCIES = {
   Layout,
   NextSeo,
   ConfigureDeploymentForm,
+  RedirectIfLeased,
   usePublicTemplate,
   useConfigureDraft,
   useSearchParams,
@@ -71,18 +73,20 @@ export const ConfigureDeployment: FC<Props> = ({ dependencies: d = DEPENDENCIES 
     [fetchedTemplateId, templateQuery.isError, enqueueSnackbar, d]
   );
 
-  if (fetchedTemplateId && templateQuery.isLoading) {
-    return (
-      <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col">
-        <d.NextSeo title="Configure your deployment" />
-        <div className="flex flex-1 items-center justify-center">
-          <Spinner size="large" />
-        </div>
-      </d.Layout>
-    );
-  }
-
   const initialSdl = draft.persistedSdl ?? hardcodedTemplate?.content ?? (fetchedTemplateId ? templateQuery.data?.deploy : deploySdl?.content);
 
-  return <d.ConfigureDeploymentForm key={draft.draftId} initialSdl={initialSdl} intent={resolvedIntent} />;
+  return (
+    <d.RedirectIfLeased dseq={intent.dseq}>
+      {fetchedTemplateId && templateQuery.isLoading ? (
+        <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col">
+          <d.NextSeo title="Configure your deployment" />
+          <div className="flex flex-1 items-center justify-center">
+            <Spinner size="large" />
+          </div>
+        </d.Layout>
+      ) : (
+        <d.ConfigureDeploymentForm key={draft.draftId} initialSdl={initialSdl} intent={resolvedIntent} />
+      )}
+    </d.RedirectIfLeased>
+  );
 };

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -213,13 +213,26 @@ describe(ConfigureDeploymentForm.name, () => {
     await waitFor(() => expect(save).toHaveBeenCalledWith(expect.stringContaining("nginx:latest")));
   });
 
-  function setup(input: { initialSdl: string | undefined; Panes?: typeof SdlProbePanes; draftId?: string }) {
+  it("clears the configure draft once the deployment is deployed", () => {
+    const { clear } = setup({ initialSdl: undefined, deploySucceeded: true });
+
+    expect(clear).toHaveBeenCalled();
+  });
+
+  it("keeps the configure draft while the deployment has not been deployed", () => {
+    const { clear } = setup({ initialSdl: undefined, deploySucceeded: false });
+
+    expect(clear).not.toHaveBeenCalled();
+  });
+
+  function setup(input: { initialSdl: string | undefined; Panes?: typeof SdlProbePanes; draftId?: string; deploySucceeded?: boolean }) {
     const ConfigureDeploymentPanes = vi.fn(input.Panes ?? (() => <div data-testid="panes-mock" />));
     const enqueueSnackbar = vi.fn();
     const Snackbar = vi.fn(() => null);
     const save = vi.fn<(sdl: string) => void>();
+    const clear = vi.fn<() => void>();
     const useConfigureDraft = vi.fn(() =>
-      mock<ReturnType<typeof DEPENDENCIES.useConfigureDraft>>({ draftId: input.draftId ?? "draft-1", persistedSdl: undefined, save, clear: vi.fn() })
+      mock<ReturnType<typeof DEPENDENCIES.useConfigureDraft>>({ draftId: input.draftId ?? "draft-1", persistedSdl: undefined, save, clear })
     );
     const dependencies: typeof DEPENDENCIES = {
       Layout: vi.fn(({ children }) => <div data-testid="layout-mock">{children}</div>) as never,
@@ -227,7 +240,13 @@ describe(ConfigureDeploymentForm.name, () => {
       ConfigureDeploymentHeader: vi.fn(() => <div data-testid="header-mock" />),
       ConfigureDeploymentPanes: ConfigureDeploymentPanes as never,
       useConfigureDraft: useConfigureDraft as never,
-      useDeploymentFlow: (() => mock<ReturnType<typeof DEPENDENCIES.useDeploymentFlow>>({ phase: "configuring", dseq: null, bidStrategy: "select" })) as never,
+      useDeploymentFlow: (() =>
+        mock<ReturnType<typeof DEPENDENCIES.useDeploymentFlow>>({
+          phase: "configuring",
+          dseq: null,
+          bidStrategy: "select",
+          deploySucceeded: input.deploySucceeded ?? false
+        })) as never,
       useSnackbar: () => mock<ReturnType<typeof DEPENDENCIES.useSnackbar>>({ enqueueSnackbar }),
       Snackbar: Snackbar as never,
       ReviewAndDeployModal: () => null,
@@ -242,7 +261,7 @@ describe(ConfigureDeploymentForm.name, () => {
       />
     );
 
-    return { ConfigureDeploymentPanes, enqueueSnackbar, save };
+    return { ConfigureDeploymentPanes, enqueueSnackbar, save, clear };
   }
 });
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -135,6 +135,15 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, intent, depende
   );
 
   useEffect(
+    function clearDraftOnceDeployed() {
+      if (flow.deploySucceeded) {
+        draft.clear();
+      }
+    },
+    [flow.deploySucceeded, draft]
+  );
+
+  useEffect(
     function focusFirstBidReadyPlacement() {
       if (flow.phase !== "quoting") {
         hasAutoFocusedFirstBids.current = false;

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/RedirectIfLeased/RedirectIfLeased.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/RedirectIfLeased/RedirectIfLeased.spec.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { UrlService } from "@src/utils/urlUtils";
+import type { DEPENDENCIES } from "./RedirectIfLeased";
+import { RedirectIfLeased } from "./RedirectIfLeased";
+
+import { render, screen } from "@testing-library/react";
+
+describe(RedirectIfLeased.name, () => {
+  it("renders the children immediately when there is no dseq to resume", () => {
+    const { replace } = setup({ dseq: undefined });
+
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("renders the children once the resumed deployment resolves without leases", () => {
+    const { replace } = setup({ dseq: "555", leases: [] });
+
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("holds the children behind a spinner while the deployment resolves", () => {
+    setup({ dseq: "555", isLoading: true });
+
+    expect(screen.queryByTestId("child")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("redirects to the deployment detail page when the resumed deployment already has leases", () => {
+    const { replace } = setup({ dseq: "555", leases: [{}] });
+
+    expect(replace).toHaveBeenCalledWith(UrlService.deploymentDetails("555"));
+    expect(screen.queryByTestId("child")).not.toBeInTheDocument();
+  });
+
+  function setup(input: { dseq?: string; leases?: unknown[]; isLoading?: boolean }) {
+    const replace = vi.fn();
+    const useGetDeployment = vi.fn(() =>
+      mock<ReturnType<typeof DEPENDENCIES.useGetDeployment>>({
+        data: input.leases ? ({ data: { leases: input.leases } } as never) : undefined,
+        isLoading: input.isLoading ?? false
+      })
+    );
+    const dependencies: typeof DEPENDENCIES = {
+      Layout: vi.fn(({ children }: { children: ReactNode }) => <div data-testid="layout-mock">{children}</div>) as never,
+      useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace })) as never,
+      useGetDeployment: useGetDeployment as never
+    };
+
+    render(
+      <RedirectIfLeased dseq={input.dseq} dependencies={dependencies}>
+        <div data-testid="child" />
+      </RedirectIfLeased>
+    );
+
+    return { replace };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/RedirectIfLeased/RedirectIfLeased.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/RedirectIfLeased/RedirectIfLeased.tsx
@@ -1,0 +1,56 @@
+import type { FC, ReactNode } from "react";
+import { useEffect, useState } from "react";
+import { Spinner } from "@akashnetwork/ui/components";
+import { useRouter } from "next/navigation";
+
+import Layout from "@src/components/layout/Layout";
+import { useServices } from "@src/context/ServicesProvider";
+import { UrlService } from "@src/utils/urlUtils";
+
+function useGetDeployment(dseq: string | undefined) {
+  return useServices().api.v1.getDeployment.useQuery({ dseq: dseq ?? "" }, { enabled: !!dseq });
+}
+
+export const DEPENDENCIES = { Layout, useRouter, useGetDeployment };
+
+interface Props {
+  dseq: string | undefined;
+  children: ReactNode;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+/**
+ * Gates the configure screen for a resumed deployment: a dseq whose deployment already has leases is finished —
+ * not still being quoted — so it belongs on the detail page. The children stay unmounted behind a spinner while
+ * the deployment resolves, and throughout the redirect once it turns out leased, so the inert configure UI never
+ * flashes. Scoped to the dseq present at mount, so a dseq created during this session (no leases yet, and which
+ * redirects itself once deployed) never trips the gate. With no dseq the children render immediately without a
+ * query. The owner is resolved from auth by the API, so this needs no wallet.
+ */
+export const RedirectIfLeased: FC<Props> = ({ dseq, children, dependencies: d = DEPENDENCIES }) => {
+  const router = d.useRouter();
+  const [resumeDseq] = useState(() => dseq);
+  const { data, isLoading } = d.useGetDeployment(resumeDseq);
+  const hasLeases = !!data?.data?.leases?.length;
+
+  useEffect(
+    function redirectWhenLeased() {
+      if (resumeDseq && hasLeases) {
+        router.replace(UrlService.deploymentDetails(resumeDseq));
+      }
+    },
+    [resumeDseq, hasLeases, router]
+  );
+
+  if (resumeDseq && (isLoading || hasLeases)) {
+    return (
+      <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col">
+        <div className="flex flex-1 items-center justify-center">
+          <Spinner size="large" />
+        </div>
+      </d.Layout>
+    );
+  }
+
+  return <>{children}</>;
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { UrlService } from "@src/utils/urlUtils";
 import type { DeploymentIntent } from "./deploymentIntent";
 import type { DEPENDENCIES } from "./useDeploymentFlow";
 import { buildConfigureUrl, useDeploymentFlow } from "./useDeploymentFlow";
@@ -116,13 +117,13 @@ describe(useDeploymentFlow.name, () => {
     );
   });
 
-  it("marks the deploy succeeded, then redirects to the deployment detail after a brief dwell", () => {
+  it("marks the deploy succeeded, then replaces to the deployment's events tab after a brief dwell", () => {
     vi.useFakeTimers();
     try {
       const createDeployment = mockMutation();
       createDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({ data: { dseq: "555", manifest: "M" } }));
       const createLease = mockMutation();
-      createLease.mutate.mockImplementation((_i, o) => o.onSuccess());
+      createLease.mutate.mockImplementation((_i, o) => o.onSuccess(deployedResult("akash1owner")));
       const { result, router } = renderFlow({ createDeployment, createLease });
 
       act(() => result.current.actions.requestQuotes("sdl"));
@@ -130,10 +131,54 @@ describe(useDeploymentFlow.name, () => {
       act(() => result.current.actions.deploy("sdl"));
 
       expect(result.current.deploySucceeded).toBe(true);
-      expect(router.push).not.toHaveBeenCalled();
+      expect(router.replace).not.toHaveBeenCalledWith(UrlService.deploymentDetails("555", "EVENTS", "events"));
 
       act(() => vi.runAllTimers());
-      expect(router.push).toHaveBeenCalledWith("/deployments/555");
+      expect(router.replace).toHaveBeenCalledWith(UrlService.deploymentDetails("555", "EVENTS", "events"));
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("persists the deployment SDL keyed by the owner the lease response carries so the detail page can read it", () => {
+    vi.useFakeTimers();
+    try {
+      const createDeployment = mockMutation();
+      createDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({ data: { dseq: "555", manifest: "M" } }));
+      const createLease = mockMutation();
+      createLease.mutate.mockImplementation((_i, o) => o.onSuccess(deployedResult("akash1owner")));
+      const { result, deploymentLocalStorage } = renderFlow({ createDeployment, createLease });
+
+      act(() => result.current.actions.requestQuotes("sdl"));
+      act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+      act(() => result.current.actions.deploy("SDL_CONTENT"));
+
+      expect(deploymentLocalStorage.update).toHaveBeenCalledWith("akash1owner", "555", { manifest: "SDL_CONTENT" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still marks the deploy succeeded and redirects when caching the SDL throws", () => {
+    vi.useFakeTimers();
+    try {
+      const createDeployment = mockMutation();
+      createDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({ data: { dseq: "555", manifest: "M" } }));
+      const createLease = mockMutation();
+      createLease.mutate.mockImplementation((_i, o) => o.onSuccess(deployedResult("akash1owner")));
+      const { result, router, deploymentLocalStorage } = renderFlow({ createDeployment, createLease });
+      deploymentLocalStorage.update.mockImplementation(() => {
+        throw new Error("storage unavailable");
+      });
+
+      act(() => result.current.actions.requestQuotes("sdl"));
+      act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+      act(() => result.current.actions.deploy("sdl"));
+
+      expect(result.current.deploySucceeded).toBe(true);
+
+      act(() => vi.runAllTimers());
+      expect(router.replace).toHaveBeenCalledWith(UrlService.deploymentDetails("555", "EVENTS", "events"));
     } finally {
       vi.useRealTimers();
     }
@@ -277,6 +322,7 @@ describe(useDeploymentFlow.name, () => {
       useCreateLease: (() => mock<ReturnType<typeof DEPENDENCIES.useCreateLease>>({ mutate: vi.fn() as never })) as never,
       useListBids: (() => ({ data: { data: [] }, isLoading: false, isError: false })) as never,
       useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: (input.replace ?? vi.fn()) as never })) as never,
+      useDeploymentLocalStorage: (() => mock<ReturnType<typeof DEPENDENCIES.useDeploymentLocalStorage>>()) as never,
       manifestFromSdl: () => "manifest"
     };
     return renderHook(() => useDeploymentFlow({ intent }, dependencies));
@@ -292,20 +338,27 @@ describe(useDeploymentFlow.name, () => {
   }) {
     const intent: DeploymentIntent = { sdlStrategy: "edit", bidStrategy: "select", dseq: undefined, ...input?.intent };
     const router = mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: vi.fn(), push: vi.fn() });
+    const deploymentLocalStorage = mock<ReturnType<typeof DEPENDENCIES.useDeploymentLocalStorage>>();
     const dependencies: typeof DEPENDENCIES = {
       useCreateDeployment: (() => input?.createDeployment ?? mockMutation()) as never,
       useCloseDeployment: (() => input?.closeDeployment ?? mockMutation()) as never,
       useCreateLease: (() => input?.createLease ?? mockMutation()) as never,
       useListBids: (() => ({ data: { data: input?.listBids ?? [] }, isLoading: false, isError: false })) as never,
       useRouter: () => router,
+      useDeploymentLocalStorage: (() => deploymentLocalStorage) as never,
       manifestFromSdl: input?.manifestFromSdl ?? (() => "DERIVED_MANIFEST")
     };
     const utils = renderHook(() => useDeploymentFlow({ intent }, dependencies));
-    return { ...utils, router };
+    return { ...utils, router, deploymentLocalStorage };
   }
 
   function mockMutation() {
     return mock<{ mutate: ReturnType<typeof vi.fn> }>({ mutate: vi.fn() });
+  }
+
+  /** The create-lease success payload shape the flow reads the owner from. */
+  function deployedResult(owner: string) {
+    return { data: { deployment: { id: { owner } } } };
   }
 });
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -62,7 +62,11 @@ function useCreateLease() {
   return useServices().api.v1.createLease.useMutation();
 }
 
-export const DEPENDENCIES = { useCreateDeployment, useCloseDeployment, useCreateLease, useListBids, useRouter, manifestFromSdl };
+function useDeploymentLocalStorage() {
+  return useServices().deploymentLocalStorage;
+}
+
+export const DEPENDENCIES = { useCreateDeployment, useCloseDeployment, useCreateLease, useListBids, useRouter, useDeploymentLocalStorage, manifestFromSdl };
 
 /**
  * Controlled lifecycle state machine for the configure flow. Owns interaction state (phase, dseq,
@@ -75,6 +79,7 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
   const createDeployment = dependencies.useCreateDeployment();
   const closeDeployment = dependencies.useCloseDeployment();
   const createLease = dependencies.useCreateLease();
+  const deploymentLocalStorage = dependencies.useDeploymentLocalStorage();
 
   const [phase, setPhase] = useState<DeploymentFlowPhase>(intent.dseq ? "quoting" : "configuring");
   const [dseq, setDseq] = useState<string | null>(intent.dseq ?? null);
@@ -204,6 +209,10 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
    * captured at create time is used when present; on a reload that resumed straight into `quoting` it was
    * never captured, so it is rederived from the passed SDL (identical to the server's create-deployment
    * manifest, both being `manifestToSortedJSON` of the SDL's groups) rather than leaving deploy a no-op.
+   * On success it persists the SDL under the deployment's dseq keyed by the owner the response carries (so it
+   * needs no wallet) — the same key the detail page reads — then replaces the configure entry with the
+   * deployment's events tab (matching the legacy builder), so Back lands on the new-deployment page rather than
+   * the just-deployed config.
    * On failure it drops back to `quoting` so the progress overlay unmounts and the user is returned to where
    * they took off; `deployError` is set to drive the error toast and the header's Retry CTA. Retry re-fires
    * this same request with the current selections — provider re-selection after a lease exists is out of
@@ -221,10 +230,11 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
       createLease.mutate(
         { manifest: effectiveManifest, leases },
         {
-          onSuccess: function onDeployed() {
+          onSuccess: function onDeployed(result: { data: { deployment: { id: { owner: string } } } }) {
+            cacheDeployedSdl(deploymentLocalStorage, result.data.deployment.id.owner, dseq, sdl);
             setDeploySucceeded(true);
             redirectTimerRef.current = setTimeout(function redirectToDeployment() {
-              router.push(UrlService.deploymentDetails(dseq));
+              router.replace(UrlService.deploymentDetails(dseq, "EVENTS", "events"));
             }, DEPLOY_SUCCESS_DWELL_MS);
           },
           onError: function onDeployFailed(cause: unknown) {
@@ -234,7 +244,7 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
         }
       );
     },
-    [createLease, dseq, manifest, selections, router, dependencies]
+    [createLease, dseq, manifest, selections, router, dependencies, deploymentLocalStorage]
   );
 
   return {
@@ -247,6 +257,19 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
     error,
     actions: { requestQuotes, cancelAndEdit, setBidStrategy, refreshQuotes, retry, selectProvider, clearSelection, deploy }
   };
+}
+
+/**
+ * Best-effort cache of the deployed SDL under the deployment's owner + dseq — the key the detail page reads.
+ * Storage can be blocked, full, or hold corrupt data, so any failure is swallowed: caching must never keep the
+ * deploy-success UI or the redirect from running.
+ */
+function cacheDeployedSdl(storage: ReturnType<typeof useDeploymentLocalStorage>, owner: string, dseq: string, sdl: string): void {
+  try {
+    storage.update(owner, dseq, { manifest: sdl });
+  } catch {
+    return;
+  }
 }
 
 /**


### PR DESCRIPTION
## Why

Internal testing of the new deployment flow (configure → marketplace → deploy) surfaced several regressions vs the legacy builder:

- the deployment's SDL wasn't available on the detail page after deploying;
- the user no longer landed on the events tab after deploying;
- returning to the configure page still showed the just-deployed configuration, forcing the user to close the deployment to clear it.

Fixes CON-629

## What

Frontend-only changes to the configure/deploy flow in `deploy-web`:

- **Persist the SDL for the detail page.** On lease creation the deployment SDL is written to the same per-deployment local store the detail page reads, keyed by the owner returned in the lease response — no wallet dependency. Previously nothing was stored for deployments created through the new flow, so the detail page showed no configuration.
- **Land on the events tab after deploying.** Post-deploy navigation now targets the deployment's events tab, matching the legacy builder.
- **Reset state after deploying.** The configure draft is cleared and navigation uses `replace` on a successful deploy, so going back starts fresh from the new-deployment page instead of restoring the just-deployed config.
- **Redirect already-leased deployments.** Opening the configure page for a deployment that already has leases redirects to that deployment's detail page. The check runs behind a spinner (a gate wrapper) so the configure UI never flashes before redirecting.

No API or contract changes. No wallet-provider dependency.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic handling for already-leased deployments: the configure screen is bypassed and users are redirected to the deployment details/events page.
  * After a successful deployment, the app now stores the deployed manifest for later use, then redirects to the events view.
  * While the lease status is being determined, the configure UI is temporarily hidden behind a loading state.
* **Bug Fixes**
  * Deployment drafts are now cleared only after a successful deploy, preventing stale draft data.
  * Manifest caching is handled best-effort so failures won’t block the success redirect.
* **Tests**
  * Expanded coverage for the lease-redirect logic and deployment-success behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->