### PR TITLE
feat(auth): autofocus verification code and add sign-in loading states

### DIFF
--- a/apps/deploy-web/src/components/auth/EmailCodeStart/EmailCodeStart.spec.tsx
+++ b/apps/deploy-web/src/components/auth/EmailCodeStart/EmailCodeStart.spec.tsx
@@ -46,18 +46,49 @@ describe(EmailCodeStart.name, () => {
     });
   });
 
-  function setup(input: { defaultEmail?: string; onStarted?: (email: string) => void; getCaptchaToken?: () => Promise<string> } = {}) {
+  it("keeps the label visible and shows a loading indicator while the code is being sent", async () => {
+    const { authService } = setup();
+    authService.startEmailCode.mockReturnValue(new Promise<void>(() => {}));
+
+    await userEvent.type(screen.getByLabelText("Email"), "alice@example.com");
+    await userEvent.click(screen.getByRole("button", { name: /continue with email/i }));
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /continue with email/i })).toBeDisabled();
+  });
+
+  it("records the code-send time on a successful send", async () => {
+    const { authService, markCodeSent } = setup();
+    authService.startEmailCode.mockResolvedValue(undefined);
+
+    await userEvent.type(screen.getByLabelText("Email"), "alice@example.com");
+    await userEvent.click(screen.getByRole("button", { name: /continue with email/i }));
+
+    await vi.waitFor(() => {
+      expect(markCodeSent).toHaveBeenCalled();
+    });
+  });
+
+  function setup(input: { defaultEmail?: string; onStarted?: (email: string) => void; getCaptchaToken?: () => Promise<string>; markCodeSent?: () => void } = {}) {
     const authService = mock<AuthService>();
     const analyticsService = mock<AnalyticsService>();
     const onStarted = input.onStarted ?? vi.fn();
     const getCaptchaToken = input.getCaptchaToken ?? vi.fn().mockResolvedValue("captcha-token");
+    const markCodeSent = input.markCodeSent ?? vi.fn();
 
     render(
       <TestContainerProvider services={{ authService: () => authService, analyticsService: () => analyticsService }}>
-        <EmailCodeStart defaultEmail={input.defaultEmail} onStarted={onStarted} getCaptchaToken={getCaptchaToken} dependencies={DEPENDENCIES} />
+        <EmailCodeStart
+          defaultEmail={input.defaultEmail}
+          onStarted={onStarted}
+          getCaptchaToken={getCaptchaToken}
+          dependencies={{ ...DEPENDENCIES, markCodeSent }}
+        />
       </TestContainerProvider>
     );
 
-    return { authService, analyticsService, onStarted, getCaptchaToken };
+    return { authService, analyticsService, onStarted, getCaptchaToken, markCodeSent };
   }
 });

--- a/apps/deploy-web/src/components/auth/EmailCodeStart/EmailCodeStart.tsx
+++ b/apps/deploy-web/src/components/auth/EmailCodeStart/EmailCodeStart.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useForm } from "react-hook-form";
-import { Button, Form, FormField, FormInput, Spinner } from "@akashnetwork/ui/components";
+import { Form, FormField, FormInput, LoadingButton } from "@akashnetwork/ui/components";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
 import { z } from "zod";
 
 import { RemoteApiError } from "@src/components/shared/RemoteApiError/RemoteApiError";
 import { useServices } from "@src/context/ServicesProvider";
