### PR TITLE
feat(deployment): gate GPU preset and card for trial users on the configure screen

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.gated.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.gated.spec.tsx
@@ -1,0 +1,84 @@
+import type { PropsWithChildren } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { SdlBuilderFormValuesType } from "@src/types";
+import type { GpuVendor } from "@src/types/gpu";
+import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
+import { DEPENDENCIES, GpuCard } from "./GpuCard";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const GPU_VENDORS: GpuVendor[] = [
+  {
+    name: "nvidia",
+    models: [
+      { name: "h100", memory: ["80Gi"], interface: ["sxm"] },
+      { name: "t4", memory: ["16Gi"], interface: ["pcie"] }
+    ]
+  }
+];
+
+/**
+ * The trial-gate cases live in their own spec so they run in a fresh jsdom — see the note in
+ * GpuCard.spec: the sibling file's many Radix Select interactions leak under jsdom and make every
+ * later render progressively slower. Isolating these keeps them fast and deterministic.
+ */
+describe("GpuCard trial gate", () => {
+  it("locks a blocked model option while keeping allowed ones selectable", async () => {
+    const user = setup({ isBlockedModel: (_vendor, model) => model === "h100" });
+
+    await user.click(screen.getByRole("combobox", { name: "GPU model" }));
+
+    expect(await screen.findByRole("option", { name: /h100/ })).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("option", { name: /t4/ })).not.toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("calls onUnlock from the unlock CTA when the vendor has a blocked model", () => {
+    const onUnlock = vi.fn();
+    setup({ isBlockedModel: (_vendor, model) => model === "h100", onUnlock });
+
+    fireEvent.click(screen.getByRole("button", { name: /unlock high-end gpus/i }));
+
+    expect(onUnlock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows no unlock CTA when no model is blocked", () => {
+    setup({});
+
+    expect(screen.queryByRole("button", { name: /unlock/i })).not.toBeInTheDocument();
+  });
+
+  function setup(input: { isBlockedModel?: (vendor?: string | null, model?: string | null) => boolean; onUnlock?: () => void }) {
+    const values = defaultServiceWithPlacement({
+      profile: {
+        cpu: 0.5,
+        gpu: 1,
+        gpuModels: [{ vendor: "nvidia", name: "", memory: "", interface: "" }],
+        hasGpu: true,
+        ram: 256,
+        ramUnit: "Mi",
+        storage: [{ size: 1, unit: "Gi", isPersistent: false, type: "beta2" }]
+      }
+    });
+
+    const useGpuModels: typeof DEPENDENCIES.useGpuModels = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useGpuModels>>({ data: GPU_VENDORS, isLoading: false, isError: false } as Partial<ReturnType<typeof DEPENDENCIES.useGpuModels>>);
+    const useFieldError: typeof DEPENDENCIES.useFieldError = () => ({ error: undefined });
+
+    const Wrapper = ({ children }: PropsWithChildren) => {
+      const form = useForm<SdlBuilderFormValuesType>({ defaultValues: values, mode: "onChange" });
+      return <FormProvider {...form}>{children}</FormProvider>;
+    };
+
+    render(
+      <Wrapper>
+        <GpuCard serviceIndex={0} isBlockedModel={input.isBlockedModel} onUnlock={input.onUnlock} dependencies={{ ...DEPENDENCIES, useGpuModels, useFieldError }} />
+      </Wrapper>
+    );
+
+    return userEvent.setup();
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.spec.tsx
@@ -208,6 +208,8 @@ describe(GpuCard.name, () => {
     expect(screen.getByLabelText("GPU count")).toBeDisabled();
     expect(screen.getByRole("combobox", { name: "GPU vendor" })).toBeDisabled();
     expect(screen.getByRole("combobox", { name: "GPU model" })).toBeDisabled();
+    expect(screen.getByRole("combobox", { name: "GPU memory" })).toBeDisabled();
+    expect(screen.getByRole("combobox", { name: "GPU interface" })).toBeDisabled();
   });
 
   const StubGpuModelFields: typeof DEPENDENCIES.GpuModelFields = ({ gpuIndex }) => <div role="group" aria-label={`GPU ${gpuIndex + 1}`} />;

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
@@ -17,7 +17,7 @@ import {
   Spinner,
   useFieldError
 } from "@akashnetwork/ui/components";
-import { GpuIcon, PlusIcon, TrashIcon, XIcon } from "lucide-react";
+import { GpuIcon, LockIcon, PlusIcon, TrashIcon, XIcon } from "lucide-react";
 
 import { useGpuModels } from "@src/queries/useGpuQuery";
 import type { SdlBuilderFormValuesType } from "@src/types";
@@ -27,6 +27,7 @@ import { validationConfig } from "@src/utils/akash/units";
 import { defaultGpuModel } from "@src/utils/sdl/data";
 import { gpuTooltip } from "../cardTooltips";
 import { SELECT_TRUNCATE_VALUE } from "../selectStyles";
+import { UnlockGpusButton } from "../UnlockGpusButton/UnlockGpusButton";
 
 export const DEPENDENCIES = { CollapsibleCard, useGpuModels, useFieldError, GpuModelFields };
 
@@ -34,6 +35,10 @@ type Props = {
   serviceIndex: number;
   /** While the pane is locked the enable switch and every GPU input are disabled so the configured GPU stays viewable but read-only. */
   locked?: boolean;
+  /** Returns whether a GPU model is blocked for the current (trial) user; blocked models lock in the model picker. */
+  isBlockedModel?: (vendor?: string | null, model?: string | null) => boolean;
+  /** Opens the add-credits (unlock) sheet owned by the HardwareSection. */
+  onUnlock?: () => void;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -44,8 +49,12 @@ type Props = {
  * one collection per `profile.gpuModels` entry — vendor, model, memory and
  * interface selects — plus an "Add GPU" button. Each collection after the first
  * can be removed.
+ *
+ * While the trial restriction is in force, blocked GPU models render locked in the
+ * model picker (with an unlock CTA); allowed models stay selectable and the enable
+ * switch itself is never disabled by the restriction.
  */
-export const GpuCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+export const GpuCard: FC<Props> = ({ serviceIndex, locked = false, isBlockedModel = () => false, onUnlock, dependencies: d = DEPENDENCIES }) => {
   const { control, setValue, getValues } = useFormContext<SdlBuilderFormValuesType>();
   const { data: gpuModels, isLoading: isLoadingModels, isError: isModelsError } = d.useGpuModels();
 
@@ -87,9 +96,9 @@ export const GpuCard: FC<Props> = ({ serviceIndex, locked = false, dependencies:
       toggleAriaLabel="Enable GPU"
       toggleDisabled={locked}
     >
-      {hasGpu.field.value && (
+      {hasGpu.field.value ? (
         <fieldset disabled={locked} className="flex flex-col gap-4 border-0 p-0">
-          <GpuCountField serviceIndex={serviceIndex} dependencies={d} />
+          <GpuCountField serviceIndex={serviceIndex} locked={locked} dependencies={d} />
 
           {fields.map((field, index) => (
             <d.GpuModelFields
@@ -99,28 +108,35 @@ export const GpuCard: FC<Props> = ({ serviceIndex, locked = false, dependencies:
               gpuVendors={gpuModels}
               isLoading={isLoadingModels}
               isError={isModelsError}
+              isBlockedModel={isBlockedModel}
+              onUnlock={onUnlock}
+              locked={locked}
               onRemove={index === 0 ? undefined : () => remove(index)}
             />
           ))}
 
-          <div className="flex justify-end">
-            <button
-              type="button"
-              aria-label="Add GPU"
-              onClick={addGpuModel}
-              disabled={hasReachedGpuLimit}
-              className="flex w-full items-center justify-center rounded-md py-1.5 text-muted-foreground hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50 dark:hover:bg-black"
-            >
-              <PlusIcon className="h-4 w-4" />
-            </button>
-          </div>
+          {!locked && (
+            <div className="flex justify-end">
+              <button
+                type="button"
+                aria-label="Add GPU"
+                onClick={addGpuModel}
+                disabled={hasReachedGpuLimit}
+                className="flex w-full items-center justify-center rounded-md py-1.5 text-muted-foreground hover:bg-accent hover:text-foreground disabled:pointer-events-none disabled:opacity-50 dark:hover:bg-black"
+              >
+                <PlusIcon className="h-4 w-4" />
+              </button>
+            </div>
+          )}
         </fieldset>
+      ) : (
+        <p className="text-sm text-muted-foreground">GPU is off.</p>
       )}
     </d.CollapsibleCard>
   );
 };
 
-const GpuCountField: FC<Required<Omit<Props, "locked">>> = ({ serviceIndex, dependencies: d }) => {
+const GpuCountField: FC<{ serviceIndex: number; locked?: boolean; dependencies: typeof DEPENDENCIES }> = ({ serviceIndex, locked = false, dependencies: d }) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const { error: gpuError } = d.useFieldError(`services.${serviceIndex}.profile.gpu`);
   const errorId = useId();
@@ -137,6 +153,7 @@ const GpuCountField: FC<Required<Omit<Props, "locked">>> = ({ serviceIndex, depe
           min={1}
           max={validationConfig.maxGpuAmount}
           aria-describedby={gpuError ? errorId : undefined}
+          disabled={locked}
           onChange={gpu.field.onChange}
         />
         <FieldError id={errorId}>{gpuError}</FieldError>
@@ -151,6 +168,12 @@ type GpuModelFieldsProps = {
   gpuVendors: GpuVendor[] | undefined;
   isLoading?: boolean;
   isError?: boolean;
+  /** Returns whether a `vendor`/`model` is blocked for the current (trial) user; blocked models lock in the picker. */
+  isBlockedModel: (vendor?: string | null, model?: string | null) => boolean;
+  /** Opens the add-credits (unlock) sheet, offered when the picked vendor exposes any blocked model. */
+  onUnlock?: () => void;
+  /** While the pane is locked every input is disabled so the configured GPU stays viewable but read-only. */
+  locked?: boolean;
   onRemove?: () => void;
 };
 
@@ -165,7 +188,7 @@ type GpuModelFieldsProps = {
  * selects never sit permanently dead with no explanation (matching the legacy
  * GPU control's "Loading GPU models…" affordance).
  */
-function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError, onRemove }: GpuModelFieldsProps) {
+function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError, isBlockedModel, onUnlock, locked = false, onRemove }: GpuModelFieldsProps) {
   const { control, setValue } = useFormContext<SdlBuilderFormValuesType>();
   const basePath = `services.${serviceIndex}.profile.gpuModels.${gpuIndex}` as const;
 
@@ -211,7 +234,7 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium uppercase text-muted-foreground">GPU {gpuIndex + 1}</span>
         {onRemove && (
-          <Button size="icon" type="button" variant="ghost" className="h-6 w-6" aria-label={`Remove GPU ${gpuIndex + 1}`} onClick={onRemove}>
+          <Button size="icon" type="button" variant="ghost" className="h-6 w-6" aria-label={`Remove GPU ${gpuIndex + 1}`} disabled={locked} onClick={onRemove}>
             <TrashIcon className="h-4 w-4" />
           </Button>
         )}
@@ -220,7 +243,7 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
       <Field className="gap-2">
         <FieldLabel>Vendor</FieldLabel>
         <FieldContent>
-          <Select value={vendor.field.value || ""} onValueChange={selectGpuVendor}>
+          <Select value={vendor.field.value || ""} onValueChange={selectGpuVendor} disabled={locked}>
             <SelectTrigger aria-label="GPU vendor" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
               <SelectValue placeholder="Select" />
             </SelectTrigger>
@@ -247,17 +270,23 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
           <Field className="gap-2">
             <FieldLabel>Model</FieldLabel>
             <FieldContent>
-              <ClearableSelect clearLabel="Clear GPU model" onClear={name.field.value ? clearModel : undefined}>
-                <Select value={name.field.value || ""} onValueChange={selectGpuModel} disabled={models.length === 0}>
+              <ClearableSelect clearLabel="Clear GPU model" onClear={!locked && name.field.value ? clearModel : undefined}>
+                <Select value={name.field.value || ""} onValueChange={selectGpuModel} disabled={locked || models.length === 0}>
                   <SelectTrigger aria-label="GPU model" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
                     <SelectValue placeholder="Select" />
                   </SelectTrigger>
                   <SelectContent>
-                    {models.map(model => (
-                      <SelectItem key={model.name} value={model.name}>
-                        {model.name}
-                      </SelectItem>
-                    ))}
+                    {models.map(model => {
+                      const blocked = isBlockedModel(vendor.field.value, model.name);
+                      return (
+                        <SelectItem key={model.name} value={model.name} disabled={blocked}>
+                          <span className="flex items-center gap-1.5">
+                            {model.name}
+                            {blocked && <LockIcon className="h-3 w-3 shrink-0 text-muted-foreground" aria-label="Requires credits" />}
+                          </span>
+                        </SelectItem>
+                      );
+                    })}
                   </SelectContent>
                 </Select>
               </ClearableSelect>
@@ -267,8 +296,8 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
           <Field className="gap-2">
             <FieldLabel>Memory</FieldLabel>
             <FieldContent>
-              <ClearableSelect clearLabel="Clear GPU memory" onClear={memory.field.value ? () => memory.field.onChange("") : undefined}>
-                <Select value={memory.field.value || ""} onValueChange={memory.field.onChange} disabled={!selectedModel}>
+              <ClearableSelect clearLabel="Clear GPU memory" onClear={!locked && memory.field.value ? () => memory.field.onChange("") : undefined}>
+                <Select value={memory.field.value || ""} onValueChange={memory.field.onChange} disabled={locked || !selectedModel}>
                   <SelectTrigger aria-label="GPU memory" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
                     <SelectValue placeholder="Select" />
                   </SelectTrigger>
@@ -287,8 +316,8 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
           <Field className="gap-2">
             <FieldLabel>Interface</FieldLabel>
             <FieldContent>
-              <ClearableSelect clearLabel="Clear GPU interface" onClear={gpuInterface.field.value ? () => gpuInterface.field.onChange("") : undefined}>
-                <Select value={gpuInterface.field.value || ""} onValueChange={gpuInterface.field.onChange} disabled={!selectedModel}>
+              <ClearableSelect clearLabel="Clear GPU interface" onClear={!locked && gpuInterface.field.value ? () => gpuInterface.field.onChange("") : undefined}>
+                <Select value={gpuInterface.field.value || ""} onValueChange={gpuInterface.field.onChange} disabled={locked || !selectedModel}>
                   <SelectTrigger aria-label="GPU interface" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
                     <SelectValue placeholder="Select" />
                   </SelectTrigger>
@@ -303,6 +332,8 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
               </ClearableSelect>
             </FieldContent>
           </Field>
+
+          {models.some(model => isBlockedModel(vendor.field.value, model.name)) && <UnlockGpusButton onUnlock={onUnlock} />}
         </>
       )}
     </div>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.spec.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { DEPENDENCIES, HardwareSection } from "./HardwareSection";
 
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import { MockComponents } from "@tests/unit/mocks";
 
 describe(HardwareSection.name, () => {
@@ -40,7 +40,60 @@ describe(HardwareSection.name, () => {
     expect(RamStorageCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
   });
 
+  it("passes an isBlockedModel predicate and unlock handler to the GPU cards", () => {
+    const PresetsCard = vi.fn(() => null);
+    const GpuCard = vi.fn(() => null);
+    const useTrialGate = () => ({ isRestricted: true, isWalletReady: true });
+
+    setup({ dependencies: { PresetsCard, GpuCard, useTrialGate } });
+
+    expect(PresetsCard).toHaveBeenCalledWith(expect.objectContaining({ isBlockedModel: expect.any(Function), onUnlock: expect.any(Function) }), expect.anything());
+    expect(GpuCard).toHaveBeenCalledWith(expect.objectContaining({ isBlockedModel: expect.any(Function), onUnlock: expect.any(Function) }), expect.anything());
+  });
+
+  it("blocks nothing while the pane is locked", () => {
+    const GpuCard = vi.fn<typeof DEPENDENCIES.GpuCard>(() => null);
+    const useTrialGate = () => ({ isRestricted: true, isWalletReady: true });
+
+    setup({ locked: true, dependencies: { GpuCard, useTrialGate } });
+
+    const { isBlockedModel } = GpuCard.mock.calls.at(-1)![0];
+    expect(isBlockedModel?.("nvidia", "h100")).toBe(false);
+  });
+
+  it("blocks nothing when the trial restriction is not in force", () => {
+    const GpuCard = vi.fn<typeof DEPENDENCIES.GpuCard>(() => null);
+    const useTrialGate = () => ({ isRestricted: false, isWalletReady: true });
+
+    setup({ dependencies: { GpuCard, useTrialGate } });
+
+    const { isBlockedModel } = GpuCard.mock.calls.at(-1)![0];
+    expect(isBlockedModel?.("nvidia", "h100")).toBe(false);
+  });
+
+  it("opens the AddCreditsSheet when a card requests unlock", () => {
+    const AddCreditsSheet = vi.fn(() => <div />);
+    let requestUnlock: () => void = () => {};
+    const GpuCard = vi.fn<typeof DEPENDENCIES.GpuCard>(props => {
+      requestUnlock = props.onUnlock ?? (() => {});
+      return null;
+    });
+    const useTrialGate = () => ({ isRestricted: true, isWalletReady: true });
+
+    setup({ dependencies: { GpuCard, AddCreditsSheet, useTrialGate } });
+
+    expect(AddCreditsSheet).toHaveBeenLastCalledWith(expect.objectContaining({ open: false, isWalletReady: true }), expect.anything());
+
+    act(() => requestUnlock());
+
+    expect(AddCreditsSheet).toHaveBeenLastCalledWith(expect.objectContaining({ open: true }), expect.anything());
+  });
+
   function setup(input: { serviceIndex?: number; locked?: boolean; dependencies?: Partial<typeof DEPENDENCIES> }) {
-    render(<HardwareSection serviceIndex={input.serviceIndex ?? 0} locked={input.locked} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />);
+    const dependencies = MockComponents(DEPENDENCIES, {
+      useTrialGate: () => ({ isRestricted: false, isWalletReady: false }),
+      ...input.dependencies
+    });
+    render(<HardwareSection serviceIndex={input.serviceIndex ?? 0} locked={input.locked} dependencies={dependencies} />);
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/HardwareSection.tsx
@@ -1,7 +1,10 @@
 import type { FC } from "react";
+import { useState } from "react";
 import { CollapsibleCard } from "@akashnetwork/ui/components";
 import { CpuIcon, PackageOpenIcon } from "lucide-react";
 
+import { AddCreditsSheet } from "@src/components/auth/AddCreditsSheet/AddCreditsSheet";
+import { isTrialBlockedGpuModel } from "@src/utils/deploymentData/v1beta3";
 import { useRevalidateUniqueness } from "../../DeploymentPane/useRevalidateUniqueness/useRevalidateUniqueness";
 import { computeResourcesTooltip, presetsTooltip } from "../cardTooltips";
 import { ComputeResourcesCard } from "../ComputeResourcesCard/ComputeResourcesCard";
@@ -10,6 +13,7 @@ import { GpuCard } from "../GpuCard/GpuCard";
 import { PersistentStorageCard } from "../PersistentStorageCard/PersistentStorageCard";
 import { PresetsCard } from "../PresetsCard/PresetsCard";
 import { RamStorageCard } from "../RamStorageCard/RamStorageCard";
+import { useTrialGate } from "./useTrialGate/useTrialGate";
 
 type StorageVolume = { name?: string; mount?: string };
 
@@ -30,7 +34,9 @@ export const DEPENDENCIES = {
   RamStorageCard,
   PersistentStorageCard,
   ConfidentialComputeCard,
-  useRevalidateUniqueness
+  AddCreditsSheet,
+  useRevalidateUniqueness,
+  useTrialGate
 };
 
 type Props = {
@@ -54,16 +60,24 @@ type Props = {
  */
 export const HardwareSection: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
   d.useRevalidateUniqueness(`services.${serviceIndex}.profile.storage`, storageUniquenessKey);
+  const { isRestricted, isWalletReady } = d.useTrialGate();
+  const [isUnlockOpen, setIsUnlockOpen] = useState(false);
+
+  const openUnlock = () => setIsUnlockOpen(true);
+  const closeUnlock = () => setIsUnlockOpen(false);
+
+  /** True only for models the trial blocks and only while the pane is editable — so the lock never fights the quote-lock read-only state. */
+  const isBlockedModel = (vendor?: string | null, model?: string | null) => isRestricted && !locked && isTrialBlockedGpuModel(vendor, model);
 
   return (
     <div className="flex flex-col gap-2 px-4">
       <p className="font-mono text-xs uppercase text-muted-foreground">Hardware</p>
       <div className="flex flex-col gap-4">
         <d.CollapsibleCard locked={locked} title="Presets" icon={<PackageOpenIcon className="h-4 w-4" />} infoTooltip={presetsTooltip}>
-          <d.PresetsCard serviceIndex={serviceIndex} locked={locked} />
+          <d.PresetsCard serviceIndex={serviceIndex} locked={locked} isBlockedModel={isBlockedModel} onUnlock={openUnlock} />
         </d.CollapsibleCard>
 
-        <d.GpuCard serviceIndex={serviceIndex} locked={locked} />
+        <d.GpuCard serviceIndex={serviceIndex} locked={locked} isBlockedModel={isBlockedModel} onUnlock={openUnlock} />
 
         <d.CollapsibleCard locked={locked} title="Compute Resources" icon={<CpuIcon className="h-4 w-4" />} infoTooltip={computeResourcesTooltip}>
           <d.ComputeResourcesCard serviceIndex={serviceIndex} locked={locked} />
@@ -75,6 +89,8 @@ export const HardwareSection: FC<Props> = ({ serviceIndex, locked = false, depen
 
         <d.PersistentStorageCard serviceIndex={serviceIndex} locked={locked} />
       </div>
+
+      <d.AddCreditsSheet open={isUnlockOpen} onOpenChange={setIsUnlockOpen} isWalletReady={isWalletReady} onDone={closeUnlock} />
     </div>
   );
 };

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/useTrialGate/useTrialGate.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/useTrialGate/useTrialGate.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { useTrialGate } from "./useTrialGate";
+
+import { renderHook } from "@testing-library/react";
+import { buildWallet } from "@tests/seeders";
+
+describe("useTrialGate", () => {
+  it("restricts while the user is trialing", () => {
+    const { result } = setup({ isTrialing: true, hasManagedWallet: true });
+    expect(result.current.isRestricted).toBe(true);
+  });
+
+  it("restricts while the managed wallet is not ready", () => {
+    const { result } = setup({ isTrialing: false, hasManagedWallet: false });
+    expect(result.current.isRestricted).toBe(true);
+  });
+
+  it("does not restrict a ready, non-trial wallet", () => {
+    const { result } = setup({ isTrialing: false, hasManagedWallet: true });
+    expect(result.current.isRestricted).toBe(false);
+  });
+
+  it("reports wallet readiness from hasManagedWallet", () => {
+    expect(setup({ isTrialing: true, hasManagedWallet: true }).result.current.isWalletReady).toBe(true);
+    expect(setup({ isTrialing: true, hasManagedWallet: false }).result.current.isWalletReady).toBe(false);
+  });
+
+  function setup(input: { isTrialing: boolean; hasManagedWallet: boolean }) {
+    const useWallet = () => buildWallet({ isTrialing: input.isTrialing, hasManagedWallet: input.hasManagedWallet });
+    return renderHook(() => useTrialGate({ useWallet }));
+  }
+});

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/useTrialGate/useTrialGate.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/HardwareSection/useTrialGate/useTrialGate.ts
@@ -1,0 +1,15 @@
+import { useWallet } from "@src/context/WalletProvider";
+
+export const DEPENDENCIES = { useWallet };
+
+/**
+ * Whether managed-wallet trial restrictions apply on the configure screen: a trial user — or one whose
+ * wallet hasn't provisioned yet (`isTrialing || !isWalletReady`) — is subject to the trial's limits.
+ * Readiness is read as `hasManagedWallet` (a pure context read) rather than the side-effectful
+ * `useEnsureTrialStarted`, since the trial is already provisioned once by the `DeploymentFlowProvider`
+ * on this screen. What a restriction actually blocks (e.g. specific GPU models) is decided by the consumer.
+ */
+export function useTrialGate(dependencies: typeof DEPENDENCIES = DEPENDENCIES) {
+  const { isTrialing, hasManagedWallet } = dependencies.useWallet();
+  return { isRestricted: isTrialing || !hasManagedWallet, isWalletReady: hasManagedWallet };
+}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/PresetsCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/PresetsCard.spec.tsx
@@ -1,6 +1,6 @@
 import type { PropsWithChildren } from "react";
 import { FormProvider, useForm, type UseFormSetValue } from "react-hook-form";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
@@ -12,7 +12,8 @@ import userEvent from "@testing-library/user-event";
 
 const PRESETS: HardwarePreset[] = [
   { id: "small", label: "Small preset", group: "compute", cpu: 2, ram: 4, ramUnit: "Gi", storage: 20, storageUnit: "Gi" },
-  { id: "gpu", label: "GPU preset", group: "gpu", cpu: 4, ram: 16, ramUnit: "Gi", storage: 100, storageUnit: "Gi", gpu: 2, gpuVendor: "nvidia", gpuModel: "t4" }
+  { id: "gpu", label: "GPU preset", group: "gpu", cpu: 4, ram: 16, ramUnit: "Gi", storage: 100, storageUnit: "Gi", gpu: 2, gpuVendor: "nvidia", gpuModel: "t4" },
+  { id: "gpu-h100", label: "H100 preset", group: "gpu", cpu: 8, ram: 32, ramUnit: "Gi", storage: 100, storageUnit: "Gi", gpu: 1, gpuVendor: "nvidia", gpuModel: "h100" }
 ];
 
 describe(PresetsCard.name, () => {
@@ -101,12 +102,50 @@ describe(PresetsCard.name, () => {
     expect(screen.getByRole("combobox", { name: "Preset" })).toBeDisabled();
   });
 
+  it("locks a blocked GPU preset while keeping allowed presets selectable", async () => {
+    setup({ isBlockedModel: (_vendor, model) => model === "h100" });
+
+    await userEvent.click(screen.getByRole("combobox", { name: "Preset" }));
+
+    expect(await screen.findByRole("option", { name: /H100 preset/ })).toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("option", { name: /GPU preset/ })).not.toHaveAttribute("aria-disabled", "true");
+    expect(screen.getByRole("option", { name: /Small preset/ })).not.toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("still applies an allowed preset while some GPUs are blocked", async () => {
+    const { getValues } = setup({ isBlockedModel: (_vendor, model) => model === "h100" });
+
+    await pickPreset("Small preset");
+
+    expect(getValues().services[0].profile.cpu).toBe(2);
+  });
+
+  it("calls onUnlock from the unlock CTA when a GPU preset is blocked", async () => {
+    const onUnlock = vi.fn();
+    setup({ isBlockedModel: (_vendor, model) => model === "h100", onUnlock });
+
+    await userEvent.click(screen.getByRole("button", { name: /unlock high-end gpus/i }));
+
+    expect(onUnlock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows no unlock CTA when nothing is blocked", () => {
+    setup({});
+
+    expect(screen.queryByRole("button", { name: /unlock/i })).not.toBeInTheDocument();
+  });
+
   async function pickPreset(name: string) {
     await userEvent.click(screen.getByRole("combobox", { name: "Preset" }));
     await userEvent.click(await screen.findByRole("option", { name: new RegExp(name) }));
   }
 
-  function setup(input: { storage?: SdlBuilderFormValuesType["services"][number]["profile"]["storage"]; locked?: boolean }) {
+  function setup(input: {
+    storage?: SdlBuilderFormValuesType["services"][number]["profile"]["storage"];
+    locked?: boolean;
+    isBlockedModel?: (vendor?: string | null, model?: string | null) => boolean;
+    onUnlock?: () => void;
+  }) {
     const values = defaultServiceWithPlacement();
     if (input.storage) {
       values.services[0].profile.storage = input.storage;
@@ -123,7 +162,13 @@ describe(PresetsCard.name, () => {
 
     render(
       <Wrapper>
-        <PresetsCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES, hardwarePresets: PRESETS }} />
+        <PresetsCard
+          serviceIndex={0}
+          locked={input.locked}
+          isBlockedModel={input.isBlockedModel}
+          onUnlock={input.onUnlock}
+          dependencies={{ ...DEPENDENCIES, hardwarePresets: PRESETS }}
+        />
       </Wrapper>
     );
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/PresetsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/PresetsCard/PresetsCard.tsx
@@ -2,9 +2,11 @@ import type { FC } from "react";
 import { Fragment, useCallback, useMemo } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectSeparator, SelectTrigger, SelectValue } from "@akashnetwork/ui/components";
+import { LockIcon } from "lucide-react";
 
 import type { SdlBuilderFormValuesType } from "@src/types";
 import { SELECT_TRUNCATE_VALUE } from "../selectStyles";
+import { UnlockGpusButton } from "../UnlockGpusButton/UnlockGpusButton";
 import type { HardwarePreset, HardwarePresetGroup } from "./hardwarePresets";
 import { applyPreset, detectPreset, formatPresetSpecs, HARDWARE_PRESET_GROUP_LABELS, HARDWARE_PRESET_GROUP_ORDER, hardwarePresets } from "./hardwarePresets";
 
@@ -14,6 +16,10 @@ type Props = {
   serviceIndex: number;
   /** While the pane is locked the preset select is disabled so the active preset stays viewable but can't be re-applied. */
   locked?: boolean;
+  /** Returns whether a preset's GPU model is blocked for the current (trial) user; blocked presets render locked. */
+  isBlockedModel?: (vendor?: string | null, model?: string | null) => boolean;
+  /** Opens the add-credits (unlock) sheet owned by the HardwareSection. */
+  onUnlock?: () => void;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -29,7 +35,7 @@ type Props = {
  * Options are grouped into labelled "Compute" and "GPU" sections, each option
  * showing its name on the left and a spec summary on the right.
  */
-export const PresetsCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+export const PresetsCard: FC<Props> = ({ serviceIndex, locked = false, isBlockedModel = () => false, onUnlock, dependencies: d = DEPENDENCIES }) => {
   const { control, setValue } = useFormContext<SdlBuilderFormValuesType>();
   const profile = useWatch({ control, name: `services.${serviceIndex}.profile` });
   const selectedPresetId = useMemo(() => detectPreset(d.hardwarePresets, profile ?? {})?.id ?? "", [d.hardwarePresets, profile]);
@@ -50,33 +56,48 @@ export const PresetsCard: FC<Props> = ({ serviceIndex, locked = false, dependenc
     presets: d.hardwarePresets.filter(preset => preset.group === group)
   })).filter(({ presets }) => presets.length > 0);
 
+  const hasBlockedGpuPreset = d.hardwarePresets.some(preset => isBlockedModel(preset.gpuVendor, preset.gpuModel));
+
   return (
-    <Select value={selectedPresetId} onValueChange={applySelectedPreset} disabled={locked}>
-      <SelectTrigger aria-label="Preset" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
-        <SelectValue placeholder="Choose a starting point..." />
-      </SelectTrigger>
-      <SelectContent className="min-w-[18rem]">
-        {groups.map(({ group, presets }, index) => (
-          <Fragment key={group}>
-            {index > 0 && <SelectSeparator />}
-            <PresetGroup group={group} presets={presets} />
-          </Fragment>
-        ))}
-      </SelectContent>
-    </Select>
+    <div className="flex flex-col gap-2">
+      <Select value={selectedPresetId} onValueChange={applySelectedPreset} disabled={locked}>
+        <SelectTrigger aria-label="Preset" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
+          <SelectValue placeholder="Choose a starting point..." />
+        </SelectTrigger>
+        <SelectContent className="min-w-[18rem]">
+          {groups.map(({ group, presets }, index) => (
+            <Fragment key={group}>
+              {index > 0 && <SelectSeparator />}
+              <PresetGroup group={group} presets={presets} isBlockedModel={isBlockedModel} />
+            </Fragment>
+          ))}
+        </SelectContent>
+      </Select>
+      {hasBlockedGpuPreset && <UnlockGpusButton onUnlock={onUnlock} />}
+    </div>
   );
 };
 
-const PresetGroup: FC<{ group: HardwarePresetGroup; presets: HardwarePreset[] }> = ({ group, presets }) => (
+const PresetGroup: FC<{
+  group: HardwarePresetGroup;
+  presets: HardwarePreset[];
+  isBlockedModel: (vendor?: string | null, model?: string | null) => boolean;
+}> = ({ group, presets, isBlockedModel }) => (
   <SelectGroup>
     <SelectLabel className="px-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">{HARDWARE_PRESET_GROUP_LABELS[group]}</SelectLabel>
-    {presets.map(preset => (
-      <SelectItem key={preset.id} value={preset.id} className="[&>span:last-child]:flex [&>span:last-child]:w-full">
-        <span className="flex w-full items-center justify-between gap-6">
-          <span>{preset.label}</span>
-          <span className="font-mono text-xs text-muted-foreground">{formatPresetSpecs(preset)}</span>
-        </span>
-      </SelectItem>
-    ))}
+    {presets.map(preset => {
+      const blocked = isBlockedModel(preset.gpuVendor, preset.gpuModel);
+      return (
+        <SelectItem key={preset.id} value={preset.id} disabled={blocked} className="[&>span:last-child]:flex [&>span:last-child]:w-full">
+          <span className="flex w-full items-center justify-between gap-6">
+            <span className="flex items-center gap-1.5">
+              {preset.label}
+              {blocked && <LockIcon className="h-3 w-3 shrink-0 text-muted-foreground" aria-label="Requires credits" />}
+            </span>
+            <span className="font-mono text-xs text-muted-foreground">{formatPresetSpecs(preset)}</span>
+          </span>
+        </SelectItem>
+      );
+    })}
   </SelectGroup>
 );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/UnlockGpusButton/UnlockGpusButton.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/UnlockGpusButton/UnlockGpusButton.tsx
@@ -1,0 +1,27 @@
+import type { FC } from "react";
+import { Button, CustomTooltip, TooltipProvider } from "@akashnetwork/ui/components";
+import { LockIcon } from "lucide-react";
+
+/** Hover explanation for the unlock CTA; mirrors the add-credits sheet copy so the reason is clear before the click. */
+const UNLOCK_EXPLANATION = "High-end GPUs aren't included in your free trial. Add credits to unlock them, along with longer runtimes and the full Console.";
+
+type Props = {
+  /** Opens the add-credits (unlock) sheet owned by the HardwareSection. */
+  onUnlock?: () => void;
+};
+
+/**
+ * The "Unlock high-end GPUs" call-to-action the Presets and GPU cards show when the trial blocks a
+ * model: opens the add-credits sheet on click and explains why on hover. Wraps its own
+ * `TooltipProvider` so it works wherever it's rendered without the consumer supplying one.
+ */
+export const UnlockGpusButton: FC<Props> = ({ onUnlock }) => (
+  <TooltipProvider>
+    <CustomTooltip title={UNLOCK_EXPLANATION} className="font-sans text-sm normal-case">
+      <Button type="button" variant="ghost" size="sm" className="justify-start px-2 text-muted-foreground" onClick={onUnlock}>
+        <LockIcon className="mr-2 h-3.5 w-3.5" />
+        Unlock high-end GPUs
+      </Button>
+    </CustomTooltip>
+  </TooltipProvider>
+);

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -53,9 +53,9 @@ describe(ManifestUpdate.name, () => {
         get: vi.fn().mockReturnValue({ manifest: "version: '2.0'" })
       },
       dependencies: {
-        deploymentData: {
+        deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
           getManifestVersion: vi.fn().mockResolvedValue("abc123")
-        }
+        })
       }
     });
 
@@ -70,9 +70,9 @@ describe(ManifestUpdate.name, () => {
         get: vi.fn().mockReturnValue({ manifest: "version: '2.0'" })
       },
       dependencies: {
-        deploymentData: {
+        deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
           getManifestVersion: vi.fn().mockRejectedValue(new Error("parse error"))
-        }
+        })
       }
     });
 
@@ -167,13 +167,13 @@ describe(ManifestUpdate.name, () => {
       },
       dependencies: {
         Button: ButtonMock,
-        deploymentData: {
+        deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
           NewDeploymentData: vi.fn().mockResolvedValue({
             hash: Buffer.from("new-hash"),
             deploymentId: { dseq: "123" }
           }),
           getManifest: vi.fn().mockReturnValue([])
-        },
+        }),
         TransactionMessageData: {
           getUpdateDeploymentMsg: vi.fn().mockReturnValue({ typeUrl: "/update", value: {} })
         }
@@ -222,14 +222,14 @@ describe(ManifestUpdate.name, () => {
       },
       dependencies: {
         Button: ButtonMock,
-        deploymentData: {
+        deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
           NewDeploymentData: vi.fn().mockResolvedValue({
             hash: hashBytes,
             deploymentId: { dseq: "123" }
           }),
           getManifest: vi.fn().mockReturnValue([]),
           getManifestVersion: vi.fn().mockResolvedValue(base64Hash)
-        }
+        })
       }
     });
 
@@ -256,10 +256,10 @@ describe(ManifestUpdate.name, () => {
       editedManifest: "version: '2.0'",
       dependencies: {
         Button: ButtonMock,
-        deploymentData: {
+        deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
           NewDeploymentData: vi.fn().mockRejectedValue(Object.assign(new Error("bad yaml"), { name: "YAMLException" })),
           getManifest: vi.fn()
-        }
+        })
       }
     });
 
@@ -281,9 +281,9 @@ describe(ManifestUpdate.name, () => {
       onManifestChange,
       dependencies: {
         SDLEditor: SDLEditorMock,
-        deploymentData: {
+        deploymentData: mock<typeof DEPENDENCIES.deploymentData>({
           getManifestVersion: vi.fn().mockResolvedValue("version123")
-        }
+        })
       },
       deploymentLocalStorage: {
         get: vi.fn().mockReturnValue({ manifest: "version: '2.0'" })

--- a/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/OnboardingContainer/OnboardingContainer.spec.tsx
@@ -371,6 +371,7 @@ describe("OnboardingContainer", () => {
       appendTrialAttribute: vi.fn(),
       appendAuditorRequirement: vi.fn(sdl => sdl),
       applyTrialGpuPolicy: vi.fn((sdl: string) => sdl),
+      isTrialBlockedGpuModel: vi.fn(() => false),
       replaceSdlDenom: vi.fn((sdl: string) => sdl),
       ENDPOINT_NAME_VALIDATION_REGEX: /^[a-z]+[-_\da-z]+$/,
       TRIAL_ATTRIBUTE: "console/trials" as const,

--- a/apps/deploy-web/src/utils/deploymentData/v1beta3.spec.ts
+++ b/apps/deploy-web/src/utils/deploymentData/v1beta3.spec.ts
@@ -2,7 +2,7 @@ import { DeploymentReclamation } from "@akashnetwork/chain-sdk/private-types/aka
 import yaml from "js-yaml";
 import { describe, expect, it } from "vitest";
 
-import { applyTrialGpuPolicy, NewDeploymentData, replaceSdlDenom } from "./v1beta3";
+import { applyTrialGpuPolicy, isTrialBlockedGpuModel, NewDeploymentData, replaceSdlDenom } from "./v1beta3";
 
 describe(replaceSdlDenom.name, () => {
   it("replaces denom in a single placement pricing entry", () => {
@@ -187,6 +187,28 @@ describe(applyTrialGpuPolicy.name, () => {
     const profile = Object.values(sdl.profiles.compute)[0];
     return profile.resources.gpu?.attributes?.vendor?.nvidia;
   }
+});
+
+describe(isTrialBlockedGpuModel.name, () => {
+  const BLOCKED = ["nvidia/h100", "nvidia/a100"];
+
+  it("blocks a listed vendor/model case-insensitively", () => {
+    expect(isTrialBlockedGpuModel("nvidia", "h100", BLOCKED)).toBe(true);
+    expect(isTrialBlockedGpuModel("NVIDIA", "H100", BLOCKED)).toBe(true);
+  });
+
+  it("allows a model that is not on the blocked list", () => {
+    expect(isTrialBlockedGpuModel("nvidia", "t4", BLOCKED)).toBe(false);
+  });
+
+  it("never blocks when the vendor or model is missing", () => {
+    expect(isTrialBlockedGpuModel(undefined, "h100", BLOCKED)).toBe(false);
+    expect(isTrialBlockedGpuModel("nvidia", "", BLOCKED)).toBe(false);
+  });
+
+  it("never blocks when the blocked list is empty", () => {
+    expect(isTrialBlockedGpuModel("nvidia", "h100", [])).toBe(false);
+  });
 });
 
 describe(NewDeploymentData.name, () => {

--- a/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
+++ b/apps/deploy-web/src/utils/deploymentData/v1beta3.ts
@@ -102,6 +102,21 @@ export function appendAuditorRequirement(yamlStr: string) {
 ${result}`;
 }
 
+/**
+ * Whether a GPU `vendor`/`model` pair is blocked for managed-wallet trials — the single source of
+ * truth shared by the trial SDL policy ({@link applyTrialGpuPolicy}) and the configure-screen UI,
+ * so the options the UI locks are exactly the ones the policy strips. Matches on the normalized,
+ * lower-cased `vendor/model` key; a missing vendor or model is never blocked.
+ */
+export function isTrialBlockedGpuModel(
+  vendor: string | null | undefined,
+  model: string | null | undefined,
+  blockedModels: readonly string[] = browserEnvConfig.NEXT_PUBLIC_MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS
+): boolean {
+  if (!vendor || !model) return false;
+  return blockedModels.includes(`${vendor.toLowerCase()}/${model.toLowerCase()}`);
+}
+
 export function applyTrialGpuPolicy(
   yamlStr: string,
   blockedModels: readonly string[] = browserEnvConfig.NEXT_PUBLIC_MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS
@@ -110,8 +125,7 @@ export function applyTrialGpuPolicy(
   const computeProfiles = sdlData?.profiles?.compute;
   if (!computeProfiles || typeof computeProfiles !== "object") return yamlStr;
 
-  const blockedSet = new Set(blockedModels);
-  if (blockedSet.size === 0) return yamlStr;
+  if (blockedModels.length === 0) return yamlStr;
   let mutated = false;
 
   for (const profile of Object.values(computeProfiles)) {
@@ -121,7 +135,7 @@ export function applyTrialGpuPolicy(
 
     for (const vendor of Object.keys(vendorMap)) {
       const models = Array.isArray(vendorMap[vendor]) ? vendorMap[vendor]! : [];
-      const allowed = models.filter(entry => entry?.model && !blockedSet.has(`${vendor.toLowerCase()}/${entry.model.toLowerCase()}`));
+      const allowed = models.filter(entry => entry?.model && !isTrialBlockedGpuModel(vendor, entry.model, blockedModels));
 
       if (allowed.length === 0) {
         if (vendorMap[vendor] === null) continue;


### PR DESCRIPTION
## Why

Managed-wallet trials don't allow every GPU: `applyTrialGpuPolicy` strips models on the trial blocklist (`NEXT_PUBLIC_MANAGED_WALLET_TRIAL_BLOCKED_GPU_MODELS` — H100/A100/RTX 4090/… while e.g. T4 is allowed) from the SDL at deploy time. On the configure screen that limit was invisible: a trial user could pick a blocklisted GPU preset or model and only find out it was silently dropped when the deployment ran. This surfaces the same policy in the UI at the point of selection — blocked GPUs lock with an unlock CTA, allowed GPUs stay usable — matching how the onboarding picker gates its top-tier-GPU template.

Fixes CON-638

## What

- A shared **`isTrialBlockedGpuModel(vendor, model)`** predicate in `v1beta3.ts` is the single source of truth; `applyTrialGpuPolicy` now uses it, so the UI locks exactly what the SDL strips (they can't drift).
- **`useTrialGate`** returns `{ isRestricted, isWalletReady }` — `isRestricted = isTrialing || !isWalletReady` (readiness read as `hasManagedWallet`, a pure context read, since `DeploymentFlowProvider` already provisions the trial here). It only says whether the trial restriction is in force; what it blocks is the consumer's call.
- **`HardwareSection`** derives `isBlockedModel = isRestricted && !locked && isTrialBlockedGpuModel(...)` and threads it (plus `onUnlock`) to the hardware cards; it owns a single `AddCreditsSheet`.
- **Presets card**: GPU presets whose model is blocklisted render locked (e.g. A100/H100); allowed GPU presets (T4) and all Compute presets stay selectable. An "Unlock high-end GPUs" CTA shows when any GPU preset is blocked.
- **GPU card**: the enable toggle is unaffected (trial users can still add allowed GPUs); blocklisted **model options** lock in the model picker, allowed models stay selectable, and an inline unlock CTA appears when the picked vendor exposes a blocked model. It also now mirrors the sibling hardware cards — a **"GPU is off."** empty state when disabled, and read-only (disabled) controls while the pane is locked.
- A shared **`UnlockGpusButton`** renders the CTA plus a tooltip explaining why. All unlock CTAs open the existing `AddCreditsSheet`; adding credits ends the trial, so the locks lift reactively.
- Adding the new export widened the `v1beta3` module type, so two specs that mock the whole module (`ManifestUpdate`, `OnboardingContainer`) were updated accordingly.

### Tests

- `v1beta3.spec` (`isTrialBlockedGpuModel`): matches a listed vendor/model case-insensitively; allows unlisted models; never blocks a missing vendor/model or an empty blocklist.
- `useTrialGate.spec`: restricted while trialing; restricted while the wallet isn't ready; not restricted for a ready, non-trial wallet; readiness from `hasManagedWallet`.
- `PresetsCard.spec`: a blocked GPU preset locks while allowed presets stay selectable; an allowed preset still applies while some GPUs are blocked; the unlock CTA calls `onUnlock`; no CTA when nothing is blocked.
- `GpuCard.gated.spec` (isolated file — avoids the sibling file's jsdom Radix-leak tail): a blocked model option locks while allowed ones stay selectable; the unlock CTA calls `onUnlock`; no CTA when nothing is blocked. `GpuCard.spec` also asserts every GPU input is disabled while locked.
- `HardwareSection.spec`: passes `isBlockedModel`/`onUnlock` to the cards; blocks nothing while the pane is locked or the restriction isn't in force; a card's unlock request opens the `AddCreditsSheet`.

https://github.com/user-attachments/assets/51b64418-5312-4f4d-83b1-345ab8938bc9




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trial restrictions for high-end GPU models, with blocked options clearly marked and unavailable for selection.
  * Added an “Unlock high-end GPUs” option that opens the credits flow.
  * Locked deployment configurations now disable GPU controls and prevent GPU additions or removals.

* **Bug Fixes**
  * Improved GPU restriction handling across presets and custom GPU configuration.

* **Tests**
  * Expanded coverage for GPU restrictions, unlock interactions, wallet readiness, and locked controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->