### PR TITLE
feat(billing): email confirmation when first-purchase bonus is granted

### DIFF
--- a/apps/api/src/app/providers/jobs.provider.ts
+++ b/apps/api/src/app/providers/jobs.provider.ts
@@ -7,6 +7,7 @@ import { JobQueueService } from "@src/core/services/job-queue/job-queue.service"
 import { NotificationHandler } from "@src/notifications/services/notification-handler/notification.handler";
 import { CloseTrialDeploymentHandler } from "../services/close-trial-deployment/close-trial-deployment.handler";
 import { EnableDeploymentAlertHandler } from "../services/enable-deployment-alert/enable-deployment-alert.handler";
+import { FirstPurchaseBonusGrantedHandler } from "../services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler";
 import { TrialDeploymentLeaseCreatedHandler } from "../services/trial-deployment-lease-created/trial-deployment-lease-created.handler";
 import { TrialStartedHandler } from "../services/trial-started/trial-started.handler";
 
@@ -21,7 +22,8 @@ container.register(APP_INITIALIZER, {
         container.resolve(CloseTrialDeploymentHandler),
         container.resolve(TrialDeploymentLeaseCreatedHandler),
         container.resolve(EnableDeploymentAlertHandler),
-        container.resolve(WalletBalanceReloadCheckHandler)
+        container.resolve(WalletBalanceReloadCheckHandler),
+        container.resolve(FirstPurchaseBonusGrantedHandler)
       ]);
     }
   } satisfies AppInitializer

--- a/apps/api/src/app/services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler.spec.ts
+++ b/apps/api/src/app/services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+
+import type { FirstPurchaseBonusGranted } from "@src/billing/events/first-purchase-bonus-granted";
+import type { EventPayload } from "@src/core";
+import type { LoggerService } from "@src/core/providers/logging.provider";
+import type { NotificationService } from "@src/notifications/services/notification/notification.service";
+import { firstPurchaseBonusGrantedNotification } from "@src/notifications/services/notification-templates/first-purchase-bonus-granted-notification";
+import type { UserRepository } from "@src/user/repositories";
+import { FirstPurchaseBonusGrantedHandler } from "./first-purchase-bonus-granted.handler";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(FirstPurchaseBonusGrantedHandler.name, () => {
+  const payload: EventPayload<FirstPurchaseBonusGranted> = { userId: "user-123", bonusAmountCents: 1500, paidAmountCents: 15000, version: 1 };
+
+  it("sends the bonus-granted notification when the user has an email", async () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+    const { handler, userRepository, notificationService } = setup({ findUserById: vi.fn().mockResolvedValue(user) });
+
+    await handler.handle(payload);
+
+    expect(userRepository.findById).toHaveBeenCalledWith("user-123");
+    expect(notificationService.createNotification).toHaveBeenCalledWith(
+      firstPurchaseBonusGrantedNotification(user, { bonusAmountCents: 1500, paidAmountCents: 15000 })
+    );
+  });
+
+  it("skips and warns when the user is not found", async () => {
+    const { handler, notificationService, logger } = setup({ findUserById: vi.fn().mockResolvedValue(null) });
+
+    await handler.handle(payload);
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "FIRST_PURCHASE_BONUS_EMAIL_SKIPPED", userId: "user-123" }));
+  });
+
+  it("skips and warns when the user has no email", async () => {
+    const user = createUser({ id: "user-123", email: null });
+    const { handler, notificationService, logger } = setup({ findUserById: vi.fn().mockResolvedValue(user) });
+
+    await handler.handle(payload);
+
+    expect(notificationService.createNotification).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(expect.objectContaining({ event: "FIRST_PURCHASE_BONUS_EMAIL_SKIPPED" }));
+  });
+
+  function setup(input?: { findUserById?: UserRepository["findById"] }) {
+    const mocks = {
+      notificationService: mock<NotificationService>({
+        createNotification: vi.fn().mockResolvedValue(undefined)
+      }),
+      userRepository: mock<UserRepository>({
+        findById: input?.findUserById ?? vi.fn()
+      }),
+      logger: mock<LoggerService>()
+    };
+
+    const handler = new FirstPurchaseBonusGrantedHandler(mocks.notificationService, mocks.userRepository, mocks.logger);
+
+    return { handler, ...mocks };
+  }
+});

