### PR TITLE
feat(billing): credit managed wallet from manual-credit Stripe invoices

### DIFF
--- a/apps/api/drizzle/0031_lively_gwen_stacy.sql
+++ b/apps/api/drizzle/0031_lively_gwen_stacy.sql
@@ -1,0 +1,2 @@
+ALTER TYPE "public"."stripe_transaction_type" ADD VALUE 'manual_credit';--> statement-breakpoint
+CREATE UNIQUE INDEX "stripe_transactions_stripe_invoice_id_unique" ON "stripe_transactions" USING btree ("stripe_invoice_id") WHERE "stripe_transactions"."stripe_invoice_id" IS NOT NULL;

--- a/apps/api/drizzle/meta/0031_snapshot.json
+++ b/apps/api/drizzle/meta/0031_snapshot.json
@@ -1,0 +1,1333 @@
+{
+  "id": "4655dea1-63ec-468b-b060-502553acd772",
+  "prevId": "8df5cdb6-6cdb-45a2-96e9-aa1324c40d76",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_stripe_invoice_id_unique": {
+          "name": "stripe_transactions_stripe_invoice_id_unique",
+          "columns": [
+            {
+              "expression": "stripe_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"stripe_transactions\".\"stripe_invoice_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim",
+        "manual_credit"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1783952138833,
       "tag": "0030_worried_exodus",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1784062230879,
+      "tag": "0031_lively_gwen_stacy",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/billing/model-schemas/stripe-transaction/stripe-transaction.schema.ts
+++ b/apps/api/src/billing/model-schemas/stripe-transaction/stripe-transaction.schema.ts
@@ -1,5 +1,5 @@
 import { relations, sql } from "drizzle-orm";
-import { index, integer, pgEnum, pgTable, timestamp, uuid, varchar } from "drizzle-orm/pg-core";
+import { index, integer, pgEnum, pgTable, timestamp, uniqueIndex, uuid, varchar } from "drizzle-orm/pg-core";
 
 import { Users } from "@src/user/model-schemas";
 
@@ -13,7 +13,7 @@ export const stripeTransactionStatusEnum = pgEnum("stripe_transaction_status", [
   "canceled"
 ]);
 
-export const stripeTransactionTypeEnum = pgEnum("stripe_transaction_type", ["payment_intent", "coupon_claim"]);
+export const stripeTransactionTypeEnum = pgEnum("stripe_transaction_type", ["payment_intent", "coupon_claim", "manual_credit"]);
 
 export const StripeTransactions = pgTable(
   "stripe_transactions",
@@ -46,6 +46,12 @@ export const StripeTransactions = pgTable(
     updatedAt: timestamp("updated_at").defaultNow().notNull()
   },
   table => ({
+    // Partial unique index: enforces one transaction row per invoice (manual-credit/coupon paths) and
+    // indexes the findByInvoiceId lookup. Exactly-once crediting comes from the locked status check in
+    // the webhook; this index just guarantees a single row to credit. payment_intent rows leave it null.
+    stripeInvoiceIdUnique: uniqueIndex("stripe_transactions_stripe_invoice_id_unique")
+      .on(table.stripeInvoiceId)
+      .where(sql`${table.stripeInvoiceId} IS NOT NULL`),
     userIdIdx: index("stripe_transactions_user_id_idx").on(table.userId),
     stripePaymentIntentIdIdx: index("stripe_transactions_stripe_payment_intent_id_idx").on(table.stripePaymentIntentId),
     stripeChargeIdIdx: index("stripe_transactions_stripe_charge_id_idx").on(table.stripeChargeId),

--- a/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.integration.ts
+++ b/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.integration.ts
@@ -42,6 +42,61 @@ describe(StripeTransactionRepository.name, () => {
     });
   });
 
+  // The partial unique index on stripe_invoice_id (WHERE NOT NULL) is the one-row-per-invoice
+  // invariant that both the coupon path and the admin manual-credit path rely on.
+  describe("stripe_invoice_id partial unique index", () => {
+    it("rejects a second transaction with the same stripe invoice id", async () => {
+      const { stripeTransactionRepository, createTestUser } = setup();
+      const user = await createTestUser();
+      const invoiceId = `in_${faker.string.alphanumeric(12)}`;
+
+      await stripeTransactionRepository.create({
+        userId: user.id,
+        type: "manual_credit",
+        status: "pending",
+        amount: 50000,
+        currency: "usd",
+        stripeInvoiceId: invoiceId
+      });
+
+      await expect(
+        stripeTransactionRepository.create({
+          userId: user.id,
+          type: "manual_credit",
+          status: "pending",
+          amount: 99999,
+          currency: "usd",
+          stripeInvoiceId: invoiceId
+        })
+      ).rejects.toThrow();
+    });
+
+    it("allows multiple transactions with a null stripe invoice id", async () => {
+      const { stripeTransactionRepository, createTestUser } = setup();
+      const user = await createTestUser();
+
+      const first = await stripeTransactionRepository.create({
+        userId: user.id,
+        type: "payment_intent",
+        status: "succeeded",
+        amount: 1000,
+        currency: "usd",
+        stripeInvoiceId: null
+      });
+
+      const second = await stripeTransactionRepository.create({
+        userId: user.id,
+        type: "payment_intent",
+        status: "succeeded",
+        amount: 2000,
+        currency: "usd",
+        stripeInvoiceId: null
+      });
+
+      expect(first.id).not.toBe(second.id);
+    });
+  });
+
   let cleanup: () => Promise<void>;
   afterEach(async () => {
     await cleanup?.();
@@ -80,6 +135,12 @@ describe(StripeTransactionRepository.name, () => {
       });
     }
 
-    return { stripeTransactionRepository, userRepository, createTestTransaction };
+    async function createTestUser() {
+      const user = await userRepository.create({});
+      createdUserIds.push(user.id);
+      return user;
+    }
+
+    return { stripeTransactionRepository, userRepository, createTestTransaction, createTestUser };
   }
 });

--- a/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
+++ b/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
@@ -12,6 +12,13 @@ export type StripeTransactionOutput = Table["$inferSelect"];
 export type StripeTransactionStatus = StripeTransactionOutput["status"];
 export type StripeTransactionType = StripeTransactionOutput["type"];
 
+/**
+ * Credit-grant transaction types whose crediting must never graduate a trial user. A granted manual
+ * credit tops up the wallet without ending the trial; a redeemed coupon deliberately ends it (see #3403).
+ * Add new trial-preserving credit-grant types here.
+ */
+export const TRIAL_PRESERVING_TRANSACTION_TYPES: Set<StripeTransactionType> = new Set(["manual_credit"]);
+
 export interface FindTransactionsOptions {
   userId: string;
   limit?: number;

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -5,7 +5,7 @@ import subDays from "date-fns/subDays";
 import { singleton } from "tsyringe";
 
 import { type BillingConfig, InjectBillingConfig } from "@src/billing/providers";
-import { type UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
+import { type StripeTransactionType, type UserWalletOutput, UserWalletRepository } from "@src/billing/repositories";
 import { BalancesService } from "@src/billing/services/balances/balances.service";
 import { ManagedSignerService } from "@src/billing/services/managed-signer/managed-signer.service";
 import { ManagedUserWalletService } from "@src/billing/services/managed-user-wallet/managed-user-wallet.service";
@@ -17,7 +17,7 @@ export interface PaymentAnalyticsContext {
   cardBrand?: string;
   paymentMethodType?: string;
   transactionId?: string;
-  source?: "payment_intent" | "coupon_claim";
+  source?: StripeTransactionType;
   /** First-purchase bonus included in the topped-up amount, in cents. */
   bonusAmountCents?: number;
 }

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
@@ -466,6 +466,105 @@ describe(StripeWebhookService.name, () => {
         }
       });
     });
+
+    it("tops up the wallet with endTrial false for a matched manual_credit invoice transaction", async () => {
+      const { service, userRepository, stripeTransactionRepository, refillService } = setup();
+      const mockUser = createTestUser();
+      const invoiceId = "in_manual_1";
+      const amount = 50000;
+      // The admin app pre-creates this row (status pending) before marking the invoice paid
+      const transaction = createMockTransaction({
+        id: "tx-manual-1",
+        type: "manual_credit",
+        status: "pending",
+        amount,
+        stripeInvoiceId: invoiceId
+      });
+
+      userRepository.findOneBy.mockResolvedValue(mockUser);
+      stripeTransactionRepository.findByInvoiceId.mockResolvedValue(transaction);
+      stripeTransactionRepository.findOneByAndLock.mockResolvedValue(transaction);
+      stripeTransactionRepository.updateById.mockResolvedValue(undefined);
+      refillService.topUpWallet.mockResolvedValue();
+
+      const event = createInvoicePaidEvent({
+        id: invoiceId,
+        customer: mockUser.stripeCustomerId,
+        amount_paid: amount
+      });
+
+      await service.tryToTopUpWalletFromInvoice(event);
+
+      expect(stripeTransactionRepository.findByInvoiceId).toHaveBeenCalledWith(invoiceId);
+      expect(stripeTransactionRepository.updateById).toHaveBeenCalledWith(transaction.id, expect.objectContaining({ status: "succeeded" }));
+      // endTrial: false — a granted credit must not graduate a trial user
+      expect(refillService.topUpWallet).toHaveBeenCalledWith(amount, mockUser.id, {
+        endTrial: false,
+        payment: {
+          currency: transaction.currency,
+          cardBrand: undefined,
+          paymentMethodType: undefined,
+          transactionId: transaction.id,
+          source: "manual_credit"
+        }
+      });
+    });
+
+    it("credits only once when invoice.paid and invoice.payment_succeeded both fire for the same manual_credit invoice", async () => {
+      const { service, userRepository, stripeTransactionRepository, refillService } = setup();
+      const mockUser = createTestUser();
+      const invoiceId = "in_manual_dual";
+      const amount = 50000;
+      const pendingTransaction = createMockTransaction({
+        id: "tx-manual-dual",
+        type: "manual_credit",
+        status: "pending",
+        amount,
+        stripeInvoiceId: invoiceId
+      });
+      const succeededTransaction = createMockTransaction({ ...pendingTransaction, status: "succeeded" });
+
+      userRepository.findOneBy.mockResolvedValue(mockUser);
+      stripeTransactionRepository.findByInvoiceId.mockResolvedValue(pendingTransaction);
+      // First delivery locks the pending row; second delivery locks an already-succeeded row
+      stripeTransactionRepository.findOneByAndLock.mockResolvedValueOnce(pendingTransaction).mockResolvedValueOnce(succeededTransaction);
+      stripeTransactionRepository.updateById.mockResolvedValue(undefined);
+      refillService.topUpWallet.mockResolvedValue();
+
+      const invoice = { id: invoiceId, customer: mockUser.stripeCustomerId, amount_paid: amount };
+      await service.tryToTopUpWalletFromInvoice(createInvoicePaidEvent(invoice));
+      await service.tryToTopUpWalletFromInvoice(createInvoicePaymentSucceededEvent(invoice));
+
+      // The already-succeeded guard must credit the wallet exactly once across both event variants
+      expect(refillService.topUpWallet).toHaveBeenCalledTimes(1);
+      expect(refillService.topUpWallet).toHaveBeenCalledWith(amount, mockUser.id, {
+        endTrial: false,
+        payment: {
+          currency: pendingTransaction.currency,
+          cardBrand: undefined,
+          paymentMethodType: undefined,
+          transactionId: pendingTransaction.id,
+          source: "manual_credit"
+        }
+      });
+      expect(stripeTransactionRepository.updateById).toHaveBeenCalledTimes(1);
+      expect(stripeTransactionRepository.updateById).toHaveBeenCalledWith(pendingTransaction.id, expect.objectContaining({ status: "succeeded" }));
+    });
+  });
+
+  describe("routeStripeEvent", () => {
+    it.each([
+      createInvoicePaidEvent({ id: "in_route", customer: "cus_route", amount_paid: 1000 }),
+      createInvoicePaymentSucceededEvent({ id: "in_route", customer: "cus_route", amount_paid: 1000 })
+    ])("routes $type events to the invoice top-up handler", async event => {
+      const { service, stripeService } = setup();
+      stripeService.webhooks = { constructEvent: vi.fn().mockReturnValue(event) } as unknown as Stripe.Webhooks;
+      const handler = vi.spyOn(service, "tryToTopUpWalletFromInvoice").mockResolvedValue();
+
+      await service.routeStripeEvent("signature", "raw-body");
+
+      expect(handler).toHaveBeenCalledWith(event);
+    });
   });
 
   describe("handlePaymentIntentFailed", () => {
@@ -1099,6 +1198,16 @@ describe(StripeWebhookService.name, () => {
         object: invoice as Stripe.Invoice
       }
     } as Stripe.InvoicePaymentSucceededEvent;
+  }
+
+  function createInvoicePaidEvent(invoice: Partial<Stripe.Invoice>): Stripe.InvoicePaidEvent {
+    return {
+      id: "evt_123",
+      type: "invoice.paid",
+      data: {
+        object: invoice as Stripe.Invoice
+      }
+    } as Stripe.InvoicePaidEvent;
   }
 
   function createPaymentMethodAttachedEvent(params: {

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
@@ -3,7 +3,12 @@ import assert from "http-assert";
 import Stripe from "stripe";
 import { singleton } from "tsyringe";
 
-import { PaymentMethodRepository, type StripeTransactionOutput, StripeTransactionRepository } from "@src/billing/repositories";
+import {
+  PaymentMethodRepository,
+  type StripeTransactionOutput,
+  StripeTransactionRepository,
+  TRIAL_PRESERVING_TRANSACTION_TYPES
+} from "@src/billing/repositories";
 import { FirstPurchaseBonusService } from "@src/billing/services/first-purchase-bonus/first-purchase-bonus.service";
 import { assertIsPayingUser } from "@src/billing/services/paying-user/paying-user";
 import { RefillService } from "@src/billing/services/refill/refill.service";
@@ -40,7 +45,11 @@ export class StripeWebhookService {
         case "payment_intent.succeeded":
           await this.tryToTopUpWalletFromPaymentIntent(event);
           break;
+        case "invoice.paid":
         case "invoice.payment_succeeded":
+          // invoice.paid covers out-of-band-paid invoices (e.g. admin-comped manual credits);
+          // invoice.payment_succeeded covers charged invoices. Both credit the matching
+          // pre-created transaction row idempotently (an already-succeeded row no-ops).
           await this.tryToTopUpWalletFromInvoice(event);
           break;
         case "payment_intent.payment_failed":
@@ -70,12 +79,14 @@ export class StripeWebhookService {
     }
   }
 
-  async tryToTopUpWalletFromInvoice(event: Stripe.InvoicePaymentSucceededEvent) {
+  async tryToTopUpWalletFromInvoice(event: Stripe.InvoicePaidEvent | Stripe.InvoicePaymentSucceededEvent) {
     const invoice = event.data.object;
     const customerId = typeof invoice.customer === "string" ? invoice.customer : invoice.customer?.id ?? null;
 
     const transaction = await this.stripeTransactionRepository.findByInvoiceId(invoice.id);
     if (!transaction) {
+      // Double-credit guard: ordinary charged invoices have no pre-created row (only the coupon-claim
+      // and admin manual-credit paths pre-create one), so they no-op here.
       this.logger.info({
         event: "INVOICE_NO_MATCHING_TRANSACTION",
         invoiceId: invoice.id
@@ -90,7 +101,10 @@ export class StripeWebhookService {
         ? payment.payment_intent
         : payment.payment_intent.id
       : undefined;
-    // Invoice top-ups are coupon claims; redeeming a coupon ends the trial like a card purchase does.
+    // A granted manual credit must not graduate a trial user; every other invoice (coupon claims,
+    // card purchases) leaves endTrial undefined so RefillService's default ends the trial.
+    const endTrial = TRIAL_PRESERVING_TRANSACTION_TYPES.has(transaction.type) ? false : undefined;
+
     await this.topUpWalletFromTransaction({
       customerId,
       transaction,
@@ -98,7 +112,8 @@ export class StripeWebhookService {
       paymentMethodType: undefined,
       paymentAmount: transaction.amount,
       stripePaymentIntentId,
-      eventDescription: `invoice ${invoice.id}`
+      eventDescription: `invoice ${invoice.id}`,
+      endTrial
     });
   }
 

--- a/apps/api/test/functional/stripe-webhook.spec.ts
+++ b/apps/api/test/functional/stripe-webhook.spec.ts
@@ -17,6 +17,7 @@ import { createAkashAddress } from "@test/seeders/akash-address.seeder";
 
 describe("Stripe webhook", () => {
   const userWalletsTable = resolveTable("UserWallets");
+  const stripeTransactionsTable = resolveTable("StripeTransactions");
   const db = container.resolve<ApiPgDatabase>(POSTGRES_DB);
   const userWalletsQuery = db.query.UserWallets;
   const stripeTransactionRepository = container.resolve(StripeTransactionRepository);
@@ -37,6 +38,28 @@ describe("Stripe webhook", () => {
         }
       },
       type: "charge.refunded"
+    });
+
+  const generateInvoicePayload = ({
+    type = "invoice.paid",
+    id,
+    customer
+  }: {
+    type?: "invoice.paid" | "invoice.payment_succeeded";
+    id: string;
+    customer: string;
+  }) =>
+    JSON.stringify({
+      data: {
+        object: {
+          id,
+          object: "invoice",
+          customer,
+          amount_paid: 0,
+          currency: "usd"
+        }
+      },
+      type
     });
 
   const getWebhookResponse = async (payload: string) => {
@@ -700,18 +723,102 @@ describe("Stripe webhook", () => {
         expect(transaction?.status).toBe("succeeded"); // Still not fully refunded
       });
     });
+
+    describe("invoice.paid (manual credit)", () => {
+      it("credits the wallet once and keeps the user trialing for a pre-created manual_credit invoice", async () => {
+        const invoiceId = `in_${faker.string.alphanumeric(24)}`;
+        const amount = 50000; // $500 in cents
+
+        const { user, stripeCustomerId } = await setup();
+
+        // The admin app pre-creates the pending row (direct DB write) before marking the invoice paid
+        await stripeTransactionRepository.create({
+          userId: user.id,
+          type: "manual_credit",
+          status: "pending",
+          amount,
+          currency: "usd",
+          stripeInvoiceId: invoiceId,
+          description: "Enterprise GPU prepay"
+        });
+
+        const response = await getWebhookResponse(generateInvoicePayload({ id: invoiceId, customer: stripeCustomerId }));
+        expect(response.status).toBe(200);
+
+        const wallet = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, user.id) });
+        const expectedBalance = billingConfig.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT + amount * 10000;
+        expect(wallet).toMatchObject({
+          deploymentAllowance: `${expectedBalance}.00`,
+          isTrialing: true // a granted credit must not graduate a trial user
+        });
+
+        const rows = await db.query.StripeTransactions.findMany({ where: eq(stripeTransactionsTable.stripeInvoiceId, invoiceId) });
+        expect(rows).toHaveLength(1);
+        expect(rows[0]).toMatchObject({ type: "manual_credit", status: "succeeded", amount });
+      });
+
+      it("credits exactly once when invoice.paid and invoice.payment_succeeded both fire for the same invoice", async () => {
+        const invoiceId = `in_${faker.string.alphanumeric(24)}`;
+        const amount = 50000;
+
+        const { user, stripeCustomerId } = await setup();
+
+        await stripeTransactionRepository.create({
+          userId: user.id,
+          type: "manual_credit",
+          status: "pending",
+          amount,
+          currency: "usd",
+          stripeInvoiceId: invoiceId
+        });
+
+        const paidResponse = await getWebhookResponse(generateInvoicePayload({ type: "invoice.paid", id: invoiceId, customer: stripeCustomerId }));
+        expect(paidResponse.status).toBe(200);
+
+        const succeededResponse = await getWebhookResponse(
+          generateInvoicePayload({ type: "invoice.payment_succeeded", id: invoiceId, customer: stripeCustomerId })
+        );
+        expect(succeededResponse.status).toBe(200);
+
+        const wallet = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, user.id) });
+        const expectedBalance = billingConfig.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT + amount * 10000;
+        expect(wallet?.deploymentAllowance).toBe(`${expectedBalance}.00`);
+
+        const rows = await db.query.StripeTransactions.findMany({ where: eq(stripeTransactionsTable.stripeInvoiceId, invoiceId) });
+        expect(rows).toHaveLength(1);
+        expect(rows[0].status).toBe("succeeded");
+      });
+
+      it("does not credit for an invoice with no matching transaction (double-credit guard)", async () => {
+        const invoiceId = `in_${faker.string.alphanumeric(24)}`;
+
+        const { user, stripeCustomerId } = await setup();
+
+        const response = await getWebhookResponse(generateInvoicePayload({ id: invoiceId, customer: stripeCustomerId }));
+        expect(response.status).toBe(200);
+
+        const wallet = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, user.id) });
+        expect(wallet?.deploymentAllowance).toBe(`${billingConfig.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT}.00`);
+        expect(wallet?.isTrialing).toBe(true);
+
+        const rows = await db.query.StripeTransactions.findMany({ where: eq(stripeTransactionsTable.stripeInvoiceId, invoiceId) });
+        expect(rows).toHaveLength(0);
+      });
+    });
   });
 
   async function setup() {
     const refillService = container.resolve(RefillService);
     const userWalletRepository = container.resolve(UserWalletRepository);
 
-    vi.spyOn(refillService, "topUpWallet").mockImplementation(async (amountUsd, userId) => {
+    vi.spyOn(refillService, "topUpWallet").mockImplementation(async (amountUsd, userId, options) => {
       const wallet = await userWalletRepository.findOneBy({ userId });
       if (!wallet) return;
+      // Mirror the real service: only graduate the trial when endTrial is not explicitly false
+      const endTrial = options?.endTrial ?? true;
       await userWalletRepository.updateById(wallet.id, {
         deploymentAllowance: wallet.deploymentAllowance + amountUsd * 10000,
-        isTrialing: false
+        ...(endTrial ? { isTrialing: false } : {})
       });
     });
 


### PR DESCRIPTION
## Why

Part of CON-625.

An operator needs to grant *spendable* credit to a customer's managed wallet (e.g. enterprise GPU prepay via Brex ACH) without the customer paying or redeeming a coupon. The finance-approved mechanism is a **comped Stripe invoice** (marked paid out-of-band) that produces a paper trail, whose `invoice.paid` webhook then credits the wallet on-chain.

This PR is the **`apps/api` crediting slice**, and it reuses the existing coupon-claim mechanism rather than inventing a new one: the **admin app** (CON-626, `ovrclk/console-private`) pre-creates the pending `stripe_transactions` row — it has direct DB access, exactly as the coupon endpoint pre-creates its row internally — and marks the invoice paid out-of-band. `apps/api`'s webhook then credits the matching row through the existing idempotent path. No new endpoint, no metadata parsing, no bespoke crediting method in `apps/api`.

> Non-closing keyword on purpose: CON-625 still lists the endpoint/caps/ledger ACs that belong to CON-626 / a caps+ledger follow-up. Trim CON-625 to this crediting scope once those move.

## What

- Add `manual_credit` to the `stripe_transaction_type` enum.
- Add a **partial unique index** on `stripe_invoice_id` (`WHERE NOT NULL`): enforces one row per invoice (guards both the coupon and manual-credit paths) and indexes the previously-unindexed `findByInvoiceId` lookup.
- Subscribe the webhook to `invoice.paid` alongside `invoice.payment_succeeded` (out-of-band-paid invoices fire `invoice.paid`).
- Treat `manual_credit` like `coupon_claim` for `endTrial` — a granted credit must not graduate a trial user.
- Crediting, exactly-once, and the double-credit guard all come from the **existing** `updateTransactionAndTopUp`: it locks the matched row and no-ops if already `succeeded`; an invoice with no matching row no-ops.

The net `apps/api` change is small — enum value + index + migration + the `invoice.paid` subscription + the `endTrial` tweak, plus tests. (The PR's first commit implemented a metadata-driven variant; the second reverts that in favor of reusing the coupon path.)

**Tests:** unit (matched-row `manual_credit` credits with `endTrial:false`; `invoice.paid` / `invoice.payment_succeeded` routing), real-DB integration (partial-unique-index invariant — duplicate `stripe_invoice_id` rejected, nulls allowed), functional (HTTP end-to-end — single credit keeps the user trialing; `invoice.paid` + `invoice.payment_succeeded` double-fire credits once; an unmatched invoice creates no row and no credit).

### Migration — `0030_true_jetstream.sql`

`ALTER TYPE "stripe_transaction_type" ADD VALUE 'manual_credit'` + `CREATE UNIQUE INDEX ... WHERE stripe_invoice_id IS NOT NULL`.

- Runs cleanly on the project's **PostgreSQL 14**: the new enum value is not *used* in the same transaction, so `ADD VALUE` is fine inside drizzle's single migration transaction.
- The index is **additive and non-blocking**; only the coupon path writes `stripe_invoice_id` today (one row per invoice). **Pre-deploy check:** confirm there are no existing duplicate `stripe_invoice_id` values in prod.

### Cross-repo contract (for CON-626, admin app)

Using the same DB and the same Stripe account/keys, the admin app must:
1. **Insert** a `stripe_transactions` row `{ userId, type:"manual_credit", status:"pending", amount (cents), currency, stripeInvoiceId, description }` **before** marking the invoice paid — otherwise the `invoice.paid` webhook can fire first, find no row, and no-op. Handle the `stripe_invoice_id` unique index on insert (e.g. `ON CONFLICT DO NOTHING`).
2. Create + finalize the invoice and mark it **paid out-of-band**.
3. Reject users without a `stripeCustomerId`.

**Deploy ordering:** this migration (`0030`, which adds the `manual_credit` enum value) must ship **before** the admin app writes `manual_credit` rows, or those inserts fail.

**Coupling note:** two services now write `stripe_transactions`, so that table's shape becomes a shared contract. If that coupling becomes painful, revisit whether the admin app should instead go through an `apps/api` endpoint (the original CON-626 direction).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `manual_credit` Stripe transactions for invoice-driven wallet top-ups.
  * Extended webhook routing to handle both `invoice.paid` (manual credits) and `invoice.payment_succeeded` (charged invoices).
* **Bug Fixes**
  * Enforced uniqueness for Stripe transactions when an invoice ID is present (duplicates rejected; multiple `NULL` invoice IDs allowed).
  * Ensured invoice-based wallet crediting is idempotent across repeated/overlapping webhook events.
  * Updated trial graduation behavior so credits preserve trials appropriately.
* **Tests**
  * Added integration and functional coverage for manual credits, routing, uniqueness, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->