### PR TITLE
test(billing): disambiguate payment-success assertion in managed-wallet e2e

### DIFF
--- a/apps/deploy-web/tests/ui/managed-wallet-credits.spec.ts
+++ b/apps/deploy-web/tests/ui/managed-wallet-credits.spec.ts
@@ -29,7 +29,7 @@ test.describe("Managed wallet credits", () => {
     });
 
     await test.step("verify payment success", async () => {
-      await expect(page.getByText("Payment Successful!")).toBeVisible({ timeout: 60_000 });
+      await expect(billingPage.getPaymentSuccessMessage()).toBeVisible({ timeout: 60_000 });
     });
 
     await test.step("verify balance increased", async () => {

--- a/apps/deploy-web/tests/ui/pages/BillingPage.ts
+++ b/apps/deploy-web/tests/ui/pages/BillingPage.ts
@@ -13,6 +13,15 @@ export class BillingPage {
     return this.page.locator('[aria-label="Available balance amount"]');
   }
 
+  /**
+   * The purchase celebration overlay heading. Scoped to the success dialog so it
+   * does not also match the polling provider's "Payment successful!" snackbar
+   * (role="alert"), which renders the same words and is visible at the same time.
+   */
+  getPaymentSuccessMessage() {
+    return this.page.getByRole("dialog").getByRole("heading", { name: "Payment Successful!" });
+  }
+
   async submitPayment(amount: string) {
     const sheet = new AddCreditsSheetPage(this.page);
     await sheet.waitForOpen();


### PR DESCRIPTION
## Why

The beta Console web UI e2e gate (`Test beta (NA) / Test staging`) is failing on `managed-wallet-credits.spec.ts`, which blocks the beta → prod deploy ([failing run](https://github.com/akash-network/console/actions/runs/29285800082/job/86938064468)).

It is **not** a broken payment — the charge succeeds (the "verify balance increased" step passes and the trace has the Stripe receipts). It's a Playwright **strict-mode violation**: after #3412 a successful purchase renders two "Payment successful" elements at the same time, and the assertion matched both:

| Element | Source | Container role |
|---|---|---|
| `<h2>Payment Successful!</h2>` | `PaymentSuccessAnimation` celebration overlay | `dialog` |
| `<h5>Payment successful!</h5>` | `PaymentPollingProvider` success snackbar | `alert` |

`page.getByText("Payment Successful!")` is case-insensitive by default, so it resolved to both headings. #3412 defers the overlay (`onDone`) until polling settles — right after the snackbar appears — so the two now reliably overlap; previously the overlay fired at charge time, usually before the snackbar.

Ref #3412

## What

- Add `BillingPage.getPaymentSuccessMessage()` that scopes to the overlay's `role="dialog"` heading, excluding the snackbar `role="alert"` heading of the same words.
- Use it in the "verify payment success" step instead of the loose `getByText`.
- No product/runtime code changed.

**Validation** — reconstructed the real page DOM from the failing CI trace and ran both locators through the Playwright engine:
- old locator → 2 matches + the exact CI strict-mode violation
- new locator → exactly 1 match, visible (`"Payment Successful!"`)

> Note (non-blocking): a successful purchase now shows both the full-screen overlay **and** the toast — redundant UX that #3412's timing change made simultaneous. Out of scope here; can be de-duped separately if desired.
