### PR TITLE
feat(billing): promote first-purchase bonus in trial conversion emails

### DIFF
--- a/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.spec.ts
+++ b/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.spec.ts
@@ -104,7 +104,8 @@ describe(CloseTrialDeploymentHandler.name, () => {
         vars: {
           dseq: payload.dseq,
           owner: wallet.address!,
-          deploymentLifetimeInHours: 24
+          deploymentLifetimeInHours: 24,
+          firstPurchaseBonus: "$resolved"
         }
       }),
       {

--- a/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.ts
+++ b/apps/api/src/app/services/close-trial-deployment/close-trial-deployment.handler.ts
@@ -5,6 +5,7 @@ import { UserWalletRepository } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { Job, JOB_NAME, JobHandler, JobPayload, JobQueueService, LoggerService } from "@src/core";
 import { DeploymentWriterService } from "@src/deployment/services/deployment-writer/deployment-writer.service";
+import { RESOLVED_MARKER } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
 
 export class CloseTrialDeployment implements Job {
@@ -123,7 +124,8 @@ export class CloseTrialDeploymentHandler implements JobHandler<CloseTrialDeploym
         vars: {
           dseq: payload.dseq,
           owner: wallet.address!,
-          deploymentLifetimeInHours: this.billingConfig.get("TRIAL_DEPLOYMENT_CLEANUP_HOURS")
+          deploymentLifetimeInHours: this.billingConfig.get("TRIAL_DEPLOYMENT_CLEANUP_HOURS"),
+          firstPurchaseBonus: RESOLVED_MARKER
         }
       }),
       {

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.spec.ts
@@ -110,7 +110,8 @@ describe(TrialDeploymentLeaseCreatedHandler.name, () => {
         vars: {
           deploymentClosedAt: addHours(deploymentCreatedAt, trialDeploymentLifetimeInHours).toISOString(),
           dseq: payload.dseq,
-          owner: wallet.address!
+          owner: wallet.address!,
+          firstPurchaseBonus: "$resolved"
         }
       }),
       {

--- a/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.ts
+++ b/apps/api/src/app/services/trial-deployment-lease-created/trial-deployment-lease-created.handler.ts
@@ -5,6 +5,7 @@ import { TrialDeploymentLeaseCreated } from "@src/billing/events/trial-deploymen
 import { UserWalletRepository } from "@src/billing/repositories";
 import { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import { DOMAIN_EVENT_NAME, EventPayload, JobHandler, JobQueueService, LoggerService } from "@src/core";
+import { RESOLVED_MARKER } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import { NotificationJob } from "@src/notifications/services/notification-handler/notification.handler";
 import { CloseTrialDeployment } from "../close-trial-deployment/close-trial-deployment.handler";
 
@@ -66,7 +67,8 @@ export class TrialDeploymentLeaseCreatedHandler implements JobHandler<TrialDeplo
         vars: {
           deploymentClosedAt: addHours(deploymentCreatedAt, trialDeploymentLifetime).toISOString(),
           dseq: payload.dseq,
-          owner: wallet.address!
+          owner: wallet.address!,
+          firstPurchaseBonus: RESOLVED_MARKER
         }
       }),
       {

--- a/apps/api/src/app/services/trial-started/trial-started.handler.spec.ts
+++ b/apps/api/src/app/services/trial-started/trial-started.handler.spec.ts
@@ -61,13 +61,11 @@ describe(TrialStartedHandler.name, () => {
         subscribedToNewsletter: true,
         createdAt: USER_CREATED_AT
       });
-      const initialCredits = faker.number.int({ min: 5_000_000, max: 10_000_000 });
       const deploymentLifetimeInHours = faker.number.int({ min: 1, max: 24 });
 
       const { handler, userRepository, notificationService, jobQueueManager, logger } = setup({
         findUserById: vi.fn().mockResolvedValue(user),
         trialExpirationDays: 30,
-        initialCredits,
         deploymentLifetimeInHours
       });
 
@@ -81,8 +79,7 @@ describe(TrialStartedHandler.name, () => {
       expect(notificationService.createNotification).toHaveBeenCalledWith(
         startTrialNotification(user, {
           trialEndsAt: TRIAL_ENDS_AT,
-          deploymentLifetimeInHours,
-          initialCredits
+          deploymentLifetimeInHours
         })
       );
       expect(logger.info).toHaveBeenCalledWith({
@@ -225,7 +222,6 @@ describe(TrialStartedHandler.name, () => {
     createNotification?: NotificationService["createNotification"];
     enqueueJob?: JobQueueService["enqueue"];
     trialExpirationDays?: number;
-    initialCredits?: number;
     deploymentLifetimeInHours?: number;
   }) {
     const paymentLink = "https://console.akash.network/billing?openPayment=true";
@@ -243,7 +239,6 @@ describe(TrialStartedHandler.name, () => {
       coreConfig: mockConfig<BillingConfigService>({
         TRIAL_ALLOWANCE_EXPIRATION_DAYS: input?.trialExpirationDays ?? 30,
         CONSOLE_WEB_PAYMENT_LINK: paymentLink,
-        TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT: input?.initialCredits ?? 10_000_000,
         TRIAL_DEPLOYMENT_CLEANUP_HOURS: input?.deploymentLifetimeInHours ?? 24
       })
     };

--- a/apps/api/src/app/services/trial-started/trial-started.handler.spec.ts
+++ b/apps/api/src/app/services/trial-started/trial-started.handler.spec.ts
@@ -116,7 +116,13 @@ describe(TrialStartedHandler.name, () => {
           template: "beforeTrialEnds",
           userId: user.id,
           conditions: { trial: true },
-          vars: { trialEndsAt: trialEndsAt.toISOString(), paymentLink, remainingCredits: "$resolved", activeDeployments: "$resolved" }
+          vars: {
+            trialEndsAt: trialEndsAt.toISOString(),
+            paymentLink,
+            remainingCredits: "$resolved",
+            activeDeployments: "$resolved",
+            firstPurchaseBonus: "$resolved"
+          }
         }),
         {
           singletonKey: `notification.beforeTrialEnds.${user.id}.${trialDays - 7}`,
@@ -129,7 +135,13 @@ describe(TrialStartedHandler.name, () => {
           template: "beforeTrialEnds",
           userId: user.id,
           conditions: { trial: true },
-          vars: { trialEndsAt: trialEndsAt.toISOString(), paymentLink, remainingCredits: "$resolved", activeDeployments: "$resolved" }
+          vars: {
+            trialEndsAt: trialEndsAt.toISOString(),
+            paymentLink,
+            remainingCredits: "$resolved",
+            activeDeployments: "$resolved",
+            firstPurchaseBonus: "$resolved"
+          }
         }),
         {
           singletonKey: `notification.beforeTrialEnds.${user.id}.${trialDays - 1}`,
@@ -142,7 +154,8 @@ describe(TrialStartedHandler.name, () => {
           template: "trialEnded",
           userId: user.id,
           vars: {
-            paymentLink
+            paymentLink,
+            firstPurchaseBonus: "$resolved"
           },
           conditions: { trial: true }
         }),
@@ -158,7 +171,8 @@ describe(TrialStartedHandler.name, () => {
           userId: user.id,
           conditions: { trial: true },
           vars: {
-            paymentLink
+            paymentLink,
+            firstPurchaseBonus: "$resolved"
           }
         }),
         {

--- a/apps/api/src/app/services/trial-started/trial-started.handler.ts
+++ b/apps/api/src/app/services/trial-started/trial-started.handler.ts
@@ -42,8 +42,7 @@ export class TrialStartedHandler implements JobHandler<TrialStarted> {
       await this.notificationService.createNotification(
         startTrialNotification(user, {
           deploymentLifetimeInHours: this.billingConfig.get("TRIAL_DEPLOYMENT_CLEANUP_HOURS"),
-          trialEndsAt: trialEndsAt.toISOString(),
-          initialCredits: this.billingConfig.get("TRIAL_DEPLOYMENT_ALLOWANCE_AMOUNT")
+          trialEndsAt: trialEndsAt.toISOString()
         })
       );
       this.logger.info({ event: "START_TRIAL_NOTIFICATION_SENT", userId: user.id });

--- a/apps/api/src/app/services/trial-started/trial-started.handler.ts
+++ b/apps/api/src/app/services/trial-started/trial-started.handler.ts
@@ -54,7 +54,8 @@ export class TrialStartedHandler implements JobHandler<TrialStarted> {
       trialEndsAt: trialEndsAt.toISOString(),
       paymentLink: this.billingConfig.get("CONSOLE_WEB_PAYMENT_LINK"),
       remainingCredits: RESOLVED_MARKER,
-      activeDeployments: RESOLVED_MARKER
+      activeDeployments: RESOLVED_MARKER,
+      firstPurchaseBonus: RESOLVED_MARKER
     };
     await Promise.all([
       this.jobQueueManager.enqueue(
@@ -86,7 +87,8 @@ export class TrialStartedHandler implements JobHandler<TrialStarted> {
           template: "trialEnded",
           userId: user.id,
           vars: {
-            paymentLink: this.billingConfig.get("CONSOLE_WEB_PAYMENT_LINK")
+            paymentLink: this.billingConfig.get("CONSOLE_WEB_PAYMENT_LINK"),
+            firstPurchaseBonus: RESOLVED_MARKER
           },
           conditions: notificationConditions
         }),
@@ -100,7 +102,8 @@ export class TrialStartedHandler implements JobHandler<TrialStarted> {
           template: "afterTrialEnds",
           userId: user.id,
           vars: {
-            paymentLink: this.billingConfig.get("CONSOLE_WEB_PAYMENT_LINK")
+            paymentLink: this.billingConfig.get("CONSOLE_WEB_PAYMENT_LINK"),
+            firstPurchaseBonus: RESOLVED_MARKER
           },
           conditions: notificationConditions
         }),

--- a/apps/api/src/billing/services/first-purchase-bonus-offer/first-purchase-bonus-offer.service.spec.ts
+++ b/apps/api/src/billing/services/first-purchase-bonus-offer/first-purchase-bonus-offer.service.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { StripeTransactionRepository } from "@src/billing/repositories";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import type { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import { FirstPurchaseBonusOfferService } from "./first-purchase-bonus-offer.service";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(FirstPurchaseBonusOfferService.name, () => {
+  it("returns null and skips the repository lookup when the feature flag is disabled", async () => {
+    const user = createUser();
+    const { service, featureFlagsService, stripeTransactionRepository } = setup({ flagEnabled: false });
+
+    const result = await service.resolve(user);
+
+    expect(result).toBeNull();
+    expect(featureFlagsService.isEnabled).toHaveBeenCalledWith(FeatureFlags.FIRST_PURCHASE_BONUS);
+    expect(stripeTransactionRepository.hasCompletedPaidTransaction).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the user has already completed a paid transaction", async () => {
+    const user = createUser();
+    const { service, stripeTransactionRepository } = setup({ flagEnabled: true, hasPaidBefore: true });
+
+    const result = await service.resolve(user);
+
+    expect(result).toBeNull();
+    expect(stripeTransactionRepository.hasCompletedPaidTransaction).toHaveBeenCalledWith(user.id);
+  });
+
+  it("returns the offer when the flag is enabled and the user has not paid before", async () => {
+    const user = createUser();
+    const { service } = setup({ flagEnabled: true, hasPaidBefore: false });
+
+    const result = await service.resolve(user);
+
+    expect(result).toEqual({ bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 });
+  });
+
+  function setup(input: { flagEnabled: boolean; hasPaidBefore?: boolean }) {
+    const mocks = {
+      featureFlagsService: mock<FeatureFlagsService>({
+        isEnabled: vi.fn().mockReturnValue(input.flagEnabled)
+      }),
+      stripeTransactionRepository: mock<StripeTransactionRepository>({
+        hasCompletedPaidTransaction: vi.fn().mockResolvedValue(input.hasPaidBefore ?? false)
+      })
+    };
+
+    const service = new FirstPurchaseBonusOfferService(mocks.featureFlagsService, mocks.stripeTransactionRepository);
+
+    return { service, ...mocks };
+  }
+});

--- a/apps/api/src/billing/services/first-purchase-bonus-offer/first-purchase-bonus-offer.service.ts
+++ b/apps/api/src/billing/services/first-purchase-bonus-offer/first-purchase-bonus-offer.service.ts
@@ -6,7 +6,7 @@ import type { Resolver } from "@src/core/providers/resolvers.provider";
 import { DATA_RESOLVER } from "@src/core/providers/resolvers.provider";
 import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
 import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
-import { UserOutput } from "@src/user/repositories";
+import type { UserOutput } from "@src/user/repositories";
 
 export interface FirstPurchaseBonusOffer {
   bonusPercent: number;

--- a/apps/api/src/billing/services/first-purchase-bonus-offer/first-purchase-bonus-offer.service.ts
+++ b/apps/api/src/billing/services/first-purchase-bonus-offer/first-purchase-bonus-offer.service.ts
@@ -1,0 +1,41 @@
+import { injectable } from "tsyringe";
+
+import { StripeTransactionRepository } from "@src/billing/repositories";
+import { BONUS_PERCENT, MAX_BONUS_CENTS, MIN_QUALIFYING_AMOUNT_CENTS } from "@src/billing/services/first-purchase-bonus/first-purchase-bonus.service";
+import type { Resolver } from "@src/core/providers/resolvers.provider";
+import { DATA_RESOLVER } from "@src/core/providers/resolvers.provider";
+import { FeatureFlags } from "@src/core/services/feature-flags/feature-flags";
+import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-flags.service";
+import { UserOutput } from "@src/user/repositories";
+
+export interface FirstPurchaseBonusOffer {
+  bonusPercent: number;
+  minPurchaseUsd: number;
+  maxBonusUsd: number;
+}
+
+/**
+ * Resolves the live first-purchase bonus offer for trial emails at send time (emails are
+ * scheduled days/weeks ahead). Returns null when the offer doesn't apply so the email still
+ * sends without the pitch; DB errors propagate so pg-boss retries the notification.
+ */
+@injectable({ token: DATA_RESOLVER })
+export class FirstPurchaseBonusOfferService implements Resolver {
+  readonly key = "firstPurchaseBonus";
+
+  constructor(
+    private readonly featureFlagsService: FeatureFlagsService,
+    private readonly stripeTransactionRepository: StripeTransactionRepository
+  ) {}
+
+  async resolve(user: UserOutput): Promise<FirstPurchaseBonusOffer | null> {
+    if (!this.featureFlagsService.isEnabled(FeatureFlags.FIRST_PURCHASE_BONUS)) return null;
+    if (await this.stripeTransactionRepository.hasCompletedPaidTransaction(user.id)) return null;
+
+    return {
+      bonusPercent: BONUS_PERCENT,
+      minPurchaseUsd: MIN_QUALIFYING_AMOUNT_CENTS / 100,
+      maxBonusUsd: MAX_BONUS_CENTS / 100
+    };
+  }
+}

--- a/apps/api/src/billing/services/first-purchase-bonus/first-purchase-bonus.service.ts
+++ b/apps/api/src/billing/services/first-purchase-bonus/first-purchase-bonus.service.ts
@@ -8,11 +8,11 @@ import { FeatureFlagsService } from "@src/core/services/feature-flags/feature-fl
 import { UserRepository } from "@src/user/repositories";
 
 /** Smallest purchase that qualifies for the first-purchase bonus, in cents. */
-const MIN_QUALIFYING_AMOUNT_CENTS = 100_00;
+export const MIN_QUALIFYING_AMOUNT_CENTS = 100_00;
 /** Bonus granted as a percentage of the paid amount. */
-const BONUS_PERCENT = 10;
+export const BONUS_PERCENT = 10;
 /** Bonus ceiling, in cents. */
-const MAX_BONUS_CENTS = 100_00;
+export const MAX_BONUS_CENTS = 100_00;
 
 @singleton()
 export class FirstPurchaseBonusService {

--- a/apps/api/src/billing/services/index.ts
+++ b/apps/api/src/billing/services/index.ts
@@ -5,4 +5,5 @@ export * from "@src/billing/lib/wallet/wallet";
 export * from "@src/billing/lib/batch-signing-client/batch-signing-client.service";
 export * from "@src/billing/services/managed-signer/managed-signer.service";
 export * from "./remaining-credits/remaining-credits.service.ts";
+export * from "./first-purchase-bonus-offer/first-purchase-bonus-offer.service";
 export * from "./wallet-settings/wallet-settings.service";

--- a/apps/api/src/notifications/services/notification-handler/notification.handler.spec.ts
+++ b/apps/api/src/notifications/services/notification-handler/notification.handler.spec.ts
@@ -42,7 +42,8 @@ describe(NotificationHandler.name, () => {
       template: "trialEnded",
       userId: "non-existent-user",
       vars: {
-        paymentLink: faker.internet.url()
+        paymentLink: faker.internet.url(),
+        firstPurchaseBonus: "$resolved"
       },
       version: 1
     });
@@ -70,7 +71,8 @@ describe(NotificationHandler.name, () => {
       template: "trialEnded",
       userId: user.id,
       vars: {
-        paymentLink: faker.internet.url()
+        paymentLink: faker.internet.url(),
+        firstPurchaseBonus: "$resolved"
       },
       version: 1
     });
@@ -99,7 +101,8 @@ describe(NotificationHandler.name, () => {
       template: "trialEnded",
       userId: user.id,
       vars: {
-        paymentLink: faker.internet.url()
+        paymentLink: faker.internet.url(),
+        firstPurchaseBonus: "$resolved"
       },
       conditions: { trial: true }, // User doesn't have trial: true
       version: 1
@@ -116,23 +119,23 @@ describe(NotificationHandler.name, () => {
       trial: true
     });
 
+    const bonusOffer = { bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 };
     const { handler, userRepository, notificationService } = setup({
-      findUserById: vi.fn().mockResolvedValue(user)
+      findUserById: vi.fn().mockResolvedValue(user),
+      resolveVars: vi.fn().mockImplementation(async (_user, vars) => ({ ...vars, firstPurchaseBonus: bonusOffer }))
     });
-    const vars = {
-      paymentLink: faker.internet.url()
-    };
+    const paymentLink = faker.internet.url();
 
     await handler.handle({
       template: "trialEnded",
       userId: user.id,
-      vars,
+      vars: { paymentLink, firstPurchaseBonus: "$resolved" },
       conditions: { trial: true },
       version: 1
     });
 
     expect(userRepository.findById).toHaveBeenCalledWith(user.id);
-    expect(notificationService.createNotification).toHaveBeenCalledWith(trialEndedNotification(user, vars));
+    expect(notificationService.createNotification).toHaveBeenCalledWith(trialEndedNotification(user, { paymentLink, firstPurchaseBonus: bonusOffer }));
   });
 
   it("creates notification when no conditions are provided", async () => {
@@ -179,7 +182,12 @@ describe(NotificationHandler.name, () => {
       createdAt: createdDate,
       trial: true
     });
-    const resolvedVars = { remainingCredits: faker.number.int({ min: 1000, max: 10000 }), activeDeployments: faker.number.int({ min: 0, max: 10 }) };
+    const bonusOffer = { bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 };
+    const resolvedVars = {
+      remainingCredits: faker.number.int({ min: 1000, max: 10000 }),
+      activeDeployments: faker.number.int({ min: 0, max: 10 }),
+      firstPurchaseBonus: bonusOffer
+    };
     const resolveVars = vi.fn().mockImplementation(async (user, vars) => ({
       ...vars,
       ...resolvedVars
@@ -195,7 +203,7 @@ describe(NotificationHandler.name, () => {
     await handler.handle({
       template: "beforeTrialEnds",
       userId: user.id,
-      vars: { trialEndsAt, paymentLink, remainingCredits: "$resolved", activeDeployments: "$resolved" },
+      vars: { trialEndsAt, paymentLink, remainingCredits: "$resolved", activeDeployments: "$resolved", firstPurchaseBonus: "$resolved" },
       conditions: { trial: true },
       version: 1
     });
@@ -213,23 +221,23 @@ describe(NotificationHandler.name, () => {
       trial: true
     });
 
+    const bonusOffer = { bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 };
     const { handler, userRepository, notificationService } = setup({
-      findUserById: vi.fn().mockResolvedValue(user)
+      findUserById: vi.fn().mockResolvedValue(user),
+      resolveVars: vi.fn().mockImplementation(async (_user, vars) => ({ ...vars, firstPurchaseBonus: bonusOffer }))
     });
 
-    const vars = {
-      paymentLink: "https://example.com/billing?openPayment=true"
-    };
+    const paymentLink = "https://example.com/billing?openPayment=true";
     await handler.handle({
       template: "afterTrialEnds",
       userId: user.id,
       conditions: { trial: true },
-      vars,
+      vars: { paymentLink, firstPurchaseBonus: "$resolved" },
       version: 1
     });
 
     expect(userRepository.findById).toHaveBeenCalledWith(user.id);
-    expect(notificationService.createNotification).toHaveBeenCalledWith(afterTrialEndsNotification(user, vars));
+    expect(notificationService.createNotification).toHaveBeenCalledWith(afterTrialEndsNotification(user, { paymentLink, firstPurchaseBonus: bonusOffer }));
   });
 
   it("handles complex conditions with multiple properties", async () => {
@@ -240,18 +248,18 @@ describe(NotificationHandler.name, () => {
       emailVerified: true
     });
 
+    const bonusOffer = { bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 };
     const { handler, userRepository, notificationService } = setup({
-      findUserById: vi.fn().mockResolvedValue(user)
+      findUserById: vi.fn().mockResolvedValue(user),
+      resolveVars: vi.fn().mockImplementation(async (_user, vars) => ({ ...vars, firstPurchaseBonus: bonusOffer }))
     });
 
-    const vars = {
-      paymentLink: faker.internet.url()
-    };
+    const paymentLink = faker.internet.url();
 
     await handler.handle({
       template: "trialEnded",
       userId: user.id,
-      vars,
+      vars: { paymentLink, firstPurchaseBonus: "$resolved" },
       conditions: {
         trial: true,
         emailVerified: true
@@ -260,7 +268,7 @@ describe(NotificationHandler.name, () => {
     });
 
     expect(userRepository.findById).toHaveBeenCalledWith(user.id);
-    expect(notificationService.createNotification).toHaveBeenCalledWith(trialEndedNotification(user, vars));
+    expect(notificationService.createNotification).toHaveBeenCalledWith(trialEndedNotification(user, { paymentLink, firstPurchaseBonus: bonusOffer }));
   });
 
   it("returns early when complex conditions are not met", async () => {
@@ -279,7 +287,8 @@ describe(NotificationHandler.name, () => {
       template: "trialEnded",
       userId: user.id,
       vars: {
-        paymentLink: faker.internet.url()
+        paymentLink: faker.internet.url(),
+        firstPurchaseBonus: "$resolved"
       },
       conditions: {
         trial: true,

--- a/apps/api/src/notifications/services/notification-templates/after-trial-ends-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/after-trial-ends-notification.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { afterTrialEndsNotification } from "./after-trial-ends-notification";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(afterTrialEndsNotification.name, () => {
+  it("renders the add-payment summary and appends the first-purchase bonus offer", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = afterTrialEndsNotification(user, {
+      paymentLink: "https://console.akash.network/billing",
+      firstPurchaseBonus: { bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 }
+    });
+
+    expect(result.payload.summary).toBe("Add payment info to continue using Akash");
+    expect(result.payload.description).toContain("trial period with Akash Network has ended");
+    expect(result.payload.description).toContain("10% in bonus credits");
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/after-trial-ends-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/after-trial-ends-notification.ts
@@ -1,12 +1,20 @@
+import type { FirstPurchaseBonusOffer } from "@src/billing/services/first-purchase-bonus-offer/first-purchase-bonus-offer.service";
+import type { ResolvedValue } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import type { UserOutput } from "@src/user/repositories";
 import type { CreateNotificationInput } from "../notification/notification.service";
+import { firstPurchaseBonusSentence } from "./first-purchase-bonus-offer";
 
-export function afterTrialEndsNotification(user: UserOutput, vars: { paymentLink: string }): CreateNotificationInput {
+export function afterTrialEndsNotification(
+  user: UserOutput,
+  vars: { paymentLink: string; firstPurchaseBonus: ResolvedValue<FirstPurchaseBonusOffer | null> }
+): CreateNotificationInput {
   return {
     notificationId: `afterTrialEnds.${user.id}`,
     payload: {
       summary: "Add payment info to continue using Akash",
-      description: `Your trial period with Akash Network has ended. To keep using the platform and access all features, please add a payment method and top up your account by visiting <a href="${vars.paymentLink}">Akash Console Payment Setup</a>`
+      description:
+        `Your trial period with Akash Network has ended. To keep using the platform and access all features, please add a payment method and top up your account by visiting <a href="${vars.paymentLink}">Akash Console Payment Setup</a>` +
+        firstPurchaseBonusSentence(vars.firstPurchaseBonus)
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/before-close-trial-deployment.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/before-close-trial-deployment.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { beforeCloseTrialDeploymentNotification } from "./before-close-trial-deployment";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(beforeCloseTrialDeploymentNotification.name, () => {
+  it("renders the deployment-ending summary and appends the first-purchase bonus offer", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = beforeCloseTrialDeploymentNotification(user, {
+      deploymentClosedAt: "2025-10-22T07:58:47.770Z",
+      dseq: "123456",
+      owner: "akash1test",
+      firstPurchaseBonus: { bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 }
+    });
+
+    expect(result.payload.summary).toBe("Your Trial Deployment Ends Soon");
+    expect(result.payload.description).toContain("Your trial deployment will end");
+    expect(result.payload.description).toContain("10% in bonus credits");
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/before-close-trial-deployment.ts
+++ b/apps/api/src/notifications/services/notification-templates/before-close-trial-deployment.ts
@@ -1,11 +1,14 @@
 import { formatDistanceToNow } from "date-fns";
 
+import type { FirstPurchaseBonusOffer } from "@src/billing/services/first-purchase-bonus-offer/first-purchase-bonus-offer.service";
+import type { ResolvedValue } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import type { UserOutput } from "@src/user/repositories";
 import type { CreateNotificationInput } from "../notification/notification.service";
+import { firstPurchaseBonusSentence } from "./first-purchase-bonus-offer";
 
 export function beforeCloseTrialDeploymentNotification(
   user: UserOutput,
-  vars: { deploymentClosedAt: string; dseq: string; owner: string }
+  vars: { deploymentClosedAt: string; dseq: string; owner: string; firstPurchaseBonus: ResolvedValue<FirstPurchaseBonusOffer | null> }
 ): CreateNotificationInput {
   const deploymentClosedAt = new Date(vars.deploymentClosedAt);
   const timeLeft = deploymentClosedAt.getTime() < Date.now() ? "in a few seconds" : formatDistanceToNow(deploymentClosedAt, { addSuffix: true });
@@ -13,7 +16,9 @@ export function beforeCloseTrialDeploymentNotification(
     notificationId: `beforeCloseTrialDeployment.${deploymentClosedAt.toISOString()}.${vars.dseq}.${vars.owner}`,
     payload: {
       summary: "Your Trial Deployment Ends Soon",
-      description: `Your trial deployment will end ${timeLeft}. To keep your deployment running, please add a payment method and top up your account before then.`
+      description:
+        `Your trial deployment will end ${timeLeft}. To keep your deployment running, please add a payment method and top up your account before then.` +
+        firstPurchaseBonusSentence(vars.firstPurchaseBonus)
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/before-trial-ends-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/before-trial-ends-notification.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { beforeTrialEndsNotification } from "./before-trial-ends-notification";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(beforeTrialEndsNotification.name, () => {
+  const baseVars = {
+    trialEndsAt: "2025-10-22T07:58:47.770Z",
+    paymentLink: "https://console.akash.network/billing",
+    remainingCredits: 42,
+    activeDeployments: 2
+  };
+
+  it("renders the trial-ending summary and appends the first-purchase bonus offer", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = beforeTrialEndsNotification(user, { ...baseVars, firstPurchaseBonus: { bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 } });
+
+    expect(result.payload.summary).toBe("Your Free Trial is Ending Soon");
+    expect(result.payload.description).toContain("$42 in free credits");
+    expect(result.payload.description).toContain("10% in bonus credits");
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/before-trial-ends-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/before-trial-ends-notification.ts
@@ -1,12 +1,20 @@
 import { formatDistanceToNow } from "date-fns";
 
+import type { FirstPurchaseBonusOffer } from "@src/billing/services/first-purchase-bonus-offer/first-purchase-bonus-offer.service";
 import type { ResolvedValue } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import type { UserOutput } from "@src/user/repositories";
 import type { CreateNotificationInput } from "../notification/notification.service";
+import { firstPurchaseBonusSentence } from "./first-purchase-bonus-offer";
 
 export function beforeTrialEndsNotification(
   user: UserOutput,
-  vars: { trialEndsAt: string; paymentLink: string; remainingCredits: ResolvedValue<number>; activeDeployments: ResolvedValue<number> }
+  vars: {
+    trialEndsAt: string;
+    paymentLink: string;
+    remainingCredits: ResolvedValue<number>;
+    activeDeployments: ResolvedValue<number>;
+    firstPurchaseBonus: ResolvedValue<FirstPurchaseBonusOffer | null>;
+  }
 ): CreateNotificationInput {
   const trialEndsDate = new Date(vars.trialEndsAt);
   const timeLeft = trialEndsDate.getTime() < Date.now() ? "in a few seconds" : formatDistanceToNow(trialEndsDate, { addSuffix: true });
@@ -17,7 +25,8 @@ export function beforeTrialEndsNotification(
       description:
         `Your free trial with Akash Network will end ${timeLeft}. You still have $${vars.remainingCredits} in free credits available and, ` +
         `${vars.activeDeployments} deployments that will be lost when your free trial ends. ` +
-        `To retain the remaining free credits and to ensure your deployments keep running when the trial ends, purchase some credits today by visiting <a href="${vars.paymentLink}">Akash Console Payment Setup</a>.`
+        `To retain the remaining free credits and to ensure your deployments keep running when the trial ends, purchase some credits today by visiting <a href="${vars.paymentLink}">Akash Console Payment Setup</a>.` +
+        firstPurchaseBonusSentence(vars.firstPurchaseBonus)
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/first-purchase-bonus-offer.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/first-purchase-bonus-offer.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { firstPurchaseBonusSentence } from "./first-purchase-bonus-offer";
+
+describe(firstPurchaseBonusSentence.name, () => {
+  it("returns an empty string when there is no offer", () => {
+    expect(firstPurchaseBonusSentence(null)).toBe("");
+    expect(firstPurchaseBonusSentence(undefined)).toBe("");
+  });
+
+  it("renders the offer terms when an offer is provided", () => {
+    const sentence = firstPurchaseBonusSentence({ bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 });
+
+    expect(sentence).toContain("10% in bonus credits");
+    expect(sentence).toContain("first purchase of $100 or more");
+    expect(sentence).toContain("up to $100");
+    expect(sentence).toContain("<strong>");
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/first-purchase-bonus-offer.ts
+++ b/apps/api/src/notifications/services/notification-templates/first-purchase-bonus-offer.ts
@@ -1,0 +1,14 @@
+import type { FirstPurchaseBonusOffer } from "@src/billing/services/first-purchase-bonus-offer/first-purchase-bonus-offer.service";
+
+/**
+ * Sentence appended to trial conversion emails promoting the first-purchase bonus.
+ * Returns "" when there is no active offer. Accepts undefined because jobs enqueued before
+ * this field existed omit it (and ResolvedValue<Offer | null> erases null to the offer shape).
+ */
+export function firstPurchaseBonusSentence(offer: FirstPurchaseBonusOffer | null | undefined): string {
+  if (!offer) return "";
+  return (
+    ` <strong>Plus:</strong> get ${offer.bonusPercent}% in bonus credits on your first purchase of $${offer.minPurchaseUsd} or more, ` +
+    `up to $${offer.maxBonusUsd} in bonus credits.`
+  );
+}

--- a/apps/api/src/notifications/services/notification-templates/start-trial-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/start-trial-notification.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { startTrialNotification } from "./start-trial-notification";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(startTrialNotification.name, () => {
+  it("renders the welcome summary with the trial end date and deployment limit", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = startTrialNotification(user, {
+      trialEndsAt: "2025-10-22T07:58:47.770Z",
+      deploymentLifetimeInHours: 24
+    });
+
+    expect(result.notificationId).toBe("startTrial.user-123");
+    expect(result.payload.summary).toBe("Welcome to Akash! Your trial is ready");
+    expect(result.payload.description).toContain("Oct 22, 2025");
+    expect(result.payload.description).toContain("24 hours");
+  });
+
+  it("does not disclose a specific credit amount", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = startTrialNotification(user, {
+      trialEndsAt: "2025-10-22T07:58:47.770Z",
+      deploymentLifetimeInHours: 24
+    });
+
+    expect(result.payload.description).not.toContain("$");
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/start-trial-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/start-trial-notification.spec.ts
@@ -27,6 +27,6 @@ describe(startTrialNotification.name, () => {
       deploymentLifetimeInHours: 24
     });
 
-    expect(result.payload.description).not.toContain("$");
+    expect(result.payload.description).not.toMatch(/(?:\$\s*\d|\b\d[\d,]*(?:\.\d+)?\s*(?:credits?|USD|dollars?))/i);
   });
 });

--- a/apps/api/src/notifications/services/notification-templates/start-trial-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/start-trial-notification.ts
@@ -1,10 +1,7 @@
 import type { UserOutput } from "@src/user/repositories";
 import type { CreateNotificationInput } from "../notification/notification.service";
 
-export function startTrialNotification(
-  user: UserOutput,
-  vars: { trialEndsAt: string; deploymentLifetimeInHours: number; initialCredits: number }
-): CreateNotificationInput {
+export function startTrialNotification(user: UserOutput, vars: { trialEndsAt: string; deploymentLifetimeInHours: number }): CreateNotificationInput {
   const trialEndsAt = new Date(vars.trialEndsAt).toLocaleString("en-US", {
     timeZone: "UTC",
     hour12: false,
@@ -14,17 +11,14 @@ export function startTrialNotification(
     hour: "2-digit",
     minute: "2-digit"
   });
-  const formatter = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 });
-  const credits = formatter.format(vars.initialCredits / 1_000_000);
   return {
     notificationId: `startTrial.${user.id}`,
     payload: {
-      summary: `Welcome - here's ${credits} on the house!`,
+      summary: `Welcome to Akash! Your trial is ready`,
       description:
-        `Welcome to the Akash Supercloud - to get you going, we have loaded your account with ${credits} in trial credits! ` +
-        `Your trial will end at ${trialEndsAt} UTC. ` +
-        `To ensure that all free trials get fair access to resources, trial deployments are limited to ${vars.deploymentLifetimeInHours} hours, ` +
-        `Get started by deploying your first application today.`
+        `Welcome to the Akash Supercloud! We've added some trial credit to your account so you can take Akash for a spin and deploy your first app, no credit card required. ` +
+        `Your trial ends at ${trialEndsAt} UTC, and to keep access fair for everyone, trial deployments are limited to ${vars.deploymentLifetimeInHours} hours. ` +
+        `Deploy your first application today to get started.`
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/trial-deployment-closed.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/trial-deployment-closed.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { trialDeploymentClosedNotification } from "./trial-deployment-closed";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(trialDeploymentClosedNotification.name, () => {
+  it("renders the deployment-closed summary and appends the first-purchase bonus offer", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = trialDeploymentClosedNotification(user, {
+      dseq: "123456",
+      owner: "akash1test",
+      deploymentLifetimeInHours: 24,
+      firstPurchaseBonus: { bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 }
+    });
+
+    expect(result.payload.summary).toBe("Your Trial Deployment Has Been Closed");
+    expect(result.payload.description).toContain("has been closed by the system");
+    expect(result.payload.description).toContain("10% in bonus credits");
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/trial-deployment-closed.ts
+++ b/apps/api/src/notifications/services/notification-templates/trial-deployment-closed.ts
@@ -1,15 +1,20 @@
+import type { FirstPurchaseBonusOffer } from "@src/billing/services/first-purchase-bonus-offer/first-purchase-bonus-offer.service";
+import type { ResolvedValue } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import type { UserOutput } from "@src/user/repositories";
 import type { CreateNotificationInput } from "../notification/notification.service";
+import { firstPurchaseBonusSentence } from "./first-purchase-bonus-offer";
 
 export function trialDeploymentClosedNotification(
   user: UserOutput,
-  vars: { dseq: string; owner: string; deploymentLifetimeInHours: number }
+  vars: { dseq: string; owner: string; deploymentLifetimeInHours: number; firstPurchaseBonus: ResolvedValue<FirstPurchaseBonusOffer | null> }
 ): CreateNotificationInput {
   return {
     notificationId: `trialDeploymentClosed.${vars.dseq}.${vars.owner}`,
     payload: {
       summary: "Your Trial Deployment Has Been Closed",
-      description: `Your trial deployment (dseq: ${vars.dseq}) has been closed by the system after reaching the ${vars.deploymentLifetimeInHours}-hour limit. To keep your deployment running, please add a payment method and top up your account.`
+      description:
+        `Your trial deployment (dseq: ${vars.dseq}) has been closed by the system after reaching the ${vars.deploymentLifetimeInHours}-hour limit. To keep your deployment running, please add a payment method and top up your account.` +
+        firstPurchaseBonusSentence(vars.firstPurchaseBonus)
     },
     user: {
       id: user.id,

--- a/apps/api/src/notifications/services/notification-templates/trial-ended-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/trial-ended-notification.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { trialEndedNotification } from "./trial-ended-notification";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(trialEndedNotification.name, () => {
+  it("renders the trial-ended summary and appends the first-purchase bonus offer", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = trialEndedNotification(user, {
+      paymentLink: "https://console.akash.network/billing",
+      firstPurchaseBonus: { bonusPercent: 10, minPurchaseUsd: 100, maxBonusUsd: 100 }
+    });
+
+    expect(result.payload.summary).toBe("Your Free Trial Has Ended");
+    expect(result.payload.description).toContain("has ended");
+    expect(result.payload.description).toContain("10% in bonus credits");
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/trial-ended-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/trial-ended-notification.ts
@@ -1,12 +1,20 @@
+import type { FirstPurchaseBonusOffer } from "@src/billing/services/first-purchase-bonus-offer/first-purchase-bonus-offer.service";
+import type { ResolvedValue } from "@src/notifications/services/notification-data-resolver/notification-data-resolver.service";
 import type { UserOutput } from "@src/user/repositories";
 import type { CreateNotificationInput } from "../notification/notification.service";
+import { firstPurchaseBonusSentence } from "./first-purchase-bonus-offer";
 
-export function trialEndedNotification(user: UserOutput, vars: { paymentLink: string }): CreateNotificationInput {
+export function trialEndedNotification(
+  user: UserOutput,
+  vars: { paymentLink: string; firstPurchaseBonus: ResolvedValue<FirstPurchaseBonusOffer | null> }
+): CreateNotificationInput {
   return {
     notificationId: `trialEnded.${user.id}`,
     payload: {
       summary: "Your Free Trial Has Ended",
-      description: `Your free trial with Akash Network has ended. To continue using the platform and accessing all features, please add a payment method and purchase some credits by visiting <a href="${vars.paymentLink}">Akash Console Payment Setup</a>.`
+      description:
+        `Your free trial with Akash Network has ended. To continue using the platform and accessing all features, please add a payment method and purchase some credits by visiting <a href="${vars.paymentLink}">Akash Console Payment Setup</a>.` +
+        firstPurchaseBonusSentence(vars.firstPurchaseBonus)
     },
     user: {
       id: user.id,


### PR DESCRIPTION
## Why

The first-purchase 10% credit bonus is live, but the trial conversion emails we send to push trialing users toward their first payment still use the old "just purchase credits" messaging and never mention it. This surfaces the bonus at exactly the moments we ask users to pay.

Closes CON-658
Part of CON-657

## What

- Adds a send-time resolver that returns the current bonus offer, or nothing when the bonus is disabled or the recipient already made a paid purchase. Resolving at send time matters because these emails are scheduled days to weeks ahead, so a user who has since paid (or the flag being turned off) correctly suppresses the pitch.
- Appends the offer to the five trial conversion emails: trial ending soon (both sends), trial ended, add payment info, trial deployment ending soon, and trial deployment closed.
- Copy matches the Add Credits UI wording: 10% in bonus credits on a first purchase of $100 or more, up to $100.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-purchase bonus offer content to trial lifecycle notifications (when available), including new “bonus credits” wording in the notification descriptions.
  * Updated the trial-start notification copy to remove credit/amount-specific messaging and simplified the notification inputs accordingly.
* **Tests**
  * Expanded notification and handler expectations to include `firstPurchaseBonus` resolved variables.
  * Added coverage for the first-purchase bonus offer resolver and for rendering the bonus sentence in notification templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->