### PR TITLE
feat(deployment): edit manifest fields while quotes are live

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.spec.tsx
@@ -22,7 +22,7 @@ describe(AdditionalSection.name, () => {
     expect(LogsCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
   });
 
-  it("forwards the locked state to every additional card", () => {
+  it("locks the runtime, ports and logs cards but never env vars or commands", () => {
     const RuntimeCard = vi.fn(() => null);
     const EnvironmentVariablesCard = vi.fn(() => null);
     const CommandsCard = vi.fn(() => null);
@@ -32,10 +32,10 @@ describe(AdditionalSection.name, () => {
     setup({ locked: true, dependencies: { RuntimeCard, EnvironmentVariablesCard, CommandsCard, ExposePortsCard, LogsCard } });
 
     expect(RuntimeCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
-    expect(EnvironmentVariablesCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
-    expect(CommandsCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
     expect(ExposePortsCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
     expect(LogsCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(EnvironmentVariablesCard).not.toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(CommandsCard).not.toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
   });
 
   function setup(input: { serviceIndex?: number; locked?: boolean; dependencies?: Partial<typeof DEPENDENCIES> }) {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.tsx
@@ -10,7 +10,7 @@ export const DEPENDENCIES = { RuntimeCard, EnvironmentVariablesCard, CommandsCar
 
 type Props = {
   serviceIndex: number;
-  /** While the pane is locked the additional cards are disabled (their chevrons stay expandable for viewing). */
+  /** Locks the runtime, ports and logs cards. The env vars and commands cards are manifest-only and stay editable. */
   locked?: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
@@ -27,9 +27,9 @@ export const AdditionalSection: FC<Props> = ({ serviceIndex, locked = false, dep
       <div className="flex flex-col gap-4">
         <d.RuntimeCard serviceIndex={serviceIndex} locked={locked} />
 
-        <d.EnvironmentVariablesCard serviceIndex={serviceIndex} locked={locked} />
+        <d.EnvironmentVariablesCard serviceIndex={serviceIndex} />
 
-        <d.CommandsCard serviceIndex={serviceIndex} locked={locked} />
+        <d.CommandsCard serviceIndex={serviceIndex} />
 
         <d.ExposePortsCard serviceIndex={serviceIndex} locked={locked} />
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/CommandsCard/CommandsCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/CommandsCard/CommandsCard.spec.tsx
@@ -54,17 +54,7 @@ describe(CommandsCard.name, () => {
     expect(getValues().services[0].command?.command).toBe("sh\n-c");
   });
 
-  it("opens for viewing but disables the inputs and Save while locked", async () => {
-    const { openCard } = setup({ command: "bash -c", arg: "echo hi", locked: true });
-
-    await openCard();
-
-    expect(screen.getByLabelText("Command")).toBeDisabled();
-    expect(screen.getByLabelText("Arguments")).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
-  });
-
-  function setup(input: { command?: string; arg?: string; locked?: boolean }) {
+  function setup(input: { command?: string; arg?: string }) {
     const values = defaultServiceWithPlacement({ command: { command: input.command ?? "", arg: input.arg ?? "" } });
 
     let getValues: () => SdlBuilderFormValuesType = () => values;
@@ -76,7 +66,7 @@ describe(CommandsCard.name, () => {
 
     render(
       <Wrapper>
-        <CommandsCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES }} />
+        <CommandsCard serviceIndex={0} dependencies={{ ...DEPENDENCIES }} />
       </Wrapper>
     );
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/CommandsCard/CommandsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/CommandsCard/CommandsCard.tsx
@@ -25,8 +25,6 @@ export const DEPENDENCIES = { CollapsibleCard, DialogV2, DialogV2Content, Dialog
 
 type Props = {
   serviceIndex: number;
-  /** While the pane is locked the dialog still opens for viewing but its inputs and Save are disabled. */
-  locked?: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -41,7 +39,7 @@ type Props = {
  * image default) and clicking it opens a Dialog for editing. Changes are committed on
  * Save and reverted on Cancel.
  */
-export const CommandsCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+export const CommandsCard: FC<Props> = ({ serviceIndex, dependencies: d = DEPENDENCIES }) => {
   const { control, getValues, setValue } = useFormContext<SdlBuilderFormValuesType>();
   const command = useController({ control, name: `services.${serviceIndex}.command.command` });
   const arg = useController({ control, name: `services.${serviceIndex}.command.arg` });
@@ -93,7 +91,7 @@ export const CommandsCard: FC<Props> = ({ serviceIndex, locked = false, dependen
           </d.DialogV2Header>
 
           <d.DialogV2Body className="flex flex-col gap-4">
-            <fieldset disabled={locked} className="contents">
+            <fieldset className="contents">
               <Field className="gap-2">
                 <FieldLabel htmlFor={`command-${serviceIndex}`}>Command</FieldLabel>
                 <FieldContent>
@@ -130,7 +128,7 @@ export const CommandsCard: FC<Props> = ({ serviceIndex, locked = false, dependen
             <Button type="button" variant="ghost" onClick={handleCancel}>
               Cancel
             </Button>
-            <Button type="button" onClick={handleSave} disabled={locked}>
+            <Button type="button" onClick={handleSave}>
               Save
               <SaveIcon className="ml-2 size-4" />
             </Button>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfidentialComputeCard/ConfidentialComputeCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfidentialComputeCard/ConfidentialComputeCard.tsx
@@ -117,6 +117,7 @@ export const ConfidentialComputeCard: FC<Props> = ({ serviceIndex, locked = fals
 
   return (
     <d.CollapsibleCard
+      locked={locked}
       title="Confidential Compute"
       icon={<ShieldCheckIcon className="h-4 w-4" />}
       infoTooltip={confidentialComputeTooltip}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.spec.tsx
@@ -116,6 +116,19 @@ describe(ConfigurationPane.name, () => {
     expect(onCancelAndEdit).toHaveBeenCalled();
   });
 
+  it("locks the hardware and additional sections but never the image section", () => {
+    const ImageSection = vi.fn(() => null);
+    const HardwareSection = vi.fn(() => null);
+    const AdditionalSection = vi.fn(() => null);
+    const values = defaultServiceWithPlacement({ title: "api" });
+
+    setup({ values, selectedServiceId: values.services[0].id, locked: true, dependencies: { ImageSection, HardwareSection, AdditionalSection } });
+
+    expect(HardwareSection).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(AdditionalSection).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(ImageSection).not.toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+  });
+
   function setup(input: {
     values: SdlBuilderFormValuesType;
     selectedServiceId: string;

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.tsx
@@ -11,7 +11,7 @@ export const DEPENDENCIES = { ImageSection, HardwareSection, AdditionalSection }
 
 type Props = {
   selectedServiceId: string;
-  /** While quotes are active the configuration controls are disabled and a lock banner is shown. */
+  /** Locks the fields that can't change once the deployment exists on-chain (resources, placement, ports, …). The image, env vars and commands cards stay editable and their changes are pushed via an update on deploy. */
   locked?: boolean;
   isClosing?: boolean;
   onCancelAndEdit?: () => void;
@@ -44,7 +44,7 @@ export const ConfigurationPane: FC<Props> = ({ selectedServiceId, locked = false
       <div className="flex-1 overflow-y-auto py-4">
         {selectedServiceIndex >= 0 && (
           <div key={selectedServiceId} className="flex flex-col gap-6">
-            <d.ImageSection serviceIndex={selectedServiceIndex} locked={locked} />
+            <d.ImageSection serviceIndex={selectedServiceIndex} />
             <d.HardwareSection serviceIndex={selectedServiceIndex} locked={locked} />
             <d.AdditionalSection serviceIndex={selectedServiceIndex} locked={locked} />
           </div>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.spec.tsx
@@ -214,17 +214,6 @@ describe(EnvironmentVariablesCard.name, () => {
     expect(getValues().services[0].env).toContainEqual(expect.objectContaining({ id: "SSH_PUBKEY", key: "SSH_PUBKEY", value: "abc123" }));
   });
 
-  it("opens for viewing but disables the inputs, Add and Save while locked", async () => {
-    const { openCard } = setup({ env: [{ key: "FOO", value: "bar" }], locked: true });
-
-    await openCard();
-
-    expect(screen.getByLabelText("Environment variable 1 key")).toBeDisabled();
-    expect(screen.getByLabelText("Environment variable 1 value")).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Add variable" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
-  });
-
   describe("pasting dotenv content into a key field", () => {
     it("creates a row per pasted KEY=value line and drops the empty row pasted into", async () => {
       const { openCard } = setup({ env: [] });
@@ -335,7 +324,7 @@ describe(EnvironmentVariablesCard.name, () => {
     }
   });
 
-  function setup(input: { env?: Array<Partial<EnvironmentVariableType>>; image?: string; locked?: boolean }) {
+  function setup(input: { env?: Array<Partial<EnvironmentVariableType>>; image?: string }) {
     const env = input.env?.map(e => ({ key: "", value: "", isSecret: false, ...e })) ?? [];
 
     const values = defaultServiceWithPlacement({ env, ...(input.image !== undefined ? { image: input.image } : {}) });
@@ -348,7 +337,7 @@ describe(EnvironmentVariablesCard.name, () => {
 
     render(
       <Wrapper>
-        <EnvironmentVariablesCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES }} />
+        <EnvironmentVariablesCard serviceIndex={0} dependencies={{ ...DEPENDENCIES }} />
         <ImageErrorProbe serviceIndex={0} />
       </Wrapper>
     );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.tsx
@@ -25,8 +25,6 @@ const RESERVED_ENV_KEYS = new Set<string>(RESERVED_ENV_KEY_LIST);
 
 type Props = {
   serviceIndex: number;
-  /** While the pane is locked the dialog still opens for viewing but its inputs, Add/Remove and Save are disabled. */
-  locked?: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -35,7 +33,7 @@ type Props = {
  * a Dialog where the user edits key/value pairs. Changes are committed on Save; cancelled on Close.
  * The header shows the count of user-set variables (reserved keys like SSH_PUBKEY are excluded).
  */
-export const EnvironmentVariablesCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+export const EnvironmentVariablesCard: FC<Props> = ({ serviceIndex, dependencies: d = DEPENDENCIES }) => {
   const { control, getValues, reset, trigger, formState } = useFormContext<SdlBuilderFormValuesType>();
   const hasEnvErrors = !!formState.errors.services?.[serviceIndex]?.env;
   const env = useWatch({ control, name: `services.${serviceIndex}.env` });
@@ -94,8 +92,8 @@ export const EnvironmentVariablesCard: FC<Props> = ({ serviceIndex, locked = fal
           </d.DialogV2Header>
 
           <d.DialogV2Body>
-            <fieldset disabled={locked} className="contents">
-              <EnvironmentVariablesList serviceIndex={serviceIndex} locked={locked} />
+            <fieldset className="contents">
+              <EnvironmentVariablesList serviceIndex={serviceIndex} />
             </fieldset>
           </d.DialogV2Body>
 
@@ -107,7 +105,7 @@ export const EnvironmentVariablesCard: FC<Props> = ({ serviceIndex, locked = fal
               <Button type="button" variant="ghost" onClick={handleCancel}>
                 Cancel
               </Button>
-              <Button type="button" onClick={handleSave} disabled={hasEnvErrors || locked}>
+              <Button type="button" onClick={handleSave} disabled={hasEnvErrors}>
                 Save
                 <SaveIcon className="ml-2 size-4" />
               </Button>
@@ -121,18 +119,16 @@ export const EnvironmentVariablesCard: FC<Props> = ({ serviceIndex, locked = fal
 
 type EnvironmentVariablesListProps = {
   serviceIndex: number;
-  /** While locked the list is view-only: the seed-an-empty-row effect is skipped so opening the dialog can't mutate the form. */
-  locked?: boolean;
 };
 
-const EnvironmentVariablesList: FC<EnvironmentVariablesListProps> = ({ serviceIndex, locked = false }) => {
+const EnvironmentVariablesList: FC<EnvironmentVariablesListProps> = ({ serviceIndex }) => {
   const { control, getValues } = useFormContext<SdlBuilderFormValuesType>();
   const { fields, append, remove, replace } = useFieldArray({ control, name: `services.${serviceIndex}.env`, keyName: "fieldId" });
 
   const visibleFields = fields.filter(f => !RESERVED_ENV_KEYS.has(f.key));
 
   useEffect(() => {
-    if (visibleFields.length === 0 && !locked) {
+    if (visibleFields.length === 0) {
       append({ id: nanoid(), key: "", value: "", isSecret: false }, { shouldFocus: false });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ExposePortsCard/ExposePortsCard.tsx
@@ -156,6 +156,7 @@ export const ExposePortsCard: FC<Props> = ({ serviceIndex, locked = false, depen
   return (
     <>
       <d.CollapsibleCard
+        locked={locked}
         title="Expose Ports"
         icon={<GlobeIcon className="h-4 w-4" />}
         infoTooltip={exposePortsTooltip}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
@@ -78,6 +78,7 @@ export const GpuCard: FC<Props> = ({ serviceIndex, locked = false, dependencies:
 
   return (
     <d.CollapsibleCard
+      locked={locked}
       title="GPU"
       icon={<GpuIcon className="h-4 w-4" />}
       infoTooltip={gpuTooltip}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
@@ -59,13 +59,13 @@ export const HardwareSection: FC<Props> = ({ serviceIndex, locked = false, depen
     <div className="flex flex-col gap-2 px-4">
       <p className="font-mono text-xs uppercase text-muted-foreground">Hardware</p>
       <div className="flex flex-col gap-4">
-        <d.CollapsibleCard title="Presets" icon={<PackageOpenIcon className="h-4 w-4" />} infoTooltip={presetsTooltip}>
+        <d.CollapsibleCard locked={locked} title="Presets" icon={<PackageOpenIcon className="h-4 w-4" />} infoTooltip={presetsTooltip}>
           <d.PresetsCard serviceIndex={serviceIndex} locked={locked} />
         </d.CollapsibleCard>
 
         <d.GpuCard serviceIndex={serviceIndex} locked={locked} />
 
-        <d.CollapsibleCard title="Compute Resources" icon={<CpuIcon className="h-4 w-4" />} infoTooltip={computeResourcesTooltip}>
+        <d.CollapsibleCard locked={locked} title="Compute Resources" icon={<CpuIcon className="h-4 w-4" />} infoTooltip={computeResourcesTooltip}>
           <d.ComputeResourcesCard serviceIndex={serviceIndex} locked={locked} />
         </d.CollapsibleCard>
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageCard/ImageCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageCard/ImageCard.spec.tsx
@@ -21,15 +21,6 @@ describe(ImageCard.name, () => {
     expect(getValues().services[0].image).toBe("myimage:1.0");
   });
 
-  it("disables the image and credentials inputs while locked", () => {
-    setup({ locked: true, hasCredentials: true });
-
-    expect(screen.getByRole("textbox", { name: "Docker image" })).toBeDisabled();
-    expect(screen.getByRole("checkbox", { name: "Private registry" })).toBeDisabled();
-    expect(screen.getByRole("combobox", { name: "Registry host" })).toBeDisabled();
-    expect(screen.getByRole("textbox", { name: "Registry username" })).toBeDisabled();
-  });
-
   it("reveals credentials fields and seeds defaults when private registry is checked", async () => {
     const { getValues } = setup({});
 
@@ -131,7 +122,7 @@ describe(ImageCard.name, () => {
     });
   });
 
-  function setup(input: { hasCredentials?: boolean; locked?: boolean; resolver?: Resolver<SdlBuilderFormValuesType> }) {
+  function setup(input: { hasCredentials?: boolean; resolver?: Resolver<SdlBuilderFormValuesType> }) {
     const values = defaultServiceWithPlacement({
       image: "",
       hasCredentials: input.hasCredentials ?? false,
@@ -159,7 +150,7 @@ describe(ImageCard.name, () => {
 
     render(
       <Wrapper>
-        <ImageCard serviceIndex={0} locked={input.locked} />
+        <ImageCard serviceIndex={0} />
       </Wrapper>
     );
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageCard/ImageCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageCard/ImageCard.tsx
@@ -28,8 +28,6 @@ export const DEPENDENCIES = { CollapsibleCard };
 
 type Props = {
   serviceIndex: number;
-  /** While the pane is locked every input in the card body is disabled so configured values stay viewable but read-only. */
-  locked?: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -53,13 +51,13 @@ const defaultCredentials = { host: "docker.io", username: "", password: "" };
  * (`hasCredentials`/`credentials`). Checking "Private registry" reveals the credentials fields and
  * seeds defaults; unchecking clears them.
  */
-export const ImageCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+export const ImageCard: FC<Props> = ({ serviceIndex, dependencies: d = DEPENDENCIES }) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const hasCredentials = useController({ control, name: `services.${serviceIndex}.hasCredentials` });
 
   return (
     <d.CollapsibleCard title="Docker" icon={<BoxIcon className="h-4 w-4" />} infoTooltip={dockerImageTooltip}>
-      <fieldset disabled={locked} className="flex min-w-0 flex-col gap-4 border-0 p-0">
+      <fieldset className="flex min-w-0 flex-col gap-4 border-0 p-0">
         <ImageField serviceIndex={serviceIndex} hasCredentials={!!hasCredentials.field.value} onToggleCredentials={hasCredentials.field.onChange} />
 
         {hasCredentials.field.value && <CredentialsFields serviceIndex={serviceIndex} />}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageSection/ImageSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageSection/ImageSection.spec.tsx
@@ -14,15 +14,7 @@ describe(ImageSection.name, () => {
     expect(ImageCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
   });
 
-  it("forwards the locked state to the image card", () => {
-    const ImageCard = vi.fn(() => null);
-
-    setup({ locked: true, dependencies: { ImageCard } });
-
-    expect(ImageCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
-  });
-
-  function setup(input: { serviceIndex?: number; locked?: boolean; dependencies?: Partial<typeof DEPENDENCIES> }) {
-    render(<ImageSection serviceIndex={input.serviceIndex ?? 0} locked={input.locked} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />);
+  function setup(input: { serviceIndex?: number; dependencies?: Partial<typeof DEPENDENCIES> }) {
+    render(<ImageSection serviceIndex={input.serviceIndex ?? 0} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />);
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageSection/ImageSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageSection/ImageSection.tsx
@@ -6,8 +6,6 @@ export const DEPENDENCIES = { ImageCard };
 
 type Props = {
   serviceIndex: number;
-  /** While locked the image card is disabled (its chevron stays expandable for viewing). */
-  locked?: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -16,12 +14,12 @@ type Props = {
  * pulled to the top of the column so the one required runtime field is the first thing a fresh
  * deployment shows.
  */
-export const ImageSection: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+export const ImageSection: FC<Props> = ({ serviceIndex, dependencies: d = DEPENDENCIES }) => {
   return (
     <div className="flex flex-col gap-2 px-4">
       <p className="font-mono text-xs uppercase text-muted-foreground">Image</p>
       <div className="flex flex-col gap-4">
-        <d.ImageCard serviceIndex={serviceIndex} locked={locked} />
+        <d.ImageCard serviceIndex={serviceIndex} />
       </div>
     </div>
   );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/LogsCard/LogsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/LogsCard/LogsCard.tsx
@@ -207,6 +207,7 @@ export const LogsCard: FC<Props> = ({ serviceIndex, locked = false, dependencies
   return (
     <>
       <d.CollapsibleCard
+        locked={locked}
         title="Logs"
         icon={<ScrollTextIcon className="h-4 w-4" />}
         infoTooltip={logsTooltip}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PersistentStorageCard/PersistentStorageCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PersistentStorageCard/PersistentStorageCard.tsx
@@ -83,6 +83,7 @@ export const PersistentStorageCard: FC<Props> = ({ serviceIndex, locked = false,
 
   return (
     <d.CollapsibleCard
+      locked={locked}
       title="Persistent Storage"
       icon={<HardDriveIcon className="h-4 w-4" />}
       infoTooltip={persistentStorageTooltip}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RamStorageCard/RamStorageCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RamStorageCard/RamStorageCard.tsx
@@ -51,6 +51,7 @@ export const RamStorageCard: FC<Props> = ({ serviceIndex, locked = false, depend
 
   return (
     <d.CollapsibleCard
+      locked={locked}
       title="RAM Storage"
       icon={<MicrochipIcon className="h-4 w-4" />}
       infoTooltip={ramStorageTooltip}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.tsx
@@ -58,7 +58,7 @@ type Props = {
  */
 export const RuntimeCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
   return (
-    <d.CollapsibleCard title="Runtime" icon={<SettingsIcon className="h-4 w-4" />} infoTooltip={runtimeTooltip}>
+    <d.CollapsibleCard locked={locked} title="Runtime" icon={<SettingsIcon className="h-4 w-4" />} infoTooltip={runtimeTooltip}>
       <fieldset disabled={locked} className="flex min-w-0 flex-col gap-4 border-0 p-0">
         <ReplicasField serviceIndex={serviceIndex} dependencies={d} />
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/PaneLockBanner/PaneLockBanner.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/PaneLockBanner/PaneLockBanner.spec.tsx
@@ -5,10 +5,10 @@ import { PaneLockBanner } from "./PaneLockBanner";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 describe(PaneLockBanner.name, () => {
-  it("renders the lock message and triggers cancel-and-edit", () => {
+  it("warns that changes need new quotes and triggers cancel-and-edit", () => {
     const onCancelAndEdit = vi.fn();
     render(<PaneLockBanner onCancelAndEdit={onCancelAndEdit} />);
-    expect(screen.getByText(/changes here invalidate the active quotes/i)).toBeInTheDocument();
+    expect(screen.getByText(/changing a locked setting needs new quotes/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /cancel and edit/i }));
     expect(onCancelAndEdit).toHaveBeenCalled();
   });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/PaneLockBanner/PaneLockBanner.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/PaneLockBanner/PaneLockBanner.tsx
@@ -20,7 +20,7 @@ export const PaneLockBanner: FC<Props> = ({ onCancelAndEdit, isClosing }) => {
         <Lock className="h-4 w-4 text-foreground" aria-hidden="true" />
         <span className="text-sm font-medium">Locked</span>
       </div>
-      <p className="min-h-10 text-sm text-muted-foreground">Changes here invalidate the active quotes.</p>
+      <p className="min-h-10 text-sm text-muted-foreground">Changing a locked setting needs new quotes.</p>
       <Button type="button" variant="link" onClick={onCancelAndEdit} disabled={isClosing} className="h-auto p-0 text-sm underline">
         {isClosing ? "Cancelling…" : "Cancel and edit"}
       </Button>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
@@ -104,7 +104,7 @@ describe(useDeploymentFlow.name, () => {
     const createDeployment = mockMutation();
     createDeployment.mutate.mockImplementation((_input, opts) => opts.onSuccess({ data: { dseq: "555", manifest: "MANIFEST_JSON" } }));
     const createLease = mockMutation();
-    const { result } = renderFlow({ createDeployment, createLease });
+    const { result } = renderFlow({ createDeployment, createLease, manifestFromSdl: () => "MANIFEST_JSON" });
 
     act(() => result.current.actions.requestQuotes("sdl"));
     act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
@@ -244,10 +244,12 @@ describe(useDeploymentFlow.name, () => {
     expect(result.current.selections).toEqual({});
   });
 
-  it("derives the manifest from the sdl when deploying after a reload that resumed straight into quoting", () => {
+  it("updates then leases with the sdl-derived manifest when deploying after a reload that resumed straight into quoting", () => {
+    const updateDeployment = mockMutation();
+    updateDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({}));
     const createLease = mockMutation();
     const manifestFromSdl = vi.fn(() => "DERIVED_MANIFEST");
-    const { result } = renderFlow({ createLease, manifestFromSdl, intent: { dseq: "555" } });
+    const { result } = renderFlow({ updateDeployment, createLease, manifestFromSdl, intent: { dseq: "555" } });
 
     expect(result.current.phase).toBe("quoting");
 
@@ -255,10 +257,74 @@ describe(useDeploymentFlow.name, () => {
     act(() => result.current.actions.deploy("SDL_CONTENT"));
 
     expect(manifestFromSdl).toHaveBeenCalledWith("SDL_CONTENT");
+    expect(updateDeployment.mutate).toHaveBeenCalledWith({ dseq: "555", data: { sdl: "SDL_CONTENT" } }, expect.anything());
     expect(createLease.mutate).toHaveBeenCalledWith(
       { manifest: "DERIVED_MANIFEST", leases: [{ dseq: "555", gseq: 1, oseq: 3, provider: "akash1a" }] },
       expect.anything()
     );
+  });
+
+  it("updates the deployment before leasing when the manifest changed since create", () => {
+    const createDeployment = mockMutation();
+    createDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({ data: { dseq: "555", manifest: "M1" } }));
+    const updateDeployment = mockMutation();
+    updateDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({}));
+    const createLease = mockMutation();
+    const { result } = renderFlow({ createDeployment, updateDeployment, createLease, manifestFromSdl: () => "M2" });
+
+    act(() => result.current.actions.requestQuotes("sdl"));
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+    act(() => result.current.actions.deploy("edited-sdl"));
+
+    expect(updateDeployment.mutate).toHaveBeenCalledWith({ dseq: "555", data: { sdl: "edited-sdl" } }, expect.anything());
+    expect(createLease.mutate).toHaveBeenCalledWith({ manifest: "M2", leases: [{ dseq: "555", gseq: 1, oseq: 3, provider: "akash1a" }] }, expect.anything());
+  });
+
+  it("leases without updating when the manifest is unchanged since create", () => {
+    const createDeployment = mockMutation();
+    createDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({ data: { dseq: "555", manifest: "M1" } }));
+    const updateDeployment = mockMutation();
+    const createLease = mockMutation();
+    const { result } = renderFlow({ createDeployment, updateDeployment, createLease, manifestFromSdl: () => "M1" });
+
+    act(() => result.current.actions.requestQuotes("sdl"));
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+    act(() => result.current.actions.deploy("sdl"));
+
+    expect(updateDeployment.mutate).not.toHaveBeenCalled();
+    expect(createLease.mutate).toHaveBeenCalledWith({ manifest: "M1", leases: [{ dseq: "555", gseq: 1, oseq: 3, provider: "akash1a" }] }, expect.anything());
+  });
+
+  it("does not create the lease until the pre-lease update succeeds", () => {
+    const createDeployment = mockMutation();
+    createDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({ data: { dseq: "555", manifest: "M1" } }));
+    const updateDeployment = mockMutation();
+    const createLease = mockMutation();
+    const { result } = renderFlow({ createDeployment, updateDeployment, createLease, manifestFromSdl: () => "M2" });
+
+    act(() => result.current.actions.requestQuotes("sdl"));
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+    act(() => result.current.actions.deploy("edited-sdl"));
+
+    expect(updateDeployment.mutate).toHaveBeenCalledTimes(1);
+    expect(createLease.mutate).not.toHaveBeenCalled();
+  });
+
+  it("returns to quoting with a retryable error when the pre-lease update fails", () => {
+    const createDeployment = mockMutation();
+    createDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({ data: { dseq: "555", manifest: "M1" } }));
+    const updateDeployment = mockMutation();
+    updateDeployment.mutate.mockImplementation((_i, o) => o.onError(new Error("boom")));
+    const createLease = mockMutation();
+    const { result } = renderFlow({ createDeployment, updateDeployment, createLease, manifestFromSdl: () => "M2" });
+
+    act(() => result.current.actions.requestQuotes("sdl"));
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+    act(() => result.current.actions.deploy("edited-sdl"));
+
+    expect(createLease.mutate).not.toHaveBeenCalled();
+    expect(result.current.phase).toBe("quoting");
+    expect(result.current.deployError).toBeDefined();
   });
 
   it("clears a placement's selection when its bid is no longer open", async () => {
@@ -320,6 +386,7 @@ describe(useDeploymentFlow.name, () => {
       useCreateDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useCreateDeployment>>({ mutate: (input.createMutate ?? vi.fn()) as never })) as never,
       useCloseDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useCloseDeployment>>({ mutate: (input.closeMutate ?? vi.fn()) as never })) as never,
       useCreateLease: (() => mock<ReturnType<typeof DEPENDENCIES.useCreateLease>>({ mutate: vi.fn() as never })) as never,
+      useUpdateDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useUpdateDeployment>>({ mutate: vi.fn() as never })) as never,
       useListBids: (() => ({ data: { data: [] }, isLoading: false, isError: false })) as never,
       useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: (input.replace ?? vi.fn()) as never })) as never,
       useDeploymentLocalStorage: (() => mock<ReturnType<typeof DEPENDENCIES.useDeploymentLocalStorage>>()) as never,
@@ -333,6 +400,7 @@ describe(useDeploymentFlow.name, () => {
     createDeployment?: ReturnType<typeof mockMutation>;
     createLease?: ReturnType<typeof mockMutation>;
     closeDeployment?: ReturnType<typeof mockMutation>;
+    updateDeployment?: ReturnType<typeof mockMutation>;
     manifestFromSdl?: (sdl: string) => string | null;
     listBids?: Array<{ bid: { state: string; price: { amount: string; denom: string }; id: { provider: string; dseq: string; gseq: number; oseq: number } } }>;
   }) {
@@ -343,10 +411,11 @@ describe(useDeploymentFlow.name, () => {
       useCreateDeployment: (() => input?.createDeployment ?? mockMutation()) as never,
       useCloseDeployment: (() => input?.closeDeployment ?? mockMutation()) as never,
       useCreateLease: (() => input?.createLease ?? mockMutation()) as never,
+      useUpdateDeployment: (() => input?.updateDeployment ?? mockMutation()) as never,
       useListBids: (() => ({ data: { data: input?.listBids ?? [] }, isLoading: false, isError: false })) as never,
       useRouter: () => router,
       useDeploymentLocalStorage: (() => deploymentLocalStorage) as never,
-      manifestFromSdl: input?.manifestFromSdl ?? (() => "DERIVED_MANIFEST")
+      manifestFromSdl: input?.manifestFromSdl ?? (() => "M")
     };
     const utils = renderHook(() => useDeploymentFlow({ intent }, dependencies));
     return { ...utils, router, deploymentLocalStorage };

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -62,11 +62,24 @@ function useCreateLease() {
   return useServices().api.v1.createLease.useMutation();
 }
 
+function useUpdateDeployment() {
+  return useServices().api.v1.updateDeployment.useMutation();
+}
+
 function useDeploymentLocalStorage() {
   return useServices().deploymentLocalStorage;
 }
 
-export const DEPENDENCIES = { useCreateDeployment, useCloseDeployment, useCreateLease, useListBids, useRouter, useDeploymentLocalStorage, manifestFromSdl };
+export const DEPENDENCIES = {
+  useCreateDeployment,
+  useCloseDeployment,
+  useCreateLease,
+  useUpdateDeployment,
+  useListBids,
+  useRouter,
+  useDeploymentLocalStorage,
+  manifestFromSdl
+};
 
 /**
  * Controlled lifecycle state machine for the configure flow. Owns interaction state (phase, dseq,
@@ -79,6 +92,7 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
   const createDeployment = dependencies.useCreateDeployment();
   const closeDeployment = dependencies.useCloseDeployment();
   const createLease = dependencies.useCreateLease();
+  const updateDeployment = dependencies.useUpdateDeployment();
   const deploymentLocalStorage = dependencies.useDeploymentLocalStorage();
 
   const [phase, setPhase] = useState<DeploymentFlowPhase>(intent.dseq ? "quoting" : "configuring");
@@ -205,46 +219,54 @@ export function useDeploymentFlow({ intent }: UseDeploymentFlowInput, dependenci
   }, []);
 
   /**
-   * Creates the lease(s) and sends the manifest(s) via the combined create-lease request. The manifest
-   * captured at create time is used when present; on a reload that resumed straight into `quoting` it was
-   * never captured, so it is rederived from the passed SDL (identical to the server's create-deployment
-   * manifest, both being `manifestToSortedJSON` of the SDL's groups) rather than leaving deploy a no-op.
+   * Deploys the current selections. The manifest is always derived from the SDL being deployed, so a
+   * quoting-window edit is what gets leased — never a stale create-time manifest. When that manifest differs
+   * from the one captured at create — or none was captured, e.g. a reload that resumed straight into
+   * `quoting` — the deployment is updated first (MsgUpdateDeployment) so the on-chain manifest hash matches
+   * before the provider is sent the manifest at lease time; an unchanged manifest goes straight to the lease.
    * On success it persists the SDL under the deployment's dseq keyed by the owner the response carries (so it
    * needs no wallet) — the same key the detail page reads — then replaces the configure entry with the
    * deployment's events tab (matching the legacy builder), so Back lands on the new-deployment page rather than
    * the just-deployed config.
-   * On failure it drops back to `quoting` so the progress overlay unmounts and the user is returned to where
-   * they took off; `deployError` is set to drive the error toast and the header's Retry CTA. Retry re-fires
-   * this same request with the current selections — provider re-selection after a lease exists is out of
-   * scope here (a partial-failure-aware, idempotent retry is tracked separately).
+   * On any failure it drops back to `quoting` (unmounting the overlay) and sets `deployError` to drive the
+   * error toast and the header's Retry CTA; retry re-fires with the current selections. Provider re-selection
+   * after a lease exists is out of scope here.
    */
   const deploy = useCallback(
     function deploy(sdl: string) {
-      const effectiveManifest = manifest ?? dependencies.manifestFromSdl(sdl);
-      if (!dseq || !effectiveManifest) return;
+      const nextManifest = dependencies.manifestFromSdl(sdl);
+      if (!dseq || !nextManifest) return;
       const leases = Object.values(selections).map(parseBidId);
       if (leases.length === 0) return;
+      const activeDseq = dseq;
+      const activeManifest = nextManifest;
       setDeployError(undefined);
       setDeploySucceeded(false);
       setPhase("deploying");
-      createLease.mutate(
-        { manifest: effectiveManifest, leases },
-        {
-          onSuccess: function onDeployed(result: { data: { deployment: { id: { owner: string } } } }) {
-            cacheDeployedSdl(deploymentLocalStorage, result.data.deployment.id.owner, dseq, sdl);
-            setDeploySucceeded(true);
-            redirectTimerRef.current = setTimeout(function redirectToDeployment() {
-              router.replace(UrlService.deploymentDetails(dseq, "EVENTS", "events"));
-            }, DEPLOY_SUCCESS_DWELL_MS);
-          },
-          onError: function onDeployFailed(cause: unknown) {
-            setDeployError({ message: extractApiErrorMessage(cause) ?? undefined });
-            setPhase("quoting");
-          }
-        }
-      );
+      function completeDeploy(result: { data: { deployment: { id: { owner: string } } } }) {
+        cacheDeployedSdl(deploymentLocalStorage, result.data.deployment.id.owner, activeDseq, sdl);
+        setDeploySucceeded(true);
+        redirectTimerRef.current = setTimeout(function redirectToDeployment() {
+          router.replace(UrlService.deploymentDetails(activeDseq, "EVENTS", "events"));
+        }, DEPLOY_SUCCESS_DWELL_MS);
+      }
+
+      function failDeploy(cause: unknown) {
+        setDeployError({ message: extractApiErrorMessage(cause) ?? undefined });
+        setPhase("quoting");
+      }
+
+      function sendManifestAndLease() {
+        createLease.mutate({ manifest: activeManifest, leases }, { onSuccess: completeDeploy, onError: failDeploy });
+      }
+
+      if (activeManifest !== manifest) {
+        updateDeployment.mutate({ dseq: activeDseq, data: { sdl } }, { onSuccess: sendManifestAndLease, onError: failDeploy });
+      } else {
+        sendManifestAndLease();
+      }
     },
-    [createLease, dseq, manifest, selections, router, dependencies, deploymentLocalStorage]
+    [createLease, updateDeployment, dseq, manifest, selections, router, dependencies, deploymentLocalStorage]
   );
 
   return {

--- a/apps/deploy-web/tests/ui/configure-deployment-flow.spec.ts
+++ b/apps/deploy-web/tests/ui/configure-deployment-flow.spec.ts
@@ -20,10 +20,9 @@ test.describe("Configure deployment — request quotes flow", () => {
       // the created deployment's dseq is mirrored into the route segment
       await page.waitForURL(/\/new-deployment\/configure\/\d+/, { timeout: 90_000 });
 
-      // the spec panes lock: a banner is shown and the inputs are disabled
       await expect(configure.lockBannerText().first()).toBeVisible({ timeout: 30_000 });
       await expect(configure.cpuInput()).toBeDisabled();
-      await expect(configure.dockerImageInput()).toBeDisabled();
+      await expect(configure.dockerImageInput()).toBeEnabled();
 
       // the marketplace is scoped to the placement and lists offers
       await expect(configure.marketplaceHeading()).toBeVisible();

--- a/apps/deploy-web/tests/ui/pages/ConfigureDeploymentPage.ts
+++ b/apps/deploy-web/tests/ui/pages/ConfigureDeploymentPage.ts
@@ -54,7 +54,7 @@ export class ConfigureDeploymentPage {
 
   /** The lock banner copy shown in each spec pane while quotes are active. */
   lockBannerText() {
-    return this.page.getByText("Changes here invalidate the active quotes.");
+    return this.page.getByText("Changing a locked setting needs new quotes.");
   }
 
   marketplaceHeading() {
@@ -68,7 +68,9 @@ export class ConfigureDeploymentPage {
 
   /** Waits for the first submitted bid's Select button in the marketplace, then picks it. */
   async selectFirstAvailableProvider() {
-    const select = this.marketplace().getByRole("button", { name: /^Select / }).first();
+    const select = this.marketplace()
+      .getByRole("button", { name: /^Select / })
+      .first();
     await select.click({ timeout: 90_000 });
   }
 
@@ -77,6 +79,8 @@ export class ConfigureDeploymentPage {
   }
 
   async confirmAndDeploy() {
-    await this.reviewDialog().getByRole("button", { name: /confirm and deploy/i }).click();
+    await this.reviewDialog()
+      .getByRole("button", { name: /confirm and deploy/i })
+      .click();
   }
 }

--- a/packages/ui/components/collapsible-card.spec.tsx
+++ b/packages/ui/components/collapsible-card.spec.tsx
@@ -13,6 +13,18 @@ describe(CollapsibleCard.name, () => {
     expect(screen.getByText("card body")).toBeVisible();
   });
 
+  it("renders a lock indicator in the header when locked", () => {
+    setup({ locked: true });
+
+    expect(screen.getByLabelText("Locked")).toBeInTheDocument();
+  });
+
+  it("does not render a lock indicator when not locked", () => {
+    setup({});
+
+    expect(screen.queryByLabelText("Locked")).not.toBeInTheDocument();
+  });
+
   it("hides the body and shows the summary when collapsed", async () => {
     setup({ summary: "1 GPU" });
 
@@ -263,6 +275,12 @@ describe(CollapsibleCard.name, () => {
       expect(screen.getByText("None set")).toBeInTheDocument();
     });
 
+    it("renders a lock indicator in the header when locked", () => {
+      setup({ onHeaderClick: vi.fn(), locked: true });
+
+      expect(screen.getByLabelText("Locked")).toBeInTheDocument();
+    });
+
     it("does not fire onHeaderClick when the info icon is clicked", async () => {
       const onHeaderClick = vi.fn();
       setup({ onHeaderClick, infoTooltip: "helpful info" });
@@ -333,6 +351,7 @@ describe(CollapsibleCard.name, () => {
     onHeaderClick?: () => void;
     toggleDisabled?: boolean;
     defaultOpen?: boolean;
+    locked?: boolean;
   }) {
     const card = (overrides: Partial<typeof input>) => (
       <CollapsibleCard
@@ -349,6 +368,7 @@ describe(CollapsibleCard.name, () => {
         onHeaderClick={input.onHeaderClick}
         toggleDisabled={input.toggleDisabled}
         defaultOpen={input.defaultOpen}
+        locked={input.locked}
         {...overrides}
       >
         <p>card body</p>

--- a/packages/ui/components/collapsible-card.tsx
+++ b/packages/ui/components/collapsible-card.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import { useEffect, useRef, useState } from "react";
-import { InfoCircle } from "iconoir-react";
+import { InfoCircle, Lock } from "iconoir-react";
 import { ChevronDown, ChevronRight, ChevronUp } from "lucide-react";
 
 import { cn } from "../utils";
@@ -13,6 +13,8 @@ import { CustomTooltip, TooltipProvider } from "./tooltip";
 export interface CollapsibleCardProps {
   title: string;
   icon: React.ReactNode;
+  /** Renders a lock glyph in the header to mark the card read-only (e.g. while quotes are active). */
+  locked?: boolean;
   /**
    * Optional help content shown in a tooltip behind an info icon next to the
    * title. Accepts plain text or JSX (e.g. multi-paragraph copy with links).
@@ -74,7 +76,7 @@ export interface CollapsibleCardProps {
  */
 const CollapsibleCard = React.forwardRef<HTMLDivElement, CollapsibleCardProps>(({ onHeaderClick, ...props }, ref) => {
   if (onHeaderClick) {
-    const { title, icon, infoTooltip, summary, className, isToggled, onToggle, toggleAriaLabel, toggleDisabled } = props;
+    const { title, icon, infoTooltip, summary, className, isToggled, onToggle, toggleAriaLabel, toggleDisabled, locked } = props;
     return (
       <ActionCard
         title={title}
@@ -87,6 +89,7 @@ const CollapsibleCard = React.forwardRef<HTMLDivElement, CollapsibleCardProps>((
         onToggle={onToggle}
         toggleAriaLabel={toggleAriaLabel}
         toggleDisabled={toggleDisabled}
+        locked={locked}
       />
     );
   }
@@ -100,6 +103,7 @@ const CollapsibleCardBody = React.forwardRef<HTMLDivElement, Omit<CollapsibleCar
     {
       title,
       icon,
+      locked,
       infoTooltip,
       summary,
       headerControl,
@@ -173,7 +177,7 @@ const CollapsibleCardBody = React.forwardRef<HTMLDivElement, Omit<CollapsibleCar
             className="focus-visible:ring-ring flex flex-1 items-center gap-2 self-stretch rounded outline-none focus-visible:ring-1"
           >
             <CardIcon icon={icon} />
-            <CardTitle title={title} infoTooltip={infoTooltip} />
+            <CardTitle title={title} infoTooltip={infoTooltip} locked={locked} />
             {!open && summary && <CardSummary summary={summary} />}
             <span className="text-foreground flex h-6 w-6 shrink-0 items-center justify-center" aria-hidden>
               {open ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
@@ -198,14 +202,17 @@ CollapsibleCardBody.displayName = "CollapsibleCardBody";
  * region, so it toggles independently without firing `onHeaderClick`.
  */
 const ActionCard: React.FC<
-  Pick<CollapsibleCardProps, "title" | "icon" | "infoTooltip" | "summary" | "className" | "isToggled" | "onToggle" | "toggleAriaLabel" | "toggleDisabled"> & {
+  Pick<
+    CollapsibleCardProps,
+    "title" | "icon" | "infoTooltip" | "summary" | "className" | "isToggled" | "onToggle" | "toggleAriaLabel" | "toggleDisabled" | "locked"
+  > & {
     onHeaderClick: () => void;
   }
-> = ({ title, icon, infoTooltip, summary, onHeaderClick, className, isToggled, onToggle, toggleAriaLabel, toggleDisabled = false }) => {
+> = ({ title, icon, infoTooltip, summary, onHeaderClick, className, isToggled, onToggle, toggleAriaLabel, toggleDisabled = false, locked }) => {
   const content = (
     <>
       <CardIcon icon={icon} />
-      <CardTitle title={title} infoTooltip={infoTooltip} />
+      <CardTitle title={title} infoTooltip={infoTooltip} locked={locked} />
       {summary && <CardSummary summary={summary} />}
     </>
   );
@@ -253,9 +260,10 @@ const CardIcon: React.FC<{ icon: React.ReactNode }> = ({ icon }) => (
   </span>
 );
 
-const CardTitle: React.FC<{ title: string; infoTooltip?: React.ReactNode }> = ({ title, infoTooltip }) => (
+const CardTitle: React.FC<{ title: string; infoTooltip?: React.ReactNode; locked?: boolean }> = ({ title, infoTooltip, locked }) => (
   <div className="flex flex-1 items-center gap-2">
     <span className="text-foreground truncate text-left text-base font-semibold">{title}</span>
+    {locked && <Lock className="text-muted-foreground h-3.5 w-3.5 shrink-0" aria-label="Locked" />}
     {infoTooltip && <CardInfoTooltip>{infoTooltip}</CardInfoTooltip>}
   </div>
 );


### PR DESCRIPTION
## Why

Fixes CON-631

On the redesigned Configure screen, requesting quotes locked the entire configuration. Changing
even a minor manifest detail — a container image tag, an environment variable, the start
command — meant using "Cancel & edit", which discarded the deployment and every quote already
returned and forced a full re-quote. Those edits don't change the resources, price or placement
that providers bid on, so the existing quotes stay valid — users should be able to make them in
place and deploy without starting over.

## What

While quotes are live (after "Request quotes", before "Deploy"):

- The manifest-only cards stay editable: **image, environment variables, commands**.
- Everything that feeds the on-chain deployment group locks, with a lock glyph on the card
  header: compute resources, GPU, storage, replicas, pricing, placement/region, exposed ports,
  logs, reclamation. The lock banner now reads "Changing a locked setting needs new quotes."

On **Deploy**, when the manifest changed since the deployment was created, the deployment is
updated on-chain before the lease is created, so the provider receives the edited manifest and
the already-returned bids remain valid. When nothing changed, deploy goes straight to the lease.
This also removes a latent issue where deploy reused the create-time manifest and would have
silently dropped a quoting-window edit.

Verified end-to-end against the managed API: create → poll bids → update (manifest-only change)
→ create lease reusing a pre-update bid; the provider accepted the updated manifest.

### Testing

- **Unit**: `useDeploymentFlow` (updates before leasing only when the manifest changed,
  otherwise leases directly; returns to quoting on a failed update), `ConfigurationPane` /
  `AdditionalSection` (image/env/commands stay editable while the rest lock), `CollapsibleCard`
  (lock glyph), `PaneLockBanner` (copy).
- **E2E** (`configure-deployment-flow`): after "Request quotes" the Docker image stays editable
  while CPU is disabled, and the lock banner shows the new copy.

https://github.com/user-attachments/assets/2a08c246-e548-4260-8982-3271f8c37905


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Locked cards now show a clear lock indicator in the header, making read-only sections easier to spot.
  * Updated lock guidance explains that changing locked settings requires new quotes.

* **Bug Fixes**
  * The deployment configuration pane now keeps only the intended sections locked; image, environment variables, and commands remain editable where appropriate.
  * Deploy flow behavior was improved so updates are applied before leasing when the deployed definition has changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->