### PR TITLE
fix(onboarding): render first-deploy funnel while the trial provisions

### DIFF
--- a/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/DeploymentDetailTopBar/DeploymentDetailTopBar.spec.tsx
@@ -244,6 +244,7 @@ describe(DeploymentDetailTopBar.name, () => {
         connectManagedWallet: vi.fn(),
         logout: vi.fn(),
         isWalletLoading: false,
+        isWalletInitializing: false,
         isTrialing: false,
         isOnboarding: false,
         topUpMinAmountUsd: 20,

--- a/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ManifestUpdate/ManifestUpdate.spec.tsx
@@ -333,6 +333,7 @@ describe(ManifestUpdate.name, () => {
         connectManagedWallet: vi.fn(),
         logout: vi.fn(),
         isWalletLoading: false,
+        isWalletInitializing: false,
         isTrialing: false,
         isOnboarding: false,
         topUpMinAmountUsd: 20,

--- a/apps/deploy-web/src/components/home/YourAccount/YourAccount.spec.tsx
+++ b/apps/deploy-web/src/components/home/YourAccount/YourAccount.spec.tsx
@@ -305,6 +305,7 @@ describe(YourAccount.name, () => {
         isManaged: true,
         denom: "uact",
         isWalletLoading: false,
+        isWalletInitializing: false,
         isTrialing: false,
         isOnboarding: false,
         topUpMinAmountUsd: 20,

--- a/apps/deploy-web/src/components/layout/Layout.tsx
+++ b/apps/deploy-web/src/components/layout/Layout.tsx
@@ -77,7 +77,7 @@ const LayoutApp: React.FunctionComponent<Props> = ({
   const { isSettingsInit } = useSettings();
   const { isWalletLoaded } = useWallet();
   const { hasBanner } = useTopBanner();
-  const { isStripped, isResolving } = useOnboardingChrome();
+  const { isStripped } = useOnboardingChrome();
 
   const onOpenMenuClick = () => {
     setIsNavOpen(prev => {
@@ -92,15 +92,6 @@ const LayoutApp: React.FunctionComponent<Props> = ({
   const handleDrawerToggle = () => {
     setIsMobileOpen(!isMobileOpen);
   };
-
-  // Onboarding chrome not yet resolved: hold with a neutral spinner (no Nav/Sidebar) to avoid a chrome flash either way.
-  if (isResolving) {
-    return (
-      <div className={cn("flex h-full min-h-screen items-center justify-center", { "bg-white text-foreground": background === "white" })}>
-        <Spinner size="large" />
-      </div>
-    );
-  }
 
   return (
     <div className={cn("flex h-full flex-col", { "min-h-screen bg-white text-foreground": background === "white" })}>

--- a/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.spec.tsx
@@ -7,9 +7,19 @@ import { render, screen } from "@testing-library/react";
 
 describe(RequireOnboarding.name, () => {
   describe("flag on", () => {
-    it("shows loading until wallet and leases resolve", () => {
-      setup({ flag: true, isWalletLoading: true, path: "/deployments" });
+    it("shows loading until the initial wallet lookup and leases resolve", () => {
+      setup({ flag: true, isWalletInitializing: true, path: "/deployments" });
       expect(screen.queryByText("child")).not.toBeInTheDocument();
+    });
+
+    it("renders the page while a trial is being provisioned instead of a full-screen loader", () => {
+      setup({ flag: true, hasManagedWallet: false, isWalletLoading: true, isWalletInitializing: false, path: "/new-deployment/configure" });
+      expect(screen.getByText("child")).toBeInTheDocument();
+    });
+
+    it("renders an allow-list route immediately while the initial wallet lookup is still loading (uninterrupted deploy overlay)", () => {
+      setup({ flag: true, isWalletInitializing: true, path: "/new-deployment/configure" });
+      expect(screen.getByText("child")).toBeInTheDocument();
     });
 
     it("renders children for an onboarded user on an app route", () => {
@@ -99,6 +109,7 @@ describe(RequireOnboarding.name, () => {
     hasManagedWallet?: boolean;
     isWalletConnected?: boolean;
     isWalletLoading?: boolean;
+    isWalletInitializing?: boolean;
     leases?: number;
     leasesLoading?: boolean;
     leasesError?: boolean;
@@ -118,7 +129,8 @@ describe(RequireOnboarding.name, () => {
           address: input.address ?? "",
           hasManagedWallet: input.hasManagedWallet ?? false,
           isWalletConnected: input.isWalletConnected ?? false,
-          isWalletLoading: input.isWalletLoading ?? false
+          isWalletLoading: input.isWalletLoading ?? false,
+          isWalletInitializing: input.isWalletInitializing ?? false
         })) as typeof DEPENDENCIES.useWallet,
       useAllLeases: (() =>
         mock<ReturnType<typeof DEPENDENCIES.useAllLeases>>({

--- a/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.tsx
+++ b/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.tsx
@@ -62,7 +62,7 @@ function LeaseBasedGate({
 }: Required<Pick<Props, "children">> & { isPublic?: boolean; dependencies: typeof DEPENDENCIES }) {
   const router = d.useRouter();
   const { user, isLoading: isUserLoading } = d.useUser();
-  const { address, hasManagedWallet, isWalletLoading } = d.useWallet();
+  const { address, hasManagedWallet, isWalletInitializing } = d.useWallet();
   const { returnTo } = d.useReturnTo({ defaultReturnTo: "/" });
 
   const hasWallet = hasManagedWallet && !!address;
@@ -74,7 +74,7 @@ function LeaseBasedGate({
   const path = router.asPath.split("?")[0];
   const isOnOnboarding = path === ONBOARDING_ROUTE;
   const isAllowed = ONBOARDING_ALLOWED_PREFIXES.some(prefix => path.startsWith(prefix)) || isDeploymentDetail(path);
-  const identityKnown = !isUserLoading && !isWalletLoading;
+  const identityKnown = !isUserLoading && !isWalletInitializing;
   const leasesSettled = !isLeasesLoading;
 
   const decision = decideLeaseGate({
@@ -101,15 +101,16 @@ function LeaseBasedGate({
 }
 
 /**
- * Resolves the lease-based gate's action, in priority order: public pages and logged-out visitors always render
- * (RequireAuth owns auth); wait only until user + wallet identity is known. Allow-list pages (configure, a
- * deployment detail) render for any authenticated user — onboarded or not — so they render *without* waiting on
- * the leases query. That keeps such a page mounted when the trial wallet arrives and newly enables that query,
- * instead of flashing the loader and remounting an in-progress deploy. Everywhere else waits for leases to
- * settle: an onboarded user renders except on `/onboarding` (sent back where they came from), and a
- * not-onboarded user renders on `/onboarding` but is sent there from anywhere else. A leases *error* leaves
- * onboarding unknowable — an undefined result is not "no leases" — so we fail open and render where the user is
- * rather than eject a genuinely onboarded user into the first-deploy funnel on a transient chain-API blip.
+ * Resolves the lease-based gate's action, in priority order. Public pages always render (RequireAuth owns auth).
+ * Allow-list pages (configure, a deployment detail) render *immediately* — ahead of the identity/wallet wait and
+ * without waiting on the leases query — because they own their own loading UX (e.g. the auto-deploy progress
+ * overlay). Gating them behind wallet initialization would flash the full-screen loader over an in-progress
+ * deploy while the wallet spins up, interrupting that overlay and remounting the flow. Everywhere else first
+ * waits until user + wallet identity is known, then for leases to settle: an onboarded user renders except on
+ * `/onboarding` (sent back where they came from), and a not-onboarded user renders on `/onboarding` but is sent
+ * there from anywhere else. A leases *error* leaves onboarding unknowable — an undefined result is not "no
+ * leases" — so we fail open and render where the user is rather than eject a genuinely onboarded user into the
+ * first-deploy funnel on a transient chain-API blip.
  */
 function decideLeaseGate(input: {
   isPublic: boolean;
@@ -122,9 +123,9 @@ function decideLeaseGate(input: {
   isAllowed: boolean;
 }): GateDecision {
   if (input.isPublic) return "render";
+  if (input.isAllowed) return "render";
   if (!input.identityKnown) return "loading";
   if (!input.isAuthenticated) return "render";
-  if (input.isAllowed) return "render";
   if (!input.leasesSettled) return "loading";
   if (input.isOnboarded) return input.isOnOnboarding ? "toReturn" : "render";
   if (input.isOnOnboarding) return "render";

--- a/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
+++ b/apps/deploy-web/src/context/WalletProvider/WalletProvider.tsx
@@ -28,6 +28,8 @@ export type ContextType = {
   isManaged: true;
   denom: string;
   isWalletLoading: boolean;
+  /** True only during the initial wallet-existence lookup, not while a trial is being provisioned. */
+  isWalletInitializing: boolean;
   isTrialing: boolean;
   isOnboarding: boolean;
   creditAmount?: number;
@@ -51,7 +53,13 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const [isWalletLoaded, setIsWalletLoaded] = useState<boolean>(true);
   const router = useRouter();
   const { user } = useUser();
-  const { wallet: managedWallet, isLoading: isManagedWalletLoading, create: createManagedWallet, createError: managedWalletError } = useManagedWallet();
+  const {
+    wallet: managedWallet,
+    isLoading: isManagedWalletLoading,
+    isInitializing: isManagedWalletInitializing,
+    create: createManagedWallet,
+    createError: managedWalletError
+  } = useManagedWallet();
   const walletAddress = managedWallet?.address;
   const username = managedWallet?.username;
   const isWalletConnected = !!managedWallet?.isWalletConnected;
@@ -60,6 +68,10 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
   const isLoading = deriveWalletIsLoading({
     hasAuthenticatedUserId: !!user?.userId,
     isManagedWalletLoading
+  });
+  const isInitializing = deriveWalletIsLoading({
+    hasAuthenticatedUserId: !!user?.userId,
+    isManagedWalletLoading: isManagedWalletInitializing
   });
   const { signAndBroadcastTx, loadingState } = useSignAndBroadcast({ refetchBalances });
 
@@ -135,6 +147,7 @@ export const WalletProvider: React.FC<{ children: React.ReactNode }> = ({ childr
         isManaged: true,
         denom: managedWallet?.denom ?? "",
         isWalletLoading: isLoading,
+        isWalletInitializing: isInitializing,
         isTrialing: !!managedWallet?.isTrialing,
         isOnboarding: !!user?.userId && !!managedWallet?.isTrialing,
         creditAmount: managedWallet?.creditAmount,

--- a/apps/deploy-web/src/hooks/useManagedWallet.ts
+++ b/apps/deploy-web/src/hooks/useManagedWallet.ts
@@ -72,10 +72,16 @@ export const useManagedWallet = () => {
           }
         : undefined,
       isLoading,
+      /**
+       * True only during the initial wallet-existence lookup — never while a trial wallet is being created.
+       * Consumers gating on "do we yet know the user's wallet situation?" (the onboarding gate) use this so a
+       * provisioning trial reads as known identity and doesn't blank the page with a full-screen loader.
+       */
+      isInitializing: isInitialLoading,
       isFetching,
       createError,
       resetCreate,
       refetch
     };
-  }, [wallet, isLoading, isFetching, createError, resetCreate, refetch, user?.id, create]);
+  }, [wallet, isLoading, isInitialLoading, isFetching, createError, resetCreate, refetch, user?.id, create]);
 };

--- a/apps/deploy-web/src/hooks/useOnboardingChrome.spec.ts
+++ b/apps/deploy-web/src/hooks/useOnboardingChrome.spec.ts
@@ -13,7 +13,7 @@ describe(useOnboardingChrome.name, () => {
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
-    expect(result.current).toEqual({ isStripped: true, isResolving: false });
+    expect(result.current).toEqual({ isStripped: true });
   });
 
   it("matches nested configure routes via startsWith", () => {
@@ -29,7 +29,7 @@ describe(useOnboardingChrome.name, () => {
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
-    expect(result.current).toEqual({ isStripped: false, isResolving: false });
+    expect(result.current).toEqual({ isStripped: false });
   });
 
   it("does not strip on plain /new-deployment", () => {
@@ -37,7 +37,7 @@ describe(useOnboardingChrome.name, () => {
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
-    expect(result.current).toEqual({ isStripped: false, isResolving: false });
+    expect(result.current).toEqual({ isStripped: false });
   });
 
   it("does nothing when the flag is off", () => {
@@ -45,7 +45,7 @@ describe(useOnboardingChrome.name, () => {
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
-    expect(result.current).toEqual({ isStripped: false, isResolving: false });
+    expect(result.current).toEqual({ isStripped: false });
   });
 
   it("does nothing on an unrelated route", () => {
@@ -53,31 +53,31 @@ describe(useOnboardingChrome.name, () => {
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
-    expect(result.current).toEqual({ isStripped: false, isResolving: false });
+    expect(result.current).toEqual({ isStripped: false });
   });
 
-  it("resolves while the wallet query is loading", () => {
+  it("strips and renders while the wallet query is still loading instead of holding a spinner", () => {
     const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", leaseCount: 0, isWalletLoading: true });
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
-    expect(result.current).toEqual({ isStripped: false, isResolving: true });
+    expect(result.current).toEqual({ isStripped: true });
   });
 
-  it("resolves while the trial wallet has not appeared yet", () => {
+  it("strips and renders while the trial wallet is still provisioning instead of holding a spinner", () => {
     const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", leaseCount: 0, hasManagedWallet: false });
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
-    expect(result.current).toEqual({ isStripped: false, isResolving: true });
+    expect(result.current).toEqual({ isStripped: true });
   });
 
-  it("resolves while the leases query is loading", () => {
+  it("strips and renders while the leases query is still loading instead of holding a spinner", () => {
     const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", isLeasesLoading: true });
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
-    expect(result.current).toEqual({ isStripped: false, isResolving: true });
+    expect(result.current).toEqual({ isStripped: true });
   });
 
   it("shows full chrome when the wallet errors", () => {
@@ -91,7 +91,15 @@ describe(useOnboardingChrome.name, () => {
 
     const { result } = renderHook(() => useOnboardingChrome(dependencies));
 
-    expect(result.current).toEqual({ isStripped: false, isResolving: false });
+    expect(result.current).toEqual({ isStripped: false });
+  });
+
+  it("shows full chrome when the leases query errors for an existing wallet", () => {
+    const { dependencies } = setup({ isFlagEnabled: true, pathname: "/new-deployment/configure", isLeasesError: true });
+
+    const { result } = renderHook(() => useOnboardingChrome(dependencies));
+
+    expect(result.current).toEqual({ isStripped: false });
   });
 
   function setup(input: {
@@ -99,6 +107,7 @@ describe(useOnboardingChrome.name, () => {
     pathname: string;
     leaseCount?: number;
     isLeasesLoading?: boolean;
+    isLeasesError?: boolean;
     isWalletLoading?: boolean;
     hasManagedWallet?: boolean;
     managedWalletError?: AppError;
@@ -115,7 +124,8 @@ describe(useOnboardingChrome.name, () => {
     const useAllLeases = (() =>
       mock<ReturnType<typeof DEPENDENCIES.useAllLeases>>({
         isLoading: (input.isLeasesLoading ?? false) as never,
-        data: Array.from({ length: input.leaseCount ?? 0 }) as never
+        isError: (input.isLeasesError ?? false) as never,
+        data: (input.isLeasesError ? undefined : Array.from({ length: input.leaseCount ?? 0 })) as never
       })) as typeof DEPENDENCIES.useAllLeases;
 
     return { dependencies: { useWallet, usePathname, useFlag, useAllLeases } };

--- a/apps/deploy-web/src/hooks/useOnboardingChrome.ts
+++ b/apps/deploy-web/src/hooks/useOnboardingChrome.ts
@@ -15,8 +15,6 @@ export const ONBOARDING_CHROME_PATHS = ["/new-deployment/configure"];
 export type OnboardingChromeState = {
   /** Render minimal chrome (no sidebar, logout-only menu, no WalletStatus). */
   isStripped: boolean;
-  /** Onboarding state not yet known; hold with a neutral spinner to avoid a chrome flash either way. */
-  isResolving: boolean;
 };
 
 /**
@@ -29,7 +27,7 @@ export type OnboardingChromeState = {
  * (same key) with the gate, so it's usually cached and resolves without a spinner.
  */
 export const useOnboardingChrome = (d: typeof DEPENDENCIES = DEPENDENCIES): OnboardingChromeState => {
-  const { address, hasManagedWallet, isWalletLoading, managedWalletError } = d.useWallet();
+  const { address, hasManagedWallet, managedWalletError } = d.useWallet();
   const pathname = d.usePathname();
   const isRedesignEnabled = d.useFlag("onboarding_redesign_v1");
 
@@ -37,20 +35,21 @@ export const useOnboardingChrome = (d: typeof DEPENDENCIES = DEPENDENCIES): Onbo
   const hasWallet = hasManagedWallet && !!address;
 
   const leasesQuery = d.useAllLeases(address, { enabled: isRelevant && hasWallet });
-  const isLeasesLoading = hasWallet && leasesQuery.isLoading;
   const isOnboarded = hasWallet && (leasesQuery.data?.length ?? 0) > 0;
+  const leasesErrored = hasWallet && leasesQuery.isError;
 
-  // A wallet error leaves onboarding unknowable, so fail open to the full chrome rather than trap the user in the
-  // stripped funnel — mirrors the gate's fail-open on a transient chain-API blip.
-  if (!isRelevant || managedWalletError) {
-    return { isStripped: false, isResolving: false };
+  // A wallet error — or a leases error that leaves onboarding unknowable (an undefined result is not "no leases") —
+  // makes the funnel decision unresolvable, so fail open to the full chrome rather than trap a possibly-onboarded
+  // user in the stripped funnel. Mirrors the gate's fail-open on a transient chain-API blip.
+  if (!isRelevant || managedWalletError || leasesErrored) {
+    return { isStripped: false };
   }
 
-  // The trial wallet is still provisioning/loading, or its leases haven't settled: hold either way to avoid a flash.
-  const isResolving = isWalletLoading || !hasWallet || isLeasesLoading;
-
-  return {
-    isStripped: !isResolving && !isOnboarded,
-    isResolving
-  };
+  // Strip the chrome for the entire first-deploy funnel — including while the trial wallet is still provisioning and
+  // its leases are loading — so the page can render its own progress UX (e.g. the auto-deploy overlay) instead of
+  // being blanked behind Layout's full-screen spinner until the trial responds. We can't distinguish a brand-new
+  // user from an already-onboarded one until leases settle, so we optimistically strip and let the full chrome fill
+  // in if they turn out onboarded (leases are shared/cached in the normal in-app path, so that's rare) — a far
+  // better trade than interrupting an in-progress deploy with a spinner.
+  return { isStripped: !isOnboarded };
 };

--- a/apps/deploy-web/tests/seeders/wallet.ts
+++ b/apps/deploy-web/tests/seeders/wallet.ts
@@ -16,6 +16,7 @@ export const buildWallet = (overrides: Partial<WalletProviderContextType> = {}):
   isManaged: true,
   denom: "uact",
   isWalletLoading: false,
+  isWalletInitializing: false,
   isTrialing: false,
   isOnboarding: false,
   creditAmount: faker.number.float({ min: 0, max: 1000 }),


### PR DESCRIPTION
<!-- Suggested title: fix(onboarding): render first-deploy funnel while the trial provisions -->

## Why

Logging in and starting a first deployment ("Deploy hello world") showed a full-screen spinner until
the start-trial API call responded, blanking the page and interrupting the deploy progress overlay.
The overlay is meant to show continuously — "Creating deployment" while the trial wallet provisions
behind the scenes — but two separate gates kept the funnel pages from rendering until the wallet
existed.

While in the same login/onboarding flow, the code-verify step also logged an invalid DOM-nesting
warning on submit (a Spinner `<div>` rendered inside a `<p>`).

<!-- Add the Linear issue: Fixes CON-XXX (closing) or Part of CON-XXX (non-closing) -->

## What

- **RequireOnboarding renders the funnel immediately.** `decideLeaseGate` now returns `render` for
  allow-list pages (configure, deployment detail) ahead of the identity/wallet wait, so the auto-deploy
  overlay isn't replaced by the gate's full-screen loader while the wallet spins up.
- **Identity gate ignores the trial create.** A new `isWalletInitializing` signal (the initial wallet
  lookup only, not the start-trial mutation) drives the gate's `identityKnown`, so a provisioning trial
  no longer reads as "unknown identity". `isWalletLoading` is unchanged for the legacy gate and the
  button/status spinners.
- **Onboarding chrome no longer holds a spinner.** `useOnboardingChrome` strips the chrome for the
  whole first-deploy funnel (including while the trial provisions and leases load) instead of holding
  behind `Layout`'s `isResolving` full-screen spinner. Removed `isResolving` (Layout was its only
  consumer) and Layout's spinner gate. Trade-off: an already-onboarded user who cold-loads configure
  with uncached leases sees the sidebar fill in a beat late rather than a spinner (rare — leases are
  cached on the normal in-app path).
- **Auth DOM nesting.** The "Verifying..." status in `EmailCodeVerify` is now a `<div>` instead of a
  `<p>`, so the `<Spinner>` (a `<div>`) nests validly.

Tests: updated `RequireOnboarding` and `useOnboardingChrome` specs (the funnel now renders instead of
holding a spinner); existing `EmailCodeVerify` specs pass unchanged. Lint and type-check are clean with
no new errors.

<!-- Frontend change: attach a short clip of login → deploy hello world showing the uninterrupted overlay. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved onboarding/chrome behavior during wallet initialization, reducing unnecessary waiting and visual flicker.
  * Allow-listed deployment routes now render immediately, without being blocked by wallet initialization or lease lookups.
  * Updated onboarding gating so auth/identity waits are prioritized only when needed, preventing avoidable loading interruptions.
* **Tests**
  * Expanded and adjusted unit tests/mocks to cover the new wallet-initialization pending scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->