### PR TITLE
feat(deployment): serve prettified GPU model display names from the API

### DIFF
--- a/apps/api/src/gpu/http-schemas/gpu.schema.ts
+++ b/apps/api/src/gpu/http-schemas/gpu.schema.ts
@@ -31,9 +31,11 @@ export type ListGpuResponse = z.infer<typeof ListGpuResponseSchema>;
 export const ListGpuModelsResponseSchema = z.array(
   z.object({
     name: z.string(),
+    displayName: z.string().openapi({ example: "NVIDIA" }),
     models: z.array(
       z.object({
         name: z.string(),
+        displayName: z.string().openapi({ example: "RTX 4090" }),
         memory: z.array(z.string()),
         interface: z.array(z.string())
       })

--- a/apps/api/src/gpu/providers/gpu-models-client.provider.ts
+++ b/apps/api/src/gpu/providers/gpu-models-client.provider.ts
@@ -1,0 +1,17 @@
+import type { HttpClient } from "@akashnetwork/http-sdk";
+import { createHttpClient } from "@akashnetwork/http-sdk";
+import type { InjectionToken } from "tsyringe";
+import { container, instancePerContainerCachingFactory } from "tsyringe";
+
+/** Directory of the provider-configs GPU catalog; the supported models per vendor live in `gpus.json`. */
+const GPU_MODELS_BASE_URL = "https://raw.githubusercontent.com/akash-network/provider-configs/main/devices/pcie";
+
+/** Caps the external GitHub catalog fetch so a stalled request fails fast instead of hanging (the client's retries would otherwise compound the delay). */
+const GPU_MODELS_HTTP_TIMEOUT_MS = 10_000;
+
+/** axios client for the provider-configs GPU model catalog. */
+export const GPU_MODELS_HTTP_CLIENT: InjectionToken<HttpClient> = Symbol("GPU_MODELS_HTTP_CLIENT");
+
+container.register(GPU_MODELS_HTTP_CLIENT, {
+  useFactory: instancePerContainerCachingFactory(() => createHttpClient({ baseURL: GPU_MODELS_BASE_URL, adapter: "http", timeout: GPU_MODELS_HTTP_TIMEOUT_MS }))
+});

--- a/apps/api/src/gpu/services/gpu-formatting/gpu-formatting.service.spec.ts
+++ b/apps/api/src/gpu/services/gpu-formatting/gpu-formatting.service.spec.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import type { ProviderConfigGpusType } from "@src/types/gpu";
+import { GpuFormattingService } from "./gpu-formatting.service";
+
+describe(GpuFormattingService.name, () => {
+  describe("formatModelName", () => {
+    it("returns the curated marketing name for prioritized datacenter models", () => {
+      const { service } = setup();
+      expect(service.formatModelName("h100")).toBe("H100");
+      expect(service.formatModelName("a100")).toBe("A100");
+      expect(service.formatModelName("h200")).toBe("H200");
+    });
+
+    it("returns the curated name for GeForce models the heuristic would also produce", () => {
+      const { service } = setup();
+      expect(service.formatModelName("rtx4090")).toBe("RTX 4090");
+      expect(service.formatModelName("rtx3090")).toBe("RTX 3090");
+    });
+
+    it("returns the curated name for marketing-irregular models the heuristic cannot infer", () => {
+      const { service } = setup();
+      expect(service.formatModelName("l40s")).toBe("L40S");
+      expect(service.formatModelName("pro6000")).toBe("RTX PRO 6000");
+      expect(service.formatModelName("pro6000se")).toBe("RTX PRO 6000 SE");
+    });
+
+    it("spaces a multi-letter consumer family from its number", () => {
+      const { service } = setup();
+      expect(service.formatModelName("gtx1080")).toBe("GTX 1080");
+      expect(service.formatModelName("gt1030")).toBe("GT 1030");
+      expect(service.formatModelName("mx150")).toBe("MX 150");
+      expect(service.formatModelName("rtx4060")).toBe("RTX 4060");
+    });
+
+    it("renders a Ti suffix in title case", () => {
+      const { service } = setup();
+      expect(service.formatModelName("gtx1080ti")).toBe("GTX 1080 Ti");
+      expect(service.formatModelName("rtx3080ti")).toBe("RTX 3080 Ti");
+    });
+
+    it("expands a Super suffix", () => {
+      const { service } = setup();
+      expect(service.formatModelName("gtx1650s")).toBe("GTX 1650 SUPER");
+    });
+
+    it("keeps single-letter datacenter families glued and appends other suffixes", () => {
+      const { service } = setup();
+      expect(service.formatModelName("a800")).toBe("A800");
+      expect(service.formatModelName("h200nvl")).toBe("H200 NVL");
+    });
+
+    it("prefixes RTX workstation A-series models", () => {
+      const { service } = setup();
+      expect(service.formatModelName("rtxa2000")).toBe("RTX A2000");
+      expect(service.formatModelName("rtxa6000")).toBe("RTX A6000");
+    });
+
+    it("normalizes case and separators before formatting", () => {
+      const { service } = setup();
+      expect(service.formatModelName("RTX-4090")).toBe("RTX 4090");
+      expect(service.formatModelName("H100")).toBe("H100");
+    });
+
+    it("uppercases an unrecognized name as a fallback", () => {
+      const { service } = setup();
+      expect(service.formatModelName("titan")).toBe("TITAN");
+    });
+  });
+
+  describe("formatVendorName", () => {
+    it("returns the branded name for known vendors", () => {
+      const { service } = setup();
+      expect(service.formatVendorName("nvidia")).toBe("NVIDIA");
+      expect(service.formatVendorName("amd")).toBe("AMD");
+      expect(service.formatVendorName("intel")).toBe("Intel");
+    });
+
+    it("uppercases an unknown vendor as a fallback", () => {
+      const { service } = setup();
+      expect(service.formatVendorName("foobar")).toBe("FOOBAR");
+    });
+  });
+
+  describe("mapProviderConfig", () => {
+    it("adds a branded displayName to each vendor while keeping the raw name", () => {
+      const { service } = setup();
+      const [vendor] = service.mapProviderConfig({
+        "10de": { name: "nvidia", devices: { d1: { name: "rtx4090", memory_size: "24Gi", interface: "PCIe" } } }
+      });
+
+      expect(vendor).toMatchObject({ name: "nvidia", displayName: "NVIDIA" });
+    });
+
+    it("adds a marketing displayName to each model while keeping the raw name", () => {
+      const { service } = setup();
+      const [vendor] = service.mapProviderConfig({
+        "10de": { name: "nvidia", devices: { d1: { name: "rtx4090", memory_size: "24Gi", interface: "PCIe" } } }
+      });
+
+      expect(vendor.models[0]).toEqual({ name: "rtx4090", displayName: "RTX 4090", memory: ["24Gi"], interface: ["pcie"] });
+    });
+
+    it("collapses repeated model names into one entry with the distinct memory sizes and interfaces", () => {
+      const { service } = setup();
+      const payload: ProviderConfigGpusType = {
+        "10de": {
+          name: "nvidia",
+          devices: {
+            d1: { name: "a100", memory_size: "40Gi", interface: "SXM4" },
+            d2: { name: "a100", memory_size: "80Gi", interface: "PCIe" },
+            d3: { name: "a100", memory_size: "80Gi", interface: "PCIe" }
+          }
+        }
+      };
+
+      const [vendor] = service.mapProviderConfig(payload);
+
+      expect(vendor.models).toHaveLength(1);
+      expect(vendor.models[0]).toEqual({ name: "a100", displayName: "A100", memory: ["40Gi", "80Gi"], interface: ["sxm", "pcie"] });
+    });
+
+    it("normalizes any SXM interface revision down to the canonical sxm value", () => {
+      const { service } = setup();
+      const [vendor] = service.mapProviderConfig({
+        "10de": { name: "nvidia", devices: { d1: { name: "h100", memory_size: "80Gi", interface: "SXM5" } } }
+      });
+
+      expect(vendor.models[0].interface).toEqual(["sxm"]);
+    });
+  });
+
+  function setup() {
+    return { service: new GpuFormattingService() };
+  }
+});

--- a/apps/api/src/gpu/services/gpu-formatting/gpu-formatting.service.ts
+++ b/apps/api/src/gpu/services/gpu-formatting/gpu-formatting.service.ts
@@ -1,0 +1,130 @@
+import { singleton } from "tsyringe";
+
+import type { GpuModel, GpuVendor, ProviderConfigGpusType } from "@src/types/gpu";
+
+/** Vendor keys (lowercase) mapped to their branded display name; unknown vendors fall back to uppercase. */
+const GPU_VENDOR_LABELS: Record<string, string> = {
+  nvidia: "NVIDIA",
+  amd: "AMD",
+  intel: "Intel"
+};
+
+/**
+ * Marketing-correct display names for models whose casing/spacing the heuristic cannot infer: families
+ * that need an "RTX" brand prefix (`pro6000`), suffixes that must not be expanded as "Super" (`l40s`),
+ * and the prioritized set we want to guarantee regardless of future heuristic tweaks.
+ */
+const GPU_MODEL_LABELS: Record<string, string> = {
+  h100: "H100",
+  a100: "A100",
+  h200: "H200",
+  v100: "V100",
+  t4: "T4",
+  l4: "L4",
+  l40: "L40",
+  l40s: "L40S",
+  a10: "A10",
+  a16: "A16",
+  a30: "A30",
+  a40: "A40",
+  gh200: "GH200",
+  b200: "B200",
+  rtx3090: "RTX 3090",
+  rtx4090: "RTX 4090",
+  rtx5090: "RTX 5090",
+  rtxa4000: "RTX A4000",
+  rtxa5000: "RTX A5000",
+  rtxa6000: "RTX A6000",
+  pro6000: "RTX PRO 6000",
+  pro6000se: "RTX PRO 6000 SE"
+};
+
+/** GeForce/consumer families whose alpha prefix is separated from the model number by a space (e.g. `rtx4090` → `RTX 4090`). */
+const SPACED_FAMILIES = ["rtx", "gtx", "gt", "mx"] as const;
+
+/**
+ * Turns the raw provider-config GPU catalog into the presentation-ready vendor list served by
+ * `/v1/gpu-models`: reshapes the payload (collapse repeated model names, collect their distinct memory
+ * sizes and interfaces, normalize the interface) and attaches marketing-correct display names to the
+ * vendor and each model. The raw `name` on both stays the canonical SDL/attribute value.
+ */
+@singleton()
+export class GpuFormattingService {
+  /** Reshapes the upstream payload into the served vendor list, attaching vendor and model display names. */
+  mapProviderConfig(config: ProviderConfigGpusType): GpuVendor[] {
+    return Object.values(config).map(vendorValue => {
+      const models: GpuModel[] = [];
+
+      for (const device of Object.values(vendorValue.devices)) {
+        const gpuInterface = this.#normalizeInterface(device.interface);
+        const existing = models.find(model => model.name === device.name);
+
+        if (existing) {
+          if (!existing.memory.includes(device.memory_size)) existing.memory.push(device.memory_size);
+          if (!existing.interface.includes(gpuInterface)) existing.interface.push(gpuInterface);
+        } else {
+          models.push({
+            name: device.name,
+            displayName: this.formatModelName(device.name),
+            memory: [device.memory_size],
+            interface: [gpuInterface]
+          });
+        }
+      }
+
+      return { name: vendorValue.name, displayName: this.formatVendorName(vendorValue.name), models };
+    });
+  }
+
+  /**
+   * Turns a raw GPU model name (lowercase, no separators — e.g. `rtx4090`, `h100`, `gtx1080ti`) into a
+   * marketing-correct display label. Curated overrides win; otherwise a heuristic spaces multi-letter
+   * consumer families from their number, keeps single-letter datacenter names glued, and formats known
+   * suffixes. The raw name stays the canonical SDL/attribute value everywhere else.
+   */
+  formatModelName(name: string): string {
+    const key = this.#normalize(name);
+
+    const curated = GPU_MODEL_LABELS[key];
+    if (curated) return curated;
+
+    const aSeries = key.match(/^rtx(a\d+)([a-z]*)$/);
+    if (aSeries) return `RTX ${aSeries[1].toUpperCase()}${this.#formatSuffix(aSeries[2])}`;
+
+    for (const family of SPACED_FAMILIES) {
+      if (key.startsWith(family)) {
+        const rest = key.slice(family.length).match(/^(\d+)([a-z]*)$/);
+        if (rest) return `${family.toUpperCase()} ${rest[1]}${this.#formatSuffix(rest[2])}`;
+      }
+    }
+
+    const datacenter = key.match(/^([a-z]+\d+)([a-z]*)$/);
+    if (datacenter) return `${datacenter[1].toUpperCase()}${this.#formatSuffix(datacenter[2])}`;
+
+    return name.toUpperCase();
+  }
+
+  /** Turns a raw vendor name (e.g. `nvidia`) into its branded label (`NVIDIA`), falling back to uppercase. */
+  formatVendorName(name: string): string {
+    return GPU_VENDOR_LABELS[this.#normalize(name)] ?? name.toUpperCase();
+  }
+
+  /** Lowercases and strips every non-alphanumeric character so `RTX-4090` and `RTX 4090` share one key. */
+  #normalize(name: string): string {
+    return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+  }
+
+  /** Formats a model-name suffix: `ti` → ` Ti`, `s`/`super` → ` SUPER`, anything else uppercased (e.g. ` NVL`). */
+  #formatSuffix(suffix: string): string {
+    if (!suffix) return "";
+    if (suffix === "ti") return " Ti";
+    if (suffix === "s" || suffix === "super") return " SUPER";
+    return ` ${suffix.toUpperCase()}`;
+  }
+
+  /** Collapses every SXM revision (`SXM4`, `SXM5`, …) to the canonical `sxm`; other interfaces are lowercased. */
+  #normalizeInterface(gpuInterface: string): string {
+    const formatted = gpuInterface.toLowerCase();
+    return formatted.startsWith("sxm") ? "sxm" : formatted;
+  }
+}

--- a/apps/api/src/gpu/services/gpu.service.spec.ts
+++ b/apps/api/src/gpu/services/gpu.service.spec.ts
@@ -1,0 +1,37 @@
+import type { HttpClient } from "@akashnetwork/http-sdk";
+import type { AxiosResponse } from "axios";
+import { describe, expect, it } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import { cacheEngine } from "@src/caching/helpers";
+import type { ProviderConfigGpusType } from "@src/types/gpu";
+import type { GpuRepository } from "../repositories/gpu.repository";
+import { GpuFormattingService } from "./gpu-formatting/gpu-formatting.service";
+import { GpuService } from "./gpu.service";
+
+describe(GpuService.name, () => {
+  describe("getGpuModels", () => {
+    it("fetches the provider-config catalog and returns the formatted vendor list", async () => {
+      const { service, httpClient } = setup({
+        "10de": { name: "nvidia", devices: { d1: { name: "rtx4090", memory_size: "24Gi", interface: "PCIe" } } }
+      });
+
+      const [vendor] = await service.getGpuModels();
+
+      expect(httpClient.get).toHaveBeenCalledWith("/gpus.json");
+      expect(vendor).toMatchObject({ name: "nvidia", displayName: "NVIDIA" });
+      expect(vendor.models[0]).toMatchObject({ name: "rtx4090", displayName: "RTX 4090" });
+    });
+  });
+
+  function setup(catalog: ProviderConfigGpusType) {
+    cacheEngine.clearAllKeyInCache();
+    const httpClient = mock<HttpClient>();
+    const response = mock<AxiosResponse<ProviderConfigGpusType>>();
+    response.data = catalog;
+    httpClient.get.mockResolvedValue(response);
+
+    const service = new GpuService(mock<GpuRepository>(), new GpuFormattingService(), httpClient);
+    return { service, httpClient };
+  }
+});

--- a/apps/api/src/gpu/services/gpu.service.ts
+++ b/apps/api/src/gpu/services/gpu.service.ts
@@ -1,15 +1,21 @@
-import axios from "axios";
+import type { HttpClient } from "@akashnetwork/http-sdk";
 import { minutesToSeconds } from "date-fns";
-import { singleton } from "tsyringe";
+import { inject, singleton } from "tsyringe";
 
 import { Memoize } from "@src/caching/helpers";
-import { type GpuVendor, ProviderConfigGpusType } from "@src/types/gpu";
+import type { ProviderConfigGpusType } from "@src/types/gpu";
 import { type GpuBreakdownQuery } from "../http-schemas/gpu.schema";
+import { GPU_MODELS_HTTP_CLIENT } from "../providers/gpu-models-client.provider";
 import { GpuRepository } from "../repositories/gpu.repository";
+import { GpuFormattingService } from "./gpu-formatting/gpu-formatting.service";
 
 @singleton()
 export class GpuService {
-  constructor(private readonly gpuRepository: GpuRepository) {}
+  constructor(
+    private readonly gpuRepository: GpuRepository,
+    private readonly gpuFormattingService: GpuFormattingService,
+    @inject(GPU_MODELS_HTTP_CLIENT) private readonly httpClient: HttpClient
+  ) {}
 
   async getGpuList({
     providerAddress,
@@ -77,50 +83,8 @@ export class GpuService {
 
   @Memoize({ ttlInSeconds: minutesToSeconds(2) })
   async getGpuModels() {
-    const response = await axios.get<ProviderConfigGpusType>("https://raw.githubusercontent.com/akash-network/provider-configs/main/devices/pcie/gpus.json");
-    const gpuModels: GpuVendor[] = [];
-
-    // Loop over vendors
-    for (const [, vendorValue] of Object.entries(response.data)) {
-      const vendor: GpuVendor = {
-        name: vendorValue.name,
-        models: []
-      };
-
-      // Loop over models
-      for (const [, modelValue] of Object.entries(vendorValue.devices)) {
-        const _modelValue = modelValue as {
-          name: string;
-          memory_size: string;
-          interface: string;
-        };
-        const existingModel = vendor.models.find(x => x.name === _modelValue.name);
-
-        if (existingModel) {
-          if (!existingModel.memory.includes(_modelValue.memory_size)) {
-            existingModel.memory.push(_modelValue.memory_size);
-          }
-          if (!existingModel.interface.includes(this.getGpuInterface(_modelValue.interface))) {
-            existingModel.interface.push(this.getGpuInterface(_modelValue.interface));
-          }
-        } else {
-          vendor.models.push({
-            name: _modelValue.name,
-            memory: [_modelValue.memory_size],
-            interface: [this.getGpuInterface(_modelValue.interface)]
-          });
-        }
-      }
-
-      gpuModels.push(vendor);
-    }
-
-    return gpuModels;
-  }
-
-  private getGpuInterface(gpuInterface: string) {
-    const _formatted = gpuInterface.toLowerCase();
-    return _formatted.startsWith("sxm") ? "sxm" : _formatted;
+    const response = await this.httpClient.get<ProviderConfigGpusType>("/gpus.json");
+    return this.gpuFormattingService.mapProviderConfig(response.data);
   }
 
   @Memoize({ ttlInSeconds: minutesToSeconds(5) })

--- a/apps/api/src/types/gpu.ts
+++ b/apps/api/src/types/gpu.ts
@@ -1,10 +1,14 @@
 export interface GpuVendor {
   name: string;
+  /** Branded vendor name for display (e.g. `NVIDIA`); `name` stays the canonical value. */
+  displayName: string;
   models: GpuModel[];
 }
 
 export interface GpuModel {
   name: string;
+  /** Marketing-correct model name for display (e.g. `RTX 4090`); `name` stays the canonical SDL/attribute value. */
+  displayName: string;
   memory: string[];
   interface: string[];
 }

--- a/apps/api/swagger/openapi.json
+++ b/apps/api/swagger/openapi.json
@@ -15266,6 +15266,10 @@
                       "name": {
                         "type": "string"
                       },
+                      "displayName": {
+                        "type": "string",
+                        "example": "NVIDIA"
+                      },
                       "models": {
                         "type": "array",
                         "items": {
@@ -15273,6 +15277,10 @@
                           "properties": {
                             "name": {
                               "type": "string"
+                            },
+                            "displayName": {
+                              "type": "string",
+                              "example": "RTX 4090"
                             },
                             "memory": {
                               "type": "array",
@@ -15289,6 +15297,7 @@
                           },
                           "required": [
                             "name",
+                            "displayName",
                             "memory",
                             "interface"
                           ]
@@ -15297,6 +15306,7 @@
                     },
                     "required": [
                       "name",
+                      "displayName",
                       "models"
                     ]
                   }

--- a/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
+++ b/apps/api/test/functional/__snapshots__/docs.spec.ts.snap
@@ -8419,9 +8419,17 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                 "schema": {
                   "items": {
                     "properties": {
+                      "displayName": {
+                        "example": "NVIDIA",
+                        "type": "string",
+                      },
                       "models": {
                         "items": {
                           "properties": {
+                            "displayName": {
+                              "example": "RTX 4090",
+                              "type": "string",
+                            },
                             "interface": {
                               "items": {
                                 "type": "string",
@@ -8440,6 +8448,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                           },
                           "required": [
                             "name",
+                            "displayName",
                             "memory",
                             "interface",
                           ],
@@ -8453,6 +8462,7 @@ exports[`API Docs > GET /v1/doc > returns docs with all routes expected 1`] = `
                     },
                     "required": [
                       "name",
+                      "displayName",
                       "models",
                     ],
                     "type": "object",

--- a/apps/api/test/functional/gpu.spec.ts
+++ b/apps/api/test/functional/gpu.spec.ts
@@ -175,14 +175,17 @@ describe("GPU API", () => {
       expect(data).toEqual([
         {
           name: "amd",
+          displayName: "AMD",
           models: [
             {
               name: "mi60",
+              displayName: "MI60",
               memory: ["32Gi"],
               interface: ["pcie"]
             },
             {
               name: "mi100",
+              displayName: "MI100",
               memory: ["32Gi"],
               interface: ["pcie"]
             }
@@ -190,14 +193,17 @@ describe("GPU API", () => {
         },
         {
           name: "nvidia",
+          displayName: "NVIDIA",
           models: [
             {
               name: "a40",
+              displayName: "A40",
               memory: ["48Gi"],
               interface: ["pcie"]
             },
             {
               name: "a100",
+              displayName: "A100",
               memory: ["40Gi"],
               interface: ["pcie"]
             }

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.gated.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.gated.spec.tsx
@@ -64,8 +64,13 @@ describe("GpuCard trial gate", () => {
       }
     });
 
-    const useGpuModels: typeof DEPENDENCIES.useGpuModels = () =>
-      mock<ReturnType<typeof DEPENDENCIES.useGpuModels>>({ data: GPU_VENDORS, isLoading: false, isError: false } as Partial<ReturnType<typeof DEPENDENCIES.useGpuModels>>);
+    const useGpuModels: typeof DEPENDENCIES.useGpuModels = () => {
+      const result = mock<ReturnType<typeof DEPENDENCIES.useGpuModels>>({ isLoading: false, isError: false } as Partial<
+        ReturnType<typeof DEPENDENCIES.useGpuModels>
+      >);
+      result.data = GPU_VENDORS;
+      return result;
+    };
     const useFieldError: typeof DEPENDENCIES.useFieldError = () => ({ error: undefined });
 
     const Wrapper = ({ children }: PropsWithChildren) => {
@@ -75,7 +80,12 @@ describe("GpuCard trial gate", () => {
 
     render(
       <Wrapper>
-        <GpuCard serviceIndex={0} isBlockedModel={input.isBlockedModel} onUnlock={input.onUnlock} dependencies={{ ...DEPENDENCIES, useGpuModels, useFieldError }} />
+        <GpuCard
+          serviceIndex={0}
+          isBlockedModel={input.isBlockedModel}
+          onUnlock={input.onUnlock}
+          dependencies={{ ...DEPENDENCIES, useGpuModels, useFieldError }}
+        />
       </Wrapper>
     );
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.spec.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.spec.tsx
@@ -193,6 +193,54 @@ describe(GpuCard.name, () => {
     expect(screen.queryByRole("option", { name: "t4" })).not.toBeInTheDocument();
   });
 
+  it("shows the prettified model displayName in the options and trigger while writing the raw name", async () => {
+    const { getValues, user } = setup({
+      hasGpu: true,
+      gpuModels: [{ vendor: "nvidia", name: "", memory: "", interface: "" }],
+      vendors: [{ name: "nvidia", displayName: "NVIDIA", models: [{ name: "rtx4090", displayName: "RTX 4090", memory: ["24Gi"], interface: ["pcie"] }] }]
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "GPU model" }));
+    await user.click(await screen.findByRole("option", { name: "RTX 4090" }));
+
+    expect(screen.getByRole("combobox", { name: "GPU model" })).toHaveTextContent("RTX 4090");
+    expect(getValues().services[0].profile.gpuModels?.[0]).toMatchObject({ name: "rtx4090" });
+  });
+
+  it("matches the prettified model name in the search box in addition to the raw name", async () => {
+    const { user } = setup({
+      hasGpu: true,
+      gpuModels: [{ vendor: "nvidia", name: "", memory: "", interface: "" }],
+      vendors: [
+        {
+          name: "nvidia",
+          displayName: "NVIDIA",
+          models: [
+            { name: "rtx4090", displayName: "RTX 4090", memory: ["24Gi"], interface: ["pcie"] },
+            { name: "a100", displayName: "A100", memory: ["80Gi"], interface: ["sxm"] }
+          ]
+        }
+      ]
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "GPU model" }));
+    await user.type(await screen.findByRole("combobox", { name: "Search GPU models" }), "RTX 40");
+
+    expect(screen.getByRole("option", { name: "RTX 4090" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "A100" })).not.toBeInTheDocument();
+  });
+
+  it("labels the vendor option with its displayName", async () => {
+    const { user } = setup({
+      hasGpu: true,
+      vendors: [{ name: "nvidia", displayName: "NVIDIA", models: [{ name: "a100", displayName: "A100", memory: ["80Gi"], interface: ["sxm"] }] }]
+    });
+
+    await user.click(screen.getByRole("combobox", { name: "GPU vendor" }));
+
+    expect(await screen.findByRole("option", { name: "NVIDIA" })).toBeInTheDocument();
+  });
+
   it("clears only the memory when the memory clear button is clicked", async () => {
     const { getValues, user } = setup({ hasGpu: true, gpuModels: [{ vendor: "nvidia", name: "a100", memory: "40Gi", interface: "pcie" }] });
 
@@ -287,10 +335,10 @@ describe(GpuCard.name, () => {
     });
 
     const gpuModelsResult = mock<ReturnType<typeof DEPENDENCIES.useGpuModels>>({
-      data: input.isLoading || input.isError ? undefined : input.vendors ?? GPU_VENDORS,
       isLoading: input.isLoading ?? false,
       isError: input.isError ?? false
     } as Partial<ReturnType<typeof DEPENDENCIES.useGpuModels>>);
+    gpuModelsResult.data = input.isLoading || input.isError ? undefined : input.vendors ?? GPU_VENDORS;
     const useGpuModels: typeof DEPENDENCIES.useGpuModels = () => gpuModelsResult;
     const useFieldError: typeof DEPENDENCIES.useFieldError = () => ({ error: input.gpuError });
 

--- a/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
+++ b/apps/deploy-web/src/components/deployments/ConfigureDeployment/ConfigurationPane/GpuCard/GpuCard.tsx
@@ -202,7 +202,11 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
   const memory = useController({ control, name: `${basePath}.memory` });
   const gpuInterface = useController({ control, name: `${basePath}.interface` });
 
-  const vendorOptions = useMemo(() => (gpuVendors ? gpuVendors.map(v => v.name) : fallbackVendors.map(v => v.value)), [gpuVendors]);
+  const vendorOptions = useMemo(
+    () =>
+      gpuVendors ? gpuVendors.map(v => ({ value: v.name, label: v.displayName ?? v.name })) : fallbackVendors.map(v => ({ value: v.value, label: v.label })),
+    [gpuVendors]
+  );
   const models = useMemo(() => gpuVendors?.find(v => v.name === vendor.field.value)?.models ?? [], [gpuVendors, vendor.field.value]);
   const selectedModel = useMemo(() => models.find(m => m.name === name.field.value), [models, name.field.value]);
   const memorySizes = selectedModel?.memory ?? [];
@@ -249,12 +253,14 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
     () =>
       prioritizeGpuModels(models).map(model => {
         const blocked = isBlockedModel(vendor.field.value, model.name);
+        const label = model.displayName ?? model.name;
         return {
           value: model.name,
           disabled: blocked,
+          keywords: [label],
           label: (
             <span className="flex items-center gap-1.5">
-              {model.name}
+              {label}
               {blocked && <LockIcon className="h-3 w-3 shrink-0 text-muted-foreground" aria-label="Requires credits" />}
             </span>
           )
@@ -283,8 +289,8 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
             </SelectTrigger>
             <SelectContent>
               {vendorOptions.map(option => (
-                <SelectItem key={option} value={option}>
-                  {option}
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -313,6 +319,7 @@ function GpuModelFields({ serviceIndex, gpuIndex, gpuVendors, isLoading, isError
                 searchPlaceholder="Search models..."
                 notFoundMessage="No models found."
                 emptyOption={{ value: "", label: "Any model" }}
+                renderValue={modelName => models.find(model => model.name === modelName)?.displayName ?? modelName}
                 disabled={locked || models.length === 0}
                 triggerClassName="h-9"
               />

--- a/apps/deploy-web/src/components/sdl/GpuFormControl.tsx
+++ b/apps/deploy-web/src/components/sdl/GpuFormControl.tsx
@@ -61,7 +61,7 @@ export const GpuFormControl: React.FunctionComponent<Props> = ({ gpuModels, cont
   }, [gpuModels]);
 
   const theOnlyForModelOrEmpty = useCallback(
-    (name: string, attribute: keyof GpuModel) => {
+    (name: string, attribute: "memory" | "interface") => {
       return gpuModelsByName[name][attribute].length === 1 ? gpuModelsByName[name][attribute][0] : "";
     },
     [gpuModelsByName]

--- a/apps/deploy-web/src/components/shared/SearchableSelect/SearchableSelect.spec.tsx
+++ b/apps/deploy-web/src/components/shared/SearchableSelect/SearchableSelect.spec.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -43,6 +44,12 @@ describe("SearchableSelect", () => {
     setup({ value: "", emptyOption: { value: "", label: "Any region" } });
 
     expect(screen.getByRole("combobox", { name: "Region" })).toHaveTextContent("Any region");
+  });
+
+  it("renders the selected value through renderValue in the trigger", () => {
+    setup({ value: "na-us-west", renderValue: value => value.toUpperCase() });
+
+    expect(screen.getByRole("combobox", { name: "Region" })).toHaveTextContent("NA-US-WEST");
   });
 
   it("writes the picked option, reflects it in the trigger, and resets the search", async () => {
@@ -108,6 +115,7 @@ describe("SearchableSelect", () => {
     emptyOption?: { value: string; label: string };
     placeholder?: string;
     disabled?: boolean;
+    renderValue?: (value: string) => ReactNode;
   }) {
     const onChange = vi.fn();
     const Harness = () => {
@@ -127,6 +135,7 @@ describe("SearchableSelect", () => {
           emptyOption={input.emptyOption}
           placeholder={input.placeholder}
           disabled={input.disabled}
+          renderValue={input.renderValue}
         />
       );
     };

--- a/apps/deploy-web/src/components/shared/SearchableSelect/SearchableSelect.tsx
+++ b/apps/deploy-web/src/components/shared/SearchableSelect/SearchableSelect.tsx
@@ -33,6 +33,8 @@ type Props = {
   leadingIcon?: ReactNode;
   disabled?: boolean;
   triggerClassName?: string;
+  /** Maps the selected raw `value` to what the trigger displays (e.g. a prettified label); defaults to the raw value. */
+  renderValue?: (value: string) => ReactNode;
 };
 
 /** cmdk requires a non-empty item value; the empty option owns this sentinel while reporting `emptyOption.value` on select. */
@@ -57,7 +59,8 @@ export const SearchableSelect: FC<Props> = ({
   placeholder,
   leadingIcon,
   disabled,
-  triggerClassName
+  triggerClassName,
+  renderValue
 }) => {
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState("");
@@ -89,7 +92,7 @@ export const SearchableSelect: FC<Props> = ({
         >
           <span className="flex min-w-0 items-center gap-1.5">
             {leadingIcon}
-            <span className="truncate">{value || emptyOption?.label || placeholder}</span>
+            <span className="truncate">{value ? (renderValue ? renderValue(value) : value) : emptyOption?.label ?? placeholder}</span>
           </span>
           <NavArrowDown aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
         </Button>

--- a/apps/deploy-web/src/types/gpu.ts
+++ b/apps/deploy-web/src/types/gpu.ts
@@ -1,10 +1,14 @@
 export interface GpuVendor {
   name: string;
+  /** Branded vendor name for display (e.g. `NVIDIA`), provided by the API; absent on the hardcoded fallback. */
+  displayName?: string;
   models: GpuModel[];
 }
 
 export interface GpuModel {
   name: string;
+  /** Marketing-correct model name for display (e.g. `RTX 4090`), provided by the API; `name` stays the SDL value. */
+  displayName?: string;
   memory: string[];
   interface: string[];
 }

--- a/apps/deploy-web/src/utils/akash/gpu.ts
+++ b/apps/deploy-web/src/utils/akash/gpu.ts
@@ -1,4 +1,4 @@
-export const gpuVendors = [{ id: 1, value: "nvidia" }];
+export const gpuVendors = [{ id: 1, value: "nvidia", label: "NVIDIA" }];
 
 /** GPU model-name prefixes (normalized, lowercase) floated to the top of the model picker, most popular first (by network capacity and usage). Prefix-matched, so `pro6000` covers `pro6000se`/`we`/`mq`, `h200` covers `h200nvl`, `rtx5090` covers `rtx5090m`, etc. */
 export const PRIORITIZED_GPU_MODELS = ["h100", "a100", "h200", "pro6000", "rtx5090", "rtx4090", "rtx3090"];

--- a/apps/deploy-web/tests/ui/onboarding-picker-unlock-trial.spec.ts
+++ b/apps/deploy-web/tests/ui/onboarding-picker-unlock-trial.spec.ts
@@ -18,8 +18,8 @@ test.describe("Onboarding picker — unlocking the gated LLM template via Add Cr
 
     await onboardingPickerPage.goto();
 
-    await test.step("the gated LLM template CTA reads 'Unlock full trial to deploy' once the trial is active", async () => {
-      await expect(onboardingPickerPage.getLlmChatbotCta()).toHaveText(/unlock full trial to deploy/i, { timeout: 60_000 });
+    await test.step("the gated LLM template CTA reads 'Add credits to unlock' once the trial is active", async () => {
+      await expect(onboardingPickerPage.getLlmChatbotCta()).toHaveText(/add credits to unlock/i, { timeout: 60_000 });
     });
 
     await test.step("clicking the gated CTA opens the Add Credits sheet", async () => {


### PR DESCRIPTION
## Why

The configuration-page GPU picker showed raw catalog names — `rtx4090`, `h100`, `pro6000se` — which are hard to scan and don't match how the hardware is marketed. This serves human-readable display names (`RTX 4090`, `H100`, `RTX PRO 6000 SE`) from the API, so every client renders them consistently while the raw `name` stays the canonical SDL / attribute-matching value.

Non-breaking: `displayName` is an additive response field and the raw `name` is unchanged, so the API and clients can roll out in any order.

Fixes CON-CON-653

## What

**API — `/v1/gpu-models`**

- Add a `displayName` to every vendor and model in the response; `name`, `memory` and `interface` are unchanged.
- Model names resolve through curated marketing overrides for the models we serve, with a heuristic fallback for the long tail: multi-letter consumer families are spaced from their number (`rtx4090` → `RTX 4090`), single-letter datacenter names stay glued (`h100` → `H100`), and `Ti`/`SUPER` suffixes are formatted.
- Vendors get a branded `displayName` (`nvidia` → `NVIDIA`).
- `swagger/openapi.json` regenerated (additive only).
- Internals: a `@singleton` `GpuFormattingService` owns the name formatting and the provider-config → vendor-list reshape; `GpuService` injects it plus an `HttpClient` (via a provider token, replacing the direct `axios` call) for the catalog fetch.

**deploy-web**

- `GpuCard` renders `displayName` in the model options and the vendor select, and shows it for the selected model in the trigger. The prettified name is also a search keyword, so both `RTX 4090` and `rtx4090` match. The raw `name` is still what's written to the SDL.
- `SearchableSelect` gains an optional `renderValue` for the trigger (RegionSelect unaffected).
- The client `displayName` is optional, so the hardcoded fallback vendor list and the legacy `GpuFormControl` degrade gracefully to the raw name.

### Follow-ups

- `RegionSelect` could adopt `renderValue` to prettify its own selected display.
- Interface (`pcie`/`sxm`) and memory (`24Gi`) prettification intentionally deferred — they're arrays of primitives and readable as-is.

### Screenshots

<!-- before/after of the GPU model select: raw names (rtx4090, h100) vs prettified (RTX 4090, H100), and the search box matching both -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU vendors and models now include branded, user-friendly `displayName` values across the API and UI (while keeping `name` as the canonical identifier).
  * GPU picker labels and model search now use `displayName` (with fallback to `name`).
  * `SearchableSelect` adds a `renderValue` prop to customize the displayed selected value.
* **Bug Fixes**
  * Improved GPU catalog formatting, including model deduplication and interface normalization.
* **Documentation**
  * OpenAPI/Swagger now requires `displayName` and includes example values.
* **Tests**
  * Added/updated API and UI tests to validate `displayName`, selection/search behavior, and `renderValue`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->