### PR TITLE
feat(billing): grant first-purchase 10% credit bonus capped at $100

### DIFF
--- a/apps/api/drizzle/0030_worried_exodus.sql
+++ b/apps/api/drizzle/0030_worried_exodus.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "stripe_transactions" ADD COLUMN "bonus_amount" integer DEFAULT 0 NOT NULL;

--- a/apps/api/drizzle/meta/0030_snapshot.json
+++ b/apps/api/drizzle/meta/0030_snapshot.json
@@ -1,0 +1,1316 @@
+{
+  "id": "8df5cdb6-6cdb-45a2-96e9-aa1324c40d76",
+  "prevId": "23f3ad91-3b5d-4930-9a49-628ecd8f138a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.user_wallets": {
+      "name": "user_wallets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_allowance": {
+          "name": "deployment_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "fee_allowance": {
+          "name": "fee_allowance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "trial": {
+          "name": "trial",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_wallets_user_id_userSetting_id_fk": {
+          "name": "user_wallets_user_id_userSetting_id_fk",
+          "tableFrom": "user_wallets",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_wallets_user_id_unique": {
+          "name": "user_wallets_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "user_wallets_address_unique": {
+          "name": "user_wallets_address_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.payment_methods": {
+      "name": "payment_methods",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fingerprint": {
+          "name": "fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method_id": {
+          "name": "payment_method_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_validated": {
+          "name": "is_validated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "payment_methods_fingerprint_payment_method_id_unique": {
+          "name": "payment_methods_fingerprint_payment_method_id_unique",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_default_unique": {
+          "name": "payment_methods_user_id_is_default_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_default",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"payment_methods\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_fingerprint_idx": {
+          "name": "payment_methods_fingerprint_idx",
+          "columns": [
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_idx": {
+          "name": "payment_methods_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_is_validated_idx": {
+          "name": "payment_methods_user_id_is_validated_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_validated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "payment_methods_user_id_fingerprint_payment_method_id_idx": {
+          "name": "payment_methods_user_id_fingerprint_payment_method_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "fingerprint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "payment_method_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "payment_methods_user_id_userSetting_id_fk": {
+          "name": "payment_methods_user_id_userSetting_id_fk",
+          "tableFrom": "payment_methods",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_transactions": {
+      "name": "stripe_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "stripe_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "stripe_transaction_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'created'"
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount_refunded": {
+          "name": "amount_refunded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonus_amount": {
+          "name": "bonus_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_charge_id": {
+          "name": "stripe_charge_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_promotion_code_id": {
+          "name": "stripe_promotion_code_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_invoice_id": {
+          "name": "stripe_invoice_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_method_type": {
+          "name": "payment_method_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_brand": {
+          "name": "card_brand",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "card_last4": {
+          "name": "card_last4",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1000)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "stripe_transactions_user_id_idx": {
+          "name": "stripe_transactions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_payment_intent_id_idx": {
+          "name": "stripe_transactions_stripe_payment_intent_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_payment_intent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_charge_id_idx": {
+          "name": "stripe_transactions_stripe_charge_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_charge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_coupon_id_idx": {
+          "name": "stripe_transactions_stripe_coupon_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_coupon_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_stripe_promotion_code_id_idx": {
+          "name": "stripe_transactions_stripe_promotion_code_id_idx",
+          "columns": [
+            {
+              "expression": "stripe_promotion_code_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_status_idx": {
+          "name": "stripe_transactions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_created_at_idx": {
+          "name": "stripe_transactions_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "stripe_transactions_user_id_created_at_idx": {
+          "name": "stripe_transactions_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "stripe_transactions_user_id_userSetting_id_fk": {
+          "name": "stripe_transactions_user_id_userSetting_id_fk",
+          "tableFrom": "stripe_transactions",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wallet_settings": {
+      "name": "wallet_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "wallet_id": {
+          "name": "wallet_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_reload_enabled": {
+          "name": "auto_reload_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "wallet_settings_user_id_idx": {
+          "name": "wallet_settings_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "wallet_settings_wallet_id_user_wallets_id_fk": {
+          "name": "wallet_settings_wallet_id_user_wallets_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "user_wallets",
+          "columnsFrom": [
+            "wallet_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wallet_settings_user_id_userSetting_id_fk": {
+          "name": "wallet_settings_user_id_userSetting_id_fk",
+          "tableFrom": "wallet_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wallet_settings_wallet_id_unique": {
+          "name": "wallet_settings_wallet_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "wallet_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.userSetting": {
+      "name": "userSetting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripeCustomerId": {
+          "name": "stripeCustomerId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscribedToNewsletter": {
+          "name": "subscribedToNewsletter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "youtubeUsername": {
+          "name": "youtubeUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "githubUsername": {
+          "name": "githubUsername",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "last_ip": {
+          "name": "last_ip",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_user_agent": {
+          "name": "last_user_agent",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fingerprint": {
+          "name": "last_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "userSetting_userId_unique": {
+          "name": "userSetting_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "userSetting_username_unique": {
+          "name": "userSetting_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copiedFromId": {
+          "name": "copiedFromId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cpu": {
+          "name": "cpu",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ram": {
+          "name": "ram",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "storage": {
+          "name": "storage",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sdl": {
+          "name": "sdl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "template_userId_idx": {
+          "name": "template_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.templateFavorite": {
+      "name": "templateFavorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "templateId": {
+          "name": "templateId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "addedDate": {
+          "name": "addedDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "templateFavorite_userId_templateId_unique": {
+          "name": "templateFavorite_userId_templateId_unique",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "templateId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "templateFavorite_templateId_template_id_fk": {
+          "name": "templateFavorite_templateId_template_id_fk",
+          "tableFrom": "templateFavorite",
+          "tableTo": "template",
+          "columnsFrom": [
+            "templateId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment_settings": {
+      "name": "deployment_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dseq": {
+          "name": "dseq",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auto_top_up_enabled": {
+          "name": "auto_top_up_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "id_auto_top_up_enabled_closed_idx": {
+          "name": "id_auto_top_up_enabled_closed_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auto_top_up_enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "deployment_settings_user_id_userSetting_id_fk": {
+          "name": "deployment_settings_user_id_userSetting_id_fk",
+          "tableFrom": "deployment_settings",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "dseq_user_id_idx": {
+          "name": "dseq_user_id_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "dseq",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hashed_key": {
+          "name": "hashed_key",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_format": {
+          "name": "key_format",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "api_keys_user_id_userSetting_id_fk": {
+          "name": "api_keys_user_id_userSetting_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_hashed_key_unique": {
+          "name": "api_keys_hashed_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "hashed_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_verification_codes": {
+      "name": "email_verification_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "uuid_generate_v4()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_idx": {
+          "name": "email_verification_codes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_userSetting_id_fk": {
+          "name": "email_verification_codes_user_id_userSetting_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "userSetting",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.stripe_transaction_status": {
+      "name": "stripe_transaction_status",
+      "schema": "public",
+      "values": [
+        "created",
+        "pending",
+        "requires_action",
+        "succeeded",
+        "failed",
+        "refunded",
+        "canceled"
+      ]
+    },
+    "public.stripe_transaction_type": {
+      "name": "stripe_transaction_type",
+      "schema": "public",
+      "values": [
+        "payment_intent",
+        "coupon_claim"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1771979737373,
       "tag": "0029_fluffy_drax",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1783952138833,
+      "tag": "0030_worried_exodus",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/billing/model-schemas/stripe-transaction/stripe-transaction.schema.ts
+++ b/apps/api/src/billing/model-schemas/stripe-transaction/stripe-transaction.schema.ts
@@ -29,6 +29,7 @@ export const StripeTransactions = pgTable(
     status: stripeTransactionStatusEnum("status").notNull().default("created"),
     amount: integer("amount").notNull(), // Amount in cents
     amountRefunded: integer("amount_refunded").notNull().default(0), // Cumulative refunded amount in cents
+    bonusAmount: integer("bonus_amount").notNull().default(0), // First-purchase bonus granted with this payment, in cents
     currency: varchar("currency", { length: 3 }).notNull().default("usd"),
     stripePaymentIntentId: varchar("stripe_payment_intent_id", { length: 255 }),
     stripeChargeId: varchar("stripe_charge_id", { length: 255 }),

--- a/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
+++ b/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, lte, SQL } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lte, SQL } from "drizzle-orm";
 import { singleton } from "tsyringe";
 
 import { type ApiPgDatabase, type ApiPgTables, InjectPg, InjectPgTable } from "@src/core/providers";
@@ -91,6 +91,21 @@ export class StripeTransactionRepository extends BaseRepository<Table, StripeTra
     if (!existing) return undefined;
 
     return this.updateById(existing.id, update, { returning: true });
+  }
+
+  /**
+   * Whether the user has ever completed a paid purchase (`payment_intent` transaction that
+   * succeeded, including ones refunded afterwards). Coupon claims never count.
+   */
+  async hasCompletedPaidTransaction(userId: string): Promise<boolean> {
+    const item = await this.cursor.query.StripeTransactions.findFirst({
+      where: this.whereAccessibleBy(
+        and(eq(this.table.userId, userId), eq(this.table.type, "payment_intent"), inArray(this.table.status, ["succeeded", "refunded"]))
+      ),
+      columns: { id: true }
+    });
+
+    return !!item;
   }
 
   async countByUserId(userId: string): Promise<number> {

--- a/apps/api/src/billing/services/first-purchase-bonus/first-purchase-bonus.service.spec.ts
+++ b/apps/api/src/billing/services/first-purchase-bonus/first-purchase-bonus.service.spec.ts
@@ -5,9 +5,11 @@ import type { StripeTransactionRepository } from "@src/billing/repositories";
 import type { AnalyticsService } from "@src/core/services/analytics/analytics.service";
 import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
 import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import type { UserRepository } from "@src/user/repositories";
 import { FirstPurchaseBonusService } from "./first-purchase-bonus.service";
 
 import { generateDatabaseStripeTransaction } from "@test/seeders/database-stripe-transaction.seeder";
+import { createTestUser } from "@test/seeders/user-test.seeder";
 
 describe(FirstPurchaseBonusService.name, () => {
   describe("getEligibleBonusAmount", () => {
@@ -32,14 +34,15 @@ describe(FirstPurchaseBonusService.name, () => {
       expect(stripeTransactionRepository.hasCompletedPaidTransaction).not.toHaveBeenCalled();
     });
 
-    it("returns 0 below the qualifying amount without querying the repository", async () => {
-      const { service, stripeTransactionRepository } = setup({ flagEnabled: true });
+    it("returns 0 below the qualifying amount without querying the repository nor locking the user", async () => {
+      const { service, stripeTransactionRepository, userRepository } = setup({ flagEnabled: true });
       const transaction = generateDatabaseStripeTransaction({ type: "payment_intent" });
 
       const result = await service.getEligibleBonusAmount(transaction, 9900);
 
       expect(result).toBe(0);
       expect(stripeTransactionRepository.hasCompletedPaidTransaction).not.toHaveBeenCalled();
+      expect(userRepository.findOneByAndLock).not.toHaveBeenCalled();
     });
 
     it("returns 0 when the user already completed a paid purchase", async () => {
@@ -68,6 +71,26 @@ describe(FirstPurchaseBonusService.name, () => {
       await service.getEligibleBonusAmount(transaction, 10000);
 
       expect(featureFlagsService.isEnabled).toHaveBeenCalledWith(FeatureFlags.FIRST_PURCHASE_BONUS);
+    });
+
+    it("locks the user row before checking prior purchases so concurrent claims serialize", async () => {
+      const { service, stripeTransactionRepository, userRepository } = setup({ flagEnabled: true, hasPaidBefore: false });
+      const transaction = generateDatabaseStripeTransaction({ type: "payment_intent" });
+
+      await service.getEligibleBonusAmount(transaction, 10000);
+
+      expect(userRepository.findOneByAndLock).toHaveBeenCalledWith({ id: transaction.userId });
+      expect(userRepository.findOneByAndLock.mock.invocationCallOrder[0]).toBeLessThan(
+        stripeTransactionRepository.hasCompletedPaidTransaction.mock.invocationCallOrder[0]
+      );
+    });
+
+    it("throws when the user row cannot be locked", async () => {
+      const { service, stripeTransactionRepository } = setup({ flagEnabled: true, userLockable: false });
+      const transaction = generateDatabaseStripeTransaction({ type: "payment_intent" });
+
+      await expect(service.getEligibleBonusAmount(transaction, 10000)).rejects.toMatchObject({ status: 500 });
+      expect(stripeTransactionRepository.hasCompletedPaidTransaction).not.toHaveBeenCalled();
     });
   });
 
@@ -114,7 +137,7 @@ describe(FirstPurchaseBonusService.name, () => {
     });
   });
 
-  function setup(input?: { flagEnabled?: boolean; hasPaidBefore?: boolean }) {
+  function setup(input?: { flagEnabled?: boolean; hasPaidBefore?: boolean; userLockable?: boolean }) {
     const stripeTransactionRepository = mock<StripeTransactionRepository>();
     stripeTransactionRepository.hasCompletedPaidTransaction.mockResolvedValue(input?.hasPaidBefore ?? false);
 
@@ -123,8 +146,11 @@ describe(FirstPurchaseBonusService.name, () => {
 
     const analyticsService = mock<AnalyticsService>();
 
-    const service = new FirstPurchaseBonusService(stripeTransactionRepository, featureFlagsService, analyticsService);
+    const userRepository = mock<UserRepository>();
+    userRepository.findOneByAndLock.mockResolvedValue(input?.userLockable === false ? undefined : createTestUser());
 
-    return { service, stripeTransactionRepository, featureFlagsService, analyticsService };
+    const service = new FirstPurchaseBonusService(stripeTransactionRepository, featureFlagsService, analyticsService, userRepository);
+
+    return { service, stripeTransactionRepository, featureFlagsService, analyticsService, userRepository };
   }
 });

--- a/apps/api/src/billing/services/first-purchase-bonus/first-purchase-bonus.service.spec.ts
+++ b/apps/api/src/billing/services/first-purchase-bonus/first-purchase-bonus.service.spec.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { StripeTransactionRepository } from "@src/billing/repositories";
+import type { AnalyticsService } from "@src/core/services/analytics/analytics.service";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import { FirstPurchaseBonusService } from "./first-purchase-bonus.service";
+
+import { generateDatabaseStripeTransaction } from "@test/seeders/database-stripe-transaction.seeder";
+
+describe(FirstPurchaseBonusService.name, () => {
+  describe("getEligibleBonusAmount", () => {
+    it("returns 0 for coupon claims without querying the repository", async () => {
+      const { service, stripeTransactionRepository, featureFlagsService } = setup({ flagEnabled: true });
+      const transaction = generateDatabaseStripeTransaction({ type: "coupon_claim" });
+
+      const result = await service.getEligibleBonusAmount(transaction, 10000);
+
+      expect(result).toBe(0);
+      expect(featureFlagsService.isEnabled).not.toHaveBeenCalled();
+      expect(stripeTransactionRepository.hasCompletedPaidTransaction).not.toHaveBeenCalled();
+    });
+
+    it("returns 0 when the feature flag is disabled", async () => {
+      const { service, stripeTransactionRepository } = setup({ flagEnabled: false });
+      const transaction = generateDatabaseStripeTransaction({ type: "payment_intent" });
+
+      const result = await service.getEligibleBonusAmount(transaction, 10000);
+
+      expect(result).toBe(0);
+      expect(stripeTransactionRepository.hasCompletedPaidTransaction).not.toHaveBeenCalled();
+    });
+
+    it("returns 0 below the qualifying amount without querying the repository", async () => {
+      const { service, stripeTransactionRepository } = setup({ flagEnabled: true });
+      const transaction = generateDatabaseStripeTransaction({ type: "payment_intent" });
+
+      const result = await service.getEligibleBonusAmount(transaction, 9900);
+
+      expect(result).toBe(0);
+      expect(stripeTransactionRepository.hasCompletedPaidTransaction).not.toHaveBeenCalled();
+    });
+
+    it("returns 0 when the user already completed a paid purchase", async () => {
+      const { service, stripeTransactionRepository } = setup({ flagEnabled: true, hasPaidBefore: true });
+      const transaction = generateDatabaseStripeTransaction({ type: "payment_intent" });
+
+      const result = await service.getEligibleBonusAmount(transaction, 10000);
+
+      expect(result).toBe(0);
+      expect(stripeTransactionRepository.hasCompletedPaidTransaction).toHaveBeenCalledWith(transaction.userId);
+    });
+
+    it("grants 10% of a qualifying first purchase", async () => {
+      const { service } = setup({ flagEnabled: true, hasPaidBefore: false });
+      const transaction = generateDatabaseStripeTransaction({ type: "payment_intent" });
+
+      const result = await service.getEligibleBonusAmount(transaction, 10000);
+
+      expect(result).toBe(1000);
+    });
+
+    it("checks the first-purchase bonus feature flag", async () => {
+      const { service, featureFlagsService } = setup({ flagEnabled: true, hasPaidBefore: false });
+      const transaction = generateDatabaseStripeTransaction({ type: "payment_intent" });
+
+      await service.getEligibleBonusAmount(transaction, 10000);
+
+      expect(featureFlagsService.isEnabled).toHaveBeenCalledWith(FeatureFlags.FIRST_PURCHASE_BONUS);
+    });
+  });
+
+  describe("calculateBonusCents", () => {
+    it("returns 0 below the $100 minimum", () => {
+      const { service } = setup();
+
+      expect(service.calculateBonusCents(9900)).toBe(0);
+      expect(service.calculateBonusCents(0)).toBe(0);
+    });
+
+    it("returns 10% of the paid amount at or above the minimum", () => {
+      const { service } = setup();
+
+      expect(service.calculateBonusCents(10000)).toBe(1000);
+      expect(service.calculateBonusCents(100000)).toBe(10000);
+    });
+
+    it("caps the bonus at $100", () => {
+      const { service } = setup();
+
+      expect(service.calculateBonusCents(1000000)).toBe(10000);
+    });
+
+    it("floors non-round amounts", () => {
+      const { service } = setup();
+
+      expect(service.calculateBonusCents(10009)).toBe(1000);
+    });
+  });
+
+  describe("trackBonusGranted", () => {
+    it("tracks the grant with paid and bonus amounts", () => {
+      const { service, analyticsService } = setup();
+
+      service.trackBonusGranted("user-1", 15000, 1500);
+
+      expect(analyticsService.track).toHaveBeenCalledWith("user-1", "first_purchase_bonus_granted", {
+        paid_amount_cents: 15000,
+        paid_amount_usd: 150,
+        bonus_amount_cents: 1500,
+        bonus_amount_usd: 15
+      });
+    });
+  });
+
+  function setup(input?: { flagEnabled?: boolean; hasPaidBefore?: boolean }) {
+    const stripeTransactionRepository = mock<StripeTransactionRepository>();
+    stripeTransactionRepository.hasCompletedPaidTransaction.mockResolvedValue(input?.hasPaidBefore ?? false);
+
+    const featureFlagsService = mock<FeatureFlagsService>();
+    featureFlagsService.isEnabled.mockReturnValue(input?.flagEnabled ?? false);
+
+    const analyticsService = mock<AnalyticsService>();
+
+    const service = new FirstPurchaseBonusService(stripeTransactionRepository, featureFlagsService, analyticsService);
+
+    return { service, stripeTransactionRepository, featureFlagsService, analyticsService };
+  }
+});

--- a/apps/api/src/billing/services/first-purchase-bonus/first-purchase-bonus.service.ts
+++ b/apps/api/src/billing/services/first-purchase-bonus/first-purchase-bonus.service.ts
@@ -1,9 +1,11 @@
+import assert from "http-assert";
 import { singleton } from "tsyringe";
 
 import { type StripeTransactionOutput, StripeTransactionRepository } from "@src/billing/repositories";
 import { AnalyticsService } from "@src/core/services/analytics/analytics.service";
 import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
 import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import { UserRepository } from "@src/user/repositories";
 
 /** Smallest purchase that qualifies for the first-purchase bonus, in cents. */
 const MIN_QUALIFYING_AMOUNT_CENTS = 100_00;
@@ -17,7 +19,8 @@ export class FirstPurchaseBonusService {
   constructor(
     private readonly stripeTransactionRepository: StripeTransactionRepository,
     private readonly featureFlagsService: FeatureFlagsService,
-    private readonly analyticsService: AnalyticsService
+    private readonly analyticsService: AnalyticsService,
+    private readonly userRepository: UserRepository
   ) {}
 
   /**
@@ -27,9 +30,9 @@ export class FirstPurchaseBonusService {
    * "succeeded", so the current payment is not counted as its own prior purchase.
    * Coupon claims neither earn the bonus nor consume eligibility.
    *
-   * Known accepted race: two first-ever payment intents succeeding concurrently lock
-   * different rows and could both grant. Bounded at MAX_BONUS_CENTS per user; no
-   * user-level lock here.
+   * The user-row lock serializes concurrent first-ever payment intents: the loser
+   * waits for the winner's commit, then sees its succeeded transaction and grants 0,
+   * so a user can never be granted the bonus twice.
    */
   async getEligibleBonusAmount(transaction: StripeTransactionOutput, paidAmountCents: number): Promise<number> {
     if (transaction.type !== "payment_intent") return 0;
@@ -37,6 +40,9 @@ export class FirstPurchaseBonusService {
 
     const bonusCents = this.calculateBonusCents(paidAmountCents);
     if (bonusCents === 0) return 0;
+
+    const user = await this.userRepository.findOneByAndLock({ id: transaction.userId });
+    assert(user, 500, "Failed to lock user for first-purchase bonus eligibility", { userId: transaction.userId });
 
     const hasPaidBefore = await this.stripeTransactionRepository.hasCompletedPaidTransaction(transaction.userId);
     return hasPaidBefore ? 0 : bonusCents;

--- a/apps/api/src/billing/services/first-purchase-bonus/first-purchase-bonus.service.ts
+++ b/apps/api/src/billing/services/first-purchase-bonus/first-purchase-bonus.service.ts
@@ -1,0 +1,60 @@
+import { singleton } from "tsyringe";
+
+import { type StripeTransactionOutput, StripeTransactionRepository } from "@src/billing/repositories";
+import { AnalyticsService } from "@src/core/services/analytics/analytics.service";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+
+/** Smallest purchase that qualifies for the first-purchase bonus, in cents. */
+const MIN_QUALIFYING_AMOUNT_CENTS = 100_00;
+/** Bonus granted as a percentage of the paid amount. */
+const BONUS_PERCENT = 10;
+/** Bonus ceiling, in cents. */
+const MAX_BONUS_CENTS = 100_00;
+
+@singleton()
+export class FirstPurchaseBonusService {
+  constructor(
+    private readonly stripeTransactionRepository: StripeTransactionRepository,
+    private readonly featureFlagsService: FeatureFlagsService,
+    private readonly analyticsService: AnalyticsService
+  ) {}
+
+  /**
+   * Bonus (in cents) the given transaction earns, or 0 when it doesn't qualify.
+   *
+   * Must run inside the webhook's transaction scope BEFORE the row's status flips to
+   * "succeeded", so the current payment is not counted as its own prior purchase.
+   * Coupon claims neither earn the bonus nor consume eligibility.
+   *
+   * Known accepted race: two first-ever payment intents succeeding concurrently lock
+   * different rows and could both grant. Bounded at MAX_BONUS_CENTS per user; no
+   * user-level lock here.
+   */
+  async getEligibleBonusAmount(transaction: StripeTransactionOutput, paidAmountCents: number): Promise<number> {
+    if (transaction.type !== "payment_intent") return 0;
+    if (!this.featureFlagsService.isEnabled(FeatureFlags.FIRST_PURCHASE_BONUS)) return 0;
+
+    const bonusCents = this.calculateBonusCents(paidAmountCents);
+    if (bonusCents === 0) return 0;
+
+    const hasPaidBefore = await this.stripeTransactionRepository.hasCompletedPaidTransaction(transaction.userId);
+    return hasPaidBefore ? 0 : bonusCents;
+  }
+
+  /** `amount_received` can be non-round; flooring keeps the grant conservative. */
+  calculateBonusCents(paidAmountCents: number): number {
+    if (paidAmountCents < MIN_QUALIFYING_AMOUNT_CENTS) return 0;
+
+    return Math.min(Math.floor((paidAmountCents * BONUS_PERCENT) / 100), MAX_BONUS_CENTS);
+  }
+
+  trackBonusGranted(userId: string, paidAmountCents: number, bonusAmountCents: number): void {
+    this.analyticsService.track(userId, "first_purchase_bonus_granted", {
+      paid_amount_cents: paidAmountCents,
+      paid_amount_usd: paidAmountCents / 100,
+      bonus_amount_cents: bonusAmountCents,
+      bonus_amount_usd: bonusAmountCents / 100
+    });
+  }
+}

--- a/apps/api/src/billing/services/refill/refill.service.spec.ts
+++ b/apps/api/src/billing/services/refill/refill.service.spec.ts
@@ -52,7 +52,8 @@ describe(RefillService.name, () => {
           cardBrand: "visa",
           paymentMethodType: "card",
           transactionId: "tx-123",
-          source: "payment_intent"
+          source: "payment_intent",
+          bonusAmountCents: 10
         }
       });
 
@@ -63,7 +64,8 @@ describe(RefillService.name, () => {
         card_brand: "visa",
         payment_method_type: "card",
         transaction_id: "tx-123",
-        source: "payment_intent"
+        source: "payment_intent",
+        bonus_amount_cents: 10
       });
     });
 

--- a/apps/api/src/billing/services/refill/refill.service.ts
+++ b/apps/api/src/billing/services/refill/refill.service.ts
@@ -18,6 +18,8 @@ export interface PaymentAnalyticsContext {
   paymentMethodType?: string;
   transactionId?: string;
   source?: "payment_intent" | "coupon_claim";
+  /** First-purchase bonus included in the topped-up amount, in cents. */
+  bonusAmountCents?: number;
 }
 
 @singleton()
@@ -92,7 +94,8 @@ export class RefillService {
       card_brand: options.payment?.cardBrand,
       payment_method_type: options.payment?.paymentMethodType,
       transaction_id: options.payment?.transactionId,
-      source: options.payment?.source
+      source: options.payment?.source,
+      bonus_amount_cents: options.payment?.bonusAmountCents
     });
     this.logger.debug({ event: "WALLET_TOP_UP", userWallet, limits });
   }

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
@@ -535,7 +535,7 @@ describe(StripeWebhookService.name, () => {
       const refundedAmount = 5000;
 
       userRepository.findOneBy.mockResolvedValue(mockUser);
-      stripeTransactionRepository.findByChargeId.mockResolvedValue(createMockTransaction({ id: transactionId, amountRefunded: 0 }));
+      stripeTransactionRepository.findOneByAndLock.mockResolvedValue(createMockTransaction({ id: transactionId, amountRefunded: 0 }));
       stripeTransactionRepository.updateById.mockResolvedValue(undefined);
       refillService.reduceWalletBalance.mockResolvedValue();
 
@@ -549,7 +549,7 @@ describe(StripeWebhookService.name, () => {
       await service.handleChargeRefunded(event);
 
       expect(userRepository.findOneBy).toHaveBeenCalledWith({ stripeCustomerId: mockUser.stripeCustomerId });
-      expect(stripeTransactionRepository.findByChargeId).toHaveBeenCalledWith(chargeId);
+      expect(stripeTransactionRepository.findOneByAndLock).toHaveBeenCalledWith({ stripeChargeId: chargeId });
       expect(stripeTransactionRepository.updateById).toHaveBeenCalledWith(transactionId, { amountRefunded: refundedAmount, status: "refunded" });
       expect(refillService.reduceWalletBalance).toHaveBeenCalledWith(refundedAmount, mockUser.id, { currency: "usd", transactionId });
     });
@@ -562,7 +562,7 @@ describe(StripeWebhookService.name, () => {
 
       userRepository.findOneBy.mockResolvedValue(mockUser);
       // Transaction already has 3000 refunded
-      stripeTransactionRepository.findByChargeId.mockResolvedValue(createMockTransaction({ id: transactionId, amountRefunded: 3000 }));
+      stripeTransactionRepository.findOneByAndLock.mockResolvedValue(createMockTransaction({ id: transactionId, amountRefunded: 3000 }));
       stripeTransactionRepository.updateById.mockResolvedValue(undefined);
       refillService.reduceWalletBalance.mockResolvedValue();
 
@@ -589,7 +589,7 @@ describe(StripeWebhookService.name, () => {
 
       userRepository.findOneBy.mockResolvedValue(mockUser);
       // Transaction already has this refund processed (amountRefunded matches charge.amount_refunded)
-      stripeTransactionRepository.findByChargeId.mockResolvedValue(createMockTransaction({ id: "tx-123", amountRefunded: 5000 }));
+      stripeTransactionRepository.findOneByAndLock.mockResolvedValue(createMockTransaction({ id: "tx-123", amountRefunded: 5000 }));
 
       const event = createChargeRefundedEvent({
         id: chargeId,
@@ -644,7 +644,7 @@ describe(StripeWebhookService.name, () => {
       const mockUser = createTestUser();
 
       userRepository.findOneBy.mockResolvedValue(mockUser);
-      stripeTransactionRepository.findByChargeId.mockResolvedValue(undefined);
+      stripeTransactionRepository.findOneByAndLock.mockResolvedValue(undefined);
 
       const event = createChargeRefundedEvent({
         id: "ch_123",
@@ -664,7 +664,7 @@ describe(StripeWebhookService.name, () => {
       const mockUser = createTestUser();
 
       userRepository.findOneBy.mockResolvedValue(mockUser);
-      stripeTransactionRepository.findByChargeId.mockResolvedValue(createMockTransaction({ id: "tx-123", status: "failed" }));
+      stripeTransactionRepository.findOneByAndLock.mockResolvedValue(createMockTransaction({ id: "tx-123", status: "failed" }));
 
       const event = createChargeRefundedEvent({
         id: "ch_123",
@@ -685,7 +685,7 @@ describe(StripeWebhookService.name, () => {
       const transactionId = "tx-123";
 
       userRepository.findOneBy.mockResolvedValue(mockUser);
-      stripeTransactionRepository.findByChargeId.mockResolvedValue(
+      stripeTransactionRepository.findOneByAndLock.mockResolvedValue(
         createMockTransaction({ id: transactionId, status: "succeeded", amount: 10000, amountRefunded: 0, bonusAmount: 1000 })
       );
 
@@ -709,7 +709,7 @@ describe(StripeWebhookService.name, () => {
 
       userRepository.findOneBy.mockResolvedValue(mockUser);
       // Already transitioned to refunded by a previous delivery; a late extra refund only reduces its delta
-      stripeTransactionRepository.findByChargeId.mockResolvedValue(
+      stripeTransactionRepository.findOneByAndLock.mockResolvedValue(
         createMockTransaction({ id: transactionId, status: "refunded", amount: 10000, amountRefunded: 9000, bonusAmount: 1000 })
       );
 
@@ -731,7 +731,7 @@ describe(StripeWebhookService.name, () => {
       const transactionId = "tx-123";
 
       userRepository.findOneBy.mockResolvedValue(mockUser);
-      stripeTransactionRepository.findByChargeId.mockResolvedValue(
+      stripeTransactionRepository.findOneByAndLock.mockResolvedValue(
         createMockTransaction({ id: transactionId, status: "succeeded", amount: 10000, amountRefunded: 0, bonusAmount: 1000 })
       );
 

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
@@ -5,6 +5,7 @@ import { mock } from "vitest-mock-extended";
 
 import type { PaymentMethodRepository, StripeTransactionOutput, StripeTransactionRepository } from "@src/billing/repositories";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
+import type { FirstPurchaseBonusService } from "@src/billing/services/first-purchase-bonus/first-purchase-bonus.service";
 import type { RefillService } from "@src/billing/services/refill/refill.service";
 import type { StripeService } from "@src/billing/services/stripe/stripe.service";
 import { StripeWebhookService } from "@src/billing/services/stripe-webhook/stripe-webhook.service";
@@ -175,6 +176,103 @@ describe(StripeWebhookService.name, () => {
           stripePaymentIntentId: "pi_123"
         })
       );
+    });
+
+    it("consults the first-purchase bonus service with the locked transaction before flipping its status", async () => {
+      const { service, userRepository, stripeTransactionRepository, firstPurchaseBonusService } = setup();
+      const mockUser = createTestUser();
+      const internalTransaction = createMockTransaction({ status: "created" });
+      const amount = 10000;
+
+      userRepository.findOneBy.mockResolvedValue(mockUser);
+      stripeTransactionRepository.findById.mockResolvedValue(internalTransaction);
+      stripeTransactionRepository.findOneByAndLock.mockResolvedValue(internalTransaction);
+
+      const event = createPaymentIntentSucceededEvent({
+        id: "pi_123",
+        customer: mockUser.stripeCustomerId,
+        amount,
+        amount_received: amount,
+        metadata: { internal_transaction_id: internalTransaction.id }
+      });
+
+      await service.tryToTopUpWalletFromPaymentIntent(event);
+
+      expect(firstPurchaseBonusService.getEligibleBonusAmount).toHaveBeenCalledWith(internalTransaction, amount);
+      expect(firstPurchaseBonusService.getEligibleBonusAmount.mock.invocationCallOrder[0]).toBeLessThan(
+        stripeTransactionRepository.updateById.mock.invocationCallOrder[0]
+      );
+    });
+
+    it("tops up the combined amount, persists the bonus and tracks the grant when the bonus applies", async () => {
+      const { service, userRepository, stripeTransactionRepository, refillService, firstPurchaseBonusService } = setup();
+      const mockUser = createTestUser();
+      const internalTransaction = createMockTransaction({ status: "created" });
+      const amount = 15000;
+      const bonusAmount = 1500;
+
+      userRepository.findOneBy.mockResolvedValue(mockUser);
+      stripeTransactionRepository.findById.mockResolvedValue(internalTransaction);
+      stripeTransactionRepository.findOneByAndLock.mockResolvedValue(internalTransaction);
+      firstPurchaseBonusService.getEligibleBonusAmount.mockResolvedValue(bonusAmount);
+
+      const event = createPaymentIntentSucceededEvent({
+        id: "pi_123",
+        customer: mockUser.stripeCustomerId,
+        amount,
+        amount_received: amount,
+        metadata: { internal_transaction_id: internalTransaction.id }
+      });
+
+      await service.tryToTopUpWalletFromPaymentIntent(event);
+
+      expect(stripeTransactionRepository.updateById).toHaveBeenCalledWith(
+        internalTransaction.id,
+        expect.objectContaining({
+          status: "succeeded",
+          bonusAmount
+        })
+      );
+      expect(refillService.topUpWallet).toHaveBeenCalledWith(amount + bonusAmount, mockUser.id, {
+        endTrial: undefined,
+        payment: {
+          currency: internalTransaction.currency,
+          cardBrand: undefined,
+          paymentMethodType: undefined,
+          transactionId: internalTransaction.id,
+          source: "payment_intent",
+          bonusAmountCents: bonusAmount
+        }
+      });
+      expect(firstPurchaseBonusService.trackBonusGranted).toHaveBeenCalledWith(mockUser.id, amount, bonusAmount);
+    });
+
+    it("keeps the update payload and top-up untouched when no bonus applies", async () => {
+      const { service, userRepository, stripeTransactionRepository, refillService, firstPurchaseBonusService } = setup();
+      const mockUser = createTestUser();
+      const internalTransaction = createMockTransaction({ status: "created" });
+      const amount = 10000;
+
+      userRepository.findOneBy.mockResolvedValue(mockUser);
+      stripeTransactionRepository.findById.mockResolvedValue(internalTransaction);
+      stripeTransactionRepository.findOneByAndLock.mockResolvedValue(internalTransaction);
+
+      const event = createPaymentIntentSucceededEvent({
+        id: "pi_123",
+        customer: mockUser.stripeCustomerId,
+        amount,
+        amount_received: amount,
+        metadata: { internal_transaction_id: internalTransaction.id }
+      });
+
+      await service.tryToTopUpWalletFromPaymentIntent(event);
+
+      expect(stripeTransactionRepository.updateById).toHaveBeenCalledWith(
+        internalTransaction.id,
+        expect.not.objectContaining({ bonusAmount: expect.anything() })
+      );
+      expect(refillService.topUpWallet).toHaveBeenCalledWith(amount, mockUser.id, expect.anything());
+      expect(firstPurchaseBonusService.trackBonusGranted).not.toHaveBeenCalled();
     });
   });
 
@@ -580,6 +678,75 @@ describe(StripeWebhookService.name, () => {
       expect(stripeTransactionRepository.updateById).not.toHaveBeenCalled();
       expect(refillService.reduceWalletBalance).not.toHaveBeenCalled();
     });
+
+    it("claws back the first-purchase bonus on top of a full refund", async () => {
+      const { service, userRepository, stripeTransactionRepository, refillService } = setup();
+      const mockUser = createTestUser();
+      const transactionId = "tx-123";
+
+      userRepository.findOneBy.mockResolvedValue(mockUser);
+      stripeTransactionRepository.findByChargeId.mockResolvedValue(
+        createMockTransaction({ id: transactionId, status: "succeeded", amount: 10000, amountRefunded: 0, bonusAmount: 1000 })
+      );
+
+      const event = createChargeRefundedEvent({
+        id: "ch_123",
+        customer: mockUser.stripeCustomerId!,
+        amount_refunded: 10000,
+        refunded: true
+      });
+
+      await service.handleChargeRefunded(event);
+
+      expect(refillService.reduceWalletBalance).toHaveBeenCalledWith(11000, mockUser.id, { currency: "usd", transactionId });
+      expect(stripeTransactionRepository.updateById).toHaveBeenCalledWith(transactionId, { amountRefunded: 10000, status: "refunded" });
+    });
+
+    it("does not claw back the bonus again when the transaction is already refunded", async () => {
+      const { service, userRepository, stripeTransactionRepository, refillService } = setup();
+      const mockUser = createTestUser();
+      const transactionId = "tx-123";
+
+      userRepository.findOneBy.mockResolvedValue(mockUser);
+      // Already transitioned to refunded by a previous delivery; a late extra refund only reduces its delta
+      stripeTransactionRepository.findByChargeId.mockResolvedValue(
+        createMockTransaction({ id: transactionId, status: "refunded", amount: 10000, amountRefunded: 9000, bonusAmount: 1000 })
+      );
+
+      const event = createChargeRefundedEvent({
+        id: "ch_123",
+        customer: mockUser.stripeCustomerId!,
+        amount_refunded: 10000,
+        refunded: true
+      });
+
+      await service.handleChargeRefunded(event);
+
+      expect(refillService.reduceWalletBalance).toHaveBeenCalledWith(1000, mockUser.id, { currency: "usd", transactionId });
+    });
+
+    it("leaves the bonus untouched on partial refunds", async () => {
+      const { service, userRepository, stripeTransactionRepository, refillService } = setup();
+      const mockUser = createTestUser();
+      const transactionId = "tx-123";
+
+      userRepository.findOneBy.mockResolvedValue(mockUser);
+      stripeTransactionRepository.findByChargeId.mockResolvedValue(
+        createMockTransaction({ id: transactionId, status: "succeeded", amount: 10000, amountRefunded: 0, bonusAmount: 1000 })
+      );
+
+      const event = createChargeRefundedEvent({
+        id: "ch_123",
+        customer: mockUser.stripeCustomerId!,
+        amount_refunded: 4000,
+        refunded: false
+      });
+
+      await service.handleChargeRefunded(event);
+
+      expect(refillService.reduceWalletBalance).toHaveBeenCalledWith(4000, mockUser.id, { currency: "usd", transactionId });
+      expect(stripeTransactionRepository.updateById).toHaveBeenCalledWith(transactionId, { amountRefunded: 4000 });
+    });
   });
 
   describe("handlePaymentMethodAttached", () => {
@@ -822,13 +989,23 @@ describe(StripeWebhookService.name, () => {
     const userRepository = mock<UserRepository>();
     const paymentMethodRepository = mock<PaymentMethodRepository>();
     const stripeTransactionRepository = mock<StripeTransactionRepository>();
+    const firstPurchaseBonusService = mock<FirstPurchaseBonusService>();
+    firstPurchaseBonusService.getEligibleBonusAmount.mockResolvedValue(0);
 
     // Mock Stripe charges API
     stripeService.charges = {
       retrieve: vi.fn()
     } as unknown as Stripe.ChargesResource;
 
-    const service = new StripeWebhookService(stripeService, refillService, billingConfig, userRepository, paymentMethodRepository, stripeTransactionRepository);
+    const service = new StripeWebhookService(
+      stripeService,
+      refillService,
+      billingConfig,
+      userRepository,
+      paymentMethodRepository,
+      stripeTransactionRepository,
+      firstPurchaseBonusService
+    );
 
     return {
       service,
@@ -837,7 +1014,8 @@ describe(StripeWebhookService.name, () => {
       billingConfig,
       userRepository,
       paymentMethodRepository,
-      stripeTransactionRepository
+      stripeTransactionRepository,
+      firstPurchaseBonusService
     };
   }
 
@@ -849,6 +1027,7 @@ describe(StripeWebhookService.name, () => {
       status: "succeeded",
       amount: 10000,
       amountRefunded: 0,
+      bonusAmount: 0,
       currency: "usd",
       stripePaymentIntentId: "pi_123",
       stripeChargeId: "ch_123",

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
@@ -4,6 +4,7 @@ import Stripe from "stripe";
 import { singleton } from "tsyringe";
 
 import { PaymentMethodRepository, type StripeTransactionOutput, StripeTransactionRepository } from "@src/billing/repositories";
+import { FirstPurchaseBonusService } from "@src/billing/services/first-purchase-bonus/first-purchase-bonus.service";
 import { assertIsPayingUser } from "@src/billing/services/paying-user/paying-user";
 import { RefillService } from "@src/billing/services/refill/refill.service";
 import { StripeService } from "@src/billing/services/stripe/stripe.service";
@@ -21,7 +22,8 @@ export class StripeWebhookService {
     private readonly billingConfig: BillingConfigService,
     private readonly userRepository: UserRepository,
     private readonly paymentMethodRepository: PaymentMethodRepository,
-    private readonly stripeTransactionRepository: StripeTransactionRepository
+    private readonly stripeTransactionRepository: StripeTransactionRepository,
+    private readonly firstPurchaseBonusService: FirstPurchaseBonusService
   ) {}
 
   async routeStripeEvent(signature: string, rawEvent: string) {
@@ -236,6 +238,8 @@ export class StripeWebhookService {
       return;
     }
 
+    const bonusAmount = await this.firstPurchaseBonusService.getEligibleBonusAmount(transaction, params.paymentAmount);
+
     await this.stripeTransactionRepository.updateById(params.transactionId, {
       status: "succeeded",
       stripeChargeId: params.chargeId,
@@ -243,19 +247,33 @@ export class StripeWebhookService {
       cardBrand: params.cardBrand,
       cardLast4: params.cardLast4,
       receiptUrl: params.receiptUrl,
-      stripePaymentIntentId: params.stripePaymentIntentId
+      stripePaymentIntentId: params.stripePaymentIntentId,
+      ...(bonusAmount > 0 ? { bonusAmount } : {})
     });
 
-    await this.refillService.topUpWallet(params.paymentAmount, params.userId, {
+    // Single combined top-up: two calls would double chain fees and race on retrieveDeploymentLimit.
+    await this.refillService.topUpWallet(params.paymentAmount + bonusAmount, params.userId, {
       endTrial: params.endTrial,
       payment: {
         currency: transaction.currency,
         cardBrand: params.cardBrand,
         paymentMethodType: params.paymentMethodType,
         transactionId: transaction.id,
-        source: transaction.type
+        source: transaction.type,
+        ...(bonusAmount > 0 ? { bonusAmountCents: bonusAmount } : {})
       }
     });
+
+    if (bonusAmount > 0) {
+      this.firstPurchaseBonusService.trackBonusGranted(params.userId, params.paymentAmount, bonusAmount);
+      this.logger.info({
+        event: "FIRST_PURCHASE_BONUS_GRANTED",
+        transactionId: params.transactionId,
+        userId: params.userId,
+        paidAmountCents: params.paymentAmount,
+        bonusAmountCents: bonusAmount
+      });
+    }
   }
 
   @WithTransaction()
@@ -346,16 +364,31 @@ export class StripeWebhookService {
 
     const isFullyRefunded = charge.refunded;
 
+    // Claw back the first-purchase bonus only on the first transition to fully-refunded
+    // (pre-update status check); partial refunds never touch the bonus. bonusAmount stays
+    // on the row as the audit record of the grant.
+    const bonusClawback = isFullyRefunded && transaction.status !== "refunded" && transaction.bonusAmount > 0 ? transaction.bonusAmount : 0;
+
     // Update transaction with new refund amount and status
     await this.stripeTransactionRepository.updateById(transaction.id, {
       amountRefunded: charge.amount_refunded,
       ...(isFullyRefunded ? { status: "refunded" } : {})
     });
 
-    await this.refillService.reduceWalletBalance(refundedAmount, user.id, {
+    await this.refillService.reduceWalletBalance(refundedAmount + bonusClawback, user.id, {
       currency: transaction.currency,
       transactionId: transaction.id
     });
+
+    if (bonusClawback > 0) {
+      this.logger.info({
+        event: "FIRST_PURCHASE_BONUS_CLAWED_BACK",
+        chargeId: charge.id,
+        userId: user.id,
+        transactionId: transaction.id,
+        bonusAmountCents: bonusClawback
+      });
+    }
 
     this.logger.info({
       event: "CHARGE_REFUNDED",

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
@@ -323,7 +323,10 @@ export class StripeWebhookService {
       return;
     }
 
-    const transaction = await this.stripeTransactionRepository.findByChargeId(charge.id);
+    // Locked read: concurrent charge.refunded deliveries serialize here, so the loser
+    // re-reads the committed amountRefunded/status and bails on the idempotency check
+    // instead of double-debiting the wallet.
+    const transaction = await this.stripeTransactionRepository.findOneByAndLock({ stripeChargeId: charge.id });
 
     if (!transaction) {
       this.logger.warn({ event: "CHARGE_REFUNDED_NO_TRANSACTION", chargeId: charge.id });

--- a/apps/api/src/billing/services/stripe/stripe.service.spec.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.spec.ts
@@ -1580,6 +1580,7 @@ function setup(
     status: input.status ?? "created",
     amount: input.amount,
     amountRefunded: input.amountRefunded ?? 0,
+    bonusAmount: input.bonusAmount ?? 0,
     currency: input.currency ?? "usd",
     stripePaymentIntentId: input.stripePaymentIntentId ?? null,
     stripeChargeId: input.stripeChargeId ?? null,

--- a/apps/api/src/core/services/analytics/analytics.service.ts
+++ b/apps/api/src/core/services/analytics/analytics.service.ts
@@ -3,7 +3,7 @@ import { inject, singleton } from "tsyringe";
 import { AMPLITUDE, type Amplitude } from "@src/core/providers/amplitude.provider";
 import { LoggerService } from "@src/core/providers/logging.provider";
 
-type AnalyticsEvent = "user_registered" | "account_created" | "balance_top_up" | "balance_refund";
+type AnalyticsEvent = "user_registered" | "account_created" | "balance_top_up" | "balance_refund" | "first_purchase_bonus_granted";
 
 @singleton()
 export class AnalyticsService {

--- a/apps/api/src/core/services/feature-flags/feature-flags.ts
+++ b/apps/api/src/core/services/feature-flags/feature-flags.ts
@@ -3,7 +3,8 @@ export const FeatureFlags = {
   NOTIFICATIONS_ALERT_UPDATE: "notifications_general_alerts_update",
   AUTO_CREDIT_RELOAD: "auto_credit_reload",
   TRIAL_FINGERPRINT_CHECK: "trial_fingerprint_check",
-  ONBOARDING_REDESIGN_V1: "onboarding_redesign_v1"
+  ONBOARDING_REDESIGN_V1: "onboarding_redesign_v1",
+  FIRST_PURCHASE_BONUS: "first_purchase_bonus"
 } as const;
 
 export type FeatureFlagValue = (typeof FeatureFlags)[keyof typeof FeatureFlags];

--- a/apps/api/test/functional/stripe-webhook.spec.ts
+++ b/apps/api/test/functional/stripe-webhook.spec.ts
@@ -351,6 +351,65 @@ describe("Stripe webhook", () => {
         expect(userWallet?.deploymentAllowance).toBe(`${expectedBalance}.00`);
         expect(transaction).toMatchObject({ status: "succeeded", bonusAmount: 0 });
       });
+
+      it("grants the bonus exactly once when two first purchases are delivered concurrently", async () => {
+        const amount = 10000;
+        const paymentIntentIds = [`pi_${faker.string.alphanumeric(24)}`, `pi_${faker.string.alphanumeric(24)}`];
+        const chargeIds = [`ch_${faker.string.alphanumeric(24)}`, `ch_${faker.string.alphanumeric(24)}`];
+
+        const { user, stripeCustomerId } = await setup();
+
+        for (const paymentIntentId of paymentIntentIds) {
+          await stripeTransactionRepository.create({
+            userId: user.id,
+            type: "payment_intent",
+            status: "created",
+            amount,
+            currency: "usd",
+            stripePaymentIntentId: paymentIntentId
+          });
+        }
+
+        for (const chargeId of chargeIds) {
+          nock("https://api.stripe.com")
+            .get(`/v1/charges/${chargeId}`)
+            .reply(200, {
+              id: chargeId,
+              payment_method_details: { card: { brand: "visa", last4: "4242" } },
+              receipt_url: "https://pay.stripe.com/receipts/test"
+            });
+        }
+
+        const payloads = paymentIntentIds.map((paymentIntentId, index) =>
+          JSON.stringify({
+            data: {
+              object: {
+                id: paymentIntentId,
+                customer: stripeCustomerId,
+                amount,
+                amount_received: amount,
+                latest_charge: chargeIds[index],
+                payment_method_types: ["card"],
+                metadata: {}
+              }
+            },
+            type: "payment_intent.succeeded"
+          })
+        );
+
+        const responses = await Promise.all(payloads.map(payload => getWebhookResponse(payload)));
+        responses.forEach(response => expect(response.status).toBe(200));
+
+        // The user-row lock serializes the two eligibility checks: whichever webhook commits
+        // first wins the bonus, the other sees a prior completed purchase and grants none
+        const transactions = await Promise.all(paymentIntentIds.map(id => stripeTransactionRepository.findByPaymentIntentId(id)));
+        const bonusAmounts = transactions.map(transaction => transaction?.bonusAmount ?? 0).sort((a, b) => a - b);
+        expect(bonusAmounts).toEqual([0, amount / 10]);
+
+        const userWallet = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, user.id) });
+        const expectedBalance = billingConfig.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT + (amount * 2 + amount / 10) * 10000;
+        expect(userWallet?.deploymentAllowance).toBe(`${expectedBalance}.00`);
+      });
     });
 
     describe("invoice.payment_succeeded", () => {
@@ -515,6 +574,35 @@ describe("Stripe webhook", () => {
         const walletAfterSecond = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, user.id) });
         // Balance should be unchanged - no double deduction
         expect(walletAfterSecond?.deploymentAllowance).toBe(balanceAfterFirstRefund);
+      });
+
+      it("deducts the refund exactly once when duplicate deliveries arrive concurrently", async () => {
+        const paymentIntentId = `pi_${faker.string.alphanumeric(24)}`;
+        const chargeId = `ch_${faker.string.alphanumeric(24)}`;
+        const amount = 50;
+
+        const { user, stripeCustomerId } = await setup();
+
+        await stripeTransactionRepository.create({
+          userId: user.id,
+          type: "payment_intent",
+          status: "succeeded",
+          amount,
+          currency: "usd",
+          stripePaymentIntentId: paymentIntentId,
+          stripeChargeId: chargeId
+        });
+
+        const payload = generateChargeRefundedPayload(chargeId, stripeCustomerId, amount, 0);
+
+        // The transaction-row lock serializes the two deliveries: the loser re-reads the
+        // committed amountRefunded and bails on the idempotency check
+        const responses = await Promise.all([getWebhookResponse(payload), getWebhookResponse(payload)]);
+        responses.forEach(response => expect(response.status).toBe(200));
+
+        const userWallet = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, user.id) });
+        const expectedBalance = billingConfig.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT - amount * 10000;
+        expect(userWallet?.deploymentAllowance).toBe(`${expectedBalance}.00`);
       });
 
       it("reduces wallet balance and updates transaction status on full refund", async () => {

--- a/apps/api/test/functional/stripe-webhook.spec.ts
+++ b/apps/api/test/functional/stripe-webhook.spec.ts
@@ -107,10 +107,12 @@ describe("Stripe webhook", () => {
         expect(response1.status).toBe(200);
 
         const walletAfterFirst = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, user.id) });
-        const expectedBalance = billingConfig.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT + amount * 10000;
+        // Functional tests run with FEATURE_FLAGS_ENABLE_ALL, so this first $100 purchase earns the 10% first-purchase bonus
+        const firstPurchaseBonus = amount / 10;
+        const expectedBalance = billingConfig.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT + (amount + firstPurchaseBonus) * 10000;
         expect(walletAfterFirst?.deploymentAllowance).toBe(`${expectedBalance}.00`);
 
-        // Second webhook delivery (retry) - should not double-credit
+        // Second webhook delivery (retry) - should not double-credit nor double-grant the bonus
         const response2 = await getWebhookResponse(payload);
         expect(response2.status).toBe(200);
 
@@ -171,8 +173,9 @@ describe("Stripe webhook", () => {
         const userWallet = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, user.id) });
         const transaction = await stripeTransactionRepository.findByPaymentIntentId(paymentIntentId);
 
-        // Calculate expected balance: trial allowance + payment amount (cents * 10000 multiplier for uakt)
-        const expectedBalance = billingConfig.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT + amount * 10000;
+        // Calculate expected balance: trial allowance + payment amount + 10% first-purchase bonus (cents * 10000 multiplier for uakt)
+        const firstPurchaseBonus = amount / 10;
+        const expectedBalance = billingConfig.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT + (amount + firstPurchaseBonus) * 10000;
 
         expect(webhookResponse.status).toBe(200);
         expect(userWallet).toMatchObject({
@@ -183,8 +186,257 @@ describe("Stripe webhook", () => {
         expect(transaction).toMatchObject({
           status: "succeeded",
           stripeChargeId: chargeId,
-          paymentMethodType: "card"
+          paymentMethodType: "card",
+          bonusAmount: firstPurchaseBonus
         });
+      });
+
+      it("caps the first-purchase bonus at $100 for large payments", async () => {
+        const paymentIntentId = `pi_${faker.string.alphanumeric(24)}`;
+        const chargeId = `ch_${faker.string.alphanumeric(24)}`;
+        const amount = 1000000; // $10,000 in cents
+
+        const { user, stripeCustomerId } = await setup();
+
+        await stripeTransactionRepository.create({
+          userId: user.id,
+          type: "payment_intent",
+          status: "created",
+          amount,
+          currency: "usd",
+          stripePaymentIntentId: paymentIntentId
+        });
+
+        nock("https://api.stripe.com")
+          .get(`/v1/charges/${chargeId}`)
+          .reply(200, {
+            id: chargeId,
+            payment_method_details: { card: { brand: "visa", last4: "4242" } },
+            receipt_url: "https://pay.stripe.com/receipts/test"
+          });
+
+        const payload = JSON.stringify({
+          data: {
+            object: {
+              id: paymentIntentId,
+              customer: stripeCustomerId,
+              amount,
+              amount_received: amount,
+              latest_charge: chargeId,
+              payment_method_types: ["card"],
+              metadata: {}
+            }
+          },
+          type: "payment_intent.succeeded"
+        });
+
+        const webhookResponse = await getWebhookResponse(payload);
+
+        const userWallet = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, user.id) });
+        const transaction = await stripeTransactionRepository.findByPaymentIntentId(paymentIntentId);
+        const cappedBonus = 10000; // $100 in cents
+        const expectedBalance = billingConfig.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT + (amount + cappedBonus) * 10000;
+
+        expect(webhookResponse.status).toBe(200);
+        expect(userWallet?.deploymentAllowance).toBe(`${expectedBalance}.00`);
+        expect(transaction).toMatchObject({ status: "succeeded", bonusAmount: cappedBonus });
+      });
+
+      it("does not grant the bonus below the $100 minimum", async () => {
+        const paymentIntentId = `pi_${faker.string.alphanumeric(24)}`;
+        const chargeId = `ch_${faker.string.alphanumeric(24)}`;
+        const amount = 9900; // $99 in cents
+
+        const { user, stripeCustomerId } = await setup();
+
+        await stripeTransactionRepository.create({
+          userId: user.id,
+          type: "payment_intent",
+          status: "created",
+          amount,
+          currency: "usd",
+          stripePaymentIntentId: paymentIntentId
+        });
+
+        nock("https://api.stripe.com")
+          .get(`/v1/charges/${chargeId}`)
+          .reply(200, {
+            id: chargeId,
+            payment_method_details: { card: { brand: "visa", last4: "4242" } },
+            receipt_url: "https://pay.stripe.com/receipts/test"
+          });
+
+        const payload = JSON.stringify({
+          data: {
+            object: {
+              id: paymentIntentId,
+              customer: stripeCustomerId,
+              amount,
+              amount_received: amount,
+              latest_charge: chargeId,
+              payment_method_types: ["card"],
+              metadata: {}
+            }
+          },
+          type: "payment_intent.succeeded"
+        });
+
+        const webhookResponse = await getWebhookResponse(payload);
+
+        const userWallet = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, user.id) });
+        const transaction = await stripeTransactionRepository.findByPaymentIntentId(paymentIntentId);
+        const expectedBalance = billingConfig.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT + amount * 10000;
+
+        expect(webhookResponse.status).toBe(200);
+        expect(userWallet?.deploymentAllowance).toBe(`${expectedBalance}.00`);
+        expect(transaction).toMatchObject({ status: "succeeded", bonusAmount: 0 });
+      });
+
+      it("does not grant the bonus when the user already completed a paid purchase", async () => {
+        const paymentIntentId = `pi_${faker.string.alphanumeric(24)}`;
+        const chargeId = `ch_${faker.string.alphanumeric(24)}`;
+        const amount = 10000;
+
+        const { user, stripeCustomerId } = await setup();
+
+        // Prior completed paid purchase consumed the one-time eligibility
+        await stripeTransactionRepository.create({
+          userId: user.id,
+          type: "payment_intent",
+          status: "succeeded",
+          amount: 20000,
+          currency: "usd",
+          stripePaymentIntentId: `pi_${faker.string.alphanumeric(24)}`
+        });
+
+        await stripeTransactionRepository.create({
+          userId: user.id,
+          type: "payment_intent",
+          status: "created",
+          amount,
+          currency: "usd",
+          stripePaymentIntentId: paymentIntentId
+        });
+
+        nock("https://api.stripe.com")
+          .get(`/v1/charges/${chargeId}`)
+          .reply(200, {
+            id: chargeId,
+            payment_method_details: { card: { brand: "visa", last4: "4242" } },
+            receipt_url: "https://pay.stripe.com/receipts/test"
+          });
+
+        const payload = JSON.stringify({
+          data: {
+            object: {
+              id: paymentIntentId,
+              customer: stripeCustomerId,
+              amount,
+              amount_received: amount,
+              latest_charge: chargeId,
+              payment_method_types: ["card"],
+              metadata: {}
+            }
+          },
+          type: "payment_intent.succeeded"
+        });
+
+        const webhookResponse = await getWebhookResponse(payload);
+
+        const userWallet = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, user.id) });
+        const transaction = await stripeTransactionRepository.findByPaymentIntentId(paymentIntentId);
+        const expectedBalance = billingConfig.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT + amount * 10000;
+
+        expect(webhookResponse.status).toBe(200);
+        expect(userWallet?.deploymentAllowance).toBe(`${expectedBalance}.00`);
+        expect(transaction).toMatchObject({ status: "succeeded", bonusAmount: 0 });
+      });
+    });
+
+    describe("invoice.payment_succeeded", () => {
+      it("does not grant the bonus for coupon claims nor consume the user's eligibility", async () => {
+        const invoiceId = `in_${faker.string.alphanumeric(24)}`;
+        const paymentIntentId = `pi_${faker.string.alphanumeric(24)}`;
+        const chargeId = `ch_${faker.string.alphanumeric(24)}`;
+        const couponAmount = 15000; // $150 coupon, above the bonus minimum
+        const purchaseAmount = 10000; // $100 first real purchase
+
+        const { user, stripeCustomerId } = await setup();
+
+        // Coupon claim redeemed via invoice
+        await stripeTransactionRepository.create({
+          userId: user.id,
+          type: "coupon_claim",
+          status: "created",
+          amount: couponAmount,
+          currency: "usd",
+          stripeInvoiceId: invoiceId
+        });
+
+        const invoicePayload = JSON.stringify({
+          data: {
+            object: {
+              id: invoiceId,
+              customer: stripeCustomerId
+            }
+          },
+          type: "invoice.payment_succeeded"
+        });
+
+        const invoiceResponse = await getWebhookResponse(invoicePayload);
+        expect(invoiceResponse.status).toBe(200);
+
+        const couponTransaction = await stripeTransactionRepository.findByInvoiceId(invoiceId);
+        const walletAfterCoupon = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, user.id) });
+        const balanceAfterCoupon = billingConfig.TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT + couponAmount * 10000;
+
+        // Coupon credits only its own amount - no bonus
+        expect(couponTransaction).toMatchObject({ status: "succeeded", bonusAmount: 0 });
+        expect(walletAfterCoupon?.deploymentAllowance).toBe(`${balanceAfterCoupon}.00`);
+
+        // A later first real purchase still earns the bonus - the coupon did not consume eligibility
+        await stripeTransactionRepository.create({
+          userId: user.id,
+          type: "payment_intent",
+          status: "created",
+          amount: purchaseAmount,
+          currency: "usd",
+          stripePaymentIntentId: paymentIntentId
+        });
+
+        nock("https://api.stripe.com")
+          .get(`/v1/charges/${chargeId}`)
+          .reply(200, {
+            id: chargeId,
+            payment_method_details: { card: { brand: "visa", last4: "4242" } },
+            receipt_url: "https://pay.stripe.com/receipts/test"
+          });
+
+        const purchasePayload = JSON.stringify({
+          data: {
+            object: {
+              id: paymentIntentId,
+              customer: stripeCustomerId,
+              amount: purchaseAmount,
+              amount_received: purchaseAmount,
+              latest_charge: chargeId,
+              payment_method_types: ["card"],
+              metadata: {}
+            }
+          },
+          type: "payment_intent.succeeded"
+        });
+
+        const purchaseResponse = await getWebhookResponse(purchasePayload);
+        expect(purchaseResponse.status).toBe(200);
+
+        const purchaseTransaction = await stripeTransactionRepository.findByPaymentIntentId(paymentIntentId);
+        const walletAfterPurchase = await userWalletsQuery.findFirst({ where: eq(userWalletsTable.userId, user.id) });
+        const purchaseBonus = purchaseAmount / 10;
+        const balanceAfterPurchase = balanceAfterCoupon + (purchaseAmount + purchaseBonus) * 10000;
+
+        expect(purchaseTransaction).toMatchObject({ status: "succeeded", bonusAmount: purchaseBonus });
+        expect(walletAfterPurchase?.deploymentAllowance).toBe(`${balanceAfterPurchase}.00`);
       });
     });
 

--- a/apps/api/test/seeders/database-stripe-transaction.seeder.ts
+++ b/apps/api/test/seeders/database-stripe-transaction.seeder.ts
@@ -10,6 +10,7 @@ export function generateDatabaseStripeTransaction(overrides: Partial<StripeTrans
     status: "created",
     amount: faker.number.int({ min: 1000, max: 100000 }),
     amountRefunded: 0,
+    bonusAmount: 0,
     currency: "usd",
     stripePaymentIntentId: null,
     stripeChargeId: null,


### PR DESCRIPTION
## Why

Part of CON-410

To convert trialing users into their first real payment, a user's first successful paid credit purchase of ≥ $100 earns bonus credits equal to 10% of the amount paid, capped at $100. This PR implements the backend grant; the Add Credits UI copy ships separately in a deploy-web PR. The whole feature is inert behind the new `first_purchase_bonus` Unleash flag (on/off or environment strategy only — the webhook has no user context, so per-user gradual rollout would evaluate inconsistently against the UI).

~~Stacked on #3413~~ — #3413 merged; this PR is now based directly on `main`.

## What

- `stripe_transactions.bonus_amount` column (additive migration `0030`, no backfill) — audit record of the grant.
- `FirstPurchaseBonusService`: eligibility = `type === "payment_intent"` AND flag on AND paid ≥ $100 AND no prior succeeded/refunded `payment_intent` row for the user. Coupon claims (`coupon_claim` via invoices) neither earn the bonus nor consume the one-time eligibility. Bonus = `min(floor(10%), $100)`.
- Grant wired into `StripeWebhookService.updateTransactionAndTopUp` inside the existing row-lock transaction, computed before the status flips so the current payment isn't counted as its own prior purchase. Single combined `topUpWallet(paid + bonus)` call (one on-chain authz grant).
- Full-refund clawback: fully refunding the bonus-earning charge also reduces the wallet by the bonus, exactly once (first transition to `refunded`). Partial refunds never touch the bonus.
- Analytics: new `first_purchase_bonus_granted` Amplitude event; `balance_top_up` now carries `bonus_amount_cents` so the paid/bonus split stays recoverable (its `amount_*` reports the credited total).
- Known accepted race (documented in code): two concurrent first-ever payment intents could both grant; bounded at $100/user.

Out of scope (per CON-410 decisions): partial-refund proration, bonus line in transaction history/CSV (balance-only), retroactive grants, FE impression analytics.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a first-purchase bonus of 10% for eligible purchases of at least $100, capped at $100.
  * Bonus is credited with the purchase and stored with the related transaction; wallet top-ups include the bonus amount.
  * Prevents duplicate bonus grants, skips coupon-only claims, and handles concurrent first-purchase deliveries safely.
  * On full refunds, the bonus is clawed back; partial refunds only deduct the refunded portion.

* **Analytics**
  * Added analytics for first-purchase bonus grants and included bonus amounts in wallet top-up events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->