### PR TITLE
refactor: changes behavior of zero bids state for manual and auto flows

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.spec.ts
@@ -60,15 +60,53 @@ describe(useDeploymentFlow.name, () => {
     await waitFor(() => expect(result.current.phase).toBe("error"));
   });
 
-  it("times out to an error when no providers bid within the window", () => {
+  it("halts in error without closing the deployment when no providers bid in the auto flow", () => {
     vi.useFakeTimers();
     try {
-      const { result } = setup({ intent: { sdlStrategy: "default", bidStrategy: "auto", dseq: "777" } });
+      const closeMutate = vi.fn();
+      const { result } = setup({ intent: { sdlStrategy: "default", bidStrategy: "auto", dseq: "777" }, closeMutate });
       expect(result.current.phase).toBe("quoting");
 
       act(() => vi.advanceTimersByTime(60_000));
 
+      // The auto autopilot re-creates whenever the flow returns to `configuring` and reads its error scene off the
+      // "error" phase, so the flow must halt here — leaving the deployment for the user's "Try again"/"Choose my
+      // provider" rather than closing it and looping.
       expect(result.current.phase).toBe("error");
+      expect(result.current.error?.message).toContain("No providers");
+      expect(closeMutate).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("closes the dangling deployment and returns to configuring, surfacing the error, when no providers bid in the manual flow", () => {
+    vi.useFakeTimers();
+    try {
+      const closeMutate = vi.fn((_args, { onSuccess }) => onSuccess({}));
+      const { result } = setup({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777" }, closeMutate });
+      expect(result.current.phase).toBe("quoting");
+
+      act(() => vi.advanceTimersByTime(60_000));
+
+      expect(closeMutate).toHaveBeenCalledWith({ dseq: "777" }, expect.any(Object));
+      expect(result.current.phase).toBe("configuring");
+      expect(result.current.error?.message).toContain("No providers");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the no-providers message set while the close is still in flight in the manual flow", () => {
+    vi.useFakeTimers();
+    try {
+      // Never resolves — proves the message survives `cancelAndEdit`'s own `setError(undefined)` so the error toast fires.
+      const closeMutate = vi.fn();
+      const { result } = setup({ intent: { sdlStrategy: "edit", bidStrategy: "select", dseq: "777" }, closeMutate });
+
+      act(() => vi.advanceTimersByTime(60_000));
+
+      expect(result.current.phase).toBe("closing");
       expect(result.current.error?.message).toContain("No providers");
     } finally {
       vi.useRealTimers();

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/useDeploymentFlow/useDeploymentFlow.ts
@@ -140,6 +140,11 @@ export function useDeploymentFlow(
   const bidStrategyRef = useRef(bidStrategy);
   bidStrategyRef.current = bidStrategy;
 
+  // Latest `cancelAndEdit` for the no-providers timeout to call. It closes over `dseq`/`bidStrategy` and the per-render
+  // close mutation, so it can't be a stable effect dependency — a ref lets the timeout reach the current one without
+  // re-arming (and thus resetting) the timer on every render, which would keep it from ever firing.
+  const cancelAndEditRef = useRef<() => void>();
+
   const bidsQuery = dependencies.useListBids(dseq, { enabled: phase === "quoting", refetchInterval: BID_POLL_INTERVAL });
 
   const redirectTimerRef = useRef<ReturnType<typeof setTimeout>>();
@@ -175,8 +180,18 @@ export function useDeploymentFlow(
       // Arm only while quoting with nothing shown and no bid ever seen; once a bid has appeared it never re-arms.
       if (phase !== "quoting" || providersEverBidRef.current) return;
       const timer = setTimeout(function timeOutWithoutProviders() {
+        // Only the auto-deploy experience autopilots over this shared flow. That autopilot re-fires a create whenever
+        // the flow lands back in `configuring` and reads its error scene off `phase === "error"` (not `error`), so there
+        // we must halt in `error` — its "Try again"/"Choose my provider" drive the next step. The manual flow has no
+        // autopilot: close the now-dangling deployment and drop back to editing. Either way set the message last so it
+        // survives `cancelAndEdit`'s own `setError(undefined)` (same batch, last write wins) and the error toast fires.
+        if (intentRef.current.sdlStrategy === "default" && bidStrategyRef.current === "auto") {
+          setError({ message: NO_PROVIDERS_MESSAGE });
+          setPhase("error");
+          return;
+        }
+        cancelAndEditRef.current?.();
         setError({ message: NO_PROVIDERS_MESSAGE });
-        setPhase("error");
       }, NO_BIDS_TIMEOUT_MS);
       return function cancelNoProvidersTimeout() {
         clearTimeout(timer);
@@ -244,6 +259,7 @@ export function useDeploymentFlow(
     },
     [closeDeployment, dseq, router, bidStrategy]
   );
+  cancelAndEditRef.current = cancelAndEdit;
 
   const setBidStrategy = useCallback(
     function setBidStrategy(strategy: BidStrategy) {


### PR DESCRIPTION
## Why

to fix incorrect flow on configure screen when user receives no bids. Closes CON-643

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when no providers submit bids within the expected time.
  * Automatic deployments now close incomplete deployment attempts and display an error state.
  * Manual deployment flows return to configuration while preserving the “no providers” error message.
  * Prevented timeout handling from using outdated deployment actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->