### PR TITLE
refactor: removes bid deselection on bid selection dialog close

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.spec.tsx
@@ -210,7 +210,7 @@ describe(GpuCard.name, () => {
     expect(screen.getByRole("combobox", { name: "GPU model" })).toBeDisabled();
     expect(screen.getByRole("combobox", { name: "GPU memory" })).toBeDisabled();
     expect(screen.getByRole("combobox", { name: "GPU interface" })).toBeDisabled();
-  });
+  }, 15_000);
 
   const StubGpuModelFields: typeof DEPENDENCIES.GpuModelFields = ({ gpuIndex }) => <div role="group" aria-label={`GPU ${gpuIndex + 1}`} />;
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.spec.tsx
@@ -289,16 +289,6 @@ describe(ConfigureDeploymentForm.name, () => {
     expect(requestQuotes).toHaveBeenCalledWith("sdl-x");
   });
 
-  it("deselects the focused placement's provider when the review modal is dismissed via Back", async () => {
-    const { flow } = setup({ initialSdl: VALID_SDL, Panes: ProviderSelectProbePanes });
-    const focusedPlacementId = screen.getByTestId("focused-placement").textContent;
-
-    await userEvent.click(screen.getByRole("button", { name: "select provider" }));
-    await userEvent.click(screen.getByRole("button", { name: "back to marketplace" }));
-
-    expect(flow.actions.clearSelection).toHaveBeenCalledWith(focusedPlacementId);
-  });
-
   it("closes the review modal when it is dismissed via Back", async () => {
     setup({ initialSdl: VALID_SDL, Panes: ProviderSelectProbePanes });
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentForm/ConfigureDeploymentForm.tsx
@@ -218,13 +218,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
     }
   }
 
-  /**
-   * Closing the review modal via Back drops the provider chosen for the placement currently in focus — the one
-   * whose selection auto-opened the modal — so the user lands back on the marketplace with it deselected and ready
-   * to re-pick, rather than staring at an already-selected placement with no obvious way forward.
-   */
-  function closeReviewAndDeselect() {
-    flow.actions.clearSelection(selectedPlacement.id);
+  function closeReview() {
     setReviewOpen(false);
   }
 
@@ -288,7 +282,7 @@ export const ConfigureDeploymentForm: FC<Props> = ({ initialSdl, initialName, in
           dseq={flow.dseq}
           placements={placements}
           selections={flow.selections}
-          onBack={closeReviewAndDeselect}
+          onBack={closeReview}
           onConfirm={() => {
             setReviewOpen(false);
             flow.actions.deploy(liveSdl);

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ReviewAndDeployModal/ReviewAndDeployModal.tsx
@@ -38,10 +38,11 @@ export const ReviewAndDeployModal: FC<Props> = ({ open, dseq, placements, select
   const { rows, pricedCount, totalCount } = d.useReviewRows({ dseq, placements, selections });
   /** Only deployable once every placement is selected and still has a live (priced) bid — a closed/stale bid leaves a row unpriced and would fail at create-lease. */
   const canConfirm = totalCount > 0 && rows.length === totalCount && pricedCount === totalCount;
+  const preventDefault = (e: Event) => e.preventDefault();
 
   return (
     <DialogV2 open={open} onOpenChange={isOpen => (!isOpen ? onBack() : undefined)}>
-      <DialogV2Content className="max-w-2xl">
+      <DialogV2Content className="max-w-2xl" onEscapeKeyDown={preventDefault} onInteractOutside={preventDefault} hideCloseButton>
         <DialogV2Header>
           <DialogV2Title>Review and deploy</DialogV2Title>
           <DialogV2Description>Review your provider selections for each placement before deploying.</DialogV2Description>

--- a/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
+++ b/apps/deploy-web/src/context/ServicesProvider/ServicesProvider.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useMemo } from "react";
-import type { NetworkId } from "@akashnetwork/chain-sdk";
+import type { NetworkId } from "@akashnetwork/chain-sdk/web";
 import { AuthzHttpService, BmeHttpService } from "@akashnetwork/http-sdk";
 
 import { UACT_DENOM, UAKT_DENOM, USDC_IBC_DENOMS } from "@src/config/denom.config";


### PR DESCRIPTION
## Why

because this may be confusing in multi placement deployment

## What

<!--
- include video or images for frontend related changes
- specify BREAKING CHANGES which can break production contracts
- ensure migration can run effectively on production db without blocking it
- explain what you changed in this PR. Except for the cases above, can be left blank because coderabbit will autocomplete it
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Going back from the deployment review modal now closes it without clearing the selected provider.
  * Review modals no longer close unintentionally when pressing Escape or interacting outside the modal.
  * Updated review flow checks so the “back to marketplace” option is no longer shown after dismissing via Back.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->