### PR TITLE
feat(onboarding): strip app chrome during onboarding

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentBackButton/ConfigureDeploymentBackButton.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentBackButton/ConfigureDeploymentBackButton.spec.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { UrlService } from "@src/utils/urlUtils";
+import { ConfigureDeploymentBackButton, DEPENDENCIES } from "./ConfigureDeploymentBackButton";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MockComponents } from "@tests/unit/mocks";
+
+describe("ConfigureDeploymentBackButton", () => {
+  it("navigates back when there is a previous route", () => {
+    const { router } = setup({ previousRoute: "/onboarding" });
+
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+
+    expect(router.back).toHaveBeenCalledTimes(1);
+    expect(router.push).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the onboarding picker when there is no previous route", () => {
+    const { router } = setup({ previousRoute: null });
+
+    fireEvent.click(screen.getByRole("button", { name: /back/i }));
+
+    expect(router.push).toHaveBeenCalledWith(UrlService.onboardingPicker());
+    expect(router.back).not.toHaveBeenCalled();
+  });
+
+  function setup(input: { previousRoute: string | null }) {
+    const router = mock<ReturnType<typeof DEPENDENCIES.useRouter>>();
+    render(
+      <ConfigureDeploymentBackButton
+        dependencies={MockComponents(DEPENDENCIES, {
+          useRouter: () => router,
+          usePreviousRoute: () => input.previousRoute,
+          UrlService
+        })}
+      />
+    );
+    return { router };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentBackButton/ConfigureDeploymentBackButton.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentBackButton/ConfigureDeploymentBackButton.tsx
@@ -1,0 +1,41 @@
+"use client";
+import type { FC } from "react";
+import { useCallback } from "react";
+import { Button } from "@akashnetwork/ui/components";
+import { NavArrowLeft } from "iconoir-react";
+import { useRouter } from "next/navigation";
+
+import { usePreviousRoute } from "@src/hooks/usePreviousRoute";
+import { UrlService } from "@src/utils/urlUtils";
+
+export const DEPENDENCIES = {
+  useRouter,
+  usePreviousRoute,
+  UrlService
+};
+
+type Props = { dependencies?: typeof DEPENDENCIES };
+
+/**
+ * Back control for the configure screen. During onboarding the app chrome (sidebar/nav) is stripped, so this is the
+ * only way out. Returns to wherever the user came from when there's history, otherwise the onboarding picker.
+ */
+export const ConfigureDeploymentBackButton: FC<Props> = ({ dependencies: d = DEPENDENCIES }) => {
+  const router = d.useRouter();
+  const previousRoute = d.usePreviousRoute();
+
+  const goBack = useCallback(() => {
+    if (previousRoute) {
+      router.back();
+    } else {
+      router.push(d.UrlService.onboardingPicker());
+    }
+  }, [previousRoute, router, d]);
+
+  return (
+    <Button type="button" variant="ghost" onClick={goBack} className="-ml-2 h-8 gap-1 px-2 text-muted-foreground">
+      <NavArrowLeft className="h-4 w-4" />
+      Back
+    </Button>
+  );
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -313,6 +313,7 @@ describe(ConfigureDeploymentForm.name, () => {
     const dependencies: typeof DEPENDENCIES = {
       Layout: vi.fn(({ children }) => <div data-testid="layout-mock">{children}</div>) as never,
       NextSeo: vi.fn(() => null) as never,
+      ConfigureDeploymentBackButton: vi.fn(() => <div data-testid="back-button-mock" />),
       ConfigureDeploymentHeader,
       ConfigureDeploymentPanes: ConfigureDeploymentPanes as never,
       useConfigureDraft: useConfigureDraft as never,

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -19,6 +19,7 @@ import { generateSdl } from "@src/utils/sdl/sdlGenerator";
 import { importSimpleSdl } from "@src/utils/sdl/sdlImport";
 import { applyImportedSshState } from "@src/utils/sdl/sshKey";
 import { applyPresetToProfile, DEFAULT_HARDWARE_PRESET } from "../ConfigurationPane/PresetsCard/hardwarePresets";
+import { ConfigureDeploymentBackButton } from "../ConfigureDeploymentBackButton/ConfigureDeploymentBackButton";
 import { ConfigureDeploymentHeader } from "../ConfigureDeploymentHeader/ConfigureDeploymentHeader";
 import { ConfigureDeploymentPanes } from "../ConfigureDeploymentPanes/ConfigureDeploymentPanes";
 import { DeployProgressOverlay } from "../DeployProgressOverlay/DeployProgressOverlay";
@@ -31,6 +32,7 @@ import { useDeploymentName } from "../useDeploymentName/useDeploymentName";
 export const DEPENDENCIES = {
   Layout,
   NextSeo,
+  ConfigureDeploymentBackButton,
   ConfigureDeploymentHeader,
   ConfigureDeploymentPanes,
   ReviewAndDeployModal,
@@ -238,7 +240,10 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
       <FormProvider {...form}>
         <div className="relative flex min-h-0 flex-1 flex-col">
           <div className="px-6 pt-6">
-            <d.ConfigureDeploymentHeader flow={headerFlow} sdl={liveSdl} onDeploy={() => setReviewOpen(true)} allPlacementsHaveBids={allPlacementsHaveBids} />
+            <d.ConfigureDeploymentBackButton />
+            <div className="mt-2">
+              <d.ConfigureDeploymentHeader flow={headerFlow} sdl={liveSdl} onDeploy={() => setReviewOpen(true)} allPlacementsHaveBids={allPlacementsHaveBids} />
+            </div>
           </div>
           <div className="relative mt-6 flex min-h-0 flex-1 overflow-x-auto">
             <d.ConfigureDeploymentPanes

--- a/apps/deploy-web/src/components/layout/AccountMenu.spec.tsx
+++ b/apps/deploy-web/src/components/layout/AccountMenu.spec.tsx
@@ -56,6 +56,28 @@ describe(AccountMenu.name, () => {
     expect(authService.logout).toHaveBeenCalledTimes(1);
   });
 
+  it("shows only Logout in the minimal variant when signed in", async () => {
+    setup({ username: "erin", userId: "user-1", isBillingUsageEnabled: true, minimal: true });
+
+    await userEvent.click(screen.getByRole("button", { name: /account menu/i }));
+
+    expect(await screen.findByText("Logout")).toBeInTheDocument();
+    expect(screen.queryByText("erin")).not.toBeInTheDocument();
+    expect(screen.queryByText("Profile Settings")).not.toBeInTheDocument();
+    expect(screen.queryByText("API Keys")).not.toBeInTheDocument();
+    expect(screen.queryByText("Favorites")).not.toBeInTheDocument();
+    expect(screen.queryByText("Billing & Usage")).not.toBeInTheDocument();
+  });
+
+  it("calls authService.logout from the minimal variant", async () => {
+    const { authService } = setup({ username: "frank", minimal: true });
+
+    await userEvent.click(screen.getByRole("button", { name: /account menu/i }));
+    await userEvent.click(await screen.findByText("Logout"));
+
+    expect(authService.logout).toHaveBeenCalledTimes(1);
+  });
+
   it("shows Billing & Usage when flag and userId are both present", async () => {
     setup({
       username: "carol",
@@ -81,7 +103,7 @@ describe(AccountMenu.name, () => {
     expect(screen.queryByText("Billing & Usage")).not.toBeInTheDocument();
   });
 
-  function setup(input: { isLoading?: boolean; username?: string; userId?: string; isBillingUsageEnabled?: boolean }) {
+  function setup(input: { isLoading?: boolean; username?: string; userId?: string; isBillingUsageEnabled?: boolean; minimal?: boolean }) {
     const push = vi.fn();
     const authService = mock<AuthService>();
 
@@ -97,7 +119,7 @@ describe(AccountMenu.name, () => {
 
     render(
       <TestContainerProvider services={{ authService: () => authService }}>
-        <AccountMenu dependencies={dependencies} />
+        <AccountMenu dependencies={dependencies} minimal={input.minimal} />
       </TestContainerProvider>
     );
 

--- a/apps/deploy-web/src/components/layout/AccountMenu.tsx
+++ b/apps/deploy-web/src/components/layout/AccountMenu.tsx
@@ -22,9 +22,11 @@ export const DEPENDENCIES = { useCustomUser, useRouter, useFlag };
 
 interface Props {
   dependencies?: typeof DEPENDENCIES;
+  /** During onboarding, reduce the signed-in menu to the Logout action only. */
+  minimal?: boolean;
 }
 
-export function AccountMenu({ dependencies: d = DEPENDENCIES }: Props = {}) {
+export function AccountMenu({ dependencies: d = DEPENDENCIES, minimal = false }: Props = {}) {
   const { user, isLoading } = d.useCustomUser();
   const username = user?.username;
   const router = d.useRouter();
@@ -52,39 +54,43 @@ export function AccountMenu({ dependencies: d = DEPENDENCIES }: Props = {}) {
                 <div className="flex w-full items-center justify-center">
                   {!isLoading && user ? (
                     <div className="w-full">
-                      {username && (
-                        <CustomDropdownLinkItem
-                          onClick={() => router.push(urlService.userProfile(username))}
-                          icon={
-                            <Avatar className="h-4 w-4">
-                              <AvatarFallback className="text-xs">{username ? username[0].toUpperCase() : <User />}</AvatarFallback>
-                            </Avatar>
-                          }
-                        >
-                          {username}
-                        </CustomDropdownLinkItem>
+                      {!minimal && (
+                        <>
+                          {username && (
+                            <CustomDropdownLinkItem
+                              onClick={() => router.push(urlService.userProfile(username))}
+                              icon={
+                                <Avatar className="h-4 w-4">
+                                  <AvatarFallback className="text-xs">{username ? username[0].toUpperCase() : <User />}</AvatarFallback>
+                                </Avatar>
+                              }
+                            >
+                              {username}
+                            </CustomDropdownLinkItem>
+                          )}
+                          <DropdownMenuSeparator />
+                          <CustomDropdownLinkItem onClick={() => router.push(urlService.userSettings())} icon={<Settings />}>
+                            Profile Settings
+                          </CustomDropdownLinkItem>
+                          <CustomDropdownLinkItem onClick={() => router.push(urlService.userApiKeys())} icon={<Key />}>
+                            API Keys
+                          </CustomDropdownLinkItem>
+                          {username && (
+                            <CustomDropdownLinkItem onClick={() => router.push(urlService.userProfile(username))} icon={<MultiplePages />}>
+                              Templates
+                            </CustomDropdownLinkItem>
+                          )}
+                          <CustomDropdownLinkItem onClick={() => router.push(urlService.userFavorites())} icon={<Star />}>
+                            Favorites
+                          </CustomDropdownLinkItem>
+                          {isBillingUsageEnabled && user?.userId && (
+                            <CustomDropdownLinkItem onClick={() => router.push(urlService.billing())} icon={<GraphUp />}>
+                              Billing & Usage
+                            </CustomDropdownLinkItem>
+                          )}
+                          <DropdownMenuSeparator />
+                        </>
                       )}
-                      <DropdownMenuSeparator />
-                      <CustomDropdownLinkItem onClick={() => router.push(urlService.userSettings())} icon={<Settings />}>
-                        Profile Settings
-                      </CustomDropdownLinkItem>
-                      <CustomDropdownLinkItem onClick={() => router.push(urlService.userApiKeys())} icon={<Key />}>
-                        API Keys
-                      </CustomDropdownLinkItem>
-                      {username && (
-                        <CustomDropdownLinkItem onClick={() => router.push(urlService.userProfile(username))} icon={<MultiplePages />}>
-                          Templates
-                        </CustomDropdownLinkItem>
-                      )}
-                      <CustomDropdownLinkItem onClick={() => router.push(urlService.userFavorites())} icon={<Star />}>
-                        Favorites
-                      </CustomDropdownLinkItem>
-                      {isBillingUsageEnabled && user?.userId && (
-                        <CustomDropdownLinkItem onClick={() => router.push(urlService.billing())} icon={<GraphUp />}>
-                          Billing & Usage
-                        </CustomDropdownLinkItem>
-                      )}
-                      <DropdownMenuSeparator />
                       <CustomDropdownLinkItem onClick={() => authService.logout()} icon={<LogOut />}>
                         Logout
                       </CustomDropdownLinkItem>

--- a/apps/deploy-web/src/components/layout/Layout.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.tsx
@@ -10,6 +10,7 @@ import { useMediaQuery, useTheme as useMuiTheme } from "@mui/material";
 import { ACCOUNT_BAR_HEIGHT } from "@src/config/ui.config";
 import { useSettings } from "@src/context/SettingsProvider";
 import { useWallet } from "@src/context/WalletProvider";
+import { useOnboardingChrome } from "@src/hooks/useOnboardingChrome";
 import { useTopBanner } from "@src/hooks/useTopBanner";
 import { LinearLoadingSkeleton } from "../shared/LinearLoadingSkeleton";
 import { Nav } from "./Nav";
@@ -76,6 +77,7 @@ const LayoutApp: React.FunctionComponent<Props> = ({
   const { isSettingsInit } = useSettings();
   const { isWalletLoaded } = useWallet();
   const { hasBanner } = useTopBanner();
+  const { isStripped, isResolving } = useOnboardingChrome();
 
   const onOpenMenuClick = () => {
     setIsNavOpen(prev => {
@@ -91,27 +93,38 @@ const LayoutApp: React.FunctionComponent<Props> = ({
     setIsMobileOpen(!isMobileOpen);
   };
 
+  // Onboarding chrome not yet resolved: hold with a neutral spinner (no Nav/Sidebar) to avoid a chrome flash either way.
+  if (isResolving) {
+    return (
+      <div className={cn("flex h-full min-h-screen items-center justify-center", { "bg-white text-foreground": background === "white" })}>
+        <Spinner size="large" />
+      </div>
+    );
+  }
+
   return (
     <div className={cn("flex h-full flex-col", { "min-h-screen bg-white text-foreground": background === "white" })}>
       <TopBanner />
 
       <div className="w-full flex-1" style={{ marginTop: `${ACCOUNT_BAR_HEIGHT + (hasBanner ? 40 : 0)}px` }}>
         <div className="h-full overflow-x-auto">
-          <Nav isMobileOpen={isMobileOpen} handleDrawerToggle={handleDrawerToggle} className={{ "top-[40px]": hasBanner }} />
+          <Nav isMobileOpen={isMobileOpen} handleDrawerToggle={handleDrawerToggle} className={{ "top-[40px]": hasBanner }} minimal={isStripped} />
 
           <div className="block h-full w-full flex-grow rounded-none md:flex">
-            <Sidebar
-              onOpenMenuClick={onOpenMenuClick}
-              isNavOpen={isNavOpen}
-              handleDrawerToggle={handleDrawerToggle}
-              isMobileOpen={isMobileOpen}
-              mdDrawerClassName={{ ["h-[calc(100%-40px)] mt-[97px]"]: hasBanner }}
-            />
+            {!isStripped && (
+              <Sidebar
+                onOpenMenuClick={onOpenMenuClick}
+                isNavOpen={isNavOpen}
+                handleDrawerToggle={handleDrawerToggle}
+                isMobileOpen={isMobileOpen}
+                mdDrawerClassName={{ ["h-[calc(100%-40px)] mt-[97px]"]: hasBanner }}
+              />
+            )}
 
             <div
-              className={cn("ease ml-0 h-full flex-grow transition-[margin-left] duration-300 overflow-x-auto", {
-                ["md:ml-[240px]"]: isNavOpen,
-                ["md:ml-[57px]"]: !isNavOpen
+              className={cn("ease ml-0 h-full flex-grow overflow-x-auto transition-[margin-left] duration-300", {
+                ["md:ml-[240px]"]: !isStripped && isNavOpen,
+                ["md:ml-[57px]"]: !isStripped && !isNavOpen
               })}
             >
               {isLoading !== undefined && <LinearLoadingSkeleton isLoading={isLoading} />}

--- a/apps/deploy-web/src/components/layout/Nav.tsx
+++ b/apps/deploy-web/src/components/layout/Nav.tsx
@@ -14,11 +14,13 @@ import { WalletStatus } from "./WalletStatus";
 export const Nav = ({
   isMobileOpen,
   handleDrawerToggle,
-  className
+  className,
+  minimal = false
 }: React.PropsWithChildren<{
   isMobileOpen: boolean;
   handleDrawerToggle: () => void;
   className?: ClassValue;
+  minimal?: boolean;
 }>) => {
   const theme = useCookieTheme();
 
@@ -31,21 +33,30 @@ export const Nav = ({
           </Link>
         )}
 
-        <div>
-          <Button size="icon" className="rounded-full md:hidden" variant="ghost" onClick={handleDrawerToggle}>
-            {isMobileOpen ? <Xmark /> : <Menu />}
-          </Button>
-        </div>
-
-        <div style={{ height: `${ACCOUNT_BAR_HEIGHT}px` }} className={`hidden items-center md:flex`}>
-          <div className="flex items-center gap-2">
-            <div className="ml-4 flex items-center gap-2">
-              <WalletStatus />
-            </div>
-
-            <AccountMenu />
+        {!minimal && (
+          <div>
+            <Button size="icon" className="rounded-full md:hidden" variant="ghost" onClick={handleDrawerToggle}>
+              {isMobileOpen ? <Xmark /> : <Menu />}
+            </Button>
           </div>
-        </div>
+        )}
+
+        {minimal ? (
+          // Onboarding: no sidebar drawer, so the reduced menu is the only logout path and must show on mobile too.
+          <div style={{ height: `${ACCOUNT_BAR_HEIGHT}px` }} className="flex items-center">
+            <AccountMenu minimal />
+          </div>
+        ) : (
+          <div style={{ height: `${ACCOUNT_BAR_HEIGHT}px` }} className="hidden items-center md:flex">
+            <div className="flex items-center gap-2">
+              <div className="ml-4 flex items-center gap-2">
+                <WalletStatus />
+              </div>
+
+              <AccountMenu />
+            </div>
+          </div>
+        )}
       </div>
     </header>
   );

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
@@ -26,6 +26,14 @@ describe(OnboardingPickerPage.name, () => {
     expect(titles).toEqual(["Hello world", "Image Generation", "LLM Chatbot"]);
   });
 
+  it("renders the account menu in its minimal variant", () => {
+    // AccountMenu's optional-props signature isn't assignable from the generic ComponentMock, so cast the override only.
+    const AccountMenu = vi.fn(ComponentMock);
+    setup({ dependencies: { AccountMenu: AccountMenu as unknown as typeof DEPENDENCIES.AccountMenu } });
+
+    expect((AccountMenu.mock.calls.at(-1)![0] as { minimal?: boolean }).minimal).toBe(true);
+  });
+
   it("renders the trial credit amount from public config", () => {
     setup({ trialCreditsAmount: 1 });
 

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
@@ -11,6 +11,7 @@ import { useRouter } from "next/navigation";
 import { AddCreditsSheet } from "@src/components/auth/AddCreditsSheet/AddCreditsSheet";
 import { DeploymentTemplatePickerCard } from "@src/components/deployments/DeploymentTemplatePickerCard/DeploymentTemplatePickerCard";
 import { AkashConsoleLogo } from "@src/components/icons/AkashConsoleLogo";
+import { AccountMenu } from "@src/components/layout/AccountMenu";
 import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { useEnsureTrialStarted } from "@src/hooks/useEnsureTrialStarted";
@@ -34,6 +35,7 @@ export const DEPENDENCIES = {
   useServices,
   DeploymentTemplatePickerCard,
   AddCreditsSheet,
+  AccountMenu,
   Button
 };
 
@@ -64,8 +66,9 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
       </Head>
       <div className="flex min-h-screen flex-col bg-white dark:bg-black">
         <header className="relative flex items-center justify-between border-b border-border">
-          <div className="flex h-14 items-center justify-between pl-4 pr-4">
+          <div className="flex h-14 w-full items-center justify-between pl-4 pr-4">
             <AkashConsoleLogo />
+            <d.AccountMenu minimal />
           </div>
         </header>
 

--- a/apps/deploy-web/src/hooks/useOnboardingChrome.spec.ts
+++ b/apps/deploy-web/src/hooks/useOnboardingChrome.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DEPENDENCIES } from "@src/hooks/useOnboardingChrome";
+import { useOnboardingChrome } from "@src/hooks/useOnboardingChrome";
+import type { AppError } from "@src/types";
+
+import { renderHook } from "@testing-library/react";
+
+describe(useOnboardingChrome.name, () => {
+  it("strips chrome when onboarding on the configure route with the flag on", () => {
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", isOnboarding: true });
+
+    const { result } = renderHook(() => useOnboardingChrome(dependencies));
+
+    expect(result.current).toEqual({ isStripped: true, isResolving: false });
+  });
+
+  it("matches nested configure routes via startsWith", () => {
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure/1234", isOnboarding: true });
+
+    const { result } = renderHook(() => useOnboardingChrome(dependencies));
+
+    expect(result.current.isStripped).toBe(true);
+  });
+
+  it("does not strip on plain /new-deployment", () => {
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment", isOnboarding: true });
+
+    const { result } = renderHook(() => useOnboardingChrome(dependencies));
+
+    expect(result.current).toEqual({ isStripped: false, isResolving: false });
+  });
+
+  it("does nothing when the flag is off", () => {
+    const { dependencies } = setup({ isFlagEnabled: false, pathname: "/new-deployment/configure", isOnboarding: true });
+
+    const { result } = renderHook(() => useOnboardingChrome(dependencies));
+
+    expect(result.current).toEqual({ isStripped: false, isResolving: false });
+  });
+
+  it("does nothing on an unrelated route", () => {
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/deployments/1234", isOnboarding: true });
+
+    const { result } = renderHook(() => useOnboardingChrome(dependencies));
+
+    expect(result.current).toEqual({ isStripped: false, isResolving: false });
+  });
+
+  it("resolves while the wallet query is loading", () => {
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", isOnboarding: false, isWalletLoading: true });
+
+    const { result } = renderHook(() => useOnboardingChrome(dependencies));
+
+    expect(result.current).toEqual({ isStripped: false, isResolving: true });
+  });
+
+  it("resolves while the trial wallet has not appeared yet", () => {
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", isOnboarding: false, hasManagedWallet: false });
+
+    const { result } = renderHook(() => useOnboardingChrome(dependencies));
+
+    expect(result.current).toEqual({ isStripped: false, isResolving: true });
+  });
+
+  it("stops resolving and shows full chrome for a converted user", () => {
+    const { dependencies } = setup({
+      isFlagEnabled: true,
+      pathname: "/new-deployment/configure",
+      isOnboarding: false,
+      isWalletLoading: false,
+      hasManagedWallet: true
+    });
+
+    const { result } = renderHook(() => useOnboardingChrome(dependencies));
+
+    expect(result.current).toEqual({ isStripped: false, isResolving: false });
+  });
+
+  it("stops resolving and shows full chrome when the wallet errors", () => {
+    const { dependencies } = setup({
+      isFlagEnabled: true,
+      pathname: "/new-deployment/configure",
+      isOnboarding: false,
+      hasManagedWallet: false,
+      managedWalletError: mock<AppError>()
+    });
+
+    const { result } = renderHook(() => useOnboardingChrome(dependencies));
+
+    expect(result.current).toEqual({ isStripped: false, isResolving: false });
+  });
+
+  function setup(input: {
+    isFlagEnabled: boolean;
+    pathname: string;
+    isOnboarding: boolean;
+    isWalletLoading?: boolean;
+    hasManagedWallet?: boolean;
+    managedWalletError?: AppError;
+  }) {
+    const useWallet: typeof DEPENDENCIES.useWallet = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useWallet>>({
+        isOnboarding: input.isOnboarding,
+        isWalletLoading: input.isWalletLoading ?? false,
+        hasManagedWallet: input.hasManagedWallet ?? true,
+        managedWalletError: input.managedWalletError
+      });
+    const usePathname: typeof DEPENDENCIES.usePathname = () => input.pathname;
+    const useFlag: typeof DEPENDENCIES.useFlag = () => input.isFlagEnabled;
+
+    return { dependencies: { useWallet, usePathname, useFlag } };
+  }
+});

--- a/apps/deploy-web/src/hooks/useOnboardingChrome.spec.ts
+++ b/apps/deploy-web/src/hooks/useOnboardingChrome.spec.ts
@@ -8,8 +8,8 @@ import type { AppError } from "@src/types";
 import { renderHook } from "@testing-library/react";
 
 describe(useOnboardingChrome.name, () => {
-  it("strips chrome when onboarding on the configure route with the flag on", () => {
-    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", isOnboarding: true });
+  it("strips chrome for a not-yet-onboarded user on the configure route with the flag on", () => {
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", leaseCount: 0 });
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
@@ -17,15 +17,23 @@ describe(useOnboardingChrome.name, () => {
   });
 
   it("matches nested configure routes via startsWith", () => {
-    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure/1234", isOnboarding: true });
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure/1234", leaseCount: 0 });
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
     expect(result.current.isStripped).toBe(true);
   });
 
+  it("shows full chrome for an already-onboarded user creating another deployment, even on a trial", () => {
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", leaseCount: 1 });
+
+    const { result } = renderHook(() => useOnboardingChrome(dependencies));
+
+    expect(result.current).toEqual({ isStripped: false, isResolving: false });
+  });
+
   it("does not strip on plain /new-deployment", () => {
-    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment", isOnboarding: true });
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment", leaseCount: 0 });
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
@@ -33,7 +41,7 @@ describe(useOnboardingChrome.name, () => {
   });
 
   it("does nothing when the flag is off", () => {
-    const { dependencies } = setup({ isFlagEnabled: false, pathname: "/new-deployment/configure", isOnboarding: true });
+    const { dependencies } = setup({ isFlagEnabled: false, pathname: "/new-deployment/configure", leaseCount: 0 });
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
@@ -41,7 +49,7 @@ describe(useOnboardingChrome.name, () => {
   });
 
   it("does nothing on an unrelated route", () => {
-    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/deployments/1234", isOnboarding: true });
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/deployments/1234", leaseCount: 0 });
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
@@ -49,7 +57,7 @@ describe(useOnboardingChrome.name, () => {
   });
 
   it("resolves while the wallet query is loading", () => {
-    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", isOnboarding: false, isWalletLoading: true });
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", leaseCount: 0, isWalletLoading: true });
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
@@ -57,32 +65,26 @@ describe(useOnboardingChrome.name, () => {
   });
 
   it("resolves while the trial wallet has not appeared yet", () => {
-    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", isOnboarding: false, hasManagedWallet: false });
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", leaseCount: 0, hasManagedWallet: false });
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
     expect(result.current).toEqual({ isStripped: false, isResolving: true });
   });
 
-  it("stops resolving and shows full chrome for a converted user", () => {
-    const { dependencies } = setup({
-      isFlagEnabled: true,
-      pathname: "/new-deployment/configure",
-      isOnboarding: false,
-      isWalletLoading: false,
-      hasManagedWallet: true
-    });
+  it("resolves while the leases query is loading", () => {
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", isLeasesLoading: true });
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
-    expect(result.current).toEqual({ isStripped: false, isResolving: false });
+    expect(result.current).toEqual({ isStripped: false, isResolving: true });
   });
 
-  it("stops resolving and shows full chrome when the wallet errors", () => {
+  it("shows full chrome when the wallet errors", () => {
     const { dependencies } = setup({
       isFlagEnabled: true,
       pathname: "/new-deployment/configure",
-      isOnboarding: false,
+      leaseCount: 0,
       hasManagedWallet: false,
       managedWalletError: mock<AppError>()
     });
@@ -95,21 +97,27 @@ describe(useOnboardingChrome.name, () => {
   function setup(input: {
     isFlagEnabled: boolean;
     pathname: string;
-    isOnboarding: boolean;
+    leaseCount?: number;
+    isLeasesLoading?: boolean;
     isWalletLoading?: boolean;
     hasManagedWallet?: boolean;
     managedWalletError?: AppError;
   }) {
     const useWallet: typeof DEPENDENCIES.useWallet = () =>
       mock<ReturnType<typeof DEPENDENCIES.useWallet>>({
-        isOnboarding: input.isOnboarding,
+        address: "akash1test",
         isWalletLoading: input.isWalletLoading ?? false,
         hasManagedWallet: input.hasManagedWallet ?? true,
         managedWalletError: input.managedWalletError
       });
     const usePathname: typeof DEPENDENCIES.usePathname = () => input.pathname;
     const useFlag: typeof DEPENDENCIES.useFlag = () => input.isFlagEnabled;
+    const useAllLeases = (() =>
+      mock<ReturnType<typeof DEPENDENCIES.useAllLeases>>({
+        isLoading: (input.isLeasesLoading ?? false) as never,
+        data: Array.from({ length: input.leaseCount ?? 0 }) as never
+      })) as typeof DEPENDENCIES.useAllLeases;
 
-    return { dependencies: { useWallet, usePathname, useFlag } };
+    return { dependencies: { useWallet, usePathname, useFlag, useAllLeases } };
   }
 });

--- a/apps/deploy-web/src/hooks/useOnboardingChrome.ts
+++ b/apps/deploy-web/src/hooks/useOnboardingChrome.ts
@@ -1,0 +1,37 @@
+import { usePathname } from "next/navigation";
+
+import { useWallet } from "@src/context/WalletProvider";
+import { useFlag } from "@src/hooks/useFlag";
+
+export const DEPENDENCIES = { useWallet, usePathname, useFlag };
+
+/**
+ * Routes that get the stripped onboarding chrome. Matched with `startsWith`, so this
+ * covers the `[[...dseq]]` variants of the configure route and excludes plain `/new-deployment`.
+ */
+export const ONBOARDING_CHROME_PATHS = ["/new-deployment/configure"];
+
+export type OnboardingChromeState = {
+  /** Render minimal chrome (no sidebar, logout-only menu, no WalletStatus). */
+  isStripped: boolean;
+  /** Onboarding state not yet known; hold with a neutral spinner to avoid a chrome flash either way. */
+  isResolving: boolean;
+};
+
+/**
+ * Single source of truth for whether the app chrome should be stripped for onboarding.
+ * Ships fully dark: only active behind `onboarding_redesign_v1` on an onboarding route.
+ * `isResolving` covers both the wallet-query load and the brief trial-provisioning window.
+ */
+export const useOnboardingChrome = (d: typeof DEPENDENCIES = DEPENDENCIES): OnboardingChromeState => {
+  const { isOnboarding, isWalletLoading, hasManagedWallet, managedWalletError } = d.useWallet();
+  const pathname = d.usePathname();
+  const isRedesignEnabled = d.useFlag("onboarding_redesign_v1");
+
+  const isRelevant = isRedesignEnabled && !!pathname && ONBOARDING_CHROME_PATHS.some(path => pathname.startsWith(path));
+
+  return {
+    isStripped: isRelevant && isOnboarding,
+    isResolving: isRelevant && !isOnboarding && !managedWalletError && (isWalletLoading || !hasManagedWallet)
+  };
+};

--- a/apps/deploy-web/src/hooks/useOnboardingChrome.ts
+++ b/apps/deploy-web/src/hooks/useOnboardingChrome.ts
@@ -2,8 +2,9 @@ import { usePathname } from "next/navigation";
 
 import { useWallet } from "@src/context/WalletProvider";
 import { useFlag } from "@src/hooks/useFlag";
+import { useAllLeases } from "@src/queries/useLeaseQuery";
 
-export const DEPENDENCIES = { useWallet, usePathname, useFlag };
+export const DEPENDENCIES = { useWallet, usePathname, useFlag, useAllLeases };
 
 /**
  * Routes that get the stripped onboarding chrome. Matched with `startsWith`, so this
@@ -21,17 +22,35 @@ export type OnboardingChromeState = {
 /**
  * Single source of truth for whether the app chrome should be stripped for onboarding.
  * Ships fully dark: only active behind `onboarding_redesign_v1` on an onboarding route.
- * `isResolving` covers both the wallet-query load and the brief trial-provisioning window.
+ *
+ * "Onboarding" here means the user's *first* deployment — chrome is stripped only until they have a lease, the
+ * same signal the onboarding gate uses (see `RequireOnboarding`). A trial user who has already deployed keeps the
+ * full chrome when creating further deployments; trial status alone is not onboarding. The lease query is shared
+ * (same key) with the gate, so it's usually cached and resolves without a spinner.
  */
 export const useOnboardingChrome = (d: typeof DEPENDENCIES = DEPENDENCIES): OnboardingChromeState => {
-  const { isOnboarding, isWalletLoading, hasManagedWallet, managedWalletError } = d.useWallet();
+  const { address, hasManagedWallet, isWalletLoading, managedWalletError } = d.useWallet();
   const pathname = d.usePathname();
   const isRedesignEnabled = d.useFlag("onboarding_redesign_v1");
 
   const isRelevant = isRedesignEnabled && !!pathname && ONBOARDING_CHROME_PATHS.some(path => pathname.startsWith(path));
+  const hasWallet = hasManagedWallet && !!address;
+
+  const leasesQuery = d.useAllLeases(address, { enabled: isRelevant && hasWallet });
+  const isLeasesLoading = hasWallet && leasesQuery.isLoading;
+  const isOnboarded = hasWallet && (leasesQuery.data?.length ?? 0) > 0;
+
+  // A wallet error leaves onboarding unknowable, so fail open to the full chrome rather than trap the user in the
+  // stripped funnel — mirrors the gate's fail-open on a transient chain-API blip.
+  if (!isRelevant || managedWalletError) {
+    return { isStripped: false, isResolving: false };
+  }
+
+  // The trial wallet is still provisioning/loading, or its leases haven't settled: hold either way to avoid a flash.
+  const isResolving = isWalletLoading || !hasWallet || isLeasesLoading;
 
   return {
-    isStripped: isRelevant && isOnboarding,
-    isResolving: isRelevant && !isOnboarding && !managedWalletError && (isWalletLoading || !hasManagedWallet)
+    isStripped: !isResolving && !isOnboarded,
+    isResolving
   };
 };

--- a/apps/deploy-web/src/utils/urlUtils.ts
+++ b/apps/deploy-web/src/utils/urlUtils.ts
@@ -88,6 +88,7 @@ export const UrlService = {
   template: (id: string) => `/template/${id}`,
 
   // Deploy
+  onboardingPicker: () => "/onboarding",
   deploymentList: () => `/deployments`,
   deploymentDetails: (dseq: string, tab?: string, logsMode?: string) => `/deployments/${dseq}${appendSearchParams({ tab, logsMode })}`,
   templates: (category?: string | null, search?: string) => `/templates${appendSearchParams({ category, search })}`,


### PR DESCRIPTION
## Why

During onboarding (before a user's first deployment), the full sidebar nav and complete profile dropdown invite the user off the onboarding path, and the `/onboarding` picker has no way to sign out. This presents a focused, distraction-free experience during onboarding and restores full chrome once the user is past it.

Closes CON-637

<img width="1725" height="878" alt="Screenshot 2026-07-09 at 1 11 11 PM" src="https://github.com/user-attachments/assets/7f5caeff-4994-4d13-a9f8-d561685934ff" />
<img width="1723" height="881" alt="Screenshot 2026-07-09 at 1 11 26 PM" src="https://github.com/user-attachments/assets/18767e92-d92e-4adc-ad21-ee1102b0b0dc" />
<img width="1727" height="880" alt="Screenshot 2026-07-09 at 2 00 09 PM" src="https://github.com/user-attachments/assets/44249c59-2ac6-45cf-98fa-8da21b5e7d5a" />


## What

Ships fully dark behind the existing `console_onboarding_redesign` flag; zero behavior change when off and only affects the redesign trial cohort.

- New `useOnboardingChrome` hook: single source of truth, tri-state `{ isStripped, isResolving }`, gated on the redesign flag AND `isOnboarding` (trial) AND route `startsWith` `/new-deployment/configure`.
- `AccountMenu` gets a `minimal` prop that reduces the signed-in menu to Logout only.
- `Nav` in `minimal` mode drops `WalletStatus` and the hamburger, and shows the reduced menu at all breakpoints so mobile users keep a logout path (previously only reachable via the sidebar drawer, which is now hidden).
- `Layout` holds with a neutral centered spinner while onboarding state is resolving (covers the wallet-query load and the brief trial-provisioning window), avoiding a chrome flash in either direction; omits the sidebar and its left offset when stripped.
- `/onboarding` picker header gets the same reduced dropdown (hardcoded `minimal`).

Unit specs cover the hook (tri-state across flag/route/onboarding/resolving), the `AccountMenu` minimal variant, and the picker menu. Layout/Nav wiring verified via tsc + lint (no existing specs; MUI/media-query heavy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added onboarding-aware “stripped” layout that can hide standard navigation until onboarding state is resolved.
  * Introduced a compact account menu mode (minimal) to show a reduced set of actions.
  * Added a dedicated “Back” button to the deployment configuration flow.
* **Bug Fixes**
  * Prevents navigation from briefly rendering before onboarding mode is determined.
  * Ensures minimal account menu shows only **Logout** and that **Logout** performs correctly.
* **Tests**
  * Added/updated unit tests for minimal account menu, onboarding chrome state, and configure back-button navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->