### PR TITLE
fix(deployment): make configure screen usable on smaller screens

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.tsx
@@ -34,7 +34,7 @@ export const ConfigurationPane: FC<Props> = ({ selectedServiceId, locked = false
 
   return (
     <section aria-labelledby="configure-configuration-pane-heading" className="flex h-full min-h-0 flex-col">
-      <header className="hidden h-[52px] shrink-0 items-center gap-2 border-b border-zinc-300 px-4 md:flex dark:border-zinc-700">
+      <header className="flex h-[52px] shrink-0 items-center gap-2 border-b border-zinc-300 px-4 dark:border-zinc-700">
         <h2 id="configure-configuration-pane-heading" className="shrink-0 font-mono text-sm font-medium uppercase text-muted-foreground">
           2. Configuration
         </h2>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -186,7 +186,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
           <div className="px-6 pt-6">
             <d.ConfigureDeploymentHeader flow={flow} sdl={liveSdl} onDeploy={() => setReviewOpen(true)} allPlacementsHaveBids={allPlacementsHaveBids} />
           </div>
-          <div className="relative mt-6 flex min-h-0 flex-1">
+          <div className="relative mt-6 flex min-h-0 flex-1 overflow-x-auto">
             <d.ConfigureDeploymentPanes
               sdl={liveSdl}
               previewSdl={previewSdl}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentHeader/ConfigureDeploymentHeader.tsx
@@ -2,7 +2,6 @@ import type { FC, ReactNode } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { Button, CustomTooltip, Snackbar } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
-import { Send } from "iconoir-react";
 import { Clock, LoaderCircle } from "lucide-react";
 import { useSnackbar } from "notistack";
 
@@ -88,27 +87,28 @@ export const ConfigureDeploymentHeader: FC<Props> = ({ flow, sdl, onDeploy, allP
   });
 
   return (
-    <header className="flex flex-row items-center justify-between gap-3 md:items-end">
-      <div className="flex min-w-0 flex-1 flex-col gap-1 md:gap-2">
+    <header className="flex flex-col gap-3 xl:flex-row xl:items-end xl:justify-between">
+      <div className="flex min-w-0 flex-col gap-1 md:gap-2 xl:flex-1">
         <h1 className="text-xl font-bold leading-tight tracking-tight md:text-3xl md:leading-9">Configure your deployment</h1>
         <p className="hidden text-base text-muted-foreground md:block">
-          Adjust your deployment spec to refine available providers in the compute marketplace. Request official quotes when you&apos;re ready.
+          Adjust your deployment spec to refine available providers in the compute marketplace.
+          <br />
+          Request official quotes when you&apos;re ready.
         </p>
       </div>
 
-      <div className="flex shrink-0 items-center gap-3 md:gap-6">
+      <div className="flex items-center justify-between gap-3 md:gap-6 xl:shrink-0 xl:justify-start">
         <div className="flex items-start gap-3 md:gap-6">
           <DeploymentSummaryBlock label="Your deployment" value={deploymentSummary} />
           <div className="hidden h-12 w-px self-stretch bg-border md:block" aria-hidden="true" />
-          <div className="flex flex-col items-end gap-0.5">
+          <div className="flex flex-col items-start gap-0.5 xl:items-end">
             <DeploymentSummaryBlock label="Deployment cost" value={<CostValue cost={cost} PriceValue={d.PriceValue} />} suffix={cost ? "/hr" : undefined} />
             <div className="h-4">{expiry ? <QuoteExpiryLine expiry={expiry} CustomTooltip={d.CustomTooltip} /> : null}</div>
           </div>
         </div>
         {isEditable ? (
           <Button type="button" onClick={onRequestQuotes} className="h-9 shrink-0 px-3 md:h-10 md:px-8">
-            <Send className="h-4 w-4 md:hidden" aria-label="Request quotes" />
-            <span className="hidden md:inline">Request quotes</span>
+            Request quotes
           </Button>
         ) : quotesExpired && !hasOpenBids ? (
           <Button type="button" onClick={flow.actions.cancelAndEdit} className="h-9 shrink-0 px-3 md:h-10 md:px-8">
@@ -127,7 +127,7 @@ export const ConfigureDeploymentHeader: FC<Props> = ({ flow, sdl, onDeploy, allP
         ) : (
           <Button type="button" disabled aria-label={isClosing ? "Cancelling" : "Requesting"} className="h-9 shrink-0 gap-2 px-3 md:h-10 md:px-8">
             <LoaderCircle className="h-4 w-4 animate-spin text-current" aria-hidden="true" />
-            <span className="hidden md:inline">{isClosing ? "Cancelling…" : "Requesting…"}</span>
+            <span>{isClosing ? "Cancelling…" : "Requesting…"}</span>
           </Button>
         )}
       </div>
@@ -143,7 +143,7 @@ interface DeploymentSummaryBlockProps {
 
 function DeploymentSummaryBlock({ label, value, suffix }: DeploymentSummaryBlockProps) {
   return (
-    <div className="flex flex-col items-end">
+    <div className="flex flex-col items-start xl:items-end">
       <span className="font-mono text-[10px] uppercase text-muted-foreground md:text-sm">{label}</span>
       <div className="flex items-baseline gap-1">
         <span className="font-mono text-base font-semibold leading-tight md:text-xl md:leading-8">{value}</span>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
@@ -9,50 +9,13 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 describe("ConfigureDeploymentPanes", () => {
-  it("marks the Deployment tab active by default", () => {
+  it("renders all three panes at once without a tabbed navigation", () => {
     setup();
 
-    expect(screen.getByRole("button", { name: "1. Deployment" })).toHaveAttribute("aria-current", "page");
-    expect(screen.getByRole("button", { name: "2. Configuration" })).not.toHaveAttribute("aria-current");
-    expect(screen.getByRole("button", { name: "3. Marketplace" })).not.toHaveAttribute("aria-current");
-  });
-
-  it("activates Configuration when its tab is clicked", async () => {
-    setup();
-
-    await userEvent.click(screen.getByRole("button", { name: "2. Configuration" }));
-
-    expect(screen.getByRole("button", { name: "1. Deployment" })).not.toHaveAttribute("aria-current");
-    expect(screen.getByRole("button", { name: "2. Configuration" })).toHaveAttribute("aria-current", "page");
-    expect(screen.getByRole("button", { name: "3. Marketplace" })).not.toHaveAttribute("aria-current");
-  });
-
-  it("activates Marketplace when its tab is clicked", async () => {
-    setup();
-
-    await userEvent.click(screen.getByRole("button", { name: "3. Marketplace" }));
-
-    expect(screen.getByRole("button", { name: "1. Deployment" })).not.toHaveAttribute("aria-current");
-    expect(screen.getByRole("button", { name: "2. Configuration" })).not.toHaveAttribute("aria-current");
-    expect(screen.getByRole("button", { name: "3. Marketplace" })).toHaveAttribute("aria-current", "page");
-  });
-
-  it("keeps only the active pane wrapper visible on mobile", async () => {
-    setup();
-
-    const deploymentRegion = screen.getByTestId("deployment-pane-mock").parentElement as HTMLElement;
-    const configurationRegion = screen.getByTestId("configuration-pane-mock").parentElement as HTMLElement;
-    const marketplaceRegion = screen.getByTestId("marketplace-pane-mock").parentElement as HTMLElement;
-
-    expect(deploymentRegion).not.toHaveClass("hidden");
-    expect(configurationRegion).toHaveClass("hidden");
-    expect(marketplaceRegion).toHaveClass("hidden");
-
-    await userEvent.click(screen.getByRole("button", { name: "3. Marketplace" }));
-
-    expect(deploymentRegion).toHaveClass("hidden");
-    expect(configurationRegion).toHaveClass("hidden");
-    expect(marketplaceRegion).not.toHaveClass("hidden");
+    expect(screen.getByTestId("deployment-pane-mock")).toBeInTheDocument();
+    expect(screen.getByTestId("configuration-pane-mock")).toBeInTheDocument();
+    expect(screen.getByTestId("marketplace-pane-mock")).toBeInTheDocument();
+    expect(screen.queryByRole("navigation", { name: "Pane navigation" })).not.toBeInTheDocument();
   });
 
   it("does not render the SDL preview pane when the flag is disabled", () => {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
@@ -1,6 +1,4 @@
 import type { FC } from "react";
-import { useState } from "react";
-import { cn } from "@akashnetwork/ui/utils";
 import { useAtom } from "jotai";
 
 import { useFlag } from "@src/hooks/useFlag";
@@ -10,8 +8,6 @@ import { DeploymentPane } from "../DeploymentPane/DeploymentPane";
 import { MarketplacePane } from "../MarketplacePane/MarketplacePane";
 import { SdlPreviewPane } from "../SdlPreviewPane/SdlPreviewPane";
 import type { DeploymentFlowPhase } from "../useDeploymentFlow/useDeploymentFlow";
-
-type ActivePane = "deployment" | "configuration" | "marketplace";
 
 export const DEPENDENCIES = { DeploymentPane, ConfigurationPane, MarketplacePane, SdlPreviewPane, useFlag };
 
@@ -33,6 +29,11 @@ type Props = {
   dependencies?: typeof DEPENDENCIES;
 };
 
+/**
+ * Lays the three configure panes out as side-by-side columns at every width — Deployment and Configuration
+ * on the left, the Marketplace filling the rest. On screens too narrow to fit them the whole group scrolls
+ * horizontally (the parent owns the scroll container); there is no separate mobile/tabbed layout.
+ */
 export const ConfigureDeploymentPanes: FC<Props> = ({
   sdl,
   previewSdl,
@@ -50,82 +51,49 @@ export const ConfigureDeploymentPanes: FC<Props> = ({
   onDeploymentNameChange,
   dependencies: d = DEPENDENCIES
 }) => {
-  const [activePane, setActivePane] = useState<ActivePane>("deployment");
   const [isSdlPreviewOpen, setIsSdlPreviewOpen] = useAtom(sdlStore.sdlPreviewOpen);
   const isSdlPreviewEnabled = d.useFlag("ui_sdl_preview_panel");
   const isLocked = phase === "creating" || phase === "quoting" || phase === "closing" || phase === "deploying";
   const isClosing = phase === "closing";
 
   return (
-    <div className="flex h-full w-full flex-col">
-      <div className="grid min-h-0 flex-1 grid-rows-1 md:auto-cols-fr md:grid-flow-col md:grid-cols-[auto_1fr] md:border-t md:border-zinc-300 md:dark:border-zinc-700">
-        <div className="grid min-h-0 grid-rows-1 md:grid-flow-col md:grid-cols-[auto_360px] md:divide-x md:divide-zinc-300 md:dark:divide-zinc-700">
-          <div className={cn("min-h-0 md:block", { hidden: activePane !== "deployment" })}>
-            <d.DeploymentPane
-              selectedServiceId={selectedServiceId}
-              onSelectService={onSelectService}
-              locked={isLocked}
-              isClosing={isClosing}
-              onCancelAndEdit={onCancelAndEdit}
-              phase={phase}
-              selections={selections}
-              selectedPlacementId={selectedPlacementId}
-              sdl={sdl}
-              dseq={dseq}
-              deploymentName={deploymentName}
-              onDeploymentNameChange={onDeploymentNameChange}
-            />
-          </div>
-          <div className={cn("min-h-0 md:block", { hidden: activePane !== "configuration" })}>
-            <d.ConfigurationPane selectedServiceId={selectedServiceId} locked={isLocked} isClosing={isClosing} onCancelAndEdit={onCancelAndEdit} />
-          </div>
-        </div>
-        <div className={cn("min-h-0 md:block md:border-l md:border-zinc-300 md:dark:border-zinc-700", { hidden: activePane !== "marketplace" })}>
-          <d.MarketplacePane
-            sdl={sdl}
-            placementName={selectedPlacementName}
-            region={selectedPlacementRegion}
+    <div className="grid h-full min-h-0 flex-1 auto-cols-fr grid-flow-col grid-cols-[auto_minmax(560px,1fr)] grid-rows-1 border-t border-zinc-300 dark:border-zinc-700">
+      <div className="grid min-h-0 grid-flow-col grid-cols-[auto_360px] grid-rows-1 divide-x divide-zinc-300 dark:divide-zinc-700">
+        <div className="min-h-0">
+          <d.DeploymentPane
+            selectedServiceId={selectedServiceId}
+            onSelectService={onSelectService}
+            locked={isLocked}
+            isClosing={isClosing}
+            onCancelAndEdit={onCancelAndEdit}
             phase={phase}
-            dseq={dseq}
+            selections={selections}
             selectedPlacementId={selectedPlacementId}
-            selectedBidId={selections[selectedPlacementId]}
-            onSelectProvider={onSelectProvider}
+            sdl={sdl}
+            dseq={dseq}
+            deploymentName={deploymentName}
+            onDeploymentNameChange={onDeploymentNameChange}
           />
         </div>
-        {isSdlPreviewEnabled && (
-          <d.SdlPreviewPane sdl={previewSdl} isOpen={isSdlPreviewOpen} onOpen={() => setIsSdlPreviewOpen(true)} onClose={() => setIsSdlPreviewOpen(false)} />
-        )}
+        <div className="min-h-0">
+          <d.ConfigurationPane selectedServiceId={selectedServiceId} locked={isLocked} isClosing={isClosing} onCancelAndEdit={onCancelAndEdit} />
+        </div>
       </div>
-
-      <nav aria-label="Pane navigation" className="flex shrink-0 border-t border-zinc-300 md:hidden dark:border-zinc-700">
-        <PaneTab label="1. Deployment" value="deployment" activeValue={activePane} onSelect={setActivePane} />
-        <PaneTab label="2. Configuration" value="configuration" activeValue={activePane} onSelect={setActivePane} />
-        <PaneTab label="3. Marketplace" value="marketplace" activeValue={activePane} onSelect={setActivePane} />
-      </nav>
+      <div className="min-h-0 border-l border-zinc-300 dark:border-zinc-700">
+        <d.MarketplacePane
+          sdl={sdl}
+          placementName={selectedPlacementName}
+          region={selectedPlacementRegion}
+          phase={phase}
+          dseq={dseq}
+          selectedPlacementId={selectedPlacementId}
+          selectedBidId={selections[selectedPlacementId]}
+          onSelectProvider={onSelectProvider}
+        />
+      </div>
+      {isSdlPreviewEnabled && (
+        <d.SdlPreviewPane sdl={previewSdl} isOpen={isSdlPreviewOpen} onOpen={() => setIsSdlPreviewOpen(true)} onClose={() => setIsSdlPreviewOpen(false)} />
+      )}
     </div>
   );
 };
-
-interface PaneTabProps {
-  label: string;
-  value: ActivePane;
-  activeValue: ActivePane;
-  onSelect: (value: ActivePane) => void;
-}
-
-function PaneTab({ label, value, activeValue, onSelect }: PaneTabProps) {
-  const isActive = activeValue === value;
-  return (
-    <button
-      type="button"
-      onClick={() => onSelect(value)}
-      aria-current={isActive ? "page" : undefined}
-      className={cn("flex-1 px-3 py-3 font-mono text-xs font-medium uppercase tracking-wide transition-colors", {
-        "border-t-2 border-foreground text-foreground": isActive,
-        "border-t-2 border-transparent text-muted-foreground": !isActive
-      })}
-    >
-      {label}
-    </button>
-  );
-}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
@@ -53,7 +53,7 @@ export const DeploymentPane: FC<Props> = ({
 
   if (minimized) {
     return (
-      <aside aria-label="Deployment pane (minimized)" className="hidden h-full min-h-0 md:flex md:w-[48px] md:flex-col md:items-center md:pt-2">
+      <aside aria-label="Deployment pane (minimized)" className="flex h-full min-h-0 w-[48px] flex-col items-center pt-2">
         <Button type="button" variant="ghost" onClick={toggle} aria-label="Show deployment pane" className="h-8 w-8 rounded p-0 text-foreground">
           <SidebarExpand className="h-5 w-5" />
         </Button>
@@ -62,8 +62,8 @@ export const DeploymentPane: FC<Props> = ({
   }
 
   return (
-    <section aria-labelledby="configure-deployment-pane-heading" className="flex h-full min-h-0 flex-col md:w-[231px]">
-      <header className="hidden h-[52px] shrink-0 items-center justify-between gap-2 border-b border-zinc-300 px-4 md:flex dark:border-zinc-700">
+    <section aria-labelledby="configure-deployment-pane-heading" className="flex h-full min-h-0 w-[231px] flex-col">
+      <header className="flex h-[52px] shrink-0 items-center justify-between gap-2 border-b border-zinc-300 px-4 dark:border-zinc-700">
         <h2 id="configure-deployment-pane-heading" className="font-mono text-sm font-medium uppercase text-muted-foreground">
           1. Deployment
         </h2>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/MarketplacePane.tsx
@@ -39,12 +39,12 @@ export const MarketplacePane: FC<Props> = ({
 
   return (
     <section aria-labelledby="configure-marketplace-pane-heading" className="flex h-full min-h-0 flex-col">
-      <header className="flex h-[52px] shrink-0 items-center justify-between gap-4 px-4 md:border-b md:border-zinc-300 md:dark:border-zinc-700">
-        <div className="hidden items-center md:flex">
+      <header className="flex h-[52px] shrink-0 items-center justify-between gap-4 border-b border-zinc-300 px-4 dark:border-zinc-700">
+        <div className="flex min-w-0 items-center">
           <h2 id="configure-marketplace-pane-heading" className="shrink-0 font-mono text-sm font-medium uppercase text-muted-foreground">
             3. Compute Marketplace
           </h2>
-          <span className="ml-2 whitespace-nowrap font-mono text-sm font-semibold text-blue-500">• {placementName}</span>
+          <span className="ml-2 min-w-0 truncate font-mono text-sm font-semibold text-blue-500">• {placementName}</span>
         </div>
         <d.ProviderSearchInput value={query} onChange={setQuery} onClear={clear} />
       </header>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/ProviderSearchInput/ProviderSearchInput.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/MarketplacePane/ProviderSearchInput/ProviderSearchInput.tsx
@@ -16,7 +16,7 @@ export const ProviderSearchInput: FC<Props> = ({ value, onChange, onClear }) => 
       placeholder="Search providers..."
       value={value}
       onChange={event => onChange(event.target.value)}
-      className="w-full md:w-64"
+      className="w-56 shrink-0"
       inputClassName="h-9 [&::-ms-clear]:hidden [&::-webkit-search-cancel-button]:appearance-none"
       startIcon={<Search className="ml-3 h-4 w-4 text-muted-foreground" />}
       endIcon={

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlPreviewPane/SdlPreviewPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/SdlPreviewPane/SdlPreviewPane.tsx
@@ -39,7 +39,7 @@ export const SdlPreviewPane: FC<Props> = ({ sdl, isOpen, onOpen, onClose, depend
   if (!isOpen) return null;
 
   return (
-    <section aria-labelledby="sdl-preview-pane-heading" className="hidden h-full min-h-0 flex-col border-l-4 border-l-amber-500 md:flex">
+    <section aria-labelledby="sdl-preview-pane-heading" className="flex h-full min-h-0 flex-col border-l-4 border-l-amber-500">
       <header className="flex h-[52px] shrink-0 items-center justify-between gap-2 border-b border-zinc-300 bg-amber-500/10 px-4 dark:border-zinc-700">
         <div className="flex items-center gap-2">
           <h2 id="sdl-preview-pane-heading" className="font-mono text-sm font-medium uppercase text-muted-foreground">

--- a/apps/deploy-web/src/components/layout/Layout.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.tsx
@@ -96,7 +96,7 @@ const LayoutApp: React.FunctionComponent<Props> = ({
       <TopBanner />
 
       <div className="w-full flex-1" style={{ marginTop: `${ACCOUNT_BAR_HEIGHT + (hasBanner ? 40 : 0)}px` }}>
-        <div className="h-full">
+        <div className="h-full overflow-x-auto">
           <Nav isMobileOpen={isMobileOpen} handleDrawerToggle={handleDrawerToggle} className={{ "top-[40px]": hasBanner }} />
 
           <div className="block h-full w-full flex-grow rounded-none md:flex">
@@ -109,7 +109,7 @@ const LayoutApp: React.FunctionComponent<Props> = ({
             />
 
             <div
-              className={cn("ease ml-0 h-full flex-grow transition-[margin-left] duration-300", {
+              className={cn("ease ml-0 h-full flex-grow transition-[margin-left] duration-300 overflow-x-auto", {
                 ["md:ml-[240px]"]: isNavOpen,
                 ["md:ml-[57px]"]: !isNavOpen
               })}


### PR DESCRIPTION
## Why

The `/new-deployment/configure` three-pane screen was built for wide viewports and became unusable on smaller screens. On phones — and especially short viewports like the iPhone SE — the whole page scrolled horizontally (the header and app chrome dragged along with it), the header collided with itself, and the marketplace column collapsed to an unreadable width.

The goal here is deliberately narrow: make the screen **usable / not entirely broken** on smaller screens — not to make it fully responsive. A genuinely good small-screen experience needs dedicated design effort; this is a pragmatic pass to unblock those users in the meantime.

## What

- **Scoped the horizontal scroll to the panes.** Only the three-column panes area scrolls horizontally now; the header and everything above it stay fixed at the viewport width, so there's no more whole-page horizontal scrollbar and the white background always covers the viewport.
- **Fixed the marketplace column.** It now has a minimum width and the panes grid grows to its content, so the column is readable and its top border spans the full width instead of being clipped when scrolled into view.
- **Made the header responsive.** Title and summary stack below `xl`, the summary is left-aligned there, and the descriptive subtitle + divider are hidden on small screens to reclaim vertical space (the SE was unusable otherwise). The action buttons keep their text labels rather than collapsing to an icon, since the label reflects the current state (Request quotes / Requesting… / Deploy / Close and Edit).
- **Removed the mobile pane tabs.** The previously implemented mobile tab switcher (1. Deployment / 2. Configuration / 3. Marketplace) has been removed. All three panes now render as columns at every width and simply scroll horizontally when they don't fit. This was dropped for simplicity and to avoid introducing more issues than the tabs solved.

### Non-goals / follow-ups

- Not aiming for pixel-perfect responsiveness — just a usable baseline on small screens.
- On very narrow widths the mobile summary row (resource recap + cost) can still get tight next to the CTA; hiding the `Your deployment` recap on mobile is an easy follow-up if wanted.

https://github.com/user-attachments/assets/7cd303b4-fbab-441a-938b-9cf002913dd5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The deployment configuration screen now keeps all panes visible side by side (no mobile tab switching) and uses horizontal scrolling on narrow screens.
  * Deployment panel headers and minimized side sections now stay visible on smaller screens for a consistent experience.

* **Bug Fixes**
  * Improved overflow handling in the main layout and deployment area to better prevent content from being cut off.
  * Updated responsive header/CTA rendering and alignment, plus text truncation and cleaner loading/label display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->