### PR TITLE
fix(deployment): drop removed services and placements from the SDL

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -1,9 +1,10 @@
-import { useFormContext, useWatch } from "react-hook-form";
+import { useController, useFormContext, useWatch } from "react-hook-form";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { PlacementType, SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { defaultService } from "@src/utils/sdl/data";
+import { ConfigurationPane } from "../ConfigurationPane/ConfigurationPane";
 import { usePlacementManager } from "../DeploymentPane/usePlacementManager/usePlacementManager";
 import type { DEPENDENCIES } from "./ConfigureDeploymentForm";
 import { ConfigureDeploymentForm, firstBidReadyServiceId, nextUndoneServiceId } from "./ConfigureDeploymentForm";
@@ -181,16 +182,38 @@ describe(ConfigureDeploymentForm.name, () => {
     await userEvent.click(screen.getByRole("button", { name: "remove service" }));
 
     await waitFor(() => expect(screen.getByTestId("sdl").textContent).not.toContain("service-2"));
+    expect(screen.getByTestId("ghost-free").textContent).toBe("true");
   });
 
-  it("keeps regenerating the preview after a placement is added then removed", async () => {
+  it("drops the removed placement and its service from the preview after it is added then removed", async () => {
     setup({ initialSdl: undefined, Panes: AddRemoveProbePanes });
 
     await userEvent.click(screen.getByRole("button", { name: "add placement" }));
-    await userEvent.click(screen.getByRole("button", { name: "remove placement" }));
-    await userEvent.click(screen.getByRole("button", { name: "change image" }));
+    await waitFor(() => expect(screen.getByTestId("sdl").textContent).toContain("placement-1"));
 
-    await waitFor(() => expect(screen.getByTestId("sdl").textContent).toContain("nginx:latest"));
+    await userEvent.click(screen.getByRole("button", { name: "remove placement" }));
+
+    await waitFor(() => {
+      const sdl = screen.getByTestId("sdl").textContent ?? "";
+      expect(sdl).not.toContain("placement-1");
+      expect(sdl).not.toContain("service-2");
+    });
+    expect(screen.getByTestId("ghost-free").textContent).toBe("true");
+  });
+
+  it("removes a non-selected service without a ghost and keeps the current selection", async () => {
+    setup({ initialSdl: undefined, Panes: AddRemoveProbePanes });
+
+    await userEvent.click(screen.getByRole("button", { name: "add service" }));
+    await userEvent.click(screen.getByRole("button", { name: "add service" }));
+    await waitFor(() => expect(screen.getByTestId("sdl").textContent).toContain("service-3"));
+    const selectedService3 = screen.getByTestId("selected").textContent;
+
+    await userEvent.click(screen.getByRole("button", { name: "remove first service" }));
+
+    await waitFor(() => expect(screen.getByTestId("sdl").textContent).not.toContain("service-1"));
+    expect(screen.getByTestId("ghost-free").textContent).toBe("true");
+    expect(screen.getByTestId("selected").textContent).toBe(selectedService3);
   });
 
   it("reselects the first remaining service when the selected one is removed", async () => {
@@ -375,6 +398,18 @@ describe(firstBidReadyServiceId.name, () => {
 interface ProbePanesProps {
   sdl: string;
   selectedServiceId: string;
+  onSelectService: (serviceId: string) => void;
+}
+
+/**
+ * Stand-in for a real configuration card: registers fields on its service index via `useController`, exactly
+ * like ImageCard/RuntimeCard/etc. This registration is what resurrected a removed service before the fix, so a
+ * regression test must mount something that registers.
+ */
+function FieldRegisteringSection({ serviceIndex }: { serviceIndex: number }) {
+  useController<SdlBuilderFormValuesType>({ name: `services.${serviceIndex}.image` as never });
+  useController<SdlBuilderFormValuesType>({ name: `services.${serviceIndex}.title` as never });
+  return null;
 }
 
 /** Panes stand-in that mutates the shared form to drive the SDL preview subscription. */
@@ -397,28 +432,45 @@ function ServiceListProbePanes() {
   return <div data-testid="service-titles">{titles.join(",")}</div>;
 }
 
-/** Panes stand-in that adds then removes a service via the real manager before editing, mirroring the UI flow. */
-function AddRemoveProbePanes({ sdl }: ProbePanesProps) {
-  const manager = usePlacementManager();
-  const { setValue, getValues } = useFormContext<SdlBuilderFormValuesType>();
+/**
+ * Panes stand-in that adds then removes a service/placement via the real manager, mirroring the UI flow —
+ * including selecting the newly added item and mounting the real ConfigurationPane, so its cards register
+ * fields on the selected service. That registration is what made a removed service linger in the SDL, so it
+ * must be present for the removal tests to guard the regression. `ghost-free` reports that every service in
+ * the form still carries an id and placementId (a resurrected partial entry would be missing them).
+ */
+function AddRemoveProbePanes({ sdl, selectedServiceId, onSelectService }: ProbePanesProps) {
+  const manager = usePlacementManager({ onSelectService });
+  const { getValues } = useFormContext<SdlBuilderFormValuesType>();
+  const services = (useWatch<SdlBuilderFormValuesType>({ name: "services" }) as SdlBuilderFormValuesType["services"]) ?? [];
   return (
     <div>
       <div data-testid="sdl">{sdl}</div>
-      <button type="button" onClick={() => manager.addService(getValues("placements")[0].id)}>
+      <div data-testid="selected">{selectedServiceId}</div>
+      <div data-testid="ghost-free">{String(services.every(service => !!service?.id && !!service?.placementId))}</div>
+      <button type="button" onClick={() => onSelectService(manager.addService(getValues("placements")[0].id))}>
         add service
       </button>
       <button type="button" onClick={() => manager.removeService(getValues("services")[1].id)}>
         remove service
       </button>
-      <button type="button" onClick={() => manager.addPlacement()}>
+      <button type="button" onClick={() => manager.removeService(getValues("services")[0].id)}>
+        remove first service
+      </button>
+      <button type="button" onClick={() => onSelectService(manager.addPlacement())}>
         add placement
       </button>
       <button type="button" onClick={() => manager.removePlacement(getValues("placements")[1].id)}>
         remove placement
       </button>
-      <button type="button" onClick={() => setValue("services.0.image", "nginx:latest")}>
-        change image
-      </button>
+      <ConfigurationPane
+        selectedServiceId={selectedServiceId}
+        dependencies={{
+          ImageSection: FieldRegisteringSection as never,
+          HardwareSection: FieldRegisteringSection as never,
+          AdditionalSection: FieldRegisteringSection as never
+        }}
+      />
     </div>
   );
 }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -58,6 +58,12 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
   const [liveSdl, setLiveSdl] = useState(initialState.sdl);
   const [previewSdl, setPreviewSdl] = useState(initialState.sdl);
   const [selectedServiceId, setSelectedServiceId] = useState<string>(initialState.selectedServiceId);
+  /**
+   * The last service the user actually had selected. A removal briefly blurs the selection to "" (so the
+   * ConfigurationPane cards unmount and can't resurrect a deleted service); this lets the reselect below
+   * restore that service if it survived, instead of jumping to the first one.
+   */
+  const lastSelectedServiceId = useRef(selectedServiceId);
   const { enqueueSnackbar } = d.useSnackbar();
   const draft = d.useConfigureDraft(intent);
   const { isWalletReady, error: trialError, retryTrial } = d.useEnsureTrialStarted();
@@ -107,9 +113,16 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
   );
 
   useEffect(
+    function rememberLastSelection() {
+      if (selectedServiceId) lastSelectedServiceId.current = selectedServiceId;
+    },
+    [selectedServiceId]
+  );
+
+  useEffect(
     function reselectRemovedService() {
       const subscription = form.watch(values => {
-        setSelectedServiceId(previous => nextSelectedServiceId(values as SdlBuilderFormValuesType, previous));
+        setSelectedServiceId(previous => nextSelectedServiceId(values as SdlBuilderFormValuesType, previous || lastSelectedServiceId.current));
       });
       return function teardownReselect() {
         subscription.unsubscribe();

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.spec.tsx
@@ -159,6 +159,24 @@ describe("DeploymentPane placement management", () => {
     expect(values.services.every(service => service.placementId === values.placements[0].id)).toBe(true);
   });
 
+  it("renders the surviving placements' service names correctly after a middle placement is removed", async () => {
+    setup();
+    const addServiceButtons = () => screen.getAllByRole("button", { name: "Add service" });
+
+    await userEvent.click(addServiceButtons()[0]);
+    await userEvent.click(addServiceButtons()[0]);
+    await userEvent.click(screen.getByRole("button", { name: "Add Placement" }));
+    await userEvent.click(addServiceButtons()[1]);
+    await userEvent.click(screen.getByRole("button", { name: "Add Placement" }));
+    await userEvent.click(addServiceButtons()[2]);
+    await userEvent.click(addServiceButtons()[2]);
+
+    await userEvent.click(screen.getAllByRole("button", { name: "Remove placement" })[1]);
+
+    const renderedNames = (screen.getAllByLabelText("Service name") as HTMLInputElement[]).map(input => input.value);
+    expect(renderedNames).toEqual(["service-1", "service-2", "service-3", "service-6", "service-7", "service-8"]);
+  });
+
   function setup() {
     const RegionSelectStub: typeof PLACEMENT_CARD_DEPENDENCIES.RegionSelect = () => null;
     const PlacementCardWithStubbedRegion: typeof PlacementCard = props => (

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/DeploymentPane.tsx
@@ -47,7 +47,7 @@ export const DeploymentPane: FC<Props> = ({
   dependencies: d = DEPENDENCIES
 }) => {
   const [minimized, setMinimized] = useState(false);
-  const manager = d.usePlacementManager();
+  const manager = d.usePlacementManager({ onSelectService });
   const placementsWithBids = d.usePlacementsWithBids({ enabled: phase === "quoting", dseq, sdl, placements: manager.placements });
   const toggle = () => setMinimized(prev => !prev);
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/usePlacementManager/usePlacementManager.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentPane/usePlacementManager/usePlacementManager.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from "react";
+import { flushSync } from "react-dom";
 import { useFieldArray, useFormContext, useWatch } from "react-hook-form";
 
 import { isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
@@ -11,7 +12,16 @@ import { useRevalidateUniqueness } from "../useRevalidateUniqueness/useRevalidat
 
 export type IndexedService = { service: ServiceType; index: number };
 
-export const usePlacementManager = () => {
+type SelectionControls = {
+  /**
+   * Blurs the ConfigurationPane's selection (pass ""). Used to unmount every card around a structural
+   * removal so react-hook-form can't resurrect a "ghost" service; reselection is left to the caller's
+   * reselect effect, which runs after the splice commits.
+   */
+  onSelectService?: (serviceId: string) => void;
+};
+
+export const usePlacementManager = ({ onSelectService }: SelectionControls = {}) => {
   const { control, getValues } = useFormContext<SdlBuilderFormValuesType>();
 
   useRevalidateUniqueness("placements", placement => placement.name);
@@ -55,6 +65,30 @@ export const usePlacementManager = () => {
     return service.id as string;
   }, [appendPlacement, appendService, getValues]);
 
+  /**
+   * Runs a structural splice of the services array without leaving a resurrected "ghost" service behind.
+   *
+   * A ConfigurationPane card registers its service index via `useController`, and react-hook-form keeps
+   * registered values across unmounts (`shouldUnregister` is off). Splicing the array while a card is mounted
+   * — whether on the removed index or on one that shifts down — resurrects a partial entry there, which then
+   * keeps the deleted service in the generated SDL. Blurring the selection first unmounts every card so the
+   * splice is clean; `flushSync` makes that unmount commit before the splice instead of batching with it.
+   * Reselection is deliberately left to the consumer's reselect effect, which runs after the splice commits:
+   * reselecting synchronously here would re-mount a card mid-splice and bring the ghost back. No-op passthrough
+   * when there is no selection to manage (the splice is already safe).
+   */
+  const spliceServicesWithoutGhost = useCallback(
+    (mutate: () => void) => {
+      if (!onSelectService) {
+        mutate();
+        return;
+      }
+      flushSync(() => onSelectService(""));
+      mutate();
+    },
+    [onSelectService]
+  );
+
   const canRemovePlacement = placements.length > 1;
 
   const removePlacement = useCallback(
@@ -67,10 +101,12 @@ export const usePlacementManager = () => {
         .map((service, index) => ({ service, index }))
         .filter(({ service }) => service.placementId === placementId)
         .map(({ index }) => index);
-      removeServicesAt(serviceIndexes);
-      removePlacementsAt(placementIndex);
+      spliceServicesWithoutGhost(() => {
+        removeServicesAt(serviceIndexes);
+        removePlacementsAt(placementIndex);
+      });
     },
-    [getValues, removeServicesAt, removePlacementsAt]
+    [getValues, removeServicesAt, removePlacementsAt, spliceServicesWithoutGhost]
   );
 
   const addService = useCallback(
@@ -91,9 +127,9 @@ export const usePlacementManager = () => {
       if (index === -1) {
         return;
       }
-      removeServicesAt(serviceRemovalIndexes(currentServices, index));
+      spliceServicesWithoutGhost(() => removeServicesAt(serviceRemovalIndexes(currentServices, index)));
     },
-    [getValues, removeServicesAt]
+    [getValues, removeServicesAt, spliceServicesWithoutGhost]
   );
 
   return useMemo(


### PR DESCRIPTION
## Why

On `/new-deployment/configure`, removing a service or placement didn't actually remove it from the generated SDL — the deleted service/placement kept showing up in the SDL preview (and would be carried into the deployment). Repro: add a service, remove it; add a placement, remove it — the removed item stays in the SDL.

Root cause is a react-hook-form interaction, not the removal logic itself:

- The Configuration pane registers the **selected** service's fields via `useController` (`services.${index}.*`).
- `useFieldArray.remove()` clears only the indexes it **deletes**, not the ones it **shifts down**, and registered values persist across unmounts (`shouldUnregister` is off by default).
- So splicing the services array while a card is mounted resurrects a partial **"ghost"** entry at the affected index (e.g. `{ title: "service-2" }` with no `placementId`). `generateSdl` then throws on the ghost and the preview silently falls back to the **previous** SDL — so the removed item never disappears.


## What

- `usePlacementManager` now performs every structural splice with the selection blurred, so no Configuration-pane card is mounted on a service during the removal:
  - `flushSync` a deselect so the cards unmount **before** the splice (instead of batching with it),
  - splice,
  - `unregister` the now-unused trailing indexes (clears the stale registration left on a card that shifted down),
  - restore the selection to the same service if it survived, else the first remaining one.
- `DeploymentPane` passes the selection context (`selectedServiceId`, `onSelectService`) into the manager. With no selection context (other callers / tests) it's a plain passthrough — the splice is already safe there.
- Strengthened the add→remove tests to mount the real `ConfigurationPane` (so its cards register fields, reproducing the flow) and assert both that the removed item leaves the SDL **and** that no ghost entry remains. Confirmed the tests fail without the fix and pass with it.


https://github.com/user-attachments/assets/bb58d5c7-8632-4aa5-960a-4a4ec3d5f54b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where removing a placement or service could leave behind hidden “ghost” entries in the deployment form.
  * Improved deployment selection behavior by remembering the last selected service and reselecting it after removals when possible.
  * Updated SDL preview regeneration and validation so removed placements and their related services are fully excluded from the preview.
* **Tests**
  * Expanded and refined regression coverage around add/remove flows and preview cleanup, including service name rendering after removals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->