### PR TITLE
feat(deployment): carry an uploaded SDL into the configure screen

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.spec.ts
@@ -3,7 +3,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { DeploymentIntent } from "../useDeploymentFlow/deploymentIntent";
 import type { DEPENDENCIES } from "./useConfigureDraft";
-import { useConfigureDraft } from "./useConfigureDraft";
+import { createConfigureDraft, useConfigureDraft } from "./useConfigureDraft";
 
 import { renderHook } from "@testing-library/react";
 
@@ -186,5 +186,37 @@ describe(useConfigureDraft.name, () => {
       replace,
       mintDraftId
     };
+  }
+});
+
+describe(createConfigureDraft.name, () => {
+  it("persists the sdl under a freshly minted id and returns that id", () => {
+    const { create } = setup({ mintedDraftId: "fresh-1" });
+
+    const draftId = create("version: '2.0'");
+
+    expect(draftId).toBe("fresh-1");
+    expect(readSdl("fresh-1")).toBe("version: '2.0'");
+  });
+
+  it("returns the minted id without throwing when storage is unavailable", () => {
+    const { create } = setup({ mintedDraftId: "fresh-1", getStorage: () => undefined });
+
+    expect(create("version: '2.0'")).toBe("fresh-1");
+  });
+
+  function readSdl(draftId: string) {
+    const raw = window.localStorage.getItem(`${DRAFT_KEY_PREFIX}${draftId}`);
+    return raw ? (JSON.parse(raw) as { sdl: string }).sdl : undefined;
+  }
+
+  function setup(input: { mintedDraftId?: string; getStorage?: typeof DEPENDENCIES.getStorage }) {
+    window.localStorage.clear();
+    const dependencies: typeof DEPENDENCIES = {
+      getStorage: input.getStorage ?? (() => window.localStorage),
+      useRouter: () => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({}),
+      mintDraftId: vi.fn(() => input.mintedDraftId ?? "minted-id")
+    };
+    return { create: (sdl: string) => createConfigureDraft(sdl, dependencies) };
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft.ts
@@ -88,6 +88,19 @@ export function useConfigureDraft(intent: DeploymentIntent, dependencies: typeof
   );
 }
 
+/**
+ * Starts a configure session from an SDL produced outside the screen (e.g. an uploaded file): mints a draft id,
+ * persists the SDL under it, and returns the id so the caller can route to `configure?draftId=<id>`. Uses the same
+ * storage format as in-screen saves, so the configure screen restores it via `persistedSdl` on arrival. Storage-safe:
+ * if storage is blocked or full the write no-ops and the id is still returned (configure then seeds from its other
+ * sources), matching how `saveDraft` already swallows failures.
+ */
+export function createConfigureDraft(sdl: string, dependencies: typeof DEPENDENCIES = DEPENDENCIES): string {
+  const draftId = dependencies.mintDraftId();
+  saveDraft(dependencies.getStorage(), draftId, sdl);
+  return draftId;
+}
+
 /** Mints the id that keys a configure session's persisted draft. */
 function mintDraftId(): string {
   return nanoid();

--- a/apps/deploy-web/src/components/new-deployment/TemplateList.spec.tsx
+++ b/apps/deploy-web/src/components/new-deployment/TemplateList.spec.tsx
@@ -2,11 +2,13 @@ import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
 import type { AnalyticsService } from "@src/services/analytics/analytics.service";
+import { RouteStep } from "@src/types/route-steps.type";
 import { UrlService } from "@src/utils/urlUtils";
 import type { DEPENDENCIES } from "./TemplateList";
 import { TemplateList } from "./TemplateList";
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { TestContainerProvider } from "@tests/unit/TestContainerProvider";
 
 describe(TemplateList.name, () => {
@@ -26,27 +28,89 @@ describe(TemplateList.name, () => {
     expect(screen.getByText("Run Custom Container")).toBeInTheDocument();
   });
 
-  function setup(input: { isBuildAndDeployEnabled?: boolean }) {
+  it("uploads a valid SDL into a configure draft and routes to configure when the redesign flag is on", async () => {
+    const { push, createConfigureDraft, onTemplateSelected, enqueueSnackbar } = setup({ isRedesignEnabled: true });
+
+    await userEvent.upload(screen.getByLabelText("Upload SDL"), sdlFile("deploy: from-file"));
+
+    await waitFor(() => expect(createConfigureDraft).toHaveBeenCalledWith("deploy: from-file"));
+    expect(push).toHaveBeenCalledWith(UrlService.configureDeployment({ draftId: "draft-xyz" }));
+    expect(onTemplateSelected).not.toHaveBeenCalled();
+    expect(enqueueSnackbar).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid SDL at the picker: surfaces an error and neither drafts nor navigates", async () => {
+    const { push, createConfigureDraft, enqueueSnackbar } = setup({ isRedesignEnabled: true, importSdlThrows: true });
+
+    await userEvent.upload(screen.getByLabelText("Upload SDL"), sdlFile("not a valid sdl"));
+
+    await waitFor(() => expect(enqueueSnackbar).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ variant: "error" })));
+    expect(createConfigureDraft).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("uploads an SDL into the legacy editor step when the redesign flag is off", async () => {
+    const { push, createConfigureDraft, onTemplateSelected, setEditedManifest } = setup({ isRedesignEnabled: false });
+
+    await userEvent.upload(screen.getByLabelText("Upload SDL"), sdlFile("deploy: from-file"));
+
+    await waitFor(() => expect(setEditedManifest).toHaveBeenCalledWith("deploy: from-file"));
+    expect(onTemplateSelected).toHaveBeenCalledWith(expect.objectContaining({ code: "from-file", content: "deploy: from-file" }));
+    expect(push).toHaveBeenCalledWith(UrlService.newDeployment({ step: RouteStep.editDeployment }));
+    expect(createConfigureDraft).not.toHaveBeenCalled();
+  });
+
+  /** A YAML File the mocked FileButton hands to the upload handler, standing in for the browser's file picker. */
+  function sdlFile(content: string) {
+    return new File([content], "deploy.yaml", { type: "application/x-yaml" });
+  }
+
+  function setup(input: { isBuildAndDeployEnabled?: boolean; isRedesignEnabled?: boolean; importSdlThrows?: boolean }) {
     const push = vi.fn();
+    const onTemplateSelected = vi.fn();
+    const setEditedManifest = vi.fn();
+    const createConfigureDraft = vi.fn(() => "draft-xyz");
+    const enqueueSnackbar = vi.fn();
+    const importSimpleSdl: typeof DEPENDENCIES.importSimpleSdl = input.importSdlThrows
+      ? vi.fn(() => {
+          throw new Error("invalid sdl");
+        })
+      : vi.fn();
     const analyticsService = mock<AnalyticsService>();
     // Stable references across renders — a fresh `templates` array each render would re-trigger
     // TemplateList's `useEffect([templates])` indefinitely (react-query returns a stable ref in prod).
     const templatesResult = mock<ReturnType<typeof DEPENDENCIES.useTemplates>>({ templates: [] });
     const router = mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ push });
 
+    const FileButton: typeof DEPENDENCIES.FileButton = ({ onFileSelect }) => (
+      <label>
+        Upload SDL
+        <input type="file" onChange={event => onFileSelect?.(event.currentTarget.files?.[0] ?? null)} />
+      </label>
+    );
+
     const dependencies: typeof DEPENDENCIES = {
       useTemplates: () => templatesResult,
       useRouter: () => router,
-      useFlag: flagName => (flagName === "ui_build_and_deploy" && input.isBuildAndDeployEnabled) ?? false,
-      useNewDeploymentUrl: () => params => UrlService.newDeployment(params)
+      useFlag: flagName => {
+        if (flagName === "ui_build_and_deploy") return input.isBuildAndDeployEnabled ?? false;
+        if (flagName === "onboarding_redesign_v1") return input.isRedesignEnabled ?? false;
+        return false;
+      },
+      useNewDeploymentUrl: () => params => UrlService.newDeployment(params),
+      useSnackbar: () => mock<ReturnType<typeof DEPENDENCIES.useSnackbar>>({ enqueueSnackbar }),
+      Snackbar: () => null,
+      importSimpleSdl,
+      FileButton,
+      createConfigureDraft
     };
 
     render(
       <TestContainerProvider services={{ analyticsService: () => analyticsService }}>
-        <TemplateList onChangeGitProvider={vi.fn()} onTemplateSelected={vi.fn()} setEditedManifest={vi.fn()} dependencies={dependencies} />
+        <TemplateList onChangeGitProvider={vi.fn()} onTemplateSelected={onTemplateSelected} setEditedManifest={setEditedManifest} dependencies={dependencies} />
       </TestContainerProvider>
     );
 
-    return { push, analyticsService };
+    return { push, analyticsService, onTemplateSelected, setEditedManifest, createConfigureDraft, enqueueSnackbar };
   }
 });

--- a/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
+++ b/apps/deploy-web/src/components/new-deployment/TemplateList.tsx
@@ -1,12 +1,14 @@
 "use client";
 import React, { useEffect, useState } from "react";
-import { buttonVariants, Card, CardContent, CardHeader, FileButton } from "@akashnetwork/ui/components";
+import { buttonVariants, Card, CardContent, CardHeader, FileButton, Snackbar } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
 import { OpenNewWindow, Upload } from "iconoir-react";
 import { useAtom } from "jotai";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useSnackbar } from "notistack";
 
