### PR TITLE
fix(onboarding): keep the picker mounted while the trial wallet provisions

### DIFF
--- a/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.spec.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
@@ -59,9 +60,23 @@ describe(RequireOnboarding.name, () => {
       expect(replace).not.toHaveBeenCalled();
     });
 
-    it("keeps the onboarding picker mounted while leases load after the trial wallet arrives (no loader flash / remount)", () => {
-      const { replace } = setup({ flag: true, address: "akash1", hasManagedWallet: true, leasesLoading: true, path: "/onboarding" });
+    it("keeps the same onboarding picker instance mounted when the trial wallet address arrives mid-provisioning (no loader flash / remount)", () => {
+      // Render the picker before the trial wallet has an address, then have the address arrive while leases load —
+      // the exact regression this PR fixes. The child must never unmount/remount and we must never redirect.
+      const { replace, getChildMountCount, rerender } = setup({
+        flag: true,
+        hasManagedWallet: true,
+        address: "",
+        isWalletLoading: true,
+        path: "/onboarding"
+      });
       expect(screen.getByText("child")).toBeInTheDocument();
+      const mountsBeforeWallet = getChildMountCount();
+
+      rerender({ address: "akash1", isWalletLoading: false, leasesLoading: true });
+
+      expect(screen.getByText("child")).toBeInTheDocument();
+      expect(getChildMountCount()).toBe(mountsBeforeWallet);
       expect(replace).not.toHaveBeenCalled();
     });
 
@@ -122,41 +137,59 @@ describe(RequireOnboarding.name, () => {
     returnTo?: string;
   }) {
     const replace = vi.fn();
-    const d: typeof DEPENDENCIES = {
+    let mountCount = 0;
+    // Counts DOM mounts of the gated child so a test can prove the child instance survives a wallet-arrival
+    // transition (no unmount/remount) rather than only checking final presence.
+    function Child() {
+      useEffect(() => {
+        mountCount += 1;
+      }, []);
+      return <div>child</div>;
+    }
+
+    const buildDependencies = (props: typeof input): typeof DEPENDENCIES => ({
       ...DEPENDENCIES,
-      useFlag: (() => input.flag) as typeof DEPENDENCIES.useFlag,
+      useFlag: (() => props.flag) as typeof DEPENDENCIES.useFlag,
       useUser: (() =>
         mock<ReturnType<typeof DEPENDENCIES.useUser>>({
-          user: input.loggedOut ? undefined : ({ userId: input.userId ?? "u1" } as never),
+          user: props.loggedOut ? undefined : ({ userId: props.userId ?? "u1" } as never),
           isLoading: false
         })) as typeof DEPENDENCIES.useUser,
       useWallet: (() =>
         mock<ReturnType<typeof DEPENDENCIES.useWallet>>({
-          address: input.address ?? "",
-          hasManagedWallet: input.hasManagedWallet ?? false,
-          isWalletConnected: input.isWalletConnected ?? false,
-          isWalletLoading: input.isWalletLoading ?? false,
-          isWalletInitializing: input.isWalletInitializing ?? false
+          address: props.address ?? "",
+          hasManagedWallet: props.hasManagedWallet ?? false,
+          isWalletConnected: props.isWalletConnected ?? false,
+          isWalletLoading: props.isWalletLoading ?? false,
+          isWalletInitializing: props.isWalletInitializing ?? false
         })) as typeof DEPENDENCIES.useWallet,
       useAllLeases: (() =>
         mock<ReturnType<typeof DEPENDENCIES.useAllLeases>>({
-          data: input.leasesError ? (undefined as never) : input.leases ? (Array.from({ length: input.leases }) as never) : [],
-          isLoading: (input.leasesLoading ?? false) as never,
-          isError: (input.leasesError ?? false) as never
+          data: props.leasesError ? (undefined as never) : props.leases ? (Array.from({ length: props.leases }) as never) : [],
+          isLoading: (props.leasesLoading ?? false) as never,
+          isError: (props.leasesError ?? false) as never
         })) as typeof DEPENDENCIES.useAllLeases,
-      useReturnTo: (() => mock<ReturnType<typeof DEPENDENCIES.useReturnTo>>({ returnTo: input.returnTo ?? "/" })) as typeof DEPENDENCIES.useReturnTo,
+      useReturnTo: (() => mock<ReturnType<typeof DEPENDENCIES.useReturnTo>>({ returnTo: props.returnTo ?? "/" })) as typeof DEPENDENCIES.useReturnTo,
       useRouter: (() =>
-        mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ asPath: input.path, pathname: input.path, replace })) as typeof DEPENDENCIES.useRouter,
+        mock<ReturnType<typeof DEPENDENCIES.useRouter>>({ asPath: props.path, pathname: props.path, replace })) as typeof DEPENDENCIES.useRouter,
       UrlService: {
         ...DEPENDENCIES.UrlService,
         onboarding: (({ returnTo } = {}) => `/signup?returnTo=${returnTo}`) as typeof DEPENDENCIES.UrlService.onboarding
       }
-    };
-    render(
-      <RequireOnboarding isPublic={input.isPublic} dependencies={d}>
-        <div>child</div>
+    });
+
+    const renderGate = (props: typeof input) => (
+      <RequireOnboarding isPublic={props.isPublic} dependencies={buildDependencies(props)}>
+        <Child />
       </RequireOnboarding>
     );
-    return { replace };
+
+    const { rerender } = render(renderGate(input));
+
+    return {
+      replace,
+      getChildMountCount: () => mountCount,
+      rerender: (patch: Partial<typeof input>) => rerender(renderGate({ ...input, ...patch }))
+    };
   }
 });

