### PR TITLE
feat(deployment): show a disabled state for locked configuration cards

### DIFF
--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
+import type { ConfigurationLock } from "../configurationLock";
 import { AdditionalSection, DEPENDENCIES } from "./AdditionalSection";
 
 import { render } from "@testing-library/react";
@@ -22,23 +23,33 @@ describe(AdditionalSection.name, () => {
     expect(LogsCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
   });
 
-  it("locks the runtime, ports and logs cards but never env vars or commands", () => {
+  it("locks the runtime, ports and logs cards but leaves env vars and commands editable while only on-chain fields are locked", () => {
     const RuntimeCard = vi.fn(() => null);
     const EnvironmentVariablesCard = vi.fn(() => null);
     const CommandsCard = vi.fn(() => null);
     const ExposePortsCard = vi.fn(() => null);
     const LogsCard = vi.fn(() => null);
 
-    setup({ locked: true, dependencies: { RuntimeCard, EnvironmentVariablesCard, CommandsCard, ExposePortsCard, LogsCard } });
+    setup({ locked: "onchain", dependencies: { RuntimeCard, EnvironmentVariablesCard, CommandsCard, ExposePortsCard, LogsCard } });
 
     expect(RuntimeCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
     expect(ExposePortsCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
     expect(LogsCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
-    expect(EnvironmentVariablesCard).not.toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
-    expect(CommandsCard).not.toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(EnvironmentVariablesCard).toHaveBeenCalledWith(expect.objectContaining({ locked: false }), expect.anything());
+    expect(CommandsCard).toHaveBeenCalledWith(expect.objectContaining({ locked: false }), expect.anything());
   });
 
-  function setup(input: { serviceIndex?: number; locked?: boolean; dependencies?: Partial<typeof DEPENDENCIES> }) {
+  it("locks the env-var and command cards too while a create/close/deploy is in flight", () => {
+    const EnvironmentVariablesCard = vi.fn(() => null);
+    const CommandsCard = vi.fn(() => null);
+
+    setup({ locked: "all", dependencies: { EnvironmentVariablesCard, CommandsCard } });
+
+    expect(EnvironmentVariablesCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(CommandsCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+  });
+
+  function setup(input: { serviceIndex?: number; locked?: ConfigurationLock; dependencies?: Partial<typeof DEPENDENCIES> }) {
     render(<AdditionalSection serviceIndex={input.serviceIndex ?? 0} locked={input.locked} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />);
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/AdditionalSection/AdditionalSection.tsx
@@ -1,6 +1,7 @@
 import type { FC } from "react";
 
 import { CommandsCard } from "../CommandsCard/CommandsCard";
+import type { ConfigurationLock } from "../configurationLock";
 import { EnvironmentVariablesCard } from "../EnvironmentVariablesCard/EnvironmentVariablesCard";
 import { ExposePortsCard } from "../ExposePortsCard/ExposePortsCard";
 import { LogsCard } from "../LogsCard/LogsCard";
@@ -10,8 +11,11 @@ export const DEPENDENCIES = { RuntimeCard, EnvironmentVariablesCard, CommandsCar
 
 type Props = {
   serviceIndex: number;
-  /** Locks the runtime, ports and logs cards. The env vars and commands cards are manifest-only and stay editable. */
-  locked?: boolean;
+  /**
+   * How much of the section is locked. The runtime, ports and logs cards lock as soon as the deployment is on-chain;
+   * the manifest-only env-var and command cards lock only under a full `"all"` lock (create/close/deploy).
+   */
+  locked?: ConfigurationLock;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -20,20 +24,23 @@ type Props = {
  * the runtime-facing cards that aren't hardware sizing. Each card edits the
  * shared deployment model for `services.${serviceIndex}` directly.
  */
-export const AdditionalSection: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
+export const AdditionalSection: FC<Props> = ({ serviceIndex, locked, dependencies: d = DEPENDENCIES }) => {
+  const structuralLocked = !!locked;
+  const manifestLocked = locked === "all";
+
   return (
     <div className="flex flex-col gap-2 px-4">
       <p className="font-mono text-xs uppercase text-muted-foreground">Additional</p>
       <div className="flex flex-col gap-4">
-        <d.RuntimeCard serviceIndex={serviceIndex} locked={locked} />
+        <d.RuntimeCard serviceIndex={serviceIndex} locked={structuralLocked} />
 
-        <d.EnvironmentVariablesCard serviceIndex={serviceIndex} />
+        <d.EnvironmentVariablesCard serviceIndex={serviceIndex} locked={manifestLocked} />
 
-        <d.CommandsCard serviceIndex={serviceIndex} />
+        <d.CommandsCard serviceIndex={serviceIndex} locked={manifestLocked} />
 
-        <d.ExposePortsCard serviceIndex={serviceIndex} locked={locked} />
+        <d.ExposePortsCard serviceIndex={serviceIndex} locked={structuralLocked} />
 
-        <d.LogsCard serviceIndex={serviceIndex} locked={locked} />
+        <d.LogsCard serviceIndex={serviceIndex} locked={structuralLocked} />
       </div>
     </div>
   );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/CommandsCard/CommandsCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/CommandsCard/CommandsCard.spec.tsx
@@ -20,6 +20,16 @@ describe(CommandsCard.name, () => {
     expect(screen.getByLabelText("Arguments")).toHaveValue("echo hi");
   });
 
+  it("opens for viewing but disables the inputs and Save while locked", async () => {
+    const { openCard } = setup({ command: "bash -c", locked: true });
+
+    await openCard();
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByLabelText("Command")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
   it("commits the command and arguments on Save", async () => {
     const { getValues, openCard } = setup({});
 
@@ -54,7 +64,7 @@ describe(CommandsCard.name, () => {
     expect(getValues().services[0].command?.command).toBe("sh\n-c");
   });
 
-  function setup(input: { command?: string; arg?: string }) {
+  function setup(input: { command?: string; arg?: string; locked?: boolean }) {
     const values = defaultServiceWithPlacement({ command: { command: input.command ?? "", arg: input.arg ?? "" } });
 
     let getValues: () => SdlBuilderFormValuesType = () => values;
@@ -66,7 +76,7 @@ describe(CommandsCard.name, () => {
 
     render(
       <Wrapper>
-        <CommandsCard serviceIndex={0} dependencies={{ ...DEPENDENCIES }} />
+        <CommandsCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES }} />
       </Wrapper>
     );
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/CommandsCard/CommandsCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/CommandsCard/CommandsCard.tsx
@@ -25,6 +25,8 @@ export const DEPENDENCIES = { CollapsibleCard, DialogV2, DialogV2Content, Dialog
 
 type Props = {
   serviceIndex: number;
+  /** While locked the modal still opens for viewing but its inputs and Save are disabled; the card shows the lock glyph and dims. */
+  locked?: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -39,7 +41,7 @@ type Props = {
  * image default) and clicking it opens a Dialog for editing. Changes are committed on
  * Save and reverted on Cancel.
  */
-export const CommandsCard: FC<Props> = ({ serviceIndex, dependencies: d = DEPENDENCIES }) => {
+export const CommandsCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
   const { control, getValues, setValue } = useFormContext<SdlBuilderFormValuesType>();
   const command = useController({ control, name: `services.${serviceIndex}.command.command` });
   const arg = useController({ control, name: `services.${serviceIndex}.command.arg` });
@@ -69,6 +71,7 @@ export const CommandsCard: FC<Props> = ({ serviceIndex, dependencies: d = DEPEND
   return (
     <>
       <d.CollapsibleCard
+        locked={locked}
         title="Commands"
         icon={<TerminalIcon className="h-4 w-4" />}
         infoTooltip={commandsTooltip}
@@ -91,7 +94,7 @@ export const CommandsCard: FC<Props> = ({ serviceIndex, dependencies: d = DEPEND
           </d.DialogV2Header>
 
           <d.DialogV2Body className="flex flex-col gap-4">
-            <fieldset className="contents">
+            <fieldset disabled={locked} className="contents">
               <Field className="gap-2">
                 <FieldLabel htmlFor={`command-${serviceIndex}`}>Command</FieldLabel>
                 <FieldContent>
@@ -128,7 +131,7 @@ export const CommandsCard: FC<Props> = ({ serviceIndex, dependencies: d = DEPEND
             <Button type="button" variant="ghost" onClick={handleCancel}>
               Cancel
             </Button>
-            <Button type="button" onClick={handleSave}>
+            <Button type="button" onClick={handleSave} disabled={locked}>
               Save
               <SaveIcon className="ml-2 size-4" />
             </Button>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.spec.tsx
@@ -6,6 +6,7 @@ import type { SdlBuilderFormValuesType } from "@src/types";
 import { defaultPlacement, defaultService } from "@src/utils/sdl/data";
 import { defaultServiceWithPlacement } from "@src/utils/sdl/data";
 import { DEPENDENCIES as HARDWARE_DEPENDENCIES, HardwareSection } from "./HardwareSection/HardwareSection";
+import type { ConfigurationLock } from "./configurationLock";
 import { ConfigurationPane, DEPENDENCIES } from "./ConfigurationPane";
 
 import { render, screen } from "@testing-library/react";
@@ -109,30 +110,43 @@ describe(ConfigurationPane.name, () => {
   it("shows the lock banner with cancel-and-edit while locked", async () => {
     const onCancelAndEdit = vi.fn();
     const values = defaultServiceWithPlacement({ title: "api" });
-    setup({ values, selectedServiceId: values.services[0].id, locked: true, onCancelAndEdit });
+    setup({ values, selectedServiceId: values.services[0].id, locked: "onchain", onCancelAndEdit });
 
     await userEvent.click(screen.getByRole("button", { name: /cancel and edit/i }));
 
     expect(onCancelAndEdit).toHaveBeenCalled();
   });
 
-  it("locks the hardware and additional sections but never the image section", () => {
+  it("locks the structural sections but leaves the image editable while only the on-chain fields are locked", () => {
     const ImageSection = vi.fn(() => null);
     const HardwareSection = vi.fn(() => null);
     const AdditionalSection = vi.fn(() => null);
     const values = defaultServiceWithPlacement({ title: "api" });
 
-    setup({ values, selectedServiceId: values.services[0].id, locked: true, dependencies: { ImageSection, HardwareSection, AdditionalSection } });
+    setup({ values, selectedServiceId: values.services[0].id, locked: "onchain", dependencies: { ImageSection, HardwareSection, AdditionalSection } });
 
     expect(HardwareSection).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
-    expect(AdditionalSection).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
-    expect(ImageSection).not.toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(AdditionalSection).toHaveBeenCalledWith(expect.objectContaining({ locked: "onchain" }), expect.anything());
+    expect(ImageSection).toHaveBeenCalledWith(expect.objectContaining({ locked: false }), expect.anything());
+  });
+
+  it("locks every section while a create/close/deploy is in flight", () => {
+    const ImageSection = vi.fn(() => null);
+    const HardwareSection = vi.fn(() => null);
+    const AdditionalSection = vi.fn(() => null);
+    const values = defaultServiceWithPlacement({ title: "api" });
+
+    setup({ values, selectedServiceId: values.services[0].id, locked: "all", dependencies: { ImageSection, HardwareSection, AdditionalSection } });
+
+    expect(HardwareSection).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+    expect(AdditionalSection).toHaveBeenCalledWith(expect.objectContaining({ locked: "all" }), expect.anything());
+    expect(ImageSection).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
   });
 
   function setup(input: {
     values: SdlBuilderFormValuesType;
     selectedServiceId: string;
-    locked?: boolean;
+    locked?: ConfigurationLock;
     onCancelAndEdit?: () => void;
     dependencies?: Partial<typeof DEPENDENCIES>;
   }) {

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ConfigurationPane.tsx
@@ -6,13 +6,18 @@ import { PaneLockBanner } from "../PaneLockBanner/PaneLockBanner";
 import { AdditionalSection } from "./AdditionalSection/AdditionalSection";
 import { HardwareSection } from "./HardwareSection/HardwareSection";
 import { ImageSection } from "./ImageSection/ImageSection";
+import type { ConfigurationLock } from "./configurationLock";
 
 export const DEPENDENCIES = { ImageSection, HardwareSection, AdditionalSection };
 
 type Props = {
   selectedServiceId: string;
-  /** Locks the fields that can't change once the deployment exists on-chain (resources, placement, ports, …). The image, env vars and commands cards stay editable and their changes are pushed via an update on deploy. */
-  locked?: boolean;
+  /**
+   * How much of the pane is locked. `"onchain"` locks only the cards baked into the deployment (resources, placement,
+   * ports, …) while the manifest-only image/env/command cards stay editable; `"all"` locks every card while a
+   * create/close/deploy is in flight. Absent leaves everything editable. See {@link ConfigurationLock}.
+   */
+  locked?: ConfigurationLock;
   isClosing?: boolean;
   onCancelAndEdit?: () => void;
   dependencies?: typeof DEPENDENCIES;
@@ -25,7 +30,7 @@ type Props = {
  * index per mount rather than reacting to a changing one, which would otherwise
  * leave the previous service's values and errors on screen.
  */
-export const ConfigurationPane: FC<Props> = ({ selectedServiceId, locked = false, isClosing = false, onCancelAndEdit, dependencies: d = DEPENDENCIES }) => {
+export const ConfigurationPane: FC<Props> = ({ selectedServiceId, locked, isClosing = false, onCancelAndEdit, dependencies: d = DEPENDENCIES }) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const watchedServices = useWatch<SdlBuilderFormValuesType>({ control, name: "services" });
   const services = Array.isArray(watchedServices) ? (watchedServices as SdlBuilderFormValuesType["services"]) : [];
@@ -44,8 +49,8 @@ export const ConfigurationPane: FC<Props> = ({ selectedServiceId, locked = false
       <div className="flex-1 overflow-y-auto py-4">
         {selectedServiceIndex >= 0 && (
           <div key={selectedServiceId} className="flex flex-col gap-6">
-            <d.ImageSection serviceIndex={selectedServiceIndex} />
-            <d.HardwareSection serviceIndex={selectedServiceIndex} locked={locked} />
+            <d.ImageSection serviceIndex={selectedServiceIndex} locked={locked === "all"} />
+            <d.HardwareSection serviceIndex={selectedServiceIndex} locked={!!locked} />
             <d.AdditionalSection serviceIndex={selectedServiceIndex} locked={locked} />
           </div>
         )}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.spec.tsx
@@ -22,6 +22,16 @@ describe(EnvironmentVariablesCard.name, () => {
     expect(screen.getByText("Environment variables")).toBeInTheDocument();
   });
 
+  it("opens for viewing but disables the inputs and Save while locked", async () => {
+    const { openCard } = setup({ env: [{ key: "FOO", value: "bar" }], locked: true });
+
+    await openCard();
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByLabelText("Environment variable 1 key")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
   it("shows an empty key/value row in the modal when opened with no variables", async () => {
     const { openCard } = setup({ env: [] });
 
@@ -324,7 +334,7 @@ describe(EnvironmentVariablesCard.name, () => {
     }
   });
 
-  function setup(input: { env?: Array<Partial<EnvironmentVariableType>>; image?: string }) {
+  function setup(input: { env?: Array<Partial<EnvironmentVariableType>>; image?: string; locked?: boolean }) {
     const env = input.env?.map(e => ({ key: "", value: "", isSecret: false, ...e })) ?? [];
 
     const values = defaultServiceWithPlacement({ env, ...(input.image !== undefined ? { image: input.image } : {}) });
@@ -337,7 +347,7 @@ describe(EnvironmentVariablesCard.name, () => {
 
     render(
       <Wrapper>
-        <EnvironmentVariablesCard serviceIndex={0} dependencies={{ ...DEPENDENCIES }} />
+        <EnvironmentVariablesCard serviceIndex={0} locked={input.locked} dependencies={{ ...DEPENDENCIES }} />
         <ImageErrorProbe serviceIndex={0} />
       </Wrapper>
     );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/EnvironmentVariablesCard/EnvironmentVariablesCard.tsx
@@ -25,6 +25,8 @@ const RESERVED_ENV_KEYS = new Set<string>(RESERVED_ENV_KEY_LIST);
 
 type Props = {
   serviceIndex: number;
+  /** While locked the modal still opens for viewing but its inputs and Save are disabled; the card shows the lock glyph and dims. */
+  locked?: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -33,7 +35,7 @@ type Props = {
  * a Dialog where the user edits key/value pairs. Changes are committed on Save; cancelled on Close.
  * The header shows the count of user-set variables (reserved keys like SSH_PUBKEY are excluded).
  */
-export const EnvironmentVariablesCard: FC<Props> = ({ serviceIndex, dependencies: d = DEPENDENCIES }) => {
+export const EnvironmentVariablesCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
   const { control, getValues, reset, trigger, formState } = useFormContext<SdlBuilderFormValuesType>();
   const hasEnvErrors = !!formState.errors.services?.[serviceIndex]?.env;
   const env = useWatch({ control, name: `services.${serviceIndex}.env` });
@@ -66,6 +68,7 @@ export const EnvironmentVariablesCard: FC<Props> = ({ serviceIndex, dependencies
   return (
     <>
       <d.CollapsibleCard
+        locked={locked}
         title="Environment Variables"
         icon={<KeyRoundIcon className="h-4 w-4" />}
         summary={
@@ -92,7 +95,7 @@ export const EnvironmentVariablesCard: FC<Props> = ({ serviceIndex, dependencies
           </d.DialogV2Header>
 
           <d.DialogV2Body>
-            <fieldset className="contents">
+            <fieldset disabled={locked} className="contents">
               <EnvironmentVariablesList serviceIndex={serviceIndex} />
             </fieldset>
           </d.DialogV2Body>
@@ -105,7 +108,7 @@ export const EnvironmentVariablesCard: FC<Props> = ({ serviceIndex, dependencies
               <Button type="button" variant="ghost" onClick={handleCancel}>
                 Cancel
               </Button>
-              <Button type="button" onClick={handleSave} disabled={hasEnvErrors}>
+              <Button type="button" onClick={handleSave} disabled={hasEnvErrors || locked}>
                 Save
                 <SaveIcon className="ml-2 size-4" />
               </Button>

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageCard/ImageCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageCard/ImageCard.spec.tsx
@@ -21,6 +21,13 @@ describe(ImageCard.name, () => {
     expect(getValues().services[0].image).toBe("myimage:1.0");
   });
 
+  it("disables the image and credentials fields while locked", () => {
+    setup({ hasCredentials: true, locked: true });
+
+    expect(screen.getByLabelText("Docker image")).toBeDisabled();
+    expect(screen.getByLabelText("Registry username")).toBeDisabled();
+  });
+
   it("reveals credentials fields and seeds defaults when private registry is checked", async () => {
     const { getValues } = setup({});
 
@@ -122,7 +129,7 @@ describe(ImageCard.name, () => {
     });
   });
 
-  function setup(input: { hasCredentials?: boolean; resolver?: Resolver<SdlBuilderFormValuesType> }) {
+  function setup(input: { hasCredentials?: boolean; resolver?: Resolver<SdlBuilderFormValuesType>; locked?: boolean }) {
     const values = defaultServiceWithPlacement({
       image: "",
       hasCredentials: input.hasCredentials ?? false,
@@ -150,7 +157,7 @@ describe(ImageCard.name, () => {
 
     render(
       <Wrapper>
-        <ImageCard serviceIndex={0} />
+        <ImageCard serviceIndex={0} locked={input.locked} />
       </Wrapper>
     );
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageCard/ImageCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageCard/ImageCard.tsx
@@ -28,6 +28,8 @@ export const DEPENDENCIES = { CollapsibleCard };
 
 type Props = {
   serviceIndex: number;
+  /** While locked the Docker image and registry credentials are read-only; the card also shows the lock glyph and dims. */
+  locked?: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -51,13 +53,13 @@ const defaultCredentials = { host: "docker.io", username: "", password: "" };
  * (`hasCredentials`/`credentials`). Checking "Private registry" reveals the credentials fields and
  * seeds defaults; unchecking clears them.
  */
-export const ImageCard: FC<Props> = ({ serviceIndex, dependencies: d = DEPENDENCIES }) => {
+export const ImageCard: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
   const { control } = useFormContext<SdlBuilderFormValuesType>();
   const hasCredentials = useController({ control, name: `services.${serviceIndex}.hasCredentials` });
 
   return (
-    <d.CollapsibleCard title="Docker" icon={<BoxIcon className="h-4 w-4" />} infoTooltip={dockerImageTooltip}>
-      <fieldset className="flex min-w-0 flex-col gap-4 border-0 p-0">
+    <d.CollapsibleCard locked={locked} title="Docker" icon={<BoxIcon className="h-4 w-4" />} infoTooltip={dockerImageTooltip}>
+      <fieldset disabled={locked} className="flex min-w-0 flex-col gap-4 border-0 p-0">
         <ImageField serviceIndex={serviceIndex} hasCredentials={!!hasCredentials.field.value} onToggleCredentials={hasCredentials.field.onChange} />
 
         {hasCredentials.field.value && <CredentialsFields serviceIndex={serviceIndex} />}

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageSection/ImageSection.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageSection/ImageSection.spec.tsx
@@ -14,7 +14,15 @@ describe(ImageSection.name, () => {
     expect(ImageCard).toHaveBeenCalledWith(expect.objectContaining({ serviceIndex: 2 }), expect.anything());
   });
 
-  function setup(input: { serviceIndex?: number; dependencies?: Partial<typeof DEPENDENCIES> }) {
-    render(<ImageSection serviceIndex={input.serviceIndex ?? 0} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />);
+  it("locks the image card while locked", () => {
+    const ImageCard = vi.fn(() => null);
+
+    setup({ locked: true, dependencies: { ImageCard } });
+
+    expect(ImageCard).toHaveBeenCalledWith(expect.objectContaining({ locked: true }), expect.anything());
+  });
+
+  function setup(input: { serviceIndex?: number; locked?: boolean; dependencies?: Partial<typeof DEPENDENCIES> }) {
+    render(<ImageSection serviceIndex={input.serviceIndex ?? 0} locked={input.locked} dependencies={MockComponents(DEPENDENCIES, input.dependencies)} />);
   }
 });

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageSection/ImageSection.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/ImageSection/ImageSection.tsx
@@ -6,6 +6,8 @@ export const DEPENDENCIES = { ImageCard };
 
 type Props = {
   serviceIndex: number;
+  /** Locks the image card while a create/close/deploy is in flight; it stays editable while quoting (pushed as a manifest update). */
+  locked?: boolean;
   dependencies?: typeof DEPENDENCIES;
 };
 
@@ -14,12 +16,12 @@ type Props = {
  * pulled to the top of the column so the one required runtime field is the first thing a fresh
  * deployment shows.
  */
-export const ImageSection: FC<Props> = ({ serviceIndex, dependencies: d = DEPENDENCIES }) => {
+export const ImageSection: FC<Props> = ({ serviceIndex, locked = false, dependencies: d = DEPENDENCIES }) => {
   return (
     <div className="flex flex-col gap-2 px-4">
       <p className="font-mono text-xs uppercase text-muted-foreground">Image</p>
       <div className="flex flex-col gap-4">
-        <d.ImageCard serviceIndex={serviceIndex} />
+        <d.ImageCard serviceIndex={serviceIndex} locked={locked} />
       </div>
     </div>
   );

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/configurationLock.ts
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/configurationLock.ts
@@ -1,0 +1,9 @@
+/**
+ * How much of the configuration is locked (absent = nothing locked, still configuring):
+ * - `"onchain"`: the deployment exists on-chain, so the cards baked into it (resources, placement, ports, logs, …) are
+ *   locked; the manifest-only cards (image, env vars, commands) stay editable and get pushed as an update before the lease.
+ * - `"all"`: a create / close / deploy operation is in flight, so every card is locked.
+ *
+ * A structural card is locked whenever there's any lock (`!!lock`); a manifest card is locked only under `"all"`.
+ */
+export type ConfigurationLock = "onchain" | "all";

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.spec.tsx
@@ -80,21 +80,27 @@ describe("ConfigureDeploymentPanes", () => {
     const { DeploymentPane, ConfigurationPane } = setup({ phase: "quoting" });
 
     expect(DeploymentPane).toHaveBeenCalledWith(expect.objectContaining({ locked: true, onCancelAndEdit: expect.any(Function) }), expect.anything());
-    expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ locked: true, onCancelAndEdit: expect.any(Function) }), expect.anything());
+    expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ locked: "onchain", onCancelAndEdit: expect.any(Function) }), expect.anything());
   });
 
   it("flags close progress to both spec panes while closing", () => {
     const { DeploymentPane, ConfigurationPane } = setup({ phase: "closing" });
 
     expect(DeploymentPane).toHaveBeenCalledWith(expect.objectContaining({ locked: true, isClosing: true }), expect.anything());
-    expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ locked: true, isClosing: true }), expect.anything());
+    expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ locked: "all", isClosing: true }), expect.anything());
   });
 
   it("leaves both spec panes unlocked while configuring", () => {
     const { DeploymentPane, ConfigurationPane } = setup({ phase: "configuring" });
 
     expect(DeploymentPane).toHaveBeenCalledWith(expect.objectContaining({ locked: false }), expect.anything());
-    expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ locked: false }), expect.anything());
+    expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ locked: undefined }), expect.anything());
+  });
+
+  it("locks every configuration card while the deployment is being created", () => {
+    const { ConfigurationPane } = setup({ phase: "creating" });
+
+    expect(ConfigurationPane).toHaveBeenCalledWith(expect.objectContaining({ locked: "all" }), expect.anything());
   });
 
   function setup(

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigureDeploymentPanes/ConfigureDeploymentPanes.tsx
@@ -3,6 +3,7 @@ import { useAtom } from "jotai";
 
 import { useFlag } from "@src/hooks/useFlag";
 import sdlStore from "@src/store/sdlStore";
+import type { ConfigurationLock } from "../ConfigurationPane/configurationLock";
 import { ConfigurationPane } from "../ConfigurationPane/ConfigurationPane";
 import { DeploymentPane } from "../DeploymentPane/DeploymentPane";
 import { MarketplacePane } from "../MarketplacePane/MarketplacePane";
@@ -55,6 +56,7 @@ export const ConfigureDeploymentPanes: FC<Props> = ({
   const isSdlPreviewEnabled = d.useFlag("ui_sdl_preview_panel");
   const isLocked = phase === "creating" || phase === "quoting" || phase === "closing" || phase === "deploying";
   const isClosing = phase === "closing";
+  const configurationLock: ConfigurationLock | undefined = phase === "quoting" ? "onchain" : isLocked ? "all" : undefined;
 
   return (
     <div className="grid h-full min-h-0 flex-1 auto-cols-fr grid-flow-col grid-cols-[auto_minmax(560px,1fr)] grid-rows-1 border-t border-zinc-300 dark:border-zinc-700">
@@ -76,7 +78,7 @@ export const ConfigureDeploymentPanes: FC<Props> = ({
           />
         </div>
         <div className="min-h-0">
-          <d.ConfigurationPane selectedServiceId={selectedServiceId} locked={isLocked} isClosing={isClosing} onCancelAndEdit={onCancelAndEdit} />
+          <d.ConfigurationPane selectedServiceId={selectedServiceId} locked={configurationLock} isClosing={isClosing} onCancelAndEdit={onCancelAndEdit} />
         </div>
       </div>
       <div className="min-h-0 border-l border-zinc-300 dark:border-zinc-700">

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.spec.tsx
@@ -12,7 +12,7 @@ import { act, render, screen } from "@testing-library/react";
 import { ComponentMock, MockComponents } from "@tests/unit/mocks";
 
 const HELLO_WORLD_ID = "hello-world";
-const IMAGE_GEN_ID = "akash-network-awesome-akash-stable-diffusion-ui";
+const SPACE_AGENT_ID = "akash-network-awesome-akash-Space-Agent";
 const LLM_ID = "akash-network-awesome-akash-Llama-3.1-8B";
 
 type PickerCardProps = Parameters<typeof DEPENDENCIES.DeploymentTemplatePickerCard>[0];
@@ -25,7 +25,7 @@ describe(OnboardingPickerPage.name, () => {
     setup({ dependencies: { DeploymentTemplatePickerCard } });
 
     const titles = DeploymentTemplatePickerCard.mock.calls.map(call => (call[0] as PickerCardProps).title);
-    expect(titles).toEqual(["Hello world", "Image Generation", "LLM Chatbot"]);
+    expect(titles).toEqual(["Hello world", "Space Agent", "LLM Chatbot"]);
   });
 
   it("renders the account menu in its minimal variant", () => {
@@ -52,14 +52,14 @@ describe(OnboardingPickerPage.name, () => {
     expect(push).toHaveBeenCalledWith(UrlService.configureDeployment({ templateId: HELLO_WORLD_ID, sdlStrategy: "default", bidStrategy: "auto" }));
   });
 
-  it("redirects to the configure view with the image-generation auto-deploy intent when its card deploys", () => {
+  it("redirects to the configure view with the space-agent auto-deploy intent when its card deploys", () => {
     const push = vi.fn();
     const DeploymentTemplatePickerCard = vi.fn(ComponentMock);
     setup({ push, dependencies: { DeploymentTemplatePickerCard } });
 
-    act(() => getCard(DeploymentTemplatePickerCard, "Image Generation").onDeploy!());
+    act(() => getCard(DeploymentTemplatePickerCard, "Space Agent").onDeploy!());
 
-    expect(push).toHaveBeenCalledWith(UrlService.configureDeployment({ templateId: IMAGE_GEN_ID, sdlStrategy: "default", bidStrategy: "auto" }));
+    expect(push).toHaveBeenCalledWith(UrlService.configureDeployment({ templateId: SPACE_AGENT_ID, sdlStrategy: "default", bidStrategy: "auto" }));
   });
 
   it("renders an error alert when trial start fails terminally", () => {
@@ -80,7 +80,7 @@ describe(OnboardingPickerPage.name, () => {
     const DeploymentTemplatePickerCard = vi.fn(ComponentMock);
     setup({ isTrialing: true, dependencies: { DeploymentTemplatePickerCard } });
 
-    expect(getCard(DeploymentTemplatePickerCard, "LLM Chatbot").ctaLabel).toBe("Unlock full trial to deploy");
+    expect(getCard(DeploymentTemplatePickerCard, "LLM Chatbot").ctaLabel).toBe("Add credits to unlock");
     expect(getCard(DeploymentTemplatePickerCard, "LLM Chatbot").ctaIcon).toBe("lock");
   });
 
@@ -104,7 +104,7 @@ describe(OnboardingPickerPage.name, () => {
 
     const card = getCard(DeploymentTemplatePickerCard, "LLM Chatbot");
     expect(card.disabled).toBeFalsy();
-    expect(card.ctaLabel).toBe("Unlock full trial to deploy");
+    expect(card.ctaLabel).toBe("Add credits to unlock");
   });
 
   it("opens the verification sheet instead of redirecting when the LLM CTA is clicked while trialing", () => {

--- a/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
+++ b/apps/deploy-web/src/components/onboarding-picker/OnboardingPickerPage.tsx
@@ -20,12 +20,12 @@ import { useFlag } from "@src/hooks/useFlag";
 /**
  * Template ids the picker cards deploy. Each card redirects to the bid-screening (configure) view carrying its
  * `templateId`; that view resolves the SDL and — because the redirect also carries `sdl-strategy=default` and
- * `bid-strategy=auto` — starts the deployment automatically. The image-gen and chatbot ids are public gallery
+ * `bid-strategy=auto` — starts the deployment automatically. The space-agent and chatbot ids are public gallery
  * templates; hello-world is a hardcoded template resolved by code on the configure side.
  */
 const TEMPLATE_IDS = {
   helloWorld: "hello-world",
-  imageGen: "akash-network-awesome-akash-stable-diffusion-ui",
+  spaceAgent: "akash-network-awesome-akash-Space-Agent",
   llmChatbot: "akash-network-awesome-akash-Llama-3.1-8B"
 } as const;
 
@@ -121,7 +121,7 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
                 title="Hello world"
                 description="Spin up a modern Next.js app running in a Docker container in seconds."
                 priceBold="~$0.25/mo"
-                priceRest=" · 0.5 vCPU · 256 MB"
+                priceRest=" · 0.5 vCPU · 512MiB RAM · 512MiB"
                 ctaLabel="Deploy now"
                 ctaVariant="primary"
                 heroImageSrc="/images/onboarding/hello-world.png"
@@ -130,16 +130,16 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
               />
 
               <d.DeploymentTemplatePickerCard
-                chip="Stable Diffusion"
-                title="Image Generation"
-                description="Turn your text into stunning images. Powered by Stable Diffusion XL."
-                priceBold="~$0.29/hr"
-                priceRest=" · 6 vCPU · 1 GPU · 35GB RAM"
+                chip="Agent Zero"
+                title="Space Agent"
+                description="An open-source AI agent that runs in the browser layer and can reshape its own workspace on the fly."
+                priceBold="~$3.41/mo"
+                priceRest=" · 4 vCPU · 8GiB RAM · 50GiB"
                 ctaLabel="Deploy now"
                 ctaVariant="outline"
                 heroImageSrc="/images/onboarding/stable-diffusion.png"
-                heroImageAlt="Image generation template"
-                onDeploy={() => deployTemplate(TEMPLATE_IDS.imageGen)}
+                heroImageAlt="Space Agent template"
+                onDeploy={() => deployTemplate(TEMPLATE_IDS.spaceAgent)}
               />
 
               <d.DeploymentTemplatePickerCard
@@ -147,8 +147,8 @@ export function OnboardingPickerPage({ dependencies: d = DEPENDENCIES }: Onboard
                 title="LLM Chatbot"
                 description="Your own private AI chat. Secure, persistent, and fully under your control."
                 priceBold="~$1.50/hr"
-                priceRest=" · 1x RTX 4090 · 16 GB"
-                ctaLabel={isLlmGated ? "Unlock full trial to deploy" : "Deploy now"}
+                priceRest=" · 12 vCPU · 1 GPU · 32GiB RAM · 160GiB"
+                ctaLabel={isLlmGated ? "Add credits to unlock" : "Deploy now"}
                 ctaIcon={isLlmGated ? "lock" : "arrow"}
                 ctaVariant="outline"
                 heroImageSrc="/images/onboarding/llm-chatbot.png"

--- a/apps/deploy-web/tests/ui/pages/OnboardingPickerPage.ts
+++ b/apps/deploy-web/tests/ui/pages/OnboardingPickerPage.ts
@@ -13,7 +13,7 @@ export class OnboardingPickerPage {
     return this.page.getByRole("heading", { name: /deploy your first app/i });
   }
 
-  async deploy(template: "Hello world" | "Image Generation" | "LLM Chatbot") {
+  async deploy(template: "Hello world" | "Space Agent" | "LLM Chatbot") {
     const heading = this.page.getByRole("heading", { name: template, exact: true });
     const card = this.page
       .locator("div")

--- a/packages/ui/components/collapsible-card.spec.tsx
+++ b/packages/ui/components/collapsible-card.spec.tsx
@@ -25,6 +25,18 @@ describe(CollapsibleCard.name, () => {
     expect(screen.queryByLabelText("Locked")).not.toBeInTheDocument();
   });
 
+  it("dims the card to signal it can't be edited while locked", () => {
+    const { container } = setup({ locked: true });
+
+    expect(container.firstChild).toHaveClass("opacity-60");
+  });
+
+  it("does not dim the card when not locked", () => {
+    const { container } = setup({});
+
+    expect(container.firstChild).not.toHaveClass("opacity-60");
+  });
+
   it("hides the body and shows the summary when collapsed", async () => {
     setup({ summary: "1 GPU" });
 
@@ -281,6 +293,12 @@ describe(CollapsibleCard.name, () => {
       expect(screen.getByLabelText("Locked")).toBeInTheDocument();
     });
 
+    it("dims the action card while locked", () => {
+      const { container } = setup({ onHeaderClick: vi.fn(), locked: true });
+
+      expect(container.firstChild).toHaveClass("opacity-60");
+    });
+
     it("does not fire onHeaderClick when the info icon is clicked", async () => {
       const onHeaderClick = vi.fn();
       setup({ onHeaderClick, infoTooltip: "helpful info" });
@@ -375,6 +393,6 @@ describe(CollapsibleCard.name, () => {
       </CollapsibleCard>
     );
     const view = render(card({}));
-    return { rerender: (overrides: Partial<typeof input>) => view.rerender(card(overrides)) };
+    return { rerender: (overrides: Partial<typeof input>) => view.rerender(card(overrides)), container: view.container };
   }
 });

--- a/packages/ui/components/collapsible-card.tsx
+++ b/packages/ui/components/collapsible-card.tsx
@@ -13,7 +13,7 @@ import { CustomTooltip, TooltipProvider } from "./tooltip";
 export interface CollapsibleCardProps {
   title: string;
   icon: React.ReactNode;
-  /** Renders a lock glyph in the header to mark the card read-only (e.g. while quotes are active). */
+  /** Marks the card read-only (e.g. while quotes are active): renders a lock glyph in the header and dims the card to 60% opacity. */
   locked?: boolean;
   /**
    * Optional help content shown in a tooltip behind an info icon next to the
@@ -169,7 +169,7 @@ const CollapsibleCardBody = React.forwardRef<HTMLDivElement, Omit<CollapsibleCar
         ref={ref}
         open={open}
         onOpenChange={handleHeaderToggle}
-        className={cn("bg-card w-full rounded-lg border border-zinc-300 dark:border-zinc-700", className)}
+        className={cn("bg-card w-full rounded-lg border border-zinc-300 dark:border-zinc-700", locked && "opacity-60", className)}
       >
         <div className="relative flex h-12 items-center px-4">
           <CollapsibleTrigger
@@ -224,6 +224,7 @@ const ActionCard: React.FC<
         onClick={onHeaderClick}
         className={cn(
           "bg-card focus-visible:ring-ring flex h-12 w-full items-center gap-2 rounded-lg border border-zinc-300 px-4 text-left outline-none focus-visible:ring-1 dark:border-zinc-700",
+          locked && "opacity-60",
           className
         )}
       >
@@ -233,7 +234,7 @@ const ActionCard: React.FC<
   }
 
   return (
-    <div className={cn("bg-card flex h-12 w-full items-center gap-2 rounded-lg border border-zinc-300 px-4 dark:border-zinc-700", className)}>
+    <div className={cn("bg-card flex h-12 w-full items-center gap-2 rounded-lg border border-zinc-300 px-4 dark:border-zinc-700", locked && "opacity-60", className)}>
       <button
         type="button"
         onClick={onHeaderClick}

--- a/packages/ui/components/tooltip.tsx
+++ b/packages/ui/components/tooltip.tsx
@@ -56,7 +56,9 @@ function CustomTooltip({
   return (
     <Tooltip>
       <TooltipTrigger asChild>{children}</TooltipTrigger>
-      <TooltipContent className={cn("z-[500] max-w-md p-6", className)}>{title}</TooltipContent>
+      <TooltipPrimitive.Portal>
+        <TooltipContent className={cn("z-[500] max-w-md p-6", className)}>{title}</TooltipContent>
+      </TooltipPrimitive.Portal>
     </Tooltip>
   );
 }


### PR DESCRIPTION
## Why

Once a deployment is being created or quoted, most of the configuration can no longer change, but the column gave no visual signal — while the image / env-var / command cards must stay editable during quoting (they're pushed as a manifest update before the lease). This adds a clear, phase-aware locked state to the configuration column. Bundled with two small onboarding fixes that were already in flight.

Fixes CON-622
Fixes CON-646
Fixes CON-647

## What

**Configuration column locked state (CON-622)**

- Introduce `ConfigurationLock` (`"onchain" | "all"`), derived from the deployment phase:
  - `"onchain"` (bids being queried): the on-chain-baked cards — resources, placement, ports, logs — lock; image, env vars and commands stay editable.
  - `"all"` (create / close / deploy in flight): every card locks.
- Each card renders the locked state uniformly through `CollapsibleCard` (lock glyph, 60% opacity, disabled inputs), replacing the earlier parent-level dimming hack.
- Fix: `CustomTooltip` now portals its content, so a dimmed locked card's opacity no longer bleeds through its tooltip (this was the RAM-storage tooltip layout bug).

**Onboarding picker**

- CON-646: swap the Image Generation template for Space Agent (GPUs are disabled for trial accounts).
- CON-647: relabel the gated LLM CTA from "Unlock full trial to deploy" to "Add credits to unlock".

### Needs a look / follow-ups

- The Space Agent card still reuses `/images/onboarding/stable-diffusion.png` — no dedicated hero asset exists yet under `public/images/onboarding/`.
- Confirm the Space Agent price / specs (`~$3.41/mo · 4 vCPU · 8GiB RAM · 50GiB`) against the live template.

### Screenshots

<!-- before/after of the configuration column while quoting (only structural cards dimmed) vs while creating (everything dimmed); plus the fixed RAM-storage tooltip -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added more precise deployment configuration locking: on-chain settings can be locked while environment variables and commands remain editable; full locking disables all configuration edits.
  - Added the Space Agent template to the onboarding picker.

- **Improvements**
  - Updated LLM trial messaging to display “Add credits to unlock.”
  - Locked configuration cards now appear visibly dimmed.
  - Improved tooltip rendering for more consistent display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->