### PR TITLE
fix(billing): parse usage dates as local time in billing-usage charts

### DIFF
--- a/apps/deploy-web/src/components/billing-usage/CumulativeSpendingLineChart/CumulativeSpendingLineChart.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/CumulativeSpendingLineChart/CumulativeSpendingLineChart.spec.tsx
@@ -59,7 +59,11 @@ describe(CumulativeSpendingLineChart.name, () => {
     try {
       return fn();
     } finally {
-      process.env.TZ = original;
+      if (original === undefined) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = original;
+      }
     }
   }
 

--- a/apps/deploy-web/src/components/billing-usage/CumulativeSpendingLineChart/CumulativeSpendingLineChart.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/CumulativeSpendingLineChart/CumulativeSpendingLineChart.spec.tsx
@@ -29,6 +29,40 @@ describe(CumulativeSpendingLineChart.name, () => {
     expect(deps.LineChart.mock.calls.at(-1)?.at(0)?.data).toEqual(sample);
   });
 
+  it("formats axis ticks from the date-only value in local time regardless of timezone", () => {
+    const { deps } = setup({ isFetching: false, data: [{ date: "2025-07-01", totalUsdSpent: 100 }] });
+    const tickFormatter = deps.XAxis.mock.calls.at(-1)?.[0]?.tickFormatter as (value: string, index: number) => string;
+
+    expect(withTimezone("America/Los_Angeles", () => tickFormatter("2025-07-01", 0))).toBe("7/1");
+    expect(withTimezone("Asia/Tokyo", () => tickFormatter("2025-07-01", 0))).toBe("7/1");
+  });
+
+  it("formats the tooltip label from the date-only value in local time regardless of timezone", () => {
+    const { deps } = setup({ isFetching: false, data: [{ date: "2025-07-01", totalUsdSpent: 100 }] });
+    const content = deps.ChartTooltip.mock.calls.at(-1)?.[0]?.content as React.ReactElement<{ labelFormatter: (value: string) => string }>;
+    const labelFormatter = content.props.labelFormatter;
+
+    expect(withTimezone("America/Los_Angeles", () => labelFormatter("2025-07-01"))).toBe("Jul 1, 2025");
+    expect(withTimezone("Asia/Tokyo", () => labelFormatter("2025-07-01"))).toBe("Jul 1, 2025");
+  });
+
+  it("returns the raw value when it is not a parseable date", () => {
+    const { deps } = setup({ isFetching: false, data: [{ date: "n/a", totalUsdSpent: 0 }] });
+    const tickFormatter = deps.XAxis.mock.calls.at(-1)?.[0]?.tickFormatter as (value: string, index: number) => string;
+
+    expect(tickFormatter("n/a", 0)).toBe("n/a");
+  });
+
+  function withTimezone<T>(timeZone: string, fn: () => T): T {
+    const original = process.env.TZ;
+    process.env.TZ = timeZone;
+    try {
+      return fn();
+    } finally {
+      process.env.TZ = original;
+    }
+  }
+
   function setup(props: { isFetching: boolean; data: Array<{ date: string; totalUsdSpent: number }> }) {
     const deps = MockComponents(DEPENDENCIES, {
       LineChart: vi.fn(ComponentMock) as unknown as typeof DEPENDENCIES.LineChart,

--- a/apps/deploy-web/src/components/billing-usage/CumulativeSpendingLineChart/CumulativeSpendingLineChart.tsx
+++ b/apps/deploy-web/src/components/billing-usage/CumulativeSpendingLineChart/CumulativeSpendingLineChart.tsx
@@ -2,7 +2,7 @@ import React, { type FC } from "react";
 import type { ChartConfig } from "@akashnetwork/ui/components";
 import { Card, CardContent, CardHeader, CardTitle, ChartContainer, ChartTooltip, ChartTooltipContent, Spinner } from "@akashnetwork/ui/components";
 import { cn } from "@akashnetwork/ui/utils";
-import { format } from "date-fns";
+import { format, parseISO } from "date-fns";
 import { CartesianGrid, Line, LineChart, XAxis } from "recharts";
 
 import { TrendIndicator } from "@src/components/billing-usage/TrendIndicator/TrendIndicator";
@@ -65,7 +65,8 @@ export const CumulativeSpendingLineChart: FC<CumulativeSpendingLineChartProps> =
               axisLine={false}
               tickMargin={8}
               tickFormatter={value => {
-                const date = new Date(value);
+                // parseISO reads date-only strings (YYYY-MM-DD) as local time; native Date() treats them as UTC and shifts the label a day west of UTC
+                const date = parseISO(value);
                 return isNaN(date.getTime()) ? value : format(date, "M/d");
               }}
             />
@@ -75,7 +76,8 @@ export const CumulativeSpendingLineChart: FC<CumulativeSpendingLineChartProps> =
                   className="w-[180px]"
                   nameKey="totalUsdSpent"
                   labelFormatter={value => {
-                    const date = new Date(value);
+                    // parseISO reads date-only strings (YYYY-MM-DD) as local time; native Date() treats them as UTC and shifts the label a day west of UTC
+                    const date = parseISO(value);
                     return isNaN(date.getTime()) ? value : format(date, "MMM d, yyyy");
                   }}
                 />

--- a/apps/deploy-web/src/components/billing-usage/TrendIndicator/TrendIndicator.tsx
+++ b/apps/deploy-web/src/components/billing-usage/TrendIndicator/TrendIndicator.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { isToday } from "date-fns";
+import { isToday, parseISO } from "date-fns";
 import { GraphDown, GraphUp } from "iconoir-react";
 
 const COMPONENTS = {
@@ -41,7 +41,8 @@ export const TrendIndicator = <Field extends string & Keys<Data>, Data extends H
     if (firstValue === 0) return null;
 
     const percentageChange = ((lastValue - firstValue) / firstValue) * 100;
-    const isCurrentDay = isToday(new Date(lastItem.date));
+    // parseISO reads date-only strings (YYYY-MM-DD) as local time; native Date() treats them as UTC and misfires isToday west of UTC
+    const isCurrentDay = isToday(parseISO(lastItem.date));
 
     return {
       change: Math.round(percentageChange * 100) / 100,


### PR DESCRIPTION
## Why

The usage history `date` field arrives from the API as a `YYYY-MM-DD` date-only string. Several billing-usage components parsed it with native `new Date(...)`, which interprets a bare date as **UTC midnight**. Comparing/formatting that instant in local time shifts it a day for any user west of UTC:

- **TrendIndicator** — `isToday()` misfired, so the "today" label was wrongly hidden for western-hemisphere users.
- **CumulativeSpendingLineChart** — the X-axis tick labels and the tooltip date were rendered one day early (e.g. `7/1` shown as `6/30`).

This also made the `TrendIndicator` "today" spec fail intermittently depending on the runner's timezone.

## What

- Parse the date-only string with date-fns `parseISO`, which reads date-only ISO strings in **local** time, so date comparisons and labels are consistent in every timezone.
  - [TrendIndicator.tsx](apps/deploy-web/src/components/billing-usage/TrendIndicator/TrendIndicator.tsx)
  - [CumulativeSpendingLineChart.tsx](apps/deploy-web/src/components/billing-usage/CumulativeSpendingLineChart/CumulativeSpendingLineChart.tsx) (axis `tickFormatter` + tooltip `labelFormatter`)
- Added timezone-pinned tests for the chart formatters (asserting identical output under `America/Los_Angeles` and `Asia/Tokyo`); verified they fail on the old `new Date()` code (`6/30` vs `7/1`). The existing `TrendIndicator` spec now passes deterministically across timezones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed billing usage chart date handling by switching to date-only parsing for consistent axis and tooltip formatting in the viewer’s local timezone.
  * Improved “today” detection in trend indicators for date-only values.
  * Kept unparseable date strings from being reformatted incorrectly.
* **Tests**
  * Added unit tests to confirm axis tick and tooltip labels render identically across different `TZ` settings, including the unparseable-date case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->