### PR TITLE
feat(billing): split add-credits sheet into purchase and coupon tabs

### DIFF
--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
@@ -221,7 +221,8 @@ describe(StripeWebhookService.name, () => {
         receiptUrl: "https://receipt.stripe.com/inv",
         stripePaymentIntentId: paymentIntentId
       });
-      expect(refillService.topUpWallet).toHaveBeenCalledWith(transactionAmount, mockUser.id, { endTrial: false });
+      // Coupon invoices leave endTrial undefined so RefillService's default (true) ends the trial, like a card purchase.
+      expect(refillService.topUpWallet).toHaveBeenCalledWith(transactionAmount, mockUser.id, { endTrial: undefined });
     });
 
     it("returns early when customer ID is missing", async () => {
@@ -329,7 +330,7 @@ describe(StripeWebhookService.name, () => {
         receiptUrl: undefined,
         stripePaymentIntentId: undefined
       });
-      expect(refillService.topUpWallet).toHaveBeenCalledWith(transactionAmount, mockUser.id, { endTrial: false });
+      expect(refillService.topUpWallet).toHaveBeenCalledWith(transactionAmount, mockUser.id, { endTrial: undefined });
     });
   });
 

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
@@ -88,8 +88,7 @@ export class StripeWebhookService {
         ? payment.payment_intent
         : payment.payment_intent.id
       : undefined;
-    const endTrial = transaction.type !== "coupon_claim";
-
+    // Invoice top-ups are coupon claims; redeeming a coupon ends the trial like a card purchase does.
     await this.topUpWalletFromTransaction({
       customerId,
       transaction,
@@ -97,8 +96,7 @@ export class StripeWebhookService {
       paymentMethodType: undefined,
       paymentAmount: transaction.amount,
       stripePaymentIntentId,
-      eventDescription: `invoice ${invoice.id}`,
-      endTrial
+      eventDescription: `invoice ${invoice.id}`
     });
   }
 

--- a/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.spec.tsx
+++ b/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.spec.tsx
@@ -7,34 +7,40 @@ import { act, render } from "@testing-library/react";
 import { MockComponents } from "@tests/unit/mocks";
 
 describe(AddCreditsSheet.name, () => {
-  it("renders the AddCreditsForm when open", () => {
+  it("renders the credits tabs when open", () => {
     const { dependencies } = setup({ open: true });
 
-    expect(dependencies.AddCreditsForm).toHaveBeenCalled();
+    expect(dependencies.AddCreditsTabs).toHaveBeenCalled();
   });
 
-  it("does not render the AddCreditsForm while closed", () => {
+  it("does not render the credits tabs while closed", () => {
     const { dependencies } = setup({ open: false });
 
-    expect(dependencies.AddCreditsForm).not.toHaveBeenCalled();
+    expect(dependencies.AddCreditsTabs).not.toHaveBeenCalled();
   });
 
-  it("forwards onDone to the form", () => {
+  it("forwards onDone to the tabs", () => {
     const onDone = vi.fn();
     const { dependencies } = setup({ open: true, onDone });
 
-    expect(dependencies.AddCreditsForm).toHaveBeenCalledWith(expect.objectContaining({ onDone }), expect.anything());
+    expect(dependencies.AddCreditsTabs).toHaveBeenCalledWith(expect.objectContaining({ onDone }), expect.anything());
   });
 
-  it("forwards isWalletReady to the form", () => {
+  it("forwards isWalletReady to the tabs", () => {
     const { dependencies } = setup({ open: true, isWalletReady: false });
 
-    expect(dependencies.AddCreditsForm).toHaveBeenCalledWith(expect.objectContaining({ isWalletReady: false }), expect.anything());
+    expect(dependencies.AddCreditsTabs).toHaveBeenCalledWith(expect.objectContaining({ isWalletReady: false }), expect.anything());
   });
 
-  it("blocks closing while the form reports a payment in progress", () => {
+  it("threads the initial tab to the tabs", () => {
+    const { dependencies } = setup({ open: true, initialTab: "coupon" });
+
+    expect(dependencies.AddCreditsTabs).toHaveBeenCalledWith(expect.objectContaining({ initialTab: "coupon" }), expect.anything());
+  });
+
+  it("blocks closing while the tabs report a payment in progress", () => {
     const onOpenChange = vi.fn();
-    const { dependencies } = setup({ open: true, onOpenChange, dependencies: { AddCreditsForm: reportingForm(true) } });
+    const { dependencies } = setup({ open: true, onOpenChange, dependencies: { AddCreditsTabs: reportingTabs(true) } });
 
     act(() => dependencies.Sheet.mock.calls.at(-1)![0].onOpenChange?.(false));
 
@@ -43,21 +49,21 @@ describe(AddCreditsSheet.name, () => {
 
   it("allows closing when no payment is in progress", () => {
     const onOpenChange = vi.fn();
-    const { dependencies } = setup({ open: true, onOpenChange, dependencies: { AddCreditsForm: reportingForm(false) } });
+    const { dependencies } = setup({ open: true, onOpenChange, dependencies: { AddCreditsTabs: reportingTabs(false) } });
 
     act(() => dependencies.Sheet.mock.calls.at(-1)![0].onOpenChange?.(false));
 
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it("hides the close button while the form reports a payment in progress", () => {
-    const { dependencies } = setup({ open: true, dependencies: { AddCreditsForm: reportingForm(true) } });
+  it("hides the close button while the tabs report a payment in progress", () => {
+    const { dependencies } = setup({ open: true, dependencies: { AddCreditsTabs: reportingTabs(true) } });
 
     expect(dependencies.SheetContent.mock.calls.at(-1)![0].hideCloseButton).toBe(true);
   });
 
-  function reportingForm(isProcessing: boolean) {
-    return ({ onProcessingChange }: Parameters<typeof DEPENDENCIES.AddCreditsForm>[0]) => {
+  function reportingTabs(isProcessing: boolean) {
+    return ({ onProcessingChange }: Parameters<typeof DEPENDENCIES.AddCreditsTabs>[0]) => {
       useEffect(() => onProcessingChange?.(isProcessing), [onProcessingChange]);
       return <></>;
     };
@@ -68,6 +74,7 @@ describe(AddCreditsSheet.name, () => {
     onOpenChange?: (open: boolean) => void;
     onDone?: (amount: number, organization?: string) => void;
     isWalletReady?: boolean;
+    initialTab?: "purchase" | "coupon";
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {
     const dependencies = MockComponents(DEPENDENCIES, input.dependencies);
@@ -78,6 +85,7 @@ describe(AddCreditsSheet.name, () => {
         onOpenChange={input.onOpenChange ?? vi.fn()}
         onDone={input.onDone ?? vi.fn()}
         isWalletReady={input.isWalletReady}
+        initialTab={input.initialTab}
         dependencies={dependencies}
       />
     );

--- a/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.spec.tsx
+++ b/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.spec.tsx
@@ -26,6 +26,13 @@ describe(AddCreditsSheet.name, () => {
     expect(dependencies.AddCreditsTabs).toHaveBeenCalledWith(expect.objectContaining({ onDone }), expect.anything());
   });
 
+  it("forwards onRedeemed to the tabs", () => {
+    const onRedeemed = vi.fn();
+    const { dependencies } = setup({ open: true, onRedeemed });
+
+    expect(dependencies.AddCreditsTabs).toHaveBeenCalledWith(expect.objectContaining({ onRedeemed }), expect.anything());
+  });
+
   it("forwards isWalletReady to the tabs", () => {
     const { dependencies } = setup({ open: true, isWalletReady: false });
 
@@ -73,6 +80,7 @@ describe(AddCreditsSheet.name, () => {
     open: boolean;
     onOpenChange?: (open: boolean) => void;
     onDone?: (amount: number, organization?: string) => void;
+    onRedeemed?: () => void;
     isWalletReady?: boolean;
     initialTab?: "purchase" | "coupon";
     dependencies?: Partial<typeof DEPENDENCIES>;
@@ -84,6 +92,7 @@ describe(AddCreditsSheet.name, () => {
         open={input.open}
         onOpenChange={input.onOpenChange ?? vi.fn()}
         onDone={input.onDone ?? vi.fn()}
+        onRedeemed={input.onRedeemed}
         isWalletReady={input.isWalletReady}
         initialTab={input.initialTab}
         dependencies={dependencies}

--- a/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.tsx
+++ b/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.tsx
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@akashnetwork/ui/components";
 
-import { AddCreditsForm } from "@src/components/billing-usage/AddCreditsForm/AddCreditsForm";
+import { AddCreditsTabs } from "@src/components/billing-usage/AddCreditsTabs/AddCreditsTabs";
 
 export const DEPENDENCIES = {
   Sheet,
@@ -11,7 +11,7 @@ export const DEPENDENCIES = {
   SheetHeader,
   SheetTitle,
   SheetDescription,
-  AddCreditsForm
+  AddCreditsTabs
 };
 
 interface AddCreditsSheetProps {
@@ -19,10 +19,11 @@ interface AddCreditsSheetProps {
   onOpenChange: (open: boolean) => void;
   onDone: (amount: number, organization?: string) => void;
   isWalletReady?: boolean;
+  initialTab?: "purchase" | "coupon";
   dependencies?: typeof DEPENDENCIES;
 }
 
-export function AddCreditsSheet({ open, onOpenChange, onDone, isWalletReady, dependencies: d = DEPENDENCIES }: AddCreditsSheetProps) {
+export function AddCreditsSheet({ open, onOpenChange, onDone, isWalletReady, initialTab, dependencies: d = DEPENDENCIES }: AddCreditsSheetProps) {
   const [isProcessing, setIsProcessing] = useState(false);
 
   const requestOpenChange = (next: boolean) => {
@@ -36,12 +37,11 @@ export function AddCreditsSheet({ open, onOpenChange, onDone, isWalletReady, dep
         <d.SheetHeader className="space-y-2 text-left">
           <d.SheetTitle className="text-3xl font-medium leading-9">Add credits</d.SheetTitle>
           <d.SheetDescription className="text-sm leading-5 text-muted-foreground">
-            This template needs a top-tier GPU, which isn&apos;t covered by your free trial. Add credits to unlock high-end GPUs, longer runtimes, and the full
-            Console.
+            You&apos;re on the free plan — CPU deployments only. Unlock GPUs, unlimited runtime, and the full Console.
           </d.SheetDescription>
         </d.SheetHeader>
 
-        {open && <d.AddCreditsForm onDone={onDone} isWalletReady={isWalletReady} onProcessingChange={setIsProcessing} />}
+        {open && <d.AddCreditsTabs initialTab={initialTab} onDone={onDone} isWalletReady={isWalletReady} onProcessingChange={setIsProcessing} />}
       </d.SheetContent>
     </d.Sheet>
   );

--- a/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.tsx
+++ b/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.tsx
@@ -38,7 +38,8 @@ export function AddCreditsSheet({ open, onOpenChange, onDone, onRedeemed, isWall
         <d.SheetHeader className="space-y-2 text-left">
           <d.SheetTitle className="text-3xl font-medium leading-9">Add credits</d.SheetTitle>
           <d.SheetDescription className="text-sm leading-5 text-muted-foreground">
-            You&apos;re on the free plan — CPU deployments only. Unlock GPUs, unlimited runtime, and the full Console.
+            This template needs a top-tier GPU, which isn&apos;t covered by your free trial. Add credits to unlock high-end GPUs, longer runtimes, and the full
+            Console.
           </d.SheetDescription>
         </d.SheetHeader>
 

--- a/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.tsx
+++ b/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.tsx
@@ -18,12 +18,13 @@ interface AddCreditsSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onDone: (amount: number, organization?: string) => void;
+  onRedeemed?: () => void;
   isWalletReady?: boolean;
   initialTab?: "purchase" | "coupon";
   dependencies?: typeof DEPENDENCIES;
 }
 
-export function AddCreditsSheet({ open, onOpenChange, onDone, isWalletReady, initialTab, dependencies: d = DEPENDENCIES }: AddCreditsSheetProps) {
+export function AddCreditsSheet({ open, onOpenChange, onDone, onRedeemed, isWalletReady, initialTab, dependencies: d = DEPENDENCIES }: AddCreditsSheetProps) {
   const [isProcessing, setIsProcessing] = useState(false);
 
   const requestOpenChange = (next: boolean) => {
@@ -41,7 +42,15 @@ export function AddCreditsSheet({ open, onOpenChange, onDone, isWalletReady, ini
           </d.SheetDescription>
         </d.SheetHeader>
 
-        {open && <d.AddCreditsTabs initialTab={initialTab} onDone={onDone} isWalletReady={isWalletReady} onProcessingChange={setIsProcessing} />}
+        {open && (
+          <d.AddCreditsTabs
+            initialTab={initialTab}
+            onDone={onDone}
+            onRedeemed={onRedeemed}
+            isWalletReady={isWalletReady}
+            onProcessingChange={setIsProcessing}
+          />
+        )}
       </d.SheetContent>
     </d.Sheet>
   );

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsTabs/AddCreditsTabs.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsTabs/AddCreditsTabs.spec.tsx
@@ -1,0 +1,85 @@
+import { useEffect } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@akashnetwork/ui/components";
+import { describe, expect, it, vi } from "vitest";
+
+import type { DEPENDENCIES } from "./AddCreditsTabs";
+import { AddCreditsTabs } from "./AddCreditsTabs";
+
+import { render, screen } from "@testing-library/react";
+
+describe(AddCreditsTabs.name, () => {
+  it("renders a trigger for each tab", () => {
+    setup({});
+
+    expect(screen.getByRole("tab", { name: /purchase credits/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /redeem coupon/i })).toBeInTheDocument();
+  });
+
+  it("shows the purchase tab by default", () => {
+    const AddCreditsForm = vi.fn(() => <div>purchase-form</div>);
+    const RedeemCouponForm = vi.fn(() => <div>coupon-form</div>);
+
+    setup({ dependencies: { AddCreditsForm, RedeemCouponForm } });
+
+    expect(AddCreditsForm).toHaveBeenCalled();
+    expect(RedeemCouponForm).not.toHaveBeenCalled();
+  });
+
+  it("shows the coupon tab when initialTab is coupon", () => {
+    const AddCreditsForm = vi.fn(() => <div>purchase-form</div>);
+    const RedeemCouponForm = vi.fn(() => <div>coupon-form</div>);
+
+    setup({ initialTab: "coupon", dependencies: { AddCreditsForm, RedeemCouponForm } });
+
+    expect(RedeemCouponForm).toHaveBeenCalled();
+    expect(AddCreditsForm).not.toHaveBeenCalled();
+  });
+
+  it("forwards aggregated processing state to the parent", () => {
+    const onProcessingChange = vi.fn();
+
+    setup({ onProcessingChange, dependencies: { AddCreditsForm: reportingForm(true) } });
+
+    expect(onProcessingChange).toHaveBeenCalledWith(true);
+  });
+
+  it("disables the inactive tab trigger while the active tab reports processing", () => {
+    setup({ dependencies: { AddCreditsForm: reportingForm(true) } });
+
+    expect(screen.getByRole("tab", { name: /redeem coupon/i })).toBeDisabled();
+    expect(screen.getByRole("tab", { name: /purchase credits/i })).not.toBeDisabled();
+  });
+
+  function reportingForm(isProcessing: boolean) {
+    return ({ onProcessingChange }: Parameters<typeof DEPENDENCIES.AddCreditsForm>[0]) => {
+      useEffect(() => onProcessingChange?.(isProcessing), [onProcessingChange]);
+      return <></>;
+    };
+  }
+
+  function setup(input: {
+    initialTab?: "purchase" | "coupon";
+    onDone?: (amount: number, organization?: string) => void;
+    isWalletReady?: boolean;
+    onProcessingChange?: (isProcessing: boolean) => void;
+    dependencies?: Partial<typeof DEPENDENCIES>;
+  }) {
+    return render(
+      <AddCreditsTabs
+        initialTab={input.initialTab}
+        onDone={input.onDone ?? vi.fn()}
+        isWalletReady={input.isWalletReady ?? true}
+        onProcessingChange={input.onProcessingChange}
+        dependencies={{
+          Tabs,
+          TabsList,
+          TabsTrigger,
+          TabsContent,
+          AddCreditsForm: () => <></>,
+          RedeemCouponForm: () => <></>,
+          ...input.dependencies
+        }}
+      />
+    );
+  }
+});

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsTabs/AddCreditsTabs.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsTabs/AddCreditsTabs.spec.tsx
@@ -35,6 +35,15 @@ describe(AddCreditsTabs.name, () => {
     expect(AddCreditsForm).not.toHaveBeenCalled();
   });
 
+  it("forwards onRedeemed to the coupon form", () => {
+    const onRedeemed = vi.fn();
+    const RedeemCouponForm = vi.fn((_props: Parameters<typeof DEPENDENCIES.RedeemCouponForm>[0]) => <div>coupon-form</div>);
+
+    setup({ initialTab: "coupon", onRedeemed, dependencies: { RedeemCouponForm } });
+
+    expect(RedeemCouponForm.mock.calls[0][0]).toEqual(expect.objectContaining({ onRedeemed }));
+  });
+
   it("forwards aggregated processing state to the parent", () => {
     const onProcessingChange = vi.fn();
 
@@ -60,6 +69,7 @@ describe(AddCreditsTabs.name, () => {
   function setup(input: {
     initialTab?: "purchase" | "coupon";
     onDone?: (amount: number, organization?: string) => void;
+    onRedeemed?: () => void;
     isWalletReady?: boolean;
     onProcessingChange?: (isProcessing: boolean) => void;
     dependencies?: Partial<typeof DEPENDENCIES>;
@@ -68,6 +78,7 @@ describe(AddCreditsTabs.name, () => {
       <AddCreditsTabs
         initialTab={input.initialTab}
         onDone={input.onDone ?? vi.fn()}
+        onRedeemed={input.onRedeemed}
         isWalletReady={input.isWalletReady ?? true}
         onProcessingChange={input.onProcessingChange}
         dependencies={{

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsTabs/AddCreditsTabs.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsTabs/AddCreditsTabs.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@akashnetwork/ui/components";
+
+import { AddCreditsForm } from "@src/components/billing-usage/AddCreditsForm/AddCreditsForm";
+import { RedeemCouponForm } from "@src/components/billing-usage/RedeemCouponForm/RedeemCouponForm";
+
+type AddCreditsTab = "purchase" | "coupon";
+
+export const DEPENDENCIES = {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+  AddCreditsForm,
+  RedeemCouponForm
+};
+
+interface AddCreditsTabsProps {
+  initialTab?: AddCreditsTab;
+  onDone: (amount: number, organization?: string) => void;
+  isWalletReady?: boolean;
+  onProcessingChange?: (isProcessing: boolean) => void;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+/**
+ * Splits the Add Credits sheet into a purchase flow and a coupon-redemption
+ * flow. Only the active tab's content is mounted (Radix unmounts inactive
+ * content), so the purchase tab's Stripe SetupIntent is created lazily and the
+ * coupon form resets whenever the user switches away. Processing state is
+ * aggregated from both children and forwarded to the sheet's close-guard; the
+ * inactive tab trigger is disabled while a flow is in progress so the user
+ * cannot navigate away mid-transaction.
+ */
+export function AddCreditsTabs({ initialTab = "purchase", onDone, isWalletReady, onProcessingChange, dependencies: d = DEPENDENCIES }: AddCreditsTabsProps) {
+  const [activeTab, setActiveTab] = useState<AddCreditsTab>(initialTab);
+  const [purchaseProcessing, setPurchaseProcessing] = useState(false);
+  const [couponProcessing, setCouponProcessing] = useState(false);
+
+  const isProcessing = purchaseProcessing || couponProcessing;
+
+  useEffect(
+    function reportProcessing() {
+      onProcessingChange?.(isProcessing);
+    },
+    [isProcessing, onProcessingChange]
+  );
+
+  const handleTabChange = (next: string) => {
+    // Switching is blocked while processing, so the tab being left is always
+    // idle here; clear both flags so the unmounted child's state does not linger.
+    setPurchaseProcessing(false);
+    setCouponProcessing(false);
+    setActiveTab(next as AddCreditsTab);
+  };
+
+  return (
+    <d.Tabs value={activeTab} onValueChange={handleTabChange} className="space-y-6">
+      <d.TabsList className="grid w-full grid-cols-2">
+        <d.TabsTrigger value="purchase" disabled={isProcessing && activeTab !== "purchase"}>
+          Purchase credits
+        </d.TabsTrigger>
+        <d.TabsTrigger value="coupon" disabled={isProcessing && activeTab !== "coupon"}>
+          Redeem coupon
+        </d.TabsTrigger>
+      </d.TabsList>
+
+      <d.TabsContent value="purchase">
+        <d.AddCreditsForm onDone={onDone} isWalletReady={isWalletReady} onProcessingChange={setPurchaseProcessing} />
+      </d.TabsContent>
+
+      <d.TabsContent value="coupon">
+        <d.RedeemCouponForm isWalletReady={isWalletReady} onProcessingChange={setCouponProcessing} />
+      </d.TabsContent>
+    </d.Tabs>
+  );
+}

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsTabs/AddCreditsTabs.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsTabs/AddCreditsTabs.tsx
@@ -20,6 +20,7 @@ export const DEPENDENCIES = {
 interface AddCreditsTabsProps {
   initialTab?: AddCreditsTab;
   onDone: (amount: number, organization?: string) => void;
+  onRedeemed?: () => void;
   isWalletReady?: boolean;
   onProcessingChange?: (isProcessing: boolean) => void;
   dependencies?: typeof DEPENDENCIES;
@@ -34,7 +35,14 @@ interface AddCreditsTabsProps {
  * inactive tab trigger is disabled while a flow is in progress so the user
  * cannot navigate away mid-transaction.
  */
-export function AddCreditsTabs({ initialTab = "purchase", onDone, isWalletReady, onProcessingChange, dependencies: d = DEPENDENCIES }: AddCreditsTabsProps) {
+export function AddCreditsTabs({
+  initialTab = "purchase",
+  onDone,
+  onRedeemed,
+  isWalletReady,
+  onProcessingChange,
+  dependencies: d = DEPENDENCIES
+}: AddCreditsTabsProps) {
   const [activeTab, setActiveTab] = useState<AddCreditsTab>(initialTab);
   const [purchaseProcessing, setPurchaseProcessing] = useState(false);
   const [couponProcessing, setCouponProcessing] = useState(false);
@@ -72,7 +80,7 @@ export function AddCreditsTabs({ initialTab = "purchase", onDone, isWalletReady,
       </d.TabsContent>
 
       <d.TabsContent value="coupon">
-        <d.RedeemCouponForm isWalletReady={isWalletReady} onProcessingChange={setCouponProcessing} />
+        <d.RedeemCouponForm isWalletReady={isWalletReady} onProcessingChange={setCouponProcessing} onRedeemed={onRedeemed} />
       </d.TabsContent>
     </d.Tabs>
   );

--- a/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.spec.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { useForm } from "react-hook-form";
+import { IntlProvider } from "react-intl";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import { handleCouponError } from "@src/utils/stripeErrorHandler";
@@ -11,7 +12,11 @@ import { RedeemCouponForm } from "./RedeemCouponForm";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 
 describe(RedeemCouponForm.name, () => {
-  it("applies the coupon, refreshes the balance, shows inline success and resets the field", async () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("applies the coupon, refreshes the balance, shows the dollar amount inline and resets the field", async () => {
     const applyCoupon = vi.fn().mockResolvedValue({ coupon: null, amountAdded: 100 });
     const pollForPayment = vi.fn();
 
@@ -22,8 +27,8 @@ describe(RedeemCouponForm.name, () => {
     await submit();
 
     expect(applyCoupon).toHaveBeenCalledWith({ coupon: "AKASH-1234-5678", userId: "user_1" });
-    expect(pollForPayment).toHaveBeenCalledTimes(1);
-    expect(screen.getByText(/100 credits added/i)).toBeInTheDocument();
+    expect(pollForPayment).toHaveBeenCalledWith({ variant: "coupon" });
+    expect(screen.getByText(/added to your balance/i)).toHaveTextContent("$100.00");
     expect(couponInput().value).toBe("");
   });
 
@@ -52,7 +57,7 @@ describe(RedeemCouponForm.name, () => {
     await submit();
 
     expect(screen.getByText(/this coupon has expired or is no longer valid/i)).toBeInTheDocument();
-    expect(screen.queryByText(/credits added/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/added to your balance/i)).not.toBeInTheDocument();
   });
 
   it("keeps the redeem button disabled and does not submit while the code is empty", async () => {
@@ -84,6 +89,48 @@ describe(RedeemCouponForm.name, () => {
     expect(onProcessingChange).toHaveBeenCalledWith(true);
   });
 
+  it("closes the sheet shortly after a credit-adding redemption settles", async () => {
+    const onRedeemed = vi.fn();
+    const applyCoupon = vi.fn().mockResolvedValue({ coupon: null, amountAdded: 100 });
+
+    const { setPolling } = setup({ applyCoupon, onRedeemed });
+
+    typeCoupon("AKASH-1234-5678");
+    await submit();
+
+    // The balance poll runs (processing) then settles; only then does the auto-close fire.
+    act(() => setPolling(true));
+    vi.useFakeTimers();
+    act(() => setPolling(false));
+
+    expect(onRedeemed).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(onRedeemed).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close the sheet when the coupon adds no credits", async () => {
+    const onRedeemed = vi.fn();
+    const applyCoupon = vi.fn().mockResolvedValue({ coupon: null, amountAdded: 0 });
+
+    const { setPolling } = setup({ applyCoupon, onRedeemed });
+
+    typeCoupon("AKASH-1234-5678");
+    await submit();
+
+    vi.useFakeTimers();
+    act(() => setPolling(true));
+    act(() => setPolling(false));
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(onRedeemed).not.toHaveBeenCalled();
+  });
+
   function couponInput() {
     return screen.getByLabelText(/coupon code/i) as HTMLInputElement;
   }
@@ -109,7 +156,10 @@ describe(RedeemCouponForm.name, () => {
     isPolling?: boolean;
     isWalletReady?: boolean;
     onProcessingChange?: (isProcessing: boolean) => void;
+    onRedeemed?: () => void;
   }) {
+    const pollingRef = { current: input.isPolling ?? false };
+
     const useUser: typeof DEPENDENCIES.useUser = () =>
       mock<ReturnType<typeof DEPENDENCIES.useUser>>({
         user: { userId: "user_1", id: "user_1" } as ReturnType<typeof DEPENDENCIES.useUser>["user"]
@@ -127,23 +177,39 @@ describe(RedeemCouponForm.name, () => {
       mock<ReturnType<typeof DEPENDENCIES.usePaymentPolling>>({
         pollForPayment: input.pollForPayment ?? vi.fn(),
         stopPolling: vi.fn(),
-        isPolling: input.isPolling ?? false
+        isPolling: pollingRef.current
       });
 
-    return render(
-      <RedeemCouponForm
-        isWalletReady={input.isWalletReady ?? true}
-        onProcessingChange={input.onProcessingChange}
-        dependencies={{
-          useForm,
-          zodResolver,
-          useUser,
-          usePaymentMutations,
-          usePaymentPolling,
-          handleCouponError,
-          handleStripeError: vi.fn().mockReturnValue({ message: "Something went wrong.", userAction: undefined })
-        }}
-      />
+    const dependencies = {
+      useForm,
+      zodResolver,
+      useUser,
+      usePaymentMutations,
+      usePaymentPolling,
+      handleCouponError,
+      handleStripeError: vi.fn().mockReturnValue({ message: "Something went wrong.", userAction: undefined })
+    };
+
+    // Build a fresh element each render so React does not bail out on an identical
+    // element reference; the mocked polling hook reads `pollingRef` at call time.
+    const build = () => (
+      <IntlProvider locale="en-US" defaultLocale="en-US">
+        <RedeemCouponForm
+          isWalletReady={input.isWalletReady ?? true}
+          onProcessingChange={input.onProcessingChange}
+          onRedeemed={input.onRedeemed}
+          dependencies={dependencies}
+        />
+      </IntlProvider>
     );
+
+    const utils = render(build());
+
+    const setPolling = (value: boolean) => {
+      pollingRef.current = value;
+      utils.rerender(build());
+    };
+
+    return { ...utils, setPolling };
   }
 });

--- a/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.spec.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { handleCouponError } from "@src/utils/stripeErrorHandler";
+import type { DEPENDENCIES } from "./RedeemCouponForm";
+import { RedeemCouponForm } from "./RedeemCouponForm";
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+describe(RedeemCouponForm.name, () => {
+  it("applies the coupon, refreshes the balance, shows inline success and resets the field", async () => {
+    const applyCoupon = vi.fn().mockResolvedValue({ coupon: null, amountAdded: 100 });
+    const pollForPayment = vi.fn();
+
+    setup({ applyCoupon, pollForPayment });
+
+    typeCoupon("AKASH-1234-5678");
+
+    await submit();
+
+    expect(applyCoupon).toHaveBeenCalledWith({ coupon: "AKASH-1234-5678", userId: "user_1" });
+    expect(pollForPayment).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/100 credits added/i)).toBeInTheDocument();
+    expect(couponInput().value).toBe("");
+  });
+
+  it("shows an inline error mapped from the coupon error code", async () => {
+    const applyCoupon = vi.fn().mockResolvedValue({ coupon: null, error: { code: "coupon_expired", message: "nope" } });
+
+    setup({ applyCoupon });
+
+    typeCoupon("EXPIRED-CODE");
+
+    await submit();
+
+    expect(screen.getByText(/this coupon has expired or is no longer valid/i)).toBeInTheDocument();
+    expect(screen.queryByText(/credits added/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps the redeem button disabled and does not submit while the code is empty", async () => {
+    const applyCoupon = vi.fn();
+
+    setup({ applyCoupon });
+
+    expect(redeemButton()).toBeDisabled();
+
+    await submit();
+
+    expect(applyCoupon).not.toHaveBeenCalled();
+  });
+
+  it("disables the redeem button and shows a hint while the wallet is not ready", () => {
+    setup({ isWalletReady: false });
+
+    typeCoupon("AKASH-1234-5678");
+
+    expect(redeemButton()).toBeDisabled();
+    expect(screen.getByText(/setting up your account/i)).toBeInTheDocument();
+  });
+
+  it("reports processing to the parent while the coupon is being applied", () => {
+    const onProcessingChange = vi.fn();
+
+    setup({ isApplyingCoupon: true, onProcessingChange });
+
+    expect(onProcessingChange).toHaveBeenCalledWith(true);
+  });
+
+  function couponInput() {
+    return screen.getByLabelText(/coupon code/i) as HTMLInputElement;
+  }
+
+  function redeemButton() {
+    return screen.getByRole("button", { name: /redeem coupon/i });
+  }
+
+  function typeCoupon(value: string) {
+    fireEvent.change(couponInput(), { target: { value } });
+  }
+
+  async function submit() {
+    await act(async () => {
+      fireEvent.submit(redeemButton().closest("form")!);
+    });
+  }
+
+  function setup(input: {
+    applyCoupon?: ReturnType<typeof DEPENDENCIES.usePaymentMutations>["applyCoupon"]["mutateAsync"];
+    isApplyingCoupon?: boolean;
+    pollForPayment?: ReturnType<typeof DEPENDENCIES.usePaymentPolling>["pollForPayment"];
+    isPolling?: boolean;
+    isWalletReady?: boolean;
+    onProcessingChange?: (isProcessing: boolean) => void;
+  }) {
+    const useUser: typeof DEPENDENCIES.useUser = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useUser>>({
+        user: { userId: "user_1", id: "user_1" } as ReturnType<typeof DEPENDENCIES.useUser>["user"]
+      });
+
+    const usePaymentMutations: typeof DEPENDENCIES.usePaymentMutations = () =>
+      mock<ReturnType<typeof DEPENDENCIES.usePaymentMutations>>({
+        applyCoupon: mock<ReturnType<typeof DEPENDENCIES.usePaymentMutations>["applyCoupon"]>({
+          isPending: input.isApplyingCoupon ?? false,
+          mutateAsync: input.applyCoupon ?? vi.fn().mockResolvedValue({ coupon: null, amountAdded: 0 })
+        })
+      });
+
+    const usePaymentPolling: typeof DEPENDENCIES.usePaymentPolling = () =>
+      mock<ReturnType<typeof DEPENDENCIES.usePaymentPolling>>({
+        pollForPayment: input.pollForPayment ?? vi.fn(),
+        stopPolling: vi.fn(),
+        isPolling: input.isPolling ?? false
+      });
+
+    return render(
+      <RedeemCouponForm
+        isWalletReady={input.isWalletReady ?? true}
+        onProcessingChange={input.onProcessingChange}
+        dependencies={{
+          useForm,
+          zodResolver,
+          useUser,
+          usePaymentMutations,
+          usePaymentPolling,
+          handleCouponError,
+          handleStripeError: vi.fn().mockReturnValue({ message: "Something went wrong.", userAction: undefined })
+        }}
+      />
+    );
+  }
+});

--- a/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.spec.tsx
@@ -27,6 +27,21 @@ describe(RedeemCouponForm.name, () => {
     expect(couponInput().value).toBe("");
   });
 
+  it("shows an inline applied message and skips polling when the coupon adds no credits", async () => {
+    const applyCoupon = vi.fn().mockResolvedValue({ coupon: null, amountAdded: 0 });
+    const pollForPayment = vi.fn();
+
+    setup({ applyCoupon, pollForPayment });
+
+    typeCoupon("AKASH-1234-5678");
+
+    await submit();
+
+    expect(applyCoupon).toHaveBeenCalledWith({ coupon: "AKASH-1234-5678", userId: "user_1" });
+    expect(pollForPayment).not.toHaveBeenCalled();
+    expect(screen.getByText(/no credits were added to your balance/i)).toBeInTheDocument();
+  });
+
   it("shows an inline error mapped from the coupon error code", async () => {
     const applyCoupon = vi.fn().mockResolvedValue({ coupon: null, error: { code: "coupon_expired", message: "nope" } });
 

--- a/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { Alert, AlertDescription, AlertTitle, Form, FormField, FormInput, LoadingButton } from "@akashnetwork/ui/components";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+import { usePaymentPolling } from "@src/context/PaymentPollingProvider";
+import { useUser } from "@src/hooks/useUser";
+import { usePaymentMutations } from "@src/queries";
+import { handleCouponError, handleStripeError } from "@src/utils/stripeErrorHandler";
+
+const couponFormSchema = z.object({
+  coupon: z.string().trim().min(1, "Coupon code is required")
+});
+
+type CouponFormValues = z.infer<typeof couponFormSchema>;
+
+export const DEPENDENCIES = {
+  useForm,
+  zodResolver,
+  useUser,
+  usePaymentMutations,
+  usePaymentPolling,
+  handleCouponError,
+  handleStripeError
+};
+
+interface RedeemCouponFormProps {
+  isWalletReady?: boolean;
+  onProcessingChange?: (isProcessing: boolean) => void;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+/**
+ * Redeems a fixed-amount coupon into the managed wallet. Applying a coupon is
+ * side-effecting (it creates a Stripe invoice and credits the wallet), so there
+ * is no preview step: the user submits a code, we apply it, then poll to refresh
+ * the balance. Feedback stays inline — success and failure both render an Alert
+ * and the surrounding sheet stays open so the user closes it themselves.
+ */
+export function RedeemCouponForm({ isWalletReady = true, onProcessingChange, dependencies: d = DEPENDENCIES }: RedeemCouponFormProps) {
+  const { user } = d.useUser();
+  const { pollForPayment, isPolling } = d.usePaymentPolling();
+  const {
+    applyCoupon: { isPending: isApplyingCoupon, mutateAsync: applyCoupon }
+  } = d.usePaymentMutations();
+
+  const [successAmount, setSuccessAmount] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [errorAction, setErrorAction] = useState<string | null>(null);
+
+  const form = d.useForm<CouponFormValues>({
+    defaultValues: { coupon: "" },
+    resolver: d.zodResolver(couponFormSchema)
+  });
+
+  const isProcessing = isApplyingCoupon || isPolling;
+  const coupon = form.watch("coupon");
+  const canSubmit = coupon.trim().length > 0 && isWalletReady && !isProcessing;
+
+  useEffect(
+    function reportProcessing() {
+      onProcessingChange?.(isProcessing);
+    },
+    [isProcessing, onProcessingChange]
+  );
+
+  const clearMessages = () => {
+    setSuccessAmount(null);
+    setError(null);
+    setErrorAction(null);
+  };
+
+  const finalizeError = (info: { message: string; userAction?: string }) => {
+    setSuccessAmount(null);
+    setError(info.message);
+    setErrorAction(info.userAction ?? null);
+  };
+
+  const onRedeem = async ({ coupon }: CouponFormValues) => {
+    if (!user?.id) {
+      finalizeError({ message: "Unable to apply coupon. Please refresh the page and try again." });
+      return;
+    }
+
+    clearMessages();
+
+    try {
+      const response = await applyCoupon({ coupon: coupon.trim(), userId: user.id });
+
+      if (response.error) {
+        finalizeError(d.handleCouponError(response));
+        return;
+      }
+
+      if (response.amountAdded && response.amountAdded > 0) {
+        pollForPayment();
+        setSuccessAmount(response.amountAdded);
+        form.reset();
+      }
+    } catch (err) {
+      finalizeError(d.handleStripeError(err));
+    }
+  };
+
+  return (
+    <Form {...form}>
+      <form className="space-y-6" onSubmit={form.handleSubmit(onRedeem)}>
+        <FormField
+          control={form.control}
+          name="coupon"
+          render={({ field }) => (
+            <FormInput
+              {...field}
+              type="text"
+              label="Coupon code"
+              placeholder="AKASH-XXXX-XXXX"
+              autoComplete="off"
+              onChange={e => {
+                field.onChange(e);
+                clearMessages();
+              }}
+            />
+          )}
+        />
+
+        {successAmount !== null && (
+          <Alert variant="success">
+            <AlertTitle className="text-sm font-medium">Coupon applied</AlertTitle>
+            <AlertDescription>{successAmount} credits added to your balance.</AlertDescription>
+          </Alert>
+        )}
+
+        {error && (
+          <Alert variant="destructive">
+            <AlertDescription>
+              <span className="block font-medium">{error}</span>
+              {errorAction && <span className="mt-1 block text-sm">{errorAction}</span>}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <div className="space-y-2">
+          <LoadingButton type="submit" className="w-full" loading={isProcessing} disabled={!canSubmit}>
+            Redeem coupon
+          </LoadingButton>
+          {!isWalletReady && <p className="text-center text-sm text-muted-foreground">Setting up your account…</p>}
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
+import { FormattedNumber } from "react-intl";
 import { Alert, AlertDescription, AlertTitle, Form, FormField, FormInput, LoadingButton } from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -17,6 +18,9 @@ const couponFormSchema = z.object({
 
 type CouponFormValues = z.infer<typeof couponFormSchema>;
 
+/** How long the success alert stays visible before the sheet auto-closes. */
+const AUTO_CLOSE_DELAY_MS = 1500;
+
 export const DEPENDENCIES = {
   useForm,
   zodResolver,
@@ -30,6 +34,7 @@ export const DEPENDENCIES = {
 interface RedeemCouponFormProps {
   isWalletReady?: boolean;
   onProcessingChange?: (isProcessing: boolean) => void;
+  onRedeemed?: () => void;
   dependencies?: typeof DEPENDENCIES;
 }
 
@@ -37,10 +42,12 @@ interface RedeemCouponFormProps {
  * Redeems a fixed-amount coupon into the managed wallet. Applying a coupon is
  * side-effecting (it creates a Stripe invoice and credits the wallet), so there
  * is no preview step: the user submits a code, we apply it, then poll to refresh
- * the balance. Feedback stays inline — success and failure both render an Alert
- * and the surrounding sheet stays open so the user closes it themselves.
+ * the balance. Feedback stays inline via an Alert; once a credit-adding redemption
+ * settles (balance poll done and, for trial users, the trial flipped) the success
+ * alert shows briefly and then `onRedeemed` fires to close the sheet. Failures and
+ * no-credit coupons keep the sheet open for another attempt.
  */
-export function RedeemCouponForm({ isWalletReady = true, onProcessingChange, dependencies: d = DEPENDENCIES }: RedeemCouponFormProps) {
+export function RedeemCouponForm({ isWalletReady = true, onProcessingChange, onRedeemed, dependencies: d = DEPENDENCIES }: RedeemCouponFormProps) {
   const { user } = d.useUser();
   const { pollForPayment, isPolling } = d.usePaymentPolling();
   const {
@@ -51,6 +58,9 @@ export function RedeemCouponForm({ isWalletReady = true, onProcessingChange, dep
   const [appliedMessage, setAppliedMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [errorAction, setErrorAction] = useState<string | null>(null);
+
+  const wasProcessingRef = useRef(false);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const form = d.useForm<CouponFormValues>({
     defaultValues: { coupon: "" },
@@ -67,6 +77,28 @@ export function RedeemCouponForm({ isWalletReady = true, onProcessingChange, dep
     },
     [isProcessing, onProcessingChange]
   );
+
+  useEffect(
+    function autoCloseAfterSuccessfulRedeem() {
+      const wasProcessing = wasProcessingRef.current;
+      wasProcessingRef.current = isProcessing;
+
+      // A credit-adding redemption keeps `isProcessing` true through the balance poll
+      // (and, for trial users, until the trial flips). Once it settles, leave the success
+      // alert up briefly, then close the sheet via onRedeemed.
+      if (wasProcessing && !isProcessing && successAmount !== null) {
+        if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
+        closeTimeoutRef.current = setTimeout(() => onRedeemed?.(), AUTO_CLOSE_DELAY_MS);
+      }
+    },
+    [isProcessing, successAmount, onRedeemed]
+  );
+
+  useEffect(function clearCloseTimeoutOnUnmount() {
+    return () => {
+      if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
+    };
+  }, []);
 
   const clearMessages = () => {
     setSuccessAmount(null);
@@ -99,7 +131,7 @@ export function RedeemCouponForm({ isWalletReady = true, onProcessingChange, dep
       }
 
       if (response.amountAdded && response.amountAdded > 0) {
-        pollForPayment();
+        pollForPayment({ variant: "coupon" });
         setSuccessAmount(response.amountAdded);
         form.reset();
       } else {
@@ -134,7 +166,9 @@ export function RedeemCouponForm({ isWalletReady = true, onProcessingChange, dep
         {successAmount !== null && (
           <Alert variant="success">
             <AlertTitle className="text-sm font-medium">Coupon applied</AlertTitle>
-            <AlertDescription>{successAmount} credits added to your balance.</AlertDescription>
+            <AlertDescription>
+              <FormattedNumber value={successAmount} style="currency" currency="USD" /> added to your balance.
+            </AlertDescription>
           </Alert>
         )}
 

--- a/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/RedeemCouponForm/RedeemCouponForm.tsx
@@ -48,6 +48,7 @@ export function RedeemCouponForm({ isWalletReady = true, onProcessingChange, dep
   } = d.usePaymentMutations();
 
   const [successAmount, setSuccessAmount] = useState<number | null>(null);
+  const [appliedMessage, setAppliedMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [errorAction, setErrorAction] = useState<string | null>(null);
 
@@ -69,12 +70,14 @@ export function RedeemCouponForm({ isWalletReady = true, onProcessingChange, dep
 
   const clearMessages = () => {
     setSuccessAmount(null);
+    setAppliedMessage(null);
     setError(null);
     setErrorAction(null);
   };
 
   const finalizeError = (info: { message: string; userAction?: string }) => {
     setSuccessAmount(null);
+    setAppliedMessage(null);
     setError(info.message);
     setErrorAction(info.userAction ?? null);
   };
@@ -99,6 +102,8 @@ export function RedeemCouponForm({ isWalletReady = true, onProcessingChange, dep
         pollForPayment();
         setSuccessAmount(response.amountAdded);
         form.reset();
+      } else {
+        setAppliedMessage("Coupon applied. No credits were added to your balance.");
       }
     } catch (err) {
       finalizeError(d.handleStripeError(err));
@@ -130,6 +135,13 @@ export function RedeemCouponForm({ isWalletReady = true, onProcessingChange, dep
           <Alert variant="success">
             <AlertTitle className="text-sm font-medium">Coupon applied</AlertTitle>
             <AlertDescription>{successAmount} credits added to your balance.</AlertDescription>
+          </Alert>
+        )}
+
+        {appliedMessage && (
+          <Alert variant="success">
+            <AlertTitle className="text-sm font-medium">Coupon applied</AlertTitle>
+            <AlertDescription>{appliedMessage}</AlertDescription>
           </Alert>
         )}
 

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
@@ -158,6 +158,21 @@ describe(OnboardingPickerPage.name, () => {
     expect((AddCreditsSheet.mock.calls.at(-1)![0] as SheetProps).open).toBe(false);
   });
 
+  it("closes the verification sheet without deploying when a coupon is redeemed", () => {
+    const push = vi.fn();
+    const DeploymentTemplatePickerCard = vi.fn(ComponentMock);
+    const AddCreditsSheet = vi.fn(ComponentMock);
+    setup({ isTrialing: true, push, dependencies: { DeploymentTemplatePickerCard, AddCreditsSheet } });
+
+    act(() => getCard(DeploymentTemplatePickerCard, "LLM Chatbot").onDeploy!());
+    expect((AddCreditsSheet.mock.calls.at(-1)![0] as SheetProps).open).toBe(true);
+
+    act(() => (AddCreditsSheet.mock.calls.at(-1)![0] as SheetProps).onRedeemed!());
+
+    expect((AddCreditsSheet.mock.calls.at(-1)![0] as SheetProps).open).toBe(false);
+    expect(push).not.toHaveBeenCalled();
+  });
+
   it("deploys the LLM template when the verification sheet completes after the gated LLM prompt", () => {
     const push = vi.fn();
     const DeploymentTemplatePickerCard = vi.fn(ComponentMock);

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
@@ -164,6 +164,7 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
           open={addCreditsSheetReason !== null}
           onOpenChange={open => setAddCreditsSheetReason(open ? "unlock-gpu" : null)}
           isWalletReady={isWalletReady}
+          onRedeemed={() => setAddCreditsSheetReason(null)}
           onDone={() => {
             if (addCreditsSheetReason === "unlock-gpu") {
               deployTemplate(TEMPLATE_IDS.llmChatbot);

--- a/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.spec.tsx
+++ b/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.spec.tsx
@@ -231,6 +231,28 @@ describe(PaymentPollingProvider.name, () => {
     cleanup();
   });
 
+  it("shows coupon copy instead of payment copy for a coupon redemption", async () => {
+    const { enqueueSnackbar, setIsTrialing, advancePollCycle, cleanup } = setup({
+      isTrialing: true,
+      balance: { totalUsd: 100 },
+      isWalletBalanceLoading: false
+    });
+
+    await act(async () => {
+      screen.getByTestId("start-polling-coupon").click();
+    });
+
+    expect(enqueueSnackbar).toHaveBeenCalledWith(snackbarWithTitle("Applying coupon..."), expect.anything());
+    expect(enqueueSnackbar).not.toHaveBeenCalledWith(snackbarWithTitle("Processing payment..."), expect.anything());
+
+    await setIsTrialing(false);
+    await advancePollCycle();
+
+    expect(enqueueSnackbar).toHaveBeenCalledWith(snackbarWithTitle("Coupon applied!"), expect.objectContaining({ variant: "success" }));
+
+    cleanup();
+  });
+
   function snackbarWithTitle(title: string) {
     return expect.objectContaining({ props: expect.objectContaining({ title }) });
   }
@@ -293,6 +315,9 @@ describe(PaymentPollingProvider.name, () => {
           <div data-testid="is-polling">{isPolling.toString()}</div>
           <button data-testid="start-polling" onClick={() => pollForPayment()}>
             Start Polling
+          </button>
+          <button data-testid="start-polling-coupon" onClick={() => pollForPayment({ variant: "coupon" })}>
+            Start Coupon Polling
           </button>
           <button data-testid="stop-polling" onClick={stopPolling}>
             Stop Polling

--- a/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.tsx
+++ b/apps/deploy-web/src/context/PaymentPollingProvider/PaymentPollingProvider.tsx
@@ -12,6 +12,20 @@ const POLLING_INTERVAL_MS = 2000;
 const MAX_POLLING_DURATION_MS = 30000;
 const MAX_ATTEMPTS = MAX_POLLING_DURATION_MS / POLLING_INTERVAL_MS;
 
+export type PaymentPollingVariant = "payment" | "coupon";
+
+/** Snackbar copy per flow. The coupon flow avoids "payment" wording since redeeming a coupon is not a charge. */
+const POLLING_COPY: Record<PaymentPollingVariant, { loading: { title: string; subTitle: string }; success: { title: string; subTitle: string } }> = {
+  payment: {
+    loading: { title: "Processing payment...", subTitle: "Please wait while we update your balance" },
+    success: { title: "Payment successful!", subTitle: "Your balance has been updated" }
+  },
+  coupon: {
+    loading: { title: "Applying coupon...", subTitle: "Please wait while we add your credits" },
+    success: { title: "Coupon applied!", subTitle: "Your balance has been updated" }
+  }
+};
+
 export const DEPENDENCIES = {
   useWallet,
   useWalletBalance,
@@ -23,9 +37,10 @@ export const DEPENDENCIES = {
 
 export interface PaymentPollingContextType {
   /**
-   * Start polling for balance updates after payment.
+   * Start polling for balance updates after a payment or coupon redemption.
+   * `variant` selects the snackbar copy (defaults to "payment").
    */
-  pollForPayment: (initialBalance?: number | null) => void;
+  pollForPayment: (options?: { initialBalance?: number | null; variant?: PaymentPollingVariant }) => void;
   /**
    * Stop polling (optional - usually not needed)
    */
@@ -59,6 +74,7 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
   const initialTrialingRef = useRef<boolean>(wasTrialing);
   const loadingSnackbarKeyRef = useRef<string | number | null>(null);
   const hasSignaledSuccessRef = useRef<boolean>(false);
+  const variantRef = useRef<PaymentPollingVariant>("payment");
 
   const closeLoadingSnackbar = useCallback(() => {
     if (loadingSnackbarKeyRef.current) {
@@ -99,12 +115,13 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
   }, [stopPolling, enqueueSnackbar, refetchBalance, refetchManagedWallet, d]);
 
   const pollForPayment = useCallback(
-    (initialBalance?: number | null) => {
+    (options?: { initialBalance?: number | null; variant?: PaymentPollingVariant }) => {
       if (isPolling) {
         return;
       }
 
-      const balanceToUse = initialBalance ?? currentBalance?.totalUsd ?? null;
+      variantRef.current = options?.variant ?? "payment";
+      const balanceToUse = options?.initialBalance ?? currentBalance?.totalUsd ?? null;
       initialBalanceRef.current = balanceToUse;
       initialTrialingRef.current = wasTrialing;
       hasSignaledSuccessRef.current = false;
@@ -112,7 +129,8 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
       attemptCountRef.current = 0;
       setIsPolling(true);
 
-      const loadingSnackbarKey = enqueueSnackbar(<d.Snackbar title="Processing payment..." subTitle="Please wait while we update your balance" showLoading />, {
+      const { title, subTitle } = POLLING_COPY[variantRef.current].loading;
+      const loadingSnackbarKey = enqueueSnackbar(<d.Snackbar title={title} subTitle={subTitle} showLoading />, {
         variant: "info",
         autoHideDuration: null,
         persist: true
@@ -173,7 +191,8 @@ export const PaymentPollingProvider: React.FC<PaymentPollingProviderProps> = ({ 
 
       hasSignaledSuccessRef.current = true;
       closeLoadingSnackbar();
-      enqueueSnackbar(<d.Snackbar title="Payment successful!" subTitle="Your balance has been updated" iconVariant="success" />, { variant: "success" });
+      const { title, subTitle } = POLLING_COPY[variantRef.current].success;
+      enqueueSnackbar(<d.Snackbar title={title} subTitle={subTitle} iconVariant="success" />, { variant: "success" });
 
       if (initialTrialingRef.current) {
         analyticsService.track("trial_completed", {


### PR DESCRIPTION
## Why

With coupons now being fixed-amount Stripe credits, the redesigned **Add credits** sheet needs a clear split between *buying* credit and *redeeming* a coupon. Today the new sheet only has a purchase flow; coupon redemption lives only in the legacy `PaymentPopup`.

Ref CON-368

<img width="591" height="886" alt="image" src="https://github.com/user-attachments/assets/418d0c75-88b6-470f-8d7b-ba5e81b06b57" />
<img width="631" height="882" alt="image" src="https://github.com/user-attachments/assets/59746331-95ca-4760-aa92-b4da9dbc5e89" />
<img width="613" height="876" alt="image" src="https://github.com/user-attachments/assets/85b45890-b824-4045-8709-13d46d3028e0" />



## What

Reorganizes the redesigned Add Credits sheet into two tabs — **Purchase credits** and **Redeem coupon** — reusing the existing coupon mutation and error handling. **No backend changes** (coupon apply already exists end-to-end).

- **`RedeemCouponForm`** (new): reuses `usePaymentMutations().applyCoupon`, `usePaymentPolling().pollForPayment`, and `handleCouponError`. Feedback is inline (success/destructive `Alert`); on success it polls to refresh the balance, shows a confirmation, and resets the field — the sheet stays open so the user closes it via the X. The redeem button is gated on wallet readiness with a "Setting up your account…" hint.
- **`AddCreditsTabs`** (new): controlled Radix tabs wrapper. Only the active tab's content is mounted (so the purchase tab's Stripe SetupIntent lazy-mounts and the coupon form resets on switch). Aggregates processing state from both children for the sheet's close-guard and disables the inactive trigger mid-transaction.
- **`AddCreditsSheet`** (edit): renders `AddCreditsTabs`, threads a new `initialTab` prop, and uses the generic free-plan header copy. Close-guard behavior preserved.

The legacy `PaymentPopup` is left untouched.

Follow-up (PR 2, out of scope here): hackathon entry points behind a `hackathons` feature flag that open the sheet with `initialTab="coupon"`.

### Tests

Colocated `*.spec.tsx` for all three components (18 tests): coupon success/error/empty/wallet-gating/processing, tab default/initial/aggregated-processing/inactive-disable, and sheet render/thread/close-guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a two-tab credits flow to purchase credits or redeem a coupon.
  * The credits sheet can now open on a specified tab (Purchase or Coupon).
  * Coupon redemption now supports a completion flow that can trigger sheet closure.
* **Bug Fixes**
  * Improved credits sheet close behavior to stay open during purchase/coupon processing.
  * Tab switching is disabled while the active tab’s action is in progress.
  * Coupon polling now uses coupon-specific snackbar loading and success messages.
  * Fixed invoice-based coupon top-up trial-ending behavior.
* **Tests**
  * Expanded coverage for tabs, processing-state behavior, coupon redemption outcomes, and polling/snackbar messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->