--- a/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.spec.tsx
+++ b/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.spec.tsx
@@ -59,6 +59,12 @@ describe(RequireOnboarding.name, () => {
       expect(replace).not.toHaveBeenCalled();
     });
 
+    it("keeps the onboarding picker mounted while leases load after the trial wallet arrives (no loader flash / remount)", () => {
+      const { replace } = setup({ flag: true, address: "akash1", hasManagedWallet: true, leasesLoading: true, path: "/onboarding" });
+      expect(screen.getByText("child")).toBeInTheDocument();
+      expect(replace).not.toHaveBeenCalled();
+    });
+
     it("still waits for leases on a non-allow-list route while they load", () => {
       setup({ flag: true, address: "akash1", hasManagedWallet: true, leasesLoading: true, path: "/deployments" });
       expect(screen.queryByText("child")).not.toBeInTheDocument();

--- a/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.tsx
+++ b/apps/deploy-web/src/components/onboarding/RequireOnboarding/RequireOnboarding.tsx
@@ -102,15 +102,17 @@ function LeaseBasedGate({
 
 /**
  * Resolves the lease-based gate's action, in priority order. Public pages always render (RequireAuth owns auth).
- * Allow-list pages (configure, a deployment detail) render *immediately* — ahead of the identity/wallet wait and
- * without waiting on the leases query — because they own their own loading UX (e.g. the auto-deploy progress
- * overlay). Gating them behind wallet initialization would flash the full-screen loader over an in-progress
- * deploy while the wallet spins up, interrupting that overlay and remounting the flow. Everywhere else first
- * waits until user + wallet identity is known, then for leases to settle: an onboarded user renders except on
- * `/onboarding` (sent back where they came from), and a not-onboarded user renders on `/onboarding` but is sent
- * there from anywhere else. A leases *error* leaves onboarding unknowable — an undefined result is not "no
- * leases" — so we fail open and render where the user is rather than eject a genuinely onboarded user into the
- * first-deploy funnel on a transient chain-API blip.
+ * Allow-list pages (configure, a deployment detail) render *immediately*, ahead of the identity/wallet wait and
+ * the leases query, because they own their own loading UX (e.g. the auto-deploy progress overlay). The
+ * `/onboarding` picker likewise renders once identity is known without waiting for leases: its trial wallet
+ * provisions in the background, and the leases query flips to loading the moment that wallet's address appears,
+ * which would otherwise flash the full-screen loader and remount the page (including an open Add Credits sheet).
+ * An already-onboarded user who lands on `/onboarding` is still sent back where they came from, but only once
+ * leases resolve (they render the picker until then). Everywhere else first waits until user + wallet identity is
+ * known, then for leases to settle: an onboarded user renders, a not-onboarded user is sent to `/onboarding`. A
+ * leases *error* leaves onboarding unknowable (an undefined result is not "no leases"), so we fail open and render
+ * where the user is rather than eject a genuinely onboarded user into the first-deploy funnel on a transient
+ * chain-API blip.
  */
 function decideLeaseGate(input: {
   isPublic: boolean;
@@ -126,9 +128,9 @@ function decideLeaseGate(input: {
   if (input.isAllowed) return "render";
   if (!input.identityKnown) return "loading";
   if (!input.isAuthenticated) return "render";
-  if (!input.leasesSettled) return "loading";
   if (input.isOnboarded) return input.isOnOnboarding ? "toReturn" : "render";
   if (input.isOnOnboarding) return "render";
+  if (!input.leasesSettled) return "loading";
   if (input.leasesErrored) return "render";
   return "toOnboarding";
 }


### PR DESCRIPTION
## Why

The post-deploy **Deploy App** E2E against beta has failed on every `console-web` deploy since #3425, always on one spec, deterministically: `onboarding-picker-unlock-trial` ("a fresh trialing user unlocks the LLM template by purchasing credits"). Example failing run: https://github.com/akash-network/console/actions/runs/29351291940

The `pickPredefinedAmount` line in the failure screenshot is a red herring: the CI log shows the `100` radio resolves fine, then the click fails with `element is not stable` / `element was detached from the DOM`. Across the 3 retries it fails at *different* lines (Full name, Country select, radio) — the signature of a subtree remounting mid-interaction, not a stale selector.

Root cause: `RequireOnboarding`'s `LeaseBasedGate` returns a full-screen `<Loading/>` (unmounting `children`) while the leases query is loading. On `/onboarding` the trial wallet provisions in the background; `useAllLeases(address, { enabled: hasManagedWallet && !!address })` flips to `isLoading` the moment the trial address appears, unmounting the whole page — including the portaled Add Credits sheet and its Stripe iframes — then remounting once leases settle. #3425 gave `/new-deployment/configure` render-immediately treatment via the allow-list but left `/onboarding` itself gated on leases, so the picker still blanks to a spinner when the trial provisions. This also degrades real UX: a fast user who opens the sheet gets it yanked and Stripe reloaded.

## What

- `decideLeaseGate`: render `/onboarding` while leases load, by moving the `isOnboarded` / `isOnOnboarding` decisions above the `!leasesSettled` loading gate. An already-onboarded user who lands on `/onboarding` still redirects to `returnTo`, but only once leases resolve. Non-onboarding, non-allow-list routes (e.g. `/deployments`) are unchanged — they still wait for leases before deciding render vs. redirect.
- Added a regression unit test asserting `/onboarding` stays mounted while leases load after the trial wallet arrives (fails on the pre-fix gate, passes now).

## Validation

- Unit: `npx vitest run src/components/onboarding/RequireOnboarding` — 18/18 green; the new test fails on the pre-fix code and passes with the fix (verified by stashing the source change).
- `tsc --noEmit` / `eslint --quiet`: no new issues on the changed files.
- The failing spec is a **post-deploy** E2E (runs against deployed beta), so it can't run on this PR. The unit regression test stands in pre-merge; the beta E2E will confirm green on the next Deploy App run after this merges and deploys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding gate behavior during lease revalidation/refetch by adjusting when the UI transitions from loading to the next step.
  * Prevented unnecessary unmount/remount and redirects when a trial wallet address becomes available while lease information is still loading.
  * Kept the onboarding picker visible and stable during these in-flight states.
* **Tests**
  * Added a regression test to verify onboarding picker mount stability and no redirect during lease loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->