### PR TITLE
test(deployment): close deployments left by configure e2e tests

### DIFF
--- a/apps/deploy-web/tests/ui/actions/deploy.ts
+++ b/apps/deploy-web/tests/ui/actions/deploy.ts
@@ -1,4 +1,5 @@
 import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
 
 import type { BillingPage } from "../pages/BillingPage";
 import type { DeployPage } from "../pages/DeployPage";
@@ -57,4 +58,18 @@ export async function createManagedDeployment(
   await deployPage.validateLease();
 
   await callbacks?.onLeaseValidated?.();
+}
+
+/**
+ * Closes the active deployment from its detail page (actions menu → Close → confirm). The actions menu only
+ * appears once the deployment is active, so it is awaited first; the menu disappearing confirms the close.
+ * Used as cleanup by the deployment-creating specs so a run leaves no live deployment on the shared account.
+ */
+export async function closeActiveDeployment(page: Page) {
+  const actions = page.getByRole("button", { name: "Deployment actions" });
+  await actions.waitFor({ state: "visible", timeout: 120_000 });
+  await actions.click();
+  await page.getByRole("menuitem", { name: "Close deployment" }).click();
+  await page.getByRole("button", { name: /^confirm$/i }).click();
+  await expect(actions).toBeHidden({ timeout: 60_000 });
 }

--- a/apps/deploy-web/tests/ui/configure-deployment-flow.spec.ts
+++ b/apps/deploy-web/tests/ui/configure-deployment-flow.spec.ts
@@ -1,8 +1,15 @@
+import { closeActiveDeployment } from "./actions/deploy";
 import { expect, test } from "./fixture/base-test";
 import { ConfigureDeploymentPage } from "./pages/ConfigureDeploymentPage";
 
 test.describe("Configure deployment — request quotes flow", () => {
   test.use({ userType: "existing" });
+
+  test.afterEach(async function closeDeploymentLeftByTest({ page }) {
+    if (/\/deployments\/\d+/.test(new URL(page.url()).pathname)) {
+      await closeActiveDeployment(page);
+    }
+  });
 
   test("requests quotes to create a deployment, locks the pane, then cancels and edits to close it", async ({ page }) => {
     test.setTimeout(3 * 60 * 1000);


### PR DESCRIPTION
## Why

The `configure-deployment-flow` E2E deploy test ("selects a provider, reviews, and deploys") creates a **real deployment** on the shared `existing` test user and never closes it. Every CI/local run therefore leaked one live, leased deployment. Those accumulate and drain the shared account's escrow/balance until `Request quotes` returns no bids — at which point the marketplace `Select` button never renders and `selectFirstAvailableProvider` times out (the 90s failure we were seeing).

It was the only deployment-creating spec without cleanup: `managed-wallet-deployment`, `managed-wallet-alerts`, `onboarding-quick-deploy` - all close what they create (and `onboarding-picker-unlock-trial` runs as a `new` user that the fixture deletes).

## What

- Extracted `closeActiveDeployment(page)` (actions menu → Close → Confirm → wait-hidden) into the shared `tests/ui/actions/deploy.ts`. It was previously a private helper inside the walkthrough spec; the walkthrough now imports the shared one.
- Added a URL-guarded `afterEach` to the `configure-deployment-flow` describe block:

  ```ts
  test.afterEach(async function closeDeploymentLeftByTest({ page }) {
    if (/\/deployments\/\d+/.test(new URL(page.url()).pathname)) {
      await closeActiveDeployment(page);
    }
  });
  ```

  The URL guard is deliberate: cleanup fires on the happy path **and** if an assertion fails after the lease is created, but is a **no-op with no 120s wait** when a test fails before reaching the deployment detail page — so it never hangs or masks the underlying failure.

**Not covered here:** deployments already orphaned on the shared test account by previous runs still need a one-off manual close — this change stops new leaks but cannot reclaim old ones.

**Test-only change** — no shipped artifact affected, no release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test cleanup for deployment-related flows by automatically closing any deployment left open after a test run.
  * Added a reusable UI helper that closes an active deployment and confirms the action controls update correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->