### PR TITLE
feat: implements possibility to choose custom provider

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/AutoDeployFlow/AutoDeployFlow.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/AutoDeployFlow/AutoDeployFlow.spec.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { ResumeResolution } from "../ResumeDeploymentGuard/ResumeDeploymentGuard";
+import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
 import type { DEPENDENCIES } from "./AutoDeployFlow";
 import { AutoDeployFlow } from "./AutoDeployFlow";
 
@@ -14,31 +15,17 @@ type FlowResult = ReturnType<typeof DEPENDENCIES.useAutoDeploymentFlow>;
 const CONTACT_SUPPORT_URL = "https://akash.network/discord";
 
 describe(AutoDeployFlow.name, () => {
-  it("drives the phased flow with trial readiness, the resolved SDL, the resumed dseq, and intent params", () => {
-    const useAutoDeploymentFlow = vi.fn(() => buildFlow());
+  it("drives the autopilot with the shared flow, trial readiness, and the resolved SDL", () => {
+    const useAutoDeploymentFlow = vi.fn(() => buildAutopilot());
     const trialError = new Error("trial failed");
-    setup({
-      sdl: "sdl-content",
-      templateId: "hello-world",
-      dseq: "555",
-      draftId: "d1",
-      trial: { isWalletReady: true, error: trialError },
-      useAutoDeploymentFlow
-    });
+    const flow = mock<DeploymentFlow>();
+    setup({ sdl: "sdl-content", flow, isWalletReady: true, trialError, useAutoDeploymentFlow });
 
-    expect(useAutoDeploymentFlow).toHaveBeenCalledWith({
-      sdl: "sdl-content",
-      isWalletReady: true,
-      trialError,
-      initialDseq: "555",
-      templateId: "hello-world",
-      draftId: "d1",
-      resumeLeases: []
-    });
+    expect(useAutoDeploymentFlow).toHaveBeenCalledWith({ sdl: "sdl-content", isWalletReady: true, trialError, resumeLeases: [], flow });
   });
 
   it("forwards the guard's resolved live leases to the flow so it can re-send the manifest", () => {
-    const useAutoDeploymentFlow = vi.fn(() => buildFlow());
+    const useAutoDeploymentFlow = vi.fn(() => buildAutopilot());
     const activeLeases = [{ dseq: "555", gseq: 1, oseq: 2, provider: "akash1provider" }];
     setup({ resume: { activeLeases }, useAutoDeploymentFlow });
 
@@ -49,7 +36,7 @@ describe(AutoDeployFlow.name, () => {
     const PhasedDeployProgressScene = vi.fn(ComponentMock);
     setup({
       templateName: "my-app",
-      flow: { state: { kind: "matching" }, progressPercent: 42 },
+      autopilot: { state: { kind: "matching" }, progressPercent: 42 },
       dependencies: { PhasedDeployProgressScene }
     });
 
@@ -61,14 +48,14 @@ describe(AutoDeployFlow.name, () => {
 
   it("focuses the scene on the matched provider address", () => {
     const PhasedDeployProgressScene = vi.fn(ComponentMock);
-    setup({ flow: { matchedProviderAddress: "akash1provider" }, dependencies: { PhasedDeployProgressScene } });
+    setup({ autopilot: { matchedProviderAddress: "akash1provider" }, dependencies: { PhasedDeployProgressScene } });
 
     expect(PhasedDeployProgressScene).toHaveBeenCalledWith(expect.objectContaining({ focusedProviderAddress: "akash1provider" }), expect.anything());
   });
 
   it("asks the flow to try again when the scene requests it", () => {
     const tryAgain = vi.fn();
-    const { sceneProps } = setup({ flow: { tryAgain } });
+    const { sceneProps } = setup({ autopilot: { tryAgain } });
 
     sceneProps().onTryAgain?.();
 
@@ -78,7 +65,7 @@ describe(AutoDeployFlow.name, () => {
   it("resets the trial before restarting when the trial has errored, so the retry is not a dead-end", () => {
     const tryAgain = vi.fn();
     const retryTrial = vi.fn();
-    const { sceneProps } = setup({ flow: { tryAgain }, trial: { isWalletReady: false, error: new Error("trial failed"), retryTrial } });
+    const { sceneProps } = setup({ autopilot: { tryAgain }, isWalletReady: false, trialError: new Error("trial failed"), retryTrial });
 
     sceneProps().onTryAgain?.();
 
@@ -88,11 +75,23 @@ describe(AutoDeployFlow.name, () => {
 
   it("does not reset the trial on retry when there was no trial error", () => {
     const retryTrial = vi.fn();
-    const { sceneProps } = setup({ flow: { tryAgain: vi.fn() }, trial: { isWalletReady: true, retryTrial } });
+    const { sceneProps } = setup({ autopilot: { tryAgain: vi.fn() }, isWalletReady: true, retryTrial });
 
     sceneProps().onTryAgain?.();
 
     expect(retryTrial).not.toHaveBeenCalled();
+  });
+
+  it("stops the autopilot and switches to manual bid selection when the user chooses a provider", () => {
+    const stopAutopilot = vi.fn();
+    const setBidStrategy = vi.fn();
+    const flow = mock<DeploymentFlow>({ actions: mock<DeploymentFlow["actions"]>({ setBidStrategy }) });
+    const { sceneProps } = setup({ flow, autopilot: { stopAutopilot } });
+
+    sceneProps().onChooseProvider?.();
+
+    expect(stopAutopilot).toHaveBeenCalledTimes(1);
+    expect(setBidStrategy).toHaveBeenCalledWith("select");
   });
 
   it("opens the configured contact-support URL when the scene requests support", () => {
@@ -104,7 +103,7 @@ describe(AutoDeployFlow.name, () => {
     expect(open).toHaveBeenCalledWith("https://support.example", "_blank", "noopener,noreferrer");
   });
 
-  function buildFlow(overrides: Partial<FlowResult> = {}): FlowResult {
+  function buildAutopilot(overrides: Partial<FlowResult> = {}): FlowResult {
     return {
       state: { kind: "creating" },
       progressPercent: 0,
@@ -115,6 +114,7 @@ describe(AutoDeployFlow.name, () => {
       ],
       matchedProviderAddress: null,
       tryAgain: vi.fn(),
+      stopAutopilot: vi.fn(),
       ...overrides
     };
   }
@@ -123,29 +123,19 @@ describe(AutoDeployFlow.name, () => {
     input: {
       templateName?: string;
       sdl?: string;
-      templateId?: string;
-      dseq?: string;
-      draftId?: string;
       resume?: ResumeResolution;
-      trial?: { isWalletReady?: boolean; error?: unknown; retryTrial?: () => void };
+      flow?: DeploymentFlow;
+      isWalletReady?: boolean;
+      trialError?: unknown;
+      retryTrial?: () => void;
       contactSupportUrl?: string;
-      flow?: Partial<FlowResult>;
+      autopilot?: Partial<FlowResult>;
       useAutoDeploymentFlow?: typeof DEPENDENCIES.useAutoDeploymentFlow;
       dependencies?: Partial<typeof DEPENDENCIES>;
     } = {}
   ) {
     const PhasedDeployProgressScene = input.dependencies?.PhasedDeployProgressScene ?? vi.fn(ComponentMock);
-    const useAutoDeploymentFlow: typeof DEPENDENCIES.useAutoDeploymentFlow = input.useAutoDeploymentFlow ?? (() => buildFlow(input.flow));
-
-    // Built as a plain object (not mock<T>) so the passed-through trialError stays referentially intact rather than deep-mocked.
-    const useEnsureTrialStarted: typeof DEPENDENCIES.useEnsureTrialStarted = () =>
-      ({
-        isWalletReady: input.trial?.isWalletReady ?? true,
-        isLoading: false,
-        error: input.trial?.error,
-        refreshWallet: vi.fn(),
-        retryTrial: input.trial?.retryTrial ?? vi.fn()
-      }) as ReturnType<typeof DEPENDENCIES.useEnsureTrialStarted>;
+    const useAutoDeploymentFlow: typeof DEPENDENCIES.useAutoDeploymentFlow = input.useAutoDeploymentFlow ?? (() => buildAutopilot(input.autopilot));
     const useServices: typeof DEPENDENCIES.useServices = () =>
       mock<ReturnType<typeof DEPENDENCIES.useServices>>({
         publicConfig: { NEXT_PUBLIC_CONTACT_SUPPORT_URL: input.contactSupportUrl ?? CONTACT_SUPPORT_URL }
@@ -155,14 +145,14 @@ describe(AutoDeployFlow.name, () => {
       <AutoDeployFlow
         templateName={input.templateName ?? "Hello World"}
         sdl={input.sdl ?? "sdl-content"}
-        templateId={input.templateId}
-        dseq={input.dseq}
-        draftId={input.draftId}
         resume={input.resume ?? { activeLeases: [] }}
+        flow={input.flow ?? mock<DeploymentFlow>()}
+        isWalletReady={input.isWalletReady ?? true}
+        trialError={input.trialError}
+        retryTrial={input.retryTrial ?? vi.fn()}
         dependencies={{
           Layout: ComponentMock,
           PhasedDeployProgressScene,
-          useEnsureTrialStarted,
           useAutoDeploymentFlow,
           useServices,
           ...input.dependencies

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/AutoDeployFlow/AutoDeployFlow.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/AutoDeployFlow/AutoDeployFlow.tsx
@@ -5,14 +5,13 @@ import { useCallback } from "react";
 import Layout from "@src/components/layout/Layout";
 import { useServices } from "@src/context/ServicesProvider";
 import { useAutoDeploymentFlow } from "@src/hooks/useAutoDeploymentFlow/useAutoDeploymentFlow";
-import { useEnsureTrialStarted } from "@src/hooks/useEnsureTrialStarted";
 import { PhasedDeployProgressScene } from "../DeployProgressOverlay/PhasedDeployProgressScene";
 import type { ResumeResolution } from "../ResumeDeploymentGuard/ResumeDeploymentGuard";
+import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
 
 export const DEPENDENCIES = {
   Layout,
   PhasedDeployProgressScene,
-  useEnsureTrialStarted,
   useAutoDeploymentFlow,
   useServices
 };
@@ -22,14 +21,16 @@ type Props = {
   templateName: string;
   /** The resolved SDL to deploy, already derived from the intent's template on the configure screen. */
   sdl: string;
-  /** The template the flow deploys; mirrored into the flow's intent so a URL resume preserves it. */
-  templateId?: string;
-  /** The deployment's dseq when resuming (a reload of the progress view); absent on a fresh start. */
-  dseq?: string;
-  /** The active configure draft id, preserved in the URL when the created dseq is written so a reload resolves the same session. */
-  draftId?: string;
   /** The resume resolution from the {@link ResumeDeploymentGuard}: any live leases to reconstruct so the manifest re-sends. */
   resume: ResumeResolution;
+  /** The shared base flow, created once by the `DeploymentFlowProvider` (seeded from the resolved intent, including a resumed dseq). */
+  flow: DeploymentFlow;
+  /** Whether the trial wallet can broadcast — gates the autopilot's create. */
+  isWalletReady: boolean;
+  /** A terminal start-trial failure, projected to the flow's error state so a held create fails instead of waiting forever. */
+  trialError: unknown;
+  /** Clears a terminal start-trial failure so "Try again" can re-attempt it. */
+  retryTrial: () => void;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -37,26 +38,23 @@ type Props = {
  * The auto-deploy experience of the bid-screening view: when the configure intent is `sdl-strategy=default` +
  * `bid-strategy=auto`, the screen skips the manual form and drives the deployment automatically through the
  * globe + phased progress panel (create deployment → matching providers → preparing), then redirects to the
- * deployment details. Trial readiness is ensured here (mirroring the onboarding picker) so the flow can wait
- * on the trial wallet spinning up before broadcasting. Rendered only in the auto branch so the trial is never
- * auto-started for manual configure visitors.
+ * deployment details. The base flow and trial readiness come from the `DeploymentFlowProvider` (shared with the
+ * manual branch), so this component only autopilots over the flow, waiting on the trial wallet spinning up before
+ * broadcasting.
  *
  * The created deployment's dseq is written into the URL by the underlying `useDeploymentFlow` state machine (the
  * phased flow autopilots over it), so a reload resumes the same deployment — picking up at matching, or at
  * preparing if a lease already exists — instead of creating a new one. Deploy-success navigation is likewise owned
  * by that flow's built-in redirect.
  */
-export const AutoDeployFlow: FC<Props> = ({ templateName, sdl, templateId, dseq, draftId, resume, dependencies: d = DEPENDENCIES }) => {
-  const { isWalletReady, error: trialError, retryTrial } = d.useEnsureTrialStarted();
+export const AutoDeployFlow: FC<Props> = ({ templateName, sdl, resume, flow, isWalletReady, trialError, retryTrial, dependencies: d = DEPENDENCIES }) => {
   const { publicConfig } = d.useServices();
-  const { state, progressPercent, phases, matchedProviderAddress, tryAgain } = d.useAutoDeploymentFlow({
+  const { state, progressPercent, phases, matchedProviderAddress, tryAgain, stopAutopilot } = d.useAutoDeploymentFlow({
     sdl,
     isWalletReady,
     trialError,
-    initialDseq: dseq,
-    templateId,
-    draftId,
-    resumeLeases: resume.activeLeases
+    resumeLeases: resume.activeLeases,
+    flow
   });
 
   /**
@@ -79,6 +77,12 @@ export const AutoDeployFlow: FC<Props> = ({ templateName, sdl, templateId, dseq,
         onTryAgain={resetTrialAndRetryDeploy}
         onContactSupport={() => {
           window.open(publicConfig.NEXT_PUBLIC_CONTACT_SUPPORT_URL, "_blank", "noopener,noreferrer");
+        }}
+        onChooseProvider={() => {
+          // Halt the autopilot before flipping to manual: the bid-strategy change only unmounts this flow once the URL
+          // propagates, so stopping here keeps the autopilot from leasing the shared deployment during that window.
+          stopAutopilot();
+          flow.actions.setBidStrategy("select");
         }}
       />
     </d.Layout>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.spec.tsx
@@ -7,6 +7,7 @@ import { mock } from "vitest-mock-extended";
 import sdlStore from "@src/store/sdlStore";
 import type { TemplateCreation } from "@src/types";
 import { helloWorldTemplate } from "@src/utils/templates";
+import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
 import type { DEPENDENCIES } from "./ConfigureDeployment";
 import { ConfigureDeployment } from "./ConfigureDeployment";
 
@@ -103,8 +104,25 @@ describe(ConfigureDeployment.name, () => {
     expect(ConfigureDeploymentForm).toHaveBeenCalledWith(expect.objectContaining({ initialName: "resumed-name" }), expect.anything());
   });
 
+  it("routes an auto-deploy intent to the auto flow with the shared flow, not the manual form", () => {
+    const { AutoDeployFlow, ConfigureDeploymentForm, DeploymentFlowProvider } = setup({
+      templateId: helloWorldTemplate.code,
+      sdlStrategy: "default",
+      bidStrategy: "auto"
+    });
+
+    expect(ConfigureDeploymentForm).not.toHaveBeenCalled();
+    expect(DeploymentFlowProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: expect.objectContaining({ sdlStrategy: "default", bidStrategy: "auto" }) }),
+      expect.anything()
+    );
+    expect(AutoDeployFlow).toHaveBeenCalledWith(expect.objectContaining({ sdl: helloWorldTemplate.content, flow: expect.anything() }), expect.anything());
+  });
+
   function setup(input: {
     templateId?: string | null;
+    sdlStrategy?: string;
+    bidStrategy?: string;
     draftId?: string;
     persistedSdl?: string;
     persistedName?: string;
@@ -112,6 +130,10 @@ describe(ConfigureDeployment.name, () => {
     deploySdl?: TemplateCreation | null;
   }) {
     const ConfigureDeploymentForm = vi.fn(() => <div data-testid="form-mock" />);
+    const AutoDeployFlow = vi.fn(() => <div data-testid="auto-mock" />);
+    const DeploymentFlowProvider = vi.fn(({ children }) => (
+      <>{children({ flow: mock<DeploymentFlow>(), isWalletReady: true, trialError: undefined, retryTrial: vi.fn() })}</>
+    ));
     const enqueueSnackbar = vi.fn();
     const usePublicTemplate = vi.fn(() => mock<ReturnType<typeof DEPENDENCIES.usePublicTemplate>>(input.template as never));
     const save = vi.fn();
@@ -128,13 +150,16 @@ describe(ConfigureDeployment.name, () => {
 
     const query: Record<string, string> = {};
     if (input.templateId) query.templateId = input.templateId;
+    if (input.sdlStrategy) query["sdl-strategy"] = input.sdlStrategy;
+    if (input.bidStrategy) query["bid-strategy"] = input.bidStrategy;
     const params = new URLSearchParams(query);
 
     const dependencies: typeof DEPENDENCIES = {
       Layout: vi.fn(({ children }) => <div data-testid="layout-mock">{children}</div>) as never,
       NextSeo: vi.fn(() => null) as never,
-      AutoDeployFlow: vi.fn(() => null) as never,
+      AutoDeployFlow: AutoDeployFlow as never,
       ConfigureDeploymentForm: ConfigureDeploymentForm as never,
+      DeploymentFlowProvider: DeploymentFlowProvider as never,
       ResumeDeploymentGuard: vi.fn(({ children }) => <>{children({ activeLeases: [] })}</>) as never,
       usePublicTemplate: usePublicTemplate as never,
       useConfigureDraft: useConfigureDraft as never,
@@ -153,6 +178,6 @@ describe(ConfigureDeployment.name, () => {
       </JotaiStoreProvider>
     );
 
-    return { ConfigureDeploymentForm, usePublicTemplate, useConfigureDraft, enqueueSnackbar };
+    return { ConfigureDeploymentForm, AutoDeployFlow, DeploymentFlowProvider, usePublicTemplate, useConfigureDraft, enqueueSnackbar };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeployment/ConfigureDeployment.tsx
@@ -14,6 +14,7 @@ import type { TemplateCreation } from "@src/types";
 import { hardcodedTemplates } from "@src/utils/templates";
 import { AutoDeployFlow } from "../AutoDeployFlow/AutoDeployFlow";
 import { ConfigureDeploymentForm } from "../ConfigureDeploymentForm/ConfigureDeploymentForm";
+import { DeploymentFlowProvider } from "../DeploymentFlowProvider/DeploymentFlowProvider";
 import { ResumeDeploymentGuard } from "../ResumeDeploymentGuard/ResumeDeploymentGuard";
 import { useConfigureDraft } from "../useConfigureDraft/useConfigureDraft";
 import type { DeploymentIntent } from "../useDeploymentFlow/deploymentIntent";
@@ -24,6 +25,7 @@ export const DEPENDENCIES = {
   NextSeo,
   AutoDeployFlow,
   ConfigureDeploymentForm,
+  DeploymentFlowProvider,
   ResumeDeploymentGuard,
   usePublicTemplate,
   useConfigureDraft,
@@ -83,23 +85,13 @@ export const ConfigureDeployment: FC<Props> = ({ dependencies: d = DEPENDENCIES 
   const templateName = templateQuery.data?.name ?? hardcodedTemplate?.title ?? "your deployment";
 
   // Only the auto flow (with an SDL in hand) can finish an already-leased deployment by re-sending its manifest;
-  // a manual visitor or a cold resume with no SDL is sent to the detail page instead.
+  // a manual visitor or a cold resume with no SDL is sent to the detail page instead. The DeploymentFlowProvider owns
+  // the single flow both branches share — keyed by the draft so a draft change remounts a fresh flow, while an
+  // auto↔manual switch within one draft keeps it. It sits below the guard so the flow only mounts once the guard has
+  // settled the dseq. The template-loading spinner stays above the provider so the trial isn't started mid-fetch.
   return (
     <d.ResumeDeploymentGuard intent={resolvedIntent} canResume={isAutoDeploy && !!initialSdl}>
       {resume => {
-        if (isAutoDeploy && initialSdl) {
-          return (
-            <d.AutoDeployFlow
-              templateId={resolvedIntent.templateId}
-              templateName={templateName}
-              sdl={initialSdl}
-              dseq={resolvedIntent.dseq}
-              draftId={resolvedIntent.draftId}
-              resume={resume}
-            />
-          );
-        }
-
         if (fetchedTemplateId && templateQuery.isLoading) {
           return (
             <d.Layout background="white" disableContainer containerClassName="flex h-[calc(100vh-57px)] flex-col">
@@ -111,7 +103,32 @@ export const ConfigureDeployment: FC<Props> = ({ dependencies: d = DEPENDENCIES 
           );
         }
 
-        return <d.ConfigureDeploymentForm key={draft.draftId} initialSdl={initialSdl} initialName={initialName} intent={resolvedIntent} />;
+        return (
+          <d.DeploymentFlowProvider key={draft.draftId} intent={resolvedIntent}>
+            {({ flow, isWalletReady, trialError, retryTrial }) =>
+              isAutoDeploy && initialSdl ? (
+                <d.AutoDeployFlow
+                  templateName={templateName}
+                  sdl={initialSdl}
+                  resume={resume}
+                  flow={flow}
+                  isWalletReady={isWalletReady}
+                  trialError={trialError}
+                  retryTrial={retryTrial}
+                />
+              ) : (
+                <d.ConfigureDeploymentForm
+                  initialSdl={initialSdl}
+                  initialName={initialName}
+                  intent={resolvedIntent}
+                  flow={flow}
+                  trialError={trialError}
+                  retryTrial={retryTrial}
+                />
+              )
+            }
+          </d.DeploymentFlowProvider>
+        );
       }}
     </d.ResumeDeploymentGuard>
   );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -6,6 +6,7 @@ import type { PlacementType, SdlBuilderFormValuesType, ServiceType } from "@src/
 import { defaultService } from "@src/utils/sdl/data";
 import { ConfigurationPane } from "../ConfigurationPane/ConfigurationPane";
 import { usePlacementManager } from "../DeploymentPane/usePlacementManager/usePlacementManager";
+import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
 import type { DEPENDENCIES } from "./ConfigureDeploymentForm";
 import { ConfigureDeploymentForm, firstBidReadyServiceId, nextUndoneServiceId } from "./ConfigureDeploymentForm";
 
@@ -270,7 +271,7 @@ describe(ConfigureDeploymentForm.name, () => {
 
   it("resets the trial before re-requesting quotes when a previous trial start terminally errored", () => {
     const { ConfigureDeploymentHeader, requestQuotes, retryTrial } = setup({ initialSdl: undefined, trialError: new Error("trial boom") });
-    const headerFlow = (ConfigureDeploymentHeader as ReturnType<typeof vi.fn>).mock.calls[0][0].flow as ReturnType<typeof DEPENDENCIES.useDeploymentFlow>;
+    const headerFlow = (ConfigureDeploymentHeader as ReturnType<typeof vi.fn>).mock.calls[0][0].flow as DeploymentFlow;
 
     headerFlow.actions.requestQuotes("sdl-x");
 
@@ -280,7 +281,7 @@ describe(ConfigureDeploymentForm.name, () => {
 
   it("does not reset the trial when re-requesting quotes without a prior trial error", () => {
     const { ConfigureDeploymentHeader, requestQuotes, retryTrial } = setup({ initialSdl: undefined });
-    const headerFlow = (ConfigureDeploymentHeader as ReturnType<typeof vi.fn>).mock.calls[0][0].flow as ReturnType<typeof DEPENDENCIES.useDeploymentFlow>;
+    const headerFlow = (ConfigureDeploymentHeader as ReturnType<typeof vi.fn>).mock.calls[0][0].flow as DeploymentFlow;
 
     headerFlow.actions.requestQuotes("sdl-x");
 
@@ -310,27 +311,26 @@ describe(ConfigureDeploymentForm.name, () => {
       mock<ReturnType<typeof DEPENDENCIES.useConfigureDraft>>({ draftId: input.draftId ?? "draft-1", persistedSdl: undefined, save, clear })
     );
     const useDeploymentName = ((args: { initialName?: string }) => ({ name: args.initialName ?? "", setName: setDeploymentName })) as never;
+    // The base flow is created upstream by the DeploymentFlowProvider now, so it arrives as a prop rather than a hook.
+    const flow = mock<DeploymentFlow>({
+      phase: "configuring",
+      dseq: null,
+      bidStrategy: "select",
+      deploySucceeded: input.deploySucceeded ?? false,
+      error: input.flowError,
+      actions: mock<DeploymentFlow["actions"]>({ requestQuotes })
+    });
     const dependencies: typeof DEPENDENCIES = {
       Layout: vi.fn(({ children }) => <div data-testid="layout-mock">{children}</div>) as never,
       NextSeo: vi.fn(() => null) as never,
       ConfigureDeploymentHeader,
       ConfigureDeploymentPanes: ConfigureDeploymentPanes as never,
       useConfigureDraft: useConfigureDraft as never,
-      useDeploymentFlow: (() =>
-        mock<ReturnType<typeof DEPENDENCIES.useDeploymentFlow>>({
-          phase: "configuring",
-          dseq: null,
-          bidStrategy: "select",
-          deploySucceeded: input.deploySucceeded ?? false,
-          error: input.flowError,
-          actions: mock<ReturnType<typeof DEPENDENCIES.useDeploymentFlow>["actions"]>({ requestQuotes })
-        })) as never,
       useDeploymentName,
-      useEnsureTrialStarted: () =>
-        mock<ReturnType<typeof DEPENDENCIES.useEnsureTrialStarted>>({ isWalletReady: !input.trialError, error: input.trialError as never, retryTrial }),
       useSnackbar: () => mock<ReturnType<typeof DEPENDENCIES.useSnackbar>>({ enqueueSnackbar }),
       Snackbar: Snackbar as never,
       ReviewAndDeployModal: () => null,
+      DeployProgressOverlay: () => null,
       usePlacementsWithBids: () => new Set<string>()
     };
 
@@ -339,6 +339,9 @@ describe(ConfigureDeploymentForm.name, () => {
         initialSdl={input.initialSdl}
         initialName={input.initialName}
         intent={{ sdlStrategy: "edit", bidStrategy: "select", dseq: undefined, draftId: input.draftId }}
+        flow={flow}
+        trialError={input.trialError}
+        retryTrial={retryTrial}
         dependencies={dependencies}
       />
     );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -289,6 +289,25 @@ describe(ConfigureDeploymentForm.name, () => {
     expect(requestQuotes).toHaveBeenCalledWith("sdl-x");
   });
 
+  it("deselects the focused placement's provider when the review modal is dismissed via Back", async () => {
+    const { flow } = setup({ initialSdl: VALID_SDL, Panes: ProviderSelectProbePanes });
+    const focusedPlacementId = screen.getByTestId("focused-placement").textContent;
+
+    await userEvent.click(screen.getByRole("button", { name: "select provider" }));
+    await userEvent.click(screen.getByRole("button", { name: "back to marketplace" }));
+
+    expect(flow.actions.clearSelection).toHaveBeenCalledWith(focusedPlacementId);
+  });
+
+  it("closes the review modal when it is dismissed via Back", async () => {
+    setup({ initialSdl: VALID_SDL, Panes: ProviderSelectProbePanes });
+
+    await userEvent.click(screen.getByRole("button", { name: "select provider" }));
+    await userEvent.click(screen.getByRole("button", { name: "back to marketplace" }));
+
+    expect(screen.queryByRole("button", { name: "back to marketplace" })).not.toBeInTheDocument();
+  });
+
   function setup(input: {
     initialSdl: string | undefined;
     initialName?: string;
@@ -307,6 +326,13 @@ describe(ConfigureDeploymentForm.name, () => {
     const requestQuotes = vi.fn();
     const retryTrial = vi.fn();
     const setDeploymentName = vi.fn();
+    const ReviewAndDeployModal = vi.fn((props: { open: boolean; onBack: () => void }) =>
+      props.open ? (
+        <button type="button" onClick={props.onBack}>
+          back to marketplace
+        </button>
+      ) : null
+    );
     const useConfigureDraft = vi.fn(() =>
       mock<ReturnType<typeof DEPENDENCIES.useConfigureDraft>>({ draftId: input.draftId ?? "draft-1", persistedSdl: undefined, save, clear })
     );
@@ -316,6 +342,7 @@ describe(ConfigureDeploymentForm.name, () => {
       phase: "configuring",
       dseq: null,
       bidStrategy: "select",
+      selections: {},
       deploySucceeded: input.deploySucceeded ?? false,
       error: input.flowError,
       actions: mock<DeploymentFlow["actions"]>({ requestQuotes })
@@ -329,7 +356,7 @@ describe(ConfigureDeploymentForm.name, () => {
       useDeploymentName,
       useSnackbar: () => mock<ReturnType<typeof DEPENDENCIES.useSnackbar>>({ enqueueSnackbar }),
       Snackbar: Snackbar as never,
-      ReviewAndDeployModal: () => null,
+      ReviewAndDeployModal: ReviewAndDeployModal as never,
       DeployProgressOverlay: () => null,
       usePlacementsWithBids: () => new Set<string>()
     };
@@ -346,7 +373,7 @@ describe(ConfigureDeploymentForm.name, () => {
       />
     );
 
-    return { ConfigureDeploymentPanes, ConfigureDeploymentHeader, enqueueSnackbar, save, clear, requestQuotes, retryTrial };
+    return { ConfigureDeploymentPanes, ConfigureDeploymentHeader, ReviewAndDeployModal, flow, enqueueSnackbar, save, clear, requestQuotes, retryTrial };
   }
 });
 
@@ -402,6 +429,24 @@ interface ProbePanesProps {
   sdl: string;
   selectedServiceId: string;
   onSelectService: (serviceId: string) => void;
+  selectedPlacementId: string;
+  onSelectProvider: (placementId: string, bidId: string) => void;
+}
+
+/**
+ * Panes stand-in that selects a provider for the focused placement, mirroring the marketplace click that
+ * auto-opens the review modal once every placement is chosen. Exposes the focused placement id so the
+ * deselect-on-back behavior can be asserted against the exact placement the modal was opened for.
+ */
+function ProviderSelectProbePanes({ selectedPlacementId, onSelectProvider }: ProbePanesProps) {
+  return (
+    <div>
+      <div data-testid="focused-placement">{selectedPlacementId}</div>
+      <button type="button" onClick={() => onSelectProvider(selectedPlacementId, "bid-1")}>
+        select provider
+      </button>
+    </div>
+  );
 }
 
 /**

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -216,6 +216,16 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
     }
   }
 
+  /**
+   * Closing the review modal via Back drops the provider chosen for the placement currently in focus — the one
+   * whose selection auto-opened the modal — so the user lands back on the marketplace with it deselected and ready
+   * to re-pick, rather than staring at an already-selected placement with no obvious way forward.
+   */
+  function closeReviewAndDeselect() {
+    flow.actions.clearSelection(selectedPlacement.id);
+    setReviewOpen(false);
+  }
+
   const requestQuotes = flow.actions.requestQuotes;
   /**
    * A terminal start-trial error is sticky, so requesting quotes again after one would otherwise fail straight
@@ -273,7 +283,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
           dseq={flow.dseq}
           placements={placements}
           selections={flow.selections}
-          onBack={() => setReviewOpen(false)}
+          onBack={closeReviewAndDeselect}
           onConfirm={() => {
             setReviewOpen(false);
             flow.actions.deploy(liveSdl);

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -9,7 +9,6 @@ import { useSnackbar } from "notistack";
 
 import Layout from "@src/components/layout/Layout";
 import { isLogCollectorService } from "@src/components/sdl/LogCollectorControl/LogCollectorControl";
-import { useEnsureTrialStarted } from "@src/hooks/useEnsureTrialStarted";
 import { usePlacementsWithBids } from "@src/queries/usePlacementsWithBids";
 import type { SdlBuilderFormValuesType, ServiceType } from "@src/types";
 import { SdlBuilderFormValuesSchema } from "@src/types";
@@ -25,7 +24,7 @@ import { DeployProgressOverlay } from "../DeployProgressOverlay/DeployProgressOv
 import { ReviewAndDeployModal } from "../ReviewAndDeployModal/ReviewAndDeployModal";
 import { useConfigureDraft } from "../useConfigureDraft/useConfigureDraft";
 import type { DeploymentIntent } from "../useDeploymentFlow/deploymentIntent";
-import { useDeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
+import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
 import { useDeploymentName } from "../useDeploymentName/useDeploymentName";
 
 export const DEPENDENCIES = {
@@ -36,9 +35,7 @@ export const DEPENDENCIES = {
   ReviewAndDeployModal,
   DeployProgressOverlay,
   useConfigureDraft,
-  useDeploymentFlow,
   useDeploymentName,
-  useEnsureTrialStarted,
   usePlacementsWithBids,
   useSnackbar,
   Snackbar
@@ -51,10 +48,16 @@ type Props = {
   initialSdl?: string;
   initialName?: string;
   intent: DeploymentIntent;
+  /** The shared base flow, created once by the `DeploymentFlowProvider`; this form drives it via the header/panes. */
+  flow: DeploymentFlow;
+  /** A terminal start-trial failure, surfaced so a held quote request fails instead of waiting forever. */
+  trialError: unknown;
+  /** Clears a terminal start-trial failure so requesting quotes again re-attempts the trial first. */
+  retryTrial: () => void;
   dependencies?: typeof DEPENDENCIES;
 };
 
-export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, intent, dependencies: d = DEPENDENCIES }) => {
+export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, intent, flow, trialError, retryTrial, dependencies: d = DEPENDENCIES }) => {
   const [initialState] = useState(() => getInitialState(initialSdl));
   const [liveSdl, setLiveSdl] = useState(initialState.sdl);
   const [previewSdl, setPreviewSdl] = useState(initialState.sdl);
@@ -67,8 +70,6 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
   const lastSelectedServiceId = useRef(selectedServiceId);
   const { enqueueSnackbar } = d.useSnackbar();
   const draft = d.useConfigureDraft(intent);
-  const { isWalletReady, error: trialError, retryTrial } = d.useEnsureTrialStarted();
-  const flow = d.useDeploymentFlow({ intent, isWalletReady, trialError });
   const { name: deploymentName, setName: setDeploymentName } = d.useDeploymentName({ initialName, dseq: flow.dseq });
   const form = useForm<SdlBuilderFormValuesType>({
     defaultValues: initialState.values,

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentFlowProvider/DeploymentFlowProvider.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentFlowProvider/DeploymentFlowProvider.spec.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DeploymentIntent } from "../useDeploymentFlow/deploymentIntent";
+import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
+import type { DEPENDENCIES, DeploymentFlowContext } from "./DeploymentFlowProvider";
+import { DeploymentFlowProvider } from "./DeploymentFlowProvider";
+
+import { render, screen } from "@testing-library/react";
+
+describe(DeploymentFlowProvider.name, () => {
+  it("passes the given intent into the deployment flow", () => {
+    const useDeploymentFlow = vi.fn(() => mock<DeploymentFlow>());
+    const intent = intentFor("555");
+    setup({ intent, useDeploymentFlow });
+
+    expect(useDeploymentFlow).toHaveBeenCalledWith(expect.objectContaining({ intent }));
+  });
+
+  it("exposes the flow and trial handles to its children", () => {
+    const flow = mock<DeploymentFlow>();
+    const retryTrial = vi.fn();
+    const trialError = new Error("trial failed");
+    const { getContext } = setup({ flow, trial: { isWalletReady: true, error: trialError, retryTrial } });
+
+    const context = getContext() as DeploymentFlowContext;
+    expect(context.flow).toBe(flow);
+    expect(context.isWalletReady).toBe(true);
+    expect(context.trialError).toBe(trialError);
+    expect(context.retryTrial).toBe(retryTrial);
+  });
+
+  it("renders its children", () => {
+    setup({});
+
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+  });
+
+  function intentFor(dseq: string | undefined): DeploymentIntent {
+    return { sdlStrategy: "default", bidStrategy: "auto", dseq };
+  }
+
+  function setup(input: {
+    intent?: DeploymentIntent;
+    flow?: DeploymentFlow;
+    trial?: { isWalletReady?: boolean; error?: Error | null; retryTrial?: () => void };
+    useDeploymentFlow?: typeof DEPENDENCIES.useDeploymentFlow;
+  }) {
+    const flow = input.flow ?? mock<DeploymentFlow>();
+    const useDeploymentFlow = input.useDeploymentFlow ?? vi.fn(() => flow);
+    const trial = mock<ReturnType<typeof DEPENDENCIES.useEnsureTrialStarted>>({
+      isWalletReady: input.trial?.isWalletReady ?? false,
+      retryTrial: input.trial?.retryTrial ?? vi.fn()
+    });
+    // Assigned after construction: an Error passed inside the mock<T>() partial gets auto-mocked, losing its identity.
+    trial.error = input.trial?.error ?? null;
+    const useEnsureTrialStarted: typeof DEPENDENCIES.useEnsureTrialStarted = () => trial;
+
+    let context: DeploymentFlowContext | undefined;
+    const renderChild = (received: DeploymentFlowContext) => {
+      context = received;
+      return <div data-testid="child" />;
+    };
+
+    render(
+      <DeploymentFlowProvider
+        intent={input.intent ?? intentFor(undefined)}
+        dependencies={{ useDeploymentFlow: useDeploymentFlow as never, useEnsureTrialStarted }}
+      >
+        {renderChild}
+      </DeploymentFlowProvider>
+    );
+
+    return { getContext: () => context };
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentFlowProvider/DeploymentFlowProvider.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/DeploymentFlowProvider/DeploymentFlowProvider.tsx
@@ -1,0 +1,42 @@
+"use client";
+import type { FC, ReactNode } from "react";
+
+import { useEnsureTrialStarted } from "@src/hooks/useEnsureTrialStarted";
+import type { DeploymentIntent } from "../useDeploymentFlow/deploymentIntent";
+import type { DeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
+import { useDeploymentFlow } from "../useDeploymentFlow/useDeploymentFlow";
+
+export const DEPENDENCIES = { useEnsureTrialStarted, useDeploymentFlow };
+
+/** The shared flow state machine plus the trial-readiness handles both configure branches need. */
+export type DeploymentFlowContext = {
+  flow: DeploymentFlow;
+  /** Whether the trial wallet can broadcast — gates the create so requesting quotes waits for the trial to provision. */
+  isWalletReady: boolean;
+  /** A terminal start-trial failure, surfaced so a held create fails instead of waiting forever. */
+  trialError: unknown;
+  /** Clears a terminal start-trial failure so a deploy retry can re-attempt it. */
+  retryTrial: () => void;
+};
+
+interface Props {
+  /** The resolved configure intent whose dseq (already settled by the `ResumeDeploymentGuard`) seeds the flow. */
+  intent: DeploymentIntent;
+  children: (context: DeploymentFlowContext) => ReactNode;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+/**
+ * Owns the single base deployment flow (and trial readiness) for the configure screen, so the auto and manual branches
+ * share one state machine instead of each mounting their own. Rendered below the `ResumeDeploymentGuard`: the flow
+ * seeds its initial phase/dseq from `intent.dseq` at mount, so it must only be created once the guard has settled that
+ * dseq (stripped a dead one on 404, kept an open one on resume) — creating it above the guard would pin the flow to a
+ * dseq the guard may still discard. Keyed by the draft id upstream, so switching drafts remounts it (a fresh flow),
+ * while an auto→manual switch within the same draft keeps the instance so the in-progress deployment is handed off
+ * rather than abandoned.
+ */
+export const DeploymentFlowProvider: FC<Props> = ({ intent, children, dependencies: d = DEPENDENCIES }) => {
+  const { isWalletReady, error: trialError, retryTrial } = d.useEnsureTrialStarted();
+  const flow = d.useDeploymentFlow({ intent, isWalletReady, trialError });
+  return <>{children({ flow, isWalletReady, trialError, retryTrial })}</>;
+};

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ResumeDeploymentGuard/ResumeDeploymentGuard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ResumeDeploymentGuard/ResumeDeploymentGuard.spec.tsx
@@ -33,7 +33,7 @@ describe(ResumeDeploymentGuard.name, () => {
     const intent = intentFor("555");
     const { replace, enqueueSnackbar } = setup({ intent, query: { error: new ApiError(404, { message: "Deployment not found" }, "GET → 404") } });
 
-    expect(enqueueSnackbar).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "error" }));
+    expect(enqueueSnackbar).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "warning" }));
     expect(replace).toHaveBeenCalledWith(buildConfigureUrl(intent, undefined, intent.bidStrategy));
     expect(screen.queryByTestId("child")).not.toBeInTheDocument();
   });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ResumeDeploymentGuard/ResumeDeploymentGuard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ResumeDeploymentGuard/ResumeDeploymentGuard.tsx
@@ -109,7 +109,7 @@ export const ResumeDeploymentGuard: FC<Props> = ({ intent, canResume, children, 
             notifiedRef.current = true;
             enqueueSnackbar(
               <d.Snackbar title="Deployment not found" subTitle="It may have been closed. Starting a new deployment instead." iconVariant="error" />,
-              { variant: "error" }
+              { variant: "warning" }
             );
             router.replace(buildConfigureUrl(intent, undefined, intent.bidStrategy));
           }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
@@ -33,6 +33,26 @@ describe(useDeploymentFlow.name, () => {
     expect(replace).toHaveBeenCalledWith("/new-deployment/configure/999?bid-strategy=select", undefined, { shallow: true });
   });
 
+  it("mirrors the strategy current when a create resolves, not the one it was fired with", () => {
+    const replace = vi.fn();
+    let resolveCreate: ((result: { data: { dseq: string; manifest: string } }) => void) | undefined;
+    const createMutate = vi.fn((_args, { onSuccess }) => {
+      resolveCreate = onSuccess;
+    });
+    const { result } = setup({ replace, createMutate, intent: { sdlStrategy: "default", bidStrategy: "auto" } });
+
+    // The auto autopilot fires the create as "auto"; the user then picks "Choose my provider" (switches to select) while
+    // it's still in flight. When the create finally resolves, the URL must land on select — not bounce back to auto and
+    // remount the auto flow.
+    act(() => result.current.actions.requestQuotes("sdl-content"));
+    act(() => result.current.actions.setBidStrategy("select"));
+    act(() => resolveCreate?.({ data: { dseq: "999", manifest: "m" } }));
+
+    expect(result.current.bidStrategy).toBe("select");
+    expect(replace).toHaveBeenLastCalledWith(expect.stringContaining("bid-strategy=select"), undefined, { shallow: true });
+    expect(replace).not.toHaveBeenCalledWith(expect.stringContaining("bid-strategy=auto"), undefined, { shallow: true });
+  });
+
   it("surfaces a retryable error when create fails", async () => {
     const createMutate = vi.fn((_args, { onError }) => onError(new Error("boom")));
     const { result } = setup({ createMutate });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -133,6 +133,13 @@ export function useDeploymentFlow(
   const intentRef = useRef(intent);
   intentRef.current = intent;
 
+  // Always-current bid strategy for the async create-success callback below. The auto autopilot fires the create as
+  // "auto", but the user can switch to "select" ("Choose my provider") while it's still in flight; reading the ref
+  // keeps the create-success URL on whatever strategy is current, so a late create doesn't bounce the user back to the
+  // auto page after they've moved to the manual one.
+  const bidStrategyRef = useRef(bidStrategy);
+  bidStrategyRef.current = bidStrategy;
+
   const bidsQuery = dependencies.useListBids(dseq, { enabled: phase === "quoting", refetchInterval: BID_POLL_INTERVAL });
 
   const redirectTimerRef = useRef<ReturnType<typeof setTimeout>>();
@@ -194,7 +201,7 @@ export function useDeploymentFlow(
             setDeployError(undefined);
             setDeploySucceeded(false);
             setPhase("quoting");
-            router.replace(buildConfigureUrl(intentRef.current, result.data.dseq, bidStrategy), undefined, { shallow: true });
+            router.replace(buildConfigureUrl(intentRef.current, result.data.dseq, bidStrategyRef.current), undefined, { shallow: true });
           },
           onError: function onCreateFailed(cause: unknown) {
             setError({ message: extractApiErrorMessage(cause) ?? undefined });
@@ -203,7 +210,7 @@ export function useDeploymentFlow(
         }
       );
     },
-    [createDeployment, router, bidStrategy]
+    [createDeployment, router]
   );
 
   const cancelAndEdit = useCallback(

--- a/apps/deploy-web/src/components/deployments/PhasedDeploymentProgress/PhasedDeploymentProgress.tsx
+++ b/apps/deploy-web/src/components/deployments/PhasedDeploymentProgress/PhasedDeploymentProgress.tsx
@@ -41,7 +41,15 @@ export function PhasedDeploymentProgress({
     return <DeployErrorPanel templateName={templateName} message={state.message} onTryAgain={onTryAgain} onContactSupport={onContactSupport} />;
   }
 
-  return <DeployProgressPanel templateName={templateName} progressPercent={progressPercent} phases={phases} onChooseProvider={onChooseProvider} />;
+  const canChooseProvider = state.kind === "matching" || state.kind === "creating";
+  return (
+    <DeployProgressPanel
+      templateName={templateName}
+      progressPercent={progressPercent}
+      phases={phases}
+      onChooseProvider={canChooseProvider ? onChooseProvider : undefined}
+    />
+  );
 }
 
 type DeployErrorPanelProps = {

--- a/apps/deploy-web/src/hooks/useAutoDeploymentFlow/useAutoDeploymentFlow.spec.ts
+++ b/apps/deploy-web/src/hooks/useAutoDeploymentFlow/useAutoDeploymentFlow.spec.ts
@@ -28,14 +28,6 @@ describe(useAutoDeploymentFlow.name, () => {
     expect(result.current.phases[2].status).toBe("pending");
   });
 
-  it("builds an auto intent seeded with the template, draft, and resumed dseq", () => {
-    const { useDeploymentFlow } = setup({ templateId: "hello-world", draftId: "draft-1", initialDseq: DSEQ });
-
-    expect(useDeploymentFlow).toHaveBeenCalledWith(
-      expect.objectContaining({ intent: { sdlStrategy: "default", bidStrategy: "auto", dseq: DSEQ, templateId: "hello-world", draftId: "draft-1" } })
-    );
-  });
-
   it("fires requestQuotes with the current SDL once the wallet is ready", async () => {
     const { flow } = setup({ sdl: "sdl-content" });
 
@@ -115,6 +107,21 @@ describe(useAutoDeploymentFlow.name, () => {
     const { flow } = setup({ sdl: "sdl-content" });
 
     await vi.waitFor(() => expect(flow.actions.deploy).toHaveBeenCalledWith("sdl-content"));
+  });
+
+  it("stops matching a provider and deploying, but still lets the deployment creation finish, once the autopilot is stopped", async () => {
+    const { result, flow } = setup();
+
+    // Stop synchronously right after mount — before the async reachability check resolves a provider — mirroring the
+    // "Choose my provider" hand-off. The create has already fired (so the manual form inherits a live, quoting
+    // deployment rather than a dangling one), but no provider is matched and no lease is created afterwards.
+    act(() => result.current.stopAutopilot());
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    expect(flow.actions.requestQuotes).toHaveBeenCalledTimes(1);
+    expect(flow.actions.selectProvider).not.toHaveBeenCalled();
+    expect(flow.actions.deploy).not.toHaveBeenCalled();
   });
 
   it("projects to success once the underlying deploy succeeds", async () => {
@@ -248,8 +255,6 @@ describe(useAutoDeploymentFlow.name, () => {
   function setup(input?: {
     sdl?: string;
     initialDseq?: string;
-    templateId?: string;
-    draftId?: string;
     bids?: DeploymentBids;
     providers?: ApiProviderList[];
     requiredGseqs?: number[];
@@ -285,15 +290,16 @@ describe(useAutoDeploymentFlow.name, () => {
       clearSelection: vi.fn()
     };
 
-    // A stateful stub state machine: it advances phase in response to the autopilot's action calls exactly as the real
-    // `useDeploymentFlow` does, so the autopilot's effects fire against realistic transitions without the real chain logic.
     const flowControls: { setPhaseError: (message?: string) => void; setDeployError: (message?: string) => void; setClosing: () => void } = {
       setPhaseError: () => undefined,
       setDeployError: () => undefined,
       setClosing: () => undefined
     };
 
-    const useDeploymentFlow = vi.fn(function useDeploymentFlowStub({ intent }: { intent: { dseq?: string } }): DeploymentFlow {
+    // A live, stateful stub of the base flow: it advances phase in response to the autopilot's action calls exactly as
+    // the real `useDeploymentFlow` does, so the autopilot's effects fire against realistic transitions without the real
+    // chain logic. Called inside the harness below and passed to the autopilot as its `flow` input.
+    function useFlowStub({ intent }: { intent: { dseq?: string } }): DeploymentFlow {
       const [phase, setPhase] = useState<DeploymentFlow["phase"]>(intent.dseq ? "quoting" : "configuring");
       const [dseq] = useState<string | null>(intent.dseq ?? DSEQ);
       const [selections, setSelections] = useState<Record<string, string>>({});
@@ -353,7 +359,7 @@ describe(useAutoDeploymentFlow.name, () => {
         error,
         actions: { ...actions, requestQuotes, selectProvider, deploy, retry, cancelAndEdit }
       };
-    });
+    }
 
     const publicConsoleApiHttpClient = { get: vi.fn().mockResolvedValue({ data: providers }) };
 
@@ -365,19 +371,21 @@ describe(useAutoDeploymentFlow.name, () => {
     const getRequiredGseqs: typeof DEPENDENCIES.getRequiredGseqs = () => input?.requiredGseqs ?? [1];
 
     const view = setupQuery(
-      () =>
-        useAutoDeploymentFlow(
+      () => {
+        // The base flow lives outside the autopilot now, so the harness creates the live stub flow and passes it in —
+        // `initialDseq` seeds the stub in `quoting` (a resume) or `configuring` (a fresh start).
+        const flow = useFlowStub({ intent: { dseq: input?.initialDseq } });
+        return useAutoDeploymentFlow(
           {
             sdl: input?.sdl ?? "sdl-content",
             isWalletReady: input?.isWalletReady ?? true,
             trialError: input?.trialError,
-            initialDseq: input?.initialDseq,
-            templateId: input?.templateId,
-            draftId: input?.draftId,
-            resumeLeases: input?.resumeLeases
+            resumeLeases: input?.resumeLeases,
+            flow
           },
-          { useDeploymentFlow, useProviderList, useFirstReachableProvider, getRequiredGseqs }
-        ),
+          { useProviderList, useFirstReachableProvider, getRequiredGseqs }
+        );
+      },
       {
         services: {
           providerProxy: () => providerProxy,
@@ -386,6 +394,6 @@ describe(useAutoDeploymentFlow.name, () => {
       }
     );
 
-    return { ...view, useDeploymentFlow, actions, flow: { actions, ...flowControls }, providerProxy };
+    return { ...view, actions, flow: { actions, ...flowControls }, providerProxy };
   }
 });

--- a/apps/deploy-web/src/hooks/useAutoDeploymentFlow/useAutoDeploymentFlow.ts
+++ b/apps/deploy-web/src/hooks/useAutoDeploymentFlow/useAutoDeploymentFlow.ts
@@ -1,9 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { extractApiErrorMessage } from "@akashnetwork/openapi-sdk";
 
-import type { BidStrategy, DeploymentIntent } from "@src/components/deployments/ConfigureDeployment/useDeploymentFlow/deploymentIntent";
-import type { DeploymentFlowPhase } from "@src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow";
-import { useDeploymentFlow } from "@src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow";
+import type { DeploymentFlow, DeploymentFlowPhase } from "@src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow";
 import type { DeployPhase, DeployPhaseId, DeployProgressState } from "@src/hooks/useAutoDeploymentFlow/deployPhases";
 import { PHASE_ORDER, useDeployPhaseProgress } from "@src/hooks/useAutoDeploymentFlow/deployPhases";
 import { BID_POLL_INTERVAL } from "@src/queries/useListBids";
@@ -23,22 +21,19 @@ type Options = {
   /** If the trial-start mutation has terminally errored, the flow projects to the error state instead of waiting forever. */
   trialError?: unknown;
   /**
-   * A deployment's dseq carried in from the URL on a resumed session (a reload of the progress view). When present the
-   * underlying flow resumes in `quoting` — the deployment already exists on chain — and the autopilot jumps straight
-   * to the lease when an active lease is already found for it. Absent on a fresh start.
-   */
-  initialDseq?: string;
-  /** The template the flow deploys, mirrored into the intent so URL resume preserves it. */
-  templateId?: string;
-  /** The active configure draft id, mirrored into the intent so a reload resolves the same session. */
-  draftId?: string;
-  /**
    * Live (non-closed) leases already on chain for a resumed deployment, resolved once by the `ResumeDeploymentGuard`
    * and passed in so the flow reconstructs a selection per already-leased group and lets the idempotent server
    * create-lease re-send the manifest. Empty on a fresh start or when the deployment has no live leases (which
    * re-quotes from scratch).
    */
   resumeLeases?: LeaseId[];
+  /**
+   * The shared base flow state machine, created once by the `DeploymentFlowProvider` (which seeds it from the resolved
+   * intent — the resumed dseq included — and gates its create on trial readiness). This hook only autopilots over it and
+   * projects its phase onto the progress UI; it no longer owns the flow, so the auto and manual branches share one
+   * instance. When resuming a dseq, the provider seeds the flow in `quoting`, so the autopilot skips create.
+   */
+  flow: DeploymentFlow;
 };
 
 type Result = {
@@ -54,6 +49,14 @@ type Result = {
   dseq?: string;
   /** Discards the failed attempt — closing the on-chain deployment when one exists — and restarts from creating a fresh one. */
   tryAgain: () => void;
+  /**
+   * Stops the autopilot from matching a provider and deploying (creating leases). Called when the user takes over via
+   * "Choose my provider", so the deployment can be handed to the manual configure form (which shares the same flow)
+   * without the autopilot leasing it out from under them. The deployment creation is deliberately left to finish, so
+   * the hand-off always inherits a live, quoting deployment rather than a dangling one. Scoped to this auto session —
+   * a fresh attempt (a remount, or `tryAgain`) re-enables it.
+   */
+  stopAutopilot: () => void;
 };
 
 /** The four coordinates that identify a lease/bid. */
@@ -74,15 +77,15 @@ function getRequiredGseqs(sdl: string): number[] {
 }
 
 export const DEPENDENCIES = {
-  useDeploymentFlow,
   useProviderList,
   useFirstReachableProvider,
   getRequiredGseqs
 };
 
 /**
- * Autopilot + progress projection over {@link useDeploymentFlow}. There is exactly one real state machine — the
- * manual configure flow — and this hook drives it automatically for the auto-deploy (animated globe) experience:
+ * Autopilot + progress projection over the shared base {@link DeploymentFlow}. There is exactly one real state
+ * machine — the manual configure flow, created once by the `DeploymentFlowProvider` and passed in as `flow` — and this
+ * hook drives it automatically for the auto-deploy (animated globe) experience:
  * it fires `requestQuotes` once the trial wallet is ready, then — for each of the deployment's placements (groups) —
  * watches live bids for that group's first *reachable* provider and records it as the flow's selection, firing `deploy`
  * only once every placement has a provider. The underlying flow owns URL resume, multi-lease, the pre-lease
@@ -95,23 +98,18 @@ export const DEPENDENCIES = {
  * address. `flow.phase` is projected onto the three-step create → match → prepare progress UI.
  */
 export function useAutoDeploymentFlow(
-  { sdl, isWalletReady, trialError, initialDseq, templateId, draftId, resumeLeases = [] }: Options,
+  { sdl, isWalletReady, trialError, resumeLeases = [], flow }: Options,
   dependencies: typeof DEPENDENCIES = DEPENDENCIES
 ): Result {
-  const intentRef = useRef<DeploymentIntent>({
-    sdlStrategy: "default",
-    bidStrategy: "auto" as BidStrategy,
-    dseq: initialDseq,
-    templateId,
-    draftId
-  });
-
-  const flow = dependencies.useDeploymentFlow({ intent: intentRef.current, isWalletReady, trialError });
-
   const sdlRef = useRef(sdl);
   sdlRef.current = sdl;
 
   const [retryToken, setRetryToken] = useState(0);
+
+  // Latched on when the user takes manual control ("Choose my provider"): the autopilot stops matching a provider and
+  // deploying (creating leases), but still lets the deployment creation finish — so the manual form inherits a live,
+  // quoting deployment to drive rather than being handed a dangling one.
+  const [autopilotStopped, setAutopilotStopped] = useState(false);
 
   // One-shot guard per group. Unlike create/deploy (which move the flow off their phase synchronously, so a phase check
   // already prevents a re-fire), selectProvider keeps the flow in "quoting" — so without this a bid-poll refetch that
@@ -194,6 +192,8 @@ export function useAutoDeploymentFlow(
   useEffect(
     function fireCreate() {
       // requestQuotes moves the flow off "configuring" synchronously, so the phase guard alone prevents a re-fire.
+      // The flow lives in the parent provider now, so on mount this child effect runs before the flow's own effects;
+      // that's inert here — those effects early-return unless phase === "quoting", and the mount phase is "configuring".
       if (flow.phase !== "configuring" || trialError || !isWalletReady) return;
       flow.actions.requestQuotes(sdlRef.current);
     },
@@ -203,7 +203,7 @@ export function useAutoDeploymentFlow(
 
   useEffect(
     function recordSelections() {
-      if (flow.phase !== "quoting") return;
+      if (autopilotStopped || flow.phase !== "quoting") return;
       for (const target of selectionTargets) {
         if (firedGseqsRef.current.has(target.gseq)) continue;
         firedGseqsRef.current.add(target.gseq);
@@ -212,7 +212,7 @@ export function useAutoDeploymentFlow(
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [flow.phase, selectionTargets]
+    [flow.phase, selectionTargets, autopilotStopped]
   );
 
   // A multi-placement deployment leases all its groups together, so deploy waits until every required group has a
@@ -231,10 +231,10 @@ export function useAutoDeploymentFlow(
       // deploy moves the flow off "quoting" synchronously; a failure drops it back with a `deployError`, which this guard
       // treats as terminal (the auto flow has no manual "pick another provider" step). Together they fire deploy exactly
       // once per attempt, so no separate one-shot ref is needed.
-      if (flow.phase !== "quoting" || !allGroupsSelected || flow.deployError) return;
+      if (autopilotStopped || flow.phase !== "quoting" || !allGroupsSelected || flow.deployError) return;
       flow.actions.deploy(sdlRef.current);
     },
-    [flow.phase, allGroupsSelected, flow.deployError]
+    [flow.phase, allGroupsSelected, flow.deployError, autopilotStopped]
   );
 
   const projected = projectPhase(flow.phase, flow.deploySucceeded, !!trialError, !!flow.deployError);
@@ -251,7 +251,13 @@ export function useAutoDeploymentFlow(
     // re-leasing the same one. The selection guard is released so the fresh attempt can match a provider again.
     setRetryToken(previous => previous + 1);
     firedGseqsRef.current = new Set();
+    setAutopilotStopped(false);
     flow.actions.cancelAndEdit();
+  }
+
+  // Hand-off for "Choose my provider": stop the autopilot so the manual form can drive the shared flow instead.
+  function stopAutopilot() {
+    setAutopilotStopped(true);
   }
 
   return {
@@ -260,7 +266,8 @@ export function useAutoDeploymentFlow(
     phases,
     matchedProviderAddress,
     dseq: dseq ?? undefined,
-    tryAgain
+    tryAgain,
+    stopAutopilot
   };
 }
 


### PR DESCRIPTION
## Why

Closes CON-350

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared deployment flow across automatic and manual configuration.
  * Choosing a provider now safely stops autopilot and switches to manual selection.
  * Back navigation from review clears the active provider selection.
* **Bug Fixes**
  * Deployment links now preserve the latest bid strategy after asynchronous updates.
  * Provider selection is available only during applicable deployment phases.
  * “Deployment not found” notifications now use a warning style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->