--- a/apps/api/src/app/services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler.ts
+++ b/apps/api/src/app/services/first-purchase-bonus-granted/first-purchase-bonus-granted.handler.ts
@@ -1,0 +1,39 @@
+import { singleton } from "tsyringe";
+
+import { FirstPurchaseBonusGranted } from "@src/billing/events/first-purchase-bonus-granted";
+import { EventPayload, JobHandler, LoggerService } from "@src/core";
+import { NotificationService } from "@src/notifications/services/notification/notification.service";
+import { firstPurchaseBonusGrantedNotification } from "@src/notifications/services/notification-templates/first-purchase-bonus-granted-notification";
+import { UserRepository } from "@src/user/repositories";
+
+@singleton()
+export class FirstPurchaseBonusGrantedHandler implements JobHandler<FirstPurchaseBonusGranted> {
+  public readonly accepts = FirstPurchaseBonusGranted;
+
+  public readonly concurrency = 2;
+
+  constructor(
+    private readonly notificationService: NotificationService,
+    private readonly userRepository: UserRepository,
+    private readonly logger: LoggerService
+  ) {}
+
+  async handle(payload: EventPayload<FirstPurchaseBonusGranted>): Promise<void> {
+    const user = await this.userRepository.findById(payload.userId);
+    if (!user?.email) {
+      this.logger.warn({
+        event: "FIRST_PURCHASE_BONUS_EMAIL_SKIPPED",
+        userId: payload.userId,
+        reason: "User or email not found"
+      });
+      return;
+    }
+
+    await this.notificationService.createNotification(
+      firstPurchaseBonusGrantedNotification(user, {
+        bonusAmountCents: payload.bonusAmountCents,
+        paidAmountCents: payload.paidAmountCents
+      })
+    );
+  }
+}

--- a/apps/api/src/billing/events/first-purchase-bonus-granted.ts
+++ b/apps/api/src/billing/events/first-purchase-bonus-granted.ts
@@ -1,0 +1,16 @@
+import { DOMAIN_EVENT_NAME, type DomainEvent } from "@src/core/services/domain-events/domain-events.service";
+import type { UserOutput } from "@src/user/repositories";
+
+export class FirstPurchaseBonusGranted implements DomainEvent {
+  static readonly [DOMAIN_EVENT_NAME] = "FirstPurchaseBonusGranted";
+  public readonly name = FirstPurchaseBonusGranted[DOMAIN_EVENT_NAME];
+  public readonly version = 1;
+
+  constructor(
+    public readonly data: {
+      userId: UserOutput["id"];
+      bonusAmountCents: number;
+      paidAmountCents: number;
+    }
+  ) {}
+}

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.integration.ts
@@ -3,12 +3,14 @@ import type { Mock } from "vitest";
 import { describe, expect, it, vi } from "vitest";
 import { mock } from "vitest-mock-extended";
 
+import { FirstPurchaseBonusGranted } from "@src/billing/events/first-purchase-bonus-granted";
 import type { PaymentMethodRepository, StripeTransactionOutput, StripeTransactionRepository } from "@src/billing/repositories";
 import type { BillingConfigService } from "@src/billing/services/billing-config/billing-config.service";
 import type { FirstPurchaseBonusService } from "@src/billing/services/first-purchase-bonus/first-purchase-bonus.service";
 import type { RefillService } from "@src/billing/services/refill/refill.service";
 import type { StripeService } from "@src/billing/services/stripe/stripe.service";
 import { StripeWebhookService } from "@src/billing/services/stripe-webhook/stripe-webhook.service";
