### PR TITLE
feat(deployment): add a deployment name field on the configure screen

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.spec.tsx
@@ -82,10 +82,32 @@ describe(ConfigureDeployment.name, () => {
     expect(ConfigureDeploymentForm).toHaveBeenCalledWith(expect.objectContaining({ initialSdl: "version: '2.0'" }), expect.anything());
   });
 
+  it("defaults the deployment name to the fetched template's name", () => {
+    const { ConfigureDeploymentForm } = setup({
+      templateId: "tpl-1",
+      template: { isLoading: false, data: mock<TemplateOutput>({ deploy: "version: '2.0'", name: "My Template" }) }
+    });
+
+    expect(ConfigureDeploymentForm).toHaveBeenCalledWith(expect.objectContaining({ initialName: "My Template" }), expect.anything());
+  });
+
+  it("defaults the deployment name to a hardcoded template's name", () => {
+    const { ConfigureDeploymentForm } = setup({ templateId: helloWorldTemplate.code });
+
+    expect(ConfigureDeploymentForm).toHaveBeenCalledWith(expect.objectContaining({ initialName: helloWorldTemplate.name }), expect.anything());
+  });
+
+  it("prefers the persisted draft name over the template name", () => {
+    const { ConfigureDeploymentForm } = setup({ templateId: helloWorldTemplate.code, persistedName: "resumed-name" });
+
+    expect(ConfigureDeploymentForm).toHaveBeenCalledWith(expect.objectContaining({ initialName: "resumed-name" }), expect.anything());
+  });
+
   function setup(input: {
     templateId?: string | null;
     draftId?: string;
     persistedSdl?: string;
+    persistedName?: string;
     template?: { isLoading?: boolean; isError?: boolean; data?: TemplateOutput };
     deploySdl?: TemplateCreation | null;
   }) {
@@ -95,7 +117,13 @@ describe(ConfigureDeployment.name, () => {
     const save = vi.fn();
     const clear = vi.fn();
     const useConfigureDraft = vi.fn(() =>
-      mock<ReturnType<typeof DEPENDENCIES.useConfigureDraft>>({ draftId: input.draftId ?? "minted-id", persistedSdl: input.persistedSdl, save, clear })
+      mock<ReturnType<typeof DEPENDENCIES.useConfigureDraft>>({
+        draftId: input.draftId ?? "minted-id",
+        persistedSdl: input.persistedSdl,
+        persistedName: input.persistedName,
+        save,
+        clear
+      })
     );
 
     const query: Record<string, string> = {};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.tsx
@@ -10,6 +10,7 @@ import { useSnackbar } from "notistack";
 import Layout from "@src/components/layout/Layout";
 import { usePublicTemplate } from "@src/queries/useTemplateQuery";
 import sdlStore from "@src/store/sdlStore";
+import type { TemplateCreation } from "@src/types";
 import { hardcodedTemplates } from "@src/utils/templates";
 import { ConfigureDeploymentForm } from "../ConfigureDeploymentForm/ConfigureDeploymentForm";
 import { RedirectIfLeased } from "../RedirectIfLeased/RedirectIfLeased";
@@ -56,7 +57,7 @@ export const ConfigureDeployment: FC<Props> = ({ dependencies: d = DEPENDENCIES 
 
   const templateId = searchParams?.get("templateId") ?? undefined;
   const deploySdl = useAtomValue(sdlStore.deploySdl);
-  const hardcodedTemplate = templateId ? hardcodedTemplates.find(template => template.code === templateId) : undefined;
+  const hardcodedTemplate: TemplateCreation | undefined = templateId ? hardcodedTemplates.find(template => template.code === templateId) : undefined;
   const fetchedTemplateId = draft.persistedSdl === undefined && !hardcodedTemplate ? templateId : undefined;
   const templateQuery = d.usePublicTemplate(fetchedTemplateId);
   const { enqueueSnackbar } = d.useSnackbar();
@@ -74,6 +75,7 @@ export const ConfigureDeployment: FC<Props> = ({ dependencies: d = DEPENDENCIES 
   );
 
   const initialSdl = draft.persistedSdl ?? hardcodedTemplate?.content ?? (fetchedTemplateId ? templateQuery.data?.deploy : deploySdl?.content);
+  const initialName = draft.persistedName ?? hardcodedTemplate?.name ?? (fetchedTemplateId ? templateQuery.data?.name : undefined);
 
   return (
     <d.RedirectIfLeased dseq={intent.dseq}>
@@ -85,7 +87,7 @@ export const ConfigureDeployment: FC<Props> = ({ dependencies: d = DEPENDENCIES 
           </div>
         </d.Layout>
       ) : (
-        <d.ConfigureDeploymentForm key={draft.draftId} initialSdl={initialSdl} intent={resolvedIntent} />
+        <d.ConfigureDeploymentForm key={draft.draftId} initialSdl={initialSdl} initialName={initialName} intent={resolvedIntent} />
       )}
     </d.RedirectIfLeased>
   );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -210,7 +210,7 @@ describe(ConfigureDeploymentForm.name, () => {
 
     await userEvent.click(screen.getByRole("button", { name: "change image" }));
 
-    await waitFor(() => expect(save).toHaveBeenCalledWith(expect.stringContaining("nginx:latest")));
+    await waitFor(() => expect(save).toHaveBeenCalledWith(expect.stringContaining("nginx:latest"), expect.any(String)));
   });
 
   it("clears the configure draft once the deployment is deployed", () => {
@@ -225,15 +225,31 @@ describe(ConfigureDeploymentForm.name, () => {
     expect(clear).not.toHaveBeenCalled();
   });
 
-  function setup(input: { initialSdl: string | undefined; Panes?: typeof SdlProbePanes; draftId?: string; deploySucceeded?: boolean }) {
+  it("seeds the deployment name from initialName", () => {
+    const { ConfigureDeploymentPanes } = setup({ initialSdl: undefined, initialName: "my-app" });
+
+    expect(ConfigureDeploymentPanes).toHaveBeenCalledWith(expect.objectContaining({ deploymentName: "my-app" }), expect.anything());
+  });
+
+  it("persists the deployment name into the draft alongside the sdl", async () => {
+    const { save } = setup({ initialSdl: undefined, initialName: "my-app", Panes: SdlProbePanes });
+
+    await userEvent.click(screen.getByRole("button", { name: "change image" }));
+
+    await waitFor(() => expect(save).toHaveBeenCalledWith(expect.stringContaining("nginx:latest"), "my-app"));
+  });
+
+  function setup(input: { initialSdl: string | undefined; initialName?: string; Panes?: typeof SdlProbePanes; draftId?: string; deploySucceeded?: boolean }) {
     const ConfigureDeploymentPanes = vi.fn(input.Panes ?? (() => <div data-testid="panes-mock" />));
     const enqueueSnackbar = vi.fn();
     const Snackbar = vi.fn(() => null);
-    const save = vi.fn<(sdl: string) => void>();
+    const save = vi.fn<(sdl: string, name?: string) => void>();
     const clear = vi.fn<() => void>();
+    const setDeploymentName = vi.fn();
     const useConfigureDraft = vi.fn(() =>
       mock<ReturnType<typeof DEPENDENCIES.useConfigureDraft>>({ draftId: input.draftId ?? "draft-1", persistedSdl: undefined, save, clear })
     );
+    const useDeploymentName = ((args: { initialName?: string }) => ({ name: args.initialName ?? "", setName: setDeploymentName })) as never;
     const dependencies: typeof DEPENDENCIES = {
       Layout: vi.fn(({ children }) => <div data-testid="layout-mock">{children}</div>) as never,
       NextSeo: vi.fn(() => null) as never,
@@ -247,6 +263,7 @@ describe(ConfigureDeploymentForm.name, () => {
           bidStrategy: "select",
           deploySucceeded: input.deploySucceeded ?? false
         })) as never,
+      useDeploymentName,
       useSnackbar: () => mock<ReturnType<typeof DEPENDENCIES.useSnackbar>>({ enqueueSnackbar }),
       Snackbar: Snackbar as never,
       ReviewAndDeployModal: () => null,
@@ -256,6 +273,7 @@ describe(ConfigureDeploymentForm.name, () => {
     render(
       <ConfigureDeploymentForm
         initialSdl={input.initialSdl}
+        initialName={input.initialName}
         intent={{ sdlStrategy: "edit", bidStrategy: "select", dseq: undefined, draftId: input.draftId }}
         dependencies={dependencies}
       />

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -25,6 +25,7 @@ import { ReviewAndDeployModal } from "../ReviewAndDeployModal/ReviewAndDeployMod
 import { useConfigureDraft } from "../useConfigureDraft/useConfigureDraft";
 import type { DeploymentIntent } from "../useDeploymentFlow/deploymentIntent";
 import { useDeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
+import { useDeploymentName } from "../useDeploymentName/useDeploymentName";
 
 export const DEPENDENCIES = {
   Layout,
@@ -34,6 +35,7 @@ export const DEPENDENCIES = {
   ReviewAndDeployModal,
   useConfigureDraft,
   useDeploymentFlow,
+  useDeploymentName,
   usePlacementsWithBids,
   useSnackbar,
   Snackbar
@@ -44,17 +46,20 @@ const SDL_SYNC_DEBOUNCE_MS = 300;
 
 type Props = {
   initialSdl?: string;
+  initialName?: string;
   intent: DeploymentIntent;
   dependencies?: typeof DEPENDENCIES;
 };
 
-export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, intent, dependencies: d = DEPENDENCIES }) => {
+export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, intent, dependencies: d = DEPENDENCIES }) => {
   const [initialState] = useState(() => getInitialState(initialSdl));
   const [liveSdl, setLiveSdl] = useState(initialState.sdl);
   const [previewSdl, setPreviewSdl] = useState(initialState.sdl);
   const [selectedServiceId, setSelectedServiceId] = useState<string>(initialState.selectedServiceId);
   const { enqueueSnackbar } = d.useSnackbar();
   const draft = d.useConfigureDraft(intent);
+  const flow = d.useDeploymentFlow({ intent });
+  const { name: deploymentName, setName: setDeploymentName } = d.useDeploymentName({ initialName, dseq: flow.dseq });
   const form = useForm<SdlBuilderFormValuesType>({
     defaultValues: initialState.values,
     mode: "onTouched",
@@ -89,13 +94,13 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, intent, depende
     function debouncePreviewSdl() {
       const timeout = setTimeout(function commitDebouncedSdl() {
         setPreviewSdl(liveSdl);
-        draft.save(liveSdl);
+        draft.save(liveSdl, deploymentName);
       }, SDL_SYNC_DEBOUNCE_MS);
       return function cancelPreviewDebounce() {
         clearTimeout(timeout);
       };
     },
-    [liveSdl, draft]
+    [liveSdl, deploymentName, draft]
   );
 
   useEffect(
@@ -110,7 +115,6 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, intent, depende
     [form]
   );
 
-  const flow = d.useDeploymentFlow({ intent });
   const placementsWithBids = d.usePlacementsWithBids({ enabled: flow.phase === "quoting", dseq: flow.dseq, sdl: liveSdl, placements });
   const [isReviewOpen, setReviewOpen] = useState(false);
   const allPlacementsHaveBids = placements.length > 0 && placements.every(placement => placementsWithBids.has(placement.id));
@@ -196,12 +200,15 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, intent, depende
               selections={flow.selections}
               onSelectProvider={selectProviderAndAdvance}
               onCancelAndEdit={flow.actions.cancelAndEdit}
+              deploymentName={deploymentName}
+              onDeploymentNameChange={setDeploymentName}
             />
           </div>
           {flow.phase === "deploying" && (
             <DeployProgressOverlay
               providerAddress={firstSelectedProviderAddress(flow.selections)}
               activePhase={flow.deploySucceeded ? "success" : "preparing"}
+              deploymentName={deploymentName}
             />
           )}
         </div>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
@@ -188,6 +188,8 @@ describe("ConfigureDeploymentPanes", () => {
           selections={input.selections ?? {}}
           onSelectProvider={input.onSelectProvider ?? vi.fn()}
           onCancelAndEdit={input.onCancelAndEdit ?? vi.fn()}
+          deploymentName=""
+          onDeploymentNameChange={vi.fn()}
           dependencies={dependencies}
         />
       </JotaiStoreProvider>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
@@ -28,6 +28,8 @@ type Props = {
   selections: Record<string, string>;
   onSelectProvider: (placementId: string, bidId: string) => void;
   onCancelAndEdit: () => void;
+  deploymentName: string;
+  onDeploymentNameChange: (value: string) => void;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -44,6 +46,8 @@ export const ConfigureDeploymentPanes: FC<Props> = ({
   selections,
   onSelectProvider,
   onCancelAndEdit,
+  deploymentName,
+  onDeploymentNameChange,
   dependencies: d = DEPENDENCIES
 }) => {
   const [activePane, setActivePane] = useState<ActivePane>("deployment");
@@ -68,6 +72,8 @@ export const ConfigureDeploymentPanes: FC<Props> = ({
               selectedPlacementId={selectedPlacementId}
               sdl={sdl}
               dseq={dseq}
+              deploymentName={deploymentName}
+              onDeploymentNameChange={onDeploymentNameChange}
             />
           </div>
           <div className={cn("min-h-0 md:block", { hidden: activePane !== "configuration" })}>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/DeployProgressOverlay.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/DeployProgressOverlay.spec.tsx
@@ -15,8 +15,23 @@ describe(DeployProgressOverlay.name, () => {
     expect(screen.getByText(/deployment prepared/i)).toBeInTheDocument();
   });
 
-  function setup(input: { activePhase?: "preparing" | "success" } = {}) {
+  it("titles the panel with the deployment name when one is provided", () => {
+    setup({ deploymentName: "my-app" });
+    expect(screen.getByRole("heading", { name: "Deploying my-app" })).toBeInTheDocument();
+  });
+
+  it("falls back to a generic title when no deployment name is provided", () => {
+    setup({ deploymentName: "  " });
+    expect(screen.getByRole("heading", { name: "Deploying your deployment" })).toBeInTheDocument();
+  });
+
+  it("trims surrounding whitespace from the deployment name in the title", () => {
+    setup({ deploymentName: "  my-app  " });
+    expect(screen.getByRole("heading", { name: "Deploying my-app" })).toBeInTheDocument();
+  });
+
+  function setup(input: { activePhase?: "preparing" | "success"; deploymentName?: string } = {}) {
     const ProvidersGlobe: typeof DEPENDENCIES.ProvidersGlobe = () => null;
-    render(<DeployProgressOverlay activePhase={input.activePhase} dependencies={{ ...DEPENDENCIES, ProvidersGlobe }} />);
+    render(<DeployProgressOverlay activePhase={input.activePhase} deploymentName={input.deploymentName} dependencies={{ ...DEPENDENCIES, ProvidersGlobe }} />);
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/DeployProgressOverlay.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeployProgressOverlay/DeployProgressOverlay.tsx
@@ -11,6 +11,8 @@ interface Props {
   providerAddress?: string | null;
   /** The deploy's current active step, from `useDeploymentFlow`: the lease ("preparing"), then "success" once it lands. */
   activePhase?: DeployActivePhase;
+  /** The user's deployment name, shown in the title; falls back to "your deployment" when unset. */
+  deploymentName?: string;
   dependencies?: typeof DEPENDENCIES;
 }
 
@@ -21,12 +23,13 @@ interface Props {
  * Deploy failures unmount this overlay (the flow returns to quoting) and surface a toast, so no error panel
  * is rendered here; a `"success"` active phase completes the panel and is held briefly before the flow redirects.
  */
-export const DeployProgressOverlay: FC<Props> = ({ providerAddress, activePhase = "preparing", dependencies: d = DEPENDENCIES }) => {
+export const DeployProgressOverlay: FC<Props> = ({ providerAddress, activePhase = "preparing", deploymentName, dependencies: d = DEPENDENCIES }) => {
   const { state, progressPercent, phases } = d.useConfigureDeployProgress(activePhase);
+  const title = deploymentName?.trim() || "your deployment";
   return (
     <div className="absolute inset-0 z-20 flex flex-col items-center overflow-hidden bg-white dark:bg-background">
       <div className="w-[632px] max-w-full px-[20px] pt-[80px]">
-        <d.PhasedDeploymentProgress state={state} templateName="your deployment" progressPercent={progressPercent} phases={phases} />
+        <d.PhasedDeploymentProgress state={state} templateName={title} progressPercent={progressPercent} phases={phases} />
       </div>
       <d.ProvidersGlobe focusedProviderAddress={providerAddress} />
     </div>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentNameField/DeploymentNameField.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentNameField/DeploymentNameField.spec.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { DeploymentNameField } from "./DeploymentNameField";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+describe("DeploymentNameField", () => {
+  it("disables the input while locked", () => {
+    setup({ disabled: true });
+
+    expect(screen.getByRole("textbox", { name: "Deployment name" })).toBeDisabled();
+  });
+
+  it("reports typed changes", async () => {
+    const { onChange } = setup({ value: "" });
+
+    await userEvent.type(screen.getByRole("textbox", { name: "Deployment name" }), "a");
+
+    expect(onChange).toHaveBeenCalledWith("a");
+  });
+
+  function setup(input: { value?: string; disabled?: boolean }) {
+    const onChange = vi.fn();
+    render(<DeploymentNameField value={input.value ?? ""} disabled={input.disabled} onChange={onChange} />);
+    return { onChange };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentNameField/DeploymentNameField.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentNameField/DeploymentNameField.tsx
@@ -1,0 +1,16 @@
+import type { FC } from "react";
+import { Input } from "@akashnetwork/ui/components";
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+  /** Disabled once quotes are requested, matching the rest of the deployment pane. */
+  disabled?: boolean;
+};
+
+export const DeploymentNameField: FC<Props> = ({ value, onChange, disabled }) => (
+  <div className="space-y-2">
+    <div className="px-1 font-mono text-xs uppercase text-muted-foreground">Name</div>
+    <Input aria-label="Deployment name" placeholder="Name your deployment" value={value} disabled={disabled} onChange={event => onChange(event.target.value)} />
+  </div>
+);

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.spec.tsx
@@ -91,11 +91,23 @@ describe("DeploymentPane", () => {
     );
   });
 
+  it("passes the deployment name and lock state to the name field", () => {
+    const DeploymentNameField = vi.fn(() => null);
+    setup({ deploymentName: "my-app", locked: true, dependencies: { DeploymentNameField } });
+
+    expect(DeploymentNameField).toHaveBeenCalledWith(
+      expect.objectContaining({ value: "my-app", disabled: true, onChange: expect.any(Function) }),
+      expect.anything()
+    );
+  });
+
   function setup(input: {
     placements?: ReturnType<typeof defaultPlacement>[];
     onSelectService?: (serviceId: string) => void;
     locked?: boolean;
     onCancelAndEdit?: () => void;
+    deploymentName?: string;
+    onDeploymentNameChange?: (value: string) => void;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const placements = input.placements ?? [defaultPlacement({ name: "placement-1" })];
@@ -119,6 +131,8 @@ describe("DeploymentPane", () => {
           selectedPlacementId=""
           sdl=""
           dseq={null}
+          deploymentName={input.deploymentName ?? ""}
+          onDeploymentNameChange={input.onDeploymentNameChange ?? vi.fn()}
           dependencies={MockComponents(DEPENDENCIES, { usePlacementManager, usePlacementsWithBids: () => new Set<string>(), ...input.dependencies })}
         />
       </TooltipProvider>
@@ -171,6 +185,8 @@ describe("DeploymentPane placement management", () => {
           selectedPlacementId=""
           sdl=""
           dseq={null}
+          deploymentName=""
+          onDeploymentNameChange={vi.fn()}
           dependencies={{ ...DEPENDENCIES, PlacementCard: PlacementCardWithStubbedRegion, usePlacementsWithBids: () => new Set<string>() }}
         />
       </Wrapper>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
@@ -6,12 +6,13 @@ import { InfoCircle, Plus, SidebarCollapse, SidebarExpand } from "iconoir-react"
 import { usePlacementsWithBids } from "@src/queries/usePlacementsWithBids";
 import { PaneLockBanner } from "../PaneLockBanner/PaneLockBanner";
 import type { DeploymentFlowPhase } from "../useDeploymentFlow/useDeploymentFlow";
+import { DeploymentNameField } from "./DeploymentNameField/DeploymentNameField";
 import { PlacementCard } from "./PlacementCard/PlacementCard";
 import type { PlacementSelectionState } from "./PlacementSelectionBadge/PlacementSelectionBadge";
 import { ReclamationSection } from "./ReclamationSection/ReclamationSection";
 import { usePlacementManager } from "./usePlacementManager/usePlacementManager";
 
-export const DEPENDENCIES = { PlacementCard, usePlacementManager, usePlacementsWithBids, ReclamationSection };
+export const DEPENDENCIES = { PlacementCard, usePlacementManager, usePlacementsWithBids, ReclamationSection, DeploymentNameField };
 
 type Props = {
   selectedServiceId: string;
@@ -25,6 +26,8 @@ type Props = {
   selectedPlacementId: string;
   sdl: string;
   dseq: string | null;
+  deploymentName: string;
+  onDeploymentNameChange: (value: string) => void;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -39,6 +42,8 @@ export const DeploymentPane: FC<Props> = ({
   selectedPlacementId,
   sdl,
   dseq,
+  deploymentName,
+  onDeploymentNameChange,
   dependencies: d = DEPENDENCIES
 }) => {
   const [minimized, setMinimized] = useState(false);
@@ -68,6 +73,7 @@ export const DeploymentPane: FC<Props> = ({
       </header>
       {locked ? <PaneLockBanner onCancelAndEdit={onCancelAndEdit ?? noop} isClosing={isClosing} /> : null}
       <div className="flex-1 space-y-6 overflow-y-auto p-4">
+        <d.DeploymentNameField value={deploymentName} onChange={onDeploymentNameChange} disabled={locked} />
         <d.ReclamationSection locked={locked} />
         <div className="space-y-2">
           <div className="flex items-center gap-2 px-1 font-mono text-xs uppercase text-muted-foreground">

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.spec.ts
@@ -56,6 +56,26 @@ describe(useConfigureDraft.name, () => {
     expect(storedSdl("draft-1")).toBe("version: '2.0'");
   });
 
+  it("exposes the persisted name for the active draft", () => {
+    const { result } = setup({ intent: { draftId: "draft-1" }, storedName: { "draft-1": "my-app" } });
+
+    expect(result.current.persistedName).toBe("my-app");
+  });
+
+  it("has no persisted name when the stored draft omits one", () => {
+    const { result } = setup({ intent: { draftId: "draft-1" }, stored: { "draft-1": "version: '2.0'" } });
+
+    expect(result.current.persistedName).toBeUndefined();
+  });
+
+  it("saves the name alongside the sdl for the active draft", () => {
+    const { result } = setup({ intent: { draftId: "draft-1" } });
+
+    result.current.save("version: '2.0'", "my-app");
+
+    expect(storedName("draft-1")).toBe("my-app");
+  });
+
   it("clears the persisted draft", () => {
     const { result } = setup({ intent: { draftId: "draft-1" }, stored: { "draft-1": "version: '2.0'" } });
 
@@ -126,6 +146,11 @@ describe(useConfigureDraft.name, () => {
     return raw ? (JSON.parse(raw) as { sdl: string }).sdl : undefined;
   }
 
+  function storedName(draftId: string) {
+    const raw = window.localStorage.getItem(`${DRAFT_KEY_PREFIX}${draftId}`);
+    return raw ? (JSON.parse(raw) as { name?: string }).name : undefined;
+  }
+
   function countDrafts() {
     return Object.keys(window.localStorage).filter(key => key.startsWith(DRAFT_KEY_PREFIX)).length;
   }
@@ -133,6 +158,7 @@ describe(useConfigureDraft.name, () => {
   function setup(input: {
     intent?: Partial<DeploymentIntent>;
     stored?: Record<string, string>;
+    storedName?: Record<string, string>;
     rawStored?: Record<string, string>;
     getStorage?: typeof DEPENDENCIES.getStorage;
     mintedDraftId?: string;
@@ -140,6 +166,9 @@ describe(useConfigureDraft.name, () => {
     window.localStorage.clear();
     Object.entries(input.stored ?? {}).forEach(([draftId, sdl]) =>
       window.localStorage.setItem(`${DRAFT_KEY_PREFIX}${draftId}`, JSON.stringify({ sdl, updatedAt: 1 }))
+    );
+    Object.entries(input.storedName ?? {}).forEach(([draftId, name]) =>
+      window.localStorage.setItem(`${DRAFT_KEY_PREFIX}${draftId}`, JSON.stringify({ sdl: "seeded", name, updatedAt: 1 }))
     );
     Object.entries(input.rawStored ?? {}).forEach(([draftId, raw]) => window.localStorage.setItem(`${DRAFT_KEY_PREFIX}${draftId}`, raw));
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.ts
@@ -28,6 +28,7 @@ export const DEPENDENCIES = {
 
 interface StoredDraft {
   sdl: string;
+  name?: string;
   updatedAt: number;
 }
 
@@ -36,8 +37,10 @@ export interface ConfigureDraft {
   draftId: string;
   /** The persisted SDL for the active draft, or undefined when none exists — a fresh session, an evicted draft, or a link opened in another browser. */
   persistedSdl: string | undefined;
-  /** Persists `sdl` as the working draft, then evicts the oldest drafts past the cap. */
-  save(sdl: string): void;
+  /** The persisted deployment name for the active draft, or undefined when none was saved. */
+  persistedName: string | undefined;
+  /** Persists `sdl` (and the optional deployment `name`) as the working draft, then evicts the oldest drafts past the cap. */
+  save(sdl: string, name?: string): void;
   /** Removes the persisted draft. */
   clear(): void;
 }
@@ -57,7 +60,9 @@ export function useConfigureDraft(intent: DeploymentIntent, dependencies: typeof
   const mintedDraftIdRef = useRef<string>();
   const draftId = intent.draftId ?? (mintedDraftIdRef.current ??= dependencies.mintDraftId());
 
-  const persistedSdl = useMemo(() => readDraft(storage, draftId), [storage, draftId]);
+  const storedDraft = useMemo(() => readStoredDraft(storage, draftId), [storage, draftId]);
+  const persistedSdl = typeof storedDraft?.sdl === "string" ? storedDraft.sdl : undefined;
+  const persistedName = typeof storedDraft?.name === "string" ? storedDraft.name : undefined;
 
   const persistedToUrlRef = useRef<string>();
   useEffect(
@@ -75,10 +80,11 @@ export function useConfigureDraft(intent: DeploymentIntent, dependencies: typeof
     () => ({
       draftId,
       persistedSdl,
-      save: (sdl: string) => saveDraft(storage, draftId, sdl),
+      persistedName,
+      save: (sdl: string, name?: string) => saveDraft(storage, draftId, sdl, name),
       clear: () => clearDraft(storage, draftId)
     }),
-    [draftId, persistedSdl, storage]
+    [draftId, persistedSdl, persistedName, storage]
   );
 }
 
@@ -91,28 +97,25 @@ function keyOf(draftId: string): string {
   return `${DRAFT_KEY_PREFIX}${draftId}`;
 }
 
-function readDraft(storage: Storage | undefined, draftId: string | undefined): string | undefined {
+/** Reads and parses the stored draft once; callers pluck `sdl`/`name` so a render reads and parses storage a single time. */
+function readStoredDraft(storage: Storage | undefined, draftId: string | undefined): StoredDraft | undefined {
   if (!storage || !draftId) {
     return undefined;
   }
   try {
     const raw = storage.getItem(keyOf(draftId));
-    if (!raw) {
-      return undefined;
-    }
-    const parsed = JSON.parse(raw) as StoredDraft;
-    return typeof parsed?.sdl === "string" ? parsed.sdl : undefined;
+    return raw ? (JSON.parse(raw) as StoredDraft) : undefined;
   } catch {
     return undefined;
   }
 }
 
-function saveDraft(storage: Storage | undefined, draftId: string | undefined, sdl: string): void {
+function saveDraft(storage: Storage | undefined, draftId: string | undefined, sdl: string, name?: string): void {
   if (!storage || !draftId) {
     return;
   }
   try {
-    const entry: StoredDraft = { sdl, updatedAt: Date.now() };
+    const entry: StoredDraft = { sdl, name, updatedAt: Date.now() };
     storage.setItem(keyOf(draftId), JSON.stringify(entry));
     evictStaleDrafts(storage);
   } catch {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.spec.tsx
@@ -1,0 +1,74 @@
+import type { PropsWithChildren } from "react";
+import { createStore, Provider as JotaiStoreProvider } from "jotai";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { settingsIdAtom } from "@src/context/SettingsProvider/settingsStore";
+import type { DeploymentStorageService } from "@src/services/deployment-storage/deployment-storage.service";
+import type { DEPENDENCIES } from "./useDeploymentName";
+import { useDeploymentName } from "./useDeploymentName";
+
+import { act, renderHook } from "@testing-library/react";
+
+describe(useDeploymentName.name, () => {
+  it("seeds the name from initialName", () => {
+    const { result } = setup({ initialName: "my-app" });
+
+    expect(result.current.name).toBe("my-app");
+  });
+
+  it("updates the name via setName", () => {
+    const { result } = setup({ initialName: "my-app" });
+
+    act(() => result.current.setName("renamed"));
+
+    expect(result.current.name).toBe("renamed");
+  });
+
+  it("writes the name to the settings-scoped record when a dseq is first assigned", () => {
+    const { rerender, deploymentLocalStorage } = setup({ initialName: "my-app", dseq: null, settingsId: "akash1abc" });
+
+    rerender({ initialName: "my-app", dseq: "12345" });
+
+    expect(deploymentLocalStorage.update).toHaveBeenCalledWith("akash1abc", "12345", { name: "my-app" });
+  });
+
+  it("does not write before a dseq exists", () => {
+    const { deploymentLocalStorage } = setup({ initialName: "my-app", dseq: null });
+
+    expect(deploymentLocalStorage.update).not.toHaveBeenCalled();
+  });
+
+  it("does not write when the session resumed already carrying a dseq", () => {
+    const { deploymentLocalStorage } = setup({ initialName: "my-app", dseq: "12345" });
+
+    expect(deploymentLocalStorage.update).not.toHaveBeenCalled();
+  });
+
+  it("defers the write until settingsId is available instead of dropping it", () => {
+    const { rerender, store, deploymentLocalStorage } = setup({ initialName: "my-app", dseq: null, settingsId: null });
+
+    rerender({ initialName: "my-app", dseq: "12345" });
+    expect(deploymentLocalStorage.update).not.toHaveBeenCalled();
+
+    act(() => store.set(settingsIdAtom, "akash1abc"));
+
+    expect(deploymentLocalStorage.update).toHaveBeenCalledWith("akash1abc", "12345", { name: "my-app" });
+  });
+
+  function setup(input: { initialName?: string; dseq?: string | null; settingsId?: string | null }) {
+    const deploymentLocalStorage = mock<DeploymentStorageService>();
+    const useServices: typeof DEPENDENCIES.useServices = () => mock<ReturnType<typeof DEPENDENCIES.useServices>>({ deploymentLocalStorage });
+
+    const store = createStore();
+    store.set(settingsIdAtom, input.settingsId ?? null);
+    const wrapper = ({ children }: PropsWithChildren) => <JotaiStoreProvider store={store}>{children}</JotaiStoreProvider>;
+    const initialProps = { initialName: input.initialName, dseq: input.dseq ?? null };
+
+    return {
+      ...renderHook((props: { initialName?: string; dseq: string | null }) => useDeploymentName(props, { useServices }), { wrapper, initialProps }),
+      deploymentLocalStorage,
+      store
+    };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentName/useDeploymentName.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from "react";
+import { useAtomValue } from "jotai";
+
+import { useServices } from "@src/context/ServicesProvider";
+import { settingsIdAtom } from "@src/context/SettingsProvider/settingsStore";
+
+export const DEPENDENCIES = { useServices };
+
+export interface DeploymentName {
+  /** The current deployment name; seeded from `initialName`, edited via `setName`. */
+  name: string;
+  setName: (name: string) => void;
+}
+
+interface UseDeploymentNameInput {
+  /** The name to start from — the resumed draft's name, or the template's, resolved by the caller. */
+  initialName?: string;
+  /** The created deployment's sequence, from `useDeploymentFlow`; null until quotes are requested. */
+  dseq: string | null;
+}
+
+/**
+ * Owns the configure session's deployment name: its state (seeded once from `initialName`) and its write to the
+ * wallet-scoped local record the rest of the app reads via `useLocalNotes.getDeploymentName(dseq)`. The record is
+ * keyed by `settingsId` — which WalletProvider sets to the wallet address — so the name surfaces on the deployment
+ * list/detail pages after deploy, the same store the legacy builder wrote to. It deliberately avoids `useWallet()`,
+ * so no new dependency on the wallet provider is introduced. The write happens once `dseq` and `settingsId` are both
+ * present (the deployment is created for a known wallet); until the wallet-scoped key exists the write is deferred
+ * rather than dropped. A session that resumed already carrying a `dseq` has it present from mount and is treated as
+ * already-written, so a resume never clobbers a name the user may have since edited on the deployment page.
+ */
+export function useDeploymentName({ initialName, dseq }: UseDeploymentNameInput, dependencies = DEPENDENCIES): DeploymentName {
+  const { deploymentLocalStorage } = dependencies.useServices();
+  const settingsId = useAtomValue(settingsIdAtom);
+  const [name, setName] = useState(() => initialName ?? "");
+  const nameRef = useRef(name);
+  nameRef.current = name;
+  const writtenDseqRef = useRef(dseq);
+  useEffect(
+    function persistNameOnCreate() {
+      if (dseq && settingsId && dseq !== writtenDseqRef.current) {
+        writtenDseqRef.current = dseq;
+        deploymentLocalStorage.update(settingsId, dseq, { name: nameRef.current });
+      }
+    },
+    [dseq, settingsId, deploymentLocalStorage]
+  );
+  return { name, setName };
+}


### PR DESCRIPTION
## Why

The new configure flow (`/new-deployment/configure`) had no way to name a deployment. The legacy builder let users name a deployment and persisted that name to `localStorage` so it shows up across the deployment list/detail pages. This restores parity on the new screen: users can name a deployment while configuring, it defaults to the template name when launched from a template, and it survives a reload.

Closes CON-630
Part of CON-411

## What

- Adds an optional **Name** field at the top of the Deployment pane (`DeploymentNameField`), disabled while quotes are active like the rest of the pane. The name is deployment metadata — it is **not** written into the SDL.
- **Defaults to the template name** (hardcoded or gallery template); a resumed draft's saved name takes precedence over the template.
- **Persisted in two layers:**
  - the configure draft store (`useConfigureDraft` now carries `name`), so it survives an in-session reload; and
  - the wallet-scoped `DeploymentStorageService` record when the deployment is created — keyed by `settingsId`, the same store `useLocalNotes.getDeploymentName(dseq)` reads, so the name appears on the deployment list/detail pages. This deliberately avoids the wallet provider (`useWallet()`).
- The **deploy progress overlay** title now reads `Deploying <name>` when a name is set, falling back to `Deploying your deployment`.
- Introduces a `useDeploymentName` hook that owns the name state and its create-time persistence. The write fires once, when the `dseq` is first assigned; a session that resumed already carrying a `dseq` is treated as already-written, so resuming never overwrites a name the user may have edited on the deployment page.

<img width="612" height="622" alt="image" src="https://github.com/user-attachments/assets/db4f8c77-e06d-4cf5-9fd9-55a1db643011" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a deploy configuration “deployment name” field that’s editable during setup.
  * The deployment name now appears in the deploying progress panel heading (including a trim-to-empty fallback).
* **Bug Fixes**
  * Deployment name initialization now correctly follows priority: persisted draft name, selected hardcoded template name, then fetched template name.
  * Persisted draft deployment names are restored and used in the configuration flow.
* **Tests**
  * Expanded coverage for deployment-name initialization, draft name persistence, and UI save/update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->