+import { markCodeSent } from "../PasswordlessAuth/withPersistedPasswordlessFlow";
 
 /** Single-field passwordless entry form: blocks submission unless the input is a syntactically valid email. */
 const formSchema = z.object({
@@ -17,12 +18,12 @@ const formSchema = z.object({
 export type EmailCodeStartValues = z.infer<typeof formSchema>;
 
 export const DEPENDENCIES = {
-  Button,
   Form,
   FormField,
   FormInput,
+  LoadingButton,
   RemoteApiError,
-  Spinner,
+  markCodeSent,
   useForm,
   useMutation
 };
@@ -44,6 +45,7 @@ export function EmailCodeStart({ dependencies: d = DEPENDENCIES, ...props }: Pro
       await authService.startEmailCode({ email: input.email, captchaToken });
     },
     onSuccess(_data, variables) {
+      d.markCodeSent();
       props.onStarted(variables.email);
     }
   });
@@ -73,12 +75,25 @@ export function EmailCodeStart({ dependencies: d = DEPENDENCIES, ...props }: Pro
               />
             )}
           />
-          <d.Button type="submit" aria-label="Continue with email" disabled={startMutation.isPending} className="h-10 w-full">
-            {startMutation.isPending ? <d.Spinner size="small" /> : "Continue with email"}
-          </d.Button>
+          <d.LoadingButton type="submit" loading={startMutation.isPending} loadingIndicator={<ButtonSpinner />} className="h-10 w-full">
+            Continue with email
+          </d.LoadingButton>
         </form>
       </d.Form>
       <p className="text-center text-xs leading-4 text-neutral-500 dark:text-neutral-400">We&apos;ll email you a 6 digit code. No password to remember.</p>
     </>
+  );
+}
+
+/**
+ * Ring spinner tinted with the button's foreground color via `border-current`, so it stays visible on
+ * solid buttons. The shared `Spinner`'s arc is `fill-primary`, which equals `bg-primary` and vanishes there.
+ */
+function ButtonSpinner() {
+  return (
+    <span role="status" className="mr-2 flex items-center justify-center">
+      <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-r-transparent" />
+      <span className="sr-only">Loading...</span>
+    </span>
   );
 }

--- a/apps/deploy-web/src/components/auth/EmailCodeVerify/EmailCodeVerify.spec.tsx
+++ b/apps/deploy-web/src/components/auth/EmailCodeVerify/EmailCodeVerify.spec.tsx
@@ -59,24 +59,20 @@ describe(EmailCodeVerify.name, () => {
     expect(analyticsService.track).toHaveBeenCalledWith("wrong_email_clk");
   });
 
-  it("disables resend during the initial cooldown and enables it when the timer hits zero", async () => {
+  it("shows the resend cooldown counter on mount and enables resend when it elapses", async () => {
     setup();
 
-    const resend = screen.getByRole("button", { name: /resend/i });
-    expect(resend).toBeDisabled();
-    expect(resend).toHaveTextContent(`Resend in ${RESEND_COOLDOWN_SEC}s`);
+    expect(screen.getByRole("button", { name: /resend in \d+s/i })).toBeDisabled();
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(RESEND_COOLDOWN_SEC * 1000);
     });
 
-    expect(resend).toBeEnabled();
-    expect(resend).toHaveTextContent(/resend code/i);
+    expect(screen.getByRole("button", { name: /resend code/i })).toBeEnabled();
   });
 