+import type { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import type { UserRepository } from "@src/user/repositories";
 
 import { createTestUser } from "@test/seeders/user-test.seeder";
@@ -205,7 +207,7 @@ describe(StripeWebhookService.name, () => {
     });
 
     it("tops up the combined amount, persists the bonus and tracks the grant when the bonus applies", async () => {
-      const { service, userRepository, stripeTransactionRepository, refillService, firstPurchaseBonusService } = setup();
+      const { service, userRepository, stripeTransactionRepository, refillService, firstPurchaseBonusService, domainEventsService } = setup();
       const mockUser = createTestUser();
       const internalTransaction = createMockTransaction({ status: "created" });
       const amount = 15000;
@@ -245,10 +247,14 @@ describe(StripeWebhookService.name, () => {
         }
       });
       expect(firstPurchaseBonusService.trackBonusGranted).toHaveBeenCalledWith(mockUser.id, amount, bonusAmount);
+      expect(domainEventsService.publish).toHaveBeenCalledWith(
+        new FirstPurchaseBonusGranted({ userId: mockUser.id, bonusAmountCents: bonusAmount, paidAmountCents: amount })
+      );
+      expect(domainEventsService.publish.mock.invocationCallOrder[0]).toBeGreaterThan(refillService.topUpWallet.mock.invocationCallOrder[0]);
     });
 
     it("keeps the update payload and top-up untouched when no bonus applies", async () => {
-      const { service, userRepository, stripeTransactionRepository, refillService, firstPurchaseBonusService } = setup();
+      const { service, userRepository, stripeTransactionRepository, refillService, firstPurchaseBonusService, domainEventsService } = setup();
       const mockUser = createTestUser();
       const internalTransaction = createMockTransaction({ status: "created" });
       const amount = 10000;
@@ -273,6 +279,7 @@ describe(StripeWebhookService.name, () => {
       );
       expect(refillService.topUpWallet).toHaveBeenCalledWith(amount, mockUser.id, expect.anything());
       expect(firstPurchaseBonusService.trackBonusGranted).not.toHaveBeenCalled();
+      expect(domainEventsService.publish).not.toHaveBeenCalled();
     });
   });
 
