### PR TITLE
feat(billing): promote first-purchase bonus with dynamic preview in add-credits form

### DIFF
--- a/apps/api/src/billing/http-schemas/stripe.schema.ts
+++ b/apps/api/src/billing/http-schemas/stripe.schema.ts
@@ -141,6 +141,8 @@ export const ApplyCouponResponseSchema = z.object({
 export const TransactionSchema = z.object({
   id: z.string(),
   amount: z.number(),
+  /** First-purchase bonus credited with this payment, in cents. */
+  bonusAmount: z.number().optional(),
   currency: z.string(),
   status: z.string(),
   created: z.number(),

--- a/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.integration.ts
+++ b/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.integration.ts
@@ -1,0 +1,85 @@
+import { faker } from "@faker-js/faker";
+import { container } from "tsyringe";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { UserRepository } from "@src/user/repositories";
+import { type StripeTransactionInput, StripeTransactionRepository } from "./stripe-transaction.repository";
+
+describe(StripeTransactionRepository.name, () => {
+  describe("findByChargeIds", () => {
+    it("returns transactions matching the given charge ids with their bonus amounts", async () => {
+      const { stripeTransactionRepository, createTestTransaction } = setup();
+      const chargeId1 = `ch_${faker.string.alphanumeric(24)}`;
+      const chargeId2 = `ch_${faker.string.alphanumeric(24)}`;
+      await createTestTransaction({ stripeChargeId: chargeId1, bonusAmount: 1000 });
+      await createTestTransaction({ stripeChargeId: chargeId2, bonusAmount: 0 });
+
+      const result = await stripeTransactionRepository.findByChargeIds([chargeId1, chargeId2]);
+
+      expect(result).toHaveLength(2);
+      expect(result.find(transaction => transaction.stripeChargeId === chargeId1)?.bonusAmount).toBe(1000);
+      expect(result.find(transaction => transaction.stripeChargeId === chargeId2)?.bonusAmount).toBe(0);
+    });
+
+    it("returns only the transactions whose charge ids are requested", async () => {
+      const { stripeTransactionRepository, createTestTransaction } = setup();
+      const chargeId = `ch_${faker.string.alphanumeric(24)}`;
+      await createTestTransaction({ stripeChargeId: chargeId });
+      await createTestTransaction({ stripeChargeId: `ch_${faker.string.alphanumeric(24)}` });
+
+      const result = await stripeTransactionRepository.findByChargeIds([chargeId]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].stripeChargeId).toBe(chargeId);
+    });
+
+    it("returns an empty array when no charge ids are provided", async () => {
+      const { stripeTransactionRepository } = setup();
+
+      const result = await stripeTransactionRepository.findByChargeIds([]);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  let cleanup: () => Promise<void>;
+  afterEach(async () => {
+    await cleanup?.();
+  });
+
+  function setup() {
+    const stripeTransactionRepository = container.resolve(StripeTransactionRepository);
+    const userRepository = container.resolve(UserRepository);
+    const createdUserIds: string[] = [];
+    let testUserId: string | undefined;
+
+    cleanup = async () => {
+      if (createdUserIds.length > 0) {
+        await userRepository.deleteById(createdUserIds);
+      }
+    };
+
+    // Deleting the user cascades to its stripe transactions, so tracking users is enough for cleanup.
+    async function getTestUserId() {
+      if (!testUserId) {
+        const user = await userRepository.create({});
+        createdUserIds.push(user.id);
+        testUserId = user.id;
+      }
+      return testUserId;
+    }
+
+    async function createTestTransaction(overrides: Partial<StripeTransactionInput> = {}) {
+      return stripeTransactionRepository.create({
+        userId: await getTestUserId(),
+        type: "payment_intent",
+        status: "succeeded",
+        amount: faker.number.int({ min: 1000, max: 100000 }),
+        currency: "usd",
+        ...overrides
+      });
+    }
+
+    return { stripeTransactionRepository, userRepository, createTestTransaction };
+  }
+});

--- a/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
+++ b/apps/api/src/billing/repositories/stripe-transaction/stripe-transaction.repository.ts
@@ -78,6 +78,16 @@ export class StripeTransactionRepository extends BaseRepository<Table, StripeTra
     return item ? this.toOutput(item) : undefined;
   }
 
+  async findByChargeIds(chargeIds: string[]): Promise<StripeTransactionOutput[]> {
+    if (!chargeIds.length) return [];
+
+    return this.toOutputList(
+      await this.cursor.query.StripeTransactions.findMany({
+        where: this.whereAccessibleBy(inArray(this.table.stripeChargeId, chargeIds))
+      })
+    );
+  }
+
   async findByInvoiceId(invoiceId: string): Promise<StripeTransactionOutput | undefined> {
     const item = await this.cursor.query.StripeTransactions.findFirst({
       where: this.whereAccessibleBy(eq(this.table.stripeInvoiceId, invoiceId))

--- a/apps/api/src/billing/services/stripe/stripe.service.spec.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.spec.ts
@@ -111,6 +111,7 @@ describe(StripeService.name, () => {
           {
             id: mockCharge.id,
             amount: mockCharge.amount,
+            bonusAmount: 0,
             currency: mockCharge.currency,
             status: mockCharge.status,
             created: mockCharge.created,
@@ -124,6 +125,25 @@ describe(StripeService.name, () => {
         nextPage: mockCharge.id,
         prevPage: null
       });
+    });
+
+    it("attaches the recorded first-purchase bonus to matching charges", async () => {
+      const { service, stripeTransactionRepository } = setup();
+      const bonusCharge = createTestCharge({ id: "ch_bonus" });
+      const plainCharge = createTestCharge({ id: "ch_plain" });
+      const mockCharges = {
+        data: [bonusCharge, plainCharge],
+        has_more: false
+      } as unknown as Stripe.Response<Stripe.ApiList<Stripe.Charge>>;
+
+      vi.spyOn(service.charges, "list").mockResolvedValue(mockCharges);
+      stripeTransactionRepository.findByChargeIds.mockResolvedValue([generateDatabaseStripeTransaction({ stripeChargeId: "ch_bonus", bonusAmount: 1000 })]);
+
+      const result = await service.getCustomerTransactions(TEST_CONSTANTS.CUSTOMER_ID);
+
+      expect(stripeTransactionRepository.findByChargeIds).toHaveBeenCalledWith(["ch_bonus", "ch_plain"]);
+      expect(result.transactions[0].bonusAmount).toBe(1000);
+      expect(result.transactions[1].bonusAmount).toBe(0);
     });
 
     it("sanitizes link email from payment method details", async () => {
@@ -248,6 +268,7 @@ describe(StripeService.name, () => {
           {
             id: firstCharge.id,
             amount: firstCharge.amount,
+            bonusAmount: 0,
             currency: firstCharge.currency,
             status: firstCharge.status,
             created: firstCharge.created,
@@ -259,6 +280,7 @@ describe(StripeService.name, () => {
           {
             id: secondCharge.id,
             amount: secondCharge.amount,
+            bonusAmount: 0,
             currency: secondCharge.currency,
             status: secondCharge.status,
             created: secondCharge.created,
@@ -353,13 +375,40 @@ describe(StripeService.name, () => {
 
       const fullCsv = chunks.join("");
 
-      expect(fullCsv).toContain("Transaction ID,Date (America/New_York),Amount,Currency,Status,Payment Method,Card Brand,Card Last 4,Description,Receipt URL");
+      expect(fullCsv).toContain(
+        "Transaction ID,Date (America/New_York),Amount,Bonus,Currency,Status,Payment Method,Card Brand,Card Last 4,Description,Receipt URL"
+      );
 
       expect(fullCsv).toContain(mockTransaction.id);
       expect(fullCsv).toContain("2021-12-31, 7:00:00 p.m.");
       expect(fullCsv).toContain("10.00");
       expect(fullCsv).toContain("visa");
       expect(fullCsv).toContain("4242");
+    });
+
+    it("writes the recorded bonus next to the amount", async () => {
+      const { service } = setup();
+      const mockTransaction = createTestTransaction({ amount: 15000, bonusAmount: 1500 });
+
+      vi.spyOn(service, "getCustomerTransactions").mockResolvedValue({
+        transactions: [mockTransaction],
+        hasMore: false,
+        nextPage: null,
+        prevPage: null
+      });
+
+      const csvStream = service.exportTransactionsCsvStream(TEST_CONSTANTS.CUSTOMER_ID, {
+        startDate: "2022-01-01T00:00:00Z",
+        endDate: "2022-01-31T23:59:59Z",
+        timezone: "America/New_York"
+      });
+
+      const chunks: string[] = [];
+      for await (const chunk of csvStream) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks.join("")).toContain("150.00,15.00");
     });
 
     it("streams multiple pages without loading all into memory", async () => {
@@ -499,7 +548,7 @@ describe(StripeService.name, () => {
 
       expect(fullCsv).toContain("ch_123");
       expect(fullCsv).toContain("No payment method");
-      expect(fullCsv).toMatch(/ch_123,"[^"]*",[^,]*,[^,]*,[^,]*,,,,No payment method,/);
+      expect(fullCsv).toMatch(/ch_123,"[^"]*",[^,]*,[^,]*,[^,]*,[^,]*,,,,No payment method,/);
     });
 
     it("handles error during streaming gracefully", async () => {
@@ -528,7 +577,9 @@ describe(StripeService.name, () => {
 
       const fullCsv = chunks.join("");
 
-      expect(fullCsv).toContain("Transaction ID,Date (America/New_York),Amount,Currency,Status,Payment Method,Card Brand,Card Last 4,Description,Receipt URL");
+      expect(fullCsv).toContain(
+        "Transaction ID,Date (America/New_York),Amount,Bonus,Currency,Status,Payment Method,Card Brand,Card Last 4,Description,Receipt URL"
+      );
       expect(fullCsv).toContain("ch_123");
       expect(fullCsv).toContain("Error: Stripe API error");
     });
@@ -1597,6 +1648,7 @@ function setup(
     updatedAt: new Date()
   }));
   stripeTransactionRepository.updateById.mockResolvedValue(undefined);
+  stripeTransactionRepository.findByChargeIds.mockResolvedValue([]);
   const stripeData = StripeSeederCreate();
 
   // Store the last user for correct mocking

--- a/apps/api/src/billing/services/stripe/stripe.service.ts
+++ b/apps/api/src/billing/services/stripe/stripe.service.ts
@@ -555,9 +555,13 @@ export class StripeService extends Stripe {
       expand: ["data.payment_intent"]
     });
 
+    const internalTransactions = await this.stripeTransactionRepository.findByChargeIds(charges.data.map(charge => charge.id));
+    const internalByChargeId = keyBy(internalTransactions, "stripeChargeId");
+
     const transactions = charges.data.map(charge => ({
       id: charge.id,
       amount: charge.amount,
+      bonusAmount: internalByChargeId[charge.id]?.bonusAmount ?? 0,
       currency: charge.currency,
       status: charge.status,
       created: charge.created,
@@ -594,6 +598,7 @@ export class StripeService extends Stripe {
         { key: "id", header: "Transaction ID" },
         { key: "date", header: `Date (${normalizedTimezone})` },
         { key: "amount", header: "Amount" },
+        { key: "bonusAmount", header: "Bonus" },
         { key: "currency", header: "Currency" },
         { key: "status", header: "Status" },
         { key: "paymentMethodType", header: "Payment Method" },
@@ -650,6 +655,7 @@ export class StripeService extends Stripe {
           id: `Error: ${(error as Error).message}`,
           date: "",
           amount: "",
+          bonusAmount: "",
           currency: "",
           status: "",
           paymentMethodType: "",
@@ -667,6 +673,7 @@ export class StripeService extends Stripe {
         id: "No transactions found for the specified date range",
         date: "",
         amount: "",
+        bonusAmount: "",
         currency: "",
         status: "",
         paymentMethodType: "",
@@ -698,6 +705,7 @@ export class StripeService extends Stripe {
       id: transaction.id,
       date,
       amount,
+      bonusAmount: ((transaction.bonusAmount ?? 0) / 100).toFixed(2),
       currency: transaction.currency.toUpperCase(),
       status: transaction.status,
       paymentMethodType: transaction.paymentMethod?.type || "",

--- a/apps/api/src/types/transactions.ts
+++ b/apps/api/src/types/transactions.ts
@@ -22,6 +22,7 @@ export type TransactionCsvRow = {
   id: string;
   date: string;
   amount: string;
+  bonusAmount: string;
   currency: string;
   status: string;
   paymentMethodType: string;

--- a/apps/api/test/seeders/stripe-transaction.seeder.ts
+++ b/apps/api/test/seeders/stripe-transaction.seeder.ts
@@ -7,6 +7,7 @@ import { generatePaymentMethod } from "@test/seeders/payment-method.seeder";
 export const createStripeTransaction = ({
   id = faker.string.uuid(),
   amount = faker.number.int({ min: 1000, max: 100000 }),
+  bonusAmount,
   currency = "usd",
   status = "succeeded",
   description = faker.lorem.sentence(),
@@ -18,6 +19,7 @@ export const createStripeTransaction = ({
   return {
     id,
     amount,
+    bonusAmount,
     currency,
     status,
     description,

--- a/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.tsx
+++ b/apps/deploy-web/src/components/auth/AddCreditsSheet/AddCreditsSheet.tsx
@@ -20,7 +20,7 @@ const DEFAULT_DESCRIPTION =
 interface AddCreditsSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onDone: (amount: number, organization?: string) => void;
+  onDone: (amount: number, organization?: string, bonusAmount?: number) => void;
   onRedeemed?: () => void;
   isWalletReady?: boolean;
   initialTab?: AddCreditsTab;

--- a/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.spec.tsx
@@ -87,6 +87,21 @@ describe(AccountOverview.name, () => {
     expect(MockAddCreditsSheet).toHaveBeenCalledWith(expect.objectContaining({ open: false }), expect.anything());
   });
 
+  it("forwards the granted first-purchase bonus to the payment success animation", () => {
+    const { dependencies, MockAddCreditsSheet } = setup({
+      searchParamsGet: (key: string) => (key === "openPayment" ? "true" : null),
+      defaultPaymentMethod: { id: "pm_123" },
+      isLoading: false
+    });
+
+    act(() => MockAddCreditsSheet.mock.calls.at(-1)![0].onDone(100, undefined, 10));
+
+    expect(dependencies.PaymentSuccessAnimation).toHaveBeenCalledWith(
+      expect.objectContaining({ show: true, amount: "100", bonusAmount: "10" }),
+      expect.anything()
+    );
+  });
+
   function setup(input: {
     searchParamsGet?: (key: string) => string | null;
     routerReplace?: ReturnType<typeof vi.fn>;

--- a/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AccountOverview/AccountOverview.tsx
@@ -44,7 +44,11 @@ export const DEPENDENCIES = {
 
 export const AccountOverview: React.FunctionComponent<{ dependencies?: typeof DEPENDENCIES }> = ({ dependencies: d = DEPENDENCIES }) => {
   const [showAddCredits, setShowAddCredits] = useState(false);
-  const [showPaymentSuccess, setShowPaymentSuccess] = useState<{ amount: string; show: boolean }>({ amount: "", show: false });
+  const [showPaymentSuccess, setShowPaymentSuccess] = useState<{ amount: string; bonusAmount: string; show: boolean }>({
+    amount: "",
+    bonusAmount: "",
+    show: false
+  });
   const { enqueueSnackbar } = d.useSnackbar();
   const { data: defaultPaymentMethod, isLoading: isLoadingDefaultPaymentMethod } = d.useDefaultPaymentMethodQuery();
   const { balance: walletBalance, isLoading: isWalletBalanceLoading } = d.useWalletBalance();
@@ -218,7 +222,8 @@ export const AccountOverview: React.FunctionComponent<{ dependencies?: typeof DE
         <d.PaymentSuccessAnimation
           show={showPaymentSuccess.show}
           amount={showPaymentSuccess.amount}
-          onComplete={() => setShowPaymentSuccess({ amount: "", show: false })}
+          bonusAmount={showPaymentSuccess.bonusAmount}
+          onComplete={() => setShowPaymentSuccess({ amount: "", bonusAmount: "", show: false })}
         />
       </div>
 
@@ -227,8 +232,8 @@ export const AccountOverview: React.FunctionComponent<{ dependencies?: typeof DE
         onOpenChange={setShowAddCredits}
         initialTab="purchase"
         description="Buy credits or redeem a coupon to top up your balance."
-        onDone={amount => {
-          setShowPaymentSuccess({ amount: String(amount), show: true });
+        onDone={(amount, _organization, bonusAmount) => {
+          setShowPaymentSuccess({ amount: String(amount), bonusAmount: String(bonusAmount ?? 0), show: true });
           setShowAddCredits(false);
         }}
       />

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsAmountFields/AddCreditsAmountFields.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsAmountFields/AddCreditsAmountFields.spec.tsx
@@ -9,7 +9,7 @@ describe(AddCreditsAmountFields.name, () => {
   it("emits the chosen predefined amount and clears the custom amount", () => {
     const { onChange } = setup({ value: { predefinedAmount: "", customAmount: "75" } });
 
-    fireEvent.click(screen.getByRole("radio", { name: /100/i }));
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
 
     expect(onChange).toHaveBeenCalledWith({ predefinedAmount: "100", customAmount: "" });
   });

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsAmountFields/AddCreditsAmountFields.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsAmountFields/AddCreditsAmountFields.tsx
@@ -40,25 +40,25 @@ export function AddCreditsAmountFields({ value, onChange, minAmount, error }: Ad
         <RadioGroup value={value.predefinedAmount} className="grid-cols-3" onValueChange={changePredefinedAmount}>
           <FieldLabel htmlFor="plus-plan">
             <Field orientation="horizontal" className="cursor-pointer p-2">
-              <RadioGroupItem value="50" id="plus-plan" className="self-center" />
+              <RadioGroupItem value="100" id="plus-plan" className="self-center" />
               <FieldContent>
-                <FieldTitle className="font-medium">50</FieldTitle>
+                <FieldTitle className="font-medium">100</FieldTitle>
               </FieldContent>
             </Field>
           </FieldLabel>
           <FieldLabel htmlFor="pro-plan">
             <Field orientation="horizontal" className="cursor-pointer p-2">
-              <RadioGroupItem value="100" id="pro-plan" className="self-center" />
+              <RadioGroupItem value="500" id="pro-plan" className="self-center" />
               <FieldContent>
-                <FieldTitle>100</FieldTitle>
+                <FieldTitle>500</FieldTitle>
               </FieldContent>
             </Field>
           </FieldLabel>
           <FieldLabel htmlFor="enterprise-plan">
             <Field orientation="horizontal" className="cursor-pointer p-2">
-              <RadioGroupItem value="500" id="enterprise-plan" className="self-center" />
+              <RadioGroupItem value="1000" id="enterprise-plan" className="self-center" />
               <FieldContent>
-                <FieldTitle>500</FieldTitle>
+                <FieldTitle>1000</FieldTitle>
               </FieldContent>
             </Field>
           </FieldLabel>

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
@@ -32,7 +32,7 @@ describe(AddCreditsForm.name, () => {
 
     expect(screen.getByTestId("first-purchase-bonus-alert")).toHaveTextContent("0");
 
-    fireEvent.click(screen.getByRole("radio", { name: /100/i }));
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
 
     expect(screen.getByTestId("first-purchase-bonus-alert")).toHaveTextContent("100");
   });
@@ -80,7 +80,7 @@ describe(AddCreditsForm.name, () => {
       dependencies: { AddCreditsNewPaymentMethodFields }
     });
 
-    fireEvent.click(screen.getByRole("radio", { name: /100/i }));
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
@@ -119,7 +119,7 @@ describe(AddCreditsForm.name, () => {
       dependencies: { AddCreditsNewPaymentMethodFields }
     });
 
-    fireEvent.click(screen.getByRole("radio", { name: /100/i }));
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
@@ -147,7 +147,7 @@ describe(AddCreditsForm.name, () => {
       dependencies: { AddCreditsNewPaymentMethodFields }
     });
 
-    fireEvent.click(screen.getByRole("radio", { name: /100/i }));
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
@@ -177,7 +177,7 @@ describe(AddCreditsForm.name, () => {
       dependencies: { AddCreditsNewPaymentMethodFields }
     });
 
-    fireEvent.click(screen.getByRole("radio", { name: /100/i }));
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
@@ -203,7 +203,7 @@ describe(AddCreditsForm.name, () => {
       dependencies: { AddCreditsNewPaymentMethodFields }
     });
 
-    fireEvent.click(screen.getByRole("radio", { name: /100/i }));
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
@@ -233,7 +233,7 @@ describe(AddCreditsForm.name, () => {
       dependencies: { AddCreditsNewPaymentMethodFields }
     });
 
-    fireEvent.click(screen.getByRole("radio", { name: "50" }));
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
@@ -264,7 +264,7 @@ describe(AddCreditsForm.name, () => {
       dependencies: { AddCreditsNewPaymentMethodFields }
     });
 
-    fireEvent.click(screen.getByRole("radio", { name: "50" }));
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
@@ -292,7 +292,7 @@ describe(AddCreditsForm.name, () => {
       dependencies: { AddCreditsNewPaymentMethodFields }
     });
 
-    fireEvent.click(screen.getByRole("radio", { name: "50" }));
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
@@ -400,7 +400,7 @@ describe(AddCreditsForm.name, () => {
       dependencies: { AddCreditsNewPaymentMethodFields }
     });
 
-    fireEvent.click(screen.getByRole("radio", { name: "50" }));
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
@@ -414,7 +414,7 @@ describe(AddCreditsForm.name, () => {
 
     expect(addPaymentMethod).toHaveBeenCalledTimes(1);
     expect(confirmPayment).toHaveBeenCalledTimes(2);
-    expect(confirmPayment).toHaveBeenLastCalledWith({ userId: "user_1", paymentMethodId: "pm_new", amount: 50 });
+    expect(confirmPayment).toHaveBeenLastCalledWith({ userId: "user_1", paymentMethodId: "pm_new", amount: 100 });
   });
 
   it("invalidates the payment methods query when a new-card charge fails", async () => {
@@ -431,7 +431,7 @@ describe(AddCreditsForm.name, () => {
       dependencies: { AddCreditsNewPaymentMethodFields }
     });
 
-    fireEvent.click(screen.getByRole("radio", { name: "50" }));
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
@@ -456,7 +456,7 @@ describe(AddCreditsForm.name, () => {
     });
 
     fireEvent.click(screen.getByRole("button", { name: /add new payment method/i }));
-    fireEvent.click(screen.getByRole("radio", { name: "50" }));
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
@@ -490,7 +490,7 @@ describe(AddCreditsForm.name, () => {
       dependencies: { AddCreditsNewPaymentMethodFields }
     });
 
-    fireEvent.click(screen.getByRole("radio", { name: "50" }));
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
 
     await act(async () => {
       fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
@@ -27,16 +27,14 @@ describe(AddCreditsForm.name, () => {
     expect(mutate).not.toHaveBeenCalled();
   });
 
-  it("renders the first-purchase match alert while trialing", () => {
-    setup({ status: "idle", isTrialing: true });
-
-    expect(screen.getByText(/first-purchase match/i)).toBeInTheDocument();
-  });
-
-  it("hides the first-purchase match alert when not trialing", () => {
+  it("renders the first-purchase bonus alert with the entered amount regardless of trial state", () => {
     setup({ status: "idle" });
 
-    expect(screen.queryByText(/first-purchase match/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId("first-purchase-bonus-alert")).toHaveTextContent("0");
+
+    fireEvent.click(screen.getByRole("radio", { name: /100/i }));
+
+    expect(screen.getByTestId("first-purchase-bonus-alert")).toHaveTextContent("100");
   });
 
   it("pre-selects the default saved payment method", () => {
@@ -650,6 +648,7 @@ describe(AddCreditsForm.name, () => {
         dependencies={{
           AddCreditsAmountFields,
           AddCreditsNewPaymentMethodFields: makePaymentMethodFieldsMock().Mock,
+          FirstPurchaseBonusAlert: ({ amount }) => <div data-testid="first-purchase-bonus-alert">{amount}</div>,
           ThreeDSecurePopup: () => null,
           Label: MockLabel,
           Select: MockSelect,

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.spec.tsx
@@ -158,7 +158,98 @@ describe(AddCreditsForm.name, () => {
 
     rerender({ status: "success", clientSecret: "seti_secret", confirmPayment, onDone, isTrialing: false, isPolling: false });
 
-    await waitFor(() => expect(onDone).toHaveBeenCalledWith(100, "Acme"));
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith(100, "Acme", 0));
+  });
+
+  it("passes the granted first-purchase bonus to onDone", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ success: true });
+    const onDone = vi.fn();
+    const addPaymentMethod = vi.fn().mockResolvedValue({ paymentMethodId: "pm_1", organization: "Acme" });
+    const getCustomerTransactions = vi.fn().mockResolvedValue({ transactions: [{ status: "succeeded", amount: 10000, bonusAmount: 1000 }] });
+    const { Mock: AddCreditsNewPaymentMethodFields } = makePaymentMethodFieldsMock(addPaymentMethod);
+
+    const { rerender } = setup({
+      status: "success",
+      clientSecret: "seti_secret",
+      confirmPayment,
+      onDone,
+      getCustomerTransactions,
+      isTrialing: true,
+      isPolling: false,
+      dependencies: { AddCreditsNewPaymentMethodFields }
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    rerender({ status: "success", clientSecret: "seti_secret", confirmPayment, onDone, getCustomerTransactions, isTrialing: true, isPolling: true });
+    rerender({ status: "success", clientSecret: "seti_secret", confirmPayment, onDone, getCustomerTransactions, isTrialing: false, isPolling: false });
+
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith(100, "Acme", 10));
+    expect(getCustomerTransactions).toHaveBeenCalledWith({ limit: 1 });
+  });
+
+  it("reports a zero bonus when the latest transaction does not match the charge", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ success: true });
+    const onDone = vi.fn();
+    const addPaymentMethod = vi.fn().mockResolvedValue({ paymentMethodId: "pm_1", organization: "Acme" });
+    const getCustomerTransactions = vi.fn().mockResolvedValue({ transactions: [{ status: "succeeded", amount: 5000, bonusAmount: 1000 }] });
+    const { Mock: AddCreditsNewPaymentMethodFields } = makePaymentMethodFieldsMock(addPaymentMethod);
+
+    const { rerender } = setup({
+      status: "success",
+      clientSecret: "seti_secret",
+      confirmPayment,
+      onDone,
+      getCustomerTransactions,
+      isTrialing: true,
+      isPolling: false,
+      dependencies: { AddCreditsNewPaymentMethodFields }
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    rerender({ status: "success", clientSecret: "seti_secret", confirmPayment, onDone, getCustomerTransactions, isTrialing: true, isPolling: true });
+    rerender({ status: "success", clientSecret: "seti_secret", confirmPayment, onDone, getCustomerTransactions, isTrialing: false, isPolling: false });
+
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith(100, "Acme", 0));
+  });
+
+  it("completes with a zero bonus when the transaction lookup fails", async () => {
+    const confirmPayment = vi.fn().mockResolvedValue({ success: true });
+    const onDone = vi.fn();
+    const addPaymentMethod = vi.fn().mockResolvedValue({ paymentMethodId: "pm_1", organization: "Acme" });
+    const getCustomerTransactions = vi.fn().mockRejectedValue(new Error("boom"));
+    const { Mock: AddCreditsNewPaymentMethodFields } = makePaymentMethodFieldsMock(addPaymentMethod);
+
+    const { rerender } = setup({
+      status: "success",
+      clientSecret: "seti_secret",
+      confirmPayment,
+      onDone,
+      getCustomerTransactions,
+      isTrialing: true,
+      isPolling: false,
+      dependencies: { AddCreditsNewPaymentMethodFields }
+    });
+
+    fireEvent.click(screen.getByRole("radio", { name: "100" }));
+
+    await act(async () => {
+      fireEvent.submit(screen.getByRole("button", { name: /purchase credits/i }).closest("form")!);
+    });
+
+    rerender({ status: "success", clientSecret: "seti_secret", confirmPayment, onDone, getCustomerTransactions, isTrialing: true, isPolling: true });
+    rerender({ status: "success", clientSecret: "seti_secret", confirmPayment, onDone, getCustomerTransactions, isTrialing: false, isPolling: false });
+
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith(100, "Acme", 0));
   });
 
   it("shows an error when polling stops without the trial flipping", async () => {
@@ -570,6 +661,7 @@ describe(AddCreditsForm.name, () => {
     mutate?: ReturnType<typeof DEPENDENCIES.useSetupIntentMutation>["mutate"];
     reset?: ReturnType<typeof DEPENDENCIES.useSetupIntentMutation>["reset"];
     invalidateQueries?: ReturnType<typeof DEPENDENCIES.useQueryClient>["invalidateQueries"];
+    getCustomerTransactions?: ReturnType<typeof DEPENDENCIES.useServices>["stripe"]["getCustomerTransactions"];
     topUpMinAmountUsd?: number;
     confirmPayment?: ReturnType<typeof DEPENDENCIES.usePaymentMutations>["confirmPayment"]["mutateAsync"];
     pollForPayment?: ReturnType<typeof DEPENDENCIES.usePaymentPolling>["pollForPayment"];
@@ -622,6 +714,13 @@ describe(AddCreditsForm.name, () => {
         invalidateQueries: input.invalidateQueries ?? vi.fn()
       });
 
+    const useServices: typeof DEPENDENCIES.useServices = () =>
+      mock<ReturnType<typeof DEPENDENCIES.useServices>>({
+        stripe: mock<ReturnType<typeof DEPENDENCIES.useServices>["stripe"]>({
+          getCustomerTransactions: input.getCustomerTransactions ?? vi.fn().mockResolvedValue({ transactions: [] })
+        })
+      });
+
     // UseQueryResult is a discriminated union that neither mock<T>() nor a partial literal can satisfy
     const usePaymentMethodsQuery = (() => ({
       data: input.isMethodsError ? undefined : input.paymentMethods ?? [],
@@ -663,6 +762,7 @@ describe(AddCreditsForm.name, () => {
           usePaymentMutations,
           usePaymentPolling,
           useQueryClient,
+          useServices,
           useWallet,
           use3DSecure,
           getPaymentMethodDisplay,

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
@@ -25,6 +25,7 @@ import { FirstPurchaseBonusAlert } from "@src/components/billing-usage/FirstPurc
 import { getPaymentMethodDisplay } from "@src/components/shared/PaymentMethodCard/PaymentMethodCard";
 import { ThreeDSecurePopup } from "@src/components/shared/PaymentMethodForm/ThreeDSecurePopup";
 import { usePaymentPolling } from "@src/context/PaymentPollingProvider";
+import { useServices } from "@src/context/ServicesProvider";
 import { useWallet } from "@src/context/WalletProvider";
 import { use3DSecure } from "@src/hooks/use3DSecure";
 import { useUser } from "@src/hooks/useUser";
@@ -51,6 +52,7 @@ export const DEPENDENCIES = {
   usePaymentMutations,
   usePaymentPolling,
   useQueryClient,
+  useServices,
   useWallet,
   use3DSecure,
   useUser,
@@ -59,7 +61,7 @@ export const DEPENDENCIES = {
 };
 
 interface AddCreditsFormProps {
-  onDone: (amount: number, organization?: string) => void;
+  onDone: (amount: number, organization?: string, bonusAmount?: number) => void;
   isWalletReady?: boolean;
   onProcessingChange?: (isProcessing: boolean) => void;
   dependencies?: typeof DEPENDENCIES;
@@ -90,6 +92,7 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
   const { data: setupIntent, mutate: createSetupIntent, status: setupIntentStatus, reset: resetSetupIntent } = d.useSetupIntentMutation();
   const { user } = d.useUser();
   const { pollForPayment, isPolling } = d.usePaymentPolling();
+  const { stripe } = d.useServices();
   const { isTrialing, topUpMinAmountUsd } = d.useWallet();
   const queryClient = d.useQueryClient();
   const { data: paymentMethods, isLoading: isLoadingMethods, isError: isMethodsError } = d.usePaymentMethodsQuery();
@@ -257,9 +260,25 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
       confirmedNewCardRef.current = null;
       setCharge(null);
       setIsProcessing(false);
-      onDone(charge.amount, charge.organization);
+
+      const { amount, organization } = charge;
+      void (async function completeWithGrantedBonus() {
+        // Polling settles only after the webhook topped up the wallet, so the granted
+        // first-purchase bonus is already recorded on the latest transaction.
+        let bonusAmount = 0;
+        try {
+          const { transactions } = await stripe.getCustomerTransactions({ limit: 1 });
+          const latest = transactions[0];
+          if (latest?.status === "succeeded" && latest.amount === Math.round(amount * 100)) {
+            bonusAmount = (latest.bonusAmount ?? 0) / 100;
+          }
+        } catch {
+          // Bonus display is best-effort; completion must proceed without it.
+        }
+        onDone(amount, organization, bonusAmount);
+      })();
     },
-    [isPolling, isTrialing, charge, finalizeFailure, onDone]
+    [isPolling, isTrialing, charge, finalizeFailure, onDone, stripe]
   );
 
   useEffect(

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsForm/AddCreditsForm.tsx
@@ -5,7 +5,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import {
   Alert,
   AlertDescription,
-  AlertTitle,
   Button,
   Label,
   Select,
@@ -17,12 +16,12 @@ import {
   Spinner
 } from "@akashnetwork/ui/components";
 import { useQueryClient } from "@tanstack/react-query";
-import { GiftIcon } from "lucide-react";
 
 import type { AddCreditsAmountValue } from "@src/components/billing-usage/AddCreditsAmountFields/AddCreditsAmountFields";
 import { AddCreditsAmountFields } from "@src/components/billing-usage/AddCreditsAmountFields/AddCreditsAmountFields";
 import type { PaymentMethodSourceHandle } from "@src/components/billing-usage/AddCreditsNewPaymentMethodFields/AddCreditsNewPaymentMethodFields";
 import { AddCreditsNewPaymentMethodFields } from "@src/components/billing-usage/AddCreditsNewPaymentMethodFields/AddCreditsNewPaymentMethodFields";
+import { FirstPurchaseBonusAlert } from "@src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert";
 import { getPaymentMethodDisplay } from "@src/components/shared/PaymentMethodCard/PaymentMethodCard";
 import { ThreeDSecurePopup } from "@src/components/shared/PaymentMethodForm/ThreeDSecurePopup";
 import { usePaymentPolling } from "@src/context/PaymentPollingProvider";
@@ -38,6 +37,7 @@ const NEW_CARD = "new";
 export const DEPENDENCIES = {
   AddCreditsAmountFields,
   AddCreditsNewPaymentMethodFields,
+  FirstPurchaseBonusAlert,
   ThreeDSecurePopup,
   Label,
   Select,
@@ -283,13 +283,7 @@ export function AddCreditsForm({ onDone, isWalletReady = true, onProcessingChang
 
   return (
     <>
-      {isTrialing && (
-        <Alert variant="default" className="bg-blue-50 p-3 dark:bg-blue-950">
-          <GiftIcon className="h-4 w-4" />
-          <AlertTitle className="text-sm font-medium">First-purchase match.</AlertTitle>
-          <AlertDescription className="text-muted-foreground">Akash matches your first purchase dollar-dollar, up to $100.</AlertDescription>
-        </Alert>
-      )}
+      <d.FirstPurchaseBonusAlert amount={amount} />
 
       <form className="space-y-6" onSubmit={submit}>
         <d.AddCreditsAmountFields value={amountInput} onChange={setAmountInput} minAmount={topUpMinAmountUsd} error={amountError} />

--- a/apps/deploy-web/src/components/billing-usage/AddCreditsTabs/AddCreditsTabs.tsx
+++ b/apps/deploy-web/src/components/billing-usage/AddCreditsTabs/AddCreditsTabs.tsx
@@ -19,7 +19,7 @@ export const DEPENDENCIES = {
 
 interface AddCreditsTabsProps {
   initialTab?: AddCreditsTab;
-  onDone: (amount: number, organization?: string) => void;
+  onDone: (amount: number, organization?: string, bonusAmount?: number) => void;
   onRedeemed?: () => void;
   isWalletReady?: boolean;
   onProcessingChange?: (isProcessing: boolean) => void;

--- a/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.spec.tsx
@@ -42,6 +42,40 @@ describe(BillingView.name, () => {
     expect(screen.getByText(/Succeeded|Pending|Failed/i)).toBeInTheDocument();
   });
 
+  it("shows the first-purchase bonus under the amount when present", () => {
+    const transaction = createMockTransaction({ amount: 25000, status: "succeeded" });
+    setup({
+      data: [
+        mock<Charge>({
+          ...transaction,
+          paymentMethod: transaction.payment_method,
+          receiptUrl: "https://example.com/receipt",
+          bonusAmount: 1000
+        })
+      ]
+    });
+
+    expect(screen.getByText("250.00")).toBeInTheDocument();
+    expect(screen.getByText("10.00")).toBeInTheDocument();
+    expect(screen.getByText(/bonus/)).toBeInTheDocument();
+  });
+
+  it("renders no bonus line when the transaction has no bonus", () => {
+    const transaction = createMockTransaction({ amount: 25000, status: "succeeded" });
+    setup({
+      data: [
+        mock<Charge>({
+          ...transaction,
+          paymentMethod: transaction.payment_method,
+          receiptUrl: "https://example.com/receipt",
+          bonusAmount: 0
+        })
+      ]
+    });
+
+    expect(screen.queryByText(/bonus/)).not.toBeInTheDocument();
+  });
+
   it("calls onPaginationChange when changing page size", () => {
     const onPaginationChange = vi.fn();
     setup({ onPaginationChange });

--- a/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
+++ b/apps/deploy-web/src/components/billing-usage/BillingView/BillingView.tsx
@@ -81,7 +81,19 @@ export const BillingView: React.FC<BillingViewProps> = ({
     }),
     columnHelper.accessor("amount", {
       header: "Amount",
-      cell: info => <FormattedNumber value={info.getValue() / 100} style="currency" currency={info.row.original.currency} currencyDisplay="narrowSymbol" />
+      cell: info => {
+        const { currency, bonusAmount = 0 } = info.row.original;
+        return (
+          <div>
+            <FormattedNumber value={info.getValue() / 100} style="currency" currency={currency} currencyDisplay="narrowSymbol" />
+            {bonusAmount > 0 && (
+              <div className="text-xs font-medium text-primary">
+                +<FormattedNumber value={bonusAmount / 100} style="currency" currency={currency} currencyDisplay="narrowSymbol" /> bonus
+              </div>
+            )}
+          </div>
+        );
+      }
     }),
     columnHelper.accessor("paymentMethod.card.brand", {
       header: "Account source",

--- a/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.spec.tsx
@@ -29,12 +29,12 @@ describe(FirstPurchaseBonusAlert.name, () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("shows the base offer when no amount is entered", () => {
+  it("shows the base offer and qualifying threshold when no amount is entered", () => {
     const { container } = setup({ amount: 0 });
 
     expect(screen.getByText("First-purchase bonus")).toBeInTheDocument();
-    expect(container).toHaveTextContent("Get 10% bonus credits on your first purchase of $100 or more, up to $100.");
-    expect(container).not.toHaveTextContent("more to qualify");
+    expect(container).toHaveTextContent("Get 10% in bonus credits on your first purchase, up to $100.");
+    expect(container).toHaveTextContent("Add $100.00 or more to unlock your bonus.");
   });
 
   it("shows the offer to users whose only charges failed", () => {
@@ -43,24 +43,34 @@ describe(FirstPurchaseBonusAlert.name, () => {
     expect(screen.getByText("First-purchase bonus")).toBeInTheDocument();
   });
 
-  it("nudges when the amount is below the qualifying minimum", () => {
+  it("nudges to add the shortfall when the amount is below the qualifying minimum", () => {
     const { container } = setup({ amount: 50 });
 
-    expect(container).toHaveTextContent("Add $50.00 more to qualify.");
+    expect(container).toHaveTextContent("Add $50.00 more to unlock your bonus.");
   });
 
-  it("previews the bonus and total at a qualifying amount", () => {
+  it("previews the total, purchase, and bonus breakdown at a qualifying amount", () => {
+    setup({ amount: 100 });
+
+    expect(screen.getByText("You'll receive")).toBeInTheDocument();
+    expect(screen.getByText("$110.00 in credits")).toBeInTheDocument();
+    expect(screen.getByText("First-purchase bonus (10%)")).toBeInTheDocument();
+    expect(screen.getByText("+$10.00")).toBeInTheDocument();
+  });
+
+  it("nudges toward the max bonus when the bonus is not yet capped", () => {
     const { container } = setup({ amount: 100 });
 
-    expect(container).toHaveTextContent("You'll receive $110.00 in credits");
-    expect(container).toHaveTextContent("$10.00 first-purchase bonus included.");
+    expect(container).toHaveTextContent("Add $900.00 more to unlock the full $100.00 bonus.");
   });
 
-  it("caps the previewed bonus at $100", () => {
+  it("caps the previewed bonus at $100 and confirms the max bonus is unlocked", () => {
     const { container } = setup({ amount: 10000 });
 
-    expect(container).toHaveTextContent("You'll receive $10,100.00 in credits");
-    expect(container).toHaveTextContent("$100.00 first-purchase bonus included.");
+    expect(screen.getByText("$10,100.00 in credits")).toBeInTheDocument();
+    expect(screen.getByText("+$100.00")).toBeInTheDocument();
+    expect(container).toHaveTextContent("You've unlocked the maximum $100.00 bonus.");
+    expect(container).not.toHaveTextContent("more to unlock");
   });
 
   function setup(input?: { amount?: number; flagEnabled?: boolean; isSuccess?: boolean; transactions?: Charge[] }) {

--- a/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.spec.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { IntlProvider } from "react-intl";
+import type { Charge } from "@akashnetwork/http-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { DEPENDENCIES } from "./FirstPurchaseBonusAlert";
+import { FirstPurchaseBonusAlert } from "./FirstPurchaseBonusAlert";
+
+import { render, screen } from "@testing-library/react";
+
+describe(FirstPurchaseBonusAlert.name, () => {
+  it("renders nothing when the feature flag is off and disables the transactions query", () => {
+    const { container, usePaymentTransactionsQuery } = setup({ flagEnabled: false });
+
+    expect(container).toBeEmptyDOMElement();
+    expect(usePaymentTransactionsQuery).toHaveBeenCalledWith(undefined, { enabled: false });
+  });
+
+  it("renders nothing until the transactions query succeeds", () => {
+    const { container } = setup({ isSuccess: false });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the user already has a succeeded charge", () => {
+    const { container } = setup({ transactions: [mock<Charge>({ status: "succeeded" })] });
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the base offer when no amount is entered", () => {
+    const { container } = setup({ amount: 0 });
+
+    expect(screen.getByText("First-purchase bonus")).toBeInTheDocument();
+    expect(container).toHaveTextContent("Get 10% bonus credits on your first purchase of $100 or more, up to $100.");
+    expect(container).not.toHaveTextContent("more to qualify");
+  });
+
+  it("shows the offer to users whose only charges failed", () => {
+    setup({ amount: 0, transactions: [mock<Charge>({ status: "failed" })] });
+
+    expect(screen.getByText("First-purchase bonus")).toBeInTheDocument();
+  });
+
+  it("nudges when the amount is below the qualifying minimum", () => {
+    const { container } = setup({ amount: 50 });
+
+    expect(container).toHaveTextContent("Add $50.00 more to qualify.");
+  });
+
+  it("previews the bonus and total at a qualifying amount", () => {
+    const { container } = setup({ amount: 100 });
+
+    expect(container).toHaveTextContent("You'll receive $110.00 in credits");
+    expect(container).toHaveTextContent("$10.00 first-purchase bonus included.");
+  });
+
+  it("caps the previewed bonus at $100", () => {
+    const { container } = setup({ amount: 10000 });
+
+    expect(container).toHaveTextContent("You'll receive $10,100.00 in credits");
+    expect(container).toHaveTextContent("$100.00 first-purchase bonus included.");
+  });
+
+  function setup(input?: { amount?: number; flagEnabled?: boolean; isSuccess?: boolean; transactions?: Charge[] }) {
+    const useFlag: typeof DEPENDENCIES.useFlag = vi.fn().mockReturnValue(input?.flagEnabled ?? true);
+
+    // UseQueryResult is a discriminated union that neither mock<T>() nor a partial literal can satisfy
+    const usePaymentTransactionsQuery = vi.fn(() => ({
+      data: { transactions: input?.transactions ?? [] },
+      isSuccess: input?.isSuccess ?? true
+    })) as unknown as typeof DEPENDENCIES.usePaymentTransactionsQuery;
+
+    const result = render(
+      <IntlProvider locale="en-US" defaultLocale="en-US">
+        <FirstPurchaseBonusAlert amount={input?.amount ?? 0} dependencies={{ useFlag, usePaymentTransactionsQuery }} />
+      </IntlProvider>
+    );
+
+    return { ...result, useFlag, usePaymentTransactionsQuery };
+  }
+});

--- a/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.tsx
+++ b/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.tsx
@@ -10,8 +10,8 @@ import { usePaymentTransactionsQuery } from "@src/queries";
 
 /** Keep in sync with FirstPurchaseBonusService (apps/api). Amounts in dollars. */
 const MIN_QUALIFYING_AMOUNT = 100;
-const BONUS_PERCENT = 10;
-const MAX_BONUS = 100;
+export const BONUS_PERCENT = 10;
+export const MAX_BONUS = 100;
 /** Purchase that first reaches the capped bonus (e.g. $1,000 at 10% for a $100 cap). */
 const AMOUNT_FOR_MAX_BONUS = (MAX_BONUS * 100) / BONUS_PERCENT;
 

--- a/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.tsx
+++ b/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.tsx
@@ -77,7 +77,7 @@ export function FirstPurchaseBonusAlert({ amount, dependencies: d = DEPENDENCIES
           </div>
 
           <div className="space-y-1.5">
-            <Progress value={progressToMaxBonus} className="h-2" />
+            <Progress value={progressToMaxBonus} className="h-2 border border-blue-200 dark:border-blue-800" />
             <p className="text-xs text-muted-foreground">
               {bonusMaxed ? (
                 <>
@@ -102,7 +102,7 @@ export function FirstPurchaseBonusAlert({ amount, dependencies: d = DEPENDENCIES
           </div>
 
           <div className="space-y-1.5">
-            <Progress value={progressToQualify} className="h-2" />
+            <Progress value={progressToQualify} className="h-2 border border-blue-200 dark:border-blue-800" />
             <p className="text-sm font-medium">
               {amount > 0 ? (
                 <>

--- a/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.tsx
+++ b/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { FormattedNumber } from "react-intl";
-import { Alert, AlertDescription, AlertTitle } from "@akashnetwork/ui/components";
+import { Alert, Progress } from "@akashnetwork/ui/components";
 import { GiftIcon } from "lucide-react";
 
 import { useFlag } from "@src/hooks/useFlag";
@@ -12,6 +12,8 @@ import { usePaymentTransactionsQuery } from "@src/queries";
 const MIN_QUALIFYING_AMOUNT = 100;
 const BONUS_PERCENT = 10;
 const MAX_BONUS = 100;
+/** Purchase that first reaches the capped bonus (e.g. $1,000 at 10% for a $100 cap). */
+const AMOUNT_FOR_MAX_BONUS = (MAX_BONUS * 100) / BONUS_PERCENT;
 
 export const DEPENDENCIES = {
   useFlag,
@@ -42,32 +44,78 @@ export function FirstPurchaseBonusAlert({ amount, dependencies: d = DEPENDENCIES
   const bonus = Math.min(Math.floor(amount * BONUS_PERCENT) / 100, MAX_BONUS);
   const qualifies = amount >= MIN_QUALIFYING_AMOUNT;
   const missingAmount = MIN_QUALIFYING_AMOUNT - amount;
+  const amountToMaxBonus = AMOUNT_FOR_MAX_BONUS - amount;
+  const progressToMaxBonus = Math.min((amount / AMOUNT_FOR_MAX_BONUS) * 100, 100);
+  const progressToQualify = Math.min((amount / MIN_QUALIFYING_AMOUNT) * 100, 100);
+  const bonusMaxed = bonus >= MAX_BONUS;
 
   return (
-    <Alert variant="default" className="bg-blue-50 p-3 dark:bg-blue-950">
+    <Alert variant="default" className="mb-6 bg-blue-50 p-4 dark:bg-blue-950">
       <GiftIcon className="h-4 w-4" />
       {qualifies ? (
-        <>
-          <AlertTitle className="text-sm font-medium">
-            You&apos;ll receive <FormattedNumber value={amount + bonus} style="currency" currency="USD" /> in credits
-          </AlertTitle>
-          <AlertDescription className="text-muted-foreground">
-            <FormattedNumber value={bonus} style="currency" currency="USD" /> first-purchase bonus included.
-          </AlertDescription>
-        </>
+        <div className="space-y-3">
+          <div>
+            <p className="text-xs text-muted-foreground">You&apos;ll receive</p>
+            <p className="text-lg font-semibold">
+              <FormattedNumber value={amount + bonus} style="currency" currency="USD" /> in credits
+            </p>
+          </div>
+
+          <div className="space-y-1 text-sm">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Purchase</span>
+              <span>
+                <FormattedNumber value={amount} style="currency" currency="USD" />
+              </span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">First-purchase bonus ({BONUS_PERCENT}%)</span>
+              <span className="font-medium text-primary">
+                +<FormattedNumber value={bonus} style="currency" currency="USD" />
+              </span>
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Progress value={progressToMaxBonus} className="h-2" />
+            <p className="text-xs text-muted-foreground">
+              {bonusMaxed ? (
+                <>
+                  You&apos;ve unlocked the maximum <FormattedNumber value={MAX_BONUS} style="currency" currency="USD" /> bonus.
+                </>
+              ) : (
+                <>
+                  Add <FormattedNumber value={amountToMaxBonus} style="currency" currency="USD" /> more to unlock the full{" "}
+                  <FormattedNumber value={MAX_BONUS} style="currency" currency="USD" /> bonus.
+                </>
+              )}
+            </p>
+          </div>
+        </div>
       ) : (
-        <>
-          <AlertTitle className="text-sm font-medium">First-purchase bonus</AlertTitle>
-          <AlertDescription className="text-muted-foreground">
-            Get 10% bonus credits on your first purchase of $100 or more, up to $100.
-            {amount > 0 && (
-              <>
-                {" "}
-                Add <FormattedNumber value={missingAmount} style="currency" currency="USD" /> more to qualify.
-              </>
-            )}
-          </AlertDescription>
-        </>
+        <div className="space-y-3">
+          <div>
+            <p className="text-sm font-medium">First-purchase bonus</p>
+            <p className="text-xs text-muted-foreground">
+              Get {BONUS_PERCENT}% in bonus credits on your first purchase, up to <FormattedNumber value={MAX_BONUS} style="currency" currency="USD" />.
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Progress value={progressToQualify} className="h-2" />
+            <p className="text-sm font-medium">
+              {amount > 0 ? (
+                <>
+                  Add <FormattedNumber value={missingAmount} style="currency" currency="USD" /> more to unlock your bonus.
+                </>
+              ) : (
+                <>
+                  Add <FormattedNumber value={MIN_QUALIFYING_AMOUNT} style="currency" currency="USD" /> or more to unlock your bonus.
+                </>
+              )}
+            </p>
+          </div>
+        </div>
       )}
     </Alert>
   );

--- a/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.tsx
+++ b/apps/deploy-web/src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import React from "react";
+import { FormattedNumber } from "react-intl";
+import { Alert, AlertDescription, AlertTitle } from "@akashnetwork/ui/components";
+import { GiftIcon } from "lucide-react";
+
+import { useFlag } from "@src/hooks/useFlag";
+import { usePaymentTransactionsQuery } from "@src/queries";
+
+/** Keep in sync with FirstPurchaseBonusService (apps/api). Amounts in dollars. */
+const MIN_QUALIFYING_AMOUNT = 100;
+const BONUS_PERCENT = 10;
+const MAX_BONUS = 100;
+
+export const DEPENDENCIES = {
+  useFlag,
+  usePaymentTransactionsQuery
+};
+
+interface FirstPurchaseBonusAlertProps {
+  amount: number;
+  dependencies?: typeof DEPENDENCIES;
+}
+
+/**
+ * Promotes the one-time first-purchase bonus and previews it against the entered
+ * amount. Hidden for users who already completed a paid purchase (any succeeded
+ * Stripe charge — refunded charges keep the "succeeded" status and correctly count
+ * as consumed). Coupon claims create no charge, so coupon users still see the offer.
+ */
+export function FirstPurchaseBonusAlert({ amount, dependencies: d = DEPENDENCIES }: FirstPurchaseBonusAlertProps) {
+  const isEnabled = d.useFlag("first_purchase_bonus");
+  const { data, isSuccess } = d.usePaymentTransactionsQuery(undefined, { enabled: isEnabled });
+
+  const hasPaidBefore = !!data?.transactions.some(transaction => transaction.status === "succeeded");
+
+  // Gate on isSuccess (not isFetched): a failed transactions fetch also sets isFetched, leaving `data`
+  // empty and hasPaidBefore false, which would wrongly show the offer to users with unknown history.
+  if (!isEnabled || !isSuccess || hasPaidBefore) return null;
+
+  const bonus = Math.min(Math.floor(amount * BONUS_PERCENT) / 100, MAX_BONUS);
+  const qualifies = amount >= MIN_QUALIFYING_AMOUNT;
+  const missingAmount = MIN_QUALIFYING_AMOUNT - amount;
+
+  return (
+    <Alert variant="default" className="bg-blue-50 p-3 dark:bg-blue-950">
+      <GiftIcon className="h-4 w-4" />
+      {qualifies ? (
+        <>
+          <AlertTitle className="text-sm font-medium">
+            You&apos;ll receive <FormattedNumber value={amount + bonus} style="currency" currency="USD" /> in credits
+          </AlertTitle>
+          <AlertDescription className="text-muted-foreground">
+            <FormattedNumber value={bonus} style="currency" currency="USD" /> first-purchase bonus included.
+          </AlertDescription>
+        </>
+      ) : (
+        <>
+          <AlertTitle className="text-sm font-medium">First-purchase bonus</AlertTitle>
+          <AlertDescription className="text-muted-foreground">
+            Get 10% bonus credits on your first purchase of $100 or more, up to $100.
+            {amount > 0 && (
+              <>
+                {" "}
+                Add <FormattedNumber value={missingAmount} style="currency" currency="USD" /> more to qualify.
+              </>
+            )}
+          </AlertDescription>
+        </>
+      )}
+    </Alert>
+  );
+}

--- a/apps/deploy-web/src/components/billing-usage/PaymentSuccessAnimation/PaymentSuccessAnimation.spec.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentSuccessAnimation/PaymentSuccessAnimation.spec.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { IntlProvider } from "react-intl";
+import { describe, expect, it } from "vitest";
+
+import { PaymentSuccessAnimation } from "./PaymentSuccessAnimation";
+
+import { render, screen } from "@testing-library/react";
+
+describe(PaymentSuccessAnimation.name, () => {
+  it("shows the credited total including the bonus and the bonus note", () => {
+    setup({ amount: "100", bonusAmount: "10" });
+
+    expect(screen.getByText("$110.00")).toBeInTheDocument();
+    expect(screen.getByText(/\$10\.00 first-purchase bonus/)).toBeInTheDocument();
+  });
+
+  it("shows only the paid amount when there is no bonus", () => {
+    setup({ amount: "100" });
+
+    expect(screen.getByText("$100.00")).toBeInTheDocument();
+    expect(screen.queryByText(/first-purchase bonus/)).not.toBeInTheDocument();
+  });
+
+  function setup(input: { amount: string; bonusAmount?: string }) {
+    render(
+      <IntlProvider locale="en-US" defaultLocale="en-US">
+        <PaymentSuccessAnimation show amount={input.amount} bonusAmount={input.bonusAmount} />
+      </IntlProvider>
+    );
+    return input;
+  }
+});

--- a/apps/deploy-web/src/components/billing-usage/PaymentSuccessAnimation/PaymentSuccessAnimation.tsx
+++ b/apps/deploy-web/src/components/billing-usage/PaymentSuccessAnimation/PaymentSuccessAnimation.tsx
@@ -8,6 +8,8 @@ import { CheckCircle, Sparks } from "iconoir-react";
 interface PaymentSuccessAnimationProps {
   show: boolean;
   amount: string;
+  /** First-purchase bonus in dollars; shown and added to the credited total when > 0. */
+  bonusAmount?: string;
   onComplete?: () => void;
 }
 
@@ -21,8 +23,10 @@ interface Particle {
   delay: number;
 }
 
-export function PaymentSuccessAnimation({ show, amount, onComplete }: PaymentSuccessAnimationProps) {
+export function PaymentSuccessAnimation({ show, amount, bonusAmount, onComplete }: PaymentSuccessAnimationProps) {
   const [particles, setParticles] = useState<Particle[]>([]);
+  const bonus = parseFloat(bonusAmount ?? "") || 0;
+  const totalCredited = (parseFloat(amount) || 0) + bonus;
 
   useEffect(() => {
     if (show) {
@@ -164,11 +168,22 @@ export function PaymentSuccessAnimation({ show, amount, onComplete }: PaymentSuc
               >
                 <div className="flex items-center rounded-lg border border-green-500/20 bg-green-500/10 px-6 py-3">
                   <span className="text-2xl font-bold text-green-500">
-                    <FormattedNumber value={parseFloat(amount) || 0} style="currency" currency="USD" />
+                    <FormattedNumber value={totalCredited} style="currency" currency="USD" />
                   </span>
                   <span className="ml-2 text-lg text-muted-foreground">added to your account</span>
                 </div>
               </motion.div>
+
+              {bonus > 0 && (
+                <motion.p
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: 0.9, duration: 0.5 }}
+                  className="mb-4 text-sm font-medium text-primary"
+                >
+                  Includes a <FormattedNumber value={bonus} style="currency" currency="USD" /> first-purchase bonus
+                </motion.p>
+              )}
 
               <motion.p
                 initial={{ opacity: 0, y: 10 }}

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
@@ -45,7 +45,7 @@ describe(OnboardingPickerPage.name, () => {
   it("renders the first-purchase bonus offer when the first_purchase_bonus flag is on", () => {
     const { container } = setup({ isFirstPurchaseBonusEnabled: true });
 
-    expect(container).toHaveTextContent("Plus, get 10% in bonus credits on your first purchase — up to $100.");
+    expect(container).toHaveTextContent("Plus, get 10% in bonus credits on your first purchase, up to $100.");
   });
 
   it("hides the first-purchase bonus offer when the first_purchase_bonus flag is off", () => {

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
@@ -42,6 +42,18 @@ describe(OnboardingPickerPage.name, () => {
     expect(screen.getByText("$1 in free trial credits")).toBeInTheDocument();
   });
 
+  it("renders the first-purchase bonus offer when the first_purchase_bonus flag is on", () => {
+    const { container } = setup({ isFirstPurchaseBonusEnabled: true });
+
+    expect(container).toHaveTextContent("Plus, get 10% in bonus credits on your first purchase — up to $100.");
+  });
+
+  it("hides the first-purchase bonus offer when the first_purchase_bonus flag is off", () => {
+    const { container } = setup({ isFirstPurchaseBonusEnabled: false });
+
+    expect(container).not.toHaveTextContent("bonus credits");
+  });
+
   it("redirects to the configure view with the hello-world auto-deploy intent when its card deploys", () => {
     const push = vi.fn();
     const DeploymentTemplatePickerCard = vi.fn(ComponentMock);
@@ -320,6 +332,7 @@ describe(OnboardingPickerPage.name, () => {
       searchParams?: string;
       isTrialing?: boolean;
       isHackathonsEnabled?: boolean;
+      isFirstPurchaseBonusEnabled?: boolean;
       trialCreditsAmount?: number;
       wallet?: EnsureTrialStartedResult["wallet"];
       dependencies?: Partial<typeof DEPENDENCIES>;
@@ -329,6 +342,7 @@ describe(OnboardingPickerPage.name, () => {
     const replace = input.replace ?? vi.fn();
     const isTrialing = input.isTrialing ?? true;
     const isHackathonsEnabled = input.isHackathonsEnabled ?? false;
+    const isFirstPurchaseBonusEnabled = input.isFirstPurchaseBonusEnabled ?? false;
     const trialCreditsAmount = input.trialCreditsAmount ?? 100;
     const wallet = "wallet" in input ? input.wallet : mock<ApiManagedWalletOutput>({ creditAmount: 100 });
 
@@ -343,7 +357,7 @@ describe(OnboardingPickerPage.name, () => {
       })
     );
     const useWallet: typeof DEPENDENCIES.useWallet = () => mock<ReturnType<typeof DEPENDENCIES.useWallet>>({ isTrialing });
-    const useFlag: typeof DEPENDENCIES.useFlag = () => isHackathonsEnabled;
+    const useFlag: typeof DEPENDENCIES.useFlag = flag => (flag === "first_purchase_bonus" ? isFirstPurchaseBonusEnabled : isHackathonsEnabled);
     const useServices: typeof DEPENDENCIES.useServices = () =>
       mock<ReturnType<typeof DEPENDENCIES.useServices>>({ publicConfig: { NEXT_PUBLIC_TRIAL_CREDITS_AMOUNT: trialCreditsAmount }, urlService: UrlService });
 

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
@@ -9,6 +9,7 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import { AddCreditsSheet } from "@src/components/auth/AddCreditsSheet/AddCreditsSheet";
+import { BONUS_PERCENT, MAX_BONUS } from "@src/components/billing-usage/FirstPurchaseBonusAlert/FirstPurchaseBonusAlert";
 import { DeploymentTemplatePickerCard } from "@src/components/deployments/DeploymentTemplatePickerCard/DeploymentTemplatePickerCard";
 import { AkashConsoleLogo } from "@src/components/icons/AkashConsoleLogo";
 import { AccountMenu } from "@src/components/layout/AccountMenu";
@@ -54,6 +55,7 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
   const [addCreditsSheetReason, setAddCreditsSheetReason] = useState<"unlock-gpu" | "skip-trial" | "hackathon-coupon" | null>(null);
   const { isWalletReady, error: trialError, wallet } = d.useEnsureTrialStarted();
   const isHackathonsEnabled = d.useFlag("hackathons");
+  const isFirstPurchaseBonusEnabled = d.useFlag("first_purchase_bonus");
   const isLlmGated = isTrialing || !isWalletReady;
   const isLlmAvailable = !isLlmGated;
   const searchParams = d.useSearchParams();
@@ -102,6 +104,12 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
               <h1 className="text-3xl font-bold leading-9 text-foreground">Let&apos;s deploy your first app</h1>
               <p className="max-w-2xl text-sm leading-5 text-muted-foreground">
                 We&apos;ve provided you with <span className="font-medium text-blue-600 dark:text-blue-400">${trialCreditsAmount} in free trial credits</span>.
+                {isFirstPurchaseBonusEnabled && (
+                  <>
+                    {" "}
+                    Plus, get {BONUS_PERCENT}% in bonus credits on your first purchase — up to ${MAX_BONUS}.
+                  </>
+                )}{" "}
                 Pick a template to get a live URL in about 30 seconds. Some templates require identity verification to unlock.
               </p>
             </div>

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
@@ -107,7 +107,7 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
                 {isFirstPurchaseBonusEnabled && (
                   <>
                     {" "}
-                    Plus, get {BONUS_PERCENT}% in bonus credits on your first purchase — up to ${MAX_BONUS}.
+                    Plus, get {BONUS_PERCENT}% in bonus credits on your first purchase, up to ${MAX_BONUS}.
                   </>
                 )}{" "}
                 Pick a template to get a live URL in about 30 seconds. Some templates require identity verification to unlock.

--- a/apps/deploy-web/src/config/env-config.schema.ts
+++ b/apps/deploy-web/src/config/env-config.schema.ts
@@ -15,7 +15,7 @@ export const browserEnvSchema = z.object({
   NEXT_PUBLIC_NODE_ENV: z.enum(["development", "production", "test"]).optional().default("development"),
   NEXT_PUBLIC_DEFAULT_INITIAL_DEPOSIT: z.number({ coerce: true }).optional().default(500000),
   NEXT_PUBLIC_TRIAL_DEPLOYMENTS_DURATION_HOURS: z.number({ coerce: true }).optional().default(24),
-  NEXT_PUBLIC_TRIAL_CREDITS_AMOUNT: z.number({ coerce: true }).optional().default(100),
+  NEXT_PUBLIC_TRIAL_CREDITS_AMOUNT: z.number({ coerce: true }).optional().default(1),
   NEXT_PUBLIC_TRIAL_DURATION_DAYS: z.number({ coerce: true }).optional().default(30),
   NEXT_PUBLIC_BASE_API_MAINNET_URL: z.string(),
   NEXT_PUBLIC_BASE_API_TESTNET_URL: z.string(),

--- a/apps/deploy-web/src/queries/usePaymentQueries.ts
+++ b/apps/deploy-web/src/queries/usePaymentQueries.ts
@@ -2,6 +2,7 @@ import type {
   ApplyCouponParams,
   ConfirmPaymentParams,
   ConfirmPaymentResponse,
+  CustomerTransactionsResponse,
   PaymentMethod,
   SetupIntentResponse,
   ThreeDSecureAuthParams
@@ -44,9 +45,13 @@ export interface UsePaymentTransactionsOptions {
   endDate?: Date | null;
 }
 
-export const usePaymentTransactionsQuery = (options?: UsePaymentTransactionsOptions) => {
+export const usePaymentTransactionsQuery = (
+  options?: UsePaymentTransactionsOptions,
+  queryOptions?: Omit<UseQueryOptions<CustomerTransactionsResponse>, "queryKey" | "queryFn">
+) => {
   const { stripe } = useServices();
   return useQuery({
+    ...queryOptions,
     queryKey: QueryKeys.getPaymentTransactionsKey(options),
     queryFn: async () => {
       return await stripe.getCustomerTransactions(options);

--- a/apps/deploy-web/src/types/feature-flags.ts
+++ b/apps/deploy-web/src/types/feature-flags.ts
@@ -12,4 +12,5 @@ export type FeatureFlag =
   | "onboarding_redesign_v1"
   | "ui_sdl_preview_panel"
   | "ui_build_and_deploy"
-  | "hackathons";
+  | "hackathons"
+  | "first_purchase_bonus";

--- a/apps/deploy-web/tests/ui/pages/AddCreditsSheetPage.ts
+++ b/apps/deploy-web/tests/ui/pages/AddCreditsSheetPage.ts
@@ -11,7 +11,7 @@ export class AddCreditsSheetPage {
     await this.getDialog().waitFor({ state: "visible", timeout: 15_000 });
   }
 
-  async pickPredefinedAmount(amount: "50" | "100" | "500") {
+  async pickPredefinedAmount(amount: "100" | "500" | "1000") {
     await this.getDialog().getByRole("radio", { name: amount, exact: true }).click();
   }
 

--- a/packages/http-sdk/src/stripe/stripe.types.ts
+++ b/packages/http-sdk/src/stripe/stripe.types.ts
@@ -48,6 +48,8 @@ export interface PaymentMethod {
 export interface Charge {
   id: string;
   amount: number;
+  /** First-purchase bonus credited with this payment, in cents. */
+  bonusAmount?: number;
   currency: string;
   status: string;
   created: number;


### PR DESCRIPTION
## Why

Part of CON-410

The Add Credits form still promises the stale "dollar-for-dollar match" that was never implemented. CON-410 finalizes the offer as a one-time 10% bonus (min $100 purchase, capped at $100) — the backend grant ships in #3423; this PR updates the purchase UI to promote and preview it. Hidden behind the same `first_purchase_bonus` Unleash flag, so nothing changes until both sides are deployed and the flag is flipped.

**Stacked on #3412** (base = `refactor/billing-unify-add-credits-sheet`) because the unified tabbed sheet makes `AddCreditsForm` the single purchase surface (it deletes `PaymentPopup`); retarget to `main` when #3412 merges (#3404 already landed).


https://github.com/user-attachments/assets/2401aa2a-6a8e-4843-91eb-a3221ae81992



## What

- New `FirstPurchaseBonusAlert` (blue gift alert, same visual as the old copy) rendered at the top of `AddCreditsForm`, reacting to the entered amount:
  - no amount → base offer ("Get 10% bonus credits on your first purchase of $100 or more, up to $100.")
  - under $100 → adds "Add $X more to qualify."
  - $100+ → previews the outcome: "You'll receive $TOTAL in credits" with the bonus called out (floored to cents, capped at $100 — mirrors `FirstPurchaseBonusService`).
- Eligibility mirrors the backend predicate: hidden when the user has any succeeded Stripe charge (refunded charges keep `succeeded` status → correctly treated as consumed). **Not gated on `isTrialing`** — coupon claims end the trial without producing a charge, so coupon users (non-trialing) still see the offer, matching the backend rule that coupons don't consume eligibility. Replaces the `{isTrialing && ...}` wrapper from #3412.
- `usePaymentTransactionsQuery` gains an optional `queryOptions` second param (mirrors `usePaymentMethodsQuery`) so the alert can gate fetching on the flag.
- `first_purchase_bonus` added to the frontend `FeatureFlag` union.
- Onboarding picker hero promotes the bonus behind the same flag: “Plus, get 10% in bonus credits on your first purchase — up to $100.” (`BONUS_PERCENT`/`MAX_BONUS` are now exported from the alert so the two copies can't drift).

No UI when the flag is off (query disabled, renders null).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary
- **New Features**
  - Added a feature-flagged first-purchase bonus preview and breakdown in the credits purchase flow.
  - Extended the billing success screen, billing amount table, onboarding header messaging, and transaction CSV export to include bonus amounts.
- **Bug Fixes**
  - Fixed bonus calculation/display to consistently reflect the selected credit amount.
  - Updated predefined credit options to **100 / 500 / 1000**.
- **Tests**
  - Expanded UI/API test coverage for eligibility, thresholds, capping, completion payloads, and CSV output.
- **Chores**
  - Changed the default trial credits amount to **1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