+import { createConfigureDraft } from "@src/components/deployments/ConfigureDeployment/useConfigureDraft/useConfigureDraft";
 import { CI_CD_TEMPLATE_ID } from "@src/config/remote-deploy.config";
 import { useServices } from "@src/context/ServicesProvider";
 import { useFlag } from "@src/hooks/useFlag";
@@ -16,6 +18,7 @@ import { useTemplates } from "@src/queries/useTemplateQuery";
 import sdlStore from "@src/store/sdlStore";
 import type { TemplateCreation } from "@src/types";
 import { RouteStep } from "@src/types/route-steps.type";
+import { importSimpleSdl } from "@src/utils/sdl/sdlImport";
 import { helloWorldTemplate } from "@src/utils/templates";
 import type { NewDeploymentParams } from "@src/utils/urlUtils";
 import { domainName, UrlService } from "@src/utils/urlUtils";
@@ -41,7 +44,7 @@ const previewTemplateIds = [
   "akash-network-awesome-akash-FastChat"
 ];
 
-export const DEPENDENCIES = { useTemplates, useRouter, useFlag, useNewDeploymentUrl };
+export const DEPENDENCIES = { useTemplates, useRouter, useFlag, useNewDeploymentUrl, useSnackbar, Snackbar, importSimpleSdl, FileButton, createConfigureDraft };
 
 type Props = {
   onChangeGitProvider: (gh: boolean) => void;
@@ -60,9 +63,11 @@ export const TemplateList: React.FunctionComponent<Props> = ({
   const { templates } = d.useTemplates();
   const router = d.useRouter();
   const newDeploymentUrl = d.useNewDeploymentUrl();
+  const { enqueueSnackbar } = d.useSnackbar();
   const [previewTemplates, setPreviewTemplates] = useState<TemplateOutputSummaryWithCategory[]>([]);
   const [, setSdlEditMode] = useAtom(sdlStore.selectedSdlEditMode);
   const isBuildAndDeployEnabled = d.useFlag("ui_build_and_deploy");
+  const isRedesignEnabled = d.useFlag("onboarding_redesign_v1");
 
   const handleGithubTemplate = async () => {
     analyticsService.track("build_n_deploy_btn_clk", "Amplitude");
@@ -92,15 +97,29 @@ export const TemplateList: React.FunctionComponent<Props> = ({
 
     const reader = new FileReader();
 
-    reader.onload = event => {
+    reader.onload = function loadUploadedSdl(event) {
+      const content = event.target?.result as string;
+
+      if (isRedesignEnabled) {
+        if (!canImportSdl(content, d.importSimpleSdl)) {
+          enqueueSnackbar(
+            <d.Snackbar title="Invalid SDL file" subTitle="This file couldn't be read as a deployment. Please upload a valid SDL." iconVariant="error" />,
+            { variant: "error" }
+          );
+          return;
+        }
+        router.push(UrlService.configureDeployment({ draftId: d.createConfigureDraft(content) }));
+        return;
+      }
+
       onTemplateSelected({
         title: "From file",
         code: "from-file",
         category: "General",
         description: "Custom uploaded file",
-        content: event.target?.result as string
+        content
       });
-      setEditedManifest(event.target?.result as string);
+      setEditedManifest(content);
       setSdlEditMode("yaml");
 
       router.push(UrlService.newDeployment({ step: RouteStep.editDeployment }));
@@ -120,10 +139,10 @@ export const TemplateList: React.FunctionComponent<Props> = ({
             <h3 className="text-xl font-bold tracking-tight">Build Your Own</h3>
             <p className="text-sm text-muted-foreground">Select a type or upload your own SDL.</p>
           </div>
-          <FileButton onFileSelect={onFileSelect} accept=".yml,.yaml,.txt" size="sm" variant="default" className="space-x-2">
+          <d.FileButton onFileSelect={onFileSelect} accept=".yml,.yaml,.txt" size="sm" variant="default" className="space-x-2">
             <Upload className="text-xs" />
             <span>Upload SDL</span>
-          </FileButton>
+          </d.FileButton>
         </CardHeader>
         <CardContent className={cn("grid grid-cols-1 gap-4", isBuildAndDeployEnabled ? "md:grid-cols-3" : "md:grid-cols-2")}>
           {isBuildAndDeployEnabled && (
@@ -193,3 +212,16 @@ export const TemplateList: React.FunctionComponent<Props> = ({
     </div>
   );
 };
+
+/**
+ * Whether an uploaded YAML imports as a deployment. A throw means the configure form's importer can't load it, so the
+ * picker rejects the file up front rather than routing to a screen that would silently fall back to an empty deployment.
+ */
+function canImportSdl(sdl: string, importSdl: typeof importSimpleSdl): boolean {
+  try {
+    importSdl(sdl);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Why

In the redesigned deployment flow, "Upload SDL" on the new-deployment picker was a dead entry point — the uploaded file never reached the configure screen, so the user landed on a blank configure and had to start over. Uploading a file should be a first-class way to begin a deployment, on par with choosing a template or using the SDL builder.

Fixes CON-636

## What

Under the `onboarding_redesign_v1` flag:

- Uploading an SDL from the picker now persists the file as a **configure draft** and navigates to `/new-deployment/configure?draftId=<id>`. Configure restores it via the draft's `persistedSdl` (the highest-priority seed), so the form is pre-filled, survives reloads, and the SDL is carried through to review/deploy.
- A file that can't be parsed into a deployment is **rejected at the picker** with an error toast — the user stays on the picker instead of landing on a blank/broken configure.
- The `templateId` (gallery / hardcoded template) and SDL-builder paths are untouched; the legacy (flag-off) upload path still loads the YAML editor step as before.

### Tests

- `TemplateList.spec`: a valid upload creates a draft and routes to `configure?draftId=…`; an invalid upload surfaces an error toast and neither drafts nor navigates; the flag-off upload still loads the legacy editor step.
- `useConfigureDraft.spec`: `createConfigureDraft` persists the SDL under a freshly minted id and returns it.

<!-- add a short screen capture of upload → pre-filled configure -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SDL file uploads to the redesigned deployment configuration flow.
  * Valid SDL uploads now open a configuration draft automatically.
  * Invalid SDL files display an error notification.
  * Existing deployment creation behavior remains available when the redesign is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->