### PR TITLE
fix(onboarding): refresh leases cache after deploy

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { QueryKeys } from "@src/queries/queryKeys";
 import { UrlService } from "@src/utils/urlUtils";
 import type { DeploymentIntent } from "./deploymentIntent";
 import type { DEPENDENCIES } from "./useDeploymentFlow";
@@ -102,6 +103,7 @@ describe(useDeploymentFlow.name, () => {
         useUpdateDeployment: (() => mockMutation()) as never,
         useListBids: (() => ({ data: { data: bids }, isLoading: false, isError: false })) as never,
         useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: vi.fn(), push: vi.fn() })) as never,
+        useQueryClient: (() => mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>()) as never,
         useDeploymentLocalStorage: (() => mock<ReturnType<typeof DEPENDENCIES.useDeploymentLocalStorage>>()) as never,
         manifestFromSdl: () => "M"
       };
@@ -229,6 +231,21 @@ describe(useDeploymentFlow.name, () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("invalidates the leases and deployment-list caches on lease success so the onboarding gate sees the new deployment", () => {
+    const createDeployment = mockMutation();
+    createDeployment.mutate.mockImplementation((_i, o) => o.onSuccess({ data: { dseq: "555", manifest: "M" } }));
+    const createLease = mockMutation();
+    createLease.mutate.mockImplementation((_i, o) => o.onSuccess(deployedResult("akash1owner")));
+    const { result, queryClient } = renderFlow({ createDeployment, createLease });
+
+    act(() => result.current.actions.requestQuotes("sdl"));
+    act(() => result.current.actions.selectProvider("placement-1", "akash1a/555/1/3"));
+    act(() => result.current.actions.deploy("sdl"));
+
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: QueryKeys.getAllLeasesKey("akash1owner") });
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({ queryKey: QueryKeys.getDeploymentListKey("akash1owner") });
   });
 
   it("persists the deployment SDL keyed by the owner the lease response carries so the detail page can read it", () => {
@@ -480,6 +497,7 @@ describe(useDeploymentFlow.name, () => {
       useUpdateDeployment: (() => mock<ReturnType<typeof DEPENDENCIES.useUpdateDeployment>>({ mutate: vi.fn() as never })) as never,
       useListBids: (() => ({ data: { data: [] }, isLoading: false, isError: false })) as never,
       useRouter: (() => mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: (input.replace ?? vi.fn()) as never })) as never,
+      useQueryClient: (() => mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>()) as never,
       useDeploymentLocalStorage: (() => mock<ReturnType<typeof DEPENDENCIES.useDeploymentLocalStorage>>()) as never,
       manifestFromSdl: () => "manifest"
     };
@@ -498,6 +516,7 @@ describe(useDeploymentFlow.name, () => {
     const intent: DeploymentIntent = { sdlStrategy: "edit", bidStrategy: "select", dseq: undefined, ...input?.intent };
     const router = mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ replace: vi.fn(), push: vi.fn() });
     const deploymentLocalStorage = mock<ReturnType<typeof DEPENDENCIES.useDeploymentLocalStorage>>();
+    const queryClient = mock<ReturnType<typeof DEPENDENCIES.useQueryClient>>();
     const dependencies: typeof DEPENDENCIES = {
       useCreateDeployment: (() => input?.createDeployment ?? mockMutation()) as never,
       useCloseDeployment: (() => input?.closeDeployment ?? mockMutation()) as never,
@@ -505,11 +524,12 @@ describe(useDeploymentFlow.name, () => {
       useUpdateDeployment: (() => input?.updateDeployment ?? mockMutation()) as never,
       useListBids: (() => ({ data: { data: input?.listBids ?? [] }, isLoading: false, isError: false })) as never,
       useRouter: () => router,
+      useQueryClient: (() => queryClient) as never,
       useDeploymentLocalStorage: (() => deploymentLocalStorage) as never,
       manifestFromSdl: input?.manifestFromSdl ?? (() => "M")
     };
     const utils = renderHook(() => useDeploymentFlow({ intent }, dependencies));
-    return { ...utils, router, deploymentLocalStorage };
+    return { ...utils, router, deploymentLocalStorage, queryClient };
   }
 
   function mockMutation() {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { extractApiErrorMessage } from "@akashnetwork/openapi-sdk";
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/router";
 
 import { useServices } from "@src/context/ServicesProvider";
+import { QueryKeys } from "@src/queries/queryKeys";
 import { BID_POLL_INTERVAL, useListBids } from "@src/queries/useListBids";
 import { formatBidId, parseBidId } from "@src/utils/bids/bidId";
 import { ManifestYaml } from "@src/utils/deploymentData/helpers";
@@ -100,6 +102,7 @@ export const DEPENDENCIES = {
   useUpdateDeployment,
   useListBids,
   useRouter,
+  useQueryClient,
   useDeploymentLocalStorage,
   manifestFromSdl
 };
@@ -119,6 +122,7 @@ export function useDeploymentFlow(
   const closeDeployment = dependencies.useCloseDeployment();
   const createLease = dependencies.useCreateLease();
   const updateDeployment = dependencies.useUpdateDeployment();
+  const queryClient = dependencies.useQueryClient();
   const deploymentLocalStorage = dependencies.useDeploymentLocalStorage();
 
   const [phase, setPhase] = useState<DeploymentFlowPhase>(intent.dseq ? "quoting" : "configuring");
@@ -304,7 +308,13 @@ export function useDeploymentFlow(
       setDeploySucceeded(false);
       setPhase("deploying");
       function completeDeploy(result: { data: { deployment: { id: { owner: string } } } }) {
-        cacheDeployedSdl(deploymentLocalStorage, result.data.deployment.id.owner, activeDseq, sdl);
+        const owner = result.data.deployment.id.owner;
+        cacheDeployedSdl(deploymentLocalStorage, owner, activeDseq, sdl);
+        // The onboarding gate decides "onboarded" from the leases cache, which was populated empty before this
+        // first deploy. Refresh it (and the deployment list) so a client-side nav to /deployments doesn't read a
+        // stale empty cache and bounce the user back to onboarding until a full page reload.
+        queryClient.invalidateQueries({ queryKey: QueryKeys.getAllLeasesKey(owner) });
+        queryClient.invalidateQueries({ queryKey: QueryKeys.getDeploymentListKey(owner) });
         setDeploySucceeded(true);
         redirectTimerRef.current = setTimeout(function redirectToDeployment() {
           router.replace(UrlService.deploymentDetails(activeDseq, "EVENTS", "events"));
@@ -326,7 +336,7 @@ export function useDeploymentFlow(
         sendManifestAndLease();
       }
     },
-    [createLease, updateDeployment, dseq, manifest, selections, router, dependencies, deploymentLocalStorage]
+    [createLease, updateDeployment, dseq, manifest, selections, router, dependencies, deploymentLocalStorage, queryClient]
   );
 
   return {


### PR DESCRIPTION
## Why

In the redesigned onboarding flow (`onboarding_redesign_v1`), a user who creates their first deployment lands on the deployment detail page, then clicking **Deployments** in the sidebar bounces them back to `/onboarding`. Only a full page refresh reaches the deployment list.

Root cause: the app-wide onboarding gate (`LeaseBasedGate` in `RequireOnboarding`) decides "onboarded" from the `["ALL_LEASES", address]` react-query cache. That cache is populated empty during onboarding (the trial wallet enables the query while the user is still on an allow-listed route, before any lease exists) and is never invalidated after a lease is created. Because the gate lives in `_app.tsx` and persists across client-side navigation, clicking the Deployments `<Link>` (to the non-allow-listed `/deployments`) makes the gate read the stale empty cache, conclude not-onboarded, and `router.replace("/onboarding")`. A hard refresh rebuilds the QueryClient and refetches, which is why refreshing "fixes" it.

## What

On successful lease creation (`completeDeploy` in `useDeploymentFlow`), invalidate the `ALL_LEASES` and `DEPLOYMENT_LIST` caches for the deployment owner, so a client-side navigation to `/deployments` right after the first deploy sees the new lease instead of a stale empty cache.

`leaseList` reads committed chain state (not a lagging indexer) and the invalidation fires after the create-lease tx is committed, so the refetch reliably returns the new lease. No gate changes were needed.

Added a unit test asserting both caches are invalidated with the owner from the create-lease response.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deployment and lease lists now refresh automatically after a successful deployment.
  * Updated cached data ensures newly created leases and deployments appear without requiring a manual page refresh.

* **Tests**
  * Added coverage verifying that relevant deployment and lease data refreshes after deployment completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->