-  it("resends the code and restarts the cooldown on successful resend", async () => {
-    const getCaptchaToken = vi.fn().mockResolvedValue("captcha-2");
-    const { authService, analyticsService } = setup({ getCaptchaToken });
+  it("shows the resend cooldown counter again after a successful resend", async () => {
+    const { authService, analyticsService } = setup();
     authService.startEmailCode.mockResolvedValue(undefined);
 
     await act(async () => {
@@ -84,22 +80,114 @@ describe(EmailCodeVerify.name, () => {
     });
 
     await act(async () => {
-      await userEvent.click(screen.getByRole("button", { name: /resend/i }));
+      await userEvent.click(screen.getByRole("button", { name: /resend code/i }));
     });
 
     await vi.waitFor(() => {
-      expect(authService.startEmailCode).toHaveBeenCalledWith({ email: "alice@example.com", captchaToken: "captcha-2" });
+      expect(authService.startEmailCode).toHaveBeenCalled();
     });
     expect(analyticsService.track).toHaveBeenCalledWith("resend_code_clk");
-    expect(screen.getByRole("button", { name: /resend/i })).toHaveTextContent(`Resend in ${RESEND_COOLDOWN_SEC}s`);
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole("button", { name: /resend in \d+s/i })).toBeInTheDocument();
+    });
+  });
+
+  it("shows a verifying indicator while the code is being verified", async () => {
+    const { authService, captureOnComplete } = setup();
+    authService.verifyEmailCode.mockReturnValue(new Promise<void>(() => {}));
+
+    await act(async () => {
+      captureOnComplete()?.("123456");
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.getByText(/verifying/i)).toBeInTheDocument();
+    });
+  });
+
+  it("hides the resend button while the code is being resent", async () => {
+    const { authService } = setup();
+    authService.startEmailCode.mockReturnValue(new Promise<void>(() => {}));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RESEND_COOLDOWN_SEC * 1000);
+    });
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole("button", { name: /resend code/i }));
+    });
+
+    await vi.waitFor(() => {
+      expect(screen.queryByRole("button", { name: /resend/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("continues the resend cooldown from when the code was last sent", () => {
+    setup({ readCodeSentAt: () => Date.now() - 10_000 });
+
+    expect(screen.getByRole("button", { name: /resend in 20s/i })).toBeInTheDocument();
+  });
+
+  it("hides the resend control and disables the input while verifying", async () => {
+    const { authService, captureOnComplete, getVerifyDisabled } = setup();
+    authService.verifyEmailCode.mockReturnValue(new Promise<void>(() => {}));
+
+    await act(async () => {
+      captureOnComplete()?.("123456");
+    });
+
+    await vi.waitFor(() => {
+      expect(getVerifyDisabled()).toBe(true);
+      expect(screen.queryByRole("button", { name: /resend/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps the input disabled and resend hidden after a successful verify while redirecting", async () => {
+    const onVerified = vi.fn(() => new Promise<void>(() => {}));
+    const { authService, captureOnComplete, getVerifyDisabled } = setup({ onVerified });
+    authService.verifyEmailCode.mockResolvedValue(undefined);
+
+    await act(async () => {
+      captureOnComplete()?.("123456");
+    });
+
+    await vi.waitFor(() => {
+      expect(authService.verifyEmailCode).toHaveBeenCalled();
+    });
+
+    await vi.waitFor(() => {
+      expect(getVerifyDisabled()).toBe(true);
+      expect(screen.queryByRole("button", { name: /resend/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("records the code-send time when resending", async () => {
+    const markCodeSent = vi.fn();
+    const { authService } = setup({ markCodeSent });
+    authService.startEmailCode.mockResolvedValue(undefined);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RESEND_COOLDOWN_SEC * 1000);
+    });
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole("button", { name: /resend code/i }));
+    });
+
+    await vi.waitFor(() => {
+      expect(markCodeSent).toHaveBeenCalled();
+    });
   });
 
   function setup(
     input: {
-      onVerified?: () => void;
+      onVerified?: () => void | Promise<void>;
       onEditEmail?: () => void;
       getCaptchaToken?: () => Promise<string>;
       injectVerifyRef?: VerificationCodeInputRef;
+      readCodeSentAt?: () => number | null;
+      markCodeSent?: () => void;
     } = {}
   ) {
     const authService = mock<AuthService>();
@@ -107,11 +195,15 @@ describe(EmailCodeVerify.name, () => {
     const onVerified = input.onVerified ?? vi.fn();
     const onEditEmail = input.onEditEmail ?? vi.fn();
     const getCaptchaToken = input.getCaptchaToken ?? vi.fn().mockResolvedValue("captcha-token");
+    const markCodeSent = input.markCodeSent ?? vi.fn();
+    const readCodeSentAt = input.readCodeSentAt ?? (() => null);
     let capturedOnComplete: ((code: string) => void) | undefined;
+    let capturedDisabled: boolean | undefined;
 
     const VerificationCodeInputMock = forwardRef<VerificationCodeInputRef, { onComplete: (code: string) => void; disabled?: boolean }>(
       function VerificationCodeInputStub(props, ref) {
         capturedOnComplete = props.onComplete;
+        capturedDisabled = props.disabled;
         useImperativeHandle(ref, () => input.injectVerifyRef ?? mock<VerificationCodeInputRef>());
         return null;
       }
@@ -124,11 +216,19 @@ describe(EmailCodeVerify.name, () => {
           getCaptchaToken={getCaptchaToken}
           onEditEmail={onEditEmail}
           onVerified={onVerified}
-          dependencies={{ ...DEPENDENCIES, VerificationCodeInput: VerificationCodeInputMock as never }}
+          dependencies={{ ...DEPENDENCIES, VerificationCodeInput: VerificationCodeInputMock as never, markCodeSent, readCodeSentAt }}
         />
       </TestContainerProvider>
     );
 
-    return { authService, analyticsService, onVerified, onEditEmail, captureOnComplete: () => capturedOnComplete };
+    return {
+      authService,
+      analyticsService,
+      onVerified,
+      onEditEmail,
+      markCodeSent,
+      captureOnComplete: () => capturedOnComplete,
+      getVerifyDisabled: () => capturedDisabled
+    };
   }
 });

--- a/apps/deploy-web/src/components/auth/EmailCodeVerify/EmailCodeVerify.tsx
+++ b/apps/deploy-web/src/components/auth/EmailCodeVerify/EmailCodeVerify.tsx
@@ -1,21 +1,25 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { Button } from "@akashnetwork/ui/components";
+import { Button, Spinner } from "@akashnetwork/ui/components";
 import { useMutation } from "@tanstack/react-query";
 
 import type { VerificationCodeInputRef } from "@src/components/onboarding/steps/EmailVerificationStep/VerificationCodeInput";
 import { VerificationCodeInput } from "@src/components/onboarding/steps/EmailVerificationStep/VerificationCodeInput";
 import { RemoteApiError } from "@src/components/shared/RemoteApiError/RemoteApiError";
 import { useServices } from "@src/context/ServicesProvider";
+import { markCodeSent, readCodeSentAt } from "../PasswordlessAuth/withPersistedPasswordlessFlow";
 
-/** Resend cooldown for the verify screen, in seconds. Tune in one place. */
+/** Resend cooldown in seconds, applied on arrival and after each manual resend. */
 export const RESEND_COOLDOWN_SEC = 30;
 
 export const DEPENDENCIES = {
   Button,
   RemoteApiError,
+  Spinner,
   VerificationCodeInput,
+  markCodeSent,
+  readCodeSentAt,
   useMutation
 };
 
@@ -30,7 +34,7 @@ interface Props {
 export function EmailCodeVerify({ dependencies: d = DEPENDENCIES, ...props }: Props) {
   const { authService, analyticsService } = useServices();
   const verifyInputRef = useRef<VerificationCodeInputRef>(null);
-  const [resendCooldownSec, setResendCooldownSec] = useState(RESEND_COOLDOWN_SEC);
+  const [resendCooldownSec, setResendCooldownSec] = useState(() => remainingResendCooldownSec(d.readCodeSentAt()));
 
   const verifyMutation = d.useMutation({
     async mutationFn(input: { code: string }) {
@@ -57,6 +61,7 @@ export function EmailCodeVerify({ dependencies: d = DEPENDENCIES, ...props }: Pr
       verifyMutation.reset();
     },
     onSuccess() {
+      d.markCodeSent();
       setResendCooldownSec(RESEND_COOLDOWN_SEC);
     }
   });
@@ -74,10 +79,10 @@ export function EmailCodeVerify({ dependencies: d = DEPENDENCIES, ...props }: Pr
     [resendCooldownSec]
   );
 
-  const isAnyMutationPending = verifyMutation.isPending || resendMutation.isPending;
-  const isResendDisabled = resendCooldownSec > 0 || isAnyMutationPending;
+  const isVerifying = verifyMutation.isPending || verifyMutation.isSuccess;
+  const isBusy = isVerifying || resendMutation.isPending;
   const resendLabel = resendCooldownSec > 0 ? `Resend in ${resendCooldownSec}s` : "Resend code";
-  const activeError = isAnyMutationPending ? null : verifyMutation.error ?? resendMutation.error;
+  const activeError = isBusy ? null : verifyMutation.error ?? resendMutation.error;
 
   function editEmail() {
     analyticsService.track("wrong_email_clk");
@@ -99,16 +104,26 @@ export function EmailCodeVerify({ dependencies: d = DEPENDENCIES, ...props }: Pr
             Wrong email? Edit
           </d.Button>
         </p>
-        <d.VerificationCodeInput
-          ref={verifyInputRef}
-          onComplete={code => verifyMutation.mutate({ code })}
-          disabled={verifyMutation.isPending || resendMutation.isPending}
-        />
-        <p className="text-xs text-neutral-500">Code expires in 10 minutes.</p>
-        <d.Button variant="link" className="h-auto p-0 text-sm" disabled={isResendDisabled} onClick={resendCode} type="button">
-          {resendLabel}
-        </d.Button>
+        <d.VerificationCodeInput ref={verifyInputRef} onComplete={code => verifyMutation.mutate({ code })} disabled={isBusy} />
+        {isVerifying ? (
+          <p className="flex items-center gap-2 text-xs text-neutral-500">
+            <d.Spinner size="small" /> Verifying...
+          </p>
+        ) : (
+          <p className="text-xs text-neutral-500">Code expires in 10 minutes.</p>
+        )}
+        {!isBusy && (
+          <d.Button variant="link" className="h-auto p-0 text-sm" disabled={resendCooldownSec > 0} onClick={resendCode} type="button">
+            {resendLabel}
+          </d.Button>
+        )}
       </div>
     </>
   );
+}
+
+/** Cooldown remaining (whole seconds) given when the code was last sent; full cooldown when the send time is unknown. */
+function remainingResendCooldownSec(sentAt: number | null): number {
+  if (sentAt == null) return RESEND_COOLDOWN_SEC;
+  return Math.max(0, Math.ceil(RESEND_COOLDOWN_SEC - (Date.now() - sentAt) / 1000));
 }

--- a/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.spec.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.spec.tsx
@@ -184,20 +184,20 @@ describe(PasswordAuth.name, () => {
     });
   });
 
-  describe("$5 credit subtext", () => {
+  describe("$1 credit subtext", () => {
     it("renders when onboarding_redesign_v1 is enabled and the login/signup view is active", () => {
       setup({ isOnboardingRedesignEnabled: true });
-      expect(screen.getByText(/\$5 credit to deploy your first container/i)).toBeInTheDocument();
+      expect(screen.getByText(/\$1 credit to deploy your first container/i)).toBeInTheDocument();
     });
 
     it("does not render when onboarding_redesign_v1 is disabled", () => {
       setup({ isOnboardingRedesignEnabled: false });
-      expect(screen.queryByText(/\$5 credit to deploy your first container/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/\$1 credit to deploy your first container/i)).not.toBeInTheDocument();
     });
 
     it("does not render in the forgot-password view even when onboarding_redesign_v1 is enabled", () => {
       setup({ searchParams: { tab: "forgot-password" }, isOnboardingRedesignEnabled: true });
-      expect(screen.queryByText(/\$5 credit to deploy your first container/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/\$1 credit to deploy your first container/i)).not.toBeInTheDocument();
     });
   });
 

--- a/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordAuth/PasswordAuth.tsx
@@ -116,7 +116,7 @@ export function PasswordAuth({ dependencies: d = DEPENDENCIES }: Props = {}) {
             : "Create your Akash account or log in to an existing one."}
         </p>
         {activeView !== "forgot-password" && isOnboardingRedesignEnabled && (
-          <p className="text-sm leading-5 text-neutral-500 dark:text-neutral-400">$5 credit to deploy your first container. No card required.</p>
+          <p className="text-sm leading-5 text-neutral-500 dark:text-neutral-400">$1 credit to deploy your first container. No card required.</p>
         )}
       </div>
 

--- a/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.spec.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.spec.tsx
@@ -86,14 +86,14 @@ describe(PasswordlessAuth.name, () => {
     expect(token).toBe("test-captcha-token");
   });
 
-  it("shows the $5 credit subtext when onboarding_redesign_v1 is enabled", () => {
+  it("shows the $1 credit subtext when onboarding_redesign_v1 is enabled", () => {
     setup({ isOnboardingRedesignEnabled: true });
-    expect(screen.getByText(/\$5 credit to deploy your first container/i)).toBeInTheDocument();
+    expect(screen.getByText(/\$1 credit to deploy your first container/i)).toBeInTheDocument();
   });
 
-  it("hides the $5 credit subtext when onboarding_redesign_v1 is disabled", () => {
+  it("hides the $1 credit subtext when onboarding_redesign_v1 is disabled", () => {
     setup({ isOnboardingRedesignEnabled: false });
-    expect(screen.queryByText(/\$5 credit to deploy your first container/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\$1 credit to deploy your first container/i)).not.toBeInTheDocument();
   });
 
   it("tracks terms_link_clk when the Terms link is clicked", async () => {

--- a/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordlessAuth/PasswordlessAuth.tsx
@@ -90,7 +90,7 @@ export function PasswordlessAuth({ dependencies: d = DEPENDENCIES, ...props }: P
       <div className="flex w-full flex-col items-center gap-2 text-center">
         <h1 className="text-[30px] font-bold leading-9 text-neutral-950 dark:text-neutral-50">Start deploying</h1>
         {isOnboardingRedesignEnabled && (
-          <p className="text-sm leading-5 text-neutral-500 dark:text-neutral-400">$5 credit to deploy your first container. No card required.</p>
+          <p className="text-sm leading-5 text-neutral-500 dark:text-neutral-400">$1 credit to deploy your first container. No card required.</p>
         )}
       </div>
       {screen === "entry" && (

--- a/apps/deploy-web/src/components/auth/PasswordlessAuth/withPersistedPasswordlessFlow.tsx
+++ b/apps/deploy-web/src/components/auth/PasswordlessAuth/withPersistedPasswordlessFlow.tsx
@@ -6,6 +6,30 @@ import { useCallback, useState } from "react";
 /** sessionStorage key for the in-flight passwordless screen + email. Per-tab; cleared on successful verify. */
 export const EMAIL_CODE_FLOW_STORAGE_KEY = "console_email_code_flow_v1";
 
+/** sessionStorage key for the last code-send time (ms), so the resend cooldown survives a reload. Per-tab. */
+export const CODE_SENT_AT_STORAGE_KEY = "console_email_code_sent_at_v1";
+
+/** Record that a code was just sent, anchoring the resend cooldown so a page reload continues it instead of restarting. */
+export function markCodeSent(): void {
+  try {
+    window.sessionStorage.setItem(CODE_SENT_AT_STORAGE_KEY, String(Date.now()));
+  } catch {
+    return;
+  }
+}
+
+/** Read the last code-send time (ms); null when missing, corrupted, or server-side. */
+export function readCodeSentAt(): number | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(CODE_SENT_AT_STORAGE_KEY);
+    const parsed = raw == null ? NaN : Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 export interface PassedFlowProps {
   initialEmail: string;
   initialScreen: "entry" | "verify";
@@ -37,6 +61,7 @@ export function withPersistedPasswordlessFlow<P extends PassedFlowProps>(Compone
     const onFlowReset = useCallback(function clearPersistedPasswordlessFlow() {
       try {
         window.sessionStorage.removeItem(EMAIL_CODE_FLOW_STORAGE_KEY);
+        window.sessionStorage.removeItem(CODE_SENT_AT_STORAGE_KEY);
       } catch {
         return;
       }

--- a/apps/deploy-web/src/components/deployments/DeploymentTemplatePickerCard/DeploymentTemplatePickerCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentTemplatePickerCard/DeploymentTemplatePickerCard.spec.tsx
@@ -11,14 +11,14 @@ describe(DeploymentTemplatePickerCard.name, () => {
       chip: "Starter",
       title: "Hello World",
       description: "A simple deployment",
-      priceBold: "$5",
+      priceBold: "$1",
       priceRest: "/mo"
     });
 
     expect(screen.getByText("Starter")).toBeInTheDocument();
     expect(screen.getByText("Hello World")).toBeInTheDocument();
     expect(screen.getByText("A simple deployment")).toBeInTheDocument();
-    expect(screen.getByText("$5")).toBeInTheDocument();
+    expect(screen.getByText("$1")).toBeInTheDocument();
     expect(screen.getByText("/mo")).toBeInTheDocument();
   });
 
@@ -77,7 +77,7 @@ describe(DeploymentTemplatePickerCard.name, () => {
       chip: "Starter",
       title: "Hello World",
       description: "A simple deployment",
-      priceBold: "$5",
+      priceBold: "$1",
       priceRest: "/mo",
       ctaLabel: "Deploy now",
       heroImageSrc: "/hero.png",

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/VerificationCodeInput.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/VerificationCodeInput.spec.tsx
@@ -75,6 +75,45 @@ describe(VerificationCodeInput.name, () => {
     });
   });
 
+  it("focuses the first digit input on mount", () => {
+    setup();
+
+    const inputs = screen.queryAllByRole("textbox");
+    expect(inputs[0]).toHaveFocus();
+  });
+
+  it("refocuses the first digit input when the page becomes visible again", () => {
+    setup();
+
+    const inputs = screen.queryAllByRole("textbox");
+    act(() => {
+      inputs[3].focus();
+    });
+    expect(inputs[3]).toHaveFocus();
+
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(inputs[0]).toHaveFocus();
+  });
+
+  it("refocuses the first digit input when the window regains focus", () => {
+    setup();
+
+    const inputs = screen.queryAllByRole("textbox");
+    act(() => {
+      inputs[2].focus();
+    });
+    expect(inputs[2]).toHaveFocus();
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    expect(inputs[0]).toHaveFocus();
+  });
+
   it("resets digits when reset is called via ref", async () => {
     const ref = React.createRef<VerificationCodeInputRef>();
     const { onComplete } = setup({ ref });

--- a/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/VerificationCodeInput.tsx
+++ b/apps/deploy-web/src/components/onboarding/steps/EmailVerificationStep/VerificationCodeInput.tsx
@@ -19,19 +19,46 @@ export const VerificationCodeInput = React.forwardRef<VerificationCodeInputRef, 
   const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
   const submittedCodeRef = useRef<string | null>(null);
 
+  const focusFirstDigit = useCallback(() => {
+    inputRefs.current[0]?.focus();
+  }, []);
+
   const reset = useCallback(() => {
     setDigits(Array(CODE_LENGTH).fill(""));
     submittedCodeRef.current = null;
-    inputRefs.current[0]?.focus();
-  }, []);
+    focusFirstDigit();
+  }, [focusFirstDigit]);
 
   useImperativeHandle(
     ref,
     () => ({
       reset,
-      focus: () => inputRefs.current[0]?.focus()
+      focus: focusFirstDigit
     }),
-    [reset]
+    [reset, focusFirstDigit]
+  );
+
+  useEffect(
+    function focusFirstDigitOnPageVisit() {
+      if (disabled) return;
+
+      focusFirstDigit();
+
+      function refocusWhenPageVisible() {
+        if (document.visibilityState === "visible") {
+          focusFirstDigit();
+        }
+      }
+
+      document.addEventListener("visibilitychange", refocusWhenPageVisible);
+      window.addEventListener("focus", focusFirstDigit);
+
+      return function teardownPageVisitFocus() {
+        document.removeEventListener("visibilitychange", refocusWhenPageVisible);
+        window.removeEventListener("focus", focusFirstDigit);
+      };
+    },
+    [disabled, focusFirstDigit]
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Why

Passwordless email sign-in had two rough edges:

- After leaving to copy the code from their email client, users came back to a screen where the code
  field was not focused, so they had to click into it before typing or pasting.
- The screens gave no feedback while the code was being emailed, verified, or resent. The "Continue
  with email" button in particular went blank-and-disabled — its spinner used the same color as the
  button background, so it read as a broken/unresponsive state.

This PR makes the code entry cursor-ready whenever the user (re)visits the screen and adds clear
loading feedback throughout the flow. It also lowers the free-trial credit copy from $5 to $1.

## What

- **Autofocus the verification code input on visit.** The shared `VerificationCodeInput` now focuses
  the first digit on mount and refocuses it when the page/tab regains visibility — covering both
  tab-switching (`visibilitychange`) and app/window-switching (`window` focus) — so returning from the
  email client lands the cursor ready to type or paste. Skipped while the input is disabled (mid-verify).
  Benefits both the passwordless auth flow and the onboarding email-verification step, which share the
  component.
- **Loading states across passwordless sign-in:**
  - "Continue with email" now uses `LoadingButton`, keeping the label visible and showing a spinner
    while the code is sent. The indicator is tinted with the button foreground (`border-current`) so it
    stays visible on the solid button — the shared `Spinner`'s arc is `fill-primary`, the same token as
    `bg-primary`, so it was invisible there.
  - A "Verifying..." spinner shows while the entered code is being checked.
  - The resend control shows a `Resend in Ns` countdown (on arrival and after each resend) that survives a
    page reload — it is anchored to the persisted last-send time (sessionStorage), not restarted on mount —
    becomes `Resend code` once it elapses, and is hidden during any in-progress state.
  - While verifying and during the post-verify redirect, the code input stays disabled and the resend
    control stays hidden, so nothing is interactive until navigation completes.
- **Copy:** free-trial credit lowered from $5 to $1 on the sign-in screens and the starter template card.

Tests: unit specs added/updated for autofocus (mount + visibility refocus), the three loading states,
and the copy change. All affected specs pass; lint and type-check are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Passwordless email verification now preserves resend cooldowns across navigation and reloads.
  - Verification inputs automatically refocus when the page becomes visible or regains focus.
  - Email code sending and verification display clearer loading states and prevent conflicting actions.
  - Resend controls are hidden while verification is in progress.
  - Onboarding credit messaging is updated from $5 to $1.

- **Bug Fixes**
  - Resend cooldowns now reset correctly after sending a new code and when the flow is reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->