@@ -1090,6 +1097,7 @@ describe(StripeWebhookService.name, () => {
     const stripeTransactionRepository = mock<StripeTransactionRepository>();
     const firstPurchaseBonusService = mock<FirstPurchaseBonusService>();
     firstPurchaseBonusService.getEligibleBonusAmount.mockResolvedValue(0);
+    const domainEventsService = mock<DomainEventsService>();
 
     // Mock Stripe charges API
     stripeService.charges = {
@@ -1103,7 +1111,8 @@ describe(StripeWebhookService.name, () => {
       userRepository,
       paymentMethodRepository,
       stripeTransactionRepository,
-      firstPurchaseBonusService
+      firstPurchaseBonusService,
+      domainEventsService
     );
 
     return {
@@ -1114,7 +1123,8 @@ describe(StripeWebhookService.name, () => {
       userRepository,
       paymentMethodRepository,
       stripeTransactionRepository,
-      firstPurchaseBonusService
+      firstPurchaseBonusService,
+      domainEventsService
     };
   }
 

--- a/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
+++ b/apps/api/src/billing/services/stripe-webhook/stripe-webhook.service.ts
@@ -3,6 +3,7 @@ import assert from "http-assert";
 import Stripe from "stripe";
 import { singleton } from "tsyringe";
 
+import { FirstPurchaseBonusGranted } from "@src/billing/events/first-purchase-bonus-granted";
 import {
   PaymentMethodRepository,
   type StripeTransactionOutput,
@@ -14,6 +15,7 @@ import { assertIsPayingUser } from "@src/billing/services/paying-user/paying-use
 import { RefillService } from "@src/billing/services/refill/refill.service";
 import { StripeService } from "@src/billing/services/stripe/stripe.service";
 import { WithTransaction } from "@src/core";
+import { DomainEventsService } from "@src/core/services/domain-events/domain-events.service";
 import { UserRepository } from "@src/user/repositories";
 import { BillingConfigService } from "../billing-config/billing-config.service";
 
@@ -28,7 +30,8 @@ export class StripeWebhookService {
     private readonly userRepository: UserRepository,
     private readonly paymentMethodRepository: PaymentMethodRepository,
     private readonly stripeTransactionRepository: StripeTransactionRepository,
-    private readonly firstPurchaseBonusService: FirstPurchaseBonusService
+    private readonly firstPurchaseBonusService: FirstPurchaseBonusService,
+    private readonly domainEventsService: DomainEventsService
   ) {}
 
   async routeStripeEvent(signature: string, rawEvent: string) {
@@ -204,7 +207,7 @@ export class StripeWebhookService {
       }
     }
 
-    await this.updateTransactionAndTopUp({
+    const bonusAmountCents = await this.updateTransactionAndTopUp({
       transactionId: params.transaction.id,
       chargeId: params.chargeId,
       paymentMethodType: params.paymentMethodType,
@@ -217,6 +220,12 @@ export class StripeWebhookService {
       eventDescription: params.eventDescription,
       endTrial: params.endTrial
     });
+
+    // Published here, not inside updateTransactionAndTopUp: this method is not transactional but that one is,
+    // so the awaited call has committed by now and the bonus-granted email never fires on a rolled-back grant.
+    if (bonusAmountCents > 0) {
+      await this.domainEventsService.publish(new FirstPurchaseBonusGranted({ userId: user.id, bonusAmountCents, paidAmountCents: params.paymentAmount }));
+    }
   }
 
   @WithTransaction()
@@ -232,7 +241,7 @@ export class StripeWebhookService {
     userId: string;
     eventDescription: string;
     endTrial?: boolean;
-  }): Promise<void> {
+  }): Promise<number> {
     const transaction = await this.stripeTransactionRepository.findOneByAndLock({ id: params.transactionId });
 
     if (!transaction) {
@@ -241,7 +250,7 @@ export class StripeWebhookService {
         transactionId: params.transactionId,
         description: params.eventDescription
       });
-      return;
+      return 0;
     }
 
     if (transaction.status === "succeeded") {
@@ -250,7 +259,7 @@ export class StripeWebhookService {
         transactionId: params.transactionId,
         description: params.eventDescription
       });
-      return;
+      return 0;
     }
 
     const bonusAmount = await this.firstPurchaseBonusService.getEligibleBonusAmount(transaction, params.paymentAmount);
@@ -289,6 +298,8 @@ export class StripeWebhookService {
         bonusAmountCents: bonusAmount
       });
     }
+
+    return bonusAmount;
   }
 
   @WithTransaction()

--- a/apps/api/src/notifications/services/notification-handler/notification.handler.ts
+++ b/apps/api/src/notifications/services/notification-handler/notification.handler.ts
@@ -13,6 +13,7 @@ import { CreateNotificationInput, NotificationService } from "../notification/no
 import { afterTrialEndsNotification } from "../notification-templates/after-trial-ends-notification";
 import { beforeCloseTrialDeploymentNotification } from "../notification-templates/before-close-trial-deployment";
 import { beforeTrialEndsNotification } from "../notification-templates/before-trial-ends-notification";
+import { firstPurchaseBonusGrantedNotification } from "../notification-templates/first-purchase-bonus-granted-notification";
 import { startTrialNotification } from "../notification-templates/start-trial-notification";
 import { trialDeploymentClosedNotification } from "../notification-templates/trial-deployment-closed";
 import { trialEndedNotification } from "../notification-templates/trial-ended-notification";
@@ -25,7 +26,8 @@ const notificationTemplates = {
   startTrial: startTrialNotification,
   beforeCloseTrialDeployment: beforeCloseTrialDeploymentNotification,
   trialDeploymentClosed: trialDeploymentClosedNotification,
-  trialFirstDeploymentLeaseCreated: trialFirstDeploymentLeaseCreatedNotification
+  trialFirstDeploymentLeaseCreated: trialFirstDeploymentLeaseCreatedNotification,
+  firstPurchaseBonusGranted: firstPurchaseBonusGrantedNotification
 };
 
 type NotificationTemplates = typeof notificationTemplates;

--- a/apps/api/src/notifications/services/notification-templates/first-purchase-bonus-granted-notification.spec.ts
+++ b/apps/api/src/notifications/services/notification-templates/first-purchase-bonus-granted-notification.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { firstPurchaseBonusGrantedNotification } from "./first-purchase-bonus-granted-notification";
+
+import { createUser } from "@test/seeders/user.seeder";
+
+describe(firstPurchaseBonusGrantedNotification.name, () => {
+  it("returns a notification describing the granted bonus and paid amount", () => {
+    const user = createUser({ id: "user-123", email: "user@example.com" });
+
+    const result = firstPurchaseBonusGrantedNotification(user, { bonusAmountCents: 1500, paidAmountCents: 15000 });
+
+    expect(result.notificationId).toBe("firstPurchaseBonusGranted.user-123");
+    expect(result.payload.summary).toBe("You earned $15.00 in bonus credits");
+    expect(result.payload.description).toContain("<strong>$15.00</strong>");
+    expect(result.payload.description).toContain("$150.00");
+    expect(result.user).toEqual({ id: "user-123", email: "user@example.com" });
+  });
+});

--- a/apps/api/src/notifications/services/notification-templates/first-purchase-bonus-granted-notification.ts
+++ b/apps/api/src/notifications/services/notification-templates/first-purchase-bonus-granted-notification.ts
@@ -1,0 +1,23 @@
+import type { UserOutput } from "@src/user/repositories";
+import type { CreateNotificationInput } from "../notification/notification.service";
+
+export function firstPurchaseBonusGrantedNotification(user: UserOutput, vars: { bonusAmountCents: number; paidAmountCents: number }): CreateNotificationInput {
+  const formatter = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" });
+  const bonus = formatter.format(vars.bonusAmountCents / 100);
+  const paid = formatter.format(vars.paidAmountCents / 100);
+  return {
+    // Deterministic: the bonus is granted once per user, and the broker treats this as a singletonKey.
+    notificationId: `firstPurchaseBonusGranted.${user.id}`,
+    payload: {
+      summary: `You earned ${bonus} in bonus credits`,
+      description:
+        `Thanks for your first purchase of ${paid} with Akash Network! ` +
+        `We've added <strong>${bonus}</strong> in bonus credits to your account on top of the credits you purchased. ` +
+        `They're already in your balance and ready to power your deployments.`
+    },
+    user: {
+      id: user.id,
+      email: user.email
+    }
+  };
+}


### PR DESCRIPTION
## Why

When a user earns the first-purchase bonus, nothing confirms it beyond the in-app payment animation and Stripe's own receipt. A dedicated email reinforces the value moment ("you got extra credits").

Closes CON-659
Part of CON-657

## What

- Publishes a domain event from the Stripe webhook after the transaction commits, and only when a bonus was actually granted, so the confirmation email never fires on a rolled-back grant, coupon claims, repeat purchases, or duplicate webhook deliveries.
- Adds a "You earned $X in bonus credits" confirmation email, sent immediately by a dedicated handler.
- No change to the clawback path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-purchase bonus notifications with formatted bonus and paid amounts.
  * Eligible Stripe top-ups now publish a first-purchase bonus event after successful wallet top-up.
  * Introduced a background job handler to deliver the bonus notification.
* **Bug Fixes**
  * Notifications are no longer created when the user or email is missing; a warning is logged instead.
* **Tests**
  * Added integration and unit tests for event publishing, notification creation, and skipped-notification scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->