### PR TITLE
fix(deployment): refine configure screen cost display and layout

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.spec.tsx
@@ -10,10 +10,17 @@ import { SdlBuilderFormValuesSchema } from "@src/types";
 import { defaultService, defaultServiceWithPlacement } from "@src/utils/sdl/data";
 import { DEPENDENCIES, RuntimeCard } from "./RuntimeCard";
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 describe(RuntimeCard.name, () => {
+  it("renders collapsed by default", () => {
+    setup({ expanded: false });
+
+    expect(screen.queryByRole("spinbutton", { name: "Replicas" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand Runtime" })).toBeInTheDocument();
+  });
+
   it("disables the replica and ssh inputs while locked", () => {
     setup({ locked: true, hasSSHKey: true, sshPubKey: "ssh-rsa AAAATESTKEY user@host" });
 
@@ -188,6 +195,7 @@ describe(RuntimeCard.name, () => {
     env?: Array<{ key: string; value?: string }>;
     extraServices?: number;
     locked?: boolean;
+    expanded?: boolean;
     resolver?: Resolver<SdlBuilderFormValuesType>;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
@@ -248,6 +256,10 @@ describe(RuntimeCard.name, () => {
       </Wrapper>
     );
 
+    if (input.expanded ?? true) {
+      fireEvent.click(screen.getByRole("button", { name: "Expand Runtime" }));
+    }
+
     return { getValues: () => getValues() };
   }
 
@@ -288,5 +300,7 @@ describe(RuntimeCard.name, () => {
         <RuntimeCard serviceIndex={0} dependencies={{ ...DEPENDENCIES, saveAs: vi.fn(), loadJSZip: vi.fn() }} />
       </Wrapper>
     );
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand Runtime" }));
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/RuntimeCard/RuntimeCard.tsx
@@ -58,7 +58,7 @@ type Props = {
  */
 export const RuntimeCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
   return (
-    <d.CollapsibleCard locked={locked} title="Runtime" icon={<SettingsIcon className="h-4 w-4" />} infoTooltip={runtimeTooltip}>
+    <d.CollapsibleCard defaultOpen={false} locked={locked} title="Runtime" icon={<SettingsIcon className="h-4 w-4" />} infoTooltip={runtimeTooltip}>
       <fieldset disabled={locked} className="flex min-w-0 flex-col gap-4 border-0 p-0">
         <ReplicasField serviceIndex={serviceIndex} dependencies={d} />
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
@@ -59,7 +59,7 @@ export const ConfigureDeploymentPanes: FC<Props> = ({
   return (
     <div className="flex h-full w-full flex-col">
       <div className="grid min-h-0 flex-1 grid-rows-1 md:auto-cols-fr md:grid-flow-col md:grid-cols-[auto_1fr] md:border-t md:border-zinc-300 md:dark:border-zinc-700">
-        <div className="grid min-h-0 grid-rows-1 md:grid-flow-col md:grid-cols-[auto_352px] md:divide-x md:divide-zinc-300 md:dark:divide-zinc-700">
+        <div className="grid min-h-0 grid-rows-1 md:grid-flow-col md:grid-cols-[auto_360px] md:divide-x md:divide-zinc-300 md:dark:divide-zinc-700">
           <div className={cn("min-h-0 md:block", { hidden: activePane !== "deployment" })}>
             <d.DeploymentPane
               selectedServiceId={selectedServiceId}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.spec.tsx
@@ -1,0 +1,46 @@
+import type { PropsWithChildren } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it } from "vitest";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { useDeploymentHasGpu } from "./useDeploymentResourceSummary";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useDeploymentHasGpu.name, () => {
+  it("returns true when a service requests a GPU", () => {
+    const { result } = setup({ hasGpu: true, gpu: 1 });
+
+    expect(result.current).toBe(true);
+  });
+
+  it("returns false when no service requests a GPU", () => {
+    const { result } = setup({ hasGpu: false });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("returns false when the GPU flag is off even if a gpu count lingers", () => {
+    const { result } = setup({ hasGpu: false, gpu: 2 });
+
+    expect(result.current).toBe(false);
+  });
+
+  function setup(input: { hasGpu: boolean; gpu?: number }) {
+    const base = defaultServiceWithPlacement({ image: "nginx:latest" });
+    const values = {
+      ...base,
+      services: base.services.map((service, index) =>
+        index === 0 ? { ...service, profile: { ...service.profile, hasGpu: input.hasGpu, gpu: input.gpu ?? 0 } } : service
+      )
+    };
+
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values });
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    return renderHook(() => useDeploymentHasGpu(), { wrapper: Wrapper });
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentResourceSummary/useDeploymentResourceSummary.ts
@@ -10,3 +10,14 @@ export function useDeploymentResourceSummary(): string {
   const services = useWatch({ control, name: "services" });
   return useMemo(() => formatDeploymentResources(aggregateDeploymentResources(services ?? [])), [services]);
 }
+
+/**
+ * True when the current spec requests any GPU. Drives GPU-vs-CPU-only presentation choices — notably the
+ * marketplace cost unit, which shows hourly for GPU (meaningful at that scale) and monthly for CPU-only (so an
+ * inexpensive deployment reads as e.g. `$30/month` rather than rounding to `$0.00/hr`).
+ */
+export function useDeploymentHasGpu(): boolean {
+  const { control } = useFormContext<SdlBuilderFormValuesType>();
+  const services = useWatch({ control, name: "services" });
+  return useMemo(() => aggregateDeploymentResources(services ?? []).gpu > 0, [services]);
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.spec.tsx
@@ -29,6 +29,18 @@ describe(MarketplacePane.name, () => {
     expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ providers: offers, isLoading: false }), expect.anything());
   });
 
+  it("tells the table to show hourly cost when the spec uses a GPU", () => {
+    const { MarketplaceProvidersTable } = setup({ hasGpu: true, offers: [buildOffer()] });
+
+    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ showCostAsHourly: true }), expect.anything());
+  });
+
+  it("tells the table to show monthly cost for a CPU-only spec", () => {
+    const { MarketplaceProvidersTable } = setup({ hasGpu: false, offers: [buildOffer()] });
+
+    expect(MarketplaceProvidersTable).toHaveBeenCalledWith(expect.objectContaining({ showCostAsHourly: false }), expect.anything());
+  });
+
   it("renders an error message and no table when offers fail to load with no data", () => {
     const { MarketplaceProvidersTable } = setup({ isError: true });
 
@@ -92,6 +104,7 @@ describe(MarketplacePane.name, () => {
       isError?: boolean;
       isInvalid?: boolean;
       isSearchActive?: boolean;
+      hasGpu?: boolean;
       selectedPlacementId?: string;
       selectedBidId?: string;
       onSelectProvider?: (placementId: string, bidId: string) => void;
@@ -119,7 +132,8 @@ describe(MarketplacePane.name, () => {
       usePlacementOffers: usePlacementOffers as never,
       useProviderSearch: useProviderSearch as never,
       MarketplaceProvidersTable: MarketplaceProvidersTable as never,
-      ProviderSearchInput
+      ProviderSearchInput,
+      useDeploymentHasGpu: vi.fn(() => input.hasGpu ?? false)
     };
     const user = userEvent.setup();
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
@@ -1,12 +1,13 @@
 import type { FC } from "react";
 
 import { usePlacementOffers } from "@src/queries/usePlacementOffers";
+import { useDeploymentHasGpu } from "../DeploymentResourceSummary/useDeploymentResourceSummary";
 import type { DeploymentFlowPhase } from "../useDeploymentFlow/useDeploymentFlow";
 import { MarketplaceProvidersTable } from "./MarketplaceProvidersTable/MarketplaceProvidersTable";
 import { useProviderSearch } from "./MarketplaceProvidersTable/useProviderSearch/useProviderSearch";
 import { ProviderSearchInput } from "./ProviderSearchInput/ProviderSearchInput";
 
-export const DEPENDENCIES = { usePlacementOffers, useProviderSearch, MarketplaceProvidersTable, ProviderSearchInput };
+export const DEPENDENCIES = { usePlacementOffers, useProviderSearch, MarketplaceProvidersTable, ProviderSearchInput, useDeploymentHasGpu };
 
 interface Props {
   sdl: string;
@@ -34,6 +35,7 @@ export const MarketplacePane: FC<Props> = ({
   const { offers, isLoading, isError, isInvalid } = d.usePlacementOffers({ phase, dseq: dseq ?? undefined, sdl, placementName, region });
   const { query, setQuery, clear, filteredProviders, isSearchActive } = d.useProviderSearch(offers);
   const hasFailedWithoutData = isError && offers.length === 0;
+  const showCostAsHourly = d.useDeploymentHasGpu();
 
   return (
     <section aria-labelledby="configure-marketplace-pane-heading" className="flex h-full min-h-0 flex-col">
@@ -66,6 +68,7 @@ export const MarketplacePane: FC<Props> = ({
             onClearSearch={clear}
             selectedBidId={selectedBidId}
             onSelect={bidId => onSelectProvider(selectedPlacementId, bidId)}
+            showCostAsHourly={showCostAsHourly}
           />
         )}
       </div>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.spec.tsx
@@ -130,6 +130,16 @@ describe(MarketplaceProvidersTable.name, () => {
     expect(screen.getByText("Cost")).toBeInTheDocument();
   });
 
+  it("shows the cost per hour when the spec uses a GPU", () => {
+    setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" })], showCostAsHourly: true });
+    expect(screen.getByText("/hr")).toBeInTheDocument();
+  });
+
+  it("shows the cost per month for a CPU-only spec so an inexpensive deployment doesn't read as $0.00/hr", () => {
+    setup({ providers: [submittedOffer({ owner: "akash1a", bidId: "akash1a/1/1/1" })], showCostAsHourly: false });
+    expect(screen.getByText("/month")).toBeInTheDocument();
+  });
+
   it("shows only Provider, Region, and Uptime while every offer is still searching", () => {
     setup({ providers: [searchingOffer({ owner: "akash1a" })] });
     expect(screen.getAllByRole("columnheader")).toHaveLength(3);
@@ -296,7 +306,14 @@ describe(MarketplaceProvidersTable.name, () => {
     });
   }
 
-  function setup(input: { providers: PlacementOffer[]; isLoading?: boolean; isSearchActive?: boolean; onClearSearch?: () => void; selectedBidId?: string }) {
+  function setup(input: {
+    providers: PlacementOffer[];
+    isLoading?: boolean;
+    isSearchActive?: boolean;
+    onClearSearch?: () => void;
+    selectedBidId?: string;
+    showCostAsHourly?: boolean;
+  }) {
     const onSelect = vi.fn();
     const user = userEvent.setup();
     render(
@@ -310,6 +327,7 @@ describe(MarketplaceProvidersTable.name, () => {
               onClearSearch={input.onClearSearch}
               selectedBidId={input.selectedBidId}
               onSelect={onSelect}
+              showCostAsHourly={input.showCostAsHourly}
             />
           </TooltipProvider>
         </IntlProvider>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplaceProvidersTable/MarketplaceProvidersTable.tsx
@@ -30,9 +30,11 @@ interface Props {
   onClearSearch?: () => void;
   selectedBidId?: string;
   onSelect?: (bidId: string) => void;
+  /** When true the cost column renders an hourly rate (GPU specs); otherwise a monthly rate, so inexpensive CPU-only deployments don't round to `$0.00/hr`. */
+  showCostAsHourly?: boolean;
 }
 
-export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading, isSearchActive, onClearSearch, selectedBidId, onSelect }) => {
+export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading, isSearchActive, onClearSearch, selectedBidId, onSelect, showCostAsHourly = false }) => {
   const [sorting, setSorting] = useState<SortingState>([]);
 
   const uptimeByOwner = useProvidersUptime(providers);
@@ -41,8 +43,8 @@ export const MarketplaceProvidersTable: FC<Props> = ({ providers, isLoading, isS
   /** Cost only makes sense once bids arrive: a submitted bid is priced and a closed/expired one keeps its last price, but a screened-only candidate has none. */
   const showCost = providers.some(provider => !!provider.price);
   const columns = useMemo(
-    () => buildColumns(uptimeByOwner, { selectedBidId, onSelect, showCost, showStatus: isMerged }),
-    [uptimeByOwner, selectedBidId, onSelect, showCost, isMerged]
+    () => buildColumns(uptimeByOwner, { selectedBidId, onSelect, showCost, showStatus: isMerged, showCostAsHourly }),
+    [uptimeByOwner, selectedBidId, onSelect, showCost, isMerged, showCostAsHourly]
   );
 
   const table = useReactTable({
@@ -170,7 +172,7 @@ function SortableHeader({ column, title }: { column: Column<PlacementOffer, unkn
 /** Builds the columns, closing over the per-provider uptime derived once in the component. Every column is an accessor so it sorts; the trailing status column is display-only. */
 function buildColumns(
   uptimeByOwner: Map<string, ProviderUptime>,
-  selection: { selectedBidId?: string; onSelect?: (bidId: string) => void; showCost: boolean; showStatus: boolean }
+  selection: { selectedBidId?: string; onSelect?: (bidId: string) => void; showCost: boolean; showStatus: boolean; showCostAsHourly: boolean }
 ) {
   return [
     columnHelper.accessor(providerDisplayName, {
@@ -195,7 +197,7 @@ function buildColumns(
             cell: ({ row }) => {
               const { price } = row.original;
               if (!price) return <span className="text-muted-foreground">{NO_REGION}</span>;
-              return <PricePerTimeUnit denom={price.denom} perBlockValue={udenomToDenom(price.amount, PRICE_DISPLAY_PRECISION)} showAsHourly abbreviated />;
+              return <PricePerTimeUnit denom={price.denom} perBlockValue={udenomToDenom(price.amount, PRICE_DISPLAY_PRECISION)} showAsHourly={selection.showCostAsHourly} abbreviated />;
             }
           })
         ]


### PR DESCRIPTION
## Why

Three independent feedback items from reviewing the new *Configure your deployment* screen (behind `bid_screening`):

- Fixes CON-621 — the marketplace **Cost** column showed `$0.00/hr` for inexpensive CPU-only deployments, which misleadingly reads as free.
- Closes CON-616 — the **Runtime** card opened expanded, adding noise to the screen on load.
- Closes CON-615 — the **Configuration** column was `352px`; the design calls for `360px`.

Related to CON-411.

## What

Frontend-only changes to the configure screen (`apps/deploy-web`):

- **Marketplace cost unit (CON-621):** the Cost column now renders **`$/hr` for GPU specs** and **`$/month` for CPU-only specs**, so a cheap deployment shows a meaningful figure instead of `$0.00/hr`. A new `useDeploymentHasGpu()` hook derives GPU-vs-CPU from the live form spec and drives the unit; `PricePerTimeUnit` already supported monthly rendering.
- **Runtime card collapsed by default (CON-616):** the card now opens collapsed.
- **Configuration column width (CON-615):** `352px → 360px` to match the design.

Tests: added a spec for `useDeploymentHasGpu`; updated the `RuntimeCard`, `MarketplacePane`, and `MarketplaceProvidersTable` specs. 602 tests pass across the `ConfigureDeployment` subtree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pricing in the deployment marketplace now shows hourly rates for GPU-based deployments and monthly rates for CPU-only deployments.

* **Bug Fixes**
  * The Runtime section now starts collapsed by default, reducing visual clutter when configuring a deployment.
  * Adjusted the deployment configuration layout for a slightly wider left panel on larger screens.

* **Tests**
  * Expanded coverage for runtime expansion behavior and pricing display formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->