### PR TITLE
feat(deployment): searchable GPU model select with prioritized models

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.spec.tsx
@@ -129,10 +129,11 @@ describe(GpuCard.name, () => {
     expect(getValues().services[0].profile.gpuModels?.[0]).toEqual({ vendor: "amd", name: "", memory: "", interface: "" });
   });
 
-  it("clears the model along with memory and interface", async () => {
+  it("clears the model along with memory and interface when Any model is picked", async () => {
     const { getValues, user } = setup({ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "a100", memory: "40Gi", interface: "pcie" }] });
 
-    await user.click(screen.getByRole("button", { name: "Clear GPU model" }));
+    await user.click(screen.getByRole("combobox", { name: "GPU model" }));
+    await user.click(await screen.findByRole("option", { name: "Any model" }));
 
     expect(getValues().services[0].profile.gpuModels?.[0]).toMatchObject({ vendor: "nvidia", name: "", memory: "", interface: "" });
   });
@@ -142,9 +143,54 @@ describe(GpuCard.name, () => {
 
     expect(screen.getByRole("combobox", { name: "GPU model" })).toHaveTextContent("a100");
 
-    await user.click(screen.getByRole("button", { name: "Clear GPU model" }));
+    await user.click(screen.getByRole("combobox", { name: "GPU model" }));
+    await user.click(await screen.findByRole("option", { name: "Any model" }));
 
     expect(screen.getByRole("combobox", { name: "GPU model" })).not.toHaveTextContent("a100");
+  });
+
+  it("orders the model options by GPU priority", async () => {
+    const { user } = setup({
+      hasGpu: true,
+      gpuModels: [{ vendor: "nvidia", name: "", memory: "", interface: "" }],
+      vendors: [
+        {
+          name: "nvidia",
+          models: [
+            { name: "t4", memory: ["16Gi"], interface: ["pcie"] },
+            { name: "a100", memory: ["80Gi"], interface: ["sxm"] },
+            { name: "h100", memory: ["80Gi"], interface: ["sxm"] }
+          ]
+        }
+      ]
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "GPU model" }));
+
+    const optionNames = (await screen.findAllByRole("option")).map(option => option.textContent);
+    expect(optionNames).toEqual(["Any model", "h100", "a100", "t4"]);
+  });
+
+  it("filters the model options by the search box", async () => {
+    const { user } = setup({
+      hasGpu: true,
+      gpuModels: [{ vendor: "nvidia", name: "", memory: "", interface: "" }],
+      vendors: [
+        {
+          name: "nvidia",
+          models: [
+            { name: "h100", memory: ["80Gi"], interface: ["sxm"] },
+            { name: "t4", memory: ["16Gi"], interface: ["pcie"] }
+          ]
+        }
+      ]
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "GPU model" }));
+    await user.type(await screen.findByRole("combobox", { name: "Search GPU models" }), "h1");
+
+    expect(screen.getByRole("option", { name: "h100" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "t4" })).not.toBeInTheDocument();
   });
 
   it("clears only the memory when the memory clear button is clicked", async () => {
@@ -166,7 +212,6 @@ describe(GpuCard.name, () => {
   it("does not offer clear buttons while the fields are empty", () => {
     setup({ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "", memory: "", interface: "" }] });
 
-    expect(screen.queryByRole("button", { name: "Clear GPU model" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Clear GPU memory" })).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Clear GPU interface" })).not.toBeInTheDocument();
   });
@@ -222,6 +267,7 @@ describe(GpuCard.name, () => {
     gpu?: number;
     hasGpu?: boolean;
     gpuModels?: SdlBuilderFormValuesType["services"][number]["profile"]["gpuModels"];
+    vendors?: GpuVendor[];
     gpuError?: string;
     isLoading?: boolean;
     isError?: boolean;
@@ -241,7 +287,7 @@ describe(GpuCard.name, () => {
     });
 
     const gpuModelsResult = mock<ReturnType<typeof DEPENDENCIES.useGpuModels>>({
-      data: input.isLoading || input.isError ? undefined : GPU_VENDORS,
+      data: input.isLoading || input.isError ? undefined : input.vendors ?? GPU_VENDORS,
       isLoading: input.isLoading ?? false,
       isError: input.isError ?? false
     } as Partial<ReturnType<typeof DEPENDENCIES.useGpuModels>>);

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
@@ -19,10 +19,11 @@ import {
 } from "@akashnetwork/ui/components";
 import { GpuIcon, LockIcon, PlusIcon, TrashIcon, XIcon } from "lucide-react";
 
+import { SearchableSelect } from "@src/components/shared/SearchableSelect/SearchableSelect";
 import { useGpuModels } from "@src/queries/useGpuQuery";
 import type { SdlBuilderFormValuesType } from "@src/types";
 import type { GpuVendor } from "@src/types/gpu";
-import { gpuVendors as fallbackVendors } from "@src/utils/akash/gpu";
+import { gpuVendors as fallbackVendors, prioritizeGpuModels } from "@src/utils/akash/gpu";
 import { validationConfig } from "@src/utils/akash/units";
 import { defaultGpuModel } from "@src/utils/sdl/data";
 import { gpuTooltip } from "../cardTooltips";
@@ -136,7 +137,11 @@ export const GpuCard: FC<Props> = ({ serviceIndex, locked = false, isBlockedMode
   );
 };
 
-const GpuCountField: FC<{ serviceIndex: number; locked?: boolean; dependencies: typeof DEPENDENCIES }> = ({ serviceIndex, locked = false, dependencies: d }) => {
+const GpuCountField: FC<{ serviceIndex: number; locked?: boolean; dependencies: typeof DEPENDENCIES }> = ({
+  serviceIndex,
+  locked = false,
+  dependencies: d
+}) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const { error: gpuError } = d.useFieldError(`services.${serviceIndex}.profile.gpu`);
   const errorId = useId();
@@ -229,6 +234,35 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
     setValue(`${basePath}.interface`, "", { shouldValidate: true, shouldDirty: true });
   }, [name.field, setValue, basePath]);
 
+  const selectModel = useCallback(
+    (value: string) => {
+      if (value) {
+        selectGpuModel(value);
+      } else {
+        clearModel();
+      }
+    },
+    [selectGpuModel, clearModel]
+  );
+
+  const modelOptions = useMemo(
+    () =>
+      prioritizeGpuModels(models).map(model => {
+        const blocked = isBlockedModel(vendor.field.value, model.name);
+        return {
+          value: model.name,
+          disabled: blocked,
+          label: (
+            <span className="flex items-center gap-1.5">
+              {model.name}
+              {blocked && <LockIcon className="h-3 w-3 shrink-0 text-muted-foreground" aria-label="Requires credits" />}
+            </span>
+          )
+        };
+      }),
+    [models, isBlockedModel, vendor.field.value]
+  );
+
   return (
     <div role="group" aria-label={`GPU ${gpuIndex + 1}`} className="flex flex-col gap-3 rounded-md border border-zinc-200 p-3 dark:border-zinc-800">
       <div className="flex items-center justify-between">
@@ -270,26 +304,18 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
           <Field className="gap-2">
             <FieldLabel>Model</FieldLabel>
             <FieldContent>
-              <ClearableSelect clearLabel="Clear GPU model" onClear={!locked && name.field.value ? clearModel : undefined}>
-                <Select value={name.field.value || ""} onValueChange={selectGpuModel} disabled={locked || models.length === 0}>
-                  <SelectTrigger aria-label="GPU model" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
-                    <SelectValue placeholder="Select" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {models.map(model => {
-                      const blocked = isBlockedModel(vendor.field.value, model.name);
-                      return (
-                        <SelectItem key={model.name} value={model.name} disabled={blocked}>
-                          <span className="flex items-center gap-1.5">
-                            {model.name}
-                            {blocked && <LockIcon className="h-3 w-3 shrink-0 text-muted-foreground" aria-label="Requires credits" />}
-                          </span>
-                        </SelectItem>
-                      );
-                    })}
-                  </SelectContent>
-                </Select>
-              </ClearableSelect>
+              <SearchableSelect
+                value={name.field.value || ""}
+                onChange={selectModel}
+                options={modelOptions}
+                ariaLabel="GPU model"
+                searchLabel="Search GPU models"
+                searchPlaceholder="Search models..."
+                notFoundMessage="No models found."
+                emptyOption={{ value: "", label: "Any model" }}
+                disabled={locked || models.length === 0}
+                triggerClassName="h-9"
+              />
             </FieldContent>
           </Field>
 
@@ -316,7 +342,10 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
           <Field className="gap-2">
             <FieldLabel>Interface</FieldLabel>
             <FieldContent>
-              <ClearableSelect clearLabel="Clear GPU interface" onClear={!locked && gpuInterface.field.value ? () => gpuInterface.field.onChange("") : undefined}>
+              <ClearableSelect
+                clearLabel="Clear GPU interface"
+                onClear={!locked && gpuInterface.field.value ? () => gpuInterface.field.onChange("") : undefined}
+              >
                 <Select value={gpuInterface.field.value || ""} onValueChange={gpuInterface.field.onChange} disabled={locked || !selectedModel}>
                   <SelectTrigger aria-label="GPU interface" className={`h-9 ${SELECT_TRUNCATE_VALUE}`}>
                     <SelectValue placeholder="Select" />

--- a/apps/deploy-web/src/components/sdl/RegionSelect/RegionSelect.spec.tsx
+++ b/apps/deploy-web/src/components/sdl/RegionSelect/RegionSelect.spec.tsx
@@ -7,7 +7,7 @@ import type { SdlBuilderFormValuesType } from "@src/types";
 import type { ApiProviderRegion } from "@src/types/provider";
 import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
 import type { DEPENDENCIES } from "./RegionSelect";
-import { filterRegions, RegionSelect } from "./RegionSelect";
+import { RegionSelect } from "./RegionSelect";
 
 import { fireEvent, render, screen } from "@testing-library/react";
 
@@ -18,25 +18,9 @@ const REGIONS: ApiProviderRegion[] = [
 ];
 
 describe("RegionSelect", () => {
-  describe("filterRegions", () => {
-    it("returns all regions for an empty or whitespace query", () => {
-      expect(filterRegions(REGIONS, "")).toEqual(REGIONS);
-      expect(filterRegions(REGIONS, "   ")).toEqual(REGIONS);
-    });
-
-    it("matches case-insensitive substrings of the visible key", () => {
-      expect(filterRegions(REGIONS, "EU")).toEqual([REGIONS[0], REGIONS[1]]);
-    });
-
-    it("ignores text that only appears in the hidden description", () => {
-      expect(filterRegions(REGIONS, "europe")).toEqual([]);
-      expect(filterRegions(REGIONS, "america")).toEqual([]);
-    });
-  });
-
   it("writes the picked region, reflects it in the trigger, and resets the search", async () => {
     const { getValues } = setup({ regions: REGIONS });
-    const trigger = screen.getByRole("button", { name: "Region" });
+    const trigger = screen.getByRole("combobox", { name: "Region" });
 
     fireEvent.click(trigger);
     fireEvent.change(await screen.findByRole("combobox", { name: "Search regions" }), { target: { value: "na" } });
@@ -51,7 +35,7 @@ describe("RegionSelect", () => {
 
   it("clears the region and shows Any region in the trigger when Any region is picked", async () => {
     const { getValues } = setup({ regions: REGIONS, region: "eu-west" });
-    const trigger = screen.getByRole("button", { name: "Region" });
+    const trigger = screen.getByRole("combobox", { name: "Region" });
 
     fireEvent.click(trigger);
     fireEvent.click(await screen.findByRole("option", { name: "Any region" }));
@@ -63,7 +47,7 @@ describe("RegionSelect", () => {
   it("filters by the visible key, ignores description text, keeps Any region, and restores on clear", async () => {
     setup({ regions: REGIONS });
 
-    fireEvent.click(screen.getByRole("button", { name: "Region" }));
+    fireEvent.click(screen.getByRole("combobox", { name: "Region" }));
     const input = await screen.findByRole("combobox", { name: "Search regions" });
 
     fireEvent.change(input, { target: { value: "eu" } });

--- a/apps/deploy-web/src/components/sdl/RegionSelect/RegionSelect.tsx
+++ b/apps/deploy-web/src/components/sdl/RegionSelect/RegionSelect.tsx
@@ -1,12 +1,10 @@
 import type { FC } from "react";
-import { useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
-import { Button, Command, CommandInput, CommandItem, CommandList, Popover, PopoverContent, PopoverTrigger } from "@akashnetwork/ui/components";
-import { MapPin, NavArrowDown } from "iconoir-react";
+import { MapPin } from "iconoir-react";
 
+import { SearchableSelect } from "@src/components/shared/SearchableSelect/SearchableSelect";
 import { useProviderRegions } from "@src/queries/useProvidersQuery";
 import type { SdlBuilderFormValuesType } from "@src/types";
-import type { ApiProviderRegion } from "@src/types/provider";
 
 export const DEPENDENCIES = { useProviderRegions };
 
@@ -20,78 +18,27 @@ type Props = {
 export const RegionSelect: FC<Props> = ({ placementIndex, disabled, dependencies: d = DEPENDENCIES }) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const { data: regions } = d.useProviderRegions();
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState("");
-  const filteredRegions = filterRegions(regions ?? [], search);
-
-  function closeAndResetSearch(nextOpen: boolean) {
-    setOpen(nextOpen);
-    if (!nextOpen) {
-      setSearch("");
-    }
-  }
+  const options = (regions ?? []).map(region => ({ value: region.key, label: region.key }));
 
   return (
     <Controller
       control={control}
       name={`placements.${placementIndex}.region`}
       render={({ field }) => (
-        <Popover open={open} onOpenChange={closeAndResetSearch}>
-          <PopoverTrigger asChild>
-            <Button
-              type="button"
-              variant="outline"
-              aria-label="Region"
-              disabled={disabled}
-              className="h-8 w-full justify-between gap-1.5 px-3 text-xs font-normal"
-            >
-              <span className="flex min-w-0 items-center gap-1.5">
-                <MapPin aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                <span className="truncate">{field.value || "Any region"}</span>
-              </span>
-              <NavArrowDown aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
-            <Command label="Search regions" shouldFilter={false}>
-              <CommandInput value={search} onValueChange={setSearch} placeholder="Search regions..." />
-              <CommandList>
-                <CommandItem
-                  value="any"
-                  onSelect={function selectAnyRegion() {
-                    field.onChange("");
-                    closeAndResetSearch(false);
-                  }}
-                >
-                  Any region
-                </CommandItem>
-                {filteredRegions.map(region => (
-                  <CommandItem
-                    key={region.key}
-                    value={region.key}
-                    onSelect={function selectRegion() {
-                      field.onChange(region.key);
-                      closeAndResetSearch(false);
-                    }}
-                  >
-                    {region.key}
-                  </CommandItem>
-                ))}
-                {search && filteredRegions.length === 0 && <p className="py-6 text-center text-sm text-muted-foreground">No regions found.</p>}
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
+        <SearchableSelect
+          value={field.value ?? ""}
+          onChange={field.onChange}
+          options={options}
+          ariaLabel="Region"
+          searchLabel="Search regions"
+          searchPlaceholder="Search regions..."
+          notFoundMessage="No regions found."
+          emptyOption={{ value: "", label: "Any region" }}
+          leadingIcon={<MapPin aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />}
+          disabled={disabled}
+          triggerClassName="h-8 px-3 text-xs"
+        />
       )}
     />
   );
 };
-
-/** Case-insensitive substring match over each region's visible key only; an empty/whitespace query returns every region. */
-export function filterRegions(regions: ApiProviderRegion[], query: string): ApiProviderRegion[] {
-  const normalized = query.trim().toLowerCase();
-  if (!normalized) {
-    return regions;
-  }
-  return regions.filter(region => region.key.toLowerCase().includes(normalized));
-}

--- a/apps/deploy-web/src/components/shared/SearchableSelect/SearchableSelect.spec.tsx
+++ b/apps/deploy-web/src/components/shared/SearchableSelect/SearchableSelect.spec.tsx
@@ -1,0 +1,138 @@
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { SearchableSelectOption } from "./SearchableSelect";
+import { filterOptions, SearchableSelect } from "./SearchableSelect";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const OPTIONS: SearchableSelectOption[] = [
+  { value: "eu-west", label: "eu-west" },
+  { value: "eu-central", label: "eu-central" },
+  { value: "na-us-west", label: "na-us-west" }
+];
+
+describe("SearchableSelect", () => {
+  describe("filterOptions", () => {
+    it("returns all options for an empty or whitespace query", () => {
+      expect(filterOptions(OPTIONS, "")).toEqual(OPTIONS);
+      expect(filterOptions(OPTIONS, "   ")).toEqual(OPTIONS);
+    });
+
+    it("matches case-insensitive substrings of the value", () => {
+      expect(filterOptions(OPTIONS, "EU")).toEqual([OPTIONS[0], OPTIONS[1]]);
+    });
+
+    it("matches keywords in addition to the value", () => {
+      const options: SearchableSelectOption[] = [
+        { value: "a", label: "Alpha", keywords: ["first"] },
+        { value: "b", label: "Beta" }
+      ];
+      expect(filterOptions(options, "first")).toEqual([options[0]]);
+    });
+  });
+
+  it("shows the placeholder when nothing is selected and no empty option is given", () => {
+    setup({ value: "", placeholder: "Select" });
+
+    expect(screen.getByRole("combobox", { name: "Region" })).toHaveTextContent("Select");
+  });
+
+  it("shows the empty option label in the trigger when nothing is selected", () => {
+    setup({ value: "", emptyOption: { value: "", label: "Any region" } });
+
+    expect(screen.getByRole("combobox", { name: "Region" })).toHaveTextContent("Any region");
+  });
+
+  it("writes the picked option, reflects it in the trigger, and resets the search", async () => {
+    const { user, onChange } = setup({});
+    const trigger = screen.getByRole("combobox", { name: "Region" });
+
+    await user.click(trigger);
+    await user.type(await screen.findByRole("combobox", { name: "Search regions" }), "na");
+    await user.click(await screen.findByRole("option", { name: "na-us-west" }));
+
+    expect(onChange).toHaveBeenCalledWith("na-us-west");
+    expect(trigger).toHaveTextContent("na-us-west");
+
+    await user.click(trigger);
+    expect(await screen.findByRole("combobox", { name: "Search regions" })).toHaveValue("");
+  });
+
+  it("reports the empty option value when the empty option is picked", async () => {
+    const { user, onChange } = setup({ value: "eu-west", emptyOption: { value: "", label: "Any region" } });
+
+    await user.click(screen.getByRole("combobox", { name: "Region" }));
+    await user.click(await screen.findByRole("option", { name: "Any region" }));
+
+    expect(onChange).toHaveBeenCalledWith("");
+  });
+
+  it("filters options, shows the not-found message while keeping the empty option, and restores on clear", async () => {
+    const { user } = setup({ emptyOption: { value: "", label: "Any region" } });
+
+    await user.click(screen.getByRole("combobox", { name: "Region" }));
+    const input = await screen.findByRole("combobox", { name: "Search regions" });
+
+    await user.type(input, "eu");
+    expect(screen.getByRole("option", { name: "eu-west" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "na-us-west" })).not.toBeInTheDocument();
+
+    await user.clear(input);
+    await user.type(input, "zzz");
+    expect(screen.getByText("No regions found.")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Any region" })).toBeInTheDocument();
+
+    await user.clear(input);
+    expect(screen.getByRole("option", { name: "na-us-west" })).toBeInTheDocument();
+  });
+
+  it("renders a disabled option as non-selectable", async () => {
+    const { user } = setup({ options: [{ value: "eu-west", label: "eu-west", disabled: true }] });
+
+    await user.click(screen.getByRole("combobox", { name: "Region" }));
+
+    expect(await screen.findByRole("option", { name: "eu-west" })).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("disables the trigger when disabled", () => {
+    setup({ disabled: true });
+
+    expect(screen.getByRole("combobox", { name: "Region" })).toBeDisabled();
+  });
+
+  function setup(input: {
+    value?: string;
+    options?: SearchableSelectOption[];
+    emptyOption?: { value: string; label: string };
+    placeholder?: string;
+    disabled?: boolean;
+  }) {
+    const onChange = vi.fn();
+    const Harness = () => {
+      const [value, setValue] = useState(input.value ?? "");
+      return (
+        <SearchableSelect
+          value={value}
+          onChange={function trackChange(next) {
+            onChange(next);
+            setValue(next);
+          }}
+          options={input.options ?? OPTIONS}
+          ariaLabel="Region"
+          searchLabel="Search regions"
+          searchPlaceholder="Search regions..."
+          notFoundMessage="No regions found."
+          emptyOption={input.emptyOption}
+          placeholder={input.placeholder}
+          disabled={input.disabled}
+        />
+      );
+    };
+
+    render(<Harness />);
+
+    return { user: userEvent.setup(), onChange };
+  }
+});

--- a/apps/deploy-web/src/components/shared/SearchableSelect/SearchableSelect.tsx
+++ b/apps/deploy-web/src/components/shared/SearchableSelect/SearchableSelect.tsx
@@ -1,0 +1,140 @@
+import type { FC, ReactNode } from "react";
+import { useState } from "react";
+import { Button, Command, CommandInput, CommandItem, CommandList, Popover, PopoverContent, PopoverTrigger } from "@akashnetwork/ui/components";
+import { cn } from "@akashnetwork/ui/utils";
+import { NavArrowDown } from "iconoir-react";
+
+export type SearchableSelectOption = {
+  value: string;
+  /** Rendered in the option row; may include trailing adornments (e.g. a lock icon). */
+  label: ReactNode;
+  /** Renders the row non-selectable and `aria-disabled`. */
+  disabled?: boolean;
+  /** Extra terms matched by the search box in addition to `value`. */
+  keywords?: string[];
+};
+
+/** A leading "no selection" row (e.g. "Any region"/"Any model") that is always shown and never filtered out. */
+type EmptyOption = { value: string; label: ReactNode };
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+  options: SearchableSelectOption[];
+  /** Accessible name of the trigger (which exposes `role="combobox"`). */
+  ariaLabel: string;
+  /** Accessible name of the search box inside the popover. */
+  searchLabel: string;
+  searchPlaceholder?: string;
+  notFoundMessage: string;
+  emptyOption?: EmptyOption;
+  /** Trigger text when nothing is selected and no `emptyOption` is provided. */
+  placeholder?: ReactNode;
+  leadingIcon?: ReactNode;
+  disabled?: boolean;
+  triggerClassName?: string;
+};
+
+/** cmdk requires a non-empty item value; the empty option owns this sentinel while reporting `emptyOption.value` on select. */
+const EMPTY_OPTION_VALUE = "__searchable-select-empty__";
+
+/**
+ * A searchable single-select combobox: a trigger button opens a popover holding a
+ * search box and the option list. Filtering is manual (`shouldFilter={false}`) over
+ * each option's `value`/`keywords`, and the search resets whenever the popover closes.
+ * Options render in the order given, so a consumer that wants a custom order sorts
+ * `options` before passing them in.
+ */
+export const SearchableSelect: FC<Props> = ({
+  value,
+  onChange,
+  options,
+  ariaLabel,
+  searchLabel,
+  searchPlaceholder,
+  notFoundMessage,
+  emptyOption,
+  placeholder,
+  leadingIcon,
+  disabled,
+  triggerClassName
+}) => {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const filteredOptions = filterOptions(options, search);
+
+  function closeAndResetSearch(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (!nextOpen) {
+      setSearch("");
+    }
+  }
+
+  function selectValue(nextValue: string) {
+    onChange(nextValue);
+    closeAndResetSearch(false);
+  }
+
+  return (
+    <Popover open={open} onOpenChange={closeAndResetSearch}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-label={ariaLabel}
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn("w-full justify-between gap-1.5 font-normal", triggerClassName)}
+        >
+          <span className="flex min-w-0 items-center gap-1.5">
+            {leadingIcon}
+            <span className="truncate">{value || emptyOption?.label || placeholder}</span>
+          </span>
+          <NavArrowDown aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-[var(--radix-popover-trigger-width)] p-0">
+        <Command label={searchLabel} shouldFilter={false}>
+          <CommandInput value={search} onValueChange={setSearch} placeholder={searchPlaceholder} />
+          <CommandList>
+            {emptyOption && (
+              <CommandItem
+                value={EMPTY_OPTION_VALUE}
+                onSelect={function selectEmptyOption() {
+                  selectValue(emptyOption.value);
+                }}
+              >
+                {emptyOption.label}
+              </CommandItem>
+            )}
+            {filteredOptions.map(option => (
+              <CommandItem
+                key={option.value}
+                value={option.value}
+                disabled={option.disabled}
+                onSelect={function selectOption() {
+                  selectValue(option.value);
+                }}
+              >
+                {option.label}
+              </CommandItem>
+            ))}
+            {search && filteredOptions.length === 0 && <p className="py-6 text-center text-sm text-muted-foreground">{notFoundMessage}</p>}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+/** Case-insensitive substring match over each option's `value` and `keywords`; an empty/whitespace query returns every option. */
+export function filterOptions(options: SearchableSelectOption[], query: string): SearchableSelectOption[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return options;
+  }
+  return options.filter(
+    option => option.value.toLowerCase().includes(normalized) || (option.keywords ?? []).some(keyword => keyword.toLowerCase().includes(normalized))
+  );
+}

--- a/apps/deploy-web/src/utils/akash/gpu.spec.ts
+++ b/apps/deploy-web/src/utils/akash/gpu.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { prioritizeGpuModels } from "./gpu";
+
+describe("prioritizeGpuModels", () => {
+  it("floats prioritized models to the top in priority order", () => {
+    const models = [{ name: "t4" }, { name: "rtx4090" }, { name: "a100" }, { name: "h100" }, { name: "h200" }];
+
+    expect(prioritizeGpuModels(models).map(model => model.name)).toEqual(["h100", "a100", "h200", "rtx4090", "t4"]);
+  });
+
+  it("raises both pro6000 variants with the single pro6000 entry, preserving their order", () => {
+    const models = [{ name: "t4" }, { name: "pro6000we" }, { name: "pro6000se" }];
+
+    expect(prioritizeGpuModels(models).map(model => model.name)).toEqual(["pro6000we", "pro6000se", "t4"]);
+  });
+
+  it("keeps unmatched models in their original order", () => {
+    const models = [{ name: "t4" }, { name: "v100" }, { name: "a2000" }];
+
+    expect(prioritizeGpuModels(models).map(model => model.name)).toEqual(["t4", "v100", "a2000"]);
+  });
+
+  it("matches regardless of case and separators in the model name", () => {
+    const models = [{ name: "RTX-4090" }, { name: "PRO 6000 SE" }, { name: "H100" }];
+
+    expect(prioritizeGpuModels(models).map(model => model.name)).toEqual(["H100", "PRO 6000 SE", "RTX-4090"]);
+  });
+
+  it("ranks by the given priority list over the models' input order", () => {
+    const models = [{ name: "a100" }, { name: "t4" }];
+
+    expect(prioritizeGpuModels(models, ["t4", "a100"]).map(model => model.name)).toEqual(["t4", "a100"]);
+  });
+});

--- a/apps/deploy-web/src/utils/akash/gpu.ts
+++ b/apps/deploy-web/src/utils/akash/gpu.ts
@@ -1,1 +1,19 @@
 export const gpuVendors = [{ id: 1, value: "nvidia" }];
+
+/** GPU model-name prefixes (normalized, lowercase) floated to the top of the model picker, most popular first (by network capacity and usage). Prefix-matched, so `pro6000` covers `pro6000se`/`we`/`mq`, `h200` covers `h200nvl`, `rtx5090` covers `rtx5090m`, etc. */
+export const PRIORITIZED_GPU_MODELS = ["h100", "a100", "h200", "pro6000", "rtx5090", "rtx4090", "rtx3090"];
+
+/** Stable-sorts models so any whose normalized name starts with an earlier {@link PRIORITIZED_GPU_MODELS} entry rises first; unmatched models keep their original order. */
+export function prioritizeGpuModels<T extends { name: string }>(models: T[], priority: readonly string[] = PRIORITIZED_GPU_MODELS): T[] {
+  return models
+    .map((model, index) => ({ model, index, rank: priorityRank(model.name, priority) }))
+    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .map(entry => entry.model);
+}
+
+/** Index of the first priority prefix the normalized name starts with, or `Infinity` when none match. */
+function priorityRank(name: string, priority: readonly string[]): number {
+  const normalized = name.toLowerCase().replace(/[^a-z0-9]/g, "");
+  const rank = priority.findIndex(prefix => normalized.startsWith(prefix));
+  return rank === -1 ? Infinity : rank;
+}


### PR DESCRIPTION
## Why

The GPU model picker on the configure screen was a plain dropdown. On a network that exposes
dozens of models there was no way to search it, and the options were shown in the vendor
catalog's arbitrary order — so the GPUs people actually deploy (H100, A100, H200, the RTX
flagships) weren't reliably near the top. Finding a specific model meant scrolling the whole list.

This PR makes the model picker searchable and floats the most popular models to the top. The
search-combobox pattern was previously inlined only in the region picker, so this also extracts it
into a reusable component that both pickers now share.


## What

- **Reusable `SearchableSelect`.** A `Popover` + `Command` combobox driven by an options array:
  trigger (`role="combobox"`), search box, optional "Any …" empty row, disabled options, a
  "not found" state, and search-reset-on-close. Ships with a `filterOptions` helper.
- **Region picker refactored onto it.** Dropped `RegionSelect`'s inlined Popover/Command and its
  local `filterRegions`. Behavior is unchanged; the trigger now exposes the ARIA-correct
  `role="combobox"` (the plain button before did not).
- **GPU model field is now searchable.** Vendor / memory / interface stay plain selects — only the
  long model list needs search. Clearing moved to an "Any model" row (matching the region picker)
  and still resets memory + interface. Trial-blocked models still render locked with the unlock CTA.
- **Popularity ordering.** `prioritizeGpuModels` floats models matching
  `PRIORITIZED_GPU_MODELS = [h100, a100, h200, pro6000, rtx5090, rtx4090, rtx3090]` to the top, ranked
  from live network capacity/usage (`/v1/gpu-prices`). Matching is prefix-based, so one entry covers a
  variant family (`pro6000` → se/we/mq, `h200` → h200nvl, `rtx5090` → rtx5090m). Models not in the list
  keep their original order; an entry not present on the network is simply inert.

Tests: unit specs for `SearchableSelect` (filtering + selection/clear/empty/disabled behavior),
`prioritizeGpuModels` (ordering, variant prefixes, case/separator normalization), and updated GpuCard
specs (search, priority order, "Any model" clear). All affected specs pass; lint and type-check are clean.

<img width="389" height="698" alt="image" src="https://github.com/user-attachments/assets/1a459c5c-e3f7-4f1f-b9c5-f6ae7d8963f8" />

ref